### PR TITLE
fix(worker): take the claim inside the worktree so the board stops serializing (ASK-188)

### DIFF
--- a/q-system/.q-system/capability-manifest.json
+++ b/q-system/.q-system/capability-manifest.json
@@ -94,6 +94,10 @@
       "runner": "bash"
     },
     {
+      "path": "q-system/.q-system/scripts/test/test-linear-worker-parallel.sh",
+      "runner": "bash"
+    },
+    {
       "path": "q-system/.q-system/scripts/test/test-linear-queue.sh",
       "runner": "bash"
     },

--- a/q-system/.q-system/scripts/linear-worker.sh
+++ b/q-system/.q-system/scripts/linear-worker.sh
@@ -40,11 +40,18 @@
 set -uo pipefail
 
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
-SKEL="$(cd "$SCRIPT_DIR/../../.." && pwd)"
+# KIPI_SKEL / KIPI_STATE_DIR are TEST-ISOLATION SEAMS, same discipline as
+# KIPI_LINEAR_CLAIMS / KIPI_LINEAR_LEDGER / KIPI_LINEAR_QUEUE. Without them a
+# suite that drives this script end-to-end would create real worktrees and real
+# sana/* branches in the founder's checkout and stomp the live attempts ledger --
+# so the ordering this script's whole correctness rests on could only ever be
+# asserted by grepping its source. Unset in production; the defaults are the
+# real skeleton and the real state dir.
+SKEL="${KIPI_SKEL:-$(cd "$SCRIPT_DIR/../../.." && pwd)}"
 CLAIM="$SCRIPT_DIR/linear-claim.py"
 SYNC="$SCRIPT_DIR/linear-sync.py"
 NOTIFY="$SCRIPT_DIR/slack-notify.sh"
-STATE_DIR="$HOME/.config/kipi"
+STATE_DIR="${KIPI_STATE_DIR:-$HOME/.config/kipi}"
 ATTEMPTS="$STATE_DIR/linear-worker-attempts.json"
 LOG="$STATE_DIR/linear-worker.log"
 REVIEWS_DIR="$STATE_DIR/pr-reviews"
@@ -211,28 +218,52 @@ while IFS= read -r ISSUE; do
     fi
   fi
 
-  # 1. CLAIM. exit 3 = another session holds this tree; that is a skip, not an error.
-  if ! python3 "$CLAIM" claim "$ISSUE" --agent "$AGENT" --session "$SESSION" >/dev/null 2>&1; then
-    rc=$?
-    if [ "$rc" = "3" ]; then say "skip $ISSUE: working tree is claimed by another session"; continue; fi
-    say "INFRA: claim failed rc=$rc on $ISSUE (not counted against the issue)"; continue
-  fi
-
-  # WORKTREE, not the main checkout. Scar from this worker's own first live run
-  # (ASK-150, 2026-07-26): it branched in place and left the founder's main
-  # checkout sitting on sana/ask-150. The claim lock stopped a concurrent AGENT
-  # from colliding, but it cannot stop the worker yanking the FOUNDER's working
-  # tree out from under them mid-edit -- which is commit 53f2eeb, the exact scar
-  # this whole line of work started from. A worktree makes the collision
-  # impossible by construction instead of merely detected.
+  # 1. WORKTREE FIRST, and only then the claim -- in that order, because the
+  # claim has to be taken from INSIDE the tree it protects.
+  #
+  # Scar from this worker's own first live run (ASK-150, 2026-07-26): it branched
+  # in place and left the founder's main checkout sitting on sana/ask-150. The
+  # claim lock stopped a concurrent AGENT from colliding, but it cannot stop the
+  # worker yanking the FOUNDER's working tree out from under them mid-edit --
+  # commit 53f2eeb, the scar this whole line of work started from. A worktree
+  # makes that collision impossible by construction instead of merely detected.
   TREE="$STATE_DIR/worktrees/$(echo "$ISSUE" | tr 'A-Z' 'a-z')"
   if [ ! -d "$TREE" ]; then
     mkdir -p "$(dirname "$TREE")"
     if ! git -C "$SKEL" worktree add -q -B "$BRANCH" "$TREE" origin/main 2>>"$LOG"; then
-      say "INFRA: could not create worktree for $ISSUE (not counted against the issue)"
-      python3 "$CLAIM" release "$ISSUE" --agent "$AGENT" --session "$SESSION" >/dev/null 2>&1 || true
-      continue
+      # A concurrent worker on the SAME issue can create this tree between the
+      # test above and this line. That is the collision the claim below exists to
+      # adjudicate, not an infra failure -- so fall through and let it, rather
+      # than reporting a phantom outage and burning nothing.
+      if [ ! -d "$TREE" ]; then
+        say "INFRA: could not create worktree for $ISSUE (not counted against the issue)"
+        continue
+      fi
     fi
+  fi
+
+  # 2. CLAIM, from INSIDE $TREE. exit 3 = another session holds THIS tree; that
+  # is a skip, not an error.
+  #
+  # ASK-188: the claim used to run here at step 1, BEFORE the worktree existed,
+  # so its cwd was the skeleton. `linear-claim.py::claims_path()` resolves the
+  # lock from `git rev-parse --show-toplevel` OF THE CALLER'S CWD, which meant
+  # every issue on the board contended for one file at the skeleton root -- one
+  # lock, whole repo, total serialization. Measured 2026-07-27: 50+ ready issues
+  # behind a queue that could only ever run one. Inside a worktree that same
+  # command returns THAT worktree's path, so the lock lands in the tree it
+  # actually protects, which is what the function's own docstring says it is for.
+  # Two workers on the SAME issue still share one worktree and still collide, so
+  # the mutex is unweakened -- that is case 4 of test-linear-worker-parallel.sh.
+  #
+  # `rc=$?` cannot live under `if ! cmd`: bash sets $? from the NEGATION there, so
+  # it read 0 on every failure and the collision branch was unreachable -- a real
+  # collision reported as "INFRA: claim failed rc=0". Capture the status directly.
+  ( cd "$TREE" && python3 "$CLAIM" claim "$ISSUE" --agent "$AGENT" --session "$SESSION" ) >/dev/null 2>&1
+  rc=$?
+  if [ "$rc" != "0" ]; then
+    if [ "$rc" = "3" ]; then say "skip $ISSUE: working tree is claimed by another session"; continue; fi
+    say "INFRA: claim failed rc=$rc on $ISSUE (not counted against the issue)"; continue
   fi
   say "start $ISSUE on $BRANCH in $TREE (attempt $((N+1))/$MAX_ATTEMPTS)"
   python3 "$SYNC" progress "$ISSUE" \
@@ -403,7 +434,12 @@ json.dump(d,open('$ATTEMPTS','w'),indent=2); print(e['rounds'])" 2>/dev/null || 
   fi
 
   # 6. RELEASE at PR-open, not at close, so a reviewer can pick the tree up.
-  python3 "$CLAIM" release "$ISSUE" --agent "$AGENT" --session "$SESSION" >/dev/null 2>&1 || true
+  # From INSIDE $TREE, matching the claim above. A claim taken in one cwd and
+  # released in another does not error: release reads a DIFFERENT lock file,
+  # finds nothing, prints "not held" and exits 0 while the real lock sits in the
+  # worktree forever, wedging that issue permanently. Asserted by case 3 of
+  # test-linear-worker-parallel.sh, which reads the lock files back after the run.
+  ( cd "$TREE" && python3 "$CLAIM" release "$ISSUE" --agent "$AGENT" --session "$SESSION" ) >/dev/null 2>&1 || true
   DONE=$((DONE+1))
 done
 

--- a/q-system/.q-system/scripts/test/test-linear-worker-parallel.sh
+++ b/q-system/.q-system/scripts/test/test-linear-worker-parallel.sh
@@ -1,0 +1,189 @@
+#!/usr/bin/env bash
+# Reproducer + acceptance criterion for the claim-lock serializing the whole
+# board (ASK-188).
+#
+# THE DEFECT: linear-worker.sh took its claim at step 1, BEFORE it created or
+# entered $TREE. `linear-claim.py::claims_path()` resolves the lock from
+# `git rev-parse --show-toplevel` OF THE CALLER'S CWD, so every issue contended
+# for one file at the skeleton root. Board throughput was capped at one issue at
+# a time -- measured 2026-07-27, ASK-150 25 min, ASK-183 67 min, with 50+ ready
+# issues behind them.
+#
+# WHY THIS DRIVES THE REAL SCRIPT INSTEAD OF ASSERTING ON ITS SOURCE
+# ------------------------------------------------------------------
+# The bug IS the cwd the claim runs in. A grep for line ordering cannot see a
+# cwd, and a re-implementation of the sequence in this file would test a copy
+# that agrees with whatever I believed while writing it. So this boots the real
+# linear-worker.sh twice, concurrently, and asserts on where the lock files
+# actually landed and which runs actually reached the work phase.
+#
+# Isolation (nothing here touches the founder's checkout or the live state):
+#   KIPI_SKEL       -> a throwaway clone; worktrees and sana/* branches land there
+#   KIPI_STATE_DIR  -> a temp dir; worktrees, log and attempts ledger land there
+#   KIPI_LINEAR_CLAIMS is UNSET on purpose -- the per-tree default path is the
+#   exact thing under test, so pinning it to one file would hide the defect.
+#   PATH stubs for python3/gh/claude keep Linear, GitHub and the model out of it;
+#   `git` stays REAL, because real linked worktrees are the fix's mechanism.
+set -uo pipefail
+
+ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/../../../.." && pwd)"
+WORKER="$ROOT/q-system/.q-system/scripts/linear-worker.sh"
+
+PASS=0
+fail() { echo "FAIL: $1" >&2; exit 1; }
+ok()   { PASS=$((PASS + 1)); echo "  ok: $1"; }
+
+[ -f "$WORKER" ] || fail "linear-worker.sh does not exist at $WORKER"
+REAL_PY="$(command -v python3)" || fail "python3 not on PATH"
+REAL_GIT="$(command -v git)"    || fail "git not on PATH"
+
+WORK="$(mktemp -d)"
+trap 'rm -rf "$WORK"' EXIT
+
+# Never let the surrounding agent's session id or a claims override leak in.
+unset KIPI_LINEAR_CLAIMS KIPI_SESSION_ID CLAUDE_SESSION_ID 2>/dev/null || true
+
+# --- a throwaway skeleton with a real origin/main ---------------------------
+git init -q --bare "$WORK/origin"
+git init -q "$WORK/skel"
+git -C "$WORK/skel" -c user.email=t@t.t -c user.name=t commit -q --allow-empty -m init
+git -C "$WORK/skel" branch -M main
+git -C "$WORK/skel" remote add origin "$WORK/origin"
+git -C "$WORK/skel" push -q -u origin main
+
+# --- stubs ------------------------------------------------------------------
+# python3: the ONLY calls that must not run for real are the Linear ones.
+#   `python3 - ASK-xxx`   the issue picker heredoc -> a fixed ready list
+#   `python3 .../linear-sync.py`  progress notes    -> no-op
+# Everything else -- crucially linear-claim.py, the subject of this test --
+# is the real interpreter running the real script.
+STUB="$WORK/bin"; mkdir -p "$STUB"
+cat > "$STUB/python3" <<EOF
+#!/usr/bin/env bash
+case "\${1:-}" in
+  -)  cat >/dev/null
+      printf '{"ready":[{"id":"%s","title":"t","project":"p"}],"total_open":1}\n' "\${2:-ASK-AAA}"
+      exit 0 ;;
+  *linear-sync.py) exit 0 ;;
+esac
+exec "$REAL_PY" "\$@"
+EOF
+
+# gh: no PR exists for these branches, and none may be created.
+cat > "$STUB/gh" <<'EOF'
+#!/usr/bin/env bash
+exit 0
+EOF
+
+# claude: THE WORK PHASE. Records the tree it was invoked in, which is the
+# signal this whole test reads: a run that never reaches here was serialized out.
+cat > "$STUB/claude" <<EOF
+#!/usr/bin/env bash
+echo "\$(pwd)" >> "$WORK/worked.txt"
+[ -n "\${STUB_HOLD:-}" ] && { touch "\$STUB_HOLD.started"; while [ ! -e "\$STUB_HOLD.go" ]; do sleep 0.05; done; }
+exit 0
+EOF
+chmod +x "$STUB/python3" "$STUB/gh" "$STUB/claude"
+export PATH="$STUB:$PATH"
+
+[ "$(command -v git)" = "$REAL_GIT" ] || fail "git was shadowed by a stub; worktrees must be real"
+
+# run_worker <issue> <run-label> [hold-token]
+# cwd is the skeleton on purpose: that is where launchd runs this from, and it
+# is the cwd that made every issue share one lock.
+run_worker() {
+  local issue="$1" label="$2" hold="${3:-}"
+  ( cd "$WORK/skel" \
+    && KIPI_SKEL="$WORK/skel" KIPI_STATE_DIR="$WORK/state-$label" STUB_HOLD="$hold" \
+       bash "$WORKER" --apply --issue "$issue" --limit 1 ) \
+    >"$WORK/$label.out" 2>&1
+  echo "$?" > "$WORK/$label.rc"
+}
+
+worked_count() { grep -c . "$WORK/worked.txt" 2>/dev/null || echo 0; }
+
+# --- 1. TWO DIFFERENT ISSUES, CONCURRENTLY: both must reach the work phase ---
+# A is held inside its work phase while B runs start-to-finish, so this is the
+# real overlap, not two runs that merely happened not to collide.
+: > "$WORK/worked.txt"
+HOLD="$WORK/hold-a"
+run_worker ASK-AAA a "$HOLD" &
+A_PID=$!
+DEADLINE=$((SECONDS + 60))
+while [ ! -e "$HOLD.started" ]; do
+  [ "$SECONDS" -ge "$DEADLINE" ] && fail "worker A never reached its work phase; see $(cat "$WORK/a.out" 2>/dev/null)"
+  sleep 0.05
+done
+
+# A is inside its work phase RIGHT NOW, so this is the only window in which its
+# claim is observable -- the worker releases at the end of the run. Assert the
+# mechanism here: the lock is in A's own worktree and NOT at the skeleton root.
+HELD_IN_TREE="$([ -f "$WORK/state-a/worktrees/ask-aaa/.linear-claims.json" ] && echo yes || echo no)"
+HELD_AT_SKEL="$([ -f "$WORK/skel/.linear-claims.json" ] && echo yes || echo no)"
+
+run_worker ASK-BBB b
+touch "$HOLD.go"
+wait "$A_PID"
+
+grep -q "ask-aaa" "$WORK/worked.txt" || fail "worker A never worked: $(cat "$WORK/a.out")"
+if ! grep -q "ask-bbb" "$WORK/worked.txt"; then
+  fail "SERIALIZED: worker B on ASK-BBB never reached the work phase while A held
+      the lock on ASK-AAA. B said: $(grep -i 'skip\|INFRA' "$WORK/b.out" | head -2)"
+fi
+ok "two workers on DIFFERENT issues both reached the work phase concurrently"
+
+# --- 2. the lock landed in the issue's own worktree, not at the skeleton -----
+# The mechanism behind case 1, asserted directly. A lock at the skeleton root is
+# the defect itself: one file, every issue, total serialization.
+[ "$HELD_IN_TREE" = "yes" ] \
+  || fail "while ASK-AAA was being worked, no claim existed in its own worktree"
+ok "the claim was held in the issue's OWN worktree while it was being worked"
+
+[ "$HELD_AT_SKEL" = "no" ] \
+  || fail "a claim was written at the skeleton root; that single file is what serialized the board"
+ok "no claim was taken at the skeleton root"
+
+# --- 3. release must key on the SAME tree the claim was taken in ------------
+# A claim taken in one cwd and released in another does NOT error: release reads
+# a different file, finds nothing, prints "not held" and exits 0, while the real
+# lock sits in the worktree forever and wedges that issue permanently. So the
+# proof is the lock files being gone after the runs, not the release's exit code.
+for t in "$WORK/state-a/worktrees/ask-aaa" "$WORK/state-b/worktrees/ask-bbb" "$WORK/skel"; do
+  held="$(cat "$t/.linear-claims.json" 2>/dev/null || echo '')"
+  [ -z "$held" ] || fail "a claim was left behind in $t; the worker leaked a permanent lock: $held"
+done
+ok "both claims were released in the tree they were taken in (no leaked lock)"
+
+# --- 4. SAME issue, concurrently: still a collision, exit 3, not a grant -----
+# The mutex must not be weakened. Two workers on one issue share one worktree,
+# so they must still contend -- and the skip must SAY so, not report infra.
+: > "$WORK/worked.txt"
+HOLD2="$WORK/hold-c"
+run_worker ASK-CCC c "$HOLD2" &
+C_PID=$!
+DEADLINE=$((SECONDS + 60))
+while [ ! -e "$HOLD2.started" ]; do
+  [ "$SECONDS" -ge "$DEADLINE" ] && fail "worker C never reached its work phase"
+  sleep 0.05
+done
+
+# d shares c's state dir, so it lands on the SAME worktree for the same issue.
+( cd "$WORK/skel" \
+  && KIPI_SKEL="$WORK/skel" KIPI_STATE_DIR="$WORK/state-c" \
+     bash "$WORKER" --apply --issue ASK-CCC --limit 1 ) >"$WORK/d.out" 2>&1
+touch "$HOLD2.go"
+wait "$C_PID"
+
+[ "$(worked_count)" = "1" ] \
+  || fail "same-issue: $(worked_count) runs reached the work phase, want exactly 1 -- the mutex was weakened"
+ok "same issue, same tree: exactly one worker reached the work phase"
+
+grep -qi "claimed by another session" "$WORK/d.out" \
+  || fail "the refused run did not report a collision. It said: $(grep -i 'skip\|INFRA' "$WORK/d.out" | head -2)"
+ok "the refused run reports the collision (exit 3), not a generic infra failure"
+
+# --- 5. the script still parses -------------------------------------------
+bash -n "$WORKER" || fail "linear-worker.sh does not parse"
+ok "linear-worker.sh parses (bash -n)"
+
+echo "PASS: linear-worker parallel ($PASS checks)"


### PR DESCRIPTION
Closes the serialization cap on the autonomous board. Linear: [ASK-188](https://linear.app/ask-consulting/issue/ASK-188)

## The defect

`linear-worker.sh` took its claim at step 1, **before** it created or entered `$TREE`, so the claim ran with the skeleton as its cwd. `linear-claim.py::claims_path()` resolves the lock from `git rev-parse --show-toplevel` **of the caller's cwd**, so every issue on the board contended for one file at the skeleton root. One lock, whole repo, total serialization.

Measured 2026-07-27: ASK-150 converged in 25 min, ASK-183 in 67 min. With 50+ ready issues that is 20+ hours serial.

## The fix

Inside a linked worktree, `git rev-parse --show-toplevel` returns **that worktree's** path (verified empirically before the edit). Moving the claim to after the worktree exists, and running it from inside `$TREE`, gives each issue its own lock in the tree it actually protects.

Two workers on the SAME issue still share one worktree and still collide with exit 3. The mutex behind commit 53f2eeb is unweakened, and case 4 of the new suite pins that.

## Three things found while verifying the blast radius

The DoR named the release path and the mutex explicitly, so these are in scope rather than adjacent:

1. **Release ran in the wrong cwd too.** A claim taken in one cwd and released in another does not error. Release reads a different file, finds nothing, prints `not held` and exits 0, while the real lock sits in the worktree forever and wedges that issue permanently. Now released from inside `$TREE`, asserted by reading the lock files back after the run.

2. **`rc=$?` under `if ! cmd` reads the negation, not the command.** Bash sets `$?` from the `!`, so it was 0 on every failure and the collision branch was unreachable: a real collision reported as `INFRA: claim failed rc=0`. That is exactly what the reproducer printed on its first RED run. Status is now captured directly.

3. **Worktree-creation race reported a phantom outage.** Two workers on the same issue could both see `! -d $TREE`; the loser logged INFRA. It now falls through and lets the claim adjudicate, which is what the claim is for.

## How this is tested

`test-linear-worker-parallel.sh` boots the **real** `linear-worker.sh` twice, concurrently, and asserts on where the locks landed and which runs reached the work phase.

The bug is a cwd. A grep for line ordering cannot see a cwd, and a re-implementation of the sequence inside the test would only agree with whatever I believed while writing it. So `python3`/`gh`/`claude` are PATH stubs (Linear, GitHub and the model stay out of it) while `git` stays real, because real linked worktrees are the mechanism under test. Worker A is held inside its work phase while B runs start to finish, so the overlap is real rather than two runs that happened not to collide.

Isolation: `KIPI_SKEL` and `KIPI_STATE_DIR` are added as test seams, same discipline as the existing `KIPI_LINEAR_CLAIMS`. Without them the suite would create real worktrees and real `sana/*` branches in the founder's checkout. `KIPI_LINEAR_CLAIMS` is deliberately left UNSET here, because the per-tree default path is the thing under test.

### Observed RED, before the change

```
FAIL: SERIALIZED: worker B on ASK-BBB never reached the work phase while A held
      the lock on ASK-AAA. B said: INFRA: claim failed rc=0 on ASK-BBB
```

### Observed GREEN, after

```
  ok: two workers on DIFFERENT issues both reached the work phase concurrently
  ok: the claim was held in the issue's OWN worktree while it was being worked
  ok: no claim was taken at the skeleton root
  ok: both claims were released in the tree they were taken in (no leaked lock)
  ok: same issue, same tree: exactly one worker reached the work phase
  ok: the refused run reports the collision (exit 3), not a generic infra failure
  ok: linear-worker.sh parses (bash -n)
PASS: linear-worker parallel (7 checks)
```

### Negative self-test

A test that cannot fail is not a test. Three mutations applied by exact string replacement, each caught by its intended assertion:

| Mutation | Caught by |
|---|---|
| claim taken outside the worktree | `SERIALIZED: worker B ... never reached the work phase` |
| release taken outside the worktree | `a claim was left behind ... leaked a permanent lock` |
| old `if ! cmd; then rc=$?` shape | `the refused run did not report a collision` |

### Neighbouring suites, unchanged and green

| Suite | Result |
|---|---|
| `test-linear-claim.sh` | PASS (30 checks) |
| `test-severity-floor.sh` | PASS (24/24) |
| `test-converge.sh` | PASS (13/13) |
| `test-linear-worker-parallel.sh` | PASS (7 checks) |

`test-severity-floor.sh` line 147 asserts the severity gate fires BEFORE the claim. The claim moved later, so that ordering still holds.

## Not doing (DoR binding)

No launchd scheduling, no change to the four refusals, no change to the remote-collision half of the lock.

## Registered

`q-system/.q-system/capability-manifest.json` gains the new suite, so it is not an orphan.

Review runs next. Do not merge without it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
