### PR TITLE
fix(prd-os): spillover resolve verifies a Linear issue, so finished work can leave the ledger (ASK-209)

### DIFF
--- a/plugins/prd-os/.claude-plugin/plugin.json
+++ b/plugins/prd-os/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "prd-os",
-  "version": "0.7.1",
+  "version": "0.7.2",
   "description": "PRD operating system: capture rough ideas, draft reviewable PRDs, run standard and adversarial review (Codex or a Claude senior-staff-engineer subagent, recorded truthfully), triage findings, decompose approved PRDs into atomic issue specs, and execute those issues with scope enforcement, stop-gate receipts, and reviewer-attributed findings.",
   "author": {
     "name": "Assaf Kipnis"

--- a/plugins/prd-os/scripts/prd_runner.py
+++ b/plugins/prd-os/scripts/prd_runner.py
@@ -1039,6 +1039,115 @@ def _issue_is_closed(cfg: Config, issue_id: str) -> bool:
     return False
 
 
+class LinearRefError(Exception):
+    """A resolution reference could not be PROVEN closed.
+
+    Covers every unverifiable case alike — no API key, no network, no such
+    issue, issue still open. They collapse to one class on purpose: the caller's
+    only correct response to any of them is to refuse, so a code path that could
+    tell them apart would only invite one of them being downgraded to a warning.
+    """
+
+
+LINEAR_API_URL = "https://api.linear.app/graphql"
+# Linear identifiers are TEAMKEY-number. Anything else is a local spec id (or a
+# typo), and must never become a live lookup.
+LINEAR_ID_RE = re.compile(r"^[A-Z][A-Z0-9]{0,9}-\d+$")
+LINEAR_STATE_QUERY = "query($id: String!) { issue(id: $id) { state { name type } } }"
+
+
+def _linear_api_key() -> str:
+    """The same auth path linear-sync.py uses: env first, then the 0600 secret.
+
+    Read here rather than imported from linear-sync.py because prd-os ships as a
+    standalone plugin into repos with no q-system tree. What is shared is the
+    CONVENTION (this env name, this file path), not code that could drift.
+    """
+    env = os.environ.get("KIPI_LINEAR_API_KEY", "").strip()
+    if env:
+        return env
+    path = Path(os.path.expanduser("~/.config/kipi/linear-api-key"))
+    if not path.is_file():
+        raise LinearRefError(
+            "closure cannot be verified: no Linear API key. Create one at "
+            "https://linear.app/settings/api then:\n"
+            f"  umask 077 && printf '%s' '<key>' > {path}\n"
+            "or export KIPI_LINEAR_API_KEY. An unverified reference is never recorded")
+    key = path.read_text().strip()
+    if not key:
+        raise LinearRefError(f"closure cannot be verified: {path} is empty")
+    return key
+
+
+def _linear_issue_state(identifier: str) -> dict:
+    """The `{name, type}` of a Linear issue's workflow state.
+
+    Raises LinearRefError for anything short of a definite answer, including an
+    unreachable API — offline is a refusal, not an assumption.
+    """
+    import urllib.error
+    import urllib.request
+
+    body = json.dumps({"query": LINEAR_STATE_QUERY, "variables": {"id": identifier}}).encode("utf-8")
+    request = urllib.request.Request(
+        LINEAR_API_URL, data=body, method="POST",
+        headers={"Content-Type": "application/json", "Authorization": _linear_api_key()},
+    )
+    try:
+        with urllib.request.urlopen(request, timeout=20) as response:
+            payload = json.loads(response.read().decode("utf-8"))
+    except urllib.error.HTTPError as exc:
+        raise LinearRefError(f"Linear returned HTTP {exc.code} for {identifier}") from exc
+    except urllib.error.URLError as exc:
+        raise LinearRefError(f"cannot reach Linear to verify {identifier}: {exc.reason}") from exc
+    except json.JSONDecodeError as exc:
+        raise LinearRefError(f"Linear sent a non-JSON answer for {identifier}: {exc}") from exc
+    # Linear answers HTTP 200 with an `errors` array for application-level
+    # failures, so a status-code-only check would read a failed lookup as a
+    # verified one -- the exact shape of bug this command exists to prevent.
+    if payload.get("errors"):
+        raise LinearRefError(
+            f"Linear rejected the lookup for {identifier}: {json.dumps(payload['errors'])[:200]}")
+    issue = (payload.get("data") or {}).get("issue")
+    if not isinstance(issue, dict) or not isinstance(issue.get("state"), dict):
+        raise LinearRefError(f"Linear has no issue {identifier}")
+    return issue["state"]
+
+
+def _verify_resolution_ref(cfg: Config, ref: str) -> dict:
+    """Prove `ref` names a closed issue; return the evidence that proved it.
+
+    Raises LinearRefError with an operator-readable reason when closure cannot
+    be proven. Nothing here accepts the operator's word: the returned evidence
+    describes what the TRACKER said, which is why a resolution still cannot be
+    hand-flipped through this command.
+
+    Local specs answer first. A repo that tracks its own issues under
+    `.prd-os/issues/` keeps resolving offline even when its ids look like Linear
+    keys; the Linear path only opens for a ref this repo has no spec for.
+    """
+    local_spec = cfg.issues_dir / f"{ref}.md"
+    if local_spec.is_file() or not LINEAR_ID_RE.match(ref):
+        if _issue_is_closed(cfg, ref):
+            return {"resolution_tracker": "prd-os"}
+        raise LinearRefError(
+            f"issue '{ref}' is not closed. Build it through the normal "
+            "reproducer-first issue flow and close it first.")
+    state = _linear_issue_state(ref)
+    if state.get("type") != "completed":
+        # `canceled` lands here too, and should: a canceled issue shipped no fix,
+        # so clearing the item with it would green the gate on work that never
+        # happened. The honest exit for a non-item is --void, which records why.
+        raise LinearRefError(
+            f"Linear issue '{ref}' is not completed (state: {state.get('name')}). "
+            "Close it first, or record a non-item with --void <reason>.")
+    return {
+        "resolution_tracker": "linear",
+        "resolution_verified_state": state.get("name"),
+        "resolution_verified_at": _now_iso(),
+    }
+
+
 def cmd_spillover(cfg: Config, args) -> int:
     """add | list | check | resolve — the out-of-scope finding ledger."""
     import hashlib as _hashlib
@@ -1085,12 +1194,18 @@ def cmd_spillover(cfg: Config, args) -> int:
         if args.void:
             new.update(status="resolved", void_reason=args.void, resolved_at=_now_iso())
         else:
-            if not _issue_is_closed(cfg, args.resolution_ref):
-                sys.stderr.write(
-                    f"cannot resolve {args.id}: issue '{args.resolution_ref}' is not closed. "
-                    f"Build it through the normal reproducer-first issue flow and close it first.\n")
+            try:
+                evidence = _verify_resolution_ref(cfg, args.resolution_ref)
+            except LinearRefError as exc:
+                sys.stderr.write(f"cannot resolve {args.id}: {exc}\n")
                 return 2
-            new.update(status="resolved", resolution_ref=args.resolution_ref, resolved_at=_now_iso())
+            new.update(status="resolved", resolution_ref=args.resolution_ref,
+                       resolved_at=_now_iso(), **evidence)
+            if args.evidence:
+                # Operator-supplied context (PR, merge commit). Recorded for the
+                # next reader, never consulted above: it is a note attached to a
+                # verified resolution, not a substitute for verifying one.
+                new["resolution_evidence"] = args.evidence
         _spillover_append(cfg, new)
         print(json.dumps({"id": args.id, "status": "resolved"}))
         return 0
@@ -1222,7 +1337,12 @@ def main(argv: list[str] | None = None) -> int:
     spill_sub.add_parser("check")
     sp_res = spill_sub.add_parser("resolve")
     sp_res.add_argument("id")
-    sp_res.add_argument("--resolution-ref", dest="resolution_ref", help="closed issue-id that fixed it")
+    sp_res.add_argument("--resolution-ref", dest="resolution_ref",
+                        help="closed issue that fixed it: a local .prd-os issue-id, "
+                             "or a Linear identifier (ASK-204) verified against Linear")
+    sp_res.add_argument("--evidence",
+                        help="auditable note recorded alongside a VERIFIED resolution "
+                             "(e.g. 'PR #19 / 990d7c1'); never a substitute for closure")
     sp_res.add_argument("--void", help="record a non-item (with reason) instead of fixing")
     p_spill.set_defaults(func=cmd_spillover)
 

--- a/plugins/prd-os/tests/test_spillover.py
+++ b/plugins/prd-os/tests/test_spillover.py
@@ -10,7 +10,9 @@ can.
 
 from __future__ import annotations
 
+import importlib.util
 import json
+import os
 import subprocess
 import sys
 from pathlib import Path
@@ -26,6 +28,22 @@ def run(repo: Path, *args: str) -> subprocess.CompletedProcess:
         [sys.executable, str(PRD_RUNNER), "--repo-root", str(repo), *args],
         capture_output=True, text=True,
     )
+
+
+def _load_runner():
+    """Import prd_runner in-process so the Linear fetch can be monkeypatched.
+
+    The tracker lookup is stubbed at the function boundary rather than through
+    an env-var endpoint override on purpose: an override would be a real bypass
+    surface on the resolve path, and the whole point of this command is that a
+    resolution cannot be asserted. A test seam that production also honours is
+    a hand-clear with extra steps.
+    """
+    sys.path.insert(0, str(PLUGIN_ROOT / "scripts"))
+    spec = importlib.util.spec_from_file_location("prd_runner_under_test", PRD_RUNNER)
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module
 
 
 @pytest.fixture
@@ -121,3 +139,133 @@ def test_resolve_requires_a_target(repo):
     run(repo, "spillover", "add", "--source", "s", "--desc", "x", "--id", "sp1")
     bad = run(repo, "spillover", "resolve", "sp1")  # neither --resolution-ref nor --void
     assert bad.returncode != 0
+
+
+# --- ASK-209: resolving against the tracker that actually owns the issue -----
+#
+# This repo's work ships through Linear, so `--resolution-ref ASK-204` used to be
+# looked up in `.prd-os/issues/`, never found, and refused -- while ASK-204 was
+# provably closed (PR #19, merge 990d7c1). The ledger then held finished work
+# open forever and `gates run` went RED on nothing, which is how a gate stops
+# carrying information. The fix VERIFIES a Linear identifier against Linear.
+# It does not trust the operator's word for it: an unverifiable ref is refused,
+# never recorded as resolved.
+
+
+@pytest.fixture
+def runner():
+    return _load_runner()
+
+
+def _resolve(module, repo: Path, *args: str) -> int:
+    return module.main(["--repo-root", str(repo), "spillover", "resolve", *args])
+
+
+def _stub_linear(monkeypatch, module, table: dict):
+    """Stand in for the Linear API. Unknown identifier -> the same error the
+    real fetch raises, so 'unknown' and 'open' stay distinguishable."""
+    def fake(identifier: str) -> dict:
+        if identifier not in table:
+            raise module.LinearRefError(f"Linear has no issue {identifier}")
+        return table[identifier]
+    monkeypatch.setattr(module, "_linear_issue_state", fake)
+
+
+def test_resolve_verifies_closed_linear_issue(repo, runner, monkeypatch):
+    run(repo, "spillover", "add", "--source", "s", "--desc", "leak", "--id", "sp1")
+    _stub_linear(monkeypatch, runner, {"ASK-204": {"type": "completed", "name": "Done"}})
+
+    code = _resolve(runner, repo, "sp1", "--resolution-ref", "ASK-204",
+                    "--evidence", "PR #19 / 990d7c1")
+    assert code == 0
+
+    last = [json.loads(l) for l in _ledger(repo).read_text().splitlines()
+            if json.loads(l)["id"] == "sp1"][-1]
+    assert last["status"] == "resolved"
+    assert last["resolution_ref"] == "ASK-204"
+    # The record has to be auditable offline: which tracker answered, what it
+    # said, and when. Otherwise the next reader has to re-hit the API to know
+    # whether this was verified or asserted.
+    assert last["resolution_tracker"] == "linear"
+    assert last["resolution_verified_state"] == "Done"
+    assert last["resolution_evidence"] == "PR #19 / 990d7c1"
+    assert run(repo, "spillover", "check").returncode == 0
+    assert run(repo, "gates", "run").returncode == 0
+
+
+def test_resolve_refuses_open_linear_issue(repo, runner, monkeypatch):
+    run(repo, "spillover", "add", "--source", "s", "--desc", "leak", "--id", "sp1")
+    _stub_linear(monkeypatch, runner, {"ASK-999": {"type": "started", "name": "In Progress"}})
+
+    assert _resolve(runner, repo, "sp1", "--resolution-ref", "ASK-999") != 0
+    assert run(repo, "spillover", "check").returncode == 1  # still open
+    assert run(repo, "gates", "run").returncode != 0
+
+
+def test_resolve_refuses_canceled_linear_issue(repo, runner, monkeypatch):
+    # Canceled is not fixed. A canceled issue shipped no fix, so letting it
+    # resolve an item would clear the gate on work that never happened. The
+    # honest exit for a non-item is --void, which records a reason.
+    run(repo, "spillover", "add", "--source", "s", "--desc", "leak", "--id", "sp1")
+    _stub_linear(monkeypatch, runner, {"ASK-998": {"type": "canceled", "name": "Canceled"}})
+
+    assert _resolve(runner, repo, "sp1", "--resolution-ref", "ASK-998") != 0
+    assert run(repo, "spillover", "check").returncode == 1
+
+
+def test_resolve_refuses_unknown_linear_identifier(repo, runner, monkeypatch):
+    run(repo, "spillover", "add", "--source", "s", "--desc", "leak", "--id", "sp1")
+    _stub_linear(monkeypatch, runner, {})  # Linear knows nothing
+
+    assert _resolve(runner, repo, "sp1", "--resolution-ref", "ASK-4242") != 0
+    assert run(repo, "spillover", "check").returncode == 1
+
+
+def test_resolve_refuses_malformed_ref_without_calling_linear(repo, runner, monkeypatch):
+    # A ref that is neither a local spec nor a well-formed Linear identifier is
+    # refused before any network call, so a typo cannot become a live lookup.
+    run(repo, "spillover", "add", "--source", "s", "--desc", "leak", "--id", "sp1")
+    called = []
+    monkeypatch.setattr(runner, "_linear_issue_state",
+                        lambda ident: called.append(ident) or {"type": "completed", "name": "Done"})
+
+    assert _resolve(runner, repo, "sp1", "--resolution-ref", "ASK-two-oh-four") != 0
+    assert called == [], "a malformed ref reached the Linear API"
+    assert run(repo, "spillover", "check").returncode == 1
+
+
+def test_resolve_refuses_when_linear_auth_is_missing(repo, tmp_path):
+    """No key, no network, no resolution -- the item stays open and the gate red.
+
+    Recording an unverifiable ref as `pending` was the alternative. It is worse:
+    the operator's assertion would be the only thing standing between a finding
+    and a clean ledger, which is exactly the hand-clear this command exists to
+    prevent. Refusing keeps the item visible until someone can actually prove it.
+    """
+    run(repo, "spillover", "add", "--source", "s", "--desc", "leak", "--id", "sp1")
+    env = dict(os.environ)
+    env.pop("KIPI_LINEAR_API_KEY", None)
+    env["HOME"] = str(tmp_path / "empty-home")  # no ~/.config/kipi/linear-api-key
+    (tmp_path / "empty-home").mkdir()
+
+    bad = subprocess.run(
+        [sys.executable, str(PRD_RUNNER), "--repo-root", str(repo),
+         "spillover", "resolve", "sp1", "--resolution-ref", "ASK-204"],
+        capture_output=True, text=True, env=env,
+    )
+    assert bad.returncode != 0
+    assert "sp1" in bad.stderr
+    assert run(repo, "spillover", "check").returncode == 1
+    assert run(repo, "gates", "run").returncode != 0
+
+
+def test_local_issue_spec_still_wins_over_linear(repo, runner, monkeypatch):
+    # A repo that tracks issues locally under a Linear-shaped id keeps working
+    # offline: the local spec is checked first and Linear is never consulted.
+    run(repo, "spillover", "add", "--source", "s", "--desc", "leak", "--id", "sp1")
+    _write_issue(repo, "ASK-204", status="closed")
+    monkeypatch.setattr(runner, "_linear_issue_state",
+                        lambda ident: pytest.fail("local spec should have answered"))
+
+    assert _resolve(runner, repo, "sp1", "--resolution-ref", "ASK-204") == 0
+    assert run(repo, "spillover", "check").returncode == 0


### PR DESCRIPTION
Closes ASK-209. Resolves spillover `sp-4c59c1f5`.

## The defect

`spillover resolve --resolution-ref` verified closure by looking in `.prd-os/issues/`.
This repo's autonomous work ships through **Linear**, so a Linear identifier was never
found and the resolve was refused:

```
$ prd_runner.py spillover resolve sp-638006cc --resolution-ref ASK-204
cannot resolve sp-638006cc: issue 'ASK-204' is not closed.
```

ASK-204 **was** closed (PR #19, merge `990d7c1`). `gates run` fails while any item is
open, so every item fixed the normal way accumulated as permanently open and the gate
went RED on finished work. That is the failure mode where a gate stops carrying
information: the reader learns the red is meaningless and stops reading it.

## Which option, and why

The DoR offered two. **Picked option 1: verify the identifier against Linear.**

Option 2 (record an operator-typed external reference with evidence) cannot prove
closure. The operator's assertion would be the only thing standing between a finding
and a clean ledger, which is exactly the hand-clear this command exists to prevent. The
DoR's own line settles it: an external ref that nobody verifies is worse than the bug.

Option 2's *auditability* goal is kept without its cost: every verified resolution now
records which tracker answered, what state it reported, and when, plus an optional
operator note. The record is readable offline; the *decision* was never the operator's.

## How it works

- **Local specs answer first.** A repo tracking its own issues under `.prd-os/issues/`
  keeps resolving offline even when its ids look like Linear keys. Existing behaviour is
  unchanged, including the exact refusal string.
- A `TEAMKEY-123`-shaped ref with **no local spec** is looked up via the Linear API,
  using the same auth path `linear-sync.py` uses: `KIPI_LINEAR_API_KEY`, then the 0600
  `~/.config/kipi/linear-api-key`. Read in `prd_runner.py` rather than imported because
  prd-os ships standalone into repos with no `q-system` tree, so what is shared is the
  **convention** (env name, file path), not code that could drift apart in behaviour.
- Only workflow-state type `completed` counts. **`canceled` is refused** and pointed at
  `--void`: a canceled issue shipped no fix, so clearing an item with it would green the
  gate on work that never happened.
- Linear answers HTTP 200 with an `errors` array for application-level failures, so the
  fetch checks `errors` too. A status-code-only check would read a failed lookup as a
  verified one, which is the exact shape of bug this command exists to prevent.
- Optional `--evidence` records a note (PR, merge commit) alongside a **verified**
  resolution. It is never consulted when deciding.

## Offline / no-auth behaviour: REFUSE

No key, no network, unreachable API, unknown identifier — all refuse. The item stays
open and the gate stays red until someone can actually prove it.

Recording an unverifiable ref as `pending` was the alternative and is rejected: an item
that leaves `open` on an operator's word is a hand-clear with extra steps, and if
`pending` still counted as open it would only be a noisier refusal. Pinned by
`test_resolve_refuses_when_linear_auth_is_missing` (runs with `HOME` pointed at an empty
dir and `KIPI_LINEAR_API_KEY` stripped — no network reached, item still open, gate red).

## How hand-clearing stays impossible

Nothing on the resolve path reads an operator-supplied claim **about closure**. Every
accepted resolution is gated on what a tracker said: a local spec's `status: closed`, or
Linear's workflow-state `type`. `--evidence` is free text but is written only *after*
that gate passes and is never read by it, so it can annotate a proof and cannot become
one. There is still no third way out of the ledger: verified-closed, or `--void` with a
recorded reason.

The Linear fetch is stubbed **at the function boundary** in tests rather than through an
env-var API-URL override, deliberately. An override would be a live bypass surface on the
very path that must not be bypassable; a test seam production also honours is a hand-clear
with extra steps.

## Verification

**Reproducer first.** 7 new tests in `plugins/prd-os/tests/test_spillover.py`; 6 failed
RED before the fix existed:

```
FAILED test_resolve_verifies_closed_linear_issue
FAILED test_resolve_refuses_open_linear_issue
FAILED test_resolve_refuses_canceled_linear_issue
FAILED test_resolve_refuses_unknown_linear_identifier
FAILED test_resolve_refuses_malformed_ref_without_calling_linear
FAILED test_local_issue_spec_still_wins_over_linear
6 failed, 9 passed in 1.43s
E   AttributeError: module 'prd_runner' has no attribute '_linear_issue_state'
```

Green after:

```
$ python3 -m pytest plugins/prd-os/tests/ -q
325 passed, 1 skipped in 11.58s
```

**Acceptance demo, against the live Linear API** (not a stub):

```
$ prd_runner.py --repo-root ~/projects/kipi-system \
    spillover resolve sp-638006cc --resolution-ref ASK-204 \
    --evidence "PR #19 / merge 990d7c1"
{"id": "sp-638006cc", "status": "resolved"}
EXIT=0
```

Ledger record — `resolution_verified_state` came from Linear, not from the caller:

```json
{
  "id": "sp-638006cc",
  "status": "resolved",
  "resolution_ref": "ASK-204",
  "resolution_tracker": "linear",
  "resolution_verified_state": "Done",
  "resolution_verified_at": "2026-07-27T20:01:16Z",
  "resolution_evidence": "PR #19 / merge 990d7c1"
}
```

**Negative self-tests, same live API:**

```
$ ... spillover resolve sp-4c59c1f5 --resolution-ref ASK-209
cannot resolve sp-4c59c1f5: Linear issue 'ASK-209' is not completed (state: Backlog).
Close it first, or record a non-item with --void <reason>.
EXIT=2

$ ... spillover resolve sp-4c59c1f5 --resolution-ref ASK-99999
cannot resolve sp-4c59c1f5: Linear rejected the lookup for ASK-99999:
[{"message": "Entity not found: Issue", ...}]
EXIT=2
```

`plugins/prd-os/.claude-plugin/plugin.json` bumped 0.7.1 -> 0.7.2 (the
`plugin-version-bump` pre-commit gate blocked the first commit; without it the
version-keyed runtime cache would keep serving the stale copy).

## Out of scope, untouched

What creates spillover items, the `deferred`-triage auto-capture, and `gates run`
failure semantics are unchanged. This is only about how an item legitimately leaves.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
