### PR TITLE
fix(worker): fetch origin before cutting a worktree, and page when the fetch fails (ASK-211)

### DIFF
--- a/q-system/.q-system/capability-manifest.json
+++ b/q-system/.q-system/capability-manifest.json
@@ -102,6 +102,10 @@
       "runner": "bash"
     },
     {
+      "path": "q-system/.q-system/scripts/test/test-linear-worker-fetch.sh",
+      "runner": "bash"
+    },
+    {
       "path": "q-system/.q-system/scripts/test/test-linear-worker-parallel.sh",
       "runner": "bash"
     },

--- a/q-system/.q-system/scripts/linear-worker.sh
+++ b/q-system/.q-system/scripts/linear-worker.sh
@@ -28,6 +28,13 @@
 #   human interrupt                  -> destructive-op-deny.sh; and it cannot merge
 #   goal met                         -> the PR + the closeout gates, not this script
 #
+# EXIT CODES
+#   0  ran (or had nothing to run). A caller may treat this as healthy.
+#   1  usage error
+#   9  INFRA: the environment is down (git fetch failed) and the run did NO
+#      work. Paged on the way out. Distinct from 1 so a caller can tell a dead
+#      environment from a bad invocation.
+#
 # WHY INFRA FAILURE IS COUNTED SEPARATELY
 # ---------------------------------------
 # An expired auth token or a Linear outage is not the issue's fault. Counting it
@@ -50,7 +57,11 @@ SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 SKEL="${KIPI_SKEL:-$(cd "$SCRIPT_DIR/../../.." && pwd)}"
 CLAIM="$SCRIPT_DIR/linear-claim.py"
 SYNC="$SCRIPT_DIR/linear-sync.py"
-NOTIFY="$SCRIPT_DIR/slack-notify.sh"
+# Overridable so the suite can read back WHAT was paged without paging the
+# founder, and so "did anyone get told?" is answered by a file instead of by a
+# grep of this source. Same seam and same name converge.sh already uses -- one
+# convention, not two. Default is always the real Slack sink.
+NOTIFY="${KIPI_NOTIFY:-$SCRIPT_DIR/slack-notify.sh}"
 STATE_DIR="${KIPI_STATE_DIR:-$HOME/.config/kipi}"
 ATTEMPTS="$STATE_DIR/linear-worker-attempts.json"
 LOG="$STATE_DIR/linear-worker.log"
@@ -105,6 +116,42 @@ run_bounded() {  # run_bounded <seconds> <cmd...>
   wait "$watchdog" 2>/dev/null
   return "$rc"
 }
+
+# --- FETCH ONCE, BEFORE ANY WORKTREE EXISTS ---------------------------------
+# ASK-211 (sp-28ced3d6). This script used to contain no `git fetch` at all: it
+# cut every worktree from whatever local origin/main ref happened to be lying
+# around, so the agent was dispatched against a base that could be arbitrarily
+# old. Observed 2026-07-27 -- ASK-150 was sent to resolve a conflict against
+# main, merged 3b60af0, and the conflict survived because main was already
+# 72c782d. The agent did the right thing to the wrong target and two rounds
+# were burned.
+#
+# ONCE PER RUN, not per issue: origin does not move meaningfully inside one run,
+# and a 50-issue board would otherwise pay 50 network round-trips to learn the
+# same thing. Placed above the picker so no code path can create a worktree
+# before it.
+#
+# A fetch failure is environmental (self-healing-retry.md rule 5), so it stops
+# on attempt 1 and is NOT counted against any issue. Continuing would be worse
+# than stopping: the whole point is that a stale base silently produces
+# plausible work aimed at the wrong target, and the run could not push or open
+# a PR against an unreachable origin anyway.
+#
+# IT PAGES AND EXITS 9, it does not stop quietly (PR #22 review round 3,
+# finding 1 -- major). The first version of this guard was `say` + `exit 0`,
+# which made an expired credential at 3am byte-for-byte indistinguishable from a
+# healthy run with nothing ready: same rc, no Slack, one line in a log nobody
+# reads. The issue never became stuck either, because MAX_ATTEMPTS only counts
+# DISPATCHED runs. Rule 5 says surface it IMMEDIATELY, and a log line is not
+# surfacing.
+#
+# 9, not 1: 1 is the usage error above, and a caller has to be able to tell an
+# environment that is down from a worker that was invoked wrong.
+if ! git -C "$SKEL" fetch --quiet origin 2>>"$LOG"; then
+  say "INFRA: git fetch failed in $SKEL. Stopping before any worktree is cut from a stale base."
+  bash "$NOTIFY" "worker: git fetch failed in $SKEL -- the run did NO work. Check credentials/network." 2>/dev/null || true
+  exit 9
+fi
 
 # --- pick ready issues ------------------------------------------------------
 PICKED="$(python3 - "$ONLY_ISSUE" <<'PY'

--- a/q-system/.q-system/scripts/test/test-linear-worker-fetch.sh
+++ b/q-system/.q-system/scripts/test/test-linear-worker-fetch.sh
@@ -1,0 +1,261 @@
+#!/usr/bin/env bash
+# Reproducer + acceptance criterion for "the worker never fetches, and when the
+# fetch fails it goes dark" (ASK-211, sp-28ced3d6; re-file of fix 1 of ASK-208).
+#
+# THE DEFECT: linear-worker.sh contains no `git fetch` anywhere. It runs
+#   git -C "$SKEL" worktree add -q -B "$BRANCH" "$TREE" origin/main
+# against whatever local `origin/main` remote-tracking ref happens to exist, so
+# the agent is dispatched against a base that can be arbitrarily old.
+#
+# OBSERVED (2026-07-27): ASK-150 was dispatched to resolve a conflict against
+# main, merged 3b60af0, and the conflict survived -- main was already 72c782d.
+# The agent did the right thing to the wrong target and two rounds were burned.
+#
+# THE SECOND HALF, which failed review the first time this fix was attempted
+# (PR #22, round 3, finding 1 -- major): a fetch guard whose failure path is
+# `say` + `exit 0` makes an expired credential at 3am byte-for-byte
+# indistinguishable from a healthy run with nothing ready -- same rc, no Slack,
+# one line in a log nobody reads. MAX_ATTEMPTS counts only DISPATCHED runs, so
+# the issue never becomes stuck and never pages that way either. A fleet-wide
+# worker that goes permanently dark while reporting success cannot ride a
+# follow-up. self-healing-retry.md rule 5 says an environmental failure is
+# surfaced IMMEDIATELY, and a log line is not surfacing.
+#
+# WHY THIS DRIVES THE REAL SCRIPT: both claims are about side effects, so both
+# are read back for real. Case 1 stales the local remote-tracking ref and asserts
+# the SHA the worktree actually landed on -- a grep for "git fetch" in the source
+# would pass on a fetch placed AFTER the worktree is created, i.e. on a script
+# that still has the bug. Cases 4-6 run against a genuinely unreachable origin
+# and redirect $NOTIFY to a recorder rather than stubbing it out, so "did anyone
+# get paged, and did the page say what broke?" is answered by a file with the
+# message in it and never by a grep.
+#
+# Case 7 asserts the healthy contrast in the same run. A non-zero exit is only
+# worth something if the healthy path still exits 0 and still pages nobody --
+# otherwise the fix trades a silent failure for a permanent false alarm, which is
+# the same defect wearing the other hat.
+#
+# Isolation: KIPI_SKEL / KIPI_STATE_DIR / HOME all point inside a temp dir, and
+# python3 / gh / claude are stubbed. `git` stays REAL: real refs are the subject.
+set -uo pipefail
+
+ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/../../../.." && pwd)"
+WORKER="$ROOT/q-system/.q-system/scripts/linear-worker.sh"
+
+PASS=0
+fail() { echo "FAIL: $1" >&2; exit 1; }
+ok()   { PASS=$((PASS + 1)); echo "  ok: $1"; }
+
+[ -f "$WORKER" ] || fail "linear-worker.sh does not exist at $WORKER"
+REAL_PY="$(command -v python3)" || fail "python3 not on PATH"
+REAL_GIT="$(command -v git)"    || fail "git not on PATH"
+
+WORK="$(mktemp -d)"
+trap 'rm -rf "$WORK"' EXIT
+unset KIPI_LINEAR_CLAIMS KIPI_SESSION_ID CLAUDE_SESSION_ID 2>/dev/null || true
+
+# HOME is redirected because the run must not be able to reach the founder's
+# real ~/.config/kipi (pr-review-agent.sh writes there). Identity therefore has
+# to be passed per-command rather than read from a global config.
+G() { git -c user.email=t@t.t -c user.name=t "$@"; }
+
+STUB="$WORK/bin"; mkdir -p "$STUB" "$WORK/home"
+# No PR exists and none may be created.
+printf '#!/usr/bin/env bash\nexit 0\n' > "$STUB/gh"
+chmod +x "$STUB/gh"
+# THE PROBE for "did anyone get paged". Not a no-op stub: the message has to be
+# readable, because a page that says nothing is the failure in a different coat.
+cat > "$WORK/notify-recorder.sh" <<EOF
+#!/usr/bin/env bash
+printf '%s\n' "\$*" >> "$WORK/pages.txt"
+EOF
+chmod +x "$WORK/notify-recorder.sh"
+export PATH="$STUB:$PATH"
+[ "$(command -v git)" = "$REAL_GIT" ] || fail "git was shadowed by a stub; real refs are the subject"
+
+# picker_stub <json-for-the-heredoc-call>
+# The worker feeds its picker to `python3 -` and calls linear-sync.py for the
+# progress notes. Everything else (linear-claim.py, the ledger helpers) must run
+# for real, so the stub falls through to the real interpreter.
+picker_stub() {
+  cat > "$STUB/python3" <<EOF
+#!/usr/bin/env bash
+case "\${1:-}" in
+  -)  cat >/dev/null
+      printf '%s\n' '$1'
+      exit 0 ;;
+  *linear-sync.py) exit 0 ;;
+esac
+exec "$REAL_PY" "\$@"
+EOF
+  chmod +x "$STUB/python3"
+}
+
+# ===========================================================================
+# PART A -- a reachable origin that has moved. Does the tree get the new base?
+# ===========================================================================
+git init -q --bare "$WORK/origin"
+# The bare repo's default HEAD is refs/heads/master, so a clone of it would land
+# on an unborn branch and its push would fail -- leaving the "true remote head"
+# this test asserts against sitting in a clone that never reached origin.
+git -C "$WORK/origin" symbolic-ref HEAD refs/heads/main
+git init -q "$WORK/skel"
+G -C "$WORK/skel" commit -q --allow-empty -m c1
+git -C "$WORK/skel" branch -M main
+git -C "$WORK/skel" remote add origin "$WORK/origin"
+git -C "$WORK/skel" push -q -u origin main
+C1="$(git -C "$WORK/skel" rev-parse HEAD)"
+
+# A DIFFERENT clone advances the real remote. $WORK/skel is never told.
+git clone -q "$WORK/origin" "$WORK/other"
+G -C "$WORK/other" commit -q --allow-empty -m c2
+git -C "$WORK/other" push -q origin main
+C2="$(git -C "$WORK/other" rev-parse HEAD)"
+
+[ "$C1" != "$C2" ] || fail "fixture: the remote did not actually advance"
+[ "$(git -C "$WORK/skel" rev-parse origin/main)" = "$C1" ] \
+  || fail "fixture: skel's origin/main was not stale to begin with"
+
+# The work phase is a no-op here: this part asks only where the tree was based.
+printf '#!/usr/bin/env bash\nexit 0\n' > "$STUB/claude"
+chmod +x "$STUB/claude"
+picker_stub '{"ready":[{"id":"ASK-AAA","title":"t","project":"p"}],"total_open":1}'
+
+# cwd is the skeleton, which is where launchd runs this from.
+( cd "$WORK/skel" \
+  && HOME="$WORK/home" KIPI_SKEL="$WORK/skel" KIPI_STATE_DIR="$WORK/state" \
+     bash "$WORKER" --apply --issue ASK-AAA --limit 1 ) >"$WORK/run.out" 2>&1
+RC=$?
+
+TREE="$WORK/state/worktrees/ask-aaa"
+[ -d "$TREE" ] || fail "no worktree was created (rc=$RC): $(tail -5 "$WORK/run.out")"
+
+# --- 1. the tree is based on the TRUE remote head, not the stale local ref ---
+BASE="$(git -C "$TREE" rev-parse HEAD)"
+if [ "$BASE" = "$C1" ]; then
+  fail "STALE BASE: the worktree was cut from the stale origin/main ($C1).
+      The true remote head is $C2. The worker branched without fetching, which is
+      how ASK-150 resolved a conflict against a main that had already moved."
+fi
+[ "$BASE" = "$C2" ] || fail "worktree base $BASE is neither the stale ref nor the remote head $C2"
+ok "the worktree was cut from the TRUE remote head (fetch happened before worktree add)"
+
+# --- 2. the local remote-tracking ref was actually updated ------------------
+# The mechanism behind case 1, asserted directly: a fetch that did not move
+# refs/remotes/origin/main would leave every later `origin/main..HEAD` count wrong,
+# which is what the worker's own "open the PR in code" branch counts.
+[ "$(git -C "$WORK/skel" rev-parse origin/main)" = "$C2" ] \
+  || fail "refs/remotes/origin/main in the skeleton was not updated by the run"
+ok "the skeleton's refs/remotes/origin/main was updated to the remote head"
+
+# --- 3. ONE fetch per run, not one per issue -------------------------------
+# Counted by wrapping git in a counting stub for a 2-issue run. A per-issue fetch
+# is a real cost on a 50-issue board and the DoR asks for one.
+CSTUB="$WORK/bin2"; mkdir -p "$CSTUB"
+cat > "$CSTUB/git" <<EOF
+#!/usr/bin/env bash
+for a in "\$@"; do [ "\$a" = "fetch" ] && { echo x >> "$WORK/fetches.txt"; break; }; done
+exec "$REAL_GIT" "\$@"
+EOF
+chmod +x "$CSTUB/git"
+: > "$WORK/fetches.txt"
+picker_stub '{"ready":[{"id":"ASK-AAA","title":"t","project":"p"},{"id":"ASK-BBB","title":"t","project":"p"}],"total_open":2}'
+
+( cd "$WORK/skel" \
+  && PATH="$CSTUB:$PATH" HOME="$WORK/home" KIPI_SKEL="$WORK/skel" KIPI_STATE_DIR="$WORK/state2" \
+     bash "$WORKER" --apply --limit 2 ) >"$WORK/run2.out" 2>&1
+
+# `grep -c` exits 1 on a zero count, so the old `|| echo 0` idiom printed "0\n0"
+# and the very branch that reports "no fetch at all" died on a bad integer
+# comparison instead of failing cleanly. wc always exits 0.
+FETCHES="$(wc -l < "$WORK/fetches.txt" | tr -d ' ')"
+[ "${FETCHES:-0}" -ge 1 ] || fail "a 2-issue run performed no fetch at all"
+[ "${FETCHES:-0}" -le 1 ] \
+  || fail "a 2-issue run fetched $FETCHES times; the DoR asks for one fetch per run, not per issue"
+ok "a 2-issue run fetched exactly once"
+
+# ===========================================================================
+# PART B -- an origin that cannot be reached. Does anyone find out?
+# ===========================================================================
+git init -q "$WORK/skel2"
+G -C "$WORK/skel2" commit -q --allow-empty -m c1
+git -C "$WORK/skel2" branch -M main
+git -C "$WORK/skel2" remote add origin "$WORK/nowhere.git"   # never created
+git -C "$WORK/skel2" fetch --quiet origin 2>/dev/null \
+  && fail "fixture: the unreachable origin fetched anyway"
+
+# Reaching the agent at all would mean the run did work on a stale base.
+cat > "$STUB/claude" <<EOF
+#!/usr/bin/env bash
+echo "dispatched" >> "$WORK/worked.txt"
+exit 0
+EOF
+chmod +x "$STUB/claude"
+picker_stub '{"ready":[{"id":"ASK-AAA","title":"t","project":"p"}],"total_open":1}'
+: > "$WORK/pages.txt"; : > "$WORK/worked.txt"
+
+( cd "$WORK/skel2" \
+  && HOME="$WORK/home" KIPI_SKEL="$WORK/skel2" KIPI_STATE_DIR="$WORK/state3" \
+     KIPI_NOTIFY="$WORK/notify-recorder.sh" \
+     bash "$WORKER" --apply --issue ASK-AAA --limit 1 ) >"$WORK/run3.out" 2>&1
+RC_FAIL=$?
+
+# --- 4. the run is distinguishable from a healthy no-work run ---------------
+if [ "$RC_FAIL" = "0" ]; then
+  fail "SILENT SUCCESS: the worker exited 0 after a fetch failure that stopped
+      the entire run. A caller -- launchd, a wrapper, converge -- cannot tell
+      this apart from a healthy run with nothing ready. It said:
+      $(grep -i infra "$WORK/run3.out" | head -1)"
+fi
+ok "a fetch failure exits non-zero (rc=$RC_FAIL), so a caller can tell"
+
+# --- 5. somebody was actually paged, and the page names the cause -----------
+if [ ! -s "$WORK/pages.txt" ]; then
+  fail "NOBODY WAS PAGED: the fetch failed, the run did no work, and \$NOTIFY was
+      never called. self-healing-retry.md rule 5 says an environmental failure is
+      surfaced immediately; the only trace was a line in the log."
+fi
+ok "the fetch failure pages the founder through \$NOTIFY"
+
+grep -qi "fetch" "$WORK/pages.txt" \
+  || fail "the page does not name the cause. It said: $(head -1 "$WORK/pages.txt")"
+ok "the page names the cause (git fetch), not just 'something failed'"
+
+# --- 6. it stopped BEFORE doing anything on a stale base --------------------
+[ ! -s "$WORK/worked.txt" ] \
+  || fail "the agent was dispatched anyway; the whole point of stopping is that a
+      stale base produces plausible work aimed at the wrong target"
+[ ! -d "$WORK/state3/worktrees/ask-aaa" ] \
+  || fail "a worktree was cut despite the fetch failure"
+ok "no worktree was cut and no agent was dispatched"
+
+# --- 7. the HEALTHY path is unchanged: rc 0, and nobody is paged ------------
+# Without this the fix could 'pass' by always failing and always paging, which
+# trains the reader to ignore the channel -- the cry-wolf failure this fleet
+# keeps killing.
+git init -q --bare "$WORK/origin2"
+git -C "$WORK/origin2" symbolic-ref HEAD refs/heads/main
+git -C "$WORK/skel2" remote set-url origin "$WORK/origin2"
+git -C "$WORK/skel2" push -q -u origin main
+picker_stub '{"ready":[],"total_open":0}'
+: > "$WORK/pages.txt"
+
+( cd "$WORK/skel2" \
+  && HOME="$WORK/home" KIPI_SKEL="$WORK/skel2" KIPI_STATE_DIR="$WORK/state4" \
+     KIPI_NOTIFY="$WORK/notify-recorder.sh" \
+     bash "$WORKER" --apply --limit 1 ) >"$WORK/run4.out" 2>&1
+RC_OK=$?
+
+[ "$RC_OK" = "0" ] \
+  || fail "a healthy run with nothing ready must still exit 0, got rc=$RC_OK: $(tail -3 "$WORK/run4.out")"
+ok "a healthy run with nothing ready still exits 0"
+
+[ ! -s "$WORK/pages.txt" ] \
+  || fail "a healthy no-work run paged the founder: $(head -1 "$WORK/pages.txt")"
+ok "a healthy no-work run pages nobody"
+
+# --- 8. the script still parses --------------------------------------------
+bash -n "$WORKER" || fail "linear-worker.sh does not parse"
+ok "linear-worker.sh parses (bash -n)"
+
+echo "PASS: linear-worker fetch ($PASS checks)"


### PR DESCRIPTION
Fix 1 of 4 from ASK-208 (PR #22, closed unmerged at the round cap), re-filed on its own per the round-3 reviewer: *"worth landing fixes 1 and 2 (fetch + mergeability, ~80 lines, clean) separately from the ledger-and-cap machinery, which is where every regression has come from."*

Resolves spillover `sp-28ced3d6`.

## The defect

`linear-worker.sh` contained no `git fetch` anywhere. Every worktree was cut from whatever local `origin/main` ref happened to be lying around.

**Observed 2026-07-27:** ASK-150 was dispatched to resolve a merge conflict. It merged `3b60af0` and the conflict survived, because `main` was already `72c782d`. The agent did the right thing to the wrong target and two rounds were burned.

## The change (3 files, +52 lines)

- Fetch runs **once per run**, above the picker, so no code path can create a worktree before it.
- A fetch failure is environmental (`self-healing-retry.md` rule 5): stops on attempt 1, is **not** counted against any issue, pages through `$NOTIFY`, exits **9**.
- `NOTIFY` is overridable via `KIPI_NOTIFY` (the seam `converge.sh` already uses) so the suite reads back what was paged instead of grepping the source.
- Exit-code contract documented in the header: `0` healthy, `1` usage, `9` infra.

Exit 9 + the page are the half that **failed review the first time**. A guard whose failure path is `say` + `exit 0` makes an expired credential at 3am byte-for-byte indistinguishable from a healthy no-work run, and `MAX_ATTEMPTS` only counts DISPATCHED runs, so the issue never becomes stuck and never pages that way either.

## Reproducer: observed RED twice, then green

`q-system/.q-system/scripts/test/test-linear-worker-fetch.sh` (new, in the capability manifest).

It never greps the source. It stales a **real** remote-tracking ref and asserts the SHA the worktree actually landed on (a grep for `git fetch` would pass on a fetch placed *after* the worktree is created), and it runs against a genuinely unreachable origin with `$NOTIFY` redirected to a recorder file.

**RED 1** — against the unfetched script:
```
FAIL: STALE BASE: the worktree was cut from the stale origin/main (4cd5b85...).
      The true remote head is f6e5584...
```

**RED 2** — against a staged fetch guard that exited 0 (the exact shape round 3 rejected):
```
  ok: the worktree was cut from the TRUE remote head
  ok: the skeleton's refs/remotes/origin/main was updated to the remote head
  ok: a 2-issue run fetched exactly once
FAIL: SILENT SUCCESS: the worker exited 0 after a fetch failure that stopped
      the entire run. A caller cannot tell this apart from a healthy run.
```

**GREEN:**
```
  ok: the worktree was cut from the TRUE remote head (fetch happened before worktree add)
  ok: the skeleton's refs/remotes/origin/main was updated to the remote head
  ok: a 2-issue run fetched exactly once
  ok: a fetch failure exits non-zero (rc=9), so a caller can tell
  ok: the fetch failure pages the founder through $NOTIFY
  ok: the page names the cause (git fetch), not just 'something failed'
  ok: no worktree was cut and no agent was dispatched
  ok: a healthy run with nothing ready still exits 0
  ok: a healthy no-work run pages nobody
  ok: linear-worker.sh parses (bash -n)
PASS: linear-worker fetch (10 checks)
```

Case 7 is load-bearing: without it the fix could pass by always failing and always paging, which is the same defect wearing the other hat.

**Capability gate:**
```
  tests: ran=73 quarantined=0 skipped-skeleton-only=0
capability-gate: GREEN
```

## Not doing (binding, per the DoR)

mergeability in the rework gate; the scratch guard; operator directives; `--reset-rounds`; the round-cap ledger; `converge.sh`, `pr-verdict-lib.sh`, `pr-review-agent.sh`. All still live on `sana/ask-208`.

## Known consequence, captured not fixed

`converge.sh` on `main` stops with its own exit 7 + Slack ping when no PR exists, so a fetch failure under `converge` now pages **twice** for one event. Mapping worker exit 9 to a single converge page is part of the `converge.sh` work this issue explicitly does not touch. Captured as spillover rather than mentioned.