### PR TITLE
fix: auto-capture session_id disconnect (CLAUDE_CODE_SESSION_ID)

### DIFF
--- a/q-system/.q-system/scripts/correction_outcome.py
+++ b/q-system/.q-system/scripts/correction_outcome.py
@@ -71,10 +71,14 @@ def record_correction(memory_id: str, *, session_id: str,
 
 
 if __name__ == "__main__":
-    # CLI for the skill / manual use: correction_outcome.py <memory_id> <session_id>
-    if len(sys.argv) >= 3:
-        result = record_correction(sys.argv[1], session_id=sys.argv[2])
+    # CLI for the skill / manual use: correction_outcome.py <memory_id> [<session_id>]
+    # session_id is optional: when omitted it resolves the same id the producer and
+    # the Stop-hook consumer use (sr.resolve_session_id), so the skill does not have
+    # to know the session UUID.
+    if len(sys.argv) >= 2:
+        sid = sys.argv[2] if len(sys.argv) >= 3 else sr.resolve_session_id()
+        result = record_correction(sys.argv[1], session_id=sid)
         print("recorded" if result else "no-op (memory not surfaced this session)")
     else:
-        print("usage: correction_outcome.py <memory_id> <session_id>", file=sys.stderr)
+        print("usage: correction_outcome.py <memory_id> [<session_id>]", file=sys.stderr)
         raise SystemExit(2)

--- a/q-system/.q-system/scripts/granola-voice-harvest.py
+++ b/q-system/.q-system/scripts/granola-voice-harvest.py
@@ -1,0 +1,104 @@
+#!/usr/bin/env python3
+"""granola-voice-harvest.py — Stage 1 deterministic harvest for founder-voice enrichment.
+
+Pairs with plan: q-system/output/plans/voice-from-granola-2026-07-04.md
+
+Reads Granola meeting transcripts, isolates ONLY Assaf's utterances (the literal
+`Me:` speaker marker that Granola's solo-recording format uses), and emits a clean
+corpus + a per-meeting talk-volume ranking for curating high-talk meetings.
+
+Determinism: speaker isolation is a regex split on the literal `Me:` / `Them:`
+markers. No LLM judgment about who spoke. Transcripts that instead use
+un-attributable `Speaker A/B/C` diarization (panels, multi-party) are SKIPPED and
+logged — there is no deterministic way to know which speaker is Assaf, so they do
+not enter the voice corpus.
+
+Cleaning of disfluency (like/you know/false starts) is deliberately NOT done here.
+That is Stage 2's job (LLM pattern synthesis + durable-vs-spoken classification).
+Stage 1 stays a pure, auditable extraction.
+
+Input:  a directory of transcript files (.txt = raw transcript string, filename is
+        the title; or .json = Granola MCP result, either the raw dict with a
+        `transcript` key or the [{"type":"text","text":"<json>"}] MCP wrapper).
+Output: <out_dir>/me-corpus.txt      Assaf-only utterances, one section per meeting
+        <out_dir>/talk-ranking.json  {ranking:[...], skipped:[...]}
+
+Reproducer (defines done): grep -c 'Them:' me-corpus.txt == 0
+Usage:  python3 granola-voice-harvest.py <in_dir> <out_dir>
+"""
+import json
+import re
+import sys
+import os
+import glob
+
+
+def load_transcript(path):
+    """Return (title, transcript_text) for a .txt or .json transcript file."""
+    raw = open(path, encoding="utf-8").read()
+    if path.endswith(".txt"):
+        title = os.path.splitext(os.path.basename(path))[0]
+        return title, raw
+    data = json.loads(raw)
+    # MCP wrapper: [{"type":"text","text":"<json string>"}]
+    if isinstance(data, list) and data and isinstance(data[0], dict) and "text" in data[0]:
+        data = json.loads(data[0]["text"])
+    return data.get("title", "(untitled)"), data.get("transcript", "")
+
+
+def is_me_them_format(t):
+    """True only when the transcript uses the attributable Me:/Them: convention."""
+    return bool(re.search(r"\bMe:\s", t)) and bool(re.search(r"\bThem:\s", t))
+
+
+def extract_me(t):
+    """Return the list of Assaf ('Me:') utterance chunks, in order."""
+    parts = re.split(r"\b(Me|Them):\s", t)  # [pre, spk, chunk, spk, chunk, ...]
+    out = []
+    i = 1
+    while i < len(parts) - 1:
+        spk, chunk = parts[i], parts[i + 1]
+        if spk == "Me":
+            seg = chunk.strip()
+            if seg:
+                out.append(seg)
+        i += 2
+    return out
+
+
+def main():
+    if len(sys.argv) != 3:
+        sys.exit("usage: granola-voice-harvest.py <in_dir> <out_dir>")
+    in_dir, out_dir = sys.argv[1], sys.argv[2]
+    os.makedirs(out_dir, exist_ok=True)
+
+    corpus, ranking, skipped = [], [], []
+    files = sorted(glob.glob(os.path.join(in_dir, "*.txt")) +
+                   glob.glob(os.path.join(in_dir, "*.json")))
+    for path in files:
+        title, t = load_transcript(path)
+        if not is_me_them_format(t):
+            skipped.append({"file": os.path.basename(path), "title": title,
+                            "reason": "no Me:/Them: markers (un-attributable diarization)"})
+            continue
+        segs = extract_me(t)
+        words = sum(len(s.split()) for s in segs)
+        ranking.append({"title": title, "utterances": len(segs), "words": words})
+        corpus.append(f"\n\n===== {title} ({len(segs)} utterances, {words} words) =====\n")
+        corpus.extend(s + "\n" for s in segs)
+
+    ranking.sort(key=lambda r: -r["words"])
+    open(os.path.join(out_dir, "me-corpus.txt"), "w", encoding="utf-8").write("".join(corpus))
+    json.dump({"ranking": ranking, "skipped": skipped},
+              open(os.path.join(out_dir, "talk-ranking.json"), "w"), indent=2)
+    print(json.dumps({
+        "meetings_used": len(ranking),
+        "skipped": len(skipped),
+        "total_words": sum(r["words"] for r in ranking),
+        "ranking": ranking,
+        "skipped_detail": skipped,
+    }, indent=2))
+
+
+if __name__ == "__main__":
+    main()

--- a/q-system/.q-system/scripts/session_recall.py
+++ b/q-system/.q-system/scripts/session_recall.py
@@ -40,10 +40,17 @@ DEFAULT_PATH = QROOT / "memory" / ".session-recall.json"
 
 
 def resolve_session_id() -> str:
-    """The current session's id, from the env the harness sets. Falls back to a
-    stable per-process token so a missing id never crashes the producer; a
-    fallback session simply never matches a real Stop-hook read, which is safe."""
-    for var in ("CLAUDE_SESSION_ID", "KIPI_SESSION_ID"):
+    """The current session's id, from the env Claude Code sets for hooks. MUST
+    match the `session_id` the Stop-hook consumer reads from its stdin payload,
+    or the producer keys recall under one id and the consumer reads another and
+    captures nothing.
+
+    Claude Code exports the session UUID as `CLAUDE_CODE_SESSION_ID` (verified:
+    it equals the Stop payload session_id and the transcript filename). The old
+    `CLAUDE_SESSION_ID` name does NOT exist in the hook env, so it is kept only as
+    a defensive alias. Falls back to a per-process token so a missing id never
+    crashes the producer (that fallback simply never matches a real read)."""
+    for var in ("CLAUDE_CODE_SESSION_ID", "CLAUDE_SESSION_ID", "KIPI_SESSION_ID"):
         val = os.environ.get(var)
         if val and val.strip():
             return val.strip()

--- a/q-system/.q-system/scripts/test_session_recall.py
+++ b/q-system/.q-system/scripts/test_session_recall.py
@@ -131,6 +131,28 @@ def test_read_and_clear_missing_is_empty() -> None:
                sr.read_and_clear("nope", path=p) == [], "expected []")
 
 
+def test_resolve_reads_claude_code_session_id() -> None:
+    # Regression: the producer must resolve the SAME id the Stop-hook consumer
+    # reads from its payload. Claude Code exports it as CLAUDE_CODE_SESSION_ID.
+    # The old code checked only CLAUDE_SESSION_ID (which does not exist), so the
+    # producer keyed recall under a pid fallback and capture read nothing.
+    saved = {k: os.environ.get(k) for k in
+             ("CLAUDE_CODE_SESSION_ID", "CLAUDE_SESSION_ID", "KIPI_SESSION_ID")}
+    try:
+        for k in saved:
+            os.environ.pop(k, None)
+        os.environ["CLAUDE_CODE_SESSION_ID"] = "real-uuid-123"
+        got = sr.resolve_session_id()
+        _check("resolve_reads_claude_code_session_id", got == "real-uuid-123",
+               f"got={got} (must equal the Stop payload session_id)")
+    finally:
+        for k, v in saved.items():
+            if v is None:
+                os.environ.pop(k, None)
+            else:
+                os.environ[k] = v
+
+
 def test_surface_producer_emits() -> None:
     # The surface script, given surfaced scores, records their ids into the
     # session-recall file via the single-writer helper (producer wiring).
@@ -157,6 +179,7 @@ def main() -> int:
     test_read_missing_is_empty()
     test_read_and_clear_is_atomic_snapshot()
     test_read_and_clear_missing_is_empty()
+    test_resolve_reads_claude_code_session_id()
     test_surface_producer_emits()
     if _failures:
         print(f"\n{len(_failures)} FAILURES: {_failures}")


### PR DESCRIPTION
## The bug

Post-merge wiring audit found the referee was **live but inert** on 4_points: it recorded zero outcomes.

Root cause: `resolve_session_id()` (the SessionStart producer's key for `.session-recall.json`) checked `CLAUDE_SESSION_ID`, which Claude Code does **not** set. The real hook env var is `CLAUDE_CODE_SESSION_ID`. So the producer keyed recall under a `no-session-<pid>` fallback while the Stop-hook consumer read by the real payload `session_id` → every `read_and_clear` returned empty → nothing captured.

Why tests missed it: every existing test passed an explicit `session_id`, so the env-resolution path was never exercised.

## Fix

- `resolve_session_id()` reads `CLAUDE_CODE_SESSION_ID` first (old names kept as defensive aliases).
- Regression test asserts it — would have caught the bug.
- `correction_outcome.py` CLI: `session_id` now optional, defaults to `resolve_session_id()`.

## Proof

`producer == consumer` under a real `CLAUDE_CODE_SESSION_ID`: **MATCH True**. Full suite green (session_recall 12, capture 11, correction, wiring, e2e), validate-separation 23/0.

🤖 Generated with [Claude Code](https://claude.com/claude-code)