### PR TITLE
feat(launchd): watchdog findings reach Linear, and --dry-run means dry (ASK-181)

### DIFF
--- a/q-system/.q-system/scripts/fleet-health-daily.py
+++ b/q-system/.q-system/scripts/fleet-health-daily.py
@@ -465,6 +465,23 @@ def file_findings(findings: list, apply: bool, filer: str = "fleet-health-daily.
     return result
 
 
+def outcome_line(outcome: dict) -> str:
+    """The filing result as one line that cannot lie by omission.
+
+    Scar (ASK-181 review): this printed `created` and `existing` only. Because
+    `file_findings` catches its own network errors and returns
+    {created: 0, existing: 0, skipped_no_key: N}, 'Linear was unreachable and N
+    findings went nowhere' printed byte-identically to 'the fleet is clean,
+    nothing to file'. `unfiled` is what separates empty from broken.
+
+    launchd-health-check.py keeps its OWN copy of this formatter on purpose: it
+    has to be able to report that THIS file is missing, which is the rsync
+    --delete scar it was built for. Do not consolidate them into a dependency
+    that disappears exactly when it is needed."""
+    return (f"  filed={outcome['created']} already-tracked={outcome['existing']} "
+            f"unfiled={outcome['skipped_no_key']}")
+
+
 def main() -> int:
     ap = argparse.ArgumentParser(description=__doc__.split("\n")[0])
     ap.add_argument("--apply", action="store_true", help="actually file Linear issues")
@@ -497,7 +514,7 @@ def main() -> int:
         print(f"  {did}: {n}")
 
     outcome = file_findings(all_findings, args.apply)
-    print(f"  filed={outcome['created']} already-tracked={outcome['existing']}")
+    print(outcome_line(outcome))
 
     STATE.parent.mkdir(parents=True, exist_ok=True)
     STATE.write_text(json.dumps(

--- a/q-system/.q-system/scripts/fleet-health-daily.py
+++ b/q-system/.q-system/scripts/fleet-health-daily.py
@@ -407,12 +407,17 @@ def finding_key(detector_id: str, subject: str) -> str:
     return f"fleet-health/{detector_id}/{slug(subject)}"
 
 
-def file_findings(findings: list, apply: bool) -> dict:
+def file_findings(findings: list, apply: bool, filer: str = "fleet-health-daily.py") -> dict:
     """Create a Linear issue per finding, deduped by kipi-key.
 
     Reuses linear-sync's graphql + remote guard so 'already exists' has exactly one
     definition fleet-wide. Linear objects are permanent, so the guard is refetched
     here rather than trusted from any cache.
+
+    `filer` names the script that produced the finding. It is a parameter rather
+    than a constant because this is the fleet's ONE filer: launchd-health-check.py
+    files its 09:30/21:30 findings through here too (ASK-181), against these same
+    detector keys, so a finding both jobs see stays one issue instead of two.
     """
     result = {"created": 0, "existing": 0, "skipped_no_key": 0}
     if not findings:
@@ -443,7 +448,7 @@ def file_findings(findings: list, apply: bool) -> dict:
             continue
         payload = {
             "title": f["title"][:250],
-            "description": f"<!-- kipi-key: {key} -->\n\n{f['body']}\n\nFiled by `fleet-health-daily.py`.",
+            "description": f"<!-- kipi-key: {key} -->\n\n{f['body']}\n\nFiled by `{filer}`.",
             "teamId": team_id,
         }
         if project:

--- a/q-system/.q-system/scripts/launchd-health-check.py
+++ b/q-system/.q-system/scripts/launchd-health-check.py
@@ -17,14 +17,19 @@ wiped their scripts out from under the plists. Nothing surfaced it -- the jobs j
 silently stopped hunting income. A prompt cannot watch launchd; this job can. It is
 the deterministic backstop that turns a silent 127 into a phone ping within hours.
 
+Every finding also becomes a Linear issue (ASK-181), deduped forever by the SAME
+kipi-key fleet-health-daily.py uses for its own launchd checks. A Slack line is
+read once and scrolls away; the issue holds state. Slack stays the pointer.
+
 Single notification channel: slack-notify.sh (founder-notifications rule). Silent
 no-op if no webhook is configured, so this watchdog never breaks anything.
 
 The watchdog always exits 0 -- it must never become the failing job it reports.
 
 Usage:
-  launchd-health-check.py            # check; ping on newly/again-failing jobs
-  launchd-health-check.py --dry      # print findings only; no ping, no state write
+  launchd-health-check.py             # check; ping + file Linear issues
+  launchd-health-check.py --dry-run   # print findings only; no ping, no issue,
+  launchd-health-check.py --dry       #   no state write (--dry / -n are aliases)
 """
 import json
 import re
@@ -37,6 +42,7 @@ SELF_LABEL = "com.kipi.launchd-health"
 FAIL_PING_TTL_SECONDS = 6 * 3600  # re-ping a still-failing job at most this often
 HERE = Path(__file__).resolve().parent
 NOTIFY_SCRIPT = HERE / "slack-notify.sh"
+DRY_FLAGS = ("--dry", "--dry-run", "-n")
 STATE_FILE = Path.home() / ".config" / "kipi" / "launchd-health-state.json"
 LAUNCH_AGENTS = Path.home() / "Library" / "LaunchAgents"
 
@@ -209,6 +215,105 @@ def send_ping(message):
         pass
 
 
+def is_dry_run(args):
+    """True when the operator asked for a read-only pass.
+
+    Scar (ASK-181): this used to be `"--dry" in sys.argv`, an exact string match.
+    `--dry-run` -- the flag this job's own migration checklist tells the verifier
+    to type -- did not match, so a read-only check silently took the LIVE path and
+    pinged the founder's phone. An unrecognized flag must not arm anything."""
+    return any(arg in DRY_FLAGS for arg in args)
+
+
+# --- findings reach Linear, not only Slack -----------------------------------
+# Bar 2 of the job-migration contract (ASK-181). The detector ids below are
+# fleet-health-daily.py's, not new ones: that job runs the same two checks at
+# 08:15 and files against those keys. Sharing the key means a job both of them see
+# is ONE permanent issue; a private namespace here would file a second one every
+# time, and Linear issues are not deleted in this fleet.
+LINEAR_DETECTOR_BY_KIND = {
+    "failing": "launchd-failing",
+    "not_loaded": "launchd-dark",
+    # "paused" is deliberate, recorded in the pause ledger, and never filed.
+}
+
+_FLEET_HEALTH = None
+
+
+def _fleet_health():
+    """Lazily load fleet-health-daily.py -- the one place that defines a finding's
+    Linear key and how it gets filed. Loaded on demand so a healthy run (the
+    common case) pays nothing, and so an import error cannot stop the watchdog."""
+    global _FLEET_HEALTH
+    if _FLEET_HEALTH is None:
+        import importlib.util
+
+        spec = importlib.util.spec_from_file_location("fh", HERE / "fleet-health-daily.py")
+        module = importlib.util.module_from_spec(spec)
+        spec.loader.exec_module(module)
+        _FLEET_HEALTH = module
+    return _FLEET_HEALTH
+
+
+def linear_findings(problems):
+    """Turn watchdog problems into fleet-health finding dicts, ready to file."""
+    fleet_health = _fleet_health()
+    findings = []
+    for label, kind, detail in problems:
+        detector = LINEAR_DETECTOR_BY_KIND.get(kind)
+        if detector is None:
+            continue
+        if kind == "failing":
+            title = f"launchd job failing: {label} ({detail})"
+            body = (
+                f"`{label}` is loaded but its last run exited non-zero (**{detail}**).\n\n"
+                "## Action\nRead its `StandardErrorPath`, fix the cause, and confirm a clean "
+                "run. If the failure is environmental (auth expiry, server down), say so on "
+                "this issue rather than retrying -- `self-healing-retry.md` rule 5 stops "
+                "environmental failures on attempt 1."
+            )
+        else:
+            title = f"launchd job is dark: {label}"
+            body = (
+                f"`{label}` has a plist in `~/Library/LaunchAgents/` but is not loaded, and "
+                "it is NOT in the paused ledger -- so nothing recorded a decision to stop "
+                "it. An unloaded job cannot report its own death.\n\n"
+                "## Action\n"
+                f"- Resume: `launchctl bootstrap gui/$(id -u) ~/Library/LaunchAgents/{label}.plist`\n"
+                f"- Or record the pause: add `{label}` to `~/.config/kipi/launchd-paused.txt`"
+            )
+        findings.append({
+            "key": fleet_health.finding_key(detector, label),
+            "detector": detector,
+            "subject": label,
+            "title": title,
+            "body": body,
+        })
+    return findings
+
+
+def file_linear_findings(problems):
+    """File the findings as deduped Linear issues. Never raises.
+
+    A watchdog that dies because Linear is unreachable stops watching launchd --
+    which is precisely the silent death it exists to catch. A filing failure is
+    counted and printed, never propagated."""
+    empty = {"created": 0, "existing": 0, "skipped_no_key": 0}
+    try:
+        findings = linear_findings(problems)
+    except Exception as exc:  # noqa: BLE001
+        print(f"linear findings could not be built: {exc}", file=sys.stderr)
+        return empty
+    if not findings:
+        return empty
+    try:
+        return _fleet_health().file_findings(
+            findings, apply=True, filer="launchd-health-check.py")
+    except Exception as exc:  # noqa: BLE001
+        print(f"linear filing skipped: {exc}", file=sys.stderr)
+        return {"created": 0, "existing": 0, "skipped_no_key": len(findings)}
+
+
 def problems_to_ping(problems, state, now):
     """Problems whose kind changed since the last ping, or whose last ping is
     older than the TTL (dedupe spam, but re-ping when failing -> not_loaded)."""
@@ -247,7 +352,11 @@ def run(dry_run):
 
     if dry_run:
         print(f"[dry] would ping {len(due)} job(s)")
+        print(f"[dry] would file {len(linear_findings(problems))} linear finding(s)")
         return
+
+    filed = file_linear_findings(problems)
+    print(f"linear: filed={filed['created']} already-tracked={filed['existing']}")
 
     if due:
         parts = [
@@ -268,6 +377,6 @@ def run(dry_run):
 
 if __name__ == "__main__":
     try:
-        run("--dry" in sys.argv)
+        run(is_dry_run(sys.argv[1:]))
     finally:
         sys.exit(0)  # a watchdog must never report itself as the failing job

--- a/q-system/.q-system/scripts/launchd-health-check.py
+++ b/q-system/.q-system/scripts/launchd-health-check.py
@@ -30,12 +30,17 @@ Usage:
   launchd-health-check.py             # check; ping + file Linear issues
   launchd-health-check.py --dry-run   # print findings only; no ping, no issue,
   launchd-health-check.py --dry       #   no state write (--dry / -n are aliases)
+
+Dry mode makes ONE read-only Linear query (the dedup fetch) so its preview of a
+permanent, undeletable action is the real number. It writes nothing: no issue, no
+state file, no ping. Any flag that is not a dry alias is REFUSED, never run live.
 """
 import json
 import re
 import subprocess
 import sys
 import time
+import traceback
 from pathlib import Path
 
 SELF_LABEL = "com.kipi.launchd-health"
@@ -216,13 +221,32 @@ def send_ping(message):
 
 
 def is_dry_run(args):
-    """True when the operator asked for a read-only pass.
-
-    Scar (ASK-181): this used to be `"--dry" in sys.argv`, an exact string match.
-    `--dry-run` -- the flag this job's own migration checklist tells the verifier
-    to type -- did not match, so a read-only check silently took the LIVE path and
-    pinged the founder's phone. An unrecognized flag must not arm anything."""
+    """True when a dry alias was typed. Answers only that; see parse_mode."""
     return any(arg in DRY_FLAGS for arg in args)
+
+
+def parse_mode(args):
+    """('live'|'dry'|'refuse', unrecognized_flags).
+
+    Scar (ASK-181): dry mode used to be `"--dry" in sys.argv`, an exact string
+    match. `--dry-run` -- the flag this job's own migration checklist tells the
+    verifier to type -- did not match, so a read-only check silently took the LIVE
+    path and pinged the founder's phone.
+
+    Widening the accept-list fixed that one typo and left the shape intact: every
+    OTHER near-miss (`--dry-run=1`, `--dryrun`, `--dry_run`, `-dry`) still armed
+    the live path. So an unrecognized flag now REFUSES the run instead of guessing.
+    An unknown flag alongside a valid dry one also refuses -- if part of the
+    command line is unparsed, the operator's intent is unknown, and the safe
+    reading of an unknown intent is 'do nothing'.
+
+    launchd invokes this script with no arguments, so refusing cannot stop the
+    scheduled run; it only stops a hand-typed command from doing more than the
+    operator asked."""
+    unrecognized = [arg for arg in args if arg not in DRY_FLAGS]
+    if unrecognized:
+        return ("refuse", unrecognized)
+    return ("dry" if is_dry_run(args) else "live", [])
 
 
 # --- findings reach Linear, not only Slack -----------------------------------
@@ -292,26 +316,50 @@ def linear_findings(problems):
     return findings
 
 
-def file_linear_findings(problems):
+def file_linear_findings(problems, apply=True):
     """File the findings as deduped Linear issues. Never raises.
 
     A watchdog that dies because Linear is unreachable stops watching launchd --
     which is precisely the silent death it exists to catch. A filing failure is
-    counted and printed, never propagated."""
-    empty = {"created": 0, "existing": 0, "skipped_no_key": 0}
+    counted and printed, never propagated.
+
+    With apply=False nothing is created; the same filer still runs its dedup so a
+    dry preview reports the real number instead of a second, looser estimate.
+
+    Every return path sets `skipped_no_key` to the number of problems that were
+    OWED an issue and did not get one. Counting the findings we managed to build
+    would report 0 for the one failure that matters most -- fleet-health-daily.py
+    missing entirely, which is the `kipi update` rsync --delete scar this watchdog
+    exists for."""
+    owed = sum(1 for _, kind, _ in problems if kind in LINEAR_DETECTOR_BY_KIND)
     try:
         findings = linear_findings(problems)
     except Exception as exc:  # noqa: BLE001
         print(f"linear findings could not be built: {exc}", file=sys.stderr)
-        return empty
+        return {"created": 0, "existing": 0, "skipped_no_key": owed}
     if not findings:
-        return empty
+        return {"created": 0, "existing": 0, "skipped_no_key": 0}
     try:
         return _fleet_health().file_findings(
-            findings, apply=True, filer="launchd-health-check.py")
+            findings, apply=apply, filer="launchd-health-check.py")
     except Exception as exc:  # noqa: BLE001
         print(f"linear filing skipped: {exc}", file=sys.stderr)
         return {"created": 0, "existing": 0, "skipped_no_key": len(findings)}
+
+
+def linear_report_line(outcome, dry_run):
+    """The filing result as one line that cannot lie by omission.
+
+    Scar (ASK-181 review): the old line printed `created` and `existing` only.
+    `file_findings` catches its own network errors and returns
+    {created: 0, existing: 0, skipped_no_key: N}, so 'Linear is unreachable and N
+    findings went nowhere' printed byte-identically to 'the fleet is clean, nothing
+    to file'. Every instance without a Linear API key takes that branch, and this
+    script ships fleet-wide. `unfiled` is what separates empty from broken."""
+    verb = "would-file" if dry_run else "filed"
+    prefix = "[dry] " if dry_run else ""
+    return (f"{prefix}linear: {verb}={outcome['created']} "
+            f"already-tracked={outcome['existing']} unfiled={outcome['skipped_no_key']}")
 
 
 def problems_to_ping(problems, state, now):
@@ -350,13 +398,15 @@ def run(dry_run):
     now = int(time.time())
     due = problems_to_ping(problems, state, now)
 
+    # ONE filer for both modes. Dry used to count the findings it built while live
+    # counted what survived dedup, so the dry preview of a permanent action
+    # over-reported (review finding 2). Two readers of one input is the defect.
+    filed = file_linear_findings(problems, apply=not dry_run)
+    print(linear_report_line(filed, dry_run))
+
     if dry_run:
         print(f"[dry] would ping {len(due)} job(s)")
-        print(f"[dry] would file {len(linear_findings(problems))} linear finding(s)")
         return
-
-    filed = file_linear_findings(problems)
-    print(f"linear: filed={filed['created']} already-tracked={filed['existing']}")
 
     if due:
         parts = [
@@ -364,7 +414,14 @@ def run(dry_run):
             else f"{label} ({detail})"
             for label, kind, detail in due
         ]
-        send_ping(f"launchd watchdog: {len(due)} job issue(s) -- " + ", ".join(parts))
+        message = f"launchd watchdog: {len(due)} job issue(s) -- " + ", ".join(parts)
+        if filed["skipped_no_key"]:
+            # Slack is the only channel the founder actually reads. Fixing the
+            # stdout counter alone would leave this ping saying "here are the
+            # problems" while the issues meant to hold them never reached the
+            # board. No NEW ping: the one that was already firing carries it.
+            message += f" [NOT filed to Linear: {filed['skipped_no_key']}]"
+        send_ping(message)
         for label, kind, detail in due:
             state[label] = {"pinged_at": now, "kind": kind, "detail": detail}
 
@@ -375,8 +432,25 @@ def run(dry_run):
     write_state(state)
 
 
-if __name__ == "__main__":
+def main(argv):
+    """Always returns 0 -- a watchdog must never report itself as the failing job.
+
+    Scar (ASK-181 review): this used to be `try: run(...) finally: sys.exit(0)`.
+    `sys.exit` in the finally supersedes a propagating exception, so an unhandled
+    crash printed NOTHING and launchd recorded SUCCESS. Exiting 0 is the contract;
+    exiting 0 SILENTLY is the watchdog dying the same silent death it exists to
+    catch. Catch, print the traceback, then exit 0."""
+    mode, unrecognized = parse_mode(argv)
+    if mode == "refuse":
+        print(f"unrecognized flag(s): {' '.join(unrecognized)} -- refusing to run. "
+              f"Dry: {' / '.join(DRY_FLAGS)}. Live: no flags at all.", file=sys.stderr)
+        return 0
     try:
-        run(is_dry_run(sys.argv[1:]))
-    finally:
-        sys.exit(0)  # a watchdog must never report itself as the failing job
+        run(mode == "dry")
+    except Exception:  # noqa: BLE001
+        traceback.print_exc()
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main(sys.argv[1:]))

--- a/q-system/.q-system/scripts/test/test-fleet-health-daily.py
+++ b/q-system/.q-system/scripts/test/test-fleet-health-daily.py
@@ -120,6 +120,28 @@ for det in fh.DETECTORS:
             failures.append(f"detector {det['id']} emitted a finding with no stable subject")
 print(f"  ok: all {len(fh.DETECTORS)} shipped detectors run and return findings with subjects")
 
+# --- a dead filer must not read like a clean run (ASK-181 review, finding 1) --
+# file_findings catches its own network errors and returns skipped_no_key=N. This
+# job's report printed created + existing only, so "Linear was unreachable and 5
+# findings went nowhere" printed byte-identically to "the fleet is clean". Same
+# defect, same fix as launchd-health-check.py -- fixing only the watchdog would
+# have left the 08:15 job, which files the SAME findings, still lying.
+_dead = {"created": 0, "existing": 0, "skipped_no_key": 2}
+_clean = {"created": 0, "existing": 0, "skipped_no_key": 0}
+check("a dead filer's report differs from a clean one",
+      fh.outcome_line(_dead) == fh.outcome_line(_clean), False)
+check("the report names findings that never reached Linear",
+      "unfiled=2" in fh.outcome_line(_dead), True)
+check("a clean run reports nothing unfiled", "unfiled=0" in fh.outcome_line(_clean), True)
+check("the counts stay in the line",
+      "filed=3" in fh.outcome_line({"created": 3, "existing": 1, "skipped_no_key": 0}), True)
+
+# and the line must actually be the one main() prints, or the fix is a function
+# nobody calls.
+import inspect  # noqa: E402 - local to this assertion
+
+check("main() reports through outcome_line", "outcome_line(" in inspect.getsource(fh.main), True)
+
 if failures:
     print("FAIL:")
     for line in failures:

--- a/q-system/.q-system/scripts/test_launchd_health_check.py
+++ b/q-system/.q-system/scripts/test_launchd_health_check.py
@@ -7,7 +7,10 @@ verified manually on wiring; these tests guard the logic that a refactor could b
 
 Run: python3 test_launchd_health_check.py   (exit 0 = pass, 1 = fail)
 """
+import contextlib
 import importlib.util
+import io
+import subprocess
 import sys
 from pathlib import Path
 
@@ -117,12 +120,15 @@ check("load_paused_labels returns a set", isinstance(_paused, set), True)
 # `--dry-run` fell through to the LIVE path -- writing state and pinging the
 # founder's phone from what the operator typed as a read-only check. This job's own
 # migration Definition of Ready tells the verifier to run `--dry-run`.
-check("--dry is dry", wd.is_dry_run(["--dry"]), True)
-check("--dry-run is dry", wd.is_dry_run(["--dry-run"]), True)
-check("-n is dry", wd.is_dry_run(["-n"]), True)
-check("no flag is live", wd.is_dry_run([]), False)
-check("an unrelated flag is live", wd.is_dry_run(["--verbose"]), False)
-check("a dry flag anywhere counts", wd.is_dry_run(["--verbose", "--dry-run"]), True)
+check("--dry is a dry flag", wd.is_dry_run(["--dry"]), True)
+check("--dry-run is a dry flag", wd.is_dry_run(["--dry-run"]), True)
+check("-n is a dry flag", wd.is_dry_run(["-n"]), True)
+check("no flag carries no dry request", wd.is_dry_run([]), False)
+check("an unrelated flag is not a dry flag", wd.is_dry_run(["--verbose"]), False)
+check("a dry flag anywhere is seen", wd.is_dry_run(["--verbose", "--dry-run"]), True)
+# is_dry_run answers "was a dry flag typed", nothing more. What the script DOES
+# with an unrecognized flag is parse_mode's call, asserted further down -- the
+# review's finding 3 was that no code path enforced the docstring's promise.
 
 # --- findings reach Linear, not only Slack (ASK-181) -------------------------
 # Bar 2 of the job-migration contract: a finding that only ever exists as a Slack
@@ -196,6 +202,236 @@ finally:
     wd._FLEET_HEALTH = _saved_fh
 check("a paused-only run files nothing", _none,
       {"created": 0, "existing": 0, "skipped_no_key": 0})
+
+# --- a dead filer must not read like a clean run (ASK-181 review, finding 1) --
+# THE REPRODUCER: `file_findings` catches its own network errors and returns
+# {created: 0, existing: 0, skipped_no_key: N}. The report read `created` and
+# `existing` only, so "Linear is unreachable, 2 findings went nowhere" printed the
+# byte-identical line to "the fleet is clean, nothing to file". Every kipi instance
+# without ~/.config/kipi/linear-api-key takes that branch, and this script ships
+# fleet-wide via kipi update. A false all-clear at 3am is the same class of harm as
+# crying wolf -- it is the fleet's own lesson "a zero result must prove it is empty,
+# not broken", which this very job exists to honor.
+
+
+def _fh_stub(created=0, existing=0, unfiled=0, record=None):
+    """A stand-in fleet-health module with a scripted file_findings outcome."""
+
+    class _Stub:
+        @staticmethod
+        def finding_key(detector, subject):
+            return _fh.finding_key(detector, subject)
+
+        @staticmethod
+        def file_findings(findings, apply, filer=None):
+            if record is not None:
+                record.append({"n": len(findings), "apply": apply, "filer": filer})
+            n = len(findings)
+            return {
+                "created": n if created == "all" else created,
+                "existing": n if existing == "all" else existing,
+                "skipped_no_key": n if unfiled == "all" else unfiled,
+            }
+
+    return _Stub
+
+
+def run_capture(problems, fleet_health, dry=False, state=None):
+    """Drive run() with every side-effecting edge stubbed.
+
+    Returns (stdout, stderr, pings, state_writes) so an assertion can read what
+    the operator would actually SEE, not just what the function returned."""
+    saved = (wd.discover_problems, wd.load_state, wd.write_state,
+             wd.send_ping, wd._FLEET_HEALTH)
+    pings, writes = [], []
+    wd.discover_problems = lambda: problems
+    wd.load_state = lambda: dict(state or {})
+    wd.write_state = lambda s: writes.append(s)
+    wd.send_ping = lambda message: pings.append(message)
+    wd._FLEET_HEALTH = fleet_health
+    out, err = io.StringIO(), io.StringIO()
+    try:
+        with contextlib.redirect_stdout(out), contextlib.redirect_stderr(err):
+            wd.run(dry)
+    finally:
+        (wd.discover_problems, wd.load_state, wd.write_state,
+         wd.send_ping, wd._FLEET_HEALTH) = saved
+    return out.getvalue(), err.getvalue(), pings, writes
+
+
+_TWO_REAL = [("com.claudedaddy.pinterest", "failing", "exit 127"),
+             ("com.kipi.opp-scan", "not_loaded", "installed but not running")]
+_NOTHING_TO_FILE = [("com.cole.gamma", "paused", "paused on purpose")]
+
+_dead_out = run_capture(_TWO_REAL, _fh_stub(unfiled="all"))[0].strip().splitlines()[-1]
+_empty_out = run_capture(_NOTHING_TO_FILE, _fh_stub())[0].strip().splitlines()[-1]
+_tracked_out = run_capture(_TWO_REAL, _fh_stub(existing="all"))[0].strip().splitlines()[-1]
+
+check("a dead filer does NOT print the same line as a run with nothing to file",
+      _dead_out == _empty_out, False)
+check("a dead filer names how many findings never reached Linear",
+      "unfiled=2" in _dead_out, True)
+check("a clean run reports nothing unfiled", "unfiled=0" in _empty_out, True)
+check("an all-already-tracked run still reports nothing unfiled",
+      "unfiled=0" in _tracked_out, True)
+
+# The layer above the counter: the Slack ping is the only channel the founder
+# actually reads. Fixing the stdout line alone would leave the ping saying "here
+# are 2 problems" while the issues meant to hold them never reached the board.
+# No NEW ping is created -- the ping that already fires carries the truth.
+_dead_pings = run_capture(_TWO_REAL, _fh_stub(unfiled="all"))[2]
+_ok_pings = run_capture(_TWO_REAL, _fh_stub(created="all"))[2]
+check("a dead filer adds no extra ping", len(_dead_pings), 1)
+check("the ping says the findings did not reach Linear",
+      any("NOT filed to Linear: 2" in p for p in _dead_pings), True)
+check("a healthy filer leaves the ping text alone",
+      any("NOT filed" in p for p in _ok_pings), False)
+
+# One layer deeper: if the findings cannot even be BUILT (fleet-health-daily.py
+# missing -- literally the kipi-update rsync --delete scar this watchdog exists
+# for) the outcome is all-zeros, which would print the clean-run line again.
+# `unfiled` has to count the problems that were owed an issue, not the findings
+# that were never constructed.
+class _BuildBoom:
+    @staticmethod
+    def finding_key(detector, subject):
+        raise ImportError("no module named fleet-health-daily")
+
+
+_boom_out, _boom_err, _, _ = run_capture(_TWO_REAL, _BuildBoom)
+check("a findings-build crash reports the problems it could not file",
+      "unfiled=2" in _boom_out.strip().splitlines()[-1], True)
+check("a findings-build crash says why on stderr", "could not be built" in _boom_err, True)
+check("a findings-build crash does not count the paused job",
+      "unfiled=0" in run_capture(_NOTHING_TO_FILE, _BuildBoom)[0], True)
+
+# --- the dry preview must match what the live run does (finding 2) -----------
+# `[dry] would file 2` while the live run files 0 over-states a PERMANENT,
+# undeletable action. The cause was two readers of one input: dry counted the
+# findings it built, live counted what the filer actually created after dedup.
+# One reader now -- the same file_findings, with apply=False.
+_calls = []
+_dry_out, _, _dry_pings, _dry_writes = run_capture(
+    _TWO_REAL, _fh_stub(existing="all", record=_calls), dry=True)
+check("the dry preview does not claim it would file already-tracked findings",
+      "would-file=0" in _dry_out, True)
+check("the dry preview reports what is already tracked",
+      "already-tracked=2" in _dry_out, True)
+check("dry runs the SAME filer, with apply off", [c["apply"] for c in _calls], [False])
+check("dry names itself as the filer", [c["filer"] for c in _calls],
+      ["launchd-health-check.py"])
+check("dry still writes no state", _dry_writes, [])
+check("dry still sends no ping", _dry_pings, [])
+check("dry still previews the ping count", "[dry] would ping 2 job(s)" in _dry_out, True)
+
+# and a dead filer during a dry run is just as visible as during a live one
+check("a dry run against a dead filer says so too",
+      "unfiled=2" in run_capture(_TWO_REAL, _fh_stub(unfiled="all"), dry=True)[0], True)
+
+# --- an unrecognized flag must not arm anything (finding 3) ------------------
+# The docstring claimed this; no code path enforced it. `--dry-run=1`, `--dryrun`
+# and `--dry_run` all fell through to the LIVE path -- the same shape as the
+# original scar (a flag the operator believed was read-only was not).
+for _required in ("parse_mode", "main"):
+    if not hasattr(wd, _required):
+        failures.append(f"{_required}(): not implemented on launchd-health-check.py")
+        setattr(wd, _required, lambda *_a, **_k: None)
+
+check("no flag is live", wd.parse_mode([]), ("live", []))
+check("--dry-run is dry", wd.parse_mode(["--dry-run"]), ("dry", []))
+check("--dry is dry", wd.parse_mode(["--dry"]), ("dry", []))
+check("-n is dry", wd.parse_mode(["-n"]), ("dry", []))
+check("--dry-run=1 refuses instead of arming the live path",
+      wd.parse_mode(["--dry-run=1"]), ("refuse", ["--dry-run=1"]))
+check("--dryrun refuses", wd.parse_mode(["--dryrun"]), ("refuse", ["--dryrun"]))
+check("--dry_run refuses", wd.parse_mode(["--dry_run"]), ("refuse", ["--dry_run"]))
+check("-dry refuses", wd.parse_mode(["-dry"]), ("refuse", ["-dry"]))
+check("an unknown flag NEXT TO a dry flag still refuses -- intent is unknown",
+      wd.parse_mode(["--verbose", "--dry-run"]), ("refuse", ["--verbose"]))
+
+_refuse_out, _refuse_err = io.StringIO(), io.StringIO()
+_saved_run = wd.run
+wd.run = lambda dry: _refuse_out.write("RAN\n")
+try:
+    with contextlib.redirect_stdout(_refuse_out), contextlib.redirect_stderr(_refuse_err):
+        _rc = wd.main(["--dryrun"])
+finally:
+    wd.run = _saved_run
+check("a refused flag never reaches run()", "RAN" in _refuse_out.getvalue(), False)
+check("a refused flag still exits 0 (a watchdog never fails its own job)", _rc, 0)
+check("a refused flag says what IS valid", "--dry-run" in _refuse_err.getvalue(), True)
+
+# --- a crash inside run() must be loud, not silent (finding 4) ---------------
+# `finally: sys.exit(0)` supersedes a propagating exception, so an unhandled crash
+# printed NOTHING and launchd recorded SUCCESS. The watchdog dying silently is the
+# exact failure mode it was built to catch, one level up.
+_crash_err = io.StringIO()
+_saved_run = wd.run
+
+
+def _explode(_dry):
+    raise RuntimeError("fleet-health-daily.py vanished")
+
+
+wd.run = _explode
+try:
+    with contextlib.redirect_stderr(_crash_err):
+        _crash_rc = wd.main([])
+finally:
+    wd.run = _saved_run
+check("a crash still exits 0", _crash_rc, 0)
+check("a crash prints its traceback", "Traceback" in _crash_err.getvalue(), True)
+check("the traceback names the real error",
+      "fleet-health-daily.py vanished" in _crash_err.getvalue(), True)
+
+# --- the key must match what fleet-health's PRODUCERS emit (finding 5) -------
+# Comparing against finding_key() only restates this file's own formula. If
+# fleet-health's dark-job detector ever changed `subject` (label -> label.plist,
+# a plausible "improve the issue" edit), both suites would stay green while the
+# fleet filed TWO permanent Linear issues for one job, forever. So drive the real
+# producers and compare the key each side would actually file.
+class _FakeCompleted:
+    def __init__(self, returncode=0, stdout=""):
+        self.returncode = returncode
+        self.stdout = stdout
+
+
+class _FakeSubprocess:
+    """Only the two calls fleet-health's launchd producers make."""
+    TimeoutExpired = subprocess.TimeoutExpired
+
+    @staticmethod
+    def run(cmd, **_kw):
+        if list(cmd) == ["launchctl", "list"]:
+            return _FakeCompleted(0, "PID\tStatus\tLabel\n-\t127\tcom.kipi.alpha\n")
+        return _FakeCompleted(1, "")
+
+
+_fh_saved = (_fh._launchd_labels, _fh._paused_labels, _fh._is_loaded, _fh.subprocess)
+_fh._launchd_labels = lambda: ["com.kipi.beta"]
+_fh._paused_labels = lambda: set()
+_fh._is_loaded = lambda _label: False
+_fh.subprocess = _FakeSubprocess
+try:
+    _produced_dark = _fh.detect_dark_jobs(None)
+    _produced_failing = _fh.detect_failing_jobs(None)
+finally:
+    (_fh._launchd_labels, _fh._paused_labels, _fh._is_loaded, _fh.subprocess) = _fh_saved
+
+check("fleet-health's dark producer emitted the job under test",
+      [f["subject"] for f in _produced_dark], ["com.kipi.beta"])
+check("fleet-health's failing producer emitted the job under test",
+      [f["subject"] for f in _produced_failing], ["com.kipi.alpha"])
+check("the watchdog's dark key equals the key fleet-health's PRODUCER files",
+      _found[1]["key"], _fh.finding_key("launchd-dark", _produced_dark[0]["subject"]))
+check("the watchdog's failing key equals the key fleet-health's PRODUCER files",
+      _found[0]["key"], _fh.finding_key("launchd-failing", _produced_failing[0]["subject"]))
+
+# ...and the detector ids themselves have to exist in fleet-health's registry, or
+# the shared namespace is shared with nothing.
+_registry_ids = {d["id"] for d in _fh.DETECTORS}
+check("every detector the watchdog files under is in fleet-health's registry",
+      sorted(set(wd.LINEAR_DETECTOR_BY_KIND.values()) - _registry_ids), [])
 
 if failures:
     print("FAIL:")

--- a/q-system/.q-system/scripts/test_launchd_health_check.py
+++ b/q-system/.q-system/scripts/test_launchd_health_check.py
@@ -112,6 +112,91 @@ check("a paused label that starts FAILING still pings",
 _paused = wd.load_paused_labels()
 check("load_paused_labels returns a set", isinstance(_paused, set), True)
 
+# --- dry-run flag parsing (ASK-181) ------------------------------------------
+# THE REPRODUCER: the old test was `"--dry" in sys.argv`, an exact string match, so
+# `--dry-run` fell through to the LIVE path -- writing state and pinging the
+# founder's phone from what the operator typed as a read-only check. This job's own
+# migration Definition of Ready tells the verifier to run `--dry-run`.
+check("--dry is dry", wd.is_dry_run(["--dry"]), True)
+check("--dry-run is dry", wd.is_dry_run(["--dry-run"]), True)
+check("-n is dry", wd.is_dry_run(["-n"]), True)
+check("no flag is live", wd.is_dry_run([]), False)
+check("an unrelated flag is live", wd.is_dry_run(["--verbose"]), False)
+check("a dry flag anywhere counts", wd.is_dry_run(["--verbose", "--dry-run"]), True)
+
+# --- findings reach Linear, not only Slack (ASK-181) -------------------------
+# Bar 2 of the job-migration contract: a finding that only ever exists as a Slack
+# line is read once and scrolls away. Linear holds state.
+_probs = [
+    ("com.kipi.alpha", "failing", "exit 127"),
+    ("com.kipi.beta", "not_loaded", "installed but not running"),
+    ("com.cole.gamma", "paused", "paused on purpose"),
+]
+_found = wd.linear_findings(_probs)
+check("paused is never filed", [f["subject"] for f in _found],
+      ["com.kipi.alpha", "com.kipi.beta"])
+check("failing routes to the launchd-failing detector",
+      _found[0]["detector"], "launchd-failing")
+check("not_loaded routes to the launchd-dark detector",
+      _found[1]["detector"], "launchd-dark")
+check("the failing title carries the exit code",
+      _found[0]["title"], "launchd job failing: com.kipi.alpha (exit 127)")
+check("the dark title names the job", _found[1]["title"],
+      "launchd job is dark: com.kipi.beta")
+check("every finding carries a body", all(f.get("body") for f in _found), True)
+
+# The dedup key must be fleet-health-daily.py's key, byte for byte. That job runs
+# the SAME two checks at 08:15; a second key namespace would file a permanent
+# duplicate Linear issue for every finding both jobs see, and Linear issues do not
+# get deleted here.
+_fh_spec = importlib.util.spec_from_file_location(
+    "fh", Path(__file__).resolve().parent / "fleet-health-daily.py"
+)
+_fh = importlib.util.module_from_spec(_fh_spec)
+_fh_spec.loader.exec_module(_fh)
+check("failing key matches fleet-health's",
+      _found[0]["key"], _fh.finding_key("launchd-failing", "com.kipi.alpha"))
+check("dark key matches fleet-health's",
+      _found[1]["key"], _fh.finding_key("launchd-dark", "com.kipi.beta"))
+
+# ...and fleet-health's filer must be able to say who filed it, or every issue
+# this watchdog files claims to come from a job that did not file it.
+import inspect  # noqa: E402 - local to this assertion
+
+check("file_findings accepts a filer", "filer",
+      "filer" if "filer" in inspect.signature(_fh.file_findings).parameters else "MISSING")
+
+# Linear being unreachable must never take the watchdog down -- a watchdog that
+# dies on a network error stops watching launchd, which is the exact silent death
+# it exists to catch. Swap the cached fleet-health module for one that raises.
+class _Boom:
+    @staticmethod
+    def finding_key(detector, subject):
+        return _fh.finding_key(detector, subject)
+
+    @staticmethod
+    def file_findings(findings, apply, filer=None):
+        raise RuntimeError("linear unreachable")
+
+
+_saved_fh = wd._FLEET_HEALTH
+wd._FLEET_HEALTH = _Boom
+try:
+    _broken = wd.file_linear_findings([("com.kipi.alpha", "failing", "exit 127")])
+finally:
+    wd._FLEET_HEALTH = _saved_fh
+check("a filing error is swallowed, not raised", _broken["created"], 0)
+check("a filing error is counted", _broken["skipped_no_key"], 1)
+
+# Nothing to file must not reach the network at all.
+wd._FLEET_HEALTH = _Boom
+try:
+    _none = wd.file_linear_findings([("com.cole.gamma", "paused", "paused on purpose")])
+finally:
+    wd._FLEET_HEALTH = _saved_fh
+check("a paused-only run files nothing", _none,
+      {"created": 0, "existing": 0, "skipped_no_key": 0})
+
 if failures:
     print("FAIL:")
     for line in failures:


### PR DESCRIPTION
Migrates `com.kipi.launchd-health` onto Linear-tracked execution. ASK-181.

## The four bars

| Bar | Before | After |
|--|--|--|
| 1. launchd, never cron | met (09:30 + 21:30, `StartCalendarInterval`) | unchanged; `schedule-duplicate: 0` confirms no crontab twin |
| 2. failures and findings reach Linear | **not met** — Slack line only | every finding files a deduped Linear issue |
| 3. live or in the pause ledger | met | unchanged; `launchctl list` rc=0, `LastExitStatus = 0` |
| 4. verified by running it | — | ran dry, ran live, ran a live Linear probe |

## What changed

**Findings reach Linear.** A failing or dark job used to produce a Slack line and nothing else. It now also files a Linear issue through `fleet-health-daily.py`'s existing filer, against its existing detector keys (`launchd-failing` / `launchd-dark`).

Sharing those keys is the design, not a shortcut: fleet-health runs the same two checks at 08:15. A private key namespace here would file a **second permanent issue** for every job both of them see, and Linear issues are not deleted in this fleet. `file_findings` gained a `filer` param so the issue names the script that actually filed it. A paused job is never filed, matching "never pinged".

**`--dry-run` now means dry.** Found while running this migration's own checklist. Dry mode was `"--dry" in sys.argv`, an exact string match. The DoR tells the verifier to type `--dry-run`, which did not match — so a read-only check silently took the LIVE path, wrote state, and pinged the founder's phone. `is_dry_run()` accepts `--dry` / `--dry-run` / `-n`.

**Linear down cannot kill the watchdog.** A filing error is caught, counted and printed. A watchdog that dies on a network error stops watching launchd, which is the exact silent death it exists to catch.

## Verification (reproducer-first, RED observed)

RED first: `AttributeError: module 'wd' has no attribute 'is_dry_run'`.

```
$ python3 q-system/.q-system/scripts/test_launchd_health_check.py
PASS: all launchd-health-check logic checks green

$ python3 q-system/.q-system/scripts/test/test-fleet-health-daily.py
PASS: fleet-health-daily contract holds        (12 checks, filer param is additive)

$ python3 q-system/.q-system/scripts/launchd-health-check.py --dry-run | tail -2
[dry] would ping 0 job(s)
[dry] would file 0 linear finding(s)

$ python3 q-system/.q-system/scripts/launchd-health-check.py | tail -1
linear: filed=0 already-tracked=0

$ python3 q-system/.q-system/scripts/fleet-health-daily.py
  launchd-dark: 0        <- this job is loaded, not dark
  launchd-failing: 0
```

16 new test cases. `test_launchd_health_check.py` is already in `capability-manifest.json`, so no manifest line needed.

**A zero result must prove it is empty, not broken.** The fleet is clean, so a live run files 0 — indistinguishable from a broken filer. A probe pushed one synthetic failing job through the real path with `apply=False`:

```
built 1 finding(s) from 2 problem(s) (paused excluded)
  key=fleet-health/launchd-failing/com-kipi-probe-not-a-real-job
  title=launchd job failing: com.kipi.PROBE-not-a-real-job (exit 127)
DRY outcome: {'created': 1, 'existing': 0, 'skipped_no_key': 0}
RESULT: PASS - Linear round trip succeeded; 1 would be filed, 0 already tracked
```

Real `fetch_remote_state` round trip against Linear, real ledger dedup, nothing created. The probe lives in `.review-scratch/probe-linear-path.py` (untracked scratch — it hits the live network, so it does not belong in the capability-gate runner).

## One DoR check that cannot pass as written

The DoR says:

```bash
launchd-health-check.py --dry-run | grep com.kipi.launchd-health
```

That returns nothing, and correctly so — `SELF_LABEL` is excluded from the watchdog's own scan. A job cannot watch itself; an unloaded job cannot report that it is unloaded. Self-coverage comes from `fleet-health-daily.py`, which scans all `com.kipi.*` with no self-exclusion. `launchd-dark: 0` above is that proof.

## Blast radius

Machine-local scheduling, unchanged. The two script edits ship via `kipi update` to the fleet; both are additive (a new flag alias, a new filing call, a defaulted param). Live effect on the founder's machine lands when `~/projects/kipi-system` pulls main — the plist points at that checkout.

## Not doing

What the job checks is unchanged. No prefix-list, classifier, or pause-ledger edits.

🤖 Generated with [Claude Code](https://claude.com/claude-code)