### PR TITLE
fix(review): the verdict record pins the head sha it reviewed, so an APPROVE cannot be inherited by later pushes (ASK-216)

### DIFF
--- a/q-system/.q-system/scripts/pr-review-agent.sh
+++ b/q-system/.q-system/scripts/pr-review-agent.sh
@@ -74,10 +74,22 @@ run_bounded() {
 }
 
 command -v gh >/dev/null 2>&1 || { echo "gh CLI required" >&2; exit 1; }
-PR_TITLE="$(gh pr view "$PR" --json title -q .title 2>/dev/null)" || { echo "no PR #$PR" >&2; exit 1; }
+# ONE read of the PR's state, and the head sha comes out of it (ASK-216).
+# Capturing it here -- before the reviewer is dispatched, in the same API read
+# that proves the PR exists -- is the whole point: looked up AFTER the review,
+# a push landing mid-review would make the record claim a commit the reviewer
+# never saw, which is worse than no sha because it looks authoritative. Erring
+# the other way (a push between here and the reviewer's own `gh pr diff`) pins
+# the OLDER sha, which reads as drift and routes to a re-review. Safe direction.
+# The sha is first in the tuple so a tab inside a PR title cannot displace it.
+PR_META="$(gh pr view "$PR" --json headRefOid,title -q '.headRefOid + "\t" + .title' 2>/dev/null)" \
+  || { echo "no PR #$PR" >&2; exit 1; }
+HEAD_SHA="${PR_META%%$'\t'*}"
+PR_TITLE="${PR_META#*$'\t'}"
 [ -n "$ISSUE" ] || ISSUE="$(printf '%s' "$PR_TITLE" | grep -oE 'ASK-[0-9]+' | head -1)"
 
 echo "$(TS) reviewing PR #$PR: $PR_TITLE"
+echo "  head sha under review: ${HEAD_SHA:-unknown}"
 [ -n "$ISSUE" ] && echo "  linked issue: $ISSUE"
 
 # $REVIEW is only a variable at this point -- the file is not created until the
@@ -249,14 +261,22 @@ echo "  verdict: ${VERDICT:-unstated}"
 # Single writer for verdict state. The worker's rework gate reads THIS record,
 # never the review prose. Keyed by PR number, latest round wins; history stays
 # in the timestamped .md files.
-python3 - "$PR" "$ISSUE" "$VERDICT" "$REVIEW" "$(TS)" "$STATED_VERDICT" "$DERIVED_VERDICT" "$ROUND" <<'PY'
+#
+# head_sha is the commit this review actually examined, captured before the
+# reviewer ran (ASK-216). Without it the record binds an approval to a PR
+# NUMBER, and the worker reuses one PR across rounds, so any later push inherits
+# the approval. The key is ALWAYS written -- empty when `gh` could not answer --
+# because rework_gate reads empty as "unknown, fall back and say so", and a
+# key that sometimes vanishes is a shape the reader would have to guess at.
+python3 - "$PR" "$ISSUE" "$VERDICT" "$REVIEW" "$(TS)" "$STATED_VERDICT" "$DERIVED_VERDICT" "$ROUND" "$HEAD_SHA" <<'PY'
 import json, sys
-pr, issue, verdict, review, ts, stated, derived, rnd = sys.argv[1:9]
+pr, issue, verdict, review, ts, stated, derived, rnd, head_sha = sys.argv[1:10]
 out = review.rsplit("/", 1)[0] + f"/pr-{pr}.verdict.json"
 json.dump({"pr": int(pr), "issue": issue, "verdict": verdict,
            "stated": stated, "derived": derived,
            "source": "findings" if derived else "prose",
-           "round": int(rnd), "review": review, "ts": ts}, open(out, "w"), indent=2)
+           "round": int(rnd), "review": review, "head_sha": head_sha,
+           "ts": ts}, open(out, "w"), indent=2)
 PY
 
 # Severity floor, capture half: APPROVE WITH NITS is a TERMINAL state -- the

--- a/q-system/.q-system/scripts/pr-verdict-lib.sh
+++ b/q-system/.q-system/scripts/pr-verdict-lib.sh
@@ -77,7 +77,15 @@ pr_merge_state() {
   gh pr view "$1" --json mergeStateStatus -q .mergeStateStatus 2>/dev/null | tr -d '[:space:]'
 }
 
-# rework_gate <verdict> [merge-state]
+# _sha_norm <sha>
+# Whitespace-stripped, lower-cased sha for comparison. Hex case and a stray
+# newline are not drift. A PREFIX is deliberately NOT treated as a match: both
+# sides of the comparison come from GitHub's full 40-char headRefOid, so a short
+# sha means something unexpected wrote the record, and reading that as "same
+# commit" would be a guess in the never-merge direction's favour.
+_sha_norm() { printf '%s' "${1:-}" | tr -d '[:space:]' | tr '[:upper:]' '[:lower:]'; }
+
+# rework_gate <verdict> [merge-state] [reviewed-head-sha] [current-head-sha]
 # The deterministic slice of the severity floor: whether another rework round
 # is allowed to start. Exit codes, not prose:
 #   0  = rework      (REQUEST CHANGES or BLOCK -- the review is the spec)
@@ -89,6 +97,8 @@ pr_merge_state() {
 #   30 = conflicted  (approved, but it no longer merges -- a REBASE round, not a
 #                     review round. Distinct from 0 so the caller can cap it
 #                     separately; see the caller-owned cap note below.)
+#   40 = stale       (approving, but at a sha that is no longer the PR's head --
+#                     re-review at the new sha. NEVER merge, never auto-approve.)
 #
 # WHY MERGEABILITY IS PART OF THE GATE (ASK-212, sp-71b63e62)
 # ----------------------------------------------------------
@@ -122,11 +132,48 @@ pr_merge_state() {
 # The ONE-ARGUMENT form keeps its original semantics exactly (no merge state
 # supplied reads as "still merges"), because converge.sh calls it that way and a
 # silent behaviour change on the short form is a fleet-wide bug.
+#
+# WHY THE SHA IS PART OF THE GATE (ASK-216, sp-12f99480)
+# ------------------------------------------------------
+# A verdict record keyed on a PR NUMBER says "this PR was approved", never "this
+# CODE was approved". The worker reuses one branch and one PR across rework
+# rounds (linear-worker.sh:328), so every push landing after an approval
+# inherited that approval silently. Today that is a stale skip; under an
+# integrator it is an auto-merge of code no reviewer ever read, on a repo whose
+# main fans out fleet-wide through `kipi update`. pr-receipt-gate.py already
+# reasons this way with --head-sha; a verdict is the same class of claim.
+#
+# ABSENT IS NOT DRIFT. Every record written before this change lacks the field,
+# so absent falls back to verdict-only and SAYS SO on stdout -- reading
+# absent-as-drift would re-review every converged PR on the board at once. Same
+# posture when the CURRENT head cannot be read: fail toward terminal, exactly as
+# an empty merge state does above. A manufactured re-review round costs the
+# whole fleet at once; a missed one costs a single human diagnosis.
+#
+# DRIFT OUTRANKS THE MERGE STATE. When both fire, the sha wins: a rebase round
+# dispatched on a diff nobody reviewed is the same unreviewed-code path wearing
+# a rebase coat. Re-review first; the fresh record then decides.
+#
+# 40 IS NOT 10 AND NOT 30. Callers passing 1 or 2 arguments (converge.sh,
+# linear-worker.sh -- neither touched by this issue) can never see it, and a
+# caller that does not know 40 falls out of its if-chain into the rework path,
+# which is the safe direction: not terminal, never a merge.
 rework_gate() {
-  local verdict="${1:-}" merge_state="${2:-}"
+  local verdict="${1:-}" merge_state="${2:-}" reviewed_sha="${3:-}" current_sha="${4:-}"
   case "$verdict" in
     "REQUEST CHANGES"|"BLOCK")            return 0 ;;
     "APPROVE"|"APPROVE WITH NITS")
+      # Silent unless a caller actually asked for the sha check, so the short
+      # forms stay byte-identical and no line is printed on every worker run.
+      if [ -n "$reviewed_sha" ] || [ -n "$current_sha" ]; then
+        if [ -z "$reviewed_sha" ]; then
+          echo "  NOTE: no head_sha in this verdict record (written before ASK-216) -- cannot tell an approval from one inherited by a later push; falling back to verdict-only"
+        elif [ -z "$current_sha" ]; then
+          echo "  NOTE: could not read the PR's current head_sha; not manufacturing a re-review round on an unreadable head"
+        elif [ "$(_sha_norm "$reviewed_sha")" != "$(_sha_norm "$current_sha")" ]; then
+          return 40
+        fi
+      fi
       case "$merge_state" in
         "DIRTY"|"BEHIND")                 return 30 ;;
         *)                                return 10 ;;
@@ -165,5 +212,18 @@ verdict_from_record() {
   [ -s "$f" ] || return 0
   python3 -c 'import json,sys
 try: print(json.load(open(sys.argv[1])).get("verdict",""))
+except Exception: pass' "$f" 2>/dev/null || true
+}
+
+# head_sha_from_record <verdict-json>
+# Reads the `head_sha` field: the commit the review actually examined. EMPTY for
+# every record written before ASK-216, for a corrupt record, and for a run where
+# `gh` could not answer -- all three are the same thing to rework_gate, which
+# reads empty as "unknown, fall back and say so", never as drift.
+head_sha_from_record() {
+  local f="$1"
+  [ -s "$f" ] || return 0
+  python3 -c 'import json,sys
+try: print(json.load(open(sys.argv[1])).get("head_sha","") or "")
 except Exception: pass' "$f" 2>/dev/null || true
 }

--- a/q-system/.q-system/scripts/test/test-severity-floor.sh
+++ b/q-system/.q-system/scripts/test/test-severity-floor.sh
@@ -678,6 +678,191 @@ grep -q 'MAX_CONFLICT_ROUNDS' "$WORKER" \
   || fail "linear-worker.sh has no conflict-round cap"
 ok "worker wiring: merge state read through the lib, conflict cap present"
 
+# =============================================================================
+# THE VERDICT IS BOUND TO A SHA, NOT TO A PR NUMBER (ASK-216, sp-12f99480)
+# =============================================================================
+# THE DEFECT: the verdict record keyed on a PR NUMBER and carried no sha. The
+# worker reuses one branch and one PR across rework rounds, so every push after
+# an approval silently inherited that approval. Nothing in the record could tell
+# "reviewed and approved" from "approved, then three more commits landed".
+#
+# OBSERVED 2026-07-27, the live record for PR #25:
+#   {"pr":25,"issue":"ASK-212","verdict":"APPROVE WITH NITS", ... }  <- no sha
+#
+# Today that costs a stale skip. With an integrator on top it is an auto-merge
+# of code no reviewer ever read, on a repo whose main fans out fleet-wide.
+#
+# THE SHAPE OF THE FIX: the writer pins the sha the review actually read, and
+# the gate refuses to call an approval at a DIFFERENT sha terminal (exit 40 --
+# re-review at the new head; never merge, never auto-approve).
+SHA_A="a1b2c3d4e5f60718293a4b5c6d7e8f9012345678"
+SHA_B="ffeeddccbbaa99887766554433221100aabbccdd"
+
+# gate_sha <want-rc> <verdict> <merge-state> <recorded-sha> <current-sha> <why>
+# Never touches the live GitHub API: both shas are scripted, which is also the
+# only way to hold "the head moved" still long enough to assert on it.
+gate_sha() {
+  local want="$1" verdict="$2" state="$3" rec="$4" cur="$5" why="$6" got
+  rework_gate "$verdict" "$state" "$rec" "$cur" >/dev/null; got=$?
+  [ "$got" = "$want" ] \
+    || fail "rework_gate '$verdict' '$state' rec='$rec' cur='$cur' -> $got, want $want ($why)"
+  ok "$why"
+}
+
+# --- L1. an approval at a sha that is no longer the head is NOT terminal -----
+gate_sha 40 "APPROVE"           "CLEAN" "$SHA_A" "$SHA_B" \
+  "approved at a sha that is no longer the head is stale, not terminal"
+gate_sha 40 "APPROVE WITH NITS" "CLEAN" "$SHA_A" "$SHA_B" \
+  "approve-with-nits at a stale sha is stale too"
+
+# Drift wins over the merge state. Both are true here, and a rebase round on a
+# diff nobody reviewed is the same unreviewed-code path wearing a rebase coat:
+# re-review first, then the fresh record decides whether it is a rebase round.
+gate_sha 40 "APPROVE"           "DIRTY" "$SHA_A" "$SHA_B" \
+  "drift outranks DIRTY: re-review at the new head before any rebase round"
+
+# --- L2. a matching sha keeps every one of today's outcomes ------------------
+# The converged-PR half. Too strict here and every approved PR on the board
+# re-reviews forever, burning model budget and writing a permanent Linear
+# comment each round.
+gate_sha 10 "APPROVE"           "CLEAN" "$SHA_A" "$SHA_A" \
+  "a matching sha stays terminal (a converged PR does not re-review forever)"
+gate_sha 10 "APPROVE WITH NITS" "CLEAN" "$SHA_A" "$SHA_A" \
+  "approve-with-nits at the reviewed sha stays terminal"
+gate_sha 30 "APPROVE"           "DIRTY" "$SHA_A" "$SHA_A" \
+  "reviewed sha + DIRTY is still a rebase round (ASK-212 survives)"
+gate_sha 10 "APPROVE"           "CLEAN" "ABC123DEF" "abc123def" \
+  "sha comparison is case-insensitive (hex case is not drift)"
+
+# A non-approving verdict already routes to rework; drift cannot make it worse,
+# and must not change its code (the rework loop owns that PR either way).
+gate_sha 0  "REQUEST CHANGES"   "CLEAN" "$SHA_A" "$SHA_B" \
+  "drift does not change a REQUEST CHANGES verdict (already rework)"
+gate_sha 20 ""                  "CLEAN" "$SHA_A" "$SHA_B" \
+  "drift does not rescue an unreviewed PR from gate 20"
+
+# --- L3. ABSENT is not DRIFT, and the gate says so --------------------------
+# Every record written before this change lacks the field. Reading absent as
+# drift would re-review every converged PR on the board at once. So absent falls
+# back to today's behaviour -- and announces the blind spot instead of being
+# silently grandfathered.
+NOTE="$(rework_gate "APPROVE" "CLEAN" "" "$SHA_B")"; GOT=$?
+[ "$GOT" = "10" ] \
+  || fail "a record with NO head_sha must behave as it does today (got $GOT, want 10).
+      Reading absent-as-drift re-reviews every pre-ASK-216 PR on the board at once."
+ok "absent head_sha falls back to today's behaviour (no mass re-review)"
+
+printf '%s' "$NOTE" | grep -qi 'head_sha' \
+  || fail "the gate fell back on an unpinned verdict SILENTLY. The blind spot has to be
+      stated on stdout, not grandfathered. It said: '$NOTE'"
+ok "the gate names the unpinned-verdict blind spot on stdout"
+
+# The mirror case: the record pins a sha but the CURRENT head could not be read
+# (gh down, API slow). Same posture as ASK-212's empty merge state -- fail
+# toward terminal, because a manufactured re-review round costs every PR in the
+# fleet at once while a missed one costs a single human diagnosis.
+NOTE2="$(rework_gate "APPROVE" "CLEAN" "$SHA_A" "")"; GOT=$?
+[ "$GOT" = "10" ] \
+  || fail "an unreadable current head manufactured a re-review round (got $GOT, want 10)"
+printf '%s' "$NOTE2" | grep -qi 'head' \
+  || fail "a failed head lookup was swallowed silently: '$NOTE2'"
+ok "an unreadable current head does not manufacture a re-review round, and says so"
+
+# The one- and two-argument forms are what converge.sh and linear-worker.sh call
+# today, and this issue does not touch either file. They must be byte-identical
+# in behaviour AND silent -- a note printed on every worker run is the cry-wolf
+# failure, not a safety feature.
+QUIET="$(rework_gate "APPROVE" "CLEAN")"; GOT=$?
+[ "$GOT" = "10" ] || fail "two-arg rework_gate 'APPROVE' 'CLEAN' changed: got $GOT, want 10"
+[ -z "$QUIET" ] || fail "the two-arg form now prints on every call: '$QUIET'. That is a line on
+      every worker run for every PR, which trains the operator to skim the real ones."
+QUIET1="$(rework_gate "APPROVE")"; GOT=$?
+[ "$GOT" = "10" ] || fail "one-arg rework_gate 'APPROVE' changed: got $GOT, want 10"
+[ -z "$QUIET1" ] || fail "the one-arg form (converge.sh) now prints on every call: '$QUIET1'"
+ok "the one- and two-arg forms are unchanged and silent (converge.sh, linear-worker.sh)"
+
+# --- L4. record -> gate chain, the way a consumer will actually use it -------
+cat > "$W2/pr-901.verdict.json" <<EOF
+{"pr": 901, "issue": "ASK-901", "verdict": "APPROVE", "head_sha": "$SHA_A",
+ "review": "/tmp/x.md", "ts": "2026-07-27T05:00:00Z"}
+EOF
+[ "$(head_sha_from_record "$W2/pr-901.verdict.json")" = "$SHA_A" ] \
+  || fail "head_sha round-trip out of the record failed"
+rework_gate "$(verdict_from_record "$W2/pr-901.verdict.json")" CLEAN \
+            "$(head_sha_from_record "$W2/pr-901.verdict.json")" "$SHA_B" >/dev/null
+[ $? = 40 ] || fail "record -> gate chain: an approved record at a stale head must not be terminal"
+ok "record -> gate chain: approved record + moved head -> re-review, not merge"
+
+# A record written before this change (the whole board today) yields empty, and
+# empty is the absent case above -- not a crash and not a drift claim.
+[ -z "$(head_sha_from_record "$WORK/pr-99.verdict.json")" ] \
+  || fail "a pre-ASK-216 record must yield an EMPTY head sha, never a guess"
+ok "a pre-ASK-216 record (no head_sha key) reads as empty, not as drift"
+
+[ -z "$(head_sha_from_record "$WORK/pr-98.verdict.json")" ] \
+  || fail "a corrupt record must yield an empty head sha, not crash"
+ok "a corrupt record reads as an empty head sha (fails closed, same as the verdict)"
+
+# --- M. the WRITER pins the sha, asserted on the JSON it really produces -----
+# Not a hand-rolled fixture: the real pr-review-agent.sh runs end to end with
+# `gh` and `claude` stubbed, and the assertion is on the record it wrote. The
+# fixture rule (test-linear-claim.sh scar) is exactly this -- a record shaped by
+# the same mind as the reader proves nothing.
+#
+# ISOLATION: HOME is redirected so OUT_DIR lands in the temp tree, and the
+# stubbed review derives APPROVE with an EMPTY findings block, so the spillover
+# capture path (live ledger) is never entered.
+SW="$W2/stub-writer"; mkdir -p "$SW" "$W2/home-writer"
+# The section-E stub set swallows `python3 -` (it fakes the ready-issues query),
+# and the record writer IS a `python3 -` heredoc. So this section needs a real
+# python3 ahead of it on PATH.
+cat > "$SW/python3" <<EOF
+#!/usr/bin/env bash
+exec "$REAL_PY" "\$@"
+EOF
+cat > "$SW/gh" <<EOF
+#!/usr/bin/env bash
+case "\$*" in
+  "pr view 901 --json"*) printf '$SHA_A\tpin the sha the review actually read\n' ;;
+  *) exit 1 ;;
+esac
+exit 0
+EOF
+cat > "$SW/claude" <<'EOF'
+#!/usr/bin/env bash
+printf '## VERDICT: APPROVE\n\nNothing survived reproduction.\n\nFINDINGS:\nEND FINDINGS\n'
+EOF
+chmod +x "$SW/python3" "$SW/gh" "$SW/claude"
+
+( PATH="$SW:$PATH" HOME="$W2/home-writer" bash "$REVIEWER" 901 ) >"$W2/writer.out" 2>&1
+REC="$W2/home-writer/.config/kipi/pr-reviews/pr-901.verdict.json"
+[ -s "$REC" ] \
+  || fail "the reviewer wrote no verdict record at all. It said:
+$(sed 's/^/        /' "$W2/writer.out")"
+
+[ "$("$REAL_PY" -c "import json;print('head_sha' in json.load(open('$REC')))")" = "True" ] \
+  || fail "THE DEFECT: the record the REAL writer just produced has NO head_sha key, so the
+      approval binds to a PR number and any later push inherits it. Record was:
+$(sed 's/^/        /' "$REC")"
+ok "the writer's record carries a head_sha key"
+
+[ "$("$REAL_PY" -c "import json;print(json.load(open('$REC')).get('head_sha',''))")" = "$SHA_A" ] \
+  || fail "the record pinned the wrong sha: got
+      '$("$REAL_PY" -c "import json;print(json.load(open('$REC')).get('head_sha',''))")', want '$SHA_A'"
+ok "the pinned sha is the head the reviewer was pointed at"
+
+# The sha must be read BEFORE the reviewer runs, from the state it reads. Looked
+# up afterwards, a push landing mid-review makes the record claim a commit the
+# reviewer never saw -- worse than no sha, because it looks authoritative.
+SHA_LINE="$(grep -n 'headRefOid' "$REVIEWER" | head -1 | cut -d: -f1)"
+RUN_LINE="$(grep -n 'run_bounded "\$TIMEOUT_SECONDS"' "$REVIEWER" | head -1 | cut -d: -f1)"
+[ -n "$SHA_LINE" ] || fail "pr-review-agent.sh never reads headRefOid; it cannot pin a sha"
+[ -n "$RUN_LINE" ] || fail "could not find the reviewer dispatch line to order against"
+[ "$SHA_LINE" -lt "$RUN_LINE" ] \
+  || fail "the head sha is captured AFTER the reviewer runs (line $SHA_LINE vs $RUN_LINE). A push
+      landing mid-review would make the record claim a commit the reviewer never read."
+ok "the head sha is captured before the review is taken, not looked up afterwards"
+
 bash -n "$LIB" || fail "pr-verdict-lib.sh does not parse"
 ok "the lib parses (bash -n)"
 


### PR DESCRIPTION
Resolves `sp-12f99480`. **Build item 6a** of `merge-authority-design-2026-07-27.md`. Ships alone and first.

## The defect

`pr-review-agent.sh` is the single writer of the verdict record, and the record carried **no sha** — it bound an approval to a PR *number*. `linear-worker.sh:328` reuses one branch and one PR across rework rounds, so any push after an approval silently inherited it.

The live record for PR #25, written 2026-07-27:

```json
{"pr": 25, "issue": "ASK-212", "verdict": "APPROVE WITH NITS", "round": 2, "ts": "..."}
```

Nothing in it can tell *"reviewed and approved"* from *"approved, then three more commits landed"*. Today that costs a stale skip. Once the integrator (6c) exists it is an auto-merge of code no reviewer ever read, on a repo whose `main` fans out fleet-wide through `kipi update`. `pr-receipt-gate.py` already refuses a receipt that does not pin the current head; a verdict is the same class of claim.

## The fix — two halves, because a sha nobody checks is inert

**Writer** (`pr-review-agent.sh`). `headRefOid` is folded into the single `gh pr view` that already proves the PR exists, **before** the reviewer is dispatched. Looked up afterwards, a push landing mid-review would make the record claim a commit the reviewer never saw — worse than no sha, because it looks authoritative.

**Reader** (`pr-verdict-lib.sh`). `rework_gate` gains optional 3rd/4th args (reviewed sha, current sha) and exit **40**: an approving verdict at a sha that is no longer the head is **not terminal** — re-review at the new sha, never merge, never auto-approve. Drift outranks `DIRTY`: a rebase round on a diff nobody reviewed is the same unreviewed-code path wearing a rebase coat.

## Absent is not drift

Every record on the board today lacks the field. Absent falls back to verdict-only and **says so on stdout** — reading absent-as-drift would re-review every converged PR at once. Same posture when the current head cannot be read: fail toward terminal, exactly as an empty merge state does (ASK-212). A manufactured re-review round costs the whole fleet at once; a missed one costs one human diagnosis.

The 1- and 2-argument forms are unchanged **and silent**, asserted: `converge.sh` and `linear-worker.sh` are untouched by this issue, and a note on every worker run is the cry-wolf failure, not a safety feature. `40` is unreachable from them; a caller that does not know it falls out of its if-chain into the rework path — not terminal, never a merge.

## Checks — RED before green, real output

```
RED   rework_gate 'APPROVE' 'CLEAN' rec=a1b2... cur=ffee... -> 10, want 40
RED   the real writer's record: head_sha present? False

GREEN bash q-system/.q-system/scripts/test/test-severity-floor.sh
      PASS: 77/77 severity-floor checks     (58 pre-existing + 19 new)
GREEN python3 q-system/.q-system/scripts/capability-gate.py
      capability-gate: GREEN (ran=76 quarantined=0)
```

Extended in place — no new test file, so no `capability-manifest.json` change and no conflict on the magnet file (`sp-f3a2ad81`).

The writer half is asserted on the JSON the **real** `pr-review-agent.sh` produces (`gh` + `claude` stubbed, `HOME` redirected, APPROVE with an empty findings block so the live spillover ledger is never touched) — not on a hand-rolled fixture.

## Not doing (DoR-binding)

The integrator (6c) / `pr-integrate.sh` / any auto-merge · `linear-worker.sh` · `converge.sh` · `pr-receipt-gate.py` · the ASK-212 mergeability logic (extended beside it, not rewritten).

## Captured, not fixed

`sp-636fe840` — `converge.sh:152` keeps a private `head_sha` reader while `pr-verdict-lib.sh` is now the shared home for verdict+sha semantics. Two readers of one input is the defect class that lib exists to prevent; consolidate when 6c wires the sha gate. `converge.sh` is not-doing here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)