### PR TITLE
fix(prompt-only-enforcement-guard): mention-vs-claim false positive (sp-edf9395d)

### DIFF
--- a/.prd-os/issues/prompt-only-guard-stderr.md
+++ b/.prd-os/issues/prompt-only-guard-stderr.md
@@ -1,0 +1,26 @@
+---
+id: prompt-only-guard-stderr
+title: prompt-only-enforcement-guard block message must reach stderr (sp-cd530cc7)
+status: closed
+priority: p2
+parent_prd: prd-prompt-only-guard-stderr-2026-07-02
+allowed_files:
+  - q-system/.q-system/scripts/prompt-only-enforcement-guard.py
+  - q-system/.q-system/scripts/test/test-prompt-only-enforcement-guard-stderr.sh
+disallowed_files: []
+required_checks:
+  - bash q-system/.q-system/scripts/test/test-prompt-only-enforcement-guard-stderr.sh
+required_reviews: []
+bypass_check: "bash q-system/.q-system/scripts/test/test-prompt-only-enforcement-guard-stderr.sh"
+---
+<!-- generated-by: prd_split.py prd=prd-prompt-only-guard-stderr-2026-07-02 finding=finding-1 at=2026-07-02T23:16:54Z -->
+
+# prompt-only-enforcement-guard block message must reach stderr (sp-cd530cc7)
+
+## Context
+
+Parent PRD: `.prd-os/prds/prd-prompt-only-guard-stderr-2026-07-02.md`
+
+## Acceptance
+
+<!-- fill in -->

--- a/.prd-os/prds/prd-prompt-only-guard-stderr-2026-07-02.md
+++ b/.prd-os/prds/prd-prompt-only-guard-stderr-2026-07-02.md
@@ -1,9 +1,9 @@
 ---
 id: prd-prompt-only-guard-stderr-2026-07-02
 title: Prompt Only Guard Stderr
-status: approved
+status: archived
 created_at: 2026-07-02T23:13:41Z
-updated_at: 2026-07-02T23:16:39Z
+updated_at: 2026-07-02T23:20:51Z
 owner: assafkipnis
 reviewers: []
 findings_path: .prd-os/findings/prd-prompt-only-guard-stderr-2026-07-02-findings.jsonl

--- a/.prd-os/prds/prd-prompt-only-guard-stderr-2026-07-02.md
+++ b/.prd-os/prds/prd-prompt-only-guard-stderr-2026-07-02.md
@@ -1,0 +1,167 @@
+---
+id: prd-prompt-only-guard-stderr-2026-07-02
+title: Prompt Only Guard Stderr
+status: approved
+created_at: 2026-07-02T23:13:41Z
+updated_at: 2026-07-02T23:16:39Z
+owner: assafkipnis
+reviewers: []
+findings_path: .prd-os/findings/prd-prompt-only-guard-stderr-2026-07-02-findings.jsonl
+codex_reviewed_at: 2026-07-02T23:15:52Z
+---
+
+<!-- prompt-only-enforcement-skip: this PRD documents the guard itself; its
+     vocabulary (hook, block, enforcement) trips mention-vs-claim FPs. The
+     enforcement here IS executable: test-prompt-only-enforcement-guard-stderr.sh -->
+
+# Prompt-only-enforcement-guard: block message must reach stderr
+
+## Problem
+
+Observed live 2026-07-02 (this session): the `prompt-only-enforcement-guard.py`
+PostToolUse hook blocked a Write with exit 2 but printed its reason as JSON to
+STDOUT (`print(json.dumps({"message": ...}))`, old line 268). Claude Code feeds
+only STDERR back to the model on exit 2, so the block surfaced as
+`"No stderr output"` — the model (and founder) got a reasonless wall. Every
+block this hook has ever issued was silent. Captured as spillover sp-cd530cc7.
+
+## Goals
+
+- On block: plain-text message on stderr, exit 2, stdout clean (the
+  skill-hook-pairing exit-code contract).
+- A regression test pins the contract and was shown failing against the old
+  stdout form (negative self-test).
+
+## Non-goals
+
+- No change to detection patterns, scan windows, target-file scoping, or the
+  skip marker.
+- No audit of other hooks' stderr discipline (only this hook was observed
+  violating; a fleet sweep would be its own item if one is caught).
+
+## Proposed approach
+
+Shipped in commit 2c14139 (this PRD wraps it in the gate retroactively so
+sp-cd530cc7 can resolve):
+
+- `q-system/.q-system/scripts/prompt-only-enforcement-guard.py`: block path
+  prints the message to stderr as plain text; scar comment cites sp-cd530cc7.
+- `q-system/.q-system/scripts/test/test-prompt-only-enforcement-guard-stderr.sh`:
+  violation fixture must exit 2 with `BLOCK:` on stderr and NOTHING on stdout;
+  clean fixture must pass. Run red against the pre-fix script, green after.
+
+## Alternatives considered
+
+- **Keep JSON on stdout and also print stderr** — Rejected: exit-2 stdout JSON
+  is dead output in the PostToolUse contract; keeping it invites the next
+  reader to assume it does something.
+- **Emit hookSpecificOutput JSON (warn-style) instead of exit 2** — Rejected:
+  this hook is a blocker by design (q-system/CLAUDE.md rule 3); advisory
+  context would let prompt-only enforcement claims land.
+
+## Scenarios
+
+- **Blocked write.** Agent writes a doc claiming "enforced by the skill" with
+  no executable blocker; hook exits 2; the model sees the BLOCK message with
+  file:line on stderr and names/adds a deterministic blocker.
+- **Clean write.** Doc names the hook/test that enforces the rule; hook exits
+  0; nothing printed.
+
+## Resolved decisions
+
+- **stderr, plain text.** Decided: match `token-guard.py`'s `block()` shape.
+  Rationale: one contract across all blocking hooks; stderr is the only channel
+  Claude Code relays on exit 2.
+
+## Risks and rollback
+
+Blast radius is one print statement in one hook; no consumer parsed the old
+stdout JSON (nothing could — it was invisible). Rollback = revert 2c14139.
+
+## Open questions
+
+- None.
+
+### Skeptic
+
+Q1: What is the strongest argument against doing this?
+A1: It's a 2-line fix already shipped; the gate ceremony costs more than the
+fix. Counter: the spillover ledger refuses hand-clearing by design, and the
+receipt registers the regression test as a permanent gate.
+
+Q2: What is the smallest experiment that would disprove the thesis?
+A2: Re-run the live probe (stdin PostToolUse event on a violating file) and
+show the message arriving on stderr — done this session, exit=2 with BLOCK
+text on stderr, stdout empty.
+
+Q3: What is the cheapest non-build alternative?
+A3: Void sp-cd530cc7. Rejected: the defect is real and observed; voiding would
+be a false record.
+
+<!--
+## Persona Review (optional, fill in before /prd-review)
+
+Phase 0 of the prd-os planning-personas experiment (PRD prd-planning-personas-2026-05-13).
+For non-trivial PRDs, answer the three Skeptic questions below before invoking /prd-review.
+Brief answers are fine. The goal is to force one round of adversarial thinking before Codex.
+
+### Skeptic
+
+Q1: What is the strongest argument against doing this?
+A1:
+
+Q2: What is the smallest experiment that would disprove the thesis?
+A2:
+
+Q3: What is the cheapest non-build alternative?
+A3:
+
+When done with these questions, uncomment this section and move it to live just before `## Issues` below.
+-->
+
+## Issues
+
+<!--
+After review and approval, populate the fenced JSON block below. The manifest is
+read by TWO consumers and every entry must satisfy both:
+  - `prd_split.py` materializes one issue spec per entry (needs `id`).
+  - the approval gate proves every ACCEPTED finding is covered by an entry (needs
+    `finding_id` + a `bypass_check`). One entry per accepted finding.
+
+Required keys per entry (spine-native -- both consumers):
+  - id (kebab-case, unique across the repo)            -- prd_split.py
+  - finding_id (the accepted finding it covers, e.g. "finding-1") -- approval gate
+  - title (non-empty string)
+  - allowed_files (non-empty list of glob patterns)
+  - required_checks (non-empty list, e.g. ["pytest -q"]). The stop-gate checks
+    three receipts (verified, reviewed, findings_triaged); they are meaningless
+    unless the spec documents what must be verified, so an empty list is rejected.
+  - bypass_check (a command proving no bypass remains) OR
+    bypass_exempt: "<reason>"                          -- spine contract
+
+Optional keys:
+  - priority (default p1)
+  - disallowed_files, required_reviews, acceptance
+
+Authoring a manifest with `id` but no `finding_id` (the pre-spine shape) is
+rejected at approve. The template-vs-runner contract test enforces this list.
+-->
+
+```json
+[
+  {
+    "id": "prompt-only-guard-stderr",
+    "finding_id": "finding-1",
+    "title": "prompt-only-enforcement-guard block message must reach stderr (sp-cd530cc7)",
+    "priority": "p2",
+    "allowed_files": [
+      "q-system/.q-system/scripts/prompt-only-enforcement-guard.py",
+      "q-system/.q-system/scripts/test/test-prompt-only-enforcement-guard-stderr.sh"
+    ],
+    "required_checks": [
+      "bash q-system/.q-system/scripts/test/test-prompt-only-enforcement-guard-stderr.sh"
+    ],
+    "bypass_check": "bash q-system/.q-system/scripts/test/test-prompt-only-enforcement-guard-stderr.sh"
+  }
+]
+```

--- a/q-system/.q-system/scripts/prompt-only-enforcement-guard.py
+++ b/q-system/.q-system/scripts/prompt-only-enforcement-guard.py
@@ -265,7 +265,10 @@ def main(argv: list[str]) -> int:
             "validator, required check, or executable code.\n"
             + "\n".join(findings)
         )
-        print(json.dumps({"message": message}))
+        # stderr, plain text: on exit 2 Claude Code feeds ONLY stderr back to
+        # the model. The old json-to-stdout form surfaced every block as
+        # "No stderr output" — a reasonless wall (sp-cd530cc7, 2026-07-02).
+        print(message, file=sys.stderr)
         return 2
 
     return 0

--- a/q-system/.q-system/scripts/prompt-only-enforcement-guard.py
+++ b/q-system/.q-system/scripts/prompt-only-enforcement-guard.py
@@ -195,10 +195,32 @@ def _strip_code_fences(text: str) -> str:
     return CODE_FENCE_RE.sub("", text)
 
 
-def _window(lines: list[str], index: int, radius: int = 2) -> str:
+TRIGGER_RADIUS = 2
+# Docs name their executable blocker a few lines from the claim-shaped
+# sentence; reading the suppressors through the same +/-2 window as the
+# triggers flagged 11 lines of the guard's own PRD (sp-edf9395d, 2026-07-02).
+SUPPRESSOR_RADIUS = 6
+
+
+def _window(lines: list[str], index: int, radius: int = TRIGGER_RADIUS) -> str:
     start = max(0, index - radius)
     end = min(len(lines), index + radius + 1)
     return "\n".join(lines[start:end]).lower()
+
+
+def _frontmatter_end(lines: list[str]) -> int:
+    """Index of the closing '---' of leading YAML frontmatter, else -1.
+
+    Frontmatter keys describe the doc, they do not claim enforcement; a
+    title like "Prompt Only Guard Stderr" matches subject "prompt" +
+    action "guard" and produced pure-metadata flags (sp-edf9395d).
+    """
+    if not lines or lines[0].strip() != "---":
+        return -1
+    for index in range(1, len(lines)):
+        if lines[index].strip() == "---":
+            return index
+    return -1
 
 
 def _has_any(text: str, terms: tuple[str, ...]) -> bool:
@@ -214,12 +236,14 @@ def _is_negated_prompt_only_warning(text: str) -> bool:
     )
 
 
-def _is_violation(window_text: str) -> bool:
-    if GUARD_FILENAME in window_text:
+def _is_violation(window_text: str, suppressor_text: str) -> bool:
+    # Blocker suppressors read the wider window. Negation stays on the
+    # narrow one: a "must not" six lines away must not mask a real claim.
+    if GUARD_FILENAME in suppressor_text:
+        return False
+    if DETERMINISTIC_RE.search(suppressor_text):
         return False
     if _is_negated_prompt_only_warning(window_text):
-        return False
-    if DETERMINISTIC_RE.search(window_text):
         return False
     return bool(
         SUBJECT_ENFORCES_RE.search(window_text)
@@ -241,12 +265,16 @@ def scan(path: Path) -> list[str]:
 
     text = _strip_code_fences(text)
     lines = text.splitlines()
+    frontmatter_end = _frontmatter_end(lines)
     findings: list[str] = []
     for index, line in enumerate(lines):
+        if index <= frontmatter_end:
+            continue
         if not line.strip():
             continue
         window_text = _window(lines, index)
-        if _is_violation(window_text):
+        suppressor_text = _window(lines, index, radius=SUPPRESSOR_RADIUS)
+        if _is_violation(window_text, suppressor_text):
             findings.append(
                 f"{path}:{index + 1}: prompt-only enforcement claim needs an executable blocker"
             )

--- a/q-system/.q-system/scripts/test/test-prompt-only-enforcement-guard-stderr.sh
+++ b/q-system/.q-system/scripts/test/test-prompt-only-enforcement-guard-stderr.sh
@@ -21,11 +21,27 @@ set -e
 
 [ "$CODE" -eq 2 ] || { echo "FAIL: violation exited $CODE, want 2"; exit 1; }
 case "$ERR" in
-  *"BLOCK: prompt-only enforcement"*) ;;
-  *) echo "FAIL: block message missing from STDERR (Claude sees 'No stderr output'): '$ERR'"; exit 1;;
+  "BLOCK: prompt-only enforcement"*) ;;  # plain text, not {"message": ...} JSON
+  *) echo "FAIL: STDERR must START with the plain-text BLOCK line (Codex finding: JSON-on-stderr would pass a contains-check): '$ERR'"; exit 1;;
 esac
 [ -z "$OUT" ] || { echo "FAIL: block message leaked to STDOUT: '$OUT'"; exit 1; }
-echo "ok: block message goes to stderr, stdout stays clean"
+echo "ok: block message goes to stderr as plain text, stdout stays clean"
+
+# Hook entrypoint: Claude Code invokes with NO argv and the PostToolUse payload
+# on stdin (Codex finding: an argv-only test would miss a stdin-path regression
+# back to stdout JSON).
+set +e
+HOOK_OUT="$(printf '{"session_id":"t","hook_event_name":"PostToolUse","tool_name":"Write","tool_input":{"file_path":"%s"}}' "$FIXTURE/violation.md" | python3 "$GUARD" 2>/dev/null)"
+HOOK_ERR="$(printf '{"session_id":"t","hook_event_name":"PostToolUse","tool_name":"Write","tool_input":{"file_path":"%s"}}' "$FIXTURE/violation.md" | python3 "$GUARD" 2>&1 >/dev/null)"
+HOOK_CODE=$?
+set -e
+[ "$HOOK_CODE" -eq 2 ] || { echo "FAIL: stdin hook mode exited $HOOK_CODE, want 2"; exit 1; }
+case "$HOOK_ERR" in
+  "BLOCK: prompt-only enforcement"*) ;;
+  *) echo "FAIL: stdin hook mode lost the plain-text stderr message: '$HOOK_ERR'"; exit 1;;
+esac
+[ -z "$HOOK_OUT" ] || { echo "FAIL: stdin hook mode leaked to STDOUT: '$HOOK_OUT'"; exit 1; }
+echo "ok: stdin hook entrypoint blocks on stderr too"
 
 # A clean file passes silently.
 printf 'The lint hook blocks this at write time.\n' > "$FIXTURE/clean.md"

--- a/q-system/.q-system/scripts/test/test-prompt-only-enforcement-guard-stderr.sh
+++ b/q-system/.q-system/scripts/test/test-prompt-only-enforcement-guard-stderr.sh
@@ -1,0 +1,35 @@
+#!/usr/bin/env bash
+# Scar (2026-07-02, sp-cd530cc7): on block, the guard exited 2 but printed its
+# message as JSON to STDOUT. Claude Code feeds only STDERR back to the model on
+# exit 2, so every block surfaced as "No stderr output" — a silent wall. The
+# exit-code contract (skill-hook-pairing.md): exit 2 = block, message on stderr.
+set -euo pipefail
+
+REPO_ROOT="$(cd "$(dirname "$0")/../../../.." && pwd)"
+GUARD="$REPO_ROOT/q-system/.q-system/scripts/prompt-only-enforcement-guard.py"
+FIXTURE="$(mktemp -d)"
+trap 'python3 -c "import shutil,sys; shutil.rmtree(sys.argv[1], ignore_errors=True)" "$FIXTURE"' EXIT
+
+# A prompt-only enforcement claim with no executable blocker named must block.
+printf 'This rule is enforced by the skill.\n' > "$FIXTURE/violation.md"
+
+set +e
+OUT="$(python3 "$GUARD" "$FIXTURE/violation.md" 2>/dev/null)"
+ERR="$(python3 "$GUARD" "$FIXTURE/violation.md" 2>&1 >/dev/null)"
+CODE=$?
+set -e
+
+[ "$CODE" -eq 2 ] || { echo "FAIL: violation exited $CODE, want 2"; exit 1; }
+case "$ERR" in
+  *"BLOCK: prompt-only enforcement"*) ;;
+  *) echo "FAIL: block message missing from STDERR (Claude sees 'No stderr output'): '$ERR'"; exit 1;;
+esac
+[ -z "$OUT" ] || { echo "FAIL: block message leaked to STDOUT: '$OUT'"; exit 1; }
+echo "ok: block message goes to stderr, stdout stays clean"
+
+# A clean file passes silently.
+printf 'The lint hook blocks this at write time.\n' > "$FIXTURE/clean.md"
+python3 "$GUARD" "$FIXTURE/clean.md" || { echo "FAIL: clean file blocked"; exit 1; }
+echo "ok: clean file passes"
+
+echo "PASS: prompt-only-enforcement-guard stderr contract"

--- a/q-system/.q-system/scripts/test/test-prompt-only-enforcement-guard-stderr.sh
+++ b/q-system/.q-system/scripts/test/test-prompt-only-enforcement-guard-stderr.sh
@@ -48,4 +48,61 @@ printf 'The lint hook blocks this at write time.\n' > "$FIXTURE/clean.md"
 python3 "$GUARD" "$FIXTURE/clean.md" || { echo "FAIL: clean file blocked"; exit 1; }
 echo "ok: clean file passes"
 
+# --- mention-vs-claim FP (sp-edf9395d, 2026-07-02) ---
+# Scar: the guard flagged 11 lines of the PRD documenting the guard itself,
+# including pure frontmatter (id:/title:/status:), because the deterministic
+# suppressors read the same +/-2-line window as the trigger regexes. A doc
+# that names its executable blocker a few lines from the claim-shaped
+# sentence was indistinguishable from a prompt-only claim.
+
+# YAML frontmatter metadata is a description, not an enforcement claim.
+# (Modeled on prd-prompt-only-guard-stderr-2026-07-02: "Prompt Only Guard"
+# in a title matches subject "prompt" + action "guard".)
+cat > "$FIXTURE/frontmatter.md" <<'EOF'
+---
+id: prd-prompt-only-guard-stderr-2026-07-02
+title: Prompt Only Guard Stderr
+status: archived
+---
+
+Body text with no claim-shaped sentences at all.
+EOF
+python3 "$GUARD" "$FIXTURE/frontmatter.md" \
+  || { echo "FAIL: frontmatter metadata flagged as an enforcement claim (sp-edf9395d)"; exit 1; }
+echo "ok: frontmatter metadata passes"
+
+# An executable blocker named within the suppressor window (4 lines from the
+# claim-shaped sentence, outside the +/-2 trigger window) is a MENTION.
+cat > "$FIXTURE/nearby-blocker.md" <<'EOF'
+The skill blocks low-quality drafts before they ship.
+Detail line one about what counts as low quality.
+Detail line two about the draft flow.
+Detail line three about ownership.
+Enforcement is voice-lint.py, wired as a PostToolUse hook.
+EOF
+python3 "$GUARD" "$FIXTURE/nearby-blocker.md" \
+  || { echo "FAIL: blocker named 4 lines away still flagged (sp-edf9395d)"; exit 1; }
+echo "ok: blocker named within 6 lines suppresses"
+
+# The suppressor window is wider, NOT document-wide: a blocker named 8 lines
+# away does not license a claim.
+cat > "$FIXTURE/distant-blocker.md" <<'EOF'
+This rule is enforced by the skill.
+filler line 1
+filler line 2
+filler line 3
+filler line 4
+filler line 5
+filler line 6
+filler line 7
+The voice-lint.py PostToolUse hook lives elsewhere in this doc.
+EOF
+set +e
+python3 "$GUARD" "$FIXTURE/distant-blocker.md" 2>/dev/null
+DISTANT_CODE=$?
+set -e
+[ "$DISTANT_CODE" -eq 2 ] \
+  || { echo "FAIL: blocker 8 lines away suppressed a real claim (exit $DISTANT_CODE, want 2)"; exit 1; }
+echo "ok: distant blocker does not suppress"
+
 echo "PASS: prompt-only-enforcement-guard stderr contract"

--- a/q-system/.q-system/scripts/test/test-token-guard-hook-behavior.sh
+++ b/q-system/.q-system/scripts/test/test-token-guard-hook-behavior.sh
@@ -93,4 +93,87 @@ assert cache.get("edit_targets", {}).get("/tmp/some-file.py") == 2, \
 EOF
 echo "ok: PostToolUse failed Edit keeps the spiral counter"
 
-echo "PASS: token-guard hook behavior (warn shape + PostToolUse edit reset)"
+# --- 4) A guard-BLOCKED attempt must not escalate into a false exact-retry ---
+# Scar 3 (2026-07-02, Pure_spectrum_Q/qep_agent): at the 50-call volume ceiling,
+# each blocked Edit still incremented repeat_map; the 3rd blocked retry was
+# reported as "attempted this exact call 3 times" for a call that executed
+# ZERO times (exact-retry outranks volume in check order). Blocked attempts
+# must be un-counted so the block reason stays the true one.
+python3 - "$CACHE" "$SESSION" <<'EOF'
+import json, sys, time
+cache = {
+    "actor_key": sys.argv[2],
+    "tool_calls_since_user": 50,
+    "agent_calls_since_user": 0,
+    "mcp_timestamps": [],
+    "repeat_map": {},
+    "consecutive_reads": 0,
+    "warnings_issued": 1,
+    "file_read_counts": {},
+    "greps_since_write": 0,
+    "edit_targets": {},
+    "agents_without_write": 0,
+    "last_write_time": time.time(),
+    "calls_since_write": 1,
+    "last_volume_reset": time.time(),
+}
+json.dump(cache, open(sys.argv[1], "w"))
+EOF
+
+CEILING_EDIT="{\"session_id\": \"$SESSION\", \"hook_event_name\": \"PreToolUse\", \"tool_name\": \"Edit\", \"tool_input\": {\"file_path\": \"/tmp/deadlock-probe.py\", \"old_string\": \"a\", \"new_string\": \"b\"}}"
+for attempt in 1 2 3; do
+  set +e
+  ERR="$(printf '%s' "$CEILING_EDIT" | CLAUDECODE=1 CLAUDE_PROJECT_DIR="$FIXTURE" python3 "$GUARD" 2>&1 >/dev/null)"
+  CODE=$?
+  set -e
+  [ "$CODE" -eq 2 ] || { echo "FAIL: ceiling attempt $attempt exited $CODE, want 2"; exit 1; }
+  case "$ERR" in
+    *"attempted this exact call"*)
+      echo "FAIL: attempt $attempt escalated to false exact-retry: $ERR"; exit 1;;
+    *"tool calls"*) ;;
+    *) echo "FAIL: attempt $attempt lost the volume message: $ERR"; exit 1;;
+  esac
+done
+python3 - "$CACHE" <<'EOF'
+import json, sys
+cache = json.load(open(sys.argv[1]))
+repeats = [v for v in cache.get("repeat_map", {}).values() if v > 0]
+assert not repeats, f"blocked attempts leaked into repeat_map: {cache.get('repeat_map')}"
+assert cache.get("edit_targets", {}).get("/tmp/deadlock-probe.py", 0) == 0, \
+    f"blocked attempts leaked into edit_targets: {cache.get('edit_targets')}"
+EOF
+echo "ok: guard-blocked attempts stay volume-blocked and are un-counted"
+
+# --- 5) The volume block must name the commit escape hatch ---
+# Same scar: git commit is exempt and resets the ceiling, but the old message
+# only said "Stop. Summarize." — so the model retried edits into the deadlock
+# instead of committing its 4 finished edits.
+case "$ERR" in
+  *commit*) echo "ok: volume block names the commit escape hatch";;
+  *) echo "FAIL: volume block message does not mention commit: $ERR"; exit 1;;
+esac
+
+# --- 6) Exact-retry still fires for identical calls that PASS the guard ---
+python3 - "$CACHE" "$SESSION" <<'EOF'
+import json, sys, time
+cache = json.load(open(sys.argv[1]))
+cache.update(tool_calls_since_user=1, repeat_map={}, edit_targets={},
+             warnings_issued=0, last_volume_reset=time.time())
+json.dump(cache, open(sys.argv[1], "w"))
+EOF
+REAL_RETRY="{\"session_id\": \"$SESSION\", \"hook_event_name\": \"PreToolUse\", \"tool_name\": \"Bash\", \"tool_input\": {\"command\": \"pytest tests/flaky\"}}"
+for attempt in 1 2; do
+  printf '%s' "$REAL_RETRY" | CLAUDECODE=1 CLAUDE_PROJECT_DIR="$FIXTURE" python3 "$GUARD" >/dev/null \
+    || { echo "FAIL: allowed attempt $attempt was blocked"; exit 1; }
+done
+set +e
+ERR="$(printf '%s' "$REAL_RETRY" | CLAUDECODE=1 CLAUDE_PROJECT_DIR="$FIXTURE" python3 "$GUARD" 2>&1 >/dev/null)"
+CODE=$?
+set -e
+[ "$CODE" -eq 2 ] || { echo "FAIL: 3rd executed identical call exited $CODE, want 2"; exit 1; }
+case "$ERR" in
+  *"attempted this exact call"*) echo "ok: exact-retry still fires for executed identical calls";;
+  *) echo "FAIL: 3rd executed identical call blocked with wrong reason: $ERR"; exit 1;;
+esac
+
+echo "PASS: token-guard hook behavior (warn shape + PostToolUse edit reset + blocked-attempt un-count)"

--- a/q-system/.q-system/token-guard.py
+++ b/q-system/.q-system/token-guard.py
@@ -232,11 +232,11 @@ def check_volume(cache):
     """Block at ceiling, warn at warning threshold."""
     calls = cache.get("tool_calls_since_user", 0)
     if calls >= VOLUME_CEILING:
-        return ("block", f"{VOLUME_CEILING} tool calls without user input. Stop. Summarize what you've accomplished and what's remaining.")
+        return ("block", f"{VOLUME_CEILING} tool calls without user input or a commit. Commit finished work now (git commit is exempt from this ceiling and resets it), or stop and summarize what you've accomplished and what's remaining.")
     if calls >= VOLUME_WARNING and cache.get("warnings_issued", 0) == 0:
         remaining = VOLUME_CEILING - calls
         cache["warnings_issued"] = 1
-        return ("warn", f"You've made {calls} tool calls since the last user message. You have {remaining} remaining before hard stop. Focus on producing output.")
+        return ("warn", f"You've made {calls} tool calls since the last user message. You have {remaining} remaining before hard stop. Committing finished work resets the counter; otherwise focus on producing output.")
     return None
 
 
@@ -329,6 +329,34 @@ def block(message):
     """Exit with code 2 to block the tool call."""
     print(message, file=sys.stderr)
     sys.exit(2)
+
+
+def uncount_blocked_attempt(cache, tool_name, tool_input):
+    """A guard-BLOCKED call never executed, so it must not count toward the
+    escalation counters. Scar (2026-07-02, Pure_spectrum_Q/qep_agent): at the
+    volume ceiling each blocked Edit still incremented repeat_map; the 3rd
+    blocked retry was reported as 'attempted this exact call 3 times' for a
+    call that ran ZERO times (exact-retry outranks volume), hijacking the true
+    block reason. Only repeat_map and edit_targets are undone — the volume
+    counters stay, since a blocked attempt still spent budget and the volume
+    message stays truthful either way."""
+    input_hash = hashlib.md5(
+        (tool_name + json.dumps(tool_input, sort_keys=True)).encode()
+    ).hexdigest()[:12]
+    key = f"{tool_name}:{input_hash}"
+    repeat_map = cache.get("repeat_map", {})
+    if repeat_map.get(key, 0) > 1:
+        repeat_map[key] -= 1
+    else:
+        repeat_map.pop(key, None)
+    if tool_name == "Edit":
+        targets = cache.get("edit_targets", {})
+        file_path = tool_input.get("file_path", "")
+        if targets.get(file_path, 0) > 1:
+            targets[file_path] -= 1
+        else:
+            targets.pop(file_path, None)
+    return cache
 
 
 def warn(message):
@@ -510,12 +538,14 @@ def main():
     # 1. Sensitive file blocking (highest priority)
     msg = check_sensitive_file(tool_name, tool_input)
     if msg:
+        cache = uncount_blocked_attempt(cache, tool_name, tool_input)
         save_cache(actor, cache)
         block(msg)
 
     # 2. Exact retry detection
     msg = check_exact_retry(tool_name, tool_input, cache)
     if msg:
+        cache = uncount_blocked_attempt(cache, tool_name, tool_input)
         save_cache(actor, cache)
         block(msg)
 
@@ -527,21 +557,24 @@ def main():
         result = check_volume(cache)
         if result:
             level, msg = result
-            save_cache(actor, cache)
             if level == "block":
+                cache = uncount_blocked_attempt(cache, tool_name, tool_input)
+                save_cache(actor, cache)
                 block(msg)
-            else:
-                warn(msg)
+            save_cache(actor, cache)
+            warn(msg)
 
     # 4. Subagent ceiling
     msg = check_agent_ceiling(tool_name, cache)
     if msg:
+        cache = uncount_blocked_attempt(cache, tool_name, tool_input)
         save_cache(actor, cache)
         block(msg)
 
     # 5. MCP rate limit
     msg = check_mcp_rate(tool_name, cache)
     if msg:
+        cache = uncount_blocked_attempt(cache, tool_name, tool_input)
         save_cache(actor, cache)
         block(msg)
 
@@ -566,6 +599,7 @@ def main():
     # 9. Edit spiral block
     msg = check_edit_spiral(tool_name, tool_input, cache)
     if msg:
+        cache = uncount_blocked_attempt(cache, tool_name, tool_input)
         save_cache(actor, cache)
         block(msg)
 

--- a/q-system/output/plans/prompt-only-guard-mention-vs-claim-fp-2026-07-02.md
+++ b/q-system/output/plans/prompt-only-guard-mention-vs-claim-fp-2026-07-02.md
@@ -1,0 +1,48 @@
+<!-- prompt-only-enforcement-skip: this plan documents the guard's own
+     mention-vs-claim FP; the guard blocked this very file on first write
+     (live repro). The enforcement described here is executable:
+     test-prompt-only-enforcement-guard-stderr.sh -->
+
+# prompt-only-enforcement-guard: mention-vs-claim false positive (sp-edf9395d)
+
+**What/why:** Verified live 2026-07-02: the guard flagged 11 lines of PRD
+prd-prompt-only-guard-stderr-2026-07-02, including pure frontmatter
+(`id:`/`title:`/`status:`), even though the doc names its executable blocker
+(a hook plus a regression test) throughout. Root cause: the trigger regexes
+and the suppressors both read the same +/-2-line window, so a blocker named
+3+ lines from the trigger line is invisible to the suppressor. Frontmatter
+metadata also matches the subject+action regexes ("Prompt Only Guard" =
+subject "prompt" + action "guard") despite being a description, not a claim.
+While writing this plan the guard blocked THIS file on the same FP - a live
+second reproduction.
+
+**Approach (the two mitigations named in the spillover entry, both minimal):**
+1. Exempt leading YAML frontmatter lines (block delimited by `---` starting
+   at line 0). Metadata is not an enforcement claim.
+2. Split the windows: triggers and negation keep the +/-2 window; the
+   deterministic-blocker suppressors (guard filename + DETERMINISTIC_RE)
+   read a wider +/-6 window. Negation stays narrow on purpose - widening it
+   would let a "must not" six lines away mask a real claim.
+No changes to the regexes, target extensions, skip marker, or exit contract.
+
+**Files to touch**
+- `q-system/.q-system/scripts/prompt-only-enforcement-guard.py` - frontmatter
+  skip + dual-window `_is_violation`
+- `q-system/.q-system/scripts/test/test-prompt-only-enforcement-guard-stderr.sh`
+  - new sections pinning: frontmatter-only FP passes; blocker named 4 lines
+  away suppresses; blocker 8+ lines away still blocks; bare claim still blocks
+
+**Acceptance criteria**
+- [ ] New test sections shown FAILING against the unfixed script
+- [ ] Frontmatter-metadata fixture (modeled on the archived PRD) exits 0
+- [ ] Claim with blocker named within 6 lines exits 0
+- [ ] Claim with blocker named 8+ lines away still exits 2 (window is wider,
+      not document-wide)
+- [ ] Original violation fixture still exits 2; stderr contract sections
+      still pass
+- [ ] Resolve path: sp-edf9395d stays open until this ships through the
+      gated issue flow; this branch is the fix + reproducer
+
+**Patterns to follow:** black-box fixture tests in the existing stderr test
+(mktemp fixture dir, exit-code asserts); negative self-test before fix
+(fable-discipline); scar-anchored why-comments citing sp-edf9395d.

--- a/q-system/output/plans/token-guard-false-retry-escalation-2026-07-02.md
+++ b/q-system/output/plans/token-guard-false-retry-escalation-2026-07-02.md
@@ -1,0 +1,40 @@
+# Token-guard: blocked attempts falsely escalate to "attempted 3 times"
+
+**What/why:** Verified from Pure_spectrum_Q transcript (cd6f068f, 2026-07-02):
+at the 50-call volume ceiling, each guard-BLOCKED Edit still increments
+`repeat_map` (and `edit_targets`). The exact-retry check outranks the volume
+check, so the 3rd blocked retry reports "You've attempted this exact call 3
+times" for a call that executed zero times. Separately, the volume block/warn
+messages never mention that `git commit` is exempt and resets the counter, so
+the model retries into the deadlock instead of committing its way out.
+
+**Approach (founder-approved option 1):** un-count a guard-blocked attempt
+(decrement `repeat_map` + `edit_targets` before save on every block path in
+`token-guard.py` — executable code, pinned by a new section in
+`test-token-guard-hook-behavior.sh`); reword the volume block + warning to name
+the commit escape hatch. No threshold changes.
+
+**Files to touch**
+- `q-system/.q-system/token-guard.py` — uncount helper + block paths + messages
+- `q-system/.q-system/scripts/test/test-token-guard-hook-behavior.sh` — new
+  sections: ceiling-blocked identical Edits never produce the retry message and
+  leave `repeat_map`/`edit_targets` clean; executed identical calls still trip
+  exact-retry.
+
+**Acceptance criteria**
+- [x] New test section shown FAILING against the unfixed script ("FAIL:
+      attempt 3 escalated to false exact-retry")
+- [x] 3 identical Edits at the ceiling: every block says the volume message
+      (with commit hint), never "attempted this exact call"; `repeat_map` for
+      that key and `edit_targets` for that file end at 0/absent
+- [x] Exact-retry still fires for identical calls that pass the guard
+- [x] All existing token-guard tests still pass (behavior, wiring, runtime)
+- [x] `kipi update` propagates the script fleet-wide (commit 5f4d547; re-run
+      post-commit — the first run synced pre-commit HEAD). Pure_spectrum_Q is
+      standalone (skeleton-skipped): fixed by direct copy of token-guard.py +
+      behavior test, test PASS in place.
+
+**Patterns to follow:** black-box stdin-event tests in
+`test-token-guard-hook-behavior.sh` (seed cache, run guard, assert cache +
+stderr); negative self-test before fix (fable-discipline); scar-anchored
+why-comment citing the 2026-07-02 qep_agent incident.


### PR DESCRIPTION
## What

The guard flagged 11 lines of its own PRD — including pure frontmatter (`id:`/`title:`/`status:`) — for merely *mentioning* enforcement, even though the doc names its executable blocker throughout. Spillover `sp-edf9395d`.

Root cause: the deterministic-blocker suppressors read the same ±2-line window as the trigger regexes, so a hook/test named 3+ lines from a claim-shaped sentence was invisible to the suppressor. Frontmatter metadata (`title: Prompt Only Guard Stderr`) also matches subject+action patterns despite being a description, not a claim.

## Fix (the two mitigations named in the spillover entry, both minimal)

1. **Leading YAML frontmatter is exempt** — metadata describes the doc, it does not claim enforcement.
2. **Dual windows**: triggers + negation keep ±2; `GUARD_FILENAME` + `DETERMINISTIC_RE` suppressors read ±6. Negation stays narrow on purpose — a distant "must not" cannot mask a real claim.

No changes to the regexes, target extensions, skip marker, or exit-code contract.

## Verification

- New test sections in `test-prompt-only-enforcement-guard-stderr.sh` shown **red first** against the unfixed script (frontmatter fixture reproduced all 5 metadata flags).
- Wider-not-document-wide pinned: a blocker named 8 lines away still blocks.
- Both real FP documents verified passing with their skip markers stripped: the archived PRD `prd-prompt-only-guard-stderr-2026-07-02` and today's plan file (which the guard blocked live on first write — a second reproduction).
- All 21 scripts in `q-system/.q-system/scripts/test/` pass.

## Notes

- Branch includes 4 commits already on local main (token-guard + stderr fixes); the diff collapses to this one commit once main is pushed.
- `sp-edf9395d` stays open in the ledger until this ships through the gated issue flow; this branch is the fix + reproducer.
- Fleet propagation: `kipi update` after merge ships the script to instances.

🤖 Generated with [Claude Code](https://claude.com/claude-code)