### PR TITLE
fix(token-guard): a gate-refused commit gets a bounded budget, not a deadlock (ASK-215)

### DIFF
--- a/q-system/.q-system/scripts/test/test-token-guard-hook-behavior.sh
+++ b/q-system/.q-system/scripts/test/test-token-guard-hook-behavior.sh
@@ -465,4 +465,36 @@ assert cache.get("gate_grace_gate") == "plugin-version-bump", \
 EOF
 echo "ok: a refusal carried by exit_code alone is read the same as one carried by error"
 
+# --- 16) Holding the volume warning must not lose it --------------------------
+# The finding-3 fix defers the volume warning so the checks below it can run. A
+# later warning must therefore CARRY it, not replace it -- otherwise the fix
+# buys reachability by making the ceiling warning silent, which is the trade the
+# operator would never agree to.
+python3 - "$CACHE" "$SESSION" "$GUARD" <<'EOF'
+import json, re, sys, time
+src = open(sys.argv[3]).read()
+warning = int(re.search(r"^VOLUME_WARNING = (\d+)", src, re.M).group(1))
+spiral = int(re.search(r"^READ_SPIRAL_LIMIT = (\d+)", src, re.M).group(1))
+json.dump({
+    "actor_key": sys.argv[2], "tool_calls_since_user": warning,
+    "agent_calls_since_user": 0, "mcp_timestamps": [], "repeat_map": {},
+    "consecutive_reads": spiral - 1, "warnings_issued": 0, "file_read_counts": {},
+    "greps_since_write": 0, "edit_targets": {}, "agents_without_write": 0,
+    "last_write_time": time.time(), "calls_since_write": 1,
+    "last_volume_reset": time.time(),
+}, open(sys.argv[1], "w"))
+EOF
+OUT="$(run_guard "{\"session_id\": \"$SESSION\", \"hook_event_name\": \"PreToolUse\", \"tool_name\": \"Read\", \"tool_input\": {\"file_path\": \"/tmp/both-warnings-probe\"}}")" \
+  || { echo "FAIL: combined-warning path exited non-zero"; exit 1; }
+python3 - <<EOF
+import json
+context = json.loads(r'''$OUT''')["hookSpecificOutput"]["additionalContext"]
+volume, _, spiral = context.partition("\n\n")
+assert "before hard stop" in volume, \
+    f"the held volume warning was dropped by a later warning: {context!r}"
+assert spiral.strip(), \
+    f"the later read-spiral warning was dropped: {context!r}"
+EOF
+echo "ok: a held volume warning is carried by the next warning, not replaced"
+
 echo "PASS: token-guard hook behavior (warn shape + PostToolUse edit reset + blocked-attempt un-count + gate-refusal grace + non-gate classifier)"

--- a/q-system/.q-system/scripts/test/test-token-guard-hook-behavior.sh
+++ b/q-system/.q-system/scripts/test/test-token-guard-hook-behavior.sh
@@ -21,6 +21,10 @@ run_guard() { # $1 = event JSON on stdin; guard runs with fixture as project dir
   printf '%s' "$1" | CLAUDECODE=1 CLAUDE_PROJECT_DIR="$FIXTURE" python3 "$GUARD"
 }
 
+run_guard_file() { # $1 = path to a payload JSON file (for payloads with unicode/newlines)
+  CLAUDECODE=1 CLAUDE_PROJECT_DIR="$FIXTURE" python3 "$GUARD" < "$1"
+}
+
 # --- 1) warn() output must use the nested PreToolUse hookSpecificOutput form ---
 # Seed a cache one read short of the read-spiral threshold; the next Read warns.
 python3 - "$CACHE" "$SESSION" <<'EOF'
@@ -176,4 +180,132 @@ case "$ERR" in
   *) echo "FAIL: 3rd executed identical call blocked with wrong reason: $ERR"; exit 1;;
 esac
 
-echo "PASS: token-guard hook behavior (warn shape + PostToolUse edit reset + blocked-attempt un-count)"
+# --- 7-10) The ceiling's escape hatch must survive a pre-commit gate (ASK-215) --
+# Scar 4 (2026-07-27, ASK-214): at the ceiling the ONLY exempt call is `git
+# commit`. lefthook's plugin-version-bump REFUSED that commit, and bumping
+# plugin.json needs an Edit the ceiling blocks. The run stranded with 18/20 tests
+# done and everything staged. A refused commit is not a checkpoint, so the
+# commit-command exemption alone does not reach the deadlock: the gate's
+# PRECONDITION needs a bounded budget of its own.
+#
+# Fixture is a real lefthook v2.1.6 refusal (captured 2026-07-27). git passes a
+# hook's output through verbatim and adds no marker of its own, so the gate name
+# can only come from the gate's own text.
+mk_payloads() {
+python3 - "$FIXTURE" "$SESSION" <<'EOF'
+import json, os, sys
+fixture, session = sys.argv[1], sys.argv[2]
+
+LEFTHOOK_REFUSAL = (
+    "╭──────╮\n"
+    "│ \U0001f94a lefthook v2.1.6  hook: pre-commit │\n"
+    "╰──────╯\n"
+    "┃  gitleaks ❯ \n\nclean\n\n"
+    "┃  plugin-version-bump ❯ \n\nBLOCK: bump plugin.json\n\n"
+    "exit status 1\n"
+    "summary: (done in 0.10 seconds)\n"
+    "✔️ gitleaks (0.10 seconds)\n"
+    "\U0001f94a plugin-version-bump: A changed plugin must bump its "
+    ".claude-plugin/plugin.json version. (0.10 seconds)\n"
+)
+
+def write(name, payload):
+    with open(os.path.join(fixture, name), "w") as fh:
+        json.dump(payload, fh)
+
+def post_commit(response):
+    return {"session_id": session, "hook_event_name": "PostToolUse",
+            "tool_name": "Bash",
+            "tool_input": {"command": "git commit -m 'wip (ASK-214)'"},
+            "tool_response": response}
+
+write("refused.json", post_commit(
+    {"stdout": "", "stderr": LEFTHOOK_REFUSAL, "error": "Exit code 1"}))
+write("noop.json", post_commit(
+    {"stdout": "On branch main\nnothing to commit, working tree clean",
+     "stderr": "", "error": "Exit code 1"}))
+write("landed.json", post_commit(
+    {"stdout": "[sana/ask-215 abc1234] fix (ASK-215)\n 1 file changed", "stderr": ""}))
+EOF
+}
+mk_payloads
+
+seed_ceiling() { # reset to a clean at-the-ceiling cache, no grace recorded
+python3 - "$CACHE" "$SESSION" <<'EOF'
+import json, sys, time
+json.dump({
+    "actor_key": sys.argv[2], "tool_calls_since_user": 50,
+    "agent_calls_since_user": 0, "mcp_timestamps": [], "repeat_map": {},
+    "consecutive_reads": 0, "warnings_issued": 1, "file_read_counts": {},
+    "greps_since_write": 0, "edit_targets": {}, "agents_without_write": 0,
+    "last_write_time": time.time(), "calls_since_write": 1,
+    "last_volume_reset": time.time(),
+}, open(sys.argv[1], "w"))
+EOF
+}
+
+# Each probe Edit targets a DISTINCT path so neither the exact-retry hash nor the
+# edit-spiral counter fires -- this test is about the volume ceiling only.
+ceiling_edit() { # $1 = probe index -> exit code in CODE, stderr in ERR
+  local payload
+  payload="{\"session_id\": \"$SESSION\", \"hook_event_name\": \"PreToolUse\", \"tool_name\": \"Edit\", \"tool_input\": {\"file_path\": \"/tmp/gate-probe-$1.json\", \"old_string\": \"version-$1\", \"new_string\": \"bumped-$1\"}}"
+  set +e
+  ERR="$(printf '%s' "$payload" | CLAUDECODE=1 CLAUDE_PROJECT_DIR="$FIXTURE" python3 "$GUARD" 2>&1 >/dev/null)"
+  CODE=$?
+  set -e
+}
+
+# --- 7) A gate-refused commit grants the remediation budget ------------------
+seed_ceiling
+run_guard_file "$FIXTURE/refused.json" >/dev/null \
+  || { echo "FAIL: PostToolUse gate-refusal leg exited non-zero"; exit 1; }
+ceiling_edit 1
+[ "$CODE" -eq 0 ] || { echo "FAIL: Edit after a gate-refused commit exited $CODE, want 0 (deadlock): $ERR"; exit 1; }
+echo "ok: a gate-refused commit grants a bounded budget so the ceiling is escapable"
+
+# --- 8) A no-op commit must NOT mint budget ---------------------------------
+# Otherwise an agent clears the ceiling forever with an empty commit.
+seed_ceiling
+run_guard_file "$FIXTURE/noop.json" >/dev/null \
+  || { echo "FAIL: PostToolUse no-op commit leg exited non-zero"; exit 1; }
+ceiling_edit 2
+[ "$CODE" -eq 2 ] || { echo "FAIL: 'nothing to commit' minted grace (Edit exited $CODE, want 2)"; exit 1; }
+case "$ERR" in
+  *"plugin-version-bump"*) echo "FAIL: no-op commit recorded a refusing gate: $ERR"; exit 1;;
+  *"tool calls"*) echo "ok: a no-op commit mints no budget; the ceiling still blocks";;
+  *) echo "FAIL: no-op path blocked with the wrong reason: $ERR"; exit 1;;
+esac
+
+# --- 9) Bounded: the call after the budget is spent blocks, naming the gate --
+seed_ceiling
+run_guard_file "$FIXTURE/refused.json" >/dev/null
+GRACE="$(python3 -c "import re,sys; print(re.search(r'^GATE_GRACE = (\d+)', open(sys.argv[1]).read(), re.M).group(1))" "$GUARD")"
+probe=0
+while [ "$probe" -lt "$GRACE" ]; do
+  probe=$(( probe + 1 ))
+  ceiling_edit "9$probe"
+  [ "$CODE" -eq 0 ] || { echo "FAIL: grace call $probe/$GRACE blocked early (exit $CODE): $ERR"; exit 1; }
+done
+ceiling_edit "9over"
+[ "$CODE" -eq 2 ] || { echo "FAIL: call $(( GRACE + 1 )) after the grant exited $CODE, want 2 (budget is unbounded)"; exit 1; }
+case "$ERR" in
+  *plugin-version-bump*) echo "ok: budget is bounded at $GRACE and the hard stop names the refusing gate";;
+  *) echo "FAIL: spent-budget block does not name the refusing gate: $ERR"; exit 1;;
+esac
+
+# --- 10) A landed commit clears the budget (no stale grace at a later ceiling) --
+seed_ceiling
+run_guard_file "$FIXTURE/refused.json" >/dev/null
+run_guard_file "$FIXTURE/landed.json" >/dev/null \
+  || { echo "FAIL: PostToolUse landed-commit leg exited non-zero"; exit 1; }
+python3 - "$CACHE" <<'EOF'
+import json, sys
+cache = json.load(open(sys.argv[1]))
+assert cache.get("gate_grace_remaining", 0) == 0, \
+    f"a landed commit must clear the grace budget: {cache.get('gate_grace_remaining')}"
+assert not cache.get("gate_grace_gate"), \
+    f"a landed commit must clear the recorded gate: {cache.get('gate_grace_gate')}"
+EOF
+echo "ok: a landed commit clears the budget"
+
+echo "PASS: token-guard hook behavior (warn shape + PostToolUse edit reset + blocked-attempt un-count + gate-refusal grace)"

--- a/q-system/.q-system/scripts/test/test-token-guard-hook-behavior.sh
+++ b/q-system/.q-system/scripts/test/test-token-guard-hook-behavior.sh
@@ -438,8 +438,19 @@ import importlib.util, os, subprocess, sys, tempfile
 spec = importlib.util.spec_from_file_location("tg", sys.argv[1])
 tg = importlib.util.module_from_spec(spec)
 spec.loader.exec_module(tg)
-repo = os.path.dirname(os.path.dirname(os.path.dirname(os.path.dirname(sys.argv[1]))))
+# THREE dirnames: $GUARD is <repo>/q-system/.q-system/token-guard.py, so the
+# repo root is three levels up, not four. Four resolved to the repo's PARENT and
+# the gate path did not exist, so this check never ran its producer at all -- it
+# graded python3's own "can't open file" message. It passed on macOS (that text
+# starts with the interpreter's absolute path, which falls through to the generic
+# label) and failed on Linux CI (which prints "python3: can't open file", so the
+# reader took 'python3' as the gate name). A green test that never reached the
+# code under test is the exact defect class this suite exists to catch.
+repo = os.path.dirname(os.path.dirname(os.path.dirname(sys.argv[1])))
 gate = os.path.join(repo, "q-system/.q-system/scripts/linear-issue-ref-check.py")
+# Fail LOUDLY if the producer is missing, instead of silently grading the
+# interpreter's error text the way the 4-dirname version did.
+assert os.path.exists(gate), f"fixture cannot reach the real commit-msg gate: {gate}"
 msg = os.path.join(tempfile.mkdtemp(), "msg.txt")
 open(msg, "w").write("chore: no issue id here\n")
 run = subprocess.run(["python3", gate, msg], capture_output=True, text=True)

--- a/q-system/.q-system/scripts/test/test-token-guard-hook-behavior.sh
+++ b/q-system/.q-system/scripts/test/test-token-guard-hook-behavior.sh
@@ -226,6 +226,48 @@ write("noop.json", post_commit(
      "stderr": "", "error": "Exit code 1"}))
 write("landed.json", post_commit(
     {"stdout": "[sana/ask-215 abc1234] fix (ASK-215)\n 1 file changed", "stderr": ""}))
+
+# --- Real transient git failures (captured 2026-07-28 by
+# q-system/output/capture-git-transient-failures.sh). Every one of these is git
+# itself failing at exit 128; a hook refusal is exit 1. They are NOT a gate.
+INDEX_LOCK = (
+    "fatal: Unable to create '/tmp/repo/.git/index.lock': File exists.\n\n"
+    "Another git process seems to be running in this repository, or the lock "
+    "file may be stale\n")
+REF_LOCK = (
+    "fatal: cannot lock ref 'HEAD': Unable to create "
+    "'/tmp/repo/.git/refs/heads/main.lock': File exists.\n\n"
+    "Another git process seems to be running in this repository, or the lock "
+    "file may be stale\n")
+GPG_FAIL = (
+    "fatal: cannot exec '/usr/bin/gpg': No such file or directory\n"
+    "error: gpg failed to sign the data:\n(no gpg output)\n"
+    "fatal: failed to write commit object\n")
+
+write("indexlock.json", post_commit(
+    {"stdout": "", "stderr": INDEX_LOCK, "error": "Exit code 128"}))
+write("reflock.json", post_commit(
+    {"stdout": "", "stderr": REF_LOCK, "error": "Exit code 128"}))
+write("gpgfail.json", post_commit(
+    {"stdout": "", "stderr": GPG_FAIL, "error": "Exit code 128"}))
+# A git-self failure whose text is NOT in the phrase list. Only the exit code
+# separates it from a gate refusal, so this pins the exit-128 rule on its own.
+write("unknown128.json", post_commit(
+    {"stdout": "", "stderr": "fatal: a failure mode nobody enumerated\n",
+     "error": "Exit code 128"}))
+
+# A failing command that merely MENTIONS the string "git commit" and never
+# invokes it. Real producer: a grep over the canonical corpus with no match.
+write("mentions.json", {
+    "session_id": session, "hook_event_name": "PostToolUse", "tool_name": "Bash",
+    "tool_input": {"command": 'grep -rn "git commit" q-system/canonical/'},
+    "tool_response": {"stdout": "", "stderr": "", "error": "Exit code 1"}})
+
+# The same lefthook refusal delivered with an integer exit_code and NO error
+# key. The Bash response shape is not pinned by contract, so both readers must
+# work; without this fixture the exit_code branch is untested.
+write("refused_exitcode.json", post_commit(
+    {"stdout": "", "stderr": LEFTHOOK_REFUSAL, "exit_code": 1}))
 EOF
 }
 mk_payloads
@@ -308,4 +350,119 @@ assert not cache.get("gate_grace_gate"), \
 EOF
 echo "ok: a landed commit clears the budget"
 
-echo "PASS: token-guard hook behavior (warn shape + PostToolUse edit reset + blocked-attempt un-count + gate-refusal grace)"
+# --- 11-15) The classifier must not invent a gate (PR #27 review, round 2) ----
+# Scar 5 (2026-07-28): the first cut treated ANY failed commit that dodged a
+# short phrase list as a gate refusal. This repo runs a 15-minute auto-committer
+# and parallel sessions share a checkout, so an `index.lock` race is a routine
+# event -- and it was being reported at 3am as "a pre-commit gate refused the
+# checkpoint", after burning the whole budget chasing a gate that did not exist.
+# Ground truth (q-system/output/capture-git-transient-failures.sh): git's OWN
+# failures exit 128, and git normalises EVERY hook refusal to exit 1 whatever
+# the hook returned.
+
+# --- 11) A transient git failure mints no budget and keeps the true message --
+for probe in indexlock reflock gpgfail unknown128; do
+  seed_ceiling
+  run_guard_file "$FIXTURE/$probe.json" >/dev/null \
+    || { echo "FAIL: PostToolUse $probe leg exited non-zero"; exit 1; }
+  python3 - "$CACHE" "$probe" <<'EOF'
+import json, sys
+cache = json.load(open(sys.argv[1]))
+assert cache.get("gate_grace_remaining", 0) == 0, \
+    f"{sys.argv[2]}: a transient git failure minted budget: {cache.get('gate_grace_remaining')}"
+assert not cache.get("gate_grace_gate"), \
+    f"{sys.argv[2]}: a transient git failure recorded a gate: {cache.get('gate_grace_gate')!r}"
+EOF
+  ceiling_edit "11$probe"
+  [ "$CODE" -eq 2 ] || { echo "FAIL: $probe left the ceiling open (Edit exited $CODE, want 2)"; exit 1; }
+  case "$ERR" in
+    *"refused the checkpoint"*)
+      echo "FAIL: $probe was reported to the operator as a gate refusal: $ERR"; exit 1;;
+    *"tool calls"*) ;;
+    *) echo "FAIL: $probe blocked with the wrong reason: $ERR"; exit 1;;
+  esac
+done
+echo "ok: a transient git failure (lock/ref-lock/gpg/exit-128) is not read as a gate refusal"
+
+# --- 12) Mentioning "git commit" in a command is not committing ---------------
+seed_ceiling
+run_guard_file "$FIXTURE/mentions.json" >/dev/null \
+  || { echo "FAIL: PostToolUse mentions leg exited non-zero"; exit 1; }
+python3 - "$CACHE" <<'EOF'
+import json, sys
+cache = json.load(open(sys.argv[1]))
+assert cache.get("gate_grace_remaining", 0) == 0, \
+    f"a failing grep minted grace: {cache.get('gate_grace_remaining')}"
+assert not cache.get("gate_grace_gate"), \
+    f"a failing grep recorded a refusing gate: {cache.get('gate_grace_gate')!r}"
+EOF
+ceiling_edit 12
+[ "$CODE" -eq 2 ] || { echo "FAIL: a failing grep opened the ceiling (Edit exited $CODE, want 2)"; exit 1; }
+case "$ERR" in
+  *"refused the checkpoint"*)
+    echo "FAIL: a failing grep hijacked the ceiling message: $ERR"; exit 1;;
+  *"tool calls"*) echo "ok: a command that only mentions 'git commit' mints no budget";;
+  *) echo "FAIL: mentions path blocked with the wrong reason: $ERR"; exit 1;;
+esac
+
+# --- 13) The other detectors stay reachable while the budget is being spent ---
+# The grace path warns and returns; if it exits there, checks 4-11 never run and
+# an agent spiralling on the gate file gets GATE_GRACE unchecked edit attempts
+# and never hears "your edit approach is wrong".
+seed_ceiling
+run_guard_file "$FIXTURE/refused.json" >/dev/null
+python3 - "$CACHE" "$GUARD" <<'EOF'
+import json, re, sys
+limit = int(re.search(r"^EDIT_FAIL_LIMIT = (\d+)", open(sys.argv[2]).read(), re.M).group(1))
+cache = json.load(open(sys.argv[1]))
+cache["edit_targets"] = {"/tmp/stuck-on-the-gate.py": limit + 5}
+json.dump(cache, open(sys.argv[1], "w"))
+EOF
+SPIRAL_EDIT="{\"session_id\": \"$SESSION\", \"hook_event_name\": \"PreToolUse\", \"tool_name\": \"Edit\", \"tool_input\": {\"file_path\": \"/tmp/stuck-on-the-gate.py\", \"old_string\": \"a\", \"new_string\": \"b\"}}"
+set +e
+ERR="$(printf '%s' "$SPIRAL_EDIT" | CLAUDECODE=1 CLAUDE_PROJECT_DIR="$FIXTURE" python3 "$GUARD" 2>&1 >/dev/null)"
+CODE=$?
+set -e
+[ "$CODE" -eq 2 ] || { echo "FAIL: edit-spiral is unreachable during the grace budget (exit $CODE, want 2)"; exit 1; }
+case "$ERR" in
+  *"edit attempts on"*) echo "ok: edit-spiral still blocks while the grace budget is live";;
+  *) echo "FAIL: grace budget swallowed the edit-spiral block: $ERR"; exit 1;;
+esac
+
+# --- 14) The gate-name reader must not name a detail line of a real gate ------
+# Producer is this repo's own commit-msg gate, run for real: its BLOCK line is
+# correctly ignored, and the INDENTED "  subject: ..." detail line under it must
+# not become the gate's name.
+python3 - "$GUARD" <<'EOF'
+import importlib.util, os, subprocess, sys, tempfile
+spec = importlib.util.spec_from_file_location("tg", sys.argv[1])
+tg = importlib.util.module_from_spec(spec)
+spec.loader.exec_module(tg)
+repo = os.path.dirname(os.path.dirname(os.path.dirname(os.path.dirname(sys.argv[1]))))
+gate = os.path.join(repo, "q-system/.q-system/scripts/linear-issue-ref-check.py")
+msg = os.path.join(tempfile.mkdtemp(), "msg.txt")
+open(msg, "w").write("chore: no issue id here\n")
+run = subprocess.run(["python3", gate, msg], capture_output=True, text=True)
+assert run.returncode != 0, "the commit-msg gate did not refuse; fixture is stale"
+text = run.stdout + run.stderr
+name = tg._refusing_gate_name(text)
+assert name == "a pre-commit gate", \
+    f"gate-name reader took a detail line as the gate name: {name!r}"
+EOF
+echo "ok: the gate-name reader falls back to the generic label, not a detail line"
+
+# --- 15) The exit_code branch is live (no `error` key in the response) --------
+seed_ceiling
+run_guard_file "$FIXTURE/refused_exitcode.json" >/dev/null \
+  || { echo "FAIL: PostToolUse exit_code-shaped refusal leg exited non-zero"; exit 1; }
+python3 - "$CACHE" <<'EOF'
+import json, sys
+cache = json.load(open(sys.argv[1]))
+assert cache.get("gate_grace_remaining", 0) > 0, \
+    "a refusal delivered as exit_code (no error key) minted no budget"
+assert cache.get("gate_grace_gate") == "plugin-version-bump", \
+    f"exit_code-shaped refusal lost the gate name: {cache.get('gate_grace_gate')!r}"
+EOF
+echo "ok: a refusal carried by exit_code alone is read the same as one carried by error"
+
+echo "PASS: token-guard hook behavior (warn shape + PostToolUse edit reset + blocked-attempt un-count + gate-refusal grace + non-gate classifier)"

--- a/q-system/.q-system/token-guard.py
+++ b/q-system/.q-system/token-guard.py
@@ -60,6 +60,8 @@ EDIT_FAIL_LIMIT = 3         # Edit attempts on same file without success = block
 AGENT_NO_OUTPUT_LIMIT = 3   # Agent spawns with no write between them = warn
 STALL_TIME_SECONDS = 120    # Seconds since last write + calls = warn
 STALL_MIN_CALLS = 10        # Minimum calls before time-based stall triggers
+GATE_GRACE = 8              # Calls granted at the ceiling to clear a gate that refused the commit
+GATE_GRACE_GRANTS = 1       # Grants per user-message window (bounded: no re-arming ratchet)
 
 # Sensitive file patterns
 SENSITIVE_PATTERNS = (".env", ".pem", ".key", "credentials")
@@ -154,6 +156,9 @@ def load_cache(actor_key):
         "last_write_time": time.time(),
         "calls_since_write": 0,
         "last_volume_reset": time.time(),
+        "gate_grace_remaining": 0,
+        "gate_grace_gate": None,
+        "gate_grace_grants": 0,
     }
 
 
@@ -265,9 +270,21 @@ def check_exact_retry(tool_name, tool_input, cache):
 
 
 def check_volume(cache):
-    """Block at ceiling, warn at warning threshold."""
+    """Block at ceiling, warn at warning threshold.
+
+    The gate-refusal budget is spent HERE and nowhere else — only on a call the
+    ceiling would otherwise have blocked. That is why granting it eagerly (on any
+    refused commit, at any call count) costs nothing: a run that never reaches the
+    ceiling never touches it."""
     calls = cache.get("tool_calls_since_user", 0)
     if calls >= VOLUME_CEILING:
+        gate = cache.get("gate_grace_gate")
+        remaining = cache.get("gate_grace_remaining", 0)
+        if remaining > 0:
+            cache["gate_grace_remaining"] = remaining - 1
+            return ("warn", f"{gate} refused your commit, so you have {remaining - 1} call(s) left to satisfy that gate and retry `git commit` (which is exempt from this ceiling). At zero this run hard-stops. Do nothing else with these calls.")
+        if gate:
+            return ("block", f"{gate} refused the checkpoint and the {GATE_GRACE}-call grace budget is spent. Stop. Report what {gate} is asking for, what you tried, and that the work is staged and uncommitted.")
         return ("block", f"{VOLUME_CEILING} tool calls without user input or a commit. Commit finished work now (git commit is exempt from this ceiling and resets it), or stop and summarize what you've accomplished and what's remaining.")
     if calls >= VOLUME_WARNING and cache.get("warnings_issued", 0) == 0:
         remaining = VOLUME_CEILING - calls
@@ -451,6 +468,133 @@ def _is_successful_commit(command, tool_response):
     return True
 
 
+# --- The gate-refusal grace budget (ASK-215) ---------------------------------
+# The commit exemption above covers the commit COMMAND. It does not cover the
+# commit's PRECONDITIONS. A commit refused by a pre-commit gate is not a
+# checkpoint, and satisfying that gate needs an Edit the ceiling blocks — so the
+# run deadlocks with everything staged and nothing committed (observed 2026-07-27
+# on ASK-214: lefthook's plugin-version-bump refused the checkpoint, the agent had
+# 18 of 20 tests done, and the work was recovered by hand).
+#
+# The fix is a BOUNDED budget, not an allowlist. This repo has seven blocking
+# pre-commit gates and each can demand a different file; exempting plugin.json
+# specifically is whack-a-mole that the next gate defeats. The budget is blind to
+# which gate fired, so it also covers gates that do not exist yet.
+
+# Failures of `git commit` that are NOT a gate refusing the checkpoint. The no-op
+# entries are the load-bearing ones: without them an agent could mint budget with
+# an empty commit, which is the runaway loop the ceiling exists to stop.
+NON_GATE_COMMIT_FAILURES = (
+    "nothing to commit",
+    "no changes added to commit",
+    "nothing added to commit",
+    "empty commit message",
+    "not a git repository",
+    "please tell me who you are",
+    "unmerged files",
+    "needs merge",
+)
+
+# lefthook v2 marks each FAILED command in its summary with a boxing glove
+# (passing ones get a check mark). Verified against real output 2026-07-27.
+LEFTHOOK_FAIL_MARK = "\U0001f94a"
+
+# Words a gate shouts as a prefix; they are severity labels, not gate names.
+_NOT_A_GATE_NAME = frozenset(("block", "error", "fail", "failed", "warning",
+                              "fatal", "traceback", "hint", "usage", "note"))
+
+
+def _response_text_and_code(tool_response):
+    """(combined output text, exit code or None) from a tool_response. The Bash
+    response shape is not pinned by contract, so read every key the fleet has
+    observed — same key set as rca-notify.py's looks_failed."""
+    if isinstance(tool_response, str):
+        return tool_response, None
+    if not isinstance(tool_response, dict):
+        return "", None
+    code = tool_response.get("exit_code", tool_response.get("returncode"))
+    parts = []
+    for key in ("stdout", "stderr", "output", "content"):
+        value = tool_response.get(key)
+        if isinstance(value, str):
+            parts.append(value)
+    return "\n".join(parts), code if isinstance(code, int) else None
+
+
+def _refusing_gate_name(text):
+    """Best-effort name of the gate that refused the commit.
+
+    git passes a hook's output through verbatim and adds NO marker of its own
+    (verified 2026-07-27: a hook-refused commit printed only the hook's text and
+    exit 1), so the name can only come from the gate's own output. Two readers,
+    then a generic label — the block message must never fall back to "50 tool
+    calls", which is the wrong reason and sent the ASK-214 agent back into the
+    deadlock instead of at the gate."""
+    for line in text.splitlines():
+        stripped = line.strip()
+        if stripped.startswith(LEFTHOOK_FAIL_MARK):
+            rest = stripped[len(LEFTHOOK_FAIL_MARK):].strip(" ️")
+            name = rest.split(":")[0].split("(")[0].strip()
+            if name and " " not in name:
+                return name
+    # A plain hook / husky / pre-commit-framework line: "my-gate: refused".
+    for line in text.splitlines():
+        head = line.strip().split(":")[0]
+        if (head and head != line.strip() and " " not in head
+                and len(head) <= 48 and head[0].isalnum()
+                and head.lower() not in _NOT_A_GATE_NAME):
+            return head
+    return "a pre-commit gate"
+
+
+def _commit_gate_refusal(command, tool_response):
+    """The name of the gate that refused this `git commit`, or None.
+
+    Deliberately narrow on WHAT it excludes and blind to WHICH gate fired: any
+    commit that failed, other than the known non-gate failures above, is treated
+    as a refused checkpoint. A mis-read costs at most GATE_GRACE calls; missing a
+    real refusal costs the whole run."""
+    if not command or "git commit" not in command or "--dry-run" in command:
+        return None
+    text, code = _response_text_and_code(tool_response)
+    errored = bool(isinstance(tool_response, dict) and tool_response.get("error"))
+    failed = errored or (code is not None and code != 0)
+    if not failed:
+        return None
+    lowered = text.lower()
+    for phrase in NON_GATE_COMMIT_FAILURES:
+        if phrase in lowered:
+            return None
+    return _refusing_gate_name(text)
+
+
+def grant_gate_grace(cache, gate):
+    """Record the refusing gate always; hand out budget at most
+    GATE_GRACE_GRANTS times per user-message window.
+
+    Re-arming on every refusal would turn the ceiling into an endless ratchet —
+    refuse, get 8, spend 8, refuse again — which is the runaway loop the ceiling
+    exists to stop. A second refusal updates the NAME (so the hard stop cites the
+    gate actually blocking now) without topping the budget up: the budget is per
+    deadlock episode, not per gate."""
+    cache["gate_grace_gate"] = gate
+    if cache.get("gate_grace_grants", 0) >= GATE_GRACE_GRANTS:
+        return cache
+    cache["gate_grace_grants"] = cache.get("gate_grace_grants", 0) + 1
+    cache["gate_grace_remaining"] = GATE_GRACE
+    return cache
+
+
+def clear_gate_grace(cache):
+    """The checkpoint landed, so the episode is over. Clearing matters: stale
+    budget left on the cache would silently widen a LATER ceiling in the same
+    session by GATE_GRACE calls."""
+    cache["gate_grace_remaining"] = 0
+    cache["gate_grace_gate"] = None
+    cache["gate_grace_grants"] = 0
+    return cache
+
+
 def reset_per_message_counters(cache):
     """Reset counters that track 'since last user message'."""
     cache["tool_calls_since_user"] = 0
@@ -465,6 +609,7 @@ def reset_per_message_counters(cache):
     cache["last_write_time"] = time.time()
     cache["calls_since_write"] = 0
     cache["last_volume_reset"] = time.time()
+    cache = clear_gate_grace(cache)
     return cache
 
 
@@ -506,6 +651,7 @@ def reset_volume_if_committed(cache):
         cache["agent_calls_since_user"] = 0
         cache["warnings_issued"] = 0
         cache["last_volume_reset"] = time.time()
+        cache = clear_gate_grace(cache)
     return cache
 
 
@@ -568,7 +714,19 @@ def main():
             cache["agent_calls_since_user"] = 0
             cache["warnings_issued"] = 0
             cache["last_volume_reset"] = time.time()
+            cache = clear_gate_grace(cache)
             save_cache(actor, cache)
+        # A commit REFUSED by a pre-commit gate is the other half of the valve.
+        # It is not progress, so it must not reset the counter — but the gate's
+        # precondition needs an Edit the ceiling blocks, so the run gets a bounded
+        # budget to satisfy the gate and retry. See the grace block above (ASK-215).
+        elif tool_name == "Bash":
+            gate = _commit_gate_refusal(
+                tool_input.get("command", ""), hook_input.get("tool_response"))
+            if gate:
+                cache = load_cache(actor)
+                cache = grant_gate_grace(cache, gate)
+                save_cache(actor, cache)
         sys.exit(0)
 
     # Load cache, update counters from this invocation. The commit-progress

--- a/q-system/.q-system/token-guard.py
+++ b/q-system/.q-system/token-guard.py
@@ -494,14 +494,19 @@ def _is_successful_commit(command, tool_response):
     git-commit verb, not a dry-run, no error, and output that isn't a no-op."""
     if not _invokes_git_commit(command):
         return False
-    text = ""
-    if isinstance(tool_response, dict):
-        if tool_response.get("error"):
-            return False
-        text = (str(tool_response.get("stdout", "")) + " "
-                + str(tool_response.get("stderr", ""))).lower()
-    elif isinstance(tool_response, str):
-        text = tool_response.lower()
+    if isinstance(tool_response, dict) and tool_response.get("error"):
+        return False
+    text, code = _response_text_and_code(tool_response)
+    # A non-zero exit code is a failed commit even when the response carries no
+    # `error` key. Without this the two readers of one response disagreed: a
+    # refusal delivered as exit_code=1 was a gate refusal to
+    # _commit_gate_refusal and a landed commit here — so it reset the ceiling
+    # and cleared the budget it had just minted, one branch earlier in the same
+    # if/elif chain. (Narrower than sp-1078fbe2, which is the case where the
+    # response carries no failure signal at all; that stays captured, not fixed.)
+    if code is not None and code != 0:
+        return False
+    text = text.lower()
     if "nothing to commit" in text or "no changes added to commit" in text:
         return False
     return True

--- a/q-system/.q-system/token-guard.py
+++ b/q-system/.q-system/token-guard.py
@@ -42,6 +42,8 @@ Exit codes:
 import hashlib
 import json
 import os
+import re
+import shlex
 import sys
 import time
 
@@ -448,12 +450,49 @@ def _is_commit_command(tool_name, tool_input):
     return "git commit" in cmd and "--dry-run" not in cmd
 
 
+def _invokes_git_commit(command):
+    """True only when the command actually RUNS `git commit`.
+
+    A substring test on the command text is not that: `grep -rn "git commit"
+    canonical/` carries the string and ships nothing, and a failing one was read
+    as a refused checkpoint (PR #27 review, finding 2). Tokenising drops the
+    quoted mention while keeping `cd x && git commit -m y`.
+
+    Deliberately NOT used by _is_commit_command above. There the error costs run
+    the other way: a false negative blocks the checkpoint the ceiling is asking
+    for and deadlocks the run, while a false positive only exempts one harmless
+    call from the ceiling. Here — and in _is_successful_commit — a false positive
+    is the expensive one: it mints a grace budget, or resets the ceiling, for a
+    command that committed nothing. Two readers, two error budgets, on purpose."""
+    if not command or "--dry-run" in command:
+        return False
+    try:
+        tokens = shlex.split(command, comments=True)
+    except ValueError:
+        tokens = command.split()
+    index = 0
+    while index < len(tokens):
+        if tokens[index] == "git" or tokens[index].endswith("/git"):
+            cursor = index + 1
+            while cursor < len(tokens) and tokens[cursor].startswith("-"):
+                # git's global options; the two-word forms swallow their value.
+                if tokens[cursor] in ("-c", "-C", "--git-dir", "--work-tree",
+                                      "--namespace", "--exec-path"):
+                    cursor += 2
+                else:
+                    cursor += 1
+            if cursor < len(tokens) and tokens[cursor] == "commit":
+                return True
+        index += 1
+    return False
+
+
 def _is_successful_commit(command, tool_response):
     """True only for a `git commit` that actually created a commit. A no-op
     ('nothing to commit'), a --dry-run, or a failed commit is NOT progress and must not
     reset the volume counter — only a real commit does. Conservative: requires the
     git-commit verb, not a dry-run, no error, and output that isn't a no-op."""
-    if not command or "git commit" not in command or "--dry-run" in command:
+    if not _invokes_git_commit(command):
         return False
     text = ""
     if isinstance(tool_response, dict):
@@ -493,7 +532,28 @@ NON_GATE_COMMIT_FAILURES = (
     "please tell me who you are",
     "unmerged files",
     "needs merge",
+    # Transient / environmental git failures. A lock collision is routine in
+    # this fleet, not exotic: a 15-minute auto-committer and parallel sessions
+    # share a checkout. Reporting one as "a pre-commit gate refused the
+    # checkpoint" spends the whole budget chasing a gate that does not exist and
+    # then hands the operator a fabricated diagnosis at 3am (PR #27 review,
+    # finding 1). Nothing is lost by excluding them: the recovery is to retry
+    # `git commit`, which the ceiling already exempts, so no budget is needed.
+    "index.lock",
+    "another git process",
+    "cannot lock ref",
+    "gpg failed to sign",
+    "failed to write commit object",
 )
+
+# git's OWN failures exit 128. git normalises EVERY hook refusal to exit 1,
+# whatever status the hook returned — captured 2026-07-28 by
+# q-system/output/capture-git-transient-failures.sh (hook exits 1, 2, 3, 42 and
+# 128 all produced git exit 1; index.lock, cannot-lock-ref and a gpg failure all
+# produced 128). So a 128 is git failing, never a gate refusing. It is the one
+# near-positive signal available, since git prints no marker of its own, and it
+# covers transient failures whose text nobody has enumerated yet.
+GIT_SELF_FAILURE_EXIT = 128
 
 # lefthook v2 marks each FAILED command in its summary with a boxing glove
 # (passing ones get a check mark). Verified against real output 2026-07-27.
@@ -513,6 +573,14 @@ def _response_text_and_code(tool_response):
     if not isinstance(tool_response, dict):
         return "", None
     code = tool_response.get("exit_code", tool_response.get("returncode"))
+    if not isinstance(code, int):
+        # The runtime reports a failed Bash call as an `error` STRING
+        # ("Exit code 128"), not an integer field. Parsing it is what makes the
+        # exit-128 rule reachable on the shape the runtime actually sends; the
+        # integer keys stay supported because the shape is not pinned.
+        match = re.search(r"exit code\s+(\d+)",
+                          str(tool_response.get("error", "")), re.I)
+        code = int(match.group(1)) if match else None
     parts = []
     for key in ("stdout", "stderr", "output", "content"):
         value = tool_response.get(key)
@@ -538,7 +606,13 @@ def _refusing_gate_name(text):
             if name and " " not in name:
                 return name
     # A plain hook / husky / pre-commit-framework line: "my-gate: refused".
+    # Only UNINDENTED lines are candidates. A gate prints its name at the left
+    # margin and indents the detail beneath it, and without that rule this
+    # repo's own commit-msg gate was named `subject`, off its indented
+    # "  subject: <the message>" detail line (PR #27 review, finding 4).
     for line in text.splitlines():
+        if not line[:1].strip():
+            continue
         head = line.strip().split(":")[0]
         if (head and head != line.strip() and " " not in head
                 and len(head) <= 48 and head[0].isalnum()
@@ -554,12 +628,14 @@ def _commit_gate_refusal(command, tool_response):
     commit that failed, other than the known non-gate failures above, is treated
     as a refused checkpoint. A mis-read costs at most GATE_GRACE calls; missing a
     real refusal costs the whole run."""
-    if not command or "git commit" not in command or "--dry-run" in command:
+    if not _invokes_git_commit(command):
         return None
     text, code = _response_text_and_code(tool_response)
     errored = bool(isinstance(tool_response, dict) and tool_response.get("error"))
     failed = errored or (code is not None and code != 0)
     if not failed:
+        return None
+    if code == GIT_SELF_FAILURE_EXIT:
         return None
     lowered = text.lower()
     for phrase in NON_GATE_COMMIT_FAILURES:
@@ -756,6 +832,20 @@ def main():
     # ceiling is asking for; blocking it deadlocks the run (the PostToolUse commit-reset
     # can't fire if the commit never runs). Sensitive-file + exact-retry checks above still
     # apply to commits; only the volume ceiling is skipped.
+    #
+    # A volume WARNING is held, not emitted here. warn() exits 0, so emitting it
+    # inline made checks 4-11 unreachable — for the whole grace budget, an agent
+    # spiralling on the gate file got GATE_GRACE unchecked edit attempts and
+    # never heard "your edit approach is wrong", then got a block that blamed the
+    # gate (PR #27 review, finding 3). Held warnings are emitted at the end, or
+    # carried into a later warning; a later BLOCK outranks them and wins.
+    pending_warning = None
+
+    def emit_warning(message):
+        if pending_warning and message != pending_warning:
+            message = pending_warning + "\n\n" + message
+        warn(message)
+
     if not _is_commit_command(tool_name, tool_input):
         result = check_volume(cache)
         if result:
@@ -764,8 +854,7 @@ def main():
                 cache = uncount_blocked_attempt(cache, tool_name, tool_input)
                 save_cache(actor, cache)
                 block(msg)
-            save_cache(actor, cache)
-            warn(msg)
+            pending_warning = msg
 
     # 4. Subagent ceiling
     msg = check_agent_ceiling(tool_name, cache)
@@ -785,19 +874,19 @@ def main():
     msg = check_read_spiral(tool_name, cache)
     if msg:
         save_cache(actor, cache)
-        warn(msg)
+        emit_warning(msg)
 
     # 7. File re-read warning
     msg = check_file_reread(tool_name, tool_input, cache)
     if msg:
         save_cache(actor, cache)
-        warn(msg)
+        emit_warning(msg)
 
     # 8. Grep drift warning
     msg = check_grep_drift(tool_name, cache)
     if msg:
         save_cache(actor, cache)
-        warn(msg)
+        emit_warning(msg)
 
     # 9. Edit spiral block
     msg = check_edit_spiral(tool_name, tool_input, cache)
@@ -810,16 +899,18 @@ def main():
     msg = check_agent_no_output(tool_name, cache)
     if msg:
         save_cache(actor, cache)
-        warn(msg)
+        emit_warning(msg)
 
     # 11. Time stall warning
     msg = check_time_stall(cache)
     if msg:
         save_cache(actor, cache)
-        warn(msg)
+        emit_warning(msg)
 
     # All clear
     save_cache(actor, cache)
+    if pending_warning:
+        warn(pending_warning)
     sys.exit(0)
 
 

--- a/q-system/output/ask215-red-probe.py
+++ b/q-system/output/ask215-red-probe.py
@@ -1,0 +1,58 @@
+#!/usr/bin/env python3
+"""RED/GREEN probe for the PR #27 review findings (ASK-215). Drives the
+classifier directly so each finding's before/after is observable in one run.
+Run: python3 q-system/output/ask215-red-probe.py
+"""
+import importlib.util
+import os
+import subprocess
+import sys
+import tempfile
+
+REPO = os.path.dirname(os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
+GUARD = os.path.join(REPO, "q-system/.q-system/token-guard.py")
+spec = importlib.util.spec_from_file_location("tg", GUARD)
+tg = importlib.util.module_from_spec(spec)
+spec.loader.exec_module(tg)
+
+LOCK = ("fatal: Unable to create '/tmp/r/.git/index.lock': File exists.\n\n"
+        "Another git process seems to be running in this repository, or the "
+        "lock file may be stale\n")
+REFLOCK = ("fatal: cannot lock ref 'HEAD': Unable to create "
+           "'/tmp/r/.git/refs/heads/main.lock': File exists.\n")
+GPG = ("error: gpg failed to sign the data:\n(no gpg output)\n"
+       "fatal: failed to write commit object\n")
+
+print("F1 index.lock        ->", repr(tg._commit_gate_refusal(
+    "git commit -m x", {"stderr": LOCK, "error": "Exit code 128"})))
+print("F1 cannot lock ref   ->", repr(tg._commit_gate_refusal(
+    "git commit -m x", {"stderr": REFLOCK, "error": "Exit code 128"})))
+print("F1 gpg sign failure  ->", repr(tg._commit_gate_refusal(
+    "git commit -m x", {"stderr": GPG, "error": "Exit code 128"})))
+print("F1 unenumerated 128  ->", repr(tg._commit_gate_refusal(
+    "git commit -m x", {"stderr": "fatal: nobody enumerated this\n",
+                        "error": "Exit code 128"})))
+print("F2 failing grep      ->", repr(tg._commit_gate_refusal(
+    'grep -rn "git commit" q-system/canonical/', {"stderr": "", "error": "Exit code 1"})))
+print("F2 grep resets vol   ->", tg._is_successful_commit(
+    'grep -rn "git commit" q-system/canonical/', {"stdout": "a hit\n"}))
+
+msg = os.path.join(tempfile.mkdtemp(), "msg.txt")
+with open(msg, "w") as fh:
+    fh.write("chore: no issue id here\n")
+run = subprocess.run(
+    [sys.executable, os.path.join(REPO, "q-system/.q-system/scripts/linear-issue-ref-check.py"), msg],
+    capture_output=True, text=True)
+print("F4 real gate name    ->", repr(tg._refusing_gate_name(run.stdout + run.stderr)))
+
+print("F5 exit_code-only    ->", repr(tg._commit_gate_refusal(
+    "git commit -m x", {"stderr": "BLOCK: bump plugin.json\n", "exit_code": 1})))
+print("-- must still work --")
+print("   real refusal      ->", repr(tg._commit_gate_refusal(
+    "git commit -m x", {"stderr": "\U0001f94a plugin-version-bump: bump it. (0.1s)\n",
+                        "error": "Exit code 1"})))
+print("   real commit       ->", tg._is_successful_commit(
+    "git commit -m 'fix (ASK-215)'", {"stdout": "[b abc] fix\n 1 file changed"}))
+print("   nothing to commit ->", repr(tg._commit_gate_refusal(
+    "git commit -m x", {"stdout": "nothing to commit, working tree clean",
+                        "error": "Exit code 1"})))

--- a/q-system/output/ask215_read.py
+++ b/q-system/output/ask215_read.py
@@ -1,0 +1,32 @@
+import importlib.util
+import os
+
+REPO = "/Users/assafkipnis/.config/kipi/worktrees/ask-215"
+spec = importlib.util.spec_from_file_location(
+    "ls", os.path.join(REPO, "q-system/.q-system/scripts/linear-sync.py")
+)
+m = importlib.util.module_from_spec(spec)
+spec.loader.exec_module(m)
+
+QUERY = """
+query Q($id: String!) {
+  issue(id: $id) {
+    identifier
+    title
+    state { name }
+    description
+    comments(first: 40) { nodes { body createdAt user { name } } }
+  }
+}
+"""
+
+data = m.graphql(QUERY, {"id": "ASK-215"})
+issue = data["issue"]
+print("==", issue["identifier"], "|", issue["title"], "| state:", issue["state"]["name"])
+print("=== DESCRIPTION ===")
+print(issue["description"])
+print("=== COMMENTS ===")
+for c in issue["comments"]["nodes"]:
+    who = (c["user"] or {}).get("name")
+    print("---", c["createdAt"], who)
+    print(c["body"])

--- a/q-system/output/capture-gate-refusal.sh
+++ b/q-system/output/capture-gate-refusal.sh
@@ -1,0 +1,48 @@
+#!/usr/bin/env bash
+# One-off ground-truth capture (ASK-215): the exact text a lefthook-refused
+# commit emits, so the grace detector keys off real output, not remembered
+# output. Run: bash q-system/output/capture-gate-refusal.sh
+set -uo pipefail
+
+SCRATCH="$(mktemp -d)"
+trap 'python3 -c "import shutil,sys; shutil.rmtree(sys.argv[1], ignore_errors=True)" "$SCRATCH"' EXIT
+
+cd "$SCRATCH"
+git init -q .
+git config user.email t@t.t
+git config user.name t
+git config commit.gpgsign false
+
+cat > lefthook.yml <<'YML'
+pre-commit:
+  parallel: true
+  commands:
+    plugin-version-bump:
+      run: |
+        echo "BLOCK: bump plugin.json"
+        exit 1
+      fail_text: "A changed plugin must bump its .claude-plugin/plugin.json version."
+    gitleaks:
+      run: |
+        echo clean
+YML
+
+# lefthook install writes this shim; write it directly so no install step is needed.
+mkdir -p .git/hooks
+cat > .git/hooks/pre-commit <<'HOOK'
+#!/bin/sh
+exec lefthook run pre-commit
+HOOK
+chmod +x .git/hooks/pre-commit
+
+echo hello > a.txt
+git add a.txt lefthook.yml
+
+echo "===== LEFTHOOK-REFUSED git commit ====="
+set +e
+OUT="$(git commit -m 'test (ASK-215)' 2>&1)"
+CODE=$?
+set -e
+echo "exit_code=$CODE"
+echo "--- combined output (repr per line) ---"
+printf '%s\n' "$OUT" | python3 -c "import sys;[print(repr(l.rstrip(chr(10)))) for l in sys.stdin]"

--- a/q-system/output/capture-git-transient-failures.sh
+++ b/q-system/output/capture-git-transient-failures.sh
@@ -1,0 +1,70 @@
+#!/usr/bin/env bash
+# Ground-truth capture (ASK-215, PR #27 review round 2): the exact text and exit
+# code git emits for the TRANSIENT failures the reviewer flagged, so the
+# non-gate classifier keys off real output rather than remembered output.
+# Run: bash q-system/output/capture-git-transient-failures.sh
+set -uo pipefail
+
+S="$(mktemp -d)"
+cleanup() { python3 -c "import shutil,sys; shutil.rmtree(sys.argv[1], ignore_errors=True)" "$S"; }
+trap cleanup EXIT
+rmf() { python3 -c "import os,sys
+for p in sys.argv[1:]:
+    if os.path.exists(p):
+        os.remove(p)" "$@"; }
+
+cd "$S"
+git init -q .
+git config user.email t@t.t
+git config user.name t
+git config commit.gpgsign false
+echo hi > a.txt
+git add a.txt
+
+run_case() {
+  echo "===== $1 ====="
+  set +e
+  OUT="$(eval "$2" 2>&1)"
+  CODE=$?
+  set -e
+  echo "exit_code=$CODE"
+  printf '%s\n' "$OUT"
+  echo
+}
+
+touch .git/index.lock
+run_case "1. index.lock held (auto-committer / parallel session race)" \
+  "git commit -m 'x (ASK-215)'"
+rmf .git/index.lock
+
+run_case "2. gpg signing failure" \
+  "git -c commit.gpgsign=true -c gpg.program=/bin/false commit -m 'x (ASK-215)'"
+
+mkdir -p .git/hooks
+printf '#!/bin/sh\necho "BLOCK: bump plugin.json"\nexit 1\n' > .git/hooks/pre-commit
+chmod +x .git/hooks/pre-commit
+run_case "3. pre-commit hook REFUSAL (the real gate case)" \
+  "git commit -m 'x (ASK-215)'"
+rmf .git/hooks/pre-commit
+
+git commit -q -m 'first (ASK-215)' >/dev/null 2>&1
+run_case "4. nothing to commit" "git commit -m 'x (ASK-215)'"
+
+B="$(git symbolic-ref --short HEAD)"
+touch ".git/refs/heads/$B.lock"
+echo more >> a.txt
+git add a.txt
+run_case "5. cannot lock ref" "git commit -m 'x (ASK-215)'"
+rmf ".git/refs/heads/$B.lock"
+
+# Does git propagate a hook's OWN exit status, or normalise it to 1? Decides
+# whether "exit code 1" can be required as a positive gate signal.
+echo "===== 6. hook exit-code propagation ====="
+set +e
+for c in 1 2 3 42 128; do
+  printf '#!/bin/sh\necho "gate says no"\nexit %s\n' "$c" > .git/hooks/pre-commit
+  chmod +x .git/hooks/pre-commit
+  git commit -m "x (ASK-215)" >/dev/null 2>&1
+  echo "hook exit $c -> git exit $?"
+done
+rmf .git/hooks/pre-commit

--- a/q-system/output/pr27-reply.md
+++ b/q-system/output/pr27-reply.md
@@ -1,0 +1,180 @@
+# Round 2 reply — all five findings fixed, each with a case that fails without the fix
+
+Thanks for the index.lock finding. It is the one this fleet actually produces on
+a timer, and you are right that the block message was lying about two of its
+three claims.
+
+Head: `bf641ad`. Suite goes 10 → 16 cases, extended in place (no new test file,
+no `capability-manifest.json` change).
+
+## Ground truth first
+
+I did not want to fix a classifier by adding phrases I remembered. New capture
+script, committed as the provenance the code comments cite:
+`q-system/output/capture-git-transient-failures.sh`.
+
+```
+===== 1. index.lock held =====
+exit_code=128
+fatal: Unable to create '.../.git/index.lock': File exists.
+Another git process seems to be running in this repository, or the lock file may be stale
+
+===== 2. gpg signing failure =====
+exit_code=128
+error: gpg failed to sign the data:
+fatal: failed to write commit object
+
+===== 3. pre-commit hook REFUSAL =====
+exit_code=1
+BLOCK: bump plugin.json
+
+===== 5. cannot lock ref =====
+exit_code=128
+fatal: cannot lock ref 'HEAD': Unable to create '.../refs/heads/master.lock': File exists.
+
+===== 6. hook exit-code propagation =====
+hook exit 1   -> git exit 1
+hook exit 2   -> git exit 1
+hook exit 3   -> git exit 1
+hook exit 42  -> git exit 1
+hook exit 128 -> git exit 1
+```
+
+Two facts fall out. **git's own failures exit 128**, and **git normalises every
+hook refusal to exit 1** whatever the hook returned. So 128 is the near-positive
+signal you asked for: it is git failing, never a gate refusing, and it covers
+transient failures whose text nobody has enumerated yet. A fully positive signal
+still does not exist (exit 1 is also `nothing to commit`), so the negative list
+stays — it is just no longer the only thing holding the line.
+
+## FINDING 1 (major) — fixed
+
+`NON_GATE_COMMIT_FAILURES` gains `index.lock`, `another git process`,
+`cannot lock ref`, `gpg failed to sign`, `failed to write commit object`, and
+`_commit_gate_refusal` now returns `None` on exit 128 regardless of text.
+
+**Layer above.** A lock collision now mints no budget, so the ceiling serves its
+generic message instead. That is not a hole: the recovery from a lock is to retry
+`git commit`, which the ceiling already exempts, so the retry needs no budget.
+Deadlock-free either way.
+
+**Case 11** (four probes: index.lock, ref-lock, gpg, and an unenumerated failure
+that only exit 128 separates from a gate). Observed RED:
+
+```
+AssertionError: indexlock: a transient git failure minted budget: 8
+```
+
+## FINDING 2 (minor) — fixed
+
+New `_invokes_git_commit()` tokenises with `shlex` instead of substring-matching,
+so `grep -rn "git commit" canonical/` no longer reads as a commit while
+`cd x && git commit -m y` and `git -c user.name=x commit` still do.
+
+**Two readers, deliberately.** I did **not** point `_is_commit_command` at it.
+There a false negative blocks the checkpoint the ceiling is asking for and
+deadlocks the run; a false positive only exempts one harmless call. For the grant
+and for `_is_successful_commit` the costs invert. That asymmetry is now written
+into the docstring so the next reader does not "unify" them.
+
+**Case 12.** Observed RED (probe against the unfixed guard):
+
+```
+F2 failing grep      -> 'a pre-commit gate'
+F2 grep resets vol   -> True
+```
+
+That second line is the same defect in `_is_successful_commit`, one function up,
+which you did not flag: a *succeeding* grep that mentions `git commit` reset the
+volume ceiling outright. Fixed in the same change — the tightening is safe
+because wiring B (`reset_volume_if_committed`, HEAD epoch) still catches a real
+commit whose command form the tokeniser misses.
+
+## FINDING 3 (minor) — fixed
+
+The volume warning is now **held**, not emitted inline, so checks 4-11 run. A
+later block outranks it; a later warning carries it.
+
+**What I did not do:** buy reachability by making the ceiling warning silent.
+**Case 16** pins that — it asserts the emitted context still opens with the
+volume warning and still carries the later one. Without the carry it passes as
+"reachable" while the operator loses the 35-call warning.
+
+**Case 13** seeds `edit_targets` over `EDIT_FAIL_LIMIT` with a live grace budget
+and requires exit 2 with the edit-spiral message. On the old code that Edit
+exited 0, exactly as your `repro2-detectors-off.sh` showed.
+
+## FINDING 4 (minor) — fixed
+
+The fallback reader now only considers **unindented** lines. A gate prints its
+name at the left margin and indents the detail beneath it. Structural rule, not
+another word added to `_NOT_A_GATE_NAME`.
+
+**Case 14** runs the real `linear-issue-ref-check.py` (not a remembered fixture)
+and asserts the generic label. Observed RED / GREEN:
+
+```
+F4 real gate name    -> 'subject'            # before
+F4 real gate name    -> 'a pre-commit gate'  # after
+```
+
+## FINDING 5 (nit) — fixed, and it was hiding something
+
+**Case 15** delivers the lefthook refusal as `exit_code: 1` with no `error` key.
+It went red for a reason I did not expect:
+
+```
+AssertionError: a refusal delivered as exit_code (no error key) minted no budget
+```
+
+`_is_successful_commit` never read the exit code at all — only `error`. So that
+one response was a gate refusal to `_commit_gate_refusal` and a **landed commit**
+to `_is_successful_commit`: it reset the ceiling and cleared the budget it had
+just minted, one branch earlier in the same `if/elif` chain. Two readers of the
+same input with different semantics, which is what your nit was pointing at
+without either of us seeing the consequence. Fixed in `80b4eec`.
+
+Narrower than `sp-1078fbe2` (response with **no** failure signal at all). That
+one stays captured, not fixed here.
+
+## What got quieter (stated, per your bar)
+
+One thing: a transient git failure no longer produces
+`<gate> refused the checkpoint`. It produces the generic ceiling message instead.
+That is the point of finding 1 — the old line was false in two of three clauses
+— and nothing else lost a signal. Findings 3 and 5 both make the guard *louder*
+(three detectors come back online during grace; a refused commit no longer
+resets the ceiling).
+
+## Not regressed
+
+Your `repro3-attacks-that-failed.sh` cases A-F are cases 7-10 in the suite and
+all still pass, including the no-ratchet bound and "budget spent only at the
+ceiling".
+
+## Checks
+
+```
+$ bash q-system/.q-system/scripts/test/test-token-guard-hook-behavior.sh
+... 16 ok lines ...
+PASS: token-guard hook behavior (warn shape + PostToolUse edit reset +
+blocked-attempt un-count + gate-refusal grace + non-gate classifier)
+
+$ python3 -m pytest q-system/.q-system/tests/test_token_guard.py -q
+14 passed in 0.50s
+
+$ python3 q-system/.q-system/scripts/capability-gate.py
+tests: ran=75 quarantined=0 skipped-skeleton-only=0
+capability-gate: GREEN
+```
+
+Nothing in the DoR's Not-doing list was touched: no threshold changed, no
+lefthook gate changed, `converge.sh` / `linear-worker.sh` / `pr-verdict-lib.sh`
+untouched. The finding-3 fix moves *when* the volume warning is emitted; it does
+not change the edit-spiral / read-spiral / grep-drift / stall detectors
+themselves, it stops the grace path from hiding them.
+
+## Housekeeping
+
+The scratch you left is not in this worktree (`.pr27rev/` and `refs/pr27-review`
+live in whichever checkout you reviewed from), so I have not touched it.

--- a/q-system/output/pr27.md
+++ b/q-system/output/pr27.md
@@ -1,0 +1,111 @@
+Resolves ASK-215 (spillover `sp-97303649`).
+
+## The deadlock
+
+The volume ceiling exempts the commit **command** but not the commit's
+**preconditions**. A commit refused by a pre-commit gate is not a checkpoint, and
+satisfying that gate needs an `Edit` the ceiling blocks.
+
+Observed 2026-07-27 on ASK-214: lefthook's `plugin-version-bump` refused the
+checkpoint, the agent had 18 of 20 tests done, and the run stranded with
+everything staged and nothing committed. The block message said `50 tool calls`,
+the wrong reason, which sent it back into the deadlock instead of at the gate.
+
+## The fix
+
+A refused commit grants `GATE_GRACE = 8` calls. Bounded three ways:
+
+- spent **only** at the ceiling, on calls the ceiling would otherwise block, so a
+  run that never reaches the ceiling never touches the budget
+- at most **one grant per user-message window**, so there is no refuse / spend 8 /
+  refuse ratchet. A second refusal updates the gate *name* without topping the
+  budget up: the budget is per deadlock episode, not per gate
+- a landed commit or a new user message clears it, so no stale budget silently
+  widens a later ceiling
+
+When it is spent the run hard-stops with a message naming the gate:
+`plugin-version-bump refused the checkpoint and the 8-call grace budget is spent.`
+
+Blind to which gate fired, by design. This repo has seven blocking pre-commit
+gates and each can demand a different file, so exempting `plugin.json` is
+whack-a-mole the next gate defeats.
+
+## Reproducers (RED first, cases 7-10, extended in place)
+
+| Case | Pins |
+|---|---|
+| 7 | at the ceiling with a recorded gate-refused commit, an `Edit` is allowed |
+| 8 | `nothing to commit` mints no budget, so grace cannot be minted with an empty commit |
+| 9 | the 9th call after the grant blocks, and names `plugin-version-bump` |
+| 10 | a landed commit clears the budget |
+
+Observed RED before the fix:
+
+```
+FAIL: Edit after a gate-refused commit exited 2, want 0 (deadlock): 50 tool
+calls without user input or a commit. Commit finished work now ...
+```
+
+## Checks run
+
+```
+$ bash q-system/.q-system/scripts/test/test-token-guard-hook-behavior.sh
+ok: warn() emits nested PreToolUse hookSpecificOutput
+ok: PostToolUse successful Edit clears edit_targets
+ok: PostToolUse failed Edit keeps the spiral counter
+ok: guard-blocked attempts stay volume-blocked and are un-counted
+ok: volume block names the commit escape hatch
+ok: exact-retry still fires for executed identical calls
+ok: a gate-refused commit grants a bounded budget so the ceiling is escapable
+ok: a no-op commit mints no budget; the ceiling still blocks
+ok: budget is bounded at 8 and the hard stop names the refusing gate
+ok: a landed commit clears the budget
+PASS: token-guard hook behavior (... + gate-refusal grace)
+
+$ python3 -m pytest q-system/.q-system/tests/test_token_guard.py -q
+14 passed in 0.52s
+
+$ python3 q-system/.q-system/scripts/capability-gate.py
+tests: ran=75 quarantined=0 skipped-skeleton-only=0
+capability-gate: GREEN
+```
+
+## Grounding, not remembering
+
+The lefthook fixture is real captured output (lefthook v2.1.6, 2026-07-27), not
+recalled text. Two facts came out of that capture and shaped the design:
+
+1. A hook-refused commit prints **only the hook's own output**, exit 1. git adds
+   no marker of its own, so the gate name can only come from the gate's text, and
+   a positive "a hook refused this" signal does not exist to key off.
+2. lefthook marks the failed command in its summary with a boxing glove and
+   passing ones with a check mark, so the failing command is extractable. The
+   `lefthook v2.1.6` banner also carries the glove; the extractor anchors on the
+   stripped line *starting* with it, which the banner does not.
+
+Detection is therefore a negative list: a `git commit` that failed and is not one
+of the known non-gate failures (no-op, empty message, not a repo, unmerged, no
+identity) is treated as refused. A mis-read costs at most 8 calls; missing a real
+refusal costs the whole run.
+
+## Also wired
+
+- `PostToolUse` matcher `Edit|Write|MultiEdit|Bash` in `.claude/settings.json`
+  already covers the Bash leg, so the recorder has a live path (verified, not
+  assumed).
+- Wiring B (`reset_volume_if_committed`) clears the budget too, so a commit that
+  lands without a `PostToolUse` event still ends the episode.
+
+## Not in scope (per the DoR)
+
+No threshold changes, no lefthook-gate changes, no other detectors, no
+`converge.sh` / `linear-worker.sh` / `pr-verdict-lib.sh`.
+
+One adjacent defect found and captured rather than fixed here: `sp-1078fbe2` -
+`_is_successful_commit` reads a commit as successful when the response carries no
+`error` and no exit code, even with no "1 file changed" marker, so a refused
+commit in that response shape silently resets the ceiling. It does not cause a
+deadlock (a reset ceiling blocks nothing), which is why it is separate.
+
+🤖 Generated with [Claude Code](https://claude.com/claude-code)
+


### PR DESCRIPTION
Resolves ASK-215 (spillover `sp-97303649`).

## The deadlock

The volume ceiling exempts the commit **command** but not the commit's
**preconditions**. A commit refused by a pre-commit gate is not a checkpoint, and
satisfying that gate needs an `Edit` the ceiling blocks.

Observed 2026-07-27 on ASK-214: lefthook's `plugin-version-bump` refused the
checkpoint, the agent had 18 of 20 tests done, and the run stranded with
everything staged and nothing committed. The block message said `50 tool calls`,
the wrong reason, which sent it back into the deadlock instead of at the gate.

## The fix

A refused commit grants `GATE_GRACE = 8` calls. Bounded three ways:

- spent **only** at the ceiling, on calls the ceiling would otherwise block, so a
  run that never reaches the ceiling never touches the budget
- at most **one grant per user-message window**, so there is no refuse / spend 8 /
  refuse ratchet. A second refusal updates the gate *name* without topping the
  budget up: the budget is per deadlock episode, not per gate
- a landed commit or a new user message clears it, so no stale budget silently
  widens a later ceiling

When it is spent the run hard-stops with a message naming the gate:
`plugin-version-bump refused the checkpoint and the 8-call grace budget is spent.`

Blind to which gate fired, by design. This repo has seven blocking pre-commit
gates and each can demand a different file, so exempting `plugin.json` is
whack-a-mole the next gate defeats.

## Reproducers (RED first, cases 7-10, extended in place)

| Case | Pins |
|---|---|
| 7 | at the ceiling with a recorded gate-refused commit, an `Edit` is allowed |
| 8 | `nothing to commit` mints no budget, so grace cannot be minted with an empty commit |
| 9 | the 9th call after the grant blocks, and names `plugin-version-bump` |
| 10 | a landed commit clears the budget |

Observed RED before the fix:

```
FAIL: Edit after a gate-refused commit exited 2, want 0 (deadlock): 50 tool
calls without user input or a commit. Commit finished work now ...
```

## Checks run

```
$ bash q-system/.q-system/scripts/test/test-token-guard-hook-behavior.sh
ok: warn() emits nested PreToolUse hookSpecificOutput
ok: PostToolUse successful Edit clears edit_targets
ok: PostToolUse failed Edit keeps the spiral counter
ok: guard-blocked attempts stay volume-blocked and are un-counted
ok: volume block names the commit escape hatch
ok: exact-retry still fires for executed identical calls
ok: a gate-refused commit grants a bounded budget so the ceiling is escapable
ok: a no-op commit mints no budget; the ceiling still blocks
ok: budget is bounded at 8 and the hard stop names the refusing gate
ok: a landed commit clears the budget
PASS: token-guard hook behavior (... + gate-refusal grace)

$ python3 -m pytest q-system/.q-system/tests/test_token_guard.py -q
14 passed in 0.52s

$ python3 q-system/.q-system/scripts/capability-gate.py
tests: ran=75 quarantined=0 skipped-skeleton-only=0
capability-gate: GREEN
```

## Grounding, not remembering

The lefthook fixture is real captured output (lefthook v2.1.6, 2026-07-27), not
recalled text. Two facts came out of that capture and shaped the design:

1. A hook-refused commit prints **only the hook's own output**, exit 1. git adds
   no marker of its own, so the gate name can only come from the gate's text, and
   a positive "a hook refused this" signal does not exist to key off.
2. lefthook marks the failed command in its summary with a boxing glove and
   passing ones with a check mark, so the failing command is extractable. The
   `lefthook v2.1.6` banner also carries the glove; the extractor anchors on the
   stripped line *starting* with it, which the banner does not.

Detection is therefore a negative list: a `git commit` that failed and is not one
of the known non-gate failures (no-op, empty message, not a repo, unmerged, no
identity) is treated as refused. A mis-read costs at most 8 calls; missing a real
refusal costs the whole run.

## Also wired

- `PostToolUse` matcher `Edit|Write|MultiEdit|Bash` in `.claude/settings.json`
  already covers the Bash leg, so the recorder has a live path (verified, not
  assumed).
- Wiring B (`reset_volume_if_committed`) clears the budget too, so a commit that
  lands without a `PostToolUse` event still ends the episode.

## Not in scope (per the DoR)

No threshold changes, no lefthook-gate changes, no other detectors, no
`converge.sh` / `linear-worker.sh` / `pr-verdict-lib.sh`.

One adjacent defect found and captured rather than fixed here: `sp-1078fbe2` -
`_is_successful_commit` reads a commit as successful when the response carries no
`error` and no exit code, even with no "1 file changed" marker, so a refused
commit in that response shape silently resets the ceiling. It does not cause a
deadlock (a reset ceiling blocks nothing), which is why it is separate.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

