### PR TITLE
chore: replace KTLYST flavor in skeleton stat-verify code

### DIFF
--- a/q-system/.q-system/scripts/stat-registry-extract.py
+++ b/q-system/.q-system/scripts/stat-registry-extract.py
@@ -144,7 +144,7 @@ def hook_mode() -> None:
         if len(drift) > 20:
             print(f"  ... and {len(drift) - 20} more", file=sys.stderr)
         print(
-            "Update q-ktlyst/canonical/stat-registry.json approved_numerics or "
+            "Update the instance's canonical/stat-registry.json approved_numerics or "
             "canonical_phrasings to keep the stat-verify gate in sync.",
             file=sys.stderr,
         )

--- a/q-system/.q-system/scripts/tests/test-stat-verify.py
+++ b/q-system/.q-system/scripts/tests/test-stat-verify.py
@@ -45,7 +45,7 @@ def run_cli(file_path: str) -> tuple[int, str, str]:
 
 
 def make_instance(tmpdir: Path, stat_overrides: list | None = None) -> Path:
-    """Create a fake q-ktlyst-shaped tree with canonical/stat-registry.json."""
+    """Create a fake instance-shaped tree with canonical/stat-registry.json."""
     canonical = tmpdir / "canonical"
     canonical.mkdir(parents=True)
     bus = tmpdir / ".q-system" / "agent-pipeline" / "bus" / "2026-05-21"
@@ -68,7 +68,7 @@ def make_instance(tmpdir: Path, stat_overrides: list | None = None) -> Path:
                 "canonical_phrasings": ["42 handoffs", "7 input types", "6 teams"],
             },
             {
-                "id": "ktlyst-spec",
+                "id": "test-spec",
                 "approved_numerics": ["60+", "11", "40 seconds"],
                 "canonical_phrasings": ["60+ artifacts", "11 team folders", "40 seconds"],
             },
@@ -351,7 +351,7 @@ def test_dollar_range_extracted_as_one_token(tmpdir: Path) -> None:
     verified, not silently dropped."""
     bus = make_instance(tmpdir, stat_overrides=[
         {
-            "id": "ktlyst-acv",
+            "id": "test-acv",
             "approved_numerics": ["$25-75K"],
             "canonical_phrasings": ["$25-75K pilot"],
         },


### PR DESCRIPTION
Small companion to #2 (the hardcoded-patterns discussion) — surgical mechanical change while that broader design conversation plays out.

## Problem

Two files in the skeleton contain references to `KTLYST` / `q-ktlyst` / `ktlyst-*` that aren't real instance content leaks — they're leftover example flavor baked into the skeleton itself:

- `q-system/.q-system/scripts/stat-registry-extract.py:147` — stderr message hardcodes `q-ktlyst/canonical/stat-registry.json` as the path the user should edit
- `q-system/.q-system/scripts/tests/test-stat-verify.py` — docstring (`q-ktlyst-shaped tree`) plus two test fixture IDs (`ktlyst-spec`, `ktlyst-acv`)

These trip the leak-detection gate (`validate-separation.py` + `kipi-mcp` validator) in any fork that runs the validators against this skeleton's own content. Forks have to either patch the validator's pattern list locally or live with red CI.

## Fix

Replace with generic placeholders:

- `q-ktlyst/canonical/...` → `the instance's canonical/...` (stderr message)
- `q-ktlyst-shaped tree` → `instance-shaped tree` (docstring)
- `ktlyst-spec` → `test-spec`, `ktlyst-acv` → `test-acv` (test IDs)

## Safety

- `git grep "ktlyst-spec\|ktlyst-acv"` confirms the test IDs are referenced **only** within `test-stat-verify.py` — no cross-references, safe to rename.
- No logic change. No assertion change. Tests still describe and exercise the same shapes.
- The stderr message preserves the same information (what to update); just doesn't tie it to one specific instance name.

## Why now

Forks running `validate-separation.py 1` on this skeleton hit 3 KTLYST-related failures today (1 from `init-bus-day.sh` already independently fixed upstream; 2 from these files). This PR clears the 2 remaining and brings the leak-detection gate to green for any fork. The broader pattern-config discussion in #2 stands on its own.