### PR TITLE
fix(lessons-daily): a failed run must exit non-zero so it reaches Linear (ASK-182)

### DIFF
--- a/q-system/.q-system/capability-manifest.json
+++ b/q-system/.q-system/capability-manifest.json
@@ -86,6 +86,10 @@
       "runner": "bash"
     },
     {
+      "path": "q-system/.q-system/scripts/test/test-lessons-daily-exit.sh",
+      "runner": "bash"
+    },
+    {
       "path": "q-system/.q-system/scripts/test/test-linear-create.py",
       "runner": "python3"
     },

--- a/q-system/.q-system/scripts/lessons-daily.sh
+++ b/q-system/.q-system/scripts/lessons-daily.sh
@@ -13,10 +13,26 @@ LOG="$SKEL/q-system/output/lessons-daily.log"
 TS() { date '+%Y-%m-%dT%H:%M:%S%z'; }
 mkdir -p "$(dirname "$LOG")"
 
-command -v claude >/dev/null 2>&1 || { echo "$(TS) no claude CLI -> skip" >> "$LOG"; exit 0; }
+# The exit code IS this job's wire to Linear (ASK-182). fleet-health-daily.py's
+# `launchd-failing` detector keys on a non-zero LastExitStatus, so a run that
+# reports 0 after a bad night is invisible to the board no matter what it Slacked.
+# Observed 2026-07-27: the 06:00 run logged "propagate FAILED", Slacked it, and
+# `launchctl list` still said LastExitStatus = 0. Pinned by
+# test/test-lessons-daily-exit.sh.
+fail() { echo "$(TS) FAILURE: $*" >> "$LOG"; bash "$NOTIFY" "lessons-daily: $*" 2>/dev/null; exit 1; }
 
-SUMMARY="$(cd "$SKEL" && python3 "$DISTILL" 2>>"$LOG")"
+# The plist pins PATH to include ~/.local/bin, so a missing binary here is a
+# broken machine, not a normal night. Skipping silently would make this job dark
+# with a clean exit status -- the one state the four bars forbid.
+command -v claude >/dev/null 2>&1 || fail "no claude CLI on PATH -> nothing distilled"
+
+SUMMARY="$(cd "$SKEL" && python3 "$DISTILL" 2>>"$LOG")" || fail "lessons-distill.py exited non-zero"
 echo "$(TS) $SUMMARY" >> "$LOG"
+
+# A dead distiller emits no JSON, every count below parses as 0, and the run
+# reads as a quiet night. A zero result must prove it is empty, not broken.
+printf '%s' "$SUMMARY" | python3 -c "import json,sys; json.load(sys.stdin)" 2>/dev/null \
+  || fail "lessons-distill.py emitted no parseable JSON summary"
 
 field() { printf '%s' "$SUMMARY" | python3 -c "import json,sys;d=json.load(sys.stdin);print($1)" 2>/dev/null; }
 PUB=$(field "len(d.get('published',[]))");  PUB=${PUB:-0}
@@ -43,3 +59,13 @@ MSG="Fleet learning ($(date +%Y-%m-%d)): ${PUB} new lesson(s), ${PROP}"
 [ "$PROP" = "propagate FAILED" ] && MSG="$MSG · propagation FAILED, see log"
 bash "$NOTIFY" "$MSG"
 echo "$(TS) slacked: $MSG" >> "$LOG"
+
+# Lessons that published but never reached the fleet are a half-done run: the
+# Slack line above says so, and this makes launchd (and therefore Linear) agree.
+# Held lessons are NOT a failure -- the scrub gate holding client data is the gate
+# working, and paging on it would train the founder to ignore the channel.
+if [ "$PROP" = "propagate FAILED" ]; then
+  echo "$(TS) propagation failed -> exit 1" >> "$LOG"
+  exit 1
+fi
+exit 0

--- a/q-system/.q-system/scripts/test/test-lessons-daily-exit.sh
+++ b/q-system/.q-system/scripts/test/test-lessons-daily-exit.sh
@@ -1,0 +1,97 @@
+#!/bin/bash
+# Pins the exit contract of lessons-daily.sh (ASK-182).
+#
+# Why this test exists: the script ended on an `echo`, so its exit status was
+# always 0. Live evidence, the 06:00 run on 2026-07-27 -- it logged
+# "propagate FAILED" and Slacked it, and `launchctl list com.kipi.lessons-daily`
+# still reported LastExitStatus = 0. That makes fleet-health-daily.py's
+# `launchd-failing` detector structurally blind to this job, so its failures
+# lived in Slack and a 2591-line log and never reached Linear.
+#
+# The exit code IS the wire to Linear: non-zero here -> LastExitStatus non-zero
+# -> a deduped Linear issue on the next fleet-health run. Same contract as
+# test-open-loops-heartbeat-exit.sh (ASK-184).
+#
+# Fully hermetic: a temp SKEL git repo, stubbed distill / kipi-update / claude /
+# slack-notify. It never touches the live fleet, the real log, Slack, or git.
+set -uo pipefail
+
+SCRIPTS="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+SUT="$SCRIPTS/lessons-daily.sh"
+PASS=0
+FAIL=0
+
+# build_fixture <distill-rc> <distill-stdout> <update-rc> -> echoes the temp root
+build_fixture() {
+  local distill_rc="$1" distill_out="$2" update_rc="$3"
+  local tmp skel
+  tmp="$(mktemp -d)"
+  skel="$tmp/skel"
+  mkdir -p "$skel/q-system/.q-system/scripts" "$skel/q-system/lessons" "$tmp/bin"
+
+  cp "$SUT" "$skel/q-system/.q-system/scripts/lessons-daily.sh"
+  # Stub the ONE notification channel so a test can never reach the founder.
+  printf '#!/bin/bash\nexit 0\n' > "$skel/q-system/.q-system/scripts/slack-notify.sh"
+
+  # The distiller: exit code and stdout are the two things the job reads.
+  { printf '#!/usr/bin/env python3\nimport sys\nsys.stdout.write(%s)\nsys.exit(%s)\n' \
+      "$(printf '%s' "$distill_out" | python3 -c 'import json,sys; print(json.dumps(sys.stdin.read()))')" \
+      "$distill_rc"; } > "$skel/q-system/.q-system/scripts/lessons-distill.py"
+
+  printf '#!/bin/bash\nexit %s\n' "$update_rc" > "$skel/kipi-update.sh"
+
+  # A real (empty) git repo: the job commits new lessons before propagating.
+  git -C "$skel" init --quiet
+  git -C "$skel" config user.email "test@example.com"
+  git -C "$skel" config user.name "test"
+
+  # `claude` present on PATH is the job's own precondition check.
+  printf '#!/bin/bash\nexit 0\n' > "$tmp/bin/claude"
+  chmod +x "$tmp/bin/claude" "$skel/kipi-update.sh" \
+    "$skel/q-system/.q-system/scripts/slack-notify.sh"
+
+  printf '%s' "$tmp"
+}
+
+# run_case <name> <distill-rc> <distill-stdout> <update-rc> <expect: zero|nonzero>
+run_case() {
+  local name="$1" distill_rc="$2" distill_out="$3" update_rc="$4" expect="$5"
+  local tmp rc ok=0
+  tmp="$(build_fixture "$distill_rc" "$distill_out" "$update_rc")"
+  PATH="$tmp/bin:$PATH" \
+    bash "$tmp/skel/q-system/.q-system/scripts/lessons-daily.sh" >/dev/null 2>&1
+  rc=$?
+
+  [ "$expect" = "nonzero" ] && [ "$rc" -ne 0 ] && ok=1
+  [ "$expect" = "zero" ] && [ "$rc" -eq 0 ] && ok=1
+
+  if [ "$ok" -eq 1 ]; then
+    echo "PASS  $name (exit $rc, expected $expect)"
+    PASS=$((PASS + 1))
+  else
+    echo "FAIL  $name (exit $rc, expected $expect)"
+    echo "      log: $(tail -3 "$tmp/skel/q-system/output/lessons-daily.log" 2>/dev/null | tr '\n' ' ')"
+    FAIL=$((FAIL + 1))
+  fi
+  rm -rf "$tmp"
+}
+
+PUBLISHED='{"scanned": 1, "published": ["a lesson"], "held": []}'
+EMPTY='{"scanned": 0, "published": [], "held": []}'
+
+echo "test-lessons-daily-exit"
+# The bar-2 case, observed live on 2026-07-27: lessons published, fleet
+# propagation failed, and launchd recorded a clean run.
+run_case "propagate failure exits non-zero"   0 "$PUBLISHED" 1 nonzero
+# A distiller that dies emits no JSON, so every count parses as 0 and the run
+# reads as a quiet night. A zero result must prove it is empty, not broken.
+run_case "distill crash exits non-zero"       1 ""           0 nonzero
+run_case "distill non-JSON exits non-zero"    0 "Traceback"  0 nonzero
+# Guards against a fix that just always fails.
+run_case "clean publish+propagate exits zero" 0 "$PUBLISHED" 0 zero
+run_case "nothing new exits zero"             0 "$EMPTY"     0 zero
+
+echo "---"
+echo "passed=$PASS failed=$FAIL"
+[ "$FAIL" -eq 0 ] || exit 1
+exit 0


### PR DESCRIPTION
Migrates `com.kipi.lessons-daily` onto Linear-tracked execution (ASK-182).

## The gap, observed live

The 06:00 run on 2026-07-27 published 10 lessons, then **failed to propagate to the fleet**. It logged it and Slacked it. And:

```
launchctl list com.kipi.lessons-daily -> rc=0
    "LastExitStatus" = 0;
```

`fleet-health-daily.py`'s `launchd-failing` detector keys on that status, so this job's failures lived in Slack and a 2591-line log and never reached the board. The exit code is the wire to Linear. Same contract as ASK-184.

## The four bars

| # | Bar | State |
|---|-----|-------|
| 1 | launchd, never cron | Already met. Plist loaded; `crontab -l` has no `lessons` line. Plist pins `PATH` to include `~/.local/bin`, so `claude` resolves. |
| 2 | Failures reach Linear, not only a log | **This PR.** Four silent-success paths now exit non-zero. |
| 3 | Live or in the pause ledger, never dark | Already met. Loaded, absent from both pause ledgers, and the watchdog reports no problem for it. |
| 4 | Verified by running it, not reading it | The job ran for real at 06:00 today; its output was read from the log (10 lessons published, propagation failed). Exit contract pinned by a hermetic suite. |

## What changed

`lessons-daily.sh`, reporting only. No change to what the job does.

- `propagate FAILED` -> exit 1. Previously fell off the end of the script on an `echo`, so exit 0.
- `lessons-distill.py` exits non-zero -> exit 1.
- `lessons-distill.py` emits no parseable JSON -> exit 1. A dead distiller printed nothing, every count parsed as 0, and the run logged `nothing new`. A broken night was indistinguishable from a quiet one.
- No `claude` on PATH -> exit 1, was a silent skip. The plist pins PATH, so a missing binary is a broken machine, not a normal night, and a silent skip is exactly the dark-with-a-clean-status state the bars forbid.

Held lessons stay a non-failure: the scrub gate holding client data is the gate working, and paging on it is how a channel becomes one nobody reads.

## Check

`q-system/.q-system/scripts/test/test-lessons-daily-exit.sh`, registered in `capability-manifest.json`. Fully hermetic: temp SKEL git repo, stubbed distill / kipi-update / claude / slack-notify. It cannot touch the live fleet, the real log, Slack, or git.

Before the fix:
```
FAIL  propagate failure exits non-zero (exit 0, expected nonzero)
FAIL  distill crash exits non-zero (exit 0, expected nonzero)
FAIL  distill non-JSON exits non-zero (exit 0, expected nonzero)
PASS  clean publish+propagate exits zero
PASS  nothing new exits zero
passed=2 failed=3
```

After:
```
passed=5 failed=0
```

## Blast radius

Machine-local for the plist. The script itself is a skeleton file, so it reaches the fleet on the next `kipi update`; the change is confined to this job's exit status.

## Not doing

The job's logic is untouched. Deliberately not run end-to-end from this worktree: `lessons-daily.sh` calls `kipi-update.sh`, which would fan an unmerged branch out to all 22 fleet instances.

🤖 Generated with [Claude Code](https://claude.com/claude-code)