### PR TITLE
fix(fleet-health): the cron detector publishes a line reference, not the line (ASK-204)

### DIFF
--- a/q-system/.q-system/scripts/fleet-health-daily.py
+++ b/q-system/.q-system/scripts/fleet-health-daily.py
@@ -722,7 +722,12 @@ def _shells_claude(command: str, _depth: int = 0) -> bool:
     if _depth > 5:
         return False
     command = _strip_comment(command)
-    for tokens in _shell_segments(command):
+    # Substitutions come OUT before the segment walk lexes, and go back in as one
+    # argument-shaped token each. Their contents are walked separately below, at
+    # the same depth cap. Leaving them inline let a substitution's internal space
+    # split an assignment prefix across two tokens (see _split_substitutions).
+    masked, inner_commands = _split_substitutions(command)
+    for tokens in _shell_segments(masked):
         command_index = _command_index(tokens)
         command_token = tokens[command_index] if command_index >= 0 else ""
         if _is_claude_token(command_token):
@@ -732,9 +737,9 @@ def _shells_claude(command: str, _depth: int = 0) -> bool:
             if inner and _shells_claude(inner, _depth + 1):
                 return True
     # A substitution is a command position of its own, and the segment walk above
-    # cannot reach one that a quote has kept whole. Same recursion, same depth cap
-    # as the `-c` string: what runs inside `$( )` or backticks is a command, not text.
-    for inner in _substitutions(command):
+    # cannot reach one: it saw a placeholder. Same recursion, same depth cap as
+    # the `-c` string: what runs inside `$( )` or backticks is a command, not text.
+    for inner in inner_commands:
         if _shells_claude(inner, _depth + 1):
             return True
     return False

--- a/q-system/.q-system/scripts/fleet-health-daily.py
+++ b/q-system/.q-system/scripts/fleet-health-daily.py
@@ -119,17 +119,62 @@ def _is_loaded(label: str) -> bool:
         return True  # cannot tell -> do not cry wolf
 
 
-def detect_dark_jobs(_ctx) -> list:
-    """A plist on disk, not loaded, and NOT in the paused ledger = silent death."""
-    paused = _paused_labels()
-    out = []
-    for label in _launchd_labels():
-        if not label.startswith(("com.kipi.", "com.cole.", "com.ask.", "com.assaf.",
-                                 "com.claudedaddy.", "com.purespectrum.", "com.personal.")):
-            continue
-        if label in paused or _is_loaded(label):
-            continue
-        out.append({
+# ---------------------------------------------------------------------------
+# ONE rendering per launchd kipi-key, shared by BOTH filers
+# ---------------------------------------------------------------------------
+# Two scripts file against these keys: this one at 08:15 and
+# launchd-health-check.py at 09:30 and 21:30 (ASK-181 made them share the key on
+# purpose -- a private namespace on either side files a SECOND permanent issue for
+# the same dead job). `finding_hash` covers title + body, so sharing a key while
+# rendering different text means every alternating run sees a stale hash and
+# rewrites the issue: 13 Linear mutations a week and a "1 updated ... nothing to
+# do now" Slack line every morning on a fleet where nothing moved. That is the
+# checker training the operator to skip the line the real alert has to compete
+# with (PR #19 round-3 review, major). One key, one renderer -- both callers come
+# through here so the next edit cannot land on one side only.
+LAUNCHD_FINDING_IDS = ("launchd-failing", "launchd-dark")
+
+
+def launchd_exit_detail(list_status) -> str:
+    """`exit N` for a `launchctl list` STATUS column value.
+
+    The two readers see one machine state in TWO encodings: `launchctl list`
+    prints a SIGNED status while `launchctl list <label>` prints the RAW wait
+    status that launchd-health-check.py's `normalize_exit` decodes. Measured on
+    this machine 2026-07-27 across 210 non-zero rows: a SIGKILLed job reads `-9`
+    in the column and `"LastExitStatus" = 9`; `com.apple.BiomeAgent` reads `5`
+    and `1280`. `abs()` lands both encodings in the same space, so the detail
+    this renderer interpolates does not depend on WHICH script looked.
+
+    A column value that is not a number keeps its text rather than becoming a
+    fabricated `exit 0` -- an unparsable status is a thing to show, not to round.
+    """
+    try:
+        return f"exit {abs(int(list_status))}"
+    except (TypeError, ValueError):
+        return f"exit {list_status}"
+
+
+def launchd_finding(detector_id: str, label: str, detail: str = "") -> dict:
+    """The finding dict for one launchd problem: {subject, title, body}.
+
+    The ONLY place either filer renders these. `detail` is a `launchd_exit_detail`
+    string and is ignored for `launchd-dark`, which has no exit status.
+    """
+    if detector_id == "launchd-failing":
+        return {
+            "subject": label,
+            "title": f"launchd job failing: {label} ({detail})",
+            "body": (
+                f"`{label}` is loaded but its last run exited non-zero (**{detail}**).\n\n"
+                "## Action\nRead its `StandardErrorPath`, fix the cause, and confirm a clean "
+                "run. If the failure is environmental (auth expiry, server down), say so on "
+                "this issue rather than retrying -- `self-healing-retry.md` rule 5 stops "
+                "environmental failures on attempt 1."
+            ),
+        }
+    if detector_id == "launchd-dark":
+        return {
             "subject": label,
             "title": f"launchd job is dark: {label}",
             "body": (
@@ -140,7 +185,23 @@ def detect_dark_jobs(_ctx) -> list:
                 f"- Resume: `launchctl bootstrap gui/$(id -u) ~/Library/LaunchAgents/{label}.plist`\n"
                 f"- Or record the pause: add `{label}` to `~/.config/kipi/launchd-paused.txt`"
             ),
-        })
+        }
+    # Loud, not silent: a caller inventing a launchd detector id would otherwise
+    # file an issue with an empty body under a key the other filer also writes.
+    raise ValueError(f"no launchd rendering for detector id {detector_id!r}")
+
+
+def detect_dark_jobs(_ctx) -> list:
+    """A plist on disk, not loaded, and NOT in the paused ledger = silent death."""
+    paused = _paused_labels()
+    out = []
+    for label in _launchd_labels():
+        if not label.startswith(("com.kipi.", "com.cole.", "com.ask.", "com.assaf.",
+                                 "com.claudedaddy.", "com.purespectrum.", "com.personal.")):
+            continue
+        if label in paused or _is_loaded(label):
+            continue
+        out.append(launchd_finding("launchd-dark", label))
     return out
 
 
@@ -162,17 +223,8 @@ def detect_failing_jobs(_ctx) -> list:
             continue
         if status in ("0", "-"):
             continue
-        out.append({
-            "subject": label,
-            "title": f"launchd job failing: {label} (exit {status})",
-            "body": (
-                f"`{label}` is loaded but its last run exited **{status}**.\n\n"
-                "## Action\nRead its `StandardErrorPath`, fix the cause, and confirm a clean "
-                "run. If the failure is environmental (auth expiry, server down), say so on "
-                "this issue rather than retrying -- `self-healing-retry.md` rule 5 stops "
-                "environmental failures on attempt 1."
-            ),
-        })
+        out.append(launchd_finding("launchd-failing", label,
+                                   launchd_exit_detail(status)))
     return out
 
 
@@ -381,6 +433,19 @@ _WRAPPER_VALUE_FLAGS = {
 # a lock file or a host named `claude`.
 _WRAPPER_OPERANDS = {"flock": 1, "ssh": 1}
 
+# ssh does NOT exec its remote operands the way flock and sudo do. It joins
+# everything after the destination with single spaces and hands ONE string to a
+# shell on the far side, which lexes it itself. So the remote command has to be
+# re-parsed as a command string -- exactly like a `-c` argument -- and reading it
+# as tokens in the local segment made the QUOTED form (`ssh mini 'claude -p
+# sweep'`, the form you write so the LOCAL shell does not expand it) lex to a
+# single token whose basename is `claude -p sweep`, not `claude`. The unquoted
+# form was pinned by the suite and the quoted one was a silent false negative
+# (PR #19 round-3 review, minor 2). flock stays OUT of this set on purpose: it
+# execs its operands directly, so `flock /tmp/x.lock echo 'a; claude -p x'` runs
+# no claude and re-lexing it would invent one.
+_REMOTE_SHELL_WRAPPERS = {"ssh"}
+
 # A shell in command position does not RUN what follows; it runs the string
 # handed to its `-c` flag. `bash -lc 'claude -p ...'` is the shape a cron line
 # uses to get a login environment, so the command inside the quotes has to be
@@ -463,18 +528,32 @@ def _takes_next_token(token: str, wrapper: str) -> bool:
 
 
 def _command_index(tokens: list) -> int:
-    """Index of the real command in a shell segment, past env prefixes and
-    wrappers. -1 when the segment holds no command.
+    """Index of the real command in a shell segment. See `_command_scan`."""
+    return _command_scan(tokens)[0]
+
+
+def _command_scan(tokens: list) -> tuple:
+    """(command index, remote-command index) for a shell segment.
+
+    The command index is the real command past env prefixes and wrappers, or -1
+    when the segment holds no command.
 
     Tracks WHICH wrapper is in effect, because a bare `startswith("-")` skip
     reads a flag and leaves its value exposed: `sudo -u claude run.sh` scored
     `claude` -- the value of `-u` -- as the command (fourth review, finding 4).
     An option's argument belongs to the option, and a wrapper's leading operand
     (flock's lock file, ssh's host) belongs to the wrapper.
+
+    The remote index is where a `_REMOTE_SHELL_WRAPPERS` wrapper's remote command
+    STARTS (-1 when there is none). Recorded here rather than derived from the
+    command index because a second wrapper resets the tracked one: in `ssh mini
+    timeout 30 'claude -p x'` the wrapper in effect at the command is `timeout`,
+    yet everything from `timeout` onward is still what ssh hands the far shell.
     """
     skip_value = False
     operands_left = 0
     wrapper = ""
+    remote_index = -1
     for index, token in enumerate(tokens):
         if skip_value:
             skip_value = False
@@ -483,7 +562,10 @@ def _command_index(tokens: list) -> int:
             continue  # VAR=value prefix
         if token.startswith("-"):
             if _is_lookup_flag(token, wrapper):
-                return -1  # `command -v claude` resolves a path, it runs nothing
+                # `command -v claude` resolves a path, it runs nothing. The
+                # remote index rides along: over ssh the far shell re-parses the
+                # string and reaches the same answer for the same reason.
+                return -1, remote_index
             skip_value = _takes_next_token(token, wrapper)
             continue
         if token in SHELL_KEYWORDS:
@@ -497,9 +579,11 @@ def _command_index(tokens: list) -> int:
             continue
         if operands_left:
             operands_left -= 1
+            if not operands_left and wrapper in _REMOTE_SHELL_WRAPPERS:
+                remote_index = index + 1  # past ssh's destination: the remote command
             continue  # flock's lock file / ssh's destination, not the command
-        return index
-    return -1
+        return index, remote_index
+    return -1, remote_index
 
 
 def _command_token(tokens: list) -> str:
@@ -772,7 +856,7 @@ def _shells_claude(command: str, _depth: int = 0) -> bool:
     # split an assignment prefix across two tokens (see _split_substitutions).
     masked, inner_commands = _split_substitutions(command)
     for tokens in _shell_segments(masked):
-        command_index = _command_index(tokens)
+        command_index, remote_index = _command_scan(tokens)
         command_token = tokens[command_index] if command_index >= 0 else ""
         if _is_claude_token(command_token):
             return True
@@ -780,6 +864,25 @@ def _shells_claude(command: str, _depth: int = 0) -> bool:
             inner = _shell_c_argument(tokens, command_index)
             if inner and _shells_claude(inner, _depth + 1):
                 return True
+        # ssh's remote operands are JOINED with spaces and re-lexed by the far
+        # shell, so they are a command STRING, not tokens in this segment. Joining
+        # the already-lexed tokens is the faithful model: ssh concatenates its
+        # argv after the local shell removed the quotes, which is why `ssh mini
+        # echo "a; claude -p x"` really does run claude on the far side.
+        if remote_index >= 0:
+            remote = " ".join(tokens[remote_index:])
+            if remote and _shells_claude(remote, _depth + 1):
+                return True
+    # A line sh REFUSES TO RUN runs nothing -- including whatever sits inside its
+    # substitutions. `_shell_segments` already obeys that (an unbalanced quote
+    # collapses to one coarse segment and never splits on an operator), and its
+    # rule is "one segment can only be coarser than sh, never finer". The walk
+    # below is FINER: `_split_substitutions` happily extracts `$(claude -p x)`
+    # out of an unterminated double-quoted span and scored it as an invocation,
+    # filing a permanent Linear issue for a line /bin/sh answers with a syntax
+    # error (PR #19 round-3 review, minor 3).
+    if _lex(_strip_comment(masked)) is None:  # the exact test `_shell_segments` makes
+        return False
     # A substitution is a command position of its own, and the segment walk above
     # cannot reach one: it saw a placeholder. Same recursion, same depth cap as
     # the `-c` string: what runs inside `$( )` or backticks is a command, not text.

--- a/q-system/.q-system/scripts/fleet-health-daily.py
+++ b/q-system/.q-system/scripts/fleet-health-daily.py
@@ -222,7 +222,44 @@ def _crontab_text() -> str:
     return _read_crontab_result(res.returncode, res.stdout, res.stderr)
 
 
-def detect_duplicate_schedules(_ctx, cron_text=None) -> list:
+class RunContext:
+    """Per-run shared state for the detectors. Today: ONE `crontab -l` per run.
+
+    Two detectors read the crontab. `run_detectors` passed None as the context, so
+    each one shelled out for itself and a test asserting only that a `cron_text`
+    PARAMETER existed was labelled proof that "neither shells out twice" (PR #19
+    review, minor 4). The parameter existed; the wiring did not.
+
+    The FAILURE is cached alongside the value and re-raised per caller, so one read
+    still produces two independent blind spots. Collapsing them would buy the dedup
+    with a silent all-clear for whichever detector ran second -- the exact trade
+    `run_detectors` exists to refuse.
+    """
+
+    def __init__(self, read_crontab=None):
+        self._read_crontab = read_crontab or _crontab_text
+        self._crontab = None  # (text, exception), whichever the read produced
+
+    def crontab(self) -> str:
+        if self._crontab is None:
+            try:
+                self._crontab = (self._read_crontab(), None)
+            except Exception as exc:  # noqa: BLE001 - replayed to every caller
+                self._crontab = (None, exc)
+        text, exc = self._crontab
+        if exc is not None:
+            raise exc
+        return text
+
+
+def _crontab_for(ctx, cron_text):
+    """The crontab a detector should read: injected > shared > its own read."""
+    if cron_text is not None:
+        return cron_text
+    return ctx.crontab() if isinstance(ctx, RunContext) else _crontab_text()
+
+
+def detect_duplicate_schedules(ctx, cron_text=None) -> list:
     """The same script scheduled by BOTH launchd and crontab.
 
     Found live 2026-07-26: reddit-build-radar runs at 08:00 from
@@ -234,7 +271,7 @@ def detect_duplicate_schedules(_ctx, cron_text=None) -> list:
     that reaches the body is one that already appears in `~/Library/LaunchAgents/`.
     A path that matched nothing is never published.
     """
-    cron = _crontab_text() if cron_text is None else cron_text
+    cron = _crontab_for(ctx, cron_text)
     # Resolve to ABSOLUTE paths, never basenames. Measured 2026-07-26: matching on
     # the basename `run_daily.sh` hit 3 plists (reddit-radar-daily, daily-podcast,
     # story-podcast) when only ONE is a real duplicate -- the other two are
@@ -592,7 +629,14 @@ def _split_substitutions(command: str) -> tuple:
             masked.append(command[index:index + 2])
             index += 2  # escaped next char, in double quotes or unquoted
             continue
-        if char == "'":
+        if char == "'" and not quote:
+            # `and not quote` is load-bearing: reaching here with quote == '"'
+            # means an APOSTROPHE inside a double-quoted span, which sh treats as
+            # a literal character. Opening a single-quote span on it inverted the
+            # state for the rest of the line, so `echo "don't $(claude -p x)"` --
+            # a real invocation -- was missed, and `echo "don't" 'run `claude -p
+            # x` now'` -- prose -- was scored as one and would have filed a
+            # PERMANENT false-positive issue (PR #19 review, minor 2).
             quote = "'"
         elif char == '"':
             quote = "" if quote == '"' else '"'
@@ -760,7 +804,7 @@ def offending_cron_lines(cron: str) -> list:
             if _shells_claude(_cron_command(line))]
 
 
-def detect_cron_shells_claude(_ctx, cron_text=None) -> list:
+def detect_cron_shells_claude(ctx, cron_text=None) -> list:
     """A crontab line that invokes `claude`. It cannot work: cron has no keychain.
 
     Probed 2026-07-23 (`reddit-build-radar/logs/cron-probe/result.txt`):
@@ -782,7 +826,7 @@ def detect_cron_shells_claude(_ctx, cron_text=None) -> list:
     Raises CrontabUnavailable when the crontab could not be read at all, so a
     blind run is reported as an error rather than as a clean bill of health.
     """
-    cron = _crontab_text() if cron_text is None else cron_text
+    cron = _crontab_for(ctx, cron_text)
     numbers = offending_cron_lines(cron)
     if not numbers:
         return []
@@ -1349,9 +1393,11 @@ def run_detectors(detectors=None) -> tuple:
     """
     all_findings = []
     per_detector = {}
+    # ONE context for the whole run, so the two crontab readers share a read.
+    context = RunContext()
     for d in detectors if detectors is not None else DETECTORS:
         try:
-            found = d["detect"](None) or []
+            found = d["detect"](context) or []
         except Exception as exc:  # noqa: BLE001 - a health check must not crash its job
             print(f"  detector {d['id']} errored: {exc}", file=sys.stderr)
             per_detector[d["id"]] = DETECTOR_ERROR

--- a/q-system/.q-system/scripts/fleet-health-daily.py
+++ b/q-system/.q-system/scripts/fleet-health-daily.py
@@ -28,6 +28,24 @@ So a detector here is not shippable without all three legs:
 `validate_detectors()` refuses to run if any detector breaks that contract, and
 test-fleet-health-daily.py asserts it. Prose cannot hold this line; the registry can.
 
+A FINDING CARRIES A REFERENCE, NEVER UNTRUSTED TEXT (ASK-204):
+
+    A Linear issue filed here is PERMANENT. Any detector that reads arbitrary
+    operator input -- a crontab line, an exception message -- publishes a
+    reference to it (which line, which exception type) and never the input
+    itself. The previous design copied the crontab line in with best-effort
+    regex redaction over it; that is a denylist against unbounded shell syntax,
+    and nine review rounds found nine distinct bypasses (a Slack webhook path, a
+    Bearer token, a `bash -lc 'KEY=... claude'` credential, a backtick word
+    start, `lin_api_`/`ntn_` shapes). Each fix was correct; the architecture was
+    not. The operator opens their own crontab. Nothing untrusted crosses into a
+    permanent external record, so there is nothing to redact and no bypass left
+    to find.
+
+    This constrains what a finding CARRIES, not what a detector READS. Deciding
+    whether a line shells `claude` still parses the line in full, including
+    quoting and command substitution.
+
 ALERTING: ONE Slack summary line, never one ping per finding. The findings live in
 Linear where they hold state. Slack is a pointer, not a ledger.
 
@@ -38,13 +56,15 @@ goes to stdout and the ledger.
 from __future__ import annotations
 
 import argparse
+import hashlib
 import json
 import os
 import re
+import shlex
 import subprocess
 import sys
 from datetime import datetime, timezone
-from pathlib import Path
+from pathlib import Path, PurePosixPath
 
 HERE = Path(__file__).resolve().parent
 QROOT = HERE.parent.parent
@@ -113,65 +133,108 @@ def detect_dark_jobs(_ctx) -> list:
             "subject": label,
             "title": f"launchd job is dark: {label}",
             "body": (
-                f"`{label}` has a plist in `~/Library/LaunchAgents/` but is not loaded, "
-                "and it is NOT in the paused ledger — so nothing recorded a decision to "
-                "stop it.\n\n"
+                f"`{label}` has a plist in `~/Library/LaunchAgents/` but is not loaded, and "
+                "it is NOT in the paused ledger -- so nothing recorded a decision to stop "
+                "it. An unloaded job cannot report its own death.\n\n"
                 "## Action\n"
                 f"- Resume: `launchctl bootstrap gui/$(id -u) ~/Library/LaunchAgents/{label}.plist`\n"
-                f"- Or record the pause: add `{label}` to `~/.config/kipi/launchd-paused.txt`\n\n"
-                "Leaving it dark with no ledger entry is the state this detector exists to "
-                "make impossible."
+                f"- Or record the pause: add `{label}` to `~/.config/kipi/launchd-paused.txt`"
             ),
         })
     return out
 
 
 def detect_failing_jobs(_ctx) -> list:
-    """Loaded but last run exited non-zero."""
-    out = []
+    """Loaded, but the last run exited non-zero."""
     try:
         listing = subprocess.run(["launchctl", "list"], capture_output=True,
                                  text=True, timeout=15).stdout
     except (OSError, subprocess.TimeoutExpired):
-        return out
+        return []
+    out = []
     for line in listing.splitlines()[1:]:
         parts = line.split("\t")
         if len(parts) < 3:
             continue
-        _pid, status, label = parts[0], parts[1], parts[2].strip()
-        if not label.startswith(("com.kipi.", "com.cole.", "com.ask.", "com.assaf.")):
+        _pid, status, label = parts[0], parts[1], parts[2]
+        if not label.startswith(("com.kipi.", "com.cole.", "com.ask.", "com.assaf.",
+                                 "com.claudedaddy.", "com.purespectrum.", "com.personal.")):
             continue
-        try:
-            code = int(status)
-        except ValueError:
+        if status in ("0", "-"):
             continue
-        if code != 0:
-            out.append({
-                "subject": label,
-                "title": f"launchd job failing: {label} (exit {code})",
-                "body": (
-                    f"`{label}` is loaded but its last run exited **{code}**.\n\n"
-                    "## Action\nRead its StandardErrorPath, fix the cause, and confirm a "
-                    "clean run. If the failure is environmental (auth expiry, server down), "
-                    "say so on this issue rather than retrying — `self-healing-retry.md` "
-                    "rule 5 stops environmental failures on attempt 1."
-                ),
-            })
+        out.append({
+            "subject": label,
+            "title": f"launchd job failing: {label} (exit {status})",
+            "body": (
+                f"`{label}` is loaded but its last run exited **{status}**.\n\n"
+                "## Action\nRead its `StandardErrorPath`, fix the cause, and confirm a clean "
+                "run. If the failure is environmental (auth expiry, server down), say so on "
+                "this issue rather than retrying -- `self-healing-retry.md` rule 5 stops "
+                "environmental failures on attempt 1."
+            ),
+        })
     return out
 
 
-def detect_duplicate_schedules(_ctx) -> list:
+# ---------------------------------------------------------------------------
+# The crontab: ONE reader, shared by both cron detectors
+# ---------------------------------------------------------------------------
+
+
+class CrontabUnavailable(RuntimeError):
+    """`crontab -l` could not be read. NOT the same as an empty crontab.
+
+    This distinction is the whole point of the class. A detector whose value is a
+    NEGATIVE result ("no cron line shells claude") must never print the same
+    thing for "I looked and found nothing" and "I could not look". The first is
+    an all-clear; the second is a blind spot wearing an all-clear's clothes.
+    """
+
+
+# `crontab -l` exits non-zero when the user simply has no crontab. That is the
+# one benign non-zero, and it is identified by its stderr, not by its code.
+_NO_CRONTAB_RE = re.compile(r"no crontab for", re.IGNORECASE)
+
+
+def _read_crontab_result(returncode: int, stdout: str, stderr: str) -> str:
+    """Interpret a `crontab -l` result. Pure, so the blind-spot case is testable.
+
+    Raises CrontabUnavailable when the command ran but could not report the
+    crontab (permission denied, crontab not installed, an unexpected code).
+    """
+    if returncode == 0:
+        return stdout
+    err = (stderr or "").strip()
+    if _NO_CRONTAB_RE.search(err):
+        return ""  # the user genuinely has no crontab: a real, readable empty
+    raise CrontabUnavailable(
+        f"crontab -l exited {returncode}: {err[:200] or '(no stderr)'}"
+    )
+
+
+def _crontab_text() -> str:
+    """`crontab -l`. Empty ONLY when the user genuinely has no crontab."""
+    try:
+        res = subprocess.run(["crontab", "-l"], capture_output=True, text=True,
+                             timeout=10)
+    except (OSError, subprocess.TimeoutExpired) as exc:
+        raise CrontabUnavailable(f"crontab -l did not run: {exc}") from exc
+    return _read_crontab_result(res.returncode, res.stdout, res.stderr)
+
+
+def detect_duplicate_schedules(_ctx, cron_text=None) -> list:
     """The same script scheduled by BOTH launchd and crontab.
 
     Found live 2026-07-26: reddit-build-radar runs at 08:00 from
     com.cole.reddit-radar-daily AND from a crontab line. Two schedulers on one
     script means pausing one does nothing, which is how a 'paused' job keeps running.
+
+    The SCRIPT PATH is the finding's content here, and it is not untrusted text in
+    the ASK-204 sense: it is matched against a plist this fleet owns, so a path
+    that reaches the body is one that already appears in `~/Library/LaunchAgents/`.
+    A path that matched nothing is never published.
     """
-    try:
-        cron = subprocess.run(["crontab", "-l"], capture_output=True, text=True,
-                              timeout=10).stdout
-    except (OSError, subprocess.TimeoutExpired):
-        return []
+    cron = _crontab_text() if cron_text is None else cron_text
     # Resolve to ABSOLUTE paths, never basenames. Measured 2026-07-26: matching on
     # the basename `run_daily.sh` hit 3 plists (reddit-radar-daily, daily-podcast,
     # story-podcast) when only ONE is a real duplicate -- the other two are
@@ -218,6 +281,534 @@ def detect_duplicate_schedules(_ctx) -> list:
                     ),
                 })
     return out
+
+
+# ---------------------------------------------------------------------------
+# Does a crontab line INVOKE `claude`?
+#
+# This block only ever answers yes/no. Nothing it reads is published; see the
+# ASK-204 paragraph in the module docstring. Weakening any of it to simplify the
+# output would trade a real detection for nothing, which is the opposite trade.
+# ---------------------------------------------------------------------------
+
+CRON_COMMAND_WRAPPERS = {"env", "nohup", "nice", "time", "timeout", "caffeinate",
+                         "sudo", "exec", "stdbuf", "npx", "flock", "ssh", "command",
+                         "xargs"}
+
+# Shell KEYWORDS that stand in front of a command without being one. `if claude -p
+# x ; then ...` scored `if` as the command and answered False (fifth review,
+# finding 3). A bare one of these in leading position is always the keyword: an
+# argument never reaches here, because `_command_index` returns at the first token
+# it does not skip.
+SHELL_KEYWORDS = {"if", "then", "elif", "else", "while", "until", "do", "!"}
+
+# `command -v claude` PRINTS a path; it does not run claude. Widening the matcher
+# to reach `command claude` without this would buy a real false positive for a
+# false negative — the trade this detector exists to refuse.
+_LOOKUP_FLAG_LETTERS = {"command": {"v", "V"}}
+
+# A wrapper option whose VALUE is a separate token. Without this the value was
+# scored as command position, so `sudo -u claude /opt/svc/run.sh` -- a service
+# account named `claude`, not an invocation -- filed a permanent Linear issue
+# (PR #11 fourth review, finding 4). This is the same rule `_shell_c_argument`
+# already applies for shells: an option's argument is not a command.
+_WRAPPER_VALUE_FLAGS = {
+    "sudo": {"-u", "--user", "-g", "--group", "-U", "--other-user", "-C", "--close-from",
+             "-D", "--chdir", "-p", "--prompt", "-r", "--role", "-t", "--type",
+             "-R", "--chroot"},
+    "env": {"-u", "--unset", "-C", "--chdir", "-S", "--split-string"},
+    "npx": {"-p", "--package", "-w", "--workspace"},
+    "nice": {"-n", "--adjustment"},
+    "timeout": {"-s", "--signal", "-k", "--kill-after"},
+    "caffeinate": {"-t", "-w"},
+    "stdbuf": {"-i", "-o", "-e", "--input", "--output", "--error"},
+    "time": {"-f", "--format", "-o", "--output"},
+    "exec": {"-a"},
+    "flock": {"-w", "--wait", "--timeout", "-E", "--conflict-exit-code"},
+    "ssh": {"-i", "-l", "-p", "-o", "-F", "-b", "-c", "-D", "-E", "-e", "-I", "-J",
+            "-L", "-m", "-O", "-Q", "-R", "-S", "-W", "-w"},
+    # `xargs -I {} claude -p {}`: without `-I` here the `{}` placeholder was read
+    # as the command and `claude` never reached command position. The attached
+    # form (`-I{}`) needs nothing — it carries its own value (seventh review,
+    # finding 3).
+    "xargs": {"-I", "--replace", "-i", "-n", "--max-args", "-P", "--max-procs",
+              "-s", "--max-chars", "-L", "-l", "-d", "--delimiter", "-E",
+              "-a", "--arg-file"},
+}
+
+# Wrappers whose first POSITIONAL operand is not the command: flock takes a lock
+# file, ssh takes a destination. Both were missing entirely, so
+# `flock -n /tmp/x.lock claude -p` -- the standard way a cron job stops
+# overlapping itself -- was a silent false negative (fourth review, finding 5).
+# Skipping the operand is what keeps adding them from buying that at the price of
+# a lock file or a host named `claude`.
+_WRAPPER_OPERANDS = {"flock": 1, "ssh": 1}
+
+# A shell in command position does not RUN what follows; it runs the string
+# handed to its `-c` flag. `bash -lc 'claude -p ...'` is the shape a cron line
+# uses to get a login environment, so the command inside the quotes has to be
+# parsed as a command, not scanned as text.
+SHELL_COMMANDS = {"sh", "bash", "zsh", "dash", "ksh", "ash"}
+
+# Tokens that END a command and open the next one. Redirections (`<`, `>`, `>>`)
+# are deliberately NOT here: they take an argument, they do not start a command.
+# `{` / `}` group commands, so a segment opens after them — `{ claude -p x ; }` read
+# `{` as the command and answered False (fifth review, finding 3). Brace EXPANSION
+# (`cp ~/a/{x,y} ~/b`) and find's `{}` carry no surrounding whitespace, so they lex
+# as one token and never look like an operator.
+SHELL_OPERATORS = {"&&", "||", ";", "|", "&", "|&", "(", ")", "{", "}"}
+
+
+def _cron_command(line: str) -> str:
+    """The command part of a crontab line, with the schedule fields removed."""
+    stripped = line.strip()
+    if not stripped or stripped.startswith("#"):
+        return ""
+    fields = stripped.split()
+    if "=" in fields[0]:
+        return ""  # a crontab env assignment (PATH=..., MAILTO=...), not a job
+    if fields[0].startswith("@"):
+        return " ".join(fields[1:])  # @daily / @reboot: one schedule field, not five
+    if len(fields) < 6:
+        return ""
+    return " ".join(fields[5:])
+
+
+def _is_claude_token(token: str) -> bool:
+    """The token names the `claude` binary — by basename, so a path counts too."""
+    return PurePosixPath(token).name == "claude"
+
+
+# A wrapper's own positional argument: `timeout 1800`, `timeout 30m`,
+# `timeout 1.5h`. `.isdigit()` alone missed the GNU duration suffix, so
+# `timeout 30m claude` lost command-position tracking and slipped through as
+# benign (third review, finding 3) — a silent false negative.
+_WRAPPER_ARG_RE = re.compile(r"\d+(\.\d+)?[smhd]?")
+
+
+# A cluster of bundled SHORT options: `-Hu`, `-nu`. Long options (`--user`) have a
+# second dash and are matched whole; an attached value (`--user=x`) carries its own
+# `=` and never reaches here.
+_BUNDLED_SHORT_RE = re.compile(r"-[A-Za-z]+")
+
+
+def _is_lookup_flag(token: str, wrapper: str) -> bool:
+    """The flag turns this wrapper into a LOOKUP, so the segment runs no command."""
+    letters = _LOOKUP_FLAG_LETTERS.get(wrapper, ())
+    return bool(letters) and bool(_BUNDLED_SHORT_RE.fullmatch(token)) \
+        and any(char in letters for char in token[1:])
+
+
+def _takes_next_token(token: str, wrapper: str) -> bool:
+    """The option consumes the NEXT token as its value.
+
+    getopt's own bundling rule, because a whole-token membership test read `-u` and
+    missed `-Hu` — and `sudo -Hu svcaccount cmd` is an ordinary idiom, so on a box
+    with a `claude` service account it filed a permanent Linear issue asserting a
+    scheduler bug that does not exist (fifth review, finding 2).
+
+    Faithful, not just last-char: bundling STOPS at the first option that takes an
+    argument, and any characters after it ARE that argument. So `-Hu claude` skips
+    `claude` (H takes nothing, u is last), while `-uH claude` does not (H is already
+    -u's value, and real sudo runs `claude` as user H). Reading the second shape as
+    a flag cluster would buy the false positive back as a false negative.
+    """
+    value_flags = _WRAPPER_VALUE_FLAGS.get(wrapper, ())
+    if token in value_flags:
+        return True
+    if not _BUNDLED_SHORT_RE.fullmatch(token):
+        return False  # a long option, or `-` alone: nothing to unbundle
+    letters = token[1:]
+    for position, letter in enumerate(letters):
+        if f"-{letter}" in value_flags:
+            return position == len(letters) - 1  # last char: the value is the next token
+    return False
+
+
+def _command_index(tokens: list) -> int:
+    """Index of the real command in a shell segment, past env prefixes and
+    wrappers. -1 when the segment holds no command.
+
+    Tracks WHICH wrapper is in effect, because a bare `startswith("-")` skip
+    reads a flag and leaves its value exposed: `sudo -u claude run.sh` scored
+    `claude` -- the value of `-u` -- as the command (fourth review, finding 4).
+    An option's argument belongs to the option, and a wrapper's leading operand
+    (flock's lock file, ssh's host) belongs to the wrapper.
+    """
+    skip_value = False
+    operands_left = 0
+    wrapper = ""
+    for index, token in enumerate(tokens):
+        if skip_value:
+            skip_value = False
+            continue  # the VALUE of the option just skipped, never a command
+        if re.fullmatch(r"[A-Za-z_][A-Za-z0-9_]*=.*", token):
+            continue  # VAR=value prefix
+        if token.startswith("-"):
+            if _is_lookup_flag(token, wrapper):
+                return -1  # `command -v claude` resolves a path, it runs nothing
+            skip_value = _takes_next_token(token, wrapper)
+            continue
+        if token in SHELL_KEYWORDS:
+            continue  # a keyword in front of the command, never the command
+        if _WRAPPER_ARG_RE.fullmatch(token):
+            continue  # a wrapper's own positional arg, e.g. the 1800 in `timeout 1800`
+        name = PurePosixPath(token).name
+        if name in CRON_COMMAND_WRAPPERS:
+            wrapper = name
+            operands_left = _WRAPPER_OPERANDS.get(name, 0)
+            continue
+        if operands_left:
+            operands_left -= 1
+            continue  # flock's lock file / ssh's destination, not the command
+        return index
+    return -1
+
+
+def _command_token(tokens: list) -> str:
+    """The real command in a shell segment, past env prefixes and wrappers."""
+    index = _command_index(tokens)
+    return tokens[index] if index >= 0 else ""
+
+
+def _strip_comment(command: str) -> str:
+    """Truncate at an sh comment: an UNQUOTED `#` that starts a word.
+
+    Comment handling has to happen BEFORE lexing, on the raw string, because
+    quoting is what decides it and posix dequoting erases the evidence: after
+    `shlex`, `grep -q '#TODO'`'s argument and a genuine `# comment` are the same
+    token, and treating both as comments silenced a real invocation after the
+    `&&` (third review, finding 3). sh's own rule is positional — `a#frag` is
+    one word, `# rest` is a comment — so the scan tracks quote state and word
+    starts, the two things sh actually consults.
+    """
+    quote = ""
+    for index, char in enumerate(command):
+        if quote:
+            if char == quote:
+                quote = ""
+            continue
+        if char in "'\"":
+            quote = char
+        elif char == "#" and (index == 0 or command[index - 1] in " \t;|&()"):
+            return command[:index]
+    return command
+
+
+def _lex(command: str):
+    """Shell-aware tokens (a list), or None when the string cannot be parsed as sh.
+
+    `punctuation_chars=True` makes `&& || ; | ( )` their own tokens while leaving
+    quoted strings intact, which is what lets the operator split in
+    `_shell_segments` happen at the TOKEN level. Splitting the raw string on
+    `;`/`&&` (the shipped v1) cut inside quoted arguments: `echo "step one;
+    claude -p x"` produced a second segment whose first token was `claude`.
+
+    Comments are handled by `_strip_comment` before this runs (`commenters = ""`);
+    an unbalanced quote returns None and the CALLER decides what that means —
+    returning a whitespace split from here let the caller treat it like real sh
+    tokens, which is exactly how a quoted `&&` got re-exposed as an operator
+    (third review, finding 5).
+    """
+    lexer = shlex.shlex(command, posix=True, punctuation_chars=True)
+    lexer.whitespace_split = True
+    lexer.commenters = ""
+    try:
+        return list(lexer)
+    except ValueError:
+        return None
+
+
+def _shell_segments(command: str) -> list:
+    """The command's shell segments, each as a token list.
+
+    When the line is not parsable as sh (unbalanced quote), the whole line
+    becomes ONE whitespace-split segment. `claude -p 'sweep the repo` is a real
+    invocation with a typo and stays caught at line-lead command position; but
+    the fallback must never SPLIT on operators, because a `&&` that posix
+    parsing had absorbed into a quoted string is not a command boundary —
+    re-exposing it invented a command position sh never creates and scored
+    `echo 'reminder: && claude -p x` as an invocation (third review, finding 5).
+    One segment can only be coarser than sh, never finer.
+    """
+    command = _strip_comment(command)
+    tokens = _lex(command)
+    if tokens is None:
+        fallback = command.split()
+        return [fallback] if fallback else []
+    segments, current = [], []
+    for token in tokens:
+        if token in SHELL_OPERATORS:
+            segments.append(current)
+            current = []
+        else:
+            current.append(token)
+    segments.append(current)
+    return [s for s in segments if s]
+
+
+# What a substitution collapses to once its contents have been taken out for
+# their own walk. One token, no whitespace, no shell metacharacter, and not a
+# name any wrapper or shell answers to -- so it can only ever be an argument.
+_SUBST_PLACEHOLDER = "__kipi_subst__"
+
+
+def _split_substitutions(command: str) -> tuple:
+    """(command with every substitution masked, the command strings they run).
+
+    ONE walker for both, because they have to agree. `_substitutions` alone left
+    the substitution's TEXT in the string the segment walk lexed, and a
+    substitution containing a space breaks the assignment prefix across two
+    whitespace tokens: `` VAR=`echo secret` claude -p x `` lexed as
+    [`VAR=\\`echo`, `` secret` ``, `claude`, ...], so `_command_index` skipped the
+    first as `VAR=value`, scored `` secret` `` as the command, and answered False.
+    That is a real invocation -- sh runs `claude -p x` with VAR set -- and it was
+    a silent false negative (ASK-204, found by the reproducer this issue's
+    acceptance criterion demands).
+
+    Masking rather than deleting: the span becomes ONE argument-shaped token, so
+    the assignment stays one token and a substitution in command position
+    (`` `cmd` arg ``) cannot collapse into whatever followed it.
+
+    Quote-aware, and that is DETECTION work. Single quotes SUPPRESS substitution
+    and double quotes do not, so `echo 'run `claude -p x` now'` is prose and
+    `echo "`claude -p x`"` is an invocation. A naive split on backticks would
+    score the first — the same trap that made a quoted `&&` look like a command
+    boundary (PR #11 third review, finding 5).
+
+    An UNTERMINATED substitution yields nothing and masks nothing. sh would not
+    run it either, and guessing where it ends is how a command position gets
+    invented.
+    """
+    out, masked, index, quote, length = [], [], 0, "", len(command)
+    while index < length:
+        char = command[index]
+        if quote == "'":
+            quote = "" if char == "'" else quote
+            masked.append(char)
+            index += 1
+            continue
+        if char == "\\":
+            masked.append(command[index:index + 2])
+            index += 2  # escaped next char, in double quotes or unquoted
+            continue
+        if char == "'":
+            quote = "'"
+        elif char == '"':
+            quote = "" if quote == '"' else '"'
+        elif char == "`":
+            close = _scan_to(command, index + 1, "`")
+            if close < 0:
+                masked.append(command[index:])
+                break
+            out.append(command[index + 1:close])
+            masked.append(_SUBST_PLACEHOLDER)
+            index = close + 1
+            continue
+        elif char == "$" and command[index + 1:index + 2] == "(":
+            close = _scan_to_paren(command, index + 2)
+            if close < 0:
+                masked.append(command[index:])
+                break
+            out.append(command[index + 2:close])
+            masked.append(_SUBST_PLACEHOLDER)
+            index = close + 1
+            continue
+        masked.append(char)
+        index += 1
+    return "".join(masked), out
+
+
+def _substitutions(command: str) -> list:
+    """The COMMAND STRINGS a substitution will run: `` `...` `` and `$(...)`.
+
+    Both are command positions the segment walk cannot see, and they were handled
+    by accident rather than on purpose: `$(` split only because `punctuation_chars`
+    makes `(` its own token and `(` is in SHELL_OPERATORS. Backticks are in neither
+    set, so `` OUT=`claude -p x` `` was a silent false negative, and `$(...)` INSIDE
+    double quotes was one too — shlex keeps a quoted string whole, so no token ever
+    became an operator (seventh review, finding 3).
+
+    QUOTE-AWARE, and that is DETECTION work, not redaction work. ASK-204 lists this
+    tracking among what the redaction rewrite deletes; it does not go, because
+    single quotes SUPPRESS substitution and double quotes do not. `echo 'run
+    `claude -p x` now'` is prose and `echo "`claude -p x`"` is an invocation.
+    Dropping the tracking would score the first — a permanent false-positive
+    issue — which is the "do not weaken detection to simplify output" line in the
+    same issue. What ASK-204 removes is what the finding CARRIES; this decides
+    what it DETECTS.
+
+    An UNTERMINATED substitution yields nothing. sh would not run it either, and
+    guessing where it ends is how a command position gets invented.
+    """
+    return _split_substitutions(command)[1]
+
+
+def _scan_to(text: str, start: int, target: str) -> int:
+    """Index of the next unescaped `target`, or -1."""
+    index = start
+    while index < len(text):
+        if text[index] == "\\":
+            index += 2
+            continue
+        if text[index] == target:
+            return index
+        index += 1
+    return -1
+
+
+def _scan_to_paren(text: str, start: int) -> int:
+    """Index of the `)` closing a `$(` opened before `start`, or -1. Nesting-aware
+    so `$(echo $(claude -p x))` yields the whole inner command, not half of it."""
+    depth, index = 1, start
+    while index < len(text):
+        char = text[index]
+        if char == "\\":
+            index += 2
+            continue
+        if char == "(":
+            depth += 1
+        elif char == ")":
+            depth -= 1
+            if not depth:
+                return index
+        index += 1
+    return -1
+
+
+def _shell_c_argument(tokens: list, command_index: int) -> str:
+    """The string a shell will EXECUTE: the token after its `-c`-bearing flag.
+
+    Only consulted when the command itself is a shell, so `tar -czf` (whose flag
+    also contains a `c`) is never read this way.
+
+    Scanning stops at the first OPERAND after the shell: in `bash backup.sh -c
+    <arg>` the `-c` belongs to backup.sh's argv, not to bash, and reading it as
+    the shell's own flag scored a line that never runs claude (third review,
+    finding 2). Only tokens before the shell's first operand are its options.
+    """
+    for index in range(command_index + 1, len(tokens)):
+        token = tokens[index]
+        if token.startswith("--"):
+            continue  # a long option is still an option, not the first operand
+        if not token.startswith("-"):
+            return ""  # first operand: the script file; later flags are ITS argv
+        if "c" in token[1:] and index + 1 < len(tokens):
+            return tokens[index + 1]
+    return ""
+
+
+def _shells_claude(command: str, _depth: int = 0) -> bool:
+    """True when the command INVOKES `claude`, not merely mentions it.
+
+    COMMAND POSITION IS THE ONLY SIGNAL. v1 also scored any token whose basename
+    was `claude` immediately followed by a flag, with no command-position guard.
+    That clause was there to reach `bash -lc 'claude -p ...'`, and PR #11's review
+    measured what it actually cost: 4 of 5 ordinary housekeeping lines over
+    `~/projects/claude` (tar, rsync, du, chmod, each with a trailing flag) scored
+    as invocations. This fleet HAS that directory, and a Linear issue filed here
+    is permanent and cannot be deleted, so a false positive is forever.
+
+    The quoted-shell case it was covering is handled properly instead: when a
+    shell holds command position, the string it was handed is re-parsed as a
+    command. `bash -lc 'claude -p "x"'` still matches, and
+    `notify-send "run claude -p tomorrow"` no longer does.
+    """
+    # Bounded, not shallow. The cap exists to end recursion, not to decide which
+    # nesting depths are real: at 2 a genuine `sh -c 'sh -c "sh -c \"claude\""'`
+    # was answered False, and a silent false negative is the one failure this
+    # detector cannot afford (fourth review, finding 5). Each level costs one
+    # lex of a shorter string, so 5 is still bounded work per cron line.
+    if _depth > 5:
+        return False
+    command = _strip_comment(command)
+    for tokens in _shell_segments(command):
+        command_index = _command_index(tokens)
+        command_token = tokens[command_index] if command_index >= 0 else ""
+        if _is_claude_token(command_token):
+            return True
+        if PurePosixPath(command_token).name in SHELL_COMMANDS:
+            inner = _shell_c_argument(tokens, command_index)
+            if inner and _shells_claude(inner, _depth + 1):
+                return True
+    # A substitution is a command position of its own, and the segment walk above
+    # cannot reach one that a quote has kept whole. Same recursion, same depth cap
+    # as the `-c` string: what runs inside `$( )` or backticks is a command, not text.
+    for inner in _substitutions(command):
+        if _shells_claude(inner, _depth + 1):
+            return True
+    return False
+
+
+def offending_cron_lines(cron: str) -> list:
+    """1-based line NUMBERS of the crontab lines that invoke `claude`.
+
+    Numbers, not lines. This is the whole of ASK-204: the detector reads the line
+    in full (above) and publishes only where it is. A number cannot carry a
+    credential, so there is no redaction step to bypass.
+
+    Numbered against the RAW splitlines, including comments and blanks, because
+    the operator's editor numbers them that way too. A reference the operator
+    cannot follow is not a reference.
+    """
+    return [number for number, line in enumerate(cron.splitlines(), start=1)
+            if _shells_claude(_cron_command(line))]
+
+
+def detect_cron_shells_claude(_ctx, cron_text=None) -> list:
+    """A crontab line that invokes `claude`. It cannot work: cron has no keychain.
+
+    Probed 2026-07-23 (`reddit-build-radar/logs/cron-probe/result.txt`):
+    `keychain_read_rc=44` and `{"is_error":true,...}`. cron starts from a bare
+    environment with no keychain access, so subscription auth fails with an opaque
+    error instead of a clean one — the failure reads as a broken prompt, not a
+    broken scheduler, which is why it is worth catching at the crontab. launchd
+    jobs DO have keychain access; every working `claude -p` job in this fleet is a
+    LaunchAgent. Filed as ASK-150.
+
+    ONE rollup finding, never one per line. A crontab line is an unstable string:
+    forking a PERMANENT Linear issue per line would fork one per prompt edit too.
+    The line numbers live in the body, which `file_findings` REWRITES on every run
+    whose content changed — the same reasoning detect_open_spillover documents for
+    its count. That update path is what makes the rollup honest: a second
+    offending line added a month later lands on the same issue instead of
+    disappearing behind an already-known dedup key.
+
+    Raises CrontabUnavailable when the crontab could not be read at all, so a
+    blind run is reported as an error rather than as a clean bill of health.
+    """
+    cron = _crontab_text() if cron_text is None else cron_text
+    numbers = offending_cron_lines(cron)
+    if not numbers:
+        return []
+    return [{
+        "subject": "cron-shells-claude",
+        "title": f"{len(numbers)} crontab line(s) shell `claude` — cron has no keychain access",
+        "body": (
+            f"**{len(numbers)} crontab line(s) invoke `claude`.** They cannot "
+            "authenticate.\n\n"
+            "Run `crontab -l | cat -n` and read:\n\n"
+            + "\n".join(f"- line {n}" for n in numbers)
+            + "\n\nThe lines themselves are deliberately NOT copied here. A crontab "
+              "line is operator-authored shell, a Linear issue is permanent, and "
+              "redacting arbitrary shell before publishing it was a denylist that "
+              "leaked in nine consecutive review rounds (ASK-204). A line number "
+              "carries nothing to leak.\n\n"
+              "cron runs from a bare environment with no keychain access, so "
+              "subscription auth fails. Probed 2026-07-23 "
+              "(`reddit-build-radar/logs/cron-probe/result.txt`):\n\n"
+              "```\nkeychain_read_rc=44\n{\"is_error\":true,...,\"num_turns\":1,"
+              "\"stop_reason\":\"stop_sequence\",...}\n```\n\n"
+              "The error surfaces as a failed agent run, not as an auth failure, so "
+              "the cause is easy to misread as a bad prompt.\n\n"
+              "## Action\nMove the job to a LaunchAgent. launchd DOES have keychain "
+              "access — every working `claude -p` job in this fleet "
+              "(`open-loops-heartbeat.sh` under `com.kipi.openloops-heartbeat`) is one. "
+              "Do not try to make cron work: there is no keychain workaround, and an "
+              "API-key fallback would bill separately from the subscription.\n\n"
+              "Constraint recorded in ASK-150."
+        ),
+    }]
 
 
 def detect_open_spillover(_ctx) -> list:
@@ -357,6 +948,13 @@ DETECTORS = [
         ),
     },
     {
+        "id": "cron-shells-claude",
+        "description": "a crontab line invokes `claude`, which cannot authenticate under cron",
+        "detect": detect_cron_shells_claude,
+        "action": "file_issue",
+        "lesson": "a-scheduled-job-runs-in-a-bare-environment-not-your-shell",
+    },
+    {
         "id": "open-spillover",
         "description": "open spillover items blocking the closeout gates",
         "detect": detect_open_spillover,
@@ -407,8 +1005,116 @@ def finding_key(detector_id: str, subject: str) -> str:
     return f"fleet-health/{detector_id}/{slug(subject)}"
 
 
-def file_findings(findings: list, apply: bool, filer: str = "fleet-health-daily.py") -> dict:
-    """Create a Linear issue per finding, deduped by kipi-key.
+# The staleness compare CANNOT read the body Linear returns: Linear re-serializes
+# markdown on the read path (live evidence, PR #11 third review finding 1: `- `
+# bullets come back as `* ` on ASK-148, a body no producer ever wrote `* ` into).
+# A raw `!=` against that was stale on every run forever — a daily mutation and a
+# daily false "1 updated" Slack ping for an UNCHANGED crontab, and every operator
+# edit to the body silently reverted each morning. HTML comments DO survive the
+# round-trip verbatim (verified on all 4 live issues), so the renderer's content
+# hash rides inside one, and staleness compares hash-to-hash: "did OUR rendering
+# change", immune to Linear's serializer and blind to everything it does not own.
+_HASH_MARKER_RE = re.compile(r"<!--\s*kipi-hash:\s*([0-9a-f]+)\s*-->")
+
+
+def finding_hash(finding: dict) -> str:
+    """Hash of what the renderer owns: the finding's title and body."""
+    return hashlib.sha256(
+        f"{finding['title']}\n{finding['body']}".encode()).hexdigest()[:16]
+
+
+def tracked_hash(description: str) -> str:
+    """The kipi-hash a live issue carries, or "" (pre-hash issues read as stale
+    once, which is the migration path: one rewrite adds the marker, then settled)."""
+    found = _HASH_MARKER_RE.search(description or "")
+    return found.group(1) if found else ""
+
+
+# The end of the region this script owns. Everything below it on a live issue
+# belongs to whoever wrote it and is spliced back onto every rewrite.
+MANAGED_END = "<!-- kipi-managed-end -->"
+_MANAGED_END_RE = re.compile(r"<!--\s*kipi-managed-end\s*-->")
+
+# The last line the v1 renderer emitted, which is where an operator's note starts
+# on every issue already on the board. Both filers are matched (this script and
+# launchd-health-check.py, ASK-181), and the backticks are optional because Linear
+# re-serializes markdown on the read path. The sentinel does not exist yet on
+# those issues — this anchor is the migration, used once per issue.
+_V1_TRAILER_RE = re.compile(r"Filed by\s+`?(?:fleet-health-daily|launchd-health-check)\.py`?\.")
+
+# A kipi marker sitting on its own line. Stripped from the preserved tail so the
+# spliced body carries exactly ONE kipi-key (linear-sync's MARKER_RE parses it
+# fleet-wide) and exactly one kipi-hash (`tracked_hash` parses it here).
+_KIPI_MARKER_LINE_RE = re.compile(
+    r"(?m)^[ \t]*<!--\s*kipi-(?:key|hash|managed-end):?[^>]*-->[ \t]*$\n?")
+
+
+def operator_tail(description: str) -> str:
+    """Whatever a live issue's body holds that this script does not own.
+
+    `_refresh_one` replaced `description` wholesale, so the morning an offending
+    crontab line was added or removed, every annotation an operator had written on
+    the rollup issue was deleted — silently, with the Slack line reporting it as
+    "N updated", which reads as the body being refreshed rather than as operator
+    content being replaced (PR #11 seventh review, finding 1). The prior suite
+    asserted survival only on the UNCHANGED path, where no mutation is issued at
+    all; that check could not fail.
+
+    Blast radius is why the fallbacks are graded rather than strict: every
+    fleet-health issue on the board today predates the hash marker, so `body_stale`
+    is True for ALL of them on the first post-merge `--apply` run. They lose their
+    annotations together or not at all.
+
+    1. the sentinel, on anything this renderer wrote since;
+    2. the v1 trailer, on every issue already on the board;
+    3. failing both, the WHOLE body is treated as not-ours and preserved.
+
+    Rule 3 buys one duplicated rendering on an unrecognisable body. That is
+    recoverable and visible in the issue; deleting operator content is neither.
+    """
+    text = description or ""
+    end = _MANAGED_END_RE.search(text)
+    if end:
+        tail = text[end.end():]
+    else:
+        trailer = _V1_TRAILER_RE.search(text)
+        tail = text[trailer.end():] if trailer else text
+    return _KIPI_MARKER_LINE_RE.sub("", tail).strip()
+
+
+def issue_description(key: str, finding: dict, tail: str = "",
+                      filer: str = "fleet-health-daily.py") -> str:
+    """The issue body for a finding. ONE renderer, used by create AND update.
+
+    Two renderers would drift, and the drift would be invisible: the created body
+    and the updated body only ever exist on different days.
+
+    The kipi-hash marker is a SEPARATE comment line, never folded into the
+    kipi-key marker: linear-sync's MARKER_RE and every other kipi-key consumer
+    parse that marker fleet-wide, and changing its shape would break the dedup
+    guard that keeps these issues from forking.
+
+    `tail` is operator-owned content carried through a rewrite. It is NOT hashed:
+    `finding_hash` covers the finding's title and body only, so an operator's note
+    can never make the body read stale and start a daily mutation.
+    """
+    managed = (f"<!-- kipi-key: {key} -->\n"
+               f"<!-- kipi-hash: {finding_hash(finding)} -->\n\n"
+               f"{finding['body']}\n\n"
+               f"Filed by `{filer}`.\n"
+               f"{MANAGED_END}")
+    return f"{managed}\n\n{tail}" if tail else managed
+
+
+# Linear WorkflowState.type values that mean the issue is off the board. Held
+# here rather than read off the injected linear module so the reopen decision is
+# this file's, testable without a Linear surface that must agree about it.
+CLOSED_STATE_TYPES = ("completed", "canceled")
+
+
+def file_findings(findings: list, apply: bool, filer: str = "fleet-health-daily.py",
+                  linear=None) -> dict:
+    """Create a Linear issue per finding, deduped by kipi-key; UPDATE it if stale.
 
     Reuses linear-sync's graphql + remote guard so 'already exists' has exactly one
     definition fleet-wide. Linear objects are permanent, so the guard is refetched
@@ -418,21 +1124,54 @@ def file_findings(findings: list, apply: bool, filer: str = "fleet-health-daily.
     than a constant because this is the fleet's ONE filer: launchd-health-check.py
     files its 09:30/21:30 findings through here too (ASK-181), against these same
     detector keys, so a finding both jobs see stays one issue instead of two.
+
+    A known key is not the end of the story. Findings here roll up under stable
+    subjects on purpose (`cron-shells-claude`, `open-spillover`), so their CONTENT
+    changes while their identity does not. `continue`-on-known — the shipped v1 —
+    meant the second offending crontab line, and every one after it, was never
+    surfaced to anyone: the detector reported 1 finding forever and the count in
+    the body drifted into a lie. So a known key whose rendered body differs from
+    what Linear currently holds is rewritten in place, and an unchanged one still
+    writes nothing (an unchanged crontab must not issue a mutation every morning).
+
+    `linear` injects the linear-sync module, so the create AND update paths are
+    provable against an in-memory fake. A test that reached real Linear would
+    leave permanent objects behind and could not be re-run.
+
+    `skipped_no_key` keeps its name: launchd-health-check.py's own return paths
+    and `linear_report_line` read that exact key (ASK-181), and renaming it here
+    would make an unreachable-Linear run print `unfiled=0` on the watchdog side.
     """
-    result = {"created": 0, "existing": 0, "skipped_no_key": 0}
+    result = {"created": 0, "existing": 0, "skipped_no_key": 0, "updated": 0,
+              "reopened": 0, "relisted": 0, "errors": 0}
     if not findings:
         return result
-    import importlib.util
+    ls = linear
+    if ls is None:
+        import importlib.util
 
-    spec = importlib.util.spec_from_file_location("ls", HERE / "linear-sync.py")
-    ls = importlib.util.module_from_spec(spec)
-    spec.loader.exec_module(ls)
+        spec = importlib.util.spec_from_file_location("ls", HERE / "linear-sync.py")
+        ls = importlib.util.module_from_spec(spec)
+        spec.loader.exec_module(ls)
 
     try:
         team_id, project, remote_keys = ls.fetch_remote_state(TEAM_KEY, HEALTH_PROJECT)
     except Exception as exc:  # noqa: BLE001 - a health check must not crash its job
         print(f"  linear unreachable, findings NOT filed: {exc}", file=sys.stderr)
+        # COUNTED, and counted where the notification gate can see it. The
+        # shipped code recorded this in a bucket `should_notify` never read, so
+        # a dropped finding produced one stderr line into a file nobody reads
+        # and a Slack line that said "Board has them; nothing to do now" -- the
+        # exact lie the blind-detector branch exists to prevent (PR #11 fourth
+        # review, finding 1).
         result["skipped_no_key"] = len(findings)
+        # ASK-204: the exception TYPE and nothing else. The message is arbitrary
+        # remote text (a GraphQL error array echoes the request, and this fleet's
+        # requests carry an Authorization header), and the destination is a Slack
+        # line plus a state file. Same rule as the crontab: publish a reference,
+        # never the untrusted string. The full message is already on stderr above,
+        # which goes to the run log the operator owns.
+        result["unfiled_reason"] = f"{type(exc).__name__}; full text in the run log"
         return result
 
     ledger = ls.read_ledger()
@@ -440,29 +1179,189 @@ def file_findings(findings: list, apply: bool, filer: str = "fleet-health-daily.
 
     for f in findings:
         key = f["key"]
-        if key in known:
-            result["existing"] += 1
-            continue
-        if not apply:
-            result["created"] += 1  # would create
-            continue
-        payload = {
-            "title": f["title"][:250],
-            "description": f"<!-- kipi-key: {key} -->\n\n{f['body']}\n\nFiled by `{filer}`.",
-            "teamId": team_id,
-        }
-        if project:
-            payload["projectId"] = project["id"]
-        data = ls.graphql(ls.ISSUE_CREATE, {"input": payload})
-        node = (data.get("issueCreate") or {}).get("issue") or {}
-        if node.get("id"):
-            ls.append_ledger([{
-                "key": key, "kind": "issue", "linear_id": node["id"],
-                "identifier": node.get("identifier"), "source": "fleet-health",
-            }])
-            result["created"] += 1
-            print(f"  filed {node.get('identifier')}  {f['title'][:70]}")
+        try:
+            if key not in known:
+                result[_create_one(ls, f, apply, team_id, project, filer)] += 1
+                continue
+            tracked = _tracked_issue(ls, key, remote_keys, ledger)
+            if not tracked:
+                # Known, and the issue cannot be located anywhere: the ledger
+                # names a linear_id Linear no longer has. The shipped behaviour
+                # counted it and pinged, every morning, forever -- with no way to
+                # clear it and the finding never re-filed, so a real problem sat
+                # unfiled behind a stale cache entry (PR #11 review, minor).
+                #
+                # The clearing path is to FILE IT AGAIN. `read_ledger` is
+                # last-wins over an append-only file, so the new record's
+                # linear_id replaces the dangling one and the next run resolves
+                # the key normally. One `relisted` line, once, instead of a
+                # permanent daily ping.
+                print(f"  ledger key {key} names an issue Linear cannot find; re-filing",
+                      file=sys.stderr)
+                _create_one(ls, f, apply, team_id, project, filer)
+                result["relisted"] += 1
+                continue
+            result[_refresh_one(ls, f, apply, tracked, team_id, filer)] += 1
+        except Exception as exc:  # noqa: BLE001 - one finding's failure is not the run's
+            print(f"  filing {key} FAILED: {exc}", file=sys.stderr)
+            result["errors"] += 1
     return result
+
+
+def _tracked_issue(ls, key: str, remote_keys: dict, ledger: dict) -> dict:
+    """The live issue a known key names, or {} when it cannot be located.
+
+    `remote_keys` covers the health PROJECT only. A key in the ledger but not in
+    that project is the ordinary result of triage moving the issue, and the
+    shipped code answered it with `existing += 1; continue` on every future run:
+    the crontab could grow from 1 offending line to 5 with zero writes, zero
+    pings, and "nothing to do now" as the only sentence the operator ever saw
+    (PR #11 fourth review, finding 2). The ledger already holds the linear_id, so
+    the issue is fetched by id rather than given up on for having moved.
+    """
+    tracked = remote_keys.get(key)
+    if tracked:
+        return tracked
+    linear_id = (ledger.get(key) or {}).get("linear_id")
+    if not linear_id:
+        return {}
+    return ls.fetch_issue(linear_id) or {}
+
+
+def _create_one(ls, finding: dict, apply: bool, team_id: str, project,
+                filer: str) -> str:
+    """File ONE new issue. Returns the outcome bucket. Raises on a Linear failure."""
+    if not apply:
+        return "created"  # would create
+    payload = {
+        "title": finding["title"][:250],
+        "description": issue_description(finding["key"], finding, filer=filer),
+        "teamId": team_id,
+    }
+    if project:
+        payload["projectId"] = project["id"]
+    data = ls.graphql(ls.ISSUE_CREATE, {"input": payload})
+    node = (data.get("issueCreate") or {}).get("issue") or {}
+    if not node.get("id"):
+        # A create that returned no issue is a FAILURE, not a quiet zero. The
+        # shipped code fell off the end of the branch here and counted nothing,
+        # which reads downstream as "no findings" rather than "the write did not
+        # land".
+        raise RuntimeError(f"issueCreate returned no issue for {finding['key']}")
+    ls.append_ledger([{
+        "key": finding["key"], "kind": "issue", "linear_id": node["id"],
+        "identifier": node.get("identifier"), "source": "fleet-health",
+    }])
+    print(f"  filed {node.get('identifier')}  {finding['title'][:70]}")
+    return "created"
+
+
+def _refresh_one(ls, finding: dict, apply: bool, tracked: dict, team_id: str,
+                 filer: str) -> str:
+    """Rewrite / reopen ONE tracked issue. Returns the outcome bucket.
+
+    Raises on a Linear failure: the CALLER decides what one finding's failure
+    means for the rest of the run. Before this split exactly one network call in
+    the whole path was guarded, so a 429 on the first finding propagated out of
+    `main()` -- later findings never attempted, the state file left holding
+    yesterday's `ran_at`, and no Slack line sent at all (PR #11 fourth review,
+    finding 3).
+    """
+    title = finding["title"][:250]
+    # Hash-to-hash, never body-to-body: Linear re-serializes markdown on the read
+    # path, so a raw compare was stale forever (see the kipi-hash block above
+    # issue_description).
+    body_stale = tracked_hash(tracked.get("description")) != finding_hash(finding)
+    # A CLOSED rollup issue is the correct end state of the fix: the operator
+    # moved the job to a LaunchAgent and closed it. If the finding is back,
+    # rewriting a Done issue puts it where nobody looks while the run reports it
+    # as handled -- a false all-clear, worse than never surfacing it. State is
+    # what carries visibility. Independent of body_stale on purpose: a finding
+    # that is STILL TRUE while the board says done is the blind spot whether or
+    # not the text moved. An OPEN issue's state is never touched, so an issue the
+    # operator moved to In Progress is not dragged back to Todo daily.
+    closed = tracked.get("state_type") in CLOSED_STATE_TYPES
+    if not body_stale and not closed:
+        return "existing"
+    if not apply:
+        # A dry run reports the action it WOULD take. It cannot know whether a
+        # reopen state exists without the network call it is forbidden to make,
+        # so "reopened" here is the prediction.
+        return "reopened" if closed else "updated"
+    # Splice, never replace. The wholesale rewrite deleted every operator
+    # annotation the moment the finding's content changed (PR #11 seventh review,
+    # finding 1). This script owns the region above `MANAGED_END`; everything
+    # below it is carried through untouched.
+    update: dict = {
+        "title": title,
+        "description": issue_description(finding["key"], finding,
+                                         operator_tail(tracked.get("description")),
+                                         filer=filer),
+    }
+    reopening = False
+    if closed:
+        # The issue's OWN team, falling back to the team this lookup started
+        # from. A workflow state id belongs to one team, and an issue that left
+        # the health project may have left the team with it.
+        state_id = ls.reopen_state_id(tracked.get("team_id") or team_id)
+        if state_id:
+            update["stateId"] = state_id
+            reopening = True
+        elif not body_stale:
+            # No reopenable state and a current body: nothing useful to send.
+            # Counting a daily no-op rewrite as progress would be the same false
+            # claim one bucket over.
+            return "existing"
+    data = ls.graphql(ls.ISSUE_UPDATE, {"id": tracked["linear_id"], "input": update})
+    # A REFUSED mutation is a failure, not an update. `IssueUpdatePayload.success`
+    # is a non-null Boolean; the field exists because it can be false. Firing and
+    # never reading the payload printed `updated ISS-1`, counted updated=1, and let
+    # the Slack line close with "nothing to do now" while the new offending line
+    # never reached the issue (PR #11 fifth review, finding 1).
+    if not (data.get("issueUpdate") or {}).get("success"):
+        raise RuntimeError(f"issueUpdate refused for {finding['key']}")
+    # ONE finding lands in exactly ONE bucket, decided AFTER the mutation input
+    # is known: returning "reopened" before resolving the state id announced a
+    # reopen that was never sent when no reopenable state existed -- the issue
+    # stayed completed while Slack said it was back on the board (PR #11 third
+    # review, finding 6).
+    verb = "reopened" if reopening else "updated"
+    print(f"  {verb} {tracked.get('identifier')}  {title[:70]}")
+    return verb
+
+
+DETECTOR_ERROR = "error"
+
+
+def run_detectors(detectors=None) -> tuple:
+    """(findings, {detector_id: count | "error"}).
+
+    A detector that RAISED is recorded as "error", never as 0. v1 swallowed the
+    exception and reported a count of 0, so "I could not look" and "I looked and
+    found nothing" printed identically — the worst possible failure mode for a
+    detector whose entire value is a negative result. `crontab -l` failing on a
+    locked-down machine would have read as a clean bill of health forever.
+    """
+    all_findings = []
+    per_detector = {}
+    for d in detectors if detectors is not None else DETECTORS:
+        try:
+            found = d["detect"](None) or []
+        except Exception as exc:  # noqa: BLE001 - a health check must not crash its job
+            print(f"  detector {d['id']} errored: {exc}", file=sys.stderr)
+            per_detector[d["id"]] = DETECTOR_ERROR
+            continue
+        for f in found:
+            f["key"] = finding_key(d["id"], f["subject"])
+            f["detector"] = d["id"]
+        per_detector[d["id"]] = len(found)
+        all_findings.extend(found)
+    return all_findings, per_detector
+
+
+def blind_detectors(per_detector: dict) -> list:
+    """Detectors that could not look. Their result is unknown, not clean."""
+    return sorted(did for did, n in per_detector.items() if n == DETECTOR_ERROR)
 
 
 def outcome_line(outcome: dict) -> str:
@@ -477,9 +1376,71 @@ def outcome_line(outcome: dict) -> str:
     launchd-health-check.py keeps its OWN copy of this formatter on purpose: it
     has to be able to report that THIS file is missing, which is the rsync
     --delete scar it was built for. Do not consolidate them into a dependency
-    that disappears exactly when it is needed."""
+    that disappears exactly when it is needed.
+
+    `.get` on the newer buckets, not `[]`: launchd-health-check.py's own failure
+    paths build a 3-key outcome by hand and pass it here, and a KeyError in the
+    reporter would take out the watchdog's report of its own failure."""
     return (f"  filed={outcome['created']} already-tracked={outcome['existing']} "
-            f"unfiled={outcome['skipped_no_key']}")
+            f"unfiled={outcome['skipped_no_key']} "
+            f"rewritten={outcome.get('updated', 0)} reopened={outcome.get('reopened', 0)} "
+            f"relisted={outcome.get('relisted', 0)} errors={outcome.get('errors', 0)}")
+
+
+def should_notify(outcome: dict, per_detector: dict, apply: bool) -> bool:
+    """Whether this run has earned the ONE Slack line. Pure, so it is testable.
+
+    A blind detector pings even with nothing filed. Before this, an errored
+    detector produced one stderr line, `"error"` in a state file, exit 0, and NO
+    ping — the gate needed created-or-updated, both 0. The distinction
+    `CrontabUnavailable` exists to preserve died at the notification boundary,
+    which is the only place the operator actually reads.
+
+    Nothing pings without `--apply`. A dry run issues no mutation, so announcing
+    one is announcing something that did not happen. The 08:15 LaunchAgent always
+    passes `--apply`.
+
+    A run that could not FILE is as unclean as a run that could not LOOK. The
+    shipped gate read created/updated/reopened plus blind detectors and stopped
+    there, so Linear being unreachable — every finding dropped — cleared the gate
+    as an all-clear (PR #11 fourth review, finding 1).
+    """
+    if not apply:
+        return False
+    return bool(outcome.get("created") or outcome.get("updated")
+                or outcome.get("reopened") or outcome.get("skipped_no_key")
+                or outcome.get("relisted") or outcome.get("errors")
+                or blind_detectors(per_detector))
+
+
+def notify_text(outcome: dict, per_detector: dict) -> str:
+    """The ONE Slack line, never one per finding. Pure, so its claims are testable.
+
+    Every way this run could be WRONG about the board goes in front of the
+    counts, and any one of them removes the all-clear sentence. Silence and
+    "nothing to do now" are the two things a 3am reader cannot distinguish from
+    success, so neither is allowed over an unknown.
+    """
+    counts = (f"{outcome.get('created', 0)} new issue(s) filed, "
+              f"{outcome.get('reopened', 0)} reopened, {outcome.get('updated', 0)} updated, "
+              f"{outcome.get('existing', 0)} already tracked")
+    warnings = []
+    blind = blind_detectors(per_detector)
+    if blind:
+        warnings.append(f"BLIND SPOT — {', '.join(blind)} could not run, so that "
+                        "result is UNKNOWN, not clean")
+    if outcome.get("skipped_no_key"):
+        warnings.append(f"{outcome['skipped_no_key']} finding(s) NOT filed, Linear "
+                        f"unreachable ({outcome.get('unfiled_reason', 'no reason recorded')})")
+    if outcome.get("errors"):
+        warnings.append(f"{outcome['errors']} finding(s) failed to file — Linear "
+                        "rejected the write; see the run log")
+    if outcome.get("relisted"):
+        warnings.append(f"{outcome['relisted']} tracked issue(s) had vanished from Linear "
+                        "and were re-filed; the ledger now points at the new issue")
+    if warnings:
+        return f"fleet health: {'; '.join(warnings)}. Also: {counts}."
+    return f"fleet health: {counts}. Board has them; nothing to do now."
 
 
 def main() -> int:
@@ -495,19 +1456,7 @@ def main() -> int:
             print(f"  - {p}", file=sys.stderr)
         return 1
 
-    all_findings = []
-    per_detector = {}
-    for d in DETECTORS:
-        try:
-            found = d["detect"](None) or []
-        except Exception as exc:  # noqa: BLE001
-            print(f"  detector {d['id']} errored: {exc}", file=sys.stderr)
-            found = []
-        for f in found:
-            f["key"] = finding_key(d["id"], f["subject"])
-            f["detector"] = d["id"]
-        per_detector[d["id"]] = len(found)
-        all_findings.extend(found)
+    all_findings, per_detector = run_detectors()
 
     print(f"fleet-health {_now()}")
     for did, n in per_detector.items():
@@ -520,13 +1469,9 @@ def main() -> int:
     STATE.write_text(json.dumps(
         {"ran_at": _now(), "per_detector": per_detector, "outcome": outcome}, indent=2))
 
-    # ONE line, never one per finding.
-    if not args.quiet and outcome["created"] and NOTIFY.exists():
-        subprocess.run(
-            ["bash", str(NOTIFY),
-             f"fleet health: {outcome['created']} new issue(s) filed, "
-             f"{outcome['existing']} already tracked. Board has them; nothing to do now."],
-            timeout=20, check=False)
+    if not args.quiet and should_notify(outcome, per_detector, args.apply) and NOTIFY.exists():
+        subprocess.run(["bash", str(NOTIFY), notify_text(outcome, per_detector)],
+                       timeout=20, check=False)
     return 0
 
 

--- a/q-system/.q-system/scripts/launchd-health-check.py
+++ b/q-system/.q-system/scripts/launchd-health-check.py
@@ -336,15 +336,46 @@ def file_linear_findings(problems, apply=True):
         findings = linear_findings(problems)
     except Exception as exc:  # noqa: BLE001
         print(f"linear findings could not be built: {exc}", file=sys.stderr)
-        return {"created": 0, "existing": 0, "skipped_no_key": owed}
+        return {"created": 0, "existing": 0, "skipped_no_key": owed, "owed": owed}
     if not findings:
-        return {"created": 0, "existing": 0, "skipped_no_key": 0}
+        return {"created": 0, "existing": 0, "skipped_no_key": 0, "owed": 0}
     try:
-        return _fleet_health().file_findings(
+        outcome = _fleet_health().file_findings(
             findings, apply=apply, filer="launchd-health-check.py")
     except Exception as exc:  # noqa: BLE001
         print(f"linear filing skipped: {exc}", file=sys.stderr)
-        return {"created": 0, "existing": 0, "skipped_no_key": len(findings)}
+        return {"created": 0, "existing": 0, "skipped_no_key": len(findings),
+                "owed": len(findings)}
+    # The DENOMINATOR travels with the outcome. `file_findings` reports which
+    # findings landed; only this side knows how many were owed an issue, and
+    # without that number the reporter below can only trust the failure buckets
+    # it happens to know the names of.
+    outcome["owed"] = len(findings)
+    return outcome
+
+
+# Buckets that mean "the board HAS this finding". Everything owed and not in one
+# of these counts as unfiled. An ALLOWLIST on purpose (PR #19 review, major):
+# `file_findings` grows buckets -- ASK-204 added `updated`, `reopened`, `relisted`
+# and `errors` -- and a reporter that names FAILURE buckets goes silently dark the
+# first time a new one lands upstream. That is exactly how a refused Linear write
+# came to print byte-for-byte like a clean run here. A new bucket now has to be
+# declared landed before it stops being counted as unfiled.
+LANDED_BUCKETS = ("created", "existing", "updated", "reopened", "relisted")
+
+
+def unfiled_count(outcome):
+    """How many findings were OWED an issue and did not get one.
+
+    Falls back to `skipped_no_key` when the outcome carries no `owed` -- an
+    outcome built by hand or by an older copy of this pair mid-`kipi update`
+    degrades to the pre-fix number rather than to a wrong one.
+    """
+    fallback = outcome.get("skipped_no_key", 0)
+    if "owed" not in outcome:
+        return fallback
+    landed = sum(outcome.get(bucket, 0) for bucket in LANDED_BUCKETS)
+    return max(outcome["owed"] - landed, fallback)
 
 
 def linear_report_line(outcome, dry_run):
@@ -355,11 +386,22 @@ def linear_report_line(outcome, dry_run):
     {created: 0, existing: 0, skipped_no_key: N}, so 'Linear is unreachable and N
     findings went nowhere' printed byte-identically to 'the fleet is clean, nothing
     to file'. Every instance without a Linear API key takes that branch, and this
-    script ships fleet-wide. `unfiled` is what separates empty from broken."""
+    script ships fleet-wide. `unfiled` is what separates empty from broken.
+
+    Second scar (PR #19 review): `unfiled` read ONE bucket by name. When ASK-204
+    taught `file_findings` to catch a per-finding write failure and return it as
+    `errors` instead of raising, this line went silent on the exact failure the
+    first scar was about. It now reads owed-minus-landed (`unfiled_count`), so the
+    number cannot be defeated by a bucket added upstream.
+
+    This stays a SEPARATE formatter from fleet-health-daily's `outcome_line`: this
+    script has to be able to report that fleet-health-daily.py is missing, which is
+    the rsync --delete scar it was built for. It cannot import its own reporter
+    from the file whose absence it reports. Both are pinned by tests."""
     verb = "would-file" if dry_run else "filed"
     prefix = "[dry] " if dry_run else ""
     return (f"{prefix}linear: {verb}={outcome['created']} "
-            f"already-tracked={outcome['existing']} unfiled={outcome['skipped_no_key']}")
+            f"already-tracked={outcome['existing']} unfiled={unfiled_count(outcome)}")
 
 
 def problems_to_ping(problems, state, now):
@@ -415,12 +457,12 @@ def run(dry_run):
             for label, kind, detail in due
         ]
         message = f"launchd watchdog: {len(due)} job issue(s) -- " + ", ".join(parts)
-        if filed["skipped_no_key"]:
+        if unfiled_count(filed):
             # Slack is the only channel the founder actually reads. Fixing the
             # stdout counter alone would leave this ping saying "here are the
             # problems" while the issues meant to hold them never reached the
             # board. No NEW ping: the one that was already firing carries it.
-            message += f" [NOT filed to Linear: {filed['skipped_no_key']}]"
+            message += f" [NOT filed to Linear: {unfiled_count(filed)}]"
         send_ping(message)
         for label, kind, detail in due:
             state[label] = {"pinged_at": now, "kind": kind, "detail": detail}

--- a/q-system/.q-system/scripts/launchd-health-check.py
+++ b/q-system/.q-system/scripts/launchd-health-check.py
@@ -287,32 +287,18 @@ def linear_findings(problems):
         detector = LINEAR_DETECTOR_BY_KIND.get(kind)
         if detector is None:
             continue
-        if kind == "failing":
-            title = f"launchd job failing: {label} ({detail})"
-            body = (
-                f"`{label}` is loaded but its last run exited non-zero (**{detail}**).\n\n"
-                "## Action\nRead its `StandardErrorPath`, fix the cause, and confirm a clean "
-                "run. If the failure is environmental (auth expiry, server down), say so on "
-                "this issue rather than retrying -- `self-healing-retry.md` rule 5 stops "
-                "environmental failures on attempt 1."
-            )
-        else:
-            title = f"launchd job is dark: {label}"
-            body = (
-                f"`{label}` has a plist in `~/Library/LaunchAgents/` but is not loaded, and "
-                "it is NOT in the paused ledger -- so nothing recorded a decision to stop "
-                "it. An unloaded job cannot report its own death.\n\n"
-                "## Action\n"
-                f"- Resume: `launchctl bootstrap gui/$(id -u) ~/Library/LaunchAgents/{label}.plist`\n"
-                f"- Or record the pause: add `{label}` to `~/.config/kipi/launchd-paused.txt`"
-            )
-        findings.append({
-            "key": fleet_health.finding_key(detector, label),
-            "detector": detector,
-            "subject": label,
-            "title": title,
-            "body": body,
-        })
+        # fleet-health-daily.py RENDERS these, it does not just name their key.
+        # Both scripts file against one kipi-key and `finding_hash` covers title
+        # and body, so a second rendering here made every alternating run see a
+        # stale hash: a Linear rewrite and a "1 updated" Slack line twice a day on
+        # an unchanged fleet (PR #19 round-3 review, major). Rendering is safe to
+        # delegate for the same reason the key is: this path only runs when
+        # fleet-health-daily.py loaded, and `file_linear_findings` already reports
+        # its ABSENCE as owed-but-unfiled rather than letting it raise.
+        finding = fleet_health.launchd_finding(detector, label, detail)
+        finding["key"] = fleet_health.finding_key(detector, label)
+        finding["detector"] = detector
+        findings.append(finding)
     return findings
 
 

--- a/q-system/.q-system/scripts/linear-sync.py
+++ b/q-system/.q-system/scripts/linear-sync.py
@@ -392,9 +392,21 @@ query($key: String!) {
 PROJECT_ISSUES_QUERY = """
 query($projectId: ID!, $after: String) {
   issues(filter: { project: { id: { eq: $projectId } } }, first: 100, after: $after) {
-    nodes { id identifier description }
+    nodes { id identifier description state { id name type } team { id } }
     pageInfo { hasNextPage endCursor }
   }
+}
+"""
+
+# One issue by its Linear id, INDEPENDENT of what project it currently sits in.
+# A project-scoped listing is the wrong sole lookup for a standing rollup issue:
+# moving it to another project is ordinary triage, and after the move the owning
+# job could no longer find it, so it stopped updating it and reported an
+# all-clear instead (PR #11 fourth review, finding 2). The ledger already holds
+# the linear_id; this is how a caller uses it.
+ISSUE_BY_ID_QUERY = """
+query($id: String!) {
+  issue(id: $id) { id identifier description state { id name type } team { id } }
 }
 """
 
@@ -415,6 +427,61 @@ mutation($input: IssueCreateInput!) {
   issueCreate(input: $input) { success issue { id identifier } }
 }
 """
+
+# Rewrites an EXISTING issue rather than creating a second one. Needed by any
+# caller whose issue is a standing rollup (fleet-health's cron/spillover
+# findings): the dedup key is stable on purpose, so without an update the body
+# freezes at the truth of the day it was filed and every later occurrence is
+# swallowed by the "already exists" guard. Never used to change a kipi-key
+# marker -- that would fork the identity the whole ledger is built on.
+ISSUE_UPDATE = """
+mutation($id: String!, $input: IssueUpdateInput!) {
+  issueUpdate(id: $id, input: $input) { success issue { id identifier } }
+}
+"""
+
+TEAM_STATES_QUERY = """
+query($teamId: String!) {
+  team(id: $teamId) { states(first: 100) { nodes { id name type position } } }
+}
+"""
+
+# Linear WorkflowState.type values that mean "this issue is off the board".
+CLOSED_STATE_TYPES = ("completed", "canceled")
+
+# Where a reopen lands, best first. `unstarted` is the team's Todo column: the
+# issue is back on the board without falsely claiming someone is on it.
+_REOPEN_TYPE_PREFERENCE = ("unstarted", "backlog", "triage")
+
+_REOPEN_STATE_CACHE: dict = {}
+
+
+def reopen_state_id(team_id: str) -> str:
+    """The workflow state a CLOSED issue should be moved back to, or "".
+
+    Needed because a standing rollup issue's identity is its kipi-key, so there
+    is exactly one of them forever. Rewriting a Done issue's body leaves the
+    finding invisible on the board while the run reports it as handled. State is
+    what carries visibility; the body does not.
+
+    Returns "" when the team exposes no reopenable state, so the caller can
+    still write the body rather than failing the whole run over a missing column.
+    """
+    if team_id in _REOPEN_STATE_CACHE:
+        return _REOPEN_STATE_CACHE[team_id]
+    nodes = (
+        ((graphql(TEAM_STATES_QUERY, {"teamId": team_id}).get("team") or {}).get("states") or {})
+        .get("nodes")
+        or []
+    )
+    chosen = ""
+    for wanted in _REOPEN_TYPE_PREFERENCE:
+        matches = [n for n in nodes if n.get("type") == wanted]
+        if matches:
+            chosen = sorted(matches, key=lambda n: n.get("position") or 0)[0]["id"]
+            break
+    _REOPEN_STATE_CACHE[team_id] = chosen
+    return chosen
 
 
 def fetch_remote_state(team_key: str, repo: str) -> tuple:
@@ -460,15 +527,75 @@ def fetch_remote_state(team_key: str, repo: str) -> tuple:
             for node in page.get("nodes") or []:
                 found = MARKER_RE.search(node.get("description") or "")
                 if found:
+                    state = node.get("state") or {}
                     keys[found.group(1)] = {
                         "linear_id": node["id"],
                         "identifier": node["identifier"],
+                        # The live body, so a caller holding a standing rollup
+                        # issue can tell "unchanged" from "needs a rewrite"
+                        # without a second fetch. cmd_remote does not carry this
+                        # into its snapshot; the snapshot is a dedup guard only.
+                        "description": node.get("description") or "",
+                        # STATE, for the same reason. A standing rollup issue the
+                        # operator closed is the correct end state of the fix;
+                        # rewriting its body afterwards puts the finding somewhere
+                        # nobody looks. A caller cannot tell without this field.
+                        "state_type": state.get("type") or "",
+                        "state_name": state.get("name") or "",
+                        # The issue's OWN team. A project can span teams, and a
+                        # workflow state id belongs to one team, so a caller
+                        # moving an issue back onto the board must ask that
+                        # issue's team for the state rather than assume the
+                        # team it started the lookup from.
+                        "team_id": (node.get("team") or {}).get("id") or "",
                     }
             info = page.get("pageInfo") or {}
             if not info.get("hasNextPage"):
                 break
             after = info.get("endCursor")
     return team_id, project, keys
+
+
+# What Linear's "that id is not an issue" reads like on the wire. Matched on the
+# message rather than the status code because the call returns HTTP 200 with an
+# `errors` array (see graphql's docstring).
+_ENTITY_NOT_FOUND_RE = re.compile(r"Entity not found|Could not find referenced", re.I)
+
+
+def fetch_issue(linear_id: str) -> dict:
+    """One issue by id, in the same record shape `fetch_remote_state` returns.
+
+    Same shape ON PURPOSE: a caller that already handles a tracked issue must not
+    need a second code path for "the same issue, found a different way". Two
+    readers of one input with different semantics is the defect this avoids.
+
+    Returns {} when the issue is gone, so the caller can tell "moved" (a record)
+    from "not there any more" (empty) and report the second rather than silently
+    treating a key it can no longer maintain as handled.
+    """
+    try:
+        node = (graphql(ISSUE_BY_ID_QUERY, {"id": linear_id}) or {}).get("issue") or {}
+    except LinearAPIError as exc:
+        # Linear answers an unknown id with a GraphQL ERROR, not a null issue.
+        # Verified live 2026-07-27: `Entity not found: Issue ... code
+        # INPUT_ERROR`. The first cut of this function checked for a null node
+        # and never saw that, so a deleted issue would have surfaced to the
+        # operator as "Linear rejected the write" instead of "this key has no
+        # issue any more" -- right ping, wrong sentence.
+        if not _ENTITY_NOT_FOUND_RE.search(str(exc)):
+            raise  # a 429 or a dropped connection is NOT "gone"
+        return {}
+    if not node.get("id"):
+        return {}
+    state = node.get("state") or {}
+    return {
+        "linear_id": node["id"],
+        "identifier": node.get("identifier") or "",
+        "description": node.get("description") or "",
+        "state_type": state.get("type") or "",
+        "state_name": state.get("name") or "",
+        "team_id": (node.get("team") or {}).get("id") or "",
+    }
 
 
 COMMENT_CREATE = """

--- a/q-system/.q-system/scripts/test/test-fleet-health-daily.py
+++ b/q-system/.q-system/scripts/test/test-fleet-health-daily.py
@@ -218,6 +218,12 @@ _MUST_DETECT = [
     "npx claude",                                       # npx
     "grep -q '#TODO' notes.txt && claude -p 'sweep'",   # quoted # is not a comment
     "claude -p 'sweep the repo",                        # unbalanced quote, still real
+    # An APOSTROPHE inside a double-quoted span is literal in sh, so everything
+    # after it is still double-quoted and a substitution there still runs
+    # (PR #19 review, minor 2 — verified against /bin/sh with a stub `claude`).
+    'echo "don\'t $(claude -p x)"',                     # apostrophe then $( )
+    'echo "don\'t" `claude -p z`',                      # apostrophe then backtick
+    'echo "isn\'t `claude -p q` done"',                 # apostrophe, same span
 ]
 for _line in _MUST_DETECT:
     check(f"still detects: {_line}", fh._shells_claude(_line), True)
@@ -237,6 +243,11 @@ _MUST_NOT_DETECT = [
     "echo 'run `claude -p x` now'",                     # single quotes suppress `` ` ``
     "true && # claude -p 'x'",                          # a real comment
     "du -sh ~/projects/claude --block-size='M",         # housekeeping over the dir
+    # ...and the same apostrophe must not push the walker INTO a single-quote
+    # state, which made a genuinely single-quoted substitution later on the line
+    # score as an invocation — a PERMANENT false-positive issue (PR #19, minor 2).
+    'echo "don\'t" \'run `claude -p x` now\'',          # apostrophe then real quoting
+    'echo "won\'t" \'note: $(claude -p z)\'',           # same, with $( )
 ]
 for _line in _MUST_NOT_DETECT:
     check(f"still refuses: {_line}", fh._shells_claude(_line), False)
@@ -409,10 +420,67 @@ try:
     check("an unreadable crontab raises", "no raise", "CrontabUnavailable")
 except fh.CrontabUnavailable:
     check("an unreadable crontab raises rather than reporting clean", True, True)
-check("both cron detectors accept injected text, so neither shells out twice",
+check("both cron detectors accept injected text",
       ["cron_text" in inspect.signature(fn).parameters
        for fn in (fh.detect_cron_shells_claude, fh.detect_duplicate_schedules)],
       [True, True])
+
+# THE REPRODUCER (PR #19 review, minor 4): the assertion above was labelled "so
+# neither shells out twice" and proved no such thing -- it checked that a
+# PARAMETER existed. `run_detectors` called `detect(None)`, so `cron_text` stayed
+# None and each cron detector ran its own `crontab -l`. The claim is now measured
+# by spying on the subprocess call, which is the only thing that can go red if the
+# wiring is removed again.
+_CRON_FIXTURE = "0 3 * * * claude -p sweep\n"
+
+
+class _FakeCrontab:
+    """A `crontab -l` CompletedProcess stand-in, scripted per case."""
+
+    def __init__(self, returncode, stdout, stderr):
+        self.returncode, self.stdout, self.stderr = returncode, stdout, stderr
+
+
+def _run_cron_detectors(returncode, stdout, stderr):
+    """(crontab -l invocations, per_detector) for the two cron detectors only.
+
+    Spies on the module's own `subprocess.run` so anything that is NOT the crontab
+    read (launchctl, prd_runner) still reaches the real command -- a stub that
+    swallowed every call would prove the detectors ran, not what they ran.
+    """
+    invocations = []
+    saved = fh.subprocess.run
+
+    def spy(cmd, *args, **kwargs):
+        if list(cmd)[:2] == ["crontab", "-l"]:
+            invocations.append(list(cmd))
+            return _FakeCrontab(returncode, stdout, stderr)
+        return saved(cmd, *args, **kwargs)
+
+    registry = [d for d in fh.DETECTORS
+                if d["id"] in ("cron-shells-claude", "schedule-duplicate")]
+    fh.subprocess.run = spy
+    try:
+        _, per_detector = fh.run_detectors(registry)
+    finally:
+        fh.subprocess.run = saved
+    return invocations, per_detector
+
+
+_cron_reads, _cron_per = _run_cron_detectors(0, _CRON_FIXTURE, "")
+check("run_detectors reads the crontab ONCE for both cron detectors",
+      len(_cron_reads), 1)
+check("and the shared read still reaches the detector that files on it",
+      _cron_per["cron-shells-claude"], 1)
+
+# The layer above the dedup: one read must not collapse two blind spots into one.
+# A crontab that cannot be read still has to mark BOTH detectors unknown, or the
+# dedup buys a silent all-clear for the second one.
+_blind_reads, _blind_per = _run_cron_detectors(1, "", "crontab: permission denied")
+check("an unreadable crontab is still read only once", len(_blind_reads), 1)
+check("...and BOTH cron detectors are reported blind, not clean",
+      sorted(did for did, n in _blind_per.items() if n == fh.DETECTOR_ERROR),
+      ["cron-shells-claude", "schedule-duplicate"])
 check("a blind detector is reported as unknown, not zero",
       fh.blind_detectors({"cron-shells-claude": fh.DETECTOR_ERROR, "launchd-dark": 0}),
       ["cron-shells-claude"])

--- a/q-system/.q-system/scripts/test/test-fleet-health-daily.py
+++ b/q-system/.q-system/scripts/test/test-fleet-health-daily.py
@@ -142,6 +142,298 @@ import inspect  # noqa: E402 - local to this assertion
 
 check("main() reports through outcome_line", "outcome_line(" in inspect.getsource(fh.main), True)
 
+
+# ===========================================================================
+# ASK-204: a finding carries a REFERENCE, never untrusted text
+#
+# Nine PR #11 review rounds each found a new way past `_redact_secrets`. The fix
+# is not a tenth pattern; it is that no crontab text is published at all. These
+# assertions are what stops the redaction architecture coming back.
+# ===========================================================================
+
+# THE REPRODUCER. Both shapes are round 8 and 9's findings verbatim: a `lin_api_`
+# value whose assignment starts after a BACKTICK (outside the old lookbehind's
+# character class) and a backtick command substitution. Against the redaction
+# design this body carried both secrets; the assertion is ZERO characters of the
+# source line, which no denylist can satisfy and a line number satisfies trivially.
+_SECRET_CRON = (
+    "# a comment line, so line numbering has something to be wrong about\n"
+    "0 3 * * * bash -lc '`LINEAR_API_KEY=lin_api_realvalue claude -p sweep`'\n"
+    "0 4 * * * VAR=`echo secret` claude -p x\n"
+)
+_secret_findings = fh.detect_cron_shells_claude(None, cron_text=_SECRET_CRON)
+check("the secret-bearing fixture is DETECTED (else the leak test proves nothing)",
+      len(_secret_findings), 1)
+_secret_body = _secret_findings[0]["body"] if _secret_findings else ""
+
+for _leak in ("lin_api_realvalue", "LINEAR_API_KEY", "echo secret", "VAR="):
+    check(f"the body carries no source-line fragment: {_leak!r}",
+          _leak in _secret_body, False)
+
+# Not just the secret -- no substring of either offending line survives. A body
+# that leaked half a line would still pass a needle-by-needle check.
+for _number, _line in enumerate(_SECRET_CRON.splitlines(), start=1):
+    _payload = fh._cron_command(_line)
+    if _payload:
+        check(f"line {_number}'s command text is absent from the body",
+              _payload in _secret_body, False)
+
+# What it publishes INSTEAD: a reference the operator can follow. Numbered against
+# raw splitlines, so the leading comment counts and the numbers match `cat -n`.
+check("the body names the offending line numbers", "line 2" in _secret_body
+      and "line 3" in _secret_body, True)
+check("offending_cron_lines returns numbers, not text",
+      fh.offending_cron_lines(_SECRET_CRON), [2, 3])
+check("a clean crontab yields no numbers",
+      fh.offending_cron_lines("0 3 * * * /usr/bin/rsync -a ~/a ~/b\n"), [])
+
+# The redaction machinery is GONE, not tightened. Named explicitly because the
+# failure mode this issue exists to stop is someone re-adding a pattern table.
+for _dead in ("_redact_secrets", "_ASSIGNMENT_RE", "_SECRET_PATTERNS"):
+    check(f"{_dead} no longer exists", hasattr(fh, _dead), False)
+check("no redaction placeholder is emitted anywhere", "<redacted>" in _secret_body, False)
+
+# --- detection coverage is UNCHANGED ---------------------------------------
+# Salvaged from sana/ask-150's suite, which is nine rounds of measured shapes.
+# The reference-only rewrite changed what a finding CARRIES; if any of these
+# stops detecting, it changed what the detector SEES, which is the trade the
+# issue forbids.
+_MUST_DETECT = [
+    'claude -p "x"',                                    # bare invocation
+    "timeout 1800 claude -p 'x' </dev/null",            # wrapper + redirect
+    "/Users/x/.claude/local/claude -p 'x'",             # absolute path
+    "bash -lc 'claude -p \"x\"'",                       # quoted shell string
+    "cd ~/projects/x && claude -p 'x'",                 # after an operator
+    "OUT=`claude -p 'x'`",                              # backtick substitution
+    "OUT=$(claude -p 'x')",                             # $( ) substitution
+    'echo "$(claude -p x)"',                            # $( ) inside double quotes
+    "xargs -I {} claude -p {} < list",                   # xargs placeholder
+    "sudo -uH claude -p 'x'",                           # bundled short options
+    "flock -n /tmp/x.lock claude -p 'x'",               # lock-file operand
+    "ssh mini claude -p 'x'",                           # ssh destination operand
+    "timeout 30m claude -p 'sweep'",                    # duration suffix
+    "{ claude -p x ; }",                                # brace group
+    "if claude -p x ; then true ; fi",                  # shell keyword
+    "command claude -p x",                              # command wrapper
+    "npx claude",                                       # npx
+    "grep -q '#TODO' notes.txt && claude -p 'sweep'",   # quoted # is not a comment
+    "claude -p 'sweep the repo",                        # unbalanced quote, still real
+]
+for _line in _MUST_DETECT:
+    check(f"still detects: {_line}", fh._shells_claude(_line), True)
+
+# The false positives the matcher was narrowed to refuse. A permanent Linear
+# issue cannot be deleted, so each of these is as expensive as a miss.
+_MUST_NOT_DETECT = [
+    "cd ~/projects/claude && ./run.sh",                 # a directory named claude
+    "bash ~/.claude/hooks/rotate-logs.sh",              # a path, not a command
+    "claude-code --version",                            # a different binary
+    "command -v claude",                                # a lookup, runs nothing
+    "sudo -u claude /opt/svc/run.sh",                   # a service account
+    "ssh claude@mini ./run.sh",                         # a remote user
+    "flock -n /tmp/claude.lock /opt/svc/run.sh",        # a lock file
+    'echo "step one; claude -p x"',                     # quoted, not an operator
+    "echo 'reminder: && claude -p x",                   # unbalanced quote, prose
+    "echo 'run `claude -p x` now'",                     # single quotes suppress `` ` ``
+    "true && # claude -p 'x'",                          # a real comment
+    "du -sh ~/projects/claude --block-size='M",         # housekeeping over the dir
+]
+for _line in _MUST_NOT_DETECT:
+    check(f"still refuses: {_line}", fh._shells_claude(_line), False)
+
+# --- the exception message is a reference too (ASK-204, `unfiled_reason`) ----
+
+
+class _DeadLinear:
+    """A linear-sync stand-in whose remote fetch fails with a talkative message."""
+
+    LEAK = "Authorization: lin_api_leakedfromtheerror"
+
+    def fetch_remote_state(self, *_a, **_k):
+        raise RuntimeError(f"HTTP 401: {self.LEAK}")
+
+
+_dead_out = fh.file_findings(
+    [{"key": "fleet-health/x/y", "title": "t", "body": "b"}],
+    apply=True, linear=_DeadLinear())
+check("an unreachable Linear still counts every dropped finding",
+      _dead_out["skipped_no_key"], 1)
+check("the exception MESSAGE never reaches the outcome",
+      _DeadLinear.LEAK in _dead_out.get("unfiled_reason", ""), False)
+check("the exception TYPE does", "RuntimeError" in _dead_out.get("unfiled_reason", ""), True)
+check("and it never reaches the Slack line either",
+      _DeadLinear.LEAK in fh.notify_text(_dead_out, {}), False)
+
+# ===========================================================================
+# Operator-authored description content survives a rewrite (PR #11 major)
+# ===========================================================================
+
+_OPERATOR_NOTE = "Talked to Assaf 2026-07-20: line 3 is deliberate, do not remove."
+
+
+class _FakeLinear:
+    """Records mutations instead of sending them. ISSUE_* are opaque markers here."""
+
+    ISSUE_CREATE = "create"
+    ISSUE_UPDATE = "update"
+
+    def __init__(self, description, state_type="unstarted"):
+        self.tracked = {
+            "linear_id": "id-1", "identifier": "ASK-1",
+            "description": description, "state_type": state_type, "team_id": "team-1",
+        }
+        self.sent = []
+
+    def fetch_remote_state(self, *_a, **_k):
+        return "team-1", None, {"fleet-health/x/y": dict(self.tracked)}
+
+    def read_ledger(self):
+        return {}
+
+    def append_ledger(self, records):
+        self.sent.append(("ledger", records))
+        return len(records)
+
+    def reopen_state_id(self, _team_id):
+        return "state-todo"
+
+    def graphql(self, query, variables):
+        self.sent.append((query, variables))
+        if query == self.ISSUE_UPDATE:
+            return {"issueUpdate": {"success": True, "issue": {"id": "id-1"}}}
+        return {"issueCreate": {"issue": {"id": "id-2", "identifier": "ASK-2"}}}
+
+
+_finding = {"key": "fleet-health/x/y", "title": "new title", "body": "new body"}
+# A live issue as it exists TODAY: v1 rendering, no sentinel, operator note below.
+_live_body = (
+    "<!-- kipi-key: fleet-health/x/y -->\n\nold body\n\n"
+    "Filed by `fleet-health-daily.py`.\n\n" + _OPERATOR_NOTE
+)
+_fake = _FakeLinear(_live_body)
+_out = fh.file_findings([_finding], apply=True, linear=_fake)
+check("a content change rewrites the tracked issue", _out["updated"], 1)
+_sent_description = [v for q, v in _fake.sent if q == _FakeLinear.ISSUE_UPDATE][0]["input"]["description"]
+check("the operator's note survives the rewrite", _OPERATOR_NOTE in _sent_description, True)
+check("the new rendering is there too", "new body" in _sent_description, True)
+check("the stale rendering is gone", "old body" in _sent_description, False)
+check("exactly one kipi-key marker in the spliced body",
+      _sent_description.count("<!-- kipi-key:"), 1)
+check("exactly one kipi-hash marker in the spliced body",
+      _sent_description.count("<!-- kipi-hash:"), 1)
+
+# Round-trip: the body this run WROTE must survive the next run's splice too, or
+# the note is preserved once and lost on the following morning.
+_fake2 = _FakeLinear(_sent_description)
+fh.file_findings([{"key": "fleet-health/x/y", "title": "t3", "body": "b3"}],
+                 apply=True, linear=_fake2)
+_second = [v for q, v in _fake2.sent if q == _FakeLinear.ISSUE_UPDATE][0]["input"]["description"]
+check("the note survives a SECOND rewrite", _OPERATOR_NOTE in _second, True)
+check("and is not duplicated by it", _second.count(_OPERATOR_NOTE), 1)
+
+# An unrecognisable body is preserved whole rather than deleted (rule 3).
+check("an unknown body is treated as operator-owned",
+      "hand-written, no markers" in fh.operator_tail("hand-written, no markers"), True)
+
+# An UNCHANGED finding issues no mutation at all -- the guard that stops a daily
+# rewrite of an issue nothing changed on.
+_settled_body = fh.issue_description(_finding["key"], _finding)
+_fake3 = _FakeLinear(_settled_body)
+_out3 = fh.file_findings([_finding], apply=True, linear=_fake3)
+check("an unchanged finding is left alone", _out3["existing"], 1)
+check("and sends no mutation", [q for q, _ in _fake3.sent], [])
+
+# ===========================================================================
+# An unlocatable ledger key has a CLEARING PATH (PR #11 minor)
+# ===========================================================================
+
+
+class _VanishedLinear(_FakeLinear):
+    """The ledger names an issue id; Linear no longer has it."""
+
+    def __init__(self):
+        super().__init__("")
+        self.created = 0
+
+    def fetch_remote_state(self, *_a, **_k):
+        return "team-1", None, {}          # not in the health project
+
+    def read_ledger(self):
+        return {"fleet-health/x/y": {"key": "fleet-health/x/y", "linear_id": "gone-1"}}
+
+    def fetch_issue(self, _linear_id):
+        return {}                           # ...and not anywhere else either
+
+    def graphql(self, query, variables):
+        if query == self.ISSUE_CREATE:
+            self.created += 1
+        return super().graphql(query, variables)
+
+
+_vanished = _VanishedLinear()
+_out4 = fh.file_findings([_finding], apply=True, linear=_vanished)
+check("a vanished tracked issue is re-filed, not counted and forgotten",
+      _out4["relisted"], 1)
+check("re-filing means a real create", _vanished.created, 1)
+check("the ledger gets the NEW issue id, so the next run resolves the key",
+      [r[1][0]["linear_id"] for r in _vanished.sent if r[0] == "ledger"], ["id-2"])
+check("the run still earns a Slack line while it is unresolved",
+      fh.should_notify(_out4, {}, apply=True), True)
+check("and the line says what happened", "re-filed" in fh.notify_text(_out4, {}), True)
+
+# ===========================================================================
+# ASK-181 contract: this is the fleet's ONE filer
+# ===========================================================================
+check("file_findings still accepts a filer",
+      "filer" in inspect.signature(fh.file_findings).parameters, True)
+check("outcome_line survives a 3-key outcome built by launchd-health-check.py",
+      "unfiled=2" in fh.outcome_line({"created": 0, "existing": 0, "skipped_no_key": 2}), True)
+_fake_filer = _FakeLinear("")
+_fake_filer.tracked = {}
+fh.file_findings([_finding], apply=True, linear=_VanishedLinear(),
+                 filer="launchd-health-check.py")
+check("the filer name reaches the rendered body",
+      "launchd-health-check.py" in fh.issue_description(
+          "k", _finding, filer="launchd-health-check.py"), True)
+check("and the v1 trailer anchor recognises BOTH filers, so neither loses a note",
+      fh.operator_tail("x\n\nFiled by `launchd-health-check.py`.\n\n" + _OPERATOR_NOTE),
+      _OPERATOR_NOTE)
+
+# ===========================================================================
+# One crontab reader, and a blind read is never an all-clear
+# ===========================================================================
+check("a genuinely empty crontab is a real, readable empty",
+      fh._read_crontab_result(1, "", "crontab: no crontab for assaf"), "")
+try:
+    fh._read_crontab_result(1, "", "crontab: permission denied")
+    check("an unreadable crontab raises", "no raise", "CrontabUnavailable")
+except fh.CrontabUnavailable:
+    check("an unreadable crontab raises rather than reporting clean", True, True)
+check("both cron detectors accept injected text, so neither shells out twice",
+      ["cron_text" in inspect.signature(fn).parameters
+       for fn in (fh.detect_cron_shells_claude, fh.detect_duplicate_schedules)],
+      [True, True])
+check("a blind detector is reported as unknown, not zero",
+      fh.blind_detectors({"cron-shells-claude": fh.DETECTOR_ERROR, "launchd-dark": 0}),
+      ["cron-shells-claude"])
+check("and it earns a Slack line on its own",
+      fh.should_notify({}, {"cron-shells-claude": fh.DETECTOR_ERROR}, apply=True), True)
+check("the all-clear sentence is withheld when a detector was blind",
+      "nothing to do now" in fh.notify_text({}, {"cron-shells-claude": fh.DETECTOR_ERROR}),
+      False)
+
+# The registry entry both cron detectors need to survive with.
+_by_id = {d["id"]: d for d in fh.DETECTORS}
+for _did in ("cron-shells-claude", "schedule-duplicate"):
+    check(f"{_did} is still registered", _did in _by_id, True)
+    check(f"{_did} declares an action", _by_id.get(_did, {}).get("action"), "file_issue")
+    check(f"{_did} carries a learning leg",
+          bool(_by_id.get(_did, {}).get("lesson") or _by_id.get(_did, {}).get("lesson_waived")),
+          True)
+_LESSONS = Path(__file__).resolve().parents[3] / "lessons"
+check("cron-shells-claude's lesson slug is a real file",
+      (_LESSONS / f"{_by_id['cron-shells-claude']['lesson']}.md").is_file(), True)
+
 if failures:
     print("FAIL:")
     for line in failures:

--- a/q-system/.q-system/scripts/test/test-fleet-health-daily.py
+++ b/q-system/.q-system/scripts/test/test-fleet-health-daily.py
@@ -224,6 +224,16 @@ _MUST_DETECT = [
     'echo "don\'t $(claude -p x)"',                     # apostrophe then $( )
     'echo "don\'t" `claude -p z`',                      # apostrophe then backtick
     'echo "isn\'t `claude -p q` done"',                 # apostrophe, same span
+    # ssh JOINS its remote operands and hands one string to the far shell, which
+    # lexes it there. The quoted form -- the one you write so the LOCAL shell does
+    # not expand it -- reached `_is_claude_token` as a single token whose basename
+    # was `claude -p sweep`, so the unquoted form above was pinned while this one
+    # was a silent false negative (PR #19 round-3 review, minor 2).
+    "ssh mini 'claude -p sweep'",                       # quoted remote command
+    'ssh mini "claude -p sweep"',                       # double-quoted remote command
+    "ssh mini -- 'claude -p sweep'",                    # after an end-of-options --
+    "ssh mini timeout 30 'claude -p x'",                # a wrapper on the far side
+    'ssh mini echo "a; claude -p x"',                   # ssh's own quoting gotcha
 ]
 for _line in _MUST_DETECT:
     check(f"still detects: {_line}", fh._shells_claude(_line), True)
@@ -248,6 +258,18 @@ _MUST_NOT_DETECT = [
     # score as an invocation — a PERMANENT false-positive issue (PR #19, minor 2).
     'echo "don\'t" \'run `claude -p x` now\'',          # apostrophe then real quoting
     'echo "won\'t" \'note: $(claude -p z)\'',           # same, with $( )
+    # An UNTERMINATED double quote is a syntax error: /bin/sh runs nothing on the
+    # line, including what is inside the substitution. `_shell_segments` already
+    # refused to invent a command position on an unparsable line; the substitution
+    # walk bypassed that guard and filed a PERMANENT issue for a line that cannot
+    # execute (PR #19 round-3 review, minor 3).
+    'echo "reminder: $(claude -p x)',                   # unbalanced quote, $( )
+    'echo "note: `claude -p x`',                        # unbalanced quote, backtick
+    'VAR="x $(claude -p sweep)',                        # ...even in an assignment
+    # ssh's remote command is re-parsed, which must not make ordinary remote
+    # housekeeping over a `claude` directory look like an invocation.
+    "ssh mini tar -czf ~/b.tgz ~/projects/claude",      # remote housekeeping
+    "ssh mini echo 'run claude -p tomorrow'",           # remote prose
 ]
 for _line in _MUST_NOT_DETECT:
     check(f"still refuses: {_line}", fh._shells_claude(_line), False)

--- a/q-system/.q-system/scripts/test_launchd_health_check.py
+++ b/q-system/.q-system/scripts/test_launchd_health_check.py
@@ -181,6 +181,10 @@ class _Boom:
         return _fh.finding_key(detector, subject)
 
     @staticmethod
+    def launchd_finding(detector, label, detail=""):
+        return _fh.launchd_finding(detector, label, detail)
+
+    @staticmethod
     def file_findings(findings, apply, filer=None):
         raise RuntimeError("linear unreachable")
 
@@ -223,6 +227,13 @@ def _fh_stub(created=0, existing=0, unfiled=0, record=None):
         @staticmethod
         def finding_key(detector, subject):
             return _fh.finding_key(detector, subject)
+
+        # Delegated, never re-implemented: a stub with its own rendering would go
+        # on passing after the two filers drifted apart again, which is the whole
+        # defect (PR #19 round-3 review, major).
+        @staticmethod
+        def launchd_finding(detector, label, detail=""):
+            return _fh.launchd_finding(detector, label, detail)
 
         @staticmethod
         def file_findings(findings, apply, filer=None):
@@ -312,6 +323,13 @@ def _fh_stub_shape(record=None, **buckets):
         def finding_key(detector, subject):
             return _fh.finding_key(detector, subject)
 
+        # Delegated, never re-implemented: a stub with its own rendering would go
+        # on passing after the two filers drifted apart again, which is the whole
+        # defect (PR #19 round-3 review, major).
+        @staticmethod
+        def launchd_finding(detector, label, detail=""):
+            return _fh.launchd_finding(detector, label, detail)
+
         @staticmethod
         def file_findings(findings, apply, filer=None):
             if record is not None:
@@ -367,9 +385,137 @@ check("a bucket the reporter has never heard of still counts as unfiled",
 # for) the outcome is all-zeros, which would print the clean-run line again.
 # `unfiled` has to count the problems that were owed an issue, not the findings
 # that were never constructed.
+# ===========================================================================
+# ONE kipi-key means ONE rendering (PR #19 round-3 review, major)
+# ===========================================================================
+# This script and fleet-health-daily.py file against the SAME key by design
+# (ASK-181). `finding_hash` covers title + body, so two renderings of one key made
+# every alternating run see a stale hash: a Linear rewrite plus a "1 updated ...
+# nothing to do now" Slack line twice a day on a fleet where nothing changed.
+#
+# Driven from ONE fake launchctl answering BOTH readers rather than two
+# hand-built fixtures, because the two encodings of a single machine state are
+# half the defect: `launchctl list` prints a SIGNED status (what fleet-health-daily
+# reads) while `launchctl list <label>` prints the RAW wait status (what this
+# script reads). Measured live 2026-07-27: a SIGKILLed job is `-9` in the column
+# and `"LastExitStatus" = 9`; com.apple.BiomeAgent is `5` and `1280`. A test that
+# fed both sides the same pre-formatted detail would have passed while production
+# titled one issue "(exit -9)" and the other "(exit 9)".
+_PAIR_LABEL = "com.kipi.pairing-demo"
+
+
+class _FakeCompleted:
+    def __init__(self, stdout="", returncode=0):
+        self.stdout, self.returncode, self.stderr = stdout, returncode, ""
+
+
+def _one_fake_machine(list_status, last_exit_status):
+    """`launchctl` for ONE failing job, answering both the bulk and per-label reads."""
+    def run(argv, **_kwargs):
+        if argv[:2] == ["launchctl", "list"] and len(argv) == 2:
+            return _FakeCompleted(f"PID\tStatus\tLabel\n-\t{list_status}\t{_PAIR_LABEL}\n")
+        if argv[:2] == ["launchctl", "list"] and len(argv) == 3:
+            if argv[2] != _PAIR_LABEL:
+                return _FakeCompleted("", 1)
+            return _FakeCompleted(f'\t"LastExitStatus" = {last_exit_status};\n', 0)
+        return _FakeCompleted("", 0)
+    return run
+
+
+def _both_renderings(list_status, last_exit_status):
+    """(fleet-health-daily's finding, this watchdog's finding) for one failing job."""
+    saved_fh, saved_wd = _fh.subprocess.run, wd.subprocess.run
+    _fh.subprocess.run = _one_fake_machine(list_status, last_exit_status)
+    wd.subprocess.run = _one_fake_machine(list_status, last_exit_status)
+    saved_module = wd._FLEET_HEALTH
+    wd._FLEET_HEALTH = _fh
+    try:
+        found = _fh.detect_failing_jobs(None)
+        fleet = dict(found[0]) if found else {}
+        if fleet:
+            fleet["key"] = _fh.finding_key("launchd-failing", fleet["subject"])
+        kind, code = wd.job_status(_PAIR_LABEL)
+        problems = [(_PAIR_LABEL, kind, f"exit {code}")] if kind == "failing" else []
+        watchdog = wd.linear_findings(problems)
+        return fleet, (watchdog[0] if watchdog else {})
+    finally:
+        _fh.subprocess.run, wd.subprocess.run = saved_fh, saved_wd
+        wd._FLEET_HEALTH = saved_module
+
+
+# `1`/`256` is an ordinary exit 1; `-9`/`9` is a SIGKILL, the shape 209 of the 210
+# non-zero rows on this machine actually have.
+for _name, _column, _raw in (("exit 1", "1", 256), ("SIGKILL", "-9", 9)):
+    _fleet_f, _wd_f = _both_renderings(_column, _raw)
+    check(f"{_name}: both scripts produce a finding", bool(_fleet_f and _wd_f), True)
+    check(f"{_name}: both file against the same key",
+          _fleet_f.get("key"), _wd_f.get("key"))
+    check(f"{_name}: both render the same title",
+          _fleet_f.get("title"), _wd_f.get("title"))
+    check(f"{_name}: both render the same body", _fleet_f.get("body"), _wd_f.get("body"))
+    check(f"{_name}: so the staleness hash agrees",
+          _fh.finding_hash(_fleet_f), _fh.finding_hash(_wd_f))
+
+# The consumer, not just the strings: `_refresh_one` is what turns a hash
+# disagreement into a Linear mutation. Hand it an issue carrying the OTHER filer's
+# rendering and it must answer "existing" -- no write, no Slack line.
+_fleet_f, _wd_f = _both_renderings("-9", 9)
+_tracked = {
+    "linear_id": "id-1", "identifier": "ASK-1", "state_type": "unstarted",
+    "team_id": "team-1",
+    "description": _fh.issue_description(_fleet_f["key"], _fleet_f,
+                                         filer="fleet-health-daily.py"),
+}
+check("the watchdog leaves fleet-health-daily's issue alone",
+      _fh._refresh_one(None, _wd_f, False, _tracked, "team-1", "launchd-health-check.py"),
+      "existing")
+_tracked_wd = {
+    "linear_id": "id-1", "identifier": "ASK-1", "state_type": "unstarted",
+    "team_id": "team-1",
+    "description": _fh.issue_description(_wd_f["key"], _wd_f,
+                                         filer="launchd-health-check.py"),
+}
+check("and fleet-health-daily leaves the watchdog's issue alone",
+      _fh._refresh_one(None, _fleet_f, False, _tracked_wd, "team-1",
+                       "fleet-health-daily.py"),
+      "existing")
+
+# Every kind this script files must come through the shared renderer -- driven
+# from the mapping itself, so adding a kind without covering it fails here rather
+# than shipping a second rendering of a shared key.
+for _kind, _detector in wd.LINEAR_DETECTOR_BY_KIND.items():
+    check(f"{_kind} routes to a shared-renderer id",
+          _detector in _fh.LAUNCHD_FINDING_IDS, True)
+    _saved_module = wd._FLEET_HEALTH
+    wd._FLEET_HEALTH = _fh
+    try:
+        _built = wd.linear_findings([(_PAIR_LABEL, _kind, "exit 7")])[0]
+    finally:
+        wd._FLEET_HEALTH = _saved_module
+    _shared = _fh.launchd_finding(_detector, _PAIR_LABEL, "exit 7")
+    check(f"{_kind}: title comes from the shared renderer",
+          _built["title"], _shared["title"])
+    check(f"{_kind}: body comes from the shared renderer",
+          _built["body"], _shared["body"])
+
+# An id nobody taught the renderer must be loud, not an empty body filed under a
+# key the other script also writes.
+try:
+    _fh.launchd_finding("launchd-invented", "com.kipi.x", "exit 1")
+    check("an unknown launchd detector id is refused", False, True)
+except ValueError:
+    check("an unknown launchd detector id is refused", True, True)
+
+
 class _BuildBoom:
     @staticmethod
     def finding_key(detector, subject):
+        raise ImportError("no module named fleet-health-daily")
+
+    @staticmethod
+    def launchd_finding(detector, label, detail=""):
+        # Rendering is delegated too now, so the missing-module scar has to be
+        # modelled on the call that actually happens first.
         raise ImportError("no module named fleet-health-daily")
 
 

--- a/q-system/.q-system/scripts/test_launchd_health_check.py
+++ b/q-system/.q-system/scripts/test_launchd_health_check.py
@@ -200,8 +200,10 @@ try:
     _none = wd.file_linear_findings([("com.cole.gamma", "paused", "paused on purpose")])
 finally:
     wd._FLEET_HEALTH = _saved_fh
+# `owed` rides along on every return path: it is the denominator `unfiled_count`
+# needs, and a path that omitted it would silently fall back to reading one bucket.
 check("a paused-only run files nothing", _none,
-      {"created": 0, "existing": 0, "skipped_no_key": 0})
+      {"created": 0, "existing": 0, "skipped_no_key": 0, "owed": 0})
 
 # --- a dead filer must not read like a clean run (ASK-181 review, finding 1) --
 # THE REPRODUCER: `file_findings` catches its own network errors and returns
@@ -286,6 +288,79 @@ check("the ping says the findings did not reach Linear",
       any("NOT filed to Linear: 2" in p for p in _dead_pings), True)
 check("a healthy filer leaves the ping text alone",
       any("NOT filed" in p for p in _ok_pings), False)
+
+# --- a REFUSED write must not read like a clean run either (PR #19 review, major)
+# THE REPRODUCER: ASK-204 gave `file_findings` per-finding error handling, so a
+# Linear write that fails now RETURNS {..., "errors": N} where it used to raise.
+# This reporter read `skipped_no_key` alone, so a refused write printed the
+# byte-identical line to a clean run AND lost the `[NOT filed to Linear: N]`
+# annotation on the ping -- in the job whose whole purpose is catching silence.
+# Same class as the ASK-181 scar above, one bucket further out.
+
+
+def _fh_stub_shape(record=None, **buckets):
+    """A stand-in emitting the FULL bucket shape `file_findings` returns.
+
+    `_fh_stub` above predates ASK-204 and emits three keys; the real filer emits
+    created/existing/skipped_no_key/updated/reopened/relisted/errors. Reporting
+    has to be proved against the shape production actually produces, and against
+    shapes it does not produce YET -- hence **buckets rather than a fixed list.
+    """
+
+    class _Stub:
+        @staticmethod
+        def finding_key(detector, subject):
+            return _fh.finding_key(detector, subject)
+
+        @staticmethod
+        def file_findings(findings, apply, filer=None):
+            if record is not None:
+                record.append({"n": len(findings), "apply": apply, "filer": filer})
+            outcome = {"created": 0, "existing": 0, "skipped_no_key": 0, "updated": 0,
+                       "reopened": 0, "relisted": 0, "errors": 0}
+            outcome.update(buckets)
+            return outcome
+
+    return _Stub
+
+
+def _last_line(problems, fleet_health):
+    return run_capture(problems, fleet_health)[0].strip().splitlines()[-1]
+
+
+# two findings, one filed and one the write refused
+_rejected_line = _last_line(_TWO_REAL, _fh_stub_shape(created=1, errors=1))
+_clean_line = _last_line(_TWO_REAL, _fh_stub_shape(created=2))
+check("a REFUSED Linear write does not print the same line as a clean run",
+      _rejected_line == _clean_line, False)
+check("a refused write is counted as unfiled", "unfiled=1" in _rejected_line, True)
+# the reviewer's exact shape: EVERY write refused reads byte-for-byte like a run
+# that had nothing to file, because both print filed=0 already-tracked=0.
+check("an all-refused run does not print the same line as a run with nothing to file",
+      _last_line(_TWO_REAL, _fh_stub_shape(errors=2))
+      == _last_line(_NOTHING_TO_FILE, _fh_stub_shape()), False)
+check("a clean run still reports nothing unfiled", "unfiled=0" in _clean_line, True)
+_rejected_pings = run_capture(_TWO_REAL, _fh_stub_shape(created=1, errors=1))[2]
+check("the ping says the board does NOT have the refused finding",
+      any("NOT filed to Linear: 1" in p for p in _rejected_pings), True)
+check("a refused write adds no extra ping", len(_rejected_pings), 1)
+check("a clean run leaves the ping text alone",
+      any("NOT filed" in p for p in run_capture(_TWO_REAL, _fh_stub_shape(created=2))[2]),
+      False)
+
+# A re-filed (`relisted`) finding DID land on the board -- counting it as unfiled
+# would trade this silence for a nightly false alarm, which is the other half of
+# the same failure.
+check("a re-filed finding counts as filed, not unfiled",
+      "unfiled=0" in _last_line(_TWO_REAL, _fh_stub_shape(created=1, relisted=1)), True)
+
+# The layer above this fix: `errors` will not be the last bucket `file_findings`
+# grows. A reporter that lists FAILURE buckets by name goes dark again on the day
+# the next one lands -- which is precisely how this regression happened. So
+# unfiled is owed-minus-LANDED: a bucket this reporter has never been taught
+# about counts as not-filed until someone declares it landed.
+check("a bucket the reporter has never heard of still counts as unfiled",
+      "unfiled=1" in _last_line(_TWO_REAL, _fh_stub_shape(created=1, quarantined=1)), True)
 
 # One layer deeper: if the findings cannot even be BUILT (fleet-health-daily.py
 # missing -- literally the kipi-update rsync --delete scar this watchdog exists

--- a/q-system/output/ask204-repro.py
+++ b/q-system/output/ask204-repro.py
@@ -1,0 +1,50 @@
+"""ASK-204 reproducer: the ask-150 detector publishes crontab text into a Linear body.
+
+Run against the ask-150 HEAD copy (q-system/output/ask150-fleet-health-daily.py),
+then against the fixed file. Exit 1 = the defect reproduces.
+
+The three shapes are the ones ASK-204 names as rounds 8 and 9's findings:
+  1. an assignment whose word start is a BACKTICK -- outside _ASSIGNMENT_RE's
+     lookbehind character class, so the value is published verbatim;
+  2. a bare `lin_api_` token -- no _SECRET_PATTERNS entry;
+  3. a bare `ntn_` token -- no _SECRET_PATTERNS entry.
+"""
+import importlib.util
+import sys
+from pathlib import Path
+
+TARGET = sys.argv[1] if len(sys.argv) > 1 else "q-system/output/ask150-fleet-health-daily.py"
+spec = importlib.util.spec_from_file_location("fh", Path(TARGET).resolve())
+fh = importlib.util.module_from_spec(spec)
+spec.loader.exec_module(fh)
+
+SECRETS = {
+    "backtick-word-start assignment": "lin_api_backtickleak",
+    "bare Linear token": "lin_api_bareleak",
+    "bare Notion token": "ntn_barenotionleak",
+}
+CRON = (
+    "0 3 * * * bash -lc '`LINEAR_API_KEY=lin_api_backtickleak claude -p sweep`'\n"
+    "0 4 * * * claude -p 'sweep' --header lin_api_bareleak\n"
+    "0 5 * * * claude -p 'sweep' --header ntn_barenotionleak\n"
+)
+
+findings = fh.detect_cron_shells_claude(None, cron_text=CRON)
+if not findings:
+    print("REPRO INCONCLUSIVE: detector found nothing to publish")
+    sys.exit(2)
+
+body = findings[0]["body"]
+print("what the finding publishes:")
+for line in body.splitlines():
+    if line.startswith("- `"):
+        print("   ", line)
+
+leaks = [name for name, secret in SECRETS.items() if secret in body]
+if leaks:
+    print(f"\nRED: {len(leaks)} secret(s) reach the Linear issue body verbatim:")
+    for name in leaks:
+        print(f"    - {name}: {SECRETS[name]}")
+    sys.exit(1)
+print("\nGREEN: zero characters of any source line reach the body")
+sys.exit(0)

--- a/q-system/output/ask204-repro.py
+++ b/q-system/output/ask204-repro.py
@@ -1,22 +1,34 @@
-"""ASK-204 reproducer: the ask-150 detector publishes crontab text into a Linear body.
+"""ASK-204 reproducer: does a cron finding publish crontab TEXT into a Linear body?
 
-Run against the ask-150 HEAD copy (q-system/output/ask150-fleet-health-daily.py),
-then against the fixed file. Exit 1 = the defect reproduces.
+    python3 q-system/output/ask204-repro.py             # the shipped detector -> GREEN
+    python3 q-system/output/ask204-repro.py --legacy    # the ask-150 output channel -> RED
+    python3 q-system/output/ask204-repro.py --self-test # asserts all three exit codes
+    python3 q-system/output/ask204-repro.py <path>      # any other copy of the detector
 
-The three shapes are the ones ASK-204 names as rounds 8 and 9's findings:
+Exit 0 = GREEN (nothing leaked), 1 = RED (the defect reproduces), 2 = INCONCLUSIVE
+(the target could not be loaded, or the detector found nothing to publish).
+
+Both halves run FROM THIS BRANCH (PR #19 review, minor 3). The default target used
+to be `q-system/output/ask150-fleet-health-daily.py`, which is not on the branch:
+the RED half was unreproducible by anyone reading the PR, and the resulting
+FileNotFoundError exited 1 -- the same code as "the defect reproduces". So the
+default is now the file this branch actually ships, a missing target exits 2, and
+`--legacy` reconstructs the OLD OUTPUT CHANNEL (publish the line, not its number)
+over the shipped detector, which is the whole of what ASK-204 changed.
+
+The three shapes are rounds 8 and 9 of #11's review:
   1. an assignment whose word start is a BACKTICK -- outside _ASSIGNMENT_RE's
-     lookbehind character class, so the value is published verbatim;
+     lookbehind character class, so the value was published verbatim;
   2. a bare `lin_api_` token -- no _SECRET_PATTERNS entry;
   3. a bare `ntn_` token -- no _SECRET_PATTERNS entry.
 """
 import importlib.util
+import subprocess
 import sys
 from pathlib import Path
 
-TARGET = sys.argv[1] if len(sys.argv) > 1 else "q-system/output/ask150-fleet-health-daily.py"
-spec = importlib.util.spec_from_file_location("fh", Path(TARGET).resolve())
-fh = importlib.util.module_from_spec(spec)
-spec.loader.exec_module(fh)
+REPO_ROOT = Path(__file__).resolve().parents[2]
+DEFAULT_TARGET = REPO_ROOT / "q-system/.q-system/scripts/fleet-health-daily.py"
 
 SECRETS = {
     "backtick-word-start assignment": "lin_api_backtickleak",
@@ -29,22 +41,91 @@ CRON = (
     "0 5 * * * claude -p 'sweep' --header ntn_barenotionleak\n"
 )
 
-findings = fh.detect_cron_shells_claude(None, cron_text=CRON)
-if not findings:
-    print("REPRO INCONCLUSIVE: detector found nothing to publish")
-    sys.exit(2)
 
-body = findings[0]["body"]
-print("what the finding publishes:")
-for line in body.splitlines():
-    if line.startswith("- `"):
-        print("   ", line)
+def load(target):
+    """The detector under test, or exit 2. A target that will not load is
+    INCONCLUSIVE, never RED -- an exit-code wrapper cannot tell those apart."""
+    path = Path(target).resolve()
+    if not path.is_file():
+        print(f"INCONCLUSIVE: no such target: {path}")
+        sys.exit(2)
+    try:
+        spec = importlib.util.spec_from_file_location("fh", path)
+        module = importlib.util.module_from_spec(spec)
+        spec.loader.exec_module(module)
+    except Exception as exc:  # noqa: BLE001
+        print(f"INCONCLUSIVE: {path} did not load: {type(exc).__name__}: {exc}")
+        sys.exit(2)
+    return module
 
-leaks = [name for name, secret in SECRETS.items() if secret in body]
-if leaks:
-    print(f"\nRED: {len(leaks)} secret(s) reach the Linear issue body verbatim:")
-    for name in leaks:
-        print(f"    - {name}: {SECRETS[name]}")
-    sys.exit(1)
-print("\nGREEN: zero characters of any source line reach the body")
-sys.exit(0)
+
+def legacy_body(fh):
+    """The body the ask-150 ARCHITECTURE built: the offending lines themselves.
+
+    Same detector, old output channel. That is the honest reconstruction -- ASK-204
+    never changed what is detected, only what the finding carries -- and it keeps
+    the RED half runnable without a copy of the deleted file on the branch.
+    """
+    numbers = fh.offending_cron_lines(CRON)
+    lines = CRON.splitlines()
+    return "\n".join(f"- `{lines[n - 1]}`" for n in numbers)
+
+
+def self_test():
+    """Assert all three exit codes, so this script cannot go one-sided again."""
+    cases = [
+        ("--legacy", 1, "the old output channel reproduces the leak"),
+        (str(DEFAULT_TARGET), 0, "the shipped detector publishes no source text"),
+        (str(REPO_ROOT / "q-system/output/does-not-exist.py"), 2,
+         "a missing target is INCONCLUSIVE, not RED"),
+    ]
+    bad = []
+    for arg, want, label in cases:
+        res = subprocess.run([sys.executable, __file__, arg],
+                             capture_output=True, text=True)
+        got = res.returncode
+        print(f"  {'ok ' if got == want else 'FAIL'}: {label} (exit {got}, want {want})")
+        if got != want:
+            bad.append(f"{arg}: exit {got}, want {want}\n{res.stdout}{res.stderr}")
+    if bad:
+        print("\nSELF-TEST FAILED:")
+        for line in bad:
+            print(f"  - {line}")
+        return 1
+    print("\nSELF-TEST PASS: RED, GREEN and INCONCLUSIVE all reachable from this branch")
+    return 0
+
+
+def main(argv):
+    if "--self-test" in argv:
+        return self_test()
+    legacy = "--legacy" in argv
+    positional = [a for a in argv if not a.startswith("--")]
+    fh = load(positional[0] if positional else DEFAULT_TARGET)
+
+    if legacy:
+        body = legacy_body(fh)
+        print("what the ask-150 output channel publishes:")
+    else:
+        findings = fh.detect_cron_shells_claude(None, cron_text=CRON)
+        if not findings:
+            print("INCONCLUSIVE: detector found nothing to publish")
+            return 2
+        body = findings[0]["body"]
+        print("what the finding publishes:")
+    for line in body.splitlines():
+        if line.startswith("- "):
+            print("   ", line)
+
+    leaks = [name for name, secret in SECRETS.items() if secret in body]
+    if leaks:
+        print(f"\nRED: {len(leaks)} secret(s) reach the Linear issue body verbatim:")
+        for name in leaks:
+            print(f"    - {name}: {SECRETS[name]}")
+        return 1
+    print("\nGREEN: zero characters of any source line reach the body")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main(sys.argv[1:]))


### PR DESCRIPTION
Replaces #11 (ASK-150), closed unmerged after nine review rounds. Resolves spillover `sp-638006cc`.

Branched from `origin/main` at `72c782d` (fetched first, per the issue). The ask-150 branch was **read, not merged** — its detection logic and test corpora are salvaged; its conflicting `fleet-health-daily.py` is not.

## The defect

The detector's behaviour was correct. Its output channel was not.

It took arbitrary shell text from `crontab -l`, ran best-effort regex redaction over it, and published the result into a **permanent** Linear issue. That is a denylist against unbounded syntax, and it leaked in every round anyone looked: a Slack webhook path, a Bearer token, a `bash -lc 'KEY=... claude'` credential (one of the detector's own headline supported shapes), a backtick word start, `lin_api_` / `ntn_` token shapes. Nine rounds, nine bypasses. Each fix was correct. The architecture was the defect.

## The fix

**A finding carries a reference, never the text.** `- line 2` instead of the line's contents. The operator opens their own crontab.

Deleted, not tightened: `_redact_secrets`, `_ASSIGNMENT_RE`, `_SECRET_PATTERNS`. There is nothing left to redact and no bypass left to find. `file_findings`' unreachable-Linear path gets the same treatment — the exception **type** reaches the outcome and the Slack line; the message stays on stderr in the run log (a GraphQL error array echoes the request, and this fleet's requests carry an `Authorization` header).

**Detection is not weakened.** The parser still reads each line in full — quoting, comments, `-c` strings, command substitution, wrapper/flag/operand tracking. What changed is what the finding *carries*.

One behaviour change, and it makes detection **stronger**: `_split_substitutions` masks a substitution span before the segment walk lexes. Previously a substitution containing a space split an assignment prefix across two whitespace tokens, so `` VAR=`echo secret` claude -p x `` — a real invocation — scored `` secret` `` as the command and answered False. Silent false negative, surfaced by the reproducer this issue's acceptance criterion demands.

## Also fixed, carried from #11's review rounds

- **major** — `_refresh_one` no longer replaces the whole `description`. It renders only the region above `<!-- kipi-managed-end -->` and splices the operator's tail back, with a graded fallback (sentinel → v1 trailer → preserve the whole body) for the pre-sentinel issues already on the board. Pinned by a test asserting a note survives **two consecutive** rewrites without duplicating.
- **minor** — a ledger key whose issue Linear cannot locate is now **re-filed** instead of counted and pinged every morning forever. `read_ledger` is last-wins over an append-only file, so the new record replaces the dangling `linear_id` and the next run resolves the key normally. One `relisted` line, once.

## ASK-181's contract is preserved

`file_findings` keeps its `filer` parameter and the `skipped_no_key` bucket that `launchd-health-check.py` reads by name; `outcome_line` tolerates the 3-key outcome that script builds by hand. Both are pinned by tests here, and `test_launchd_health_check.py` still passes.

## Evidence

The reproducer takes the target file as an argument, so the same script proves both sides.

```
$ python3 q-system/output/ask204-repro.py <ask-150 head>
what the finding publishes:
    - `0 3 * * * bash -lc '`LINEAR_API_KEY=lin_api_backtickleak claude -p sweep`'`
    - `0 4 * * * claude -p 'sweep' --header lin_api_bareleak`
    - `0 5 * * * claude -p 'sweep' --header ntn_barenotionleak`

RED: 3 secret(s) reach the Linear issue body verbatim
EXIT=1

$ python3 q-system/output/ask204-repro.py <this head>
GREEN: zero characters of any source line reach the body
EXIT=0
```

```
$ python3 q-system/.q-system/scripts/test/test-fleet-health-daily.py
PASS: fleet-health-daily contract holds          # exit 0

$ python3 q-system/.q-system/scripts/test_launchd_health_check.py
PASS: all launchd-health-check logic checks green # exit 0

$ python3 q-system/.q-system/scripts/capability-gate.py --repo-root .
  tests: ran=72 quarantined=0 skipped-skeleton-only=0
capability-gate: GREEN                            # exit 0
```

Live smoke against the real crontab, no writes:

```
fleet-health 2026-07-27T18:42:37Z
  unwired-untracked: 0
  launchd-dark: 0
  launchd-failing: 0
  schedule-duplicate: 0
  cron-shells-claude: 0
  open-spillover: 0
  filed=0 already-tracked=0 unfiled=0 rewritten=0 reopened=0 relisted=0 errors=0
```

## One place I did not follow the issue

ASK-204 lists "the quote-state tracking in `_substitutions`" among what the rewrite deletes. It stays. That tracking is **detection** work, not redaction work: single quotes suppress substitution and double quotes do not, so `` echo 'run `claude -p x` now' `` is prose and ``echo "`claude -p x`"`` is an invocation. Dropping it would file a permanent false-positive issue on the first — which the same issue forbids two paragraphs later ("Do not weaken detection to simplify output"). Both cases are pinned by tests. Flagging rather than silently skipping.

## Blast radius

`q-system/.q-system/scripts/` syncs to every instance via `kipi update`, so this detector runs fleet-wide. `linear-sync.py` gains `fetch_issue`, `reopen_state_id`, `ISSUE_UPDATE`, and richer `fetch_remote_state` records — all additive; no existing caller's shape changed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
