### PR TITLE
fix(capability-gate): the deadline is on child exit, not pipe EOF (ASK-190)

### DIFF
--- a/q-system/.q-system/capability-manifest.json
+++ b/q-system/.q-system/capability-manifest.json
@@ -261,6 +261,10 @@
     {
       "path": "q-system/.q-system/scripts/test/test-converge.sh",
       "runner": "bash"
+    },
+    {
+      "path": "q-system/.q-system/scripts/test/test-capability-gate-reap.sh",
+      "runner": "bash"
     }
   ],
   "required_data": [],

--- a/q-system/.q-system/scripts/capability-gate.py
+++ b/q-system/.q-system/scripts/capability-gate.py
@@ -20,8 +20,10 @@ import argparse
 import datetime
 import json
 import os
+import signal
 import subprocess
 import sys
+import threading
 from pathlib import Path
 
 SCHEMA_VERSION = 1
@@ -285,6 +287,120 @@ def check_required_data(root, manifest, mode, errors):
             errors.append(f"required-data-missing: {entry.get('path')} (scope={scope})")
 
 
+class ContainedResult:
+    """What run_contained observed. `timed_out` is the deadline verdict; stdout /
+    stderr are always populated, partial on a timeout."""
+
+    def __init__(self, returncode, stdout, stderr, timed_out):
+        self.returncode = returncode
+        self.stdout = stdout
+        self.stderr = stderr
+        self.timed_out = timed_out
+
+
+def run_contained(cmd, cwd, env, timeout):
+    """Run a test artifact so that NOTHING it spawns can outlive it or hold the
+    gate past `timeout`.
+
+    Two failures this closes (ASK-190):
+
+    1. `subprocess.run(capture_output=True, timeout=...)` waits on pipe EOF, not
+       on child exit. A test that backgrounds a child which inherits stdout keeps
+       that pipe's write end open, so the gate blocks after the test is already
+       gone -- reporting a PASSING test as RED with no way to tell the two apart.
+    2. On timeout `run()` kills only the direct child. Grandchildren survive as
+       orphans, and the next thing that reads the same pipe inherits the hang.
+
+    `start_new_session=True` puts the child in its own process group, so the
+    group signal below reaches the whole subtree. The group id is the child's
+    own pid -- never this process's group -- so cleanup can never reach the gate
+    itself. (A cleanup that re-raised at its own pid killed its caller once; that
+    is the shape being avoided here.)
+    """
+    proc = subprocess.Popen(
+        cmd, cwd=cwd, env=env, text=True,
+        stdin=subprocess.DEVNULL,
+        stdout=subprocess.PIPE, stderr=subprocess.PIPE,
+        start_new_session=True,
+    )
+    # Read the pgid NOW. `start_new_session=True` makes it equal to proc.pid, but
+    # once the child is reaped its pid is gone and getpgid() would raise -- so
+    # looking it up during cleanup would silently skip the very orphan we are
+    # here to kill.
+    pgid = proc.pid
+
+    # Drain concurrently rather than reading after the wait: a test that writes
+    # more than one pipe buffer (64K) would block on write, never exit, and be
+    # reported as a timeout it did not earn.
+    chunks = {"out": [], "err": []}
+
+    def drain(stream, key):
+        try:
+            for line in iter(stream.readline, ""):
+                chunks[key].append(line)
+        except (ValueError, OSError):
+            pass  # closed under us by the reap; whatever we already read stands
+        finally:
+            try:
+                stream.close()
+            except (ValueError, OSError):
+                pass
+
+    readers = [
+        threading.Thread(target=drain, args=(proc.stdout, "out"), daemon=True),
+        threading.Thread(target=drain, args=(proc.stderr, "err"), daemon=True),
+    ]
+    for t in readers:
+        t.start()
+
+    # The deadline is on the CHILD'S EXIT, not on pipe EOF. That is the entire
+    # fix: a leaked grandchild holding the write end can no longer make a test
+    # that already exited 0 look like a hang.
+    timed_out = False
+    try:
+        proc.wait(timeout=timeout)
+    except subprocess.TimeoutExpired:
+        timed_out = True
+
+    # Unconditional, not timeout-only: a test that exits cleanly while leaking a
+    # child is the common case here, and that orphan both holds this pipe and
+    # outlives the run into whatever reads next.
+    reap_group(proc, pgid)
+    for t in readers:
+        t.join(timeout=5)
+
+    return ContainedResult(
+        None if timed_out else proc.returncode,
+        "".join(chunks["out"]), "".join(chunks["err"]), timed_out,
+    )
+
+
+def reap_group(proc, pgid):
+    """SIGKILL the child's whole process group, then the child, then reap it.
+
+    TERM-then-KILL is not worth the extra deadline: by the time this runs the
+    process either finished or is over budget, and a test that ignores TERM
+    would spend the grace period twice.
+    """
+    # The one line that keeps cleanup off the parent. `pgid` is a child pid, so
+    # this should never match -- but a cleanup that signalled its own group once
+    # killed the harness that called it, and a cheap identity check is worth
+    # more than the assumption that it cannot happen.
+    if pgid and pgid != os.getpgid(0):
+        try:
+            os.killpg(pgid, signal.SIGKILL)
+        except (ProcessLookupError, PermissionError, OSError):
+            pass  # already gone, or the child never got its own session
+    try:
+        proc.kill()
+    except (ProcessLookupError, OSError):
+        pass
+    try:
+        proc.wait(timeout=5)
+    except subprocess.TimeoutExpired:
+        pass
+
+
 def run_tests(root, manifest, mode, errors, notes):
     skeleton_only = set(manifest.get("skeleton_only", []))
     env = dict(os.environ, QROOT=str(root / "q-system"))
@@ -305,18 +421,12 @@ def run_tests(root, manifest, mode, errors, notes):
             continue  # already reported by the diff
         cmd = ["python3", str(full)] if entry["runner"] == "python3" else ["bash", str(full)]
         timeout = entry.get("timeout_s", DEFAULT_TIMEOUT_S)
-        try:
-            r = subprocess.run(cmd, cwd=root, env=env, capture_output=True,
-                               text=True, timeout=timeout)
-        except subprocess.TimeoutExpired as exc:
+        r = run_contained(cmd, root, env, timeout)
+        if r.timed_out:
             # the partial output often names the hang (a prompt, a URL being
             # polled) — discarding it made timeouts undiagnosable (codex,
             # sag-runner-contract)
-            partial = ((exc.stdout or b"") if isinstance(exc.stdout, (bytes, bytearray))
-                       else (exc.stdout or "").encode())
-            partial += ((exc.stderr or b"") if isinstance(exc.stderr, (bytes, bytearray))
-                        else (exc.stderr or "").encode())
-            tail = "\n".join(partial.decode(errors="replace").splitlines()[-20:])
+            tail = "\n".join((r.stdout + r.stderr).splitlines()[-20:])
             errors.append(f"test-timeout ({timeout}s): {path}" + (f"\n{tail}" if tail else ""))
             continue
         ran += 1

--- a/q-system/.q-system/scripts/test/test-capability-gate-reap.sh
+++ b/q-system/.q-system/scripts/test/test-capability-gate-reap.sh
@@ -1,0 +1,127 @@
+#!/usr/bin/env bash
+# Reproducer + acceptance criteria for the capability gate's test runner (ASK-190).
+#
+# THE DEFECT IT CLOSES: the gate ran every declared test through
+# `subprocess.run(capture_output=True, timeout=N)`, which waits on pipe EOF, not
+# on child exit. A test that backgrounds a child inheriting stdout keeps that
+# pipe's write end open after the test itself has exited, so the gate blocks
+# until its own deadline and then reports a PASSING test as
+# `RED: test-timeout`. Five reviewed PRs sat unmergeable behind exactly that.
+#
+# The second half is the orphan: on timeout `run()` killed only the direct child,
+# so backgrounded grandchildren survived the run and the next reader of the same
+# pipe inherited the hang.
+#
+# WHY THIS DRIVES run_contained DIRECTLY rather than the gate CLI: run_contained
+# IS the gate's test runner, and driving it takes seconds against real fixture
+# processes instead of scaffolding a whole fake repo root. The wiring block at
+# the bottom is what stops the unit from drifting away from its caller.
+set -uo pipefail
+ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/../../../.." && pwd)"
+GATE="$ROOT/q-system/.q-system/scripts/capability-gate.py"
+
+PASS=0
+fail() { echo "FAIL: $1" >&2; exit 1; }
+ok()   { PASS=$((PASS + 1)); echo "  ok: $1"; }
+
+[ -f "$GATE" ] || fail "capability-gate.py does not exist at $GATE"
+
+WORK="$(mktemp -d)"
+# Sentinels are distinctive sleep durations so pgrep can find a survivor without
+# matching some unrelated `sleep` on the machine.
+BG_SENTINEL=987
+HANG_SENTINEL=986
+cleanup() {
+  pkill -f "sleep $BG_SENTINEL" 2>/dev/null
+  pkill -f "sleep $HANG_SENTINEL" 2>/dev/null
+  rm -rf "$WORK"
+}
+trap cleanup EXIT
+
+# --- fixture 1: exits 0 immediately, but leaves a child holding stdout --------
+cat > "$WORK/bg-holder.sh" <<EOF
+#!/usr/bin/env bash
+echo "assertion-one ok"
+sleep $BG_SENTINEL &
+echo "assertion-two ok"
+exit 0
+EOF
+
+# --- fixture 2: hangs itself AND leaves a backgrounded child ------------------
+cat > "$WORK/hangs.sh" <<EOF
+#!/usr/bin/env bash
+echo "started"
+sleep $HANG_SENTINEL &
+sleep $HANG_SENTINEL
+EOF
+chmod +x "$WORK/bg-holder.sh" "$WORK/hangs.sh"
+
+run_contained_case() {
+  # <script> <timeout> -> prints "<timed_out> <rc> <elapsed_s> <stdout-oneline>"
+  python3 - "$GATE" "$1" "$2" <<'PY'
+import importlib.util, sys, time
+spec = importlib.util.spec_from_file_location("capgate", sys.argv[1])
+m = importlib.util.module_from_spec(spec)
+spec.loader.exec_module(m)
+t = time.time()
+r = m.run_contained(["bash", sys.argv[2]], None, None, float(sys.argv[3]))
+print(r.timed_out, r.returncode, round(time.time() - t, 1),
+      " / ".join(r.stdout.split()))
+PY
+}
+
+# --- the headline case: a passing test must be reported as passing ------------
+# Deadline is 15s. The leaked child sleeps 987s, so pre-fix this blocks on pipe
+# EOF and comes back `True` (timed out) after 15s on a test that exited 0 in
+# milliseconds.
+RES="$(run_contained_case "$WORK/bg-holder.sh" 15)"
+TIMED_OUT="$(echo "$RES" | cut -d' ' -f1)"
+RC="$(echo "$RES" | cut -d' ' -f2)"
+ELAPSED="$(echo "$RES" | cut -d' ' -f3)"
+[ "$TIMED_OUT" = "False" ] \
+  || fail "a test that exits 0 was reported as timed out; the runner waited on pipe EOF, not child exit ($RES)"
+[ "$RC" = "0" ] || fail "expected rc=0 from a passing fixture, got rc=$RC ($RES)"
+python3 -c "import sys; sys.exit(0 if $ELAPSED < 10 else 1)" \
+  || fail "runner took ${ELAPSED}s on a fixture that exits immediately; it is still blocking on the pipe"
+ok "a test that exits 0 while leaking a child is reported as PASSED, not test-timeout"
+
+echo "$RES" | grep -q 'assertion-one' \
+  || fail "stdout lost: the assertions the fixture printed are missing ($RES)"
+ok "stdout is still captured when the child is reaped (a green test keeps its output)"
+
+pgrep -f "sleep $BG_SENTINEL" >/dev/null 2>&1 \
+  && fail "the backgrounded child outlived the run; orphans are what re-create this bug"
+ok "the backgrounded child is reaped, not left running"
+
+# --- the timeout case: still bounded, still leaves nothing behind -------------
+RES2="$(run_contained_case "$WORK/hangs.sh" 3)"
+TIMED_OUT2="$(echo "$RES2" | cut -d' ' -f1)"
+ELAPSED2="$(echo "$RES2" | cut -d' ' -f3)"
+[ "$TIMED_OUT2" = "True" ] || fail "a genuinely hanging test must still time out, got $RES2"
+python3 -c "import sys; sys.exit(0 if $ELAPSED2 < 12 else 1)" \
+  || fail "timeout path took ${ELAPSED2}s against a 3s deadline; the post-kill read is unbounded"
+ok "a real hang still times out, and the deadline is not doubled by the cleanup read"
+
+echo "$RES2" | grep -q 'started' \
+  || fail "partial output discarded on timeout; that is what made timeouts undiagnosable"
+ok "partial output survives the timeout (the tail names what hung)"
+
+pgrep -f "sleep $HANG_SENTINEL" >/dev/null 2>&1 \
+  && fail "timeout killed only the direct child; the backgrounded grandchild survived"
+ok "timeout kills the whole process group, grandchildren included"
+
+# --- wiring: the unit above is the one the gate actually uses -----------------
+grep -q 'r = run_contained(' "$GATE" \
+  || fail "run_tests no longer calls run_contained; this suite would be testing dead code"
+grep -q 'start_new_session=True' "$GATE" \
+  || fail "no start_new_session: without its own session there is no group to kill"
+grep -q 'os.killpg' "$GATE" || fail "gate no longer kills the process group"
+grep -q 'proc.wait(timeout=timeout)' "$GATE" \
+  || fail "the deadline is no longer on child exit; waiting on pipe EOF is the bug itself"
+grep -q 'subprocess.run(cmd' "$GATE" \
+  && fail "a test artifact is being run through subprocess.run again; that waits on pipe EOF"
+python3 -c "import ast,sys; ast.parse(open(sys.argv[1]).read())" "$GATE" \
+  || fail "capability-gate.py does not parse"
+ok "wiring: run_tests uses run_contained, own session, group kill, and parses"
+
+echo "PASS: $PASS/$PASS capability-gate reap checks"

--- a/q-system/.q-system/scripts/test/test-converge.sh
+++ b/q-system/.q-system/scripts/test/test-converge.sh
@@ -188,9 +188,21 @@ export ISSUE_UNDER_TEST="ASK-999"
 echo "301" > "$FAKE_PR_FILE"; echo "0" > "$FAKE_ROUND_FILE"
 rm -f "$CLAIMS"
 
+# `set -m` gives this background job its OWN process group (pgid == CONV_PID), so
+# cleanup can reap the whole subtree by group instead of by name. Without it,
+# `pkill -f bin/slowworker` killed the worker shell but NOT its `sleep 120`
+# child, and that orphan outlived the entire suite (ASK-190).
+#
+# The group id is a CHILD pid, never this shell's pgid, so a group signal below
+# can never reach the test harness itself. That distinction is the whole safety
+# story here: a cleanup that re-signals its own pid killed its caller once.
+set -m
 KIPI_CONVERGE_WORKER="$WORK/bin/slowworker" bash "$CONV" --issue ASK-999 --max-rounds 1 \
   >"$WORK/out" 2>&1 &
 CONV_PID=$!
+set +m
+# Nothing from this case may outlive the suite, even on an early `fail`.
+trap 'kill -KILL -'"$CONV_PID"' 2>/dev/null; rm -rf "$WORK"' EXIT
 
 # Wait for the claim to actually exist before killing -- killing before the
 # claim is taken would pass vacuously and prove nothing.
@@ -203,8 +215,16 @@ ok "claim is held while the run is in flight (kill case is live, not vacuous)"
 # returns 143 -- which aborted this suite at exactly this line, reporting rc=143
 # with every later case silently unrun. A test harness that dies while asserting
 # on a kill is indistinguishable from the bug it is testing for.
+#
+# Signal the GROUP, not just converge.sh. converge.sh runs the worker as a
+# FOREGROUND command (converge.sh:148), and bash defers a trap handler until the
+# running foreground command returns -- so a TERM aimed only at CONV_PID sat
+# unhandled for the worker's full `sleep 120`, and the `wait` below blocked with
+# it. That is what pushed this suite to 122s and made the 60s capability gate
+# report a PASSING test as RED (ASK-190). A real `kill` from a terminal or a
+# launchd stop signals the group too, so this is also the more faithful case.
 set +e
-kill -TERM "$CONV_PID" 2>/dev/null
+kill -TERM -"$CONV_PID" 2>/dev/null
 wait "$CONV_PID" 2>/dev/null
 set -e
 # Give the trap its moment; it shells python3 to release.
@@ -226,8 +246,20 @@ print((d or {}).get('issue',''))" 2>/dev/null)"
   || fail "SIGTERM leaked the claim on ASK-999 -- this is the ASK-181 board wedge"
 ok "SIGTERM mid-run releases the claim (board is not wedged by a killed run)"
 
-pkill -f 'bin/slowworker' 2>/dev/null || true
+# Reap the group, not the name: `pkill -f bin/slowworker` never matched the
+# worker's `sleep 120` child, whose own command line is just "sleep 120".
+kill -KILL -"$CONV_PID" 2>/dev/null || true
+trap 'rm -rf "$WORK"' EXIT
 unset KIPI_LINEAR_CLAIMS REAL_CLAIM ISSUE_UNDER_TEST
+
+# The suite must leave nothing running. An orphan that survives the assertions
+# is invisible to `rc=0` and only shows up as a timeout in whatever harness runs
+# this next.
+# `|| true` inside the substitution: pgrep exits 1 on no-match, and with the
+# suite's `pipefail` + `set -e` that clean result would abort the run.
+LEAKED="$( { pgrep -g "$CONV_PID" 2>/dev/null || true; } | wc -l | tr -d ' ')"
+[ "$LEAKED" = "0" ] || fail "kill case leaked $LEAKED process(es) in group $CONV_PID"
+ok "kill case leaves no orphan behind (nothing outlives the suite)"
 
 grep -q 'trap .*TERM' "$CONV" || fail "converge lost its TERM trap"
 ok "TERM/INT/HUP traps wired"


### PR DESCRIPTION
Closes the `validate` RED that has five reviewed PRs (#11 #12 #13 #14 #15) stuck on
*"the base branch policy prohibits the merge"*.

## What was actually wrong

Run `30274434715`, failing step **Capability gate**, one error:

```
RED: test-timeout (60s): q-system/.q-system/scripts/test/test-converge.sh
```

The suite **passes**. Every assertion prints `ok`, including the last, and it still
times out.

`capability-gate.py` ran every declared test through
`subprocess.run(capture_output=True, timeout=60)`, which waits on **pipe EOF, not
child exit**. `test-converge.sh`'s kill case backgrounds a worker whose `sleep 120`
inherits stdout, so the write end of that pipe stayed open for 120s after the suite
had already exited 0. Unpiped it passes in milliseconds, which is why it shipped
(introduced by `4b5a7af`, the ASK-113 kill-leak reproducer).

## The two fixes

**1. The gate** — `run_contained()` replaces `subprocess.run` for test artifacts:

- `start_new_session=True`, so each test owns a process group.
- The deadline is on `proc.wait(timeout=...)` (child exit), not on pipe EOF.
- stdout/stderr drain on concurrent threads, so a test writing past the 64K pipe
  buffer is not misreported as a hang.
- The group reap is **unconditional**, not timeout-only: a test that exits clean
  while leaking a child is the common case, and that orphan both holds the pipe and
  outlives the run.
- Partial output still survives a real timeout (the tail is what names the hang).

**Safety, since this touches how every declared test is run:** cleanup checks
`pgid != os.getpgid(0)` before signalling, and the pgid is read at spawn (not during
cleanup, where the reaped pid would raise and silently skip the orphan). The DoR
flags this exact shape — a cleanup trap re-raised a signal at its own pid and killed
its caller earlier that night. Cleanup can never reach the parent here.

**2. The test** — stop leaking the orphan:

- `set -m` puts the kill case in its own process group.
- The TERM goes to the **group**. `converge.sh` runs the worker as a foreground
  command and bash defers a trap until that returns, so a TERM aimed only at the
  driver pid sat unhandled for the worker's full `sleep 120`. That is what made the
  suite 122s. A real terminal or launchd stop signals the group too, so this is also
  the more faithful case.
- Reap by group, not by name: `pkill -f bin/slowworker` never matched the child,
  whose own command line is just `sleep 120`.
- New assertion: the suite fails if anything survives it.

## Evidence

**RED, gate side** — `subprocess.run(..., timeout=60)` against the HEAD suite:

```
RED: test-timeout (60s): .../.red-converge-HEAD.sh  [elapsed 60.0s]
  the suite's own last lines: ok: a run with no commits still exits 7 ... | ok: claim is held while the run is in flight ...
```

**RED, suite side** — HEAD suite piped:

```
PASS: 16/16 converge checks
PIPED elapsed: 123s
```

**RED, new reap suite against the pre-fix gate:**

```
FAIL: a test that exits 0 was reported as timed out; the runner waited on pipe EOF, not child exit
rc=1
```

**GREEN** — `bash q-system/.q-system/scripts/test/test-capability-gate-reap.sh`:

```
  ok: a test that exits 0 while leaking a child is reported as PASSED, not test-timeout
  ok: stdout is still captured when the child is reaped (a green test keeps its output)
  ok: the backgrounded child is reaped, not left running
  ok: a real hang still times out, and the deadline is not doubled by the cleanup read
  ok: partial output survives the timeout (the tail names what hung)
  ok: timeout kills the whole process group, grandchildren included
  ok: wiring: run_tests uses run_contained, own session, group kill, and parses
PASS: 7/7 capability-gate reap checks
```

**GREEN** — `test-converge.sh` piped, post-fix: `PASS: 17/17 converge checks`,
`PIPED elapsed: 2s` (was 123s).

**GREEN** — the real gate, `python3 q-system/.q-system/scripts/capability-gate.py --repo-root .`:

```
  tests: ran=66 quarantined=0 skipped-skeleton-only=0
capability-gate: GREEN
gate rc=0
```

## Wiring

`test-capability-gate-reap.sh` is declared in `capability-manifest.json` (`runner:
bash`), so it runs in CI with the other 65 — the silent-absence gate would flag it
otherwise. Its last block greps the gate for `run_contained(`, `start_new_session`,
`os.killpg` and `proc.wait(timeout=timeout)`, and **fails if `subprocess.run(cmd`
comes back**, so the unit cannot drift away from its caller or silently regress.

## Not doing (per the DoR)

The 46 Gate 1.3b containment findings (ASK-58/ASK-59), any ratchet, any merge. Those
were an unverified downstream blocker — GitHub fail-fast stopped at the capability
gate, so `validate-separation.py:589` was never reached.

**If `validate` is still red after this**, it fails at **Phase 1** with a findings
count, and the answer is the ratchet this repo already ships
(`instruction-budget-audit.py --ratchet` + `instruction-budget-baseline.json`).
Gate 1.3b is binary today (`semantic_violations == []`) with no baseline; giving it
one is a code change in `validate-separation.py`, not a merge-time judgment call.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
