### PR TITLE
fix: portable in-place sed across 5 shell scripts (Linux compat)

### DIFF
--- a/fix-imports.sh
+++ b/fix-imports.sh
@@ -1,6 +1,15 @@
 #!/bin/bash
 set -euo pipefail
 
+# Portable in-place sed (BSD/macOS requires `sed -i ''`, GNU/Linux requires `sed -i`)
+sed_inplace() {
+  if [[ "$(uname)" == "Darwin" ]]; then
+    sed -i '' "$@"
+  else
+    sed -i "$@"
+  fi
+}
+
 for f in \
   ~/Desktop/ktlyst-hub/strategy/CLAUDE.md \
   ~/Desktop/ktlyst-hub/product/CLAUDE.md \
@@ -10,7 +19,7 @@ for f in \
   ~/Desktop/ktlyst-hub/lawyer/CLAUDE.md
 do
   if [ -f "$f" ]; then
-    sed -i '' 's|@q-system/q-system/CLAUDE.md|@q-system/CLAUDE.md|g' "$f"
+    sed_inplace 's|@q-system/q-system/CLAUDE.md|@q-system/CLAUDE.md|g' "$f"
     echo "fixed: $f"
   else
     echo "skip: $f"

--- a/kipi-new-instance.sh
+++ b/kipi-new-instance.sh
@@ -10,6 +10,15 @@ SKELETON_REMOTE="https://github.com/assafkip/kipi-system.git"
 SKELETON_BRANCH="main"
 PREFIX="q-system"
 
+# Portable in-place sed (BSD/macOS requires `sed -i ''`, GNU/Linux requires `sed -i`)
+sed_inplace() {
+  if [[ "$(uname)" == "Darwin" ]]; then
+    sed -i '' "$@"
+  else
+    sed -i "$@"
+  fi
+}
+
 if [ $# -lt 2 ]; then
   echo "Usage: $0 <path> <name>"
   echo "  path: directory to create the instance in"
@@ -65,7 +74,7 @@ if [ ! -f CLAUDE.md ]; then
 - Never produce fluff - every sentence must carry information or enable action
 - Mark unvalidated claims with `{{UNVALIDATED}}` or `{{NEEDS_PROOF}}`
 CLAUDE_EOF
-  sed -i '' "s/{{INSTANCE_NAME}}/$INST_NAME/g" CLAUDE.md 2>/dev/null || true
+  sed_inplace "s/{{INSTANCE_NAME}}/$INST_NAME/g" CLAUDE.md 2>/dev/null || true
   echo "  Created template CLAUDE.md"
 fi
 
@@ -75,8 +84,8 @@ mkdir -p .claude/agents .claude/output-styles .claude/rules
 cp "$SCRIPT_DIR/settings-template.json" .claude/settings.json
 
 # Fix hook paths: subtree nests the repo under q-system/, so q-system/hooks/ becomes q-system/q-system/hooks/
-sed -i '' 's|/q-system/hooks/|/q-system/q-system/hooks/|g' .claude/settings.json
-sed -i '' 's|/q-system/.q-system/|/q-system/q-system/.q-system/|g' .claude/settings.json
+sed_inplace 's|/q-system/hooks/|/q-system/q-system/hooks/|g' .claude/settings.json
+sed_inplace 's|/q-system/.q-system/|/q-system/q-system/.q-system/|g' .claude/settings.json
 
 cp "$SCRIPT_DIR"/.claude/agents/*.md .claude/agents/ 2>/dev/null || true
 cp "$SCRIPT_DIR"/.claude/output-styles/*.md .claude/output-styles/ 2>/dev/null || true

--- a/kipi-update.sh
+++ b/kipi-update.sh
@@ -15,6 +15,15 @@ SKELETON_REMOTE="https://github.com/assafkip/kipi-system.git"
 SKELETON_BRANCH="main"
 DRY_RUN="${1:-}"
 
+# Portable in-place sed (BSD/macOS requires `sed -i ''`, GNU/Linux requires `sed -i`)
+sed_inplace() {
+  if [[ "$(uname)" == "Darwin" ]]; then
+    sed -i '' "$@"
+  else
+    sed -i "$@"
+  fi
+}
+
 if [ ! -f "$REGISTRY" ]; then
   echo "ERROR: instance-registry.json not found at $REGISTRY"
   exit 1
@@ -186,8 +195,8 @@ print('    settings.json updated (MCP, plugins, permissions, tools preserved)')
 
       # Fix paths for subtree instances (q-system/ is nested under q-system/)
       if [ "$itype" = "subtree" ]; then
-        sed -i '' 's|/q-system/hooks/|/q-system/q-system/hooks/|g' "$path/.claude/settings.json" 2>/dev/null || true
-        sed -i '' 's|/q-system/.q-system/|/q-system/q-system/.q-system/|g' "$path/.claude/settings.json" 2>/dev/null || true
+        sed_inplace 's|/q-system/hooks/|/q-system/q-system/hooks/|g' "$path/.claude/settings.json" 2>/dev/null || true
+        sed_inplace 's|/q-system/.q-system/|/q-system/q-system/.q-system/|g' "$path/.claude/settings.json" 2>/dev/null || true
       fi
     fi
 

--- a/q-system/.q-system/agent-pipeline/templates/create-from-template.sh
+++ b/q-system/.q-system/agent-pipeline/templates/create-from-template.sh
@@ -4,6 +4,15 @@
 
 set -euo pipefail
 
+# Portable in-place sed (BSD/macOS requires `sed -i ''`, GNU/Linux requires `sed -i`)
+sed_inplace() {
+  if [[ "$(uname)" == "Darwin" ]]; then
+    sed -i '' "$@"
+  else
+    sed -i "$@"
+  fi
+}
+
 TEMPLATE_NAME="$1"
 OUTPUT_NAME="$2"
 SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
@@ -26,8 +35,13 @@ fi
 cp -r "${TEMPLATE_DIR}" "${OUTPUT_DIR}"
 
 # Replace date placeholder in all files
-find "${OUTPUT_DIR}" -type f -name "*.md" -exec sed -i '' "s/{{DATE}}/$(date +%Y-%m-%d)/g" {} \;
-find "${OUTPUT_DIR}" -type f -name "*.md" -exec sed -i '' "s/{{OUTPUT_NAME}}/${OUTPUT_NAME}/g" {} \;
+# Use while-read instead of find -exec so we can call the sed_inplace shell function
+# (find -exec spawns a new process and can't see shell functions)
+DATE_STR="$(date +%Y-%m-%d)"
+while IFS= read -r -d '' f; do
+  sed_inplace "s/{{DATE}}/$DATE_STR/g" "$f"
+  sed_inplace "s/{{OUTPUT_NAME}}/${OUTPUT_NAME}/g" "$f"
+done < <(find "${OUTPUT_DIR}" -type f -name "*.md" -print0)
 
 echo "Created: ${OUTPUT_DIR}"
 echo "Files:"

--- a/q-system/.q-system/scripts/instance-diet-fix.sh
+++ b/q-system/.q-system/scripts/instance-diet-fix.sh
@@ -1,6 +1,15 @@
 #!/bin/bash
 set -euo pipefail
 
+# Portable in-place sed (BSD/macOS requires `sed -i ''`, GNU/Linux requires `sed -i`)
+sed_inplace() {
+  if [[ "$(uname)" == "Darwin" ]]; then
+    sed -i '' "$@"
+  else
+    sed -i "$@"
+  fi
+}
+
 # instance-diet-fix.sh - Fix broken imports and remove duplicate sections
 # from an instance's CLAUDE.md. Creates a backup before modifying.
 #
@@ -39,7 +48,7 @@ BEFORE=$(grep -c '.' "$CLAUDE_MD" || true)
 
 # Fix broken import path
 if grep -q '@q-system/q-system/CLAUDE.md' "$CLAUDE_MD"; then
-  sed -i '' 's|@q-system/q-system/CLAUDE.md|@q-system/CLAUDE.md|g' "$CLAUDE_MD"
+  sed_inplace 's|@q-system/q-system/CLAUDE.md|@q-system/CLAUDE.md|g' "$CLAUDE_MD"
   echo "Fixed: broken import @q-system/q-system/CLAUDE.md -> @q-system/CLAUDE.md"
 fi
 


### PR DESCRIPTION
## Problem

Five shell scripts in this repo use `sed -i ''` (the BSD/macOS form, where `''` is the empty backup-suffix argument). On GNU/Linux, `sed -i` does not take a separate suffix argument — the `''` is parsed as the sed script, so the actual sed expression that follows becomes a filename, and the in-place edit silently no-ops (the `2>/dev/null || true` patterns swallow the resulting error).

This means several scripts that look like they work on Linux actually don't perform their in-place edits:

- `kipi-new-instance.sh` — the subtree path-nest transform (`/q-system/hooks/` → `/q-system/q-system/hooks/`) never runs, so new instances on Linux end up with broken hook paths in `.claude/settings.json`.
- `kipi-update.sh` — same path-nest transform never runs on Linux instances.
- `fix-imports.sh`, `q-system/.q-system/scripts/instance-diet-fix.sh` — broken-import cleanup silently skipped on Linux.
- `q-system/.q-system/agent-pipeline/templates/create-from-template.sh` — `{{DATE}}` and `{{OUTPUT_NAME}}` placeholders never get replaced in template output on Linux.

## Fix

Add a tiny `sed_inplace()` helper near the top of each affected script that branches on `uname` and call it instead of raw `sed -i ''`:

```bash
sed_inplace() {
  if [[ "$(uname)" == "Darwin" ]]; then
    sed -i '' "$@"
  else
    sed -i "$@"
  fi
}
```

Per file:
- `fix-imports.sh` — 1 call site
- `kipi-new-instance.sh` — 3 call sites
- `kipi-update.sh` — 2 call sites
- `q-system/.q-system/scripts/instance-diet-fix.sh` — 1 call site
- `q-system/.q-system/agent-pipeline/templates/create-from-template.sh` — 2 call sites, refactored from `find -exec` to `while read` because `-exec` spawns a new process that can't see shell functions

## Behavior

- **macOS:** no change — still calls `sed -i ''` exactly as before.
- **Linux:** the previously silently-broken in-place edits now actually happen.

## Verification

Each script syntax-checked with `bash -n`. Helper sourced and smoke-tested on Linux Mint 22.1 — `sed_inplace 's/hello/HOWDY/'` correctly rewrites the target file. The refactored find-loop in `create-from-template.sh` verified to substitute both `{{DATE}}` and `{{OUTPUT_NAME}}` placeholders.

## Context

Discovered while running `kipi-update.sh` on a Linux instance — the script reported success but produced a `settings.json` with single-nested hook paths instead of the intended double-nested form. Local fix lived for a day on a private fork; sending upstream so other Linux users don't get bitten.