### PR TITLE
fix(claim): a killed holder's claim is reclaimable on read, so a SIGKILL cannot wedge the board (ASK-189)

### DIFF
--- a/q-system/.q-system/scripts/linear-claim.py
+++ b/q-system/.q-system/scripts/linear-claim.py
@@ -96,6 +96,29 @@ GUARD_TIMEOUT_SECONDS = 5.0
 # which reads as alive.
 PS_TIMEOUT_SECONDS = 5.0
 
+# `ps -o lstart=` renders the start time in the READING process's timezone and
+# locale. The write and the read are different processes, hours apart, so an
+# unpinned render turned a LIVE holder into "the pid was recycled" the moment the
+# system timezone moved -- macOS sets the zone automatically and a laptop that
+# travels flips it. That is the mutex handing a live worker's tree to a second
+# worker, which is scar 53f2eeb and the one direction this feature must never go.
+# Measured 2026-07-27, one pid, same instant:
+#   TZ=UTC        -> 'Tue Jul 28 01:52:53 2026'
+#   TZ=Asia/Tokyo -> 'Tue Jul 28 10:52:53 2026'
+# Both the write and the read go through _proc_snapshot, so pinning it in one
+# place is what keeps the two sides of the comparison rendering identically.
+_PS_ENV = {**os.environ, "TZ": "UTC", "LC_ALL": "C"}
+
+# THE KEY CARRIES ITS FORMAT, because the format changed once. Records written
+# before the pin above hold a LOCAL-time render under the old name
+# `holder_pid_start`; comparing one of those against a UTC render says "recycled
+# pid" about a holder that is alive and working -- this fix causing the exact
+# defect it fixes, for the length of the upgrade window (a `kipi update` can
+# replace this script while a claim is held). Under a new name an old record
+# simply has no recorded start time, which already reads as unknown, which reads
+# as alive. Downgrade is safe for the same reason, in the other direction.
+HOLDER_START_KEY = "holder_pid_start_utc"
+
 
 class CorruptLock(Exception):
     """The lock exists but cannot be understood. Callers refuse, never grant."""
@@ -199,6 +222,9 @@ def _proc_snapshot(pid: int) -> tuple[str, str] | None:
     reaps it, and `os.kill(pid, 0)` succeeds on a zombie -- so the pid check
     alone reads a killed holder as alive for as long as nobody waits on it.
 
+    The environment is PINNED (`_PS_ENV`): `lstart` is rendered in the reading
+    process's timezone, and the writer and the reader are different processes.
+
     None on any doubt (ps missing, non-zero, unparseable, slow). Callers must
     treat None as "cannot prove death", never as death.
     """
@@ -209,6 +235,7 @@ def _proc_snapshot(pid: int) -> tuple[str, str] | None:
             text=True,
             check=False,
             timeout=PS_TIMEOUT_SECONDS,
+            env=_PS_ENV,
         )
     except (OSError, ValueError, TypeError, subprocess.SubprocessError):
         return None
@@ -237,7 +264,7 @@ def holder_death_reason(record: dict) -> str | None:
     started, state = snapshot
     if state.upper().startswith("Z"):
         return f"holder process {pid} was killed and is a zombie awaiting reap"
-    recorded_start = record.get("holder_pid_start")
+    recorded_start = record.get(HOLDER_START_KEY)
     if isinstance(recorded_start, str) and recorded_start and recorded_start != started:
         return (
             f"pid {pid} now belongs to a process started {started!r}, not the "
@@ -264,7 +291,7 @@ def holder_fields(pid: int | None) -> dict:
     fields: dict = {"holder_pid": pid}
     snapshot = _proc_snapshot(pid)
     if snapshot is not None:
-        fields["holder_pid_start"] = snapshot[0]
+        fields[HOLDER_START_KEY] = snapshot[0]
     return fields
 
 
@@ -648,7 +675,22 @@ def cmd_status(_args: argparse.Namespace) -> int:
     if held is None:
         print("no claim held in this working tree")
         return EXIT_OK
-    print(f"{held.get('issue_id')} claimed by {_describe(held)}")
+    line = f"{held.get('issue_id')} claimed by {_describe(held)}"
+    # `status` is what a human runs on a board that looks wedged. Reporting a
+    # provably-dead holder as a live claim is the REPORT contradicting the
+    # detector: `claim` reclaims that same record one line later. The fix landing
+    # on the detector alone would leave the operator reading the wrong answer
+    # from the one command they actually type.
+    #
+    # APPENDED, never substituted, and the exit code stays 0: the existing text
+    # has a reader (test-linear-claim.sh case 20 pulls the session token out of
+    # this line with sed), and a rewritten line or a new non-zero exit would
+    # break callers while every assertion about staleness still passed. This
+    # tells the truth; it does not become a new gate.
+    gone = holder_death_reason(held)
+    if gone is not None:
+        line += f" [STALE: {gone} -- the next claim will reclaim this tree]"
+    print(line)
     return EXIT_OK
 
 

--- a/q-system/.q-system/scripts/linear-claim.py
+++ b/q-system/.q-system/scripts/linear-claim.py
@@ -35,6 +35,26 @@ A pid cannot serve as that token: this is a CLI that exits immediately after
 writing the lock, so the recorded pid is a dead process within milliseconds.
 The token comes from the session's own environment.
 
+THE HOLDER'S LIVENESS IS A SEPARATE, OPTIONAL FIELD (ASK-189)
+-------------------------------------------------------------
+Because the session token says WHO holds the tree but nothing says whether that
+holder still exists, a killed session leaked its claim forever. Measured twice
+2026-07-27: a run was SIGKILLed, the claim stayed held by a session with zero
+processes alive, and a human had to run `release --holder`. SIGKILL cannot be
+trapped, so no in-process cleanup can ever close this -- the lock must be able
+to tell ON READ that its holder is gone.
+
+The caller therefore names a process that lives for the WHOLE run via
+`--holder-pid` (linear-worker.sh passes its own `$$`). That is the piece that was
+missing: not that pids are useless here, but that nothing long-lived was ever
+written down.
+
+The direction of doubt is one-way and load-bearing: a reclaim happens only on
+POSITIVE PROOF of death. A missing field, an unreadable `ps`, a permission error
+-- anything unknown -- reads as ALIVE and the claim stands. Leaking a lock wedges
+a board and a human notices; reclaiming a LIVE holder's tree hands two workers
+the same files, which is scar 53f2eeb and nobody notices.
+
 FAIL CLOSED, EVERYWHERE
 -----------------------
 A mutex that grants under doubt is worse than none, because callers trust it.
@@ -71,6 +91,10 @@ STARTED_STATUS_TYPES = ("started",)
 STARTED_STATUS_NAMES = ("in progress", "in review")
 
 GUARD_TIMEOUT_SECONDS = 5.0
+# `ps` is a local read that normally returns in milliseconds. The bound exists so
+# a wedged process table can never hang the mutex; a timeout reads as "unknown",
+# which reads as alive.
+PS_TIMEOUT_SECONDS = 5.0
 
 
 class CorruptLock(Exception):
@@ -164,6 +188,84 @@ def _pid_alive(pid: int) -> bool:
     except (OverflowError, ValueError, TypeError):
         return False
     return True
+
+
+def _proc_snapshot(pid: int) -> tuple[str, str] | None:
+    """(start_time, state) for `pid` as `ps` sees it, or None when it cannot say.
+
+    `lstart` is the process's ABSOLUTE start time, which is what distinguishes
+    the recorded holder from an unrelated process that later inherited its pid.
+    `state` is here because a SIGKILLed process stays a ZOMBIE until its parent
+    reaps it, and `os.kill(pid, 0)` succeeds on a zombie -- so the pid check
+    alone reads a killed holder as alive for as long as nobody waits on it.
+
+    None on any doubt (ps missing, non-zero, unparseable, slow). Callers must
+    treat None as "cannot prove death", never as death.
+    """
+    try:
+        result = subprocess.run(
+            ["ps", "-p", str(int(pid)), "-o", "lstart=,state="],
+            capture_output=True,
+            text=True,
+            check=False,
+            timeout=PS_TIMEOUT_SECONDS,
+        )
+    except (OSError, ValueError, TypeError, subprocess.SubprocessError):
+        return None
+    if result.returncode != 0:
+        return None
+    parts = result.stdout.strip().rsplit(None, 1)
+    if len(parts) != 2 or not parts[0].strip():
+        return None
+    return parts[0].strip(), parts[1].strip()
+
+
+def holder_death_reason(record: dict) -> str | None:
+    """Why this claim's holder is PROVABLY gone, or None when it must be respected.
+
+    The one-way doubt rule from the module docstring is implemented here and
+    nowhere else: every path that cannot prove death returns None.
+    """
+    pid = record.get("holder_pid")
+    if not isinstance(pid, int) or isinstance(pid, bool) or pid <= 0:
+        return None  # no long-lived holder was ever recorded; respect the claim
+    if not _pid_alive(pid):
+        return f"holder process {pid} no longer exists"
+    snapshot = _proc_snapshot(pid)
+    if snapshot is None:
+        return None  # ps could not answer, and silence is not proof
+    started, state = snapshot
+    if state.upper().startswith("Z"):
+        return f"holder process {pid} was killed and is a zombie awaiting reap"
+    recorded_start = record.get("holder_pid_start")
+    if isinstance(recorded_start, str) and recorded_start and recorded_start != started:
+        return (
+            f"pid {pid} now belongs to a process started {started!r}, not the "
+            f"holder recorded at {recorded_start!r} (the pid was recycled)"
+        )
+    return None
+
+
+def holder_fields(pid: int | None) -> dict:
+    """The liveness fields to store for a claim, empty when no holder was named.
+
+    Empty is the correct answer for a caller that has nothing long-lived to
+    point at, and it is why THIS process never records its own pid: the CLI
+    exits milliseconds after writing the lock, so a self-recorded pid would make
+    every claim instantly reclaimable -- the mutex disabled outright.
+
+    A pid whose start time cannot be read is still recorded, with no start key.
+    That is strictly better than recording nothing: `_pid_alive` alone still
+    catches the plain "holder is gone" case, and the absent key only costs the
+    recycling refinement.
+    """
+    if pid is None:
+        return {}
+    fields: dict = {"holder_pid": pid}
+    snapshot = _proc_snapshot(pid)
+    if snapshot is not None:
+        fields["holder_pid_start"] = snapshot[0]
+    return fields
 
 
 # ---------------------------------------------------------------------------
@@ -429,10 +531,28 @@ def cmd_claim(args: argparse.Namespace) -> int:
                 held.update(
                     issue_id=args.issue_id, refreshed_at=_now_iso(), agent=args.agent
                 )
+                # Refresh liveness too, so a long run's record keeps describing a
+                # process that is really there. A re-claim that names no holder
+                # leaves the recorded one alone rather than dropping to "no
+                # liveness" -- same direction of doubt as everywhere else.
+                held.update(holder_fields(args.holder_pid))
                 write_claim(held)
                 print(f"already held by this session: {args.issue_id}")
                 return EXIT_OK
 
+            gone = holder_death_reason(held)
+            if gone is not None:
+                # Said out loud, on stderr, every time. A mutex that silently
+                # hands a resource from one holder to another is indistinguishable
+                # from a mutex that never worked, and the operator debugging a
+                # two-workers-one-tree collision has to be able to see this line.
+                sys.stderr.write(
+                    f"RECLAIMED: the claim held by {_describe(held)} is stale -- "
+                    f"{gone}. Taking the tree; no --break-stale needed.\n"
+                )
+                held = None
+
+        if held is not None:
             if args.break_stale:
                 # Compare-and-swap, not a blind steal. Scar, adversarial review
                 # 2026-07-26: --break-stale took a demonstrably LIVE claim on
@@ -486,6 +606,7 @@ def cmd_claim(args: argparse.Namespace) -> int:
                 "agent": args.agent,
                 "session": session,
                 "acquired_at": _now_iso(),
+                **holder_fields(args.holder_pid),
             }
         )
         print(f"claimed {args.issue_id} for {args.agent} (session {session})")
@@ -545,6 +666,13 @@ def main() -> int:
     p.add_argument("--remote-state", help="verbatim mcp__linear__get_issue response")
     p.add_argument("--break-stale", action="store_true", help="requires --holder")
     p.add_argument("--holder", help="the session token you are deliberately breaking")
+    # Deliberately NOT type=int: argparse exits 2 on a bad value, and 2 is not
+    # this tool's vocabulary -- same reason --agent is validated by hand below.
+    p.add_argument(
+        "--holder-pid",
+        help="pid of a process that lives for the WHOLE run (the worker shell's "
+        "$$), so a killed holder's claim can be reclaimed on read",
+    )
     p.set_defaults(func=cmd_claim)
 
     p = sub.add_parser("release", help="drop this working tree's claim")
@@ -563,6 +691,24 @@ def main() -> int:
     if args.cmd in ("claim", "release") and not args.agent:
         sys.stderr.write(f"--agent is required for `{args.cmd}`.\n")
         return EXIT_USAGE
+    if args.cmd == "claim":
+        # A junk --holder-pid is a USAGE error, never a quietly dropped field. A
+        # caller that believes it recorded liveness and did not has a lock that
+        # leaks exactly as before, with nothing on screen to say so.
+        raw_pid = getattr(args, "holder_pid", None)
+        if raw_pid is None:
+            args.holder_pid = None
+        else:
+            try:
+                args.holder_pid = int(raw_pid)
+            except (TypeError, ValueError):
+                sys.stderr.write(f"--holder-pid must be a pid; got {raw_pid!r}.\n")
+                return EXIT_USAGE
+            if args.holder_pid <= 0:
+                sys.stderr.write(
+                    f"--holder-pid must be a positive pid; got {args.holder_pid}.\n"
+                )
+                return EXIT_USAGE
     try:
         return args.func(args)
     except TreeUnknown as exc:

--- a/q-system/.q-system/scripts/linear-worker.sh
+++ b/q-system/.q-system/scripts/linear-worker.sh
@@ -493,7 +493,27 @@ while IFS= read -r ISSUE; do
   # `rc=$?` cannot live under `if ! cmd`: bash sets $? from the NEGATION there, so
   # it read 0 on every failure and the collision branch was unreachable -- a real
   # collision reported as "INFRA: claim failed rc=0". Capture the status directly.
-  ( cd "$TREE" && python3 "$CLAIM" claim "$ISSUE" --agent "$AGENT" --session "$SESSION" ) >/dev/null 2>&1
+  #
+  # --holder-pid IS THIS SCRIPT'S OWN PID (ASK-189). The claiming python3 exits
+  # within milliseconds, so its pid means nothing -- but THIS shell lives for the
+  # entire run, and until now that fact was simply never written down. With it
+  # recorded, a claim left behind by a killed run is reclaimable on read instead
+  # of wedging the tree until a human runs `release --holder`. Measured twice
+  # 2026-07-27; the kills were SIGKILL, which converge.sh's TERM/INT/HUP trap
+  # cannot ever catch.
+  #
+  # `$$` and not `$BASHPID`: this line runs inside a subshell inside the pipeline
+  # subshell of the `while` loop, and `$$` stays the SCRIPT's pid through both
+  # (verified). `$BASHPID` would be the innermost subshell, dead on the next line
+  # -- and it does not exist at all in the bash 3.2 macOS ships.
+  #
+  # RESIDUAL, stated rather than papered over: if this shell alone is killed and
+  # its backgrounded `claude` child is orphaned, the holder reads dead while work
+  # continues. That needs a targeted kill of this pid only; a timeout, a killed
+  # process group, a slept laptop or a reboot -- every case actually observed --
+  # takes the whole tree down together.
+  ( cd "$TREE" && python3 "$CLAIM" claim "$ISSUE" --agent "$AGENT" --session "$SESSION" \
+      --holder-pid "$$" ) >/dev/null 2>&1
   rc=$?
   if [ "$rc" != "0" ]; then
     if [ "$rc" = "3" ]; then say "skip $ISSUE: working tree is claimed by another session"; continue; fi

--- a/q-system/.q-system/scripts/linear-worker.sh
+++ b/q-system/.q-system/scripts/linear-worker.sh
@@ -512,9 +512,22 @@ while IFS= read -r ISSUE; do
   # continues. That needs a targeted kill of this pid only; a timeout, a killed
   # process group, a slept laptop or a reboot -- every case actually observed --
   # takes the whole tree down together.
+  #
+  # STDERR IS KEPT. With `>/dev/null 2>&1` a tree CHANGING HANDS left this log
+  # showing a normal `start ASK-xxx` and nothing else, so the one line an
+  # operator has while debugging a two-workers-one-tree collision was the one
+  # line thrown away -- the fix landing on the detector and not on the report
+  # (PR #31 review, finding 2). Only the RECLAIMED line is echoed: an ordinary
+  # refusal already gets its own `skip ... claimed by another session` below, and
+  # repeating that here would trade a missing signal for a duplicated one.
+  CLAIM_ERR="$(mktemp)"
   ( cd "$TREE" && python3 "$CLAIM" claim "$ISSUE" --agent "$AGENT" --session "$SESSION" \
-      --holder-pid "$$" ) >/dev/null 2>&1
+      --holder-pid "$$" ) >/dev/null 2>"$CLAIM_ERR"
   rc=$?
+  while IFS= read -r claim_line; do
+    case "$claim_line" in RECLAIMED:*) say "$claim_line" ;; esac
+  done < "$CLAIM_ERR"
+  rm -f "$CLAIM_ERR"
   if [ "$rc" != "0" ]; then
     if [ "$rc" = "3" ]; then say "skip $ISSUE: working tree is claimed by another session"; continue; fi
     say "INFRA: claim failed rc=$rc on $ISSUE (not counted against the issue)"; continue

--- a/q-system/.q-system/scripts/test/test-linear-claim.sh
+++ b/q-system/.q-system/scripts/test/test-linear-claim.sh
@@ -312,7 +312,7 @@ spawn_holder() {   # a process that lives until this suite kills it
 }
 reap() { kill -9 "$1" 2>/dev/null || true; wait "$1" 2>/dev/null || true; }
 
-# --- 21. a LIVE holder is respected; a SIGKILLed one is reclaimable --------
+# --- 21. a LIVE holder is respected ---------------------------------------
 rm -f "$KIPI_LINEAR_CLAIMS"
 HOLDER="$(spawn_holder)"
 r=$(rc claim ASK-KILL --agent agent-a --session sess-DEAD --holder-pid "$HOLDER")
@@ -322,16 +322,58 @@ r=$(rc claim ASK-KILL2 --agent agent-b --session sess-B)
   fail "a claim whose holder pid is ALIVE was reclaimed (exit $r) -- the mutex is off, which is worse than the leak"
 ok "a claim whose holder process is alive is still refused"
 
-kill -9 "$HOLDER" 2>/dev/null || true
-# NOT reaped yet, on purpose. A SIGKILLed child is a ZOMBIE until its parent
-# waits, and `os.kill(pid, 0)` SUCCEEDS on a zombie -- so a pid-only liveness
-# check reads a killed holder as alive and the board stays wedged anyway.
-r=$(rc claim ASK-KILL2 --agent agent-b --session sess-B)
+reap "$HOLDER"
+
+# --- 21b. THE ZOMBIE: os.kill says alive while the process is dead ---------
+# `os.kill(pid, 0)` SUCCEEDS on a SIGKILLed process until its parent reaps it, so
+# a pid-only liveness check reads the measured scar as "holder alive" and the
+# board stays wedged. That is the half of the check `ps -o state=` earns.
+#
+# THE FIXTURE IS THE WHOLE CASE. v1 spawned the holder as a direct child of this
+# suite; bash reaps its own children in its SIGCHLD handler before the claim ever
+# runs, so the case travelled the pid-is-GONE path and stayed green with zombie
+# detection deleted -- proven by mutation in the PR #31 review, finding 3. A
+# zombie needs a parent that is alive and never wait()s: `sh` forks the holder,
+# then execs into `sleep`, which has no SIGCHLD handling at all.
+#
+# The preconditions are ASSERTED, not assumed, so this can never silently decay
+# back into a duplicate of case 22.
+rm -f "$KIPI_LINEAR_CLAIMS"
+ZPIDFILE="$WORK/zombie.pid"
+: > "$ZPIDFILE"
+sh -c 'sleep 300 & echo $! > "$1"; exec sleep 600' sh "$ZPIDFILE" >/dev/null 2>&1 &
+ZPARENT=$!
+i=0
+while [ ! -s "$ZPIDFILE" ] && [ "$i" -lt 200 ]; do sleep 0.05; i=$((i + 1)); done
+ZOMBIE="$(cat "$ZPIDFILE" 2>/dev/null || echo '')"
+[ -n "$ZOMBIE" ] || fail "the zombie fixture never reported a holder pid"
+
+run claim ASK-ZOMB --agent agent-a --session sess-DEAD --holder-pid "$ZOMBIE"
+kill -9 "$ZOMBIE" 2>/dev/null || true
+ZSTATE=""
+i=0
+while [ "$i" -lt 200 ]; do
+  ZSTATE="$(ps -p "$ZOMBIE" -o state= 2>/dev/null | tr -d ' ')"
+  case "$ZSTATE" in Z*) break ;; esac
+  sleep 0.05
+  i=$((i + 1))
+done
+case "$ZSTATE" in
+  Z*) : ;;
+  *)  fail "the fixture did not produce a zombie (ps state=[$ZSTATE]); without one this case silently duplicates case 22" ;;
+esac
+python3 -c 'import os,sys; os.kill(int(sys.argv[1]), 0)' "$ZOMBIE" 2>/dev/null \
+  || fail "os.kill reports the zombie GONE, so this case would not exercise the zombie path at all"
+ok "the fixture really makes a zombie: ps says Z while os.kill(pid,0) still succeeds"
+
+r=$(rc claim ASK-ZOMB2 --agent agent-b --session sess-B)
 [ "$r" = "$EXIT_OK" ] || \
   fail "a SIGKILLed holder that is still an unreaped zombie blocked the tree (exit $r): $(cat "$WORK/err")"
 ok "a claim whose SIGKILLed holder is an unreaped zombie is reclaimable"
-reap "$HOLDER"
-run release ASK-KILL2 --agent agent-b --session sess-B
+kill -9 "$ZPARENT" 2>/dev/null || true
+wait "$ZPARENT" 2>/dev/null || true
+reap "$ZOMBIE"
+run release ASK-ZOMB2 --agent agent-b --session sess-B
 
 # --- 22. the measured scar end-state: holder fully gone, no human needed ---
 rm -f "$KIPI_LINEAR_CLAIMS"
@@ -369,7 +411,8 @@ import json, sys
 json.dump({"issue_id": "ASK-RECYCLE", "agent": "agent-a", "session": "sess-OLD",
            "acquired_at": "2026-07-01T00:00:00Z",
            "holder_pid": int(sys.argv[2]),
-           "holder_pid_start": "Thu Jan  1 00:00:00 1970"}, open(sys.argv[1], "w"))
+           # the key name carries the render format; see HOLDER_START_KEY
+           "holder_pid_start_utc": "Thu Jan  1 00:00:00 1970"}, open(sys.argv[1], "w"))
 PY
 r=$(rc claim ASK-FRESH --agent agent-b --session sess-B)
 [ "$r" = "$EXIT_OK" ] || \
@@ -420,5 +463,78 @@ if [ "$(cat "$LIVE_LOCK" 2>/dev/null || echo '<absent>')" = "$LIVE_LOCK_BEFORE" 
 else
   fail "the suite MUTATED the live lock at repo root; the env override is not honored"
 fi
+
+# --- 26. A TIMEZONE CHANGE IS NOT A RECYCLED PID --------------------------
+# `ps -o lstart=` renders in the READING process's timezone. The claim is written
+# by one process and read by another hours later, so an unpinned render made a
+# LIVE holder read as "the pid was recycled" the moment the system zone moved --
+# macOS sets the zone automatically, and a laptop that travels flips it. That is
+# the mutex handing a live worker's tree to a second worker (scar 53f2eeb), the
+# one direction this feature must never go. PR #31 review, finding 1.
+rc_tz() {
+  local z="$1"; shift
+  set +e; TZ="$z" python3 "$CLAIM" "$@" >"$WORK/out" 2>"$WORK/err"; local r=$?; set -e
+  echo "$r"
+}
+rm -f "$KIPI_LINEAR_CLAIMS"
+HOLDER="$(spawn_holder)"
+r=$(rc_tz UTC claim ASK-TZ --agent agent-a --session sess-A --holder-pid "$HOLDER")
+[ "$r" = "$EXIT_OK" ] || fail "the claim recording the holder's start time was refused (exit $r): $(cat "$WORK/err")"
+r=$(rc_tz Asia/Tokyo claim ASK-TZ2 --agent agent-b --session sess-B)
+[ "$r" = "$EXIT_COLLISION" ] || \
+  fail "a LIVE holder was reclaimed because the timezone changed between claim and read (exit $r): $(cat "$WORK/err")"
+ok "a timezone change between claim and read does not make a live holder look recycled"
+reap "$HOLDER"
+
+# --- 27. A PRE-PIN RECORD IS NOT READ AS A RECYCLED PID -------------------
+# The layer ABOVE the fix in case 26. Records written before the pin hold a
+# local-time render; a UTC-pinned reader compares those two strings, sees a
+# difference, and reclaims a holder that is alive and working -- the fix causing
+# the exact defect it fixes, for the length of the upgrade window (`kipi update`
+# can replace the script while a claim is held). The recorded format therefore
+# lives in the KEY NAME, so an old record simply has no start time under the new
+# key: unknown, which reads as alive.
+rm -f "$KIPI_LINEAR_CLAIMS"
+HOLDER="$(spawn_holder)"
+TZ=Asia/Tokyo python3 - "$KIPI_LINEAR_CLAIMS" "$HOLDER" <<'PY'
+import json, subprocess, sys
+pid = int(sys.argv[2])
+# byte-for-byte what the pre-pin build wrote: ps rendered in the WRITER's zone
+started = subprocess.run(["ps", "-p", str(pid), "-o", "lstart="],
+                         capture_output=True, text=True).stdout.strip()
+json.dump({"issue_id": "ASK-PREPIN", "agent": "agent-a", "session": "sess-OLD",
+           "acquired_at": "2026-07-27T00:00:00Z", "holder_pid": pid,
+           "holder_pid_start": started}, open(sys.argv[1], "w"))
+PY
+r=$(rc claim ASK-PREPIN2 --agent agent-b --session sess-B)
+[ "$r" = "$EXIT_COLLISION" ] || \
+  fail "a LIVE holder recorded in the pre-pin start-time format was reclaimed (exit $r); upgrading must not steal a running worker's tree"
+ok "a claim record in the pre-pin start-time format is respected, not read as recycled"
+reap "$HOLDER"
+
+# --- 28. `status` must not call a dead holder's claim live ----------------
+# `status` is the command a human runs on a board that looks wedged. Saying
+# "claimed by ..." about a holder that `claim` reclaims one line later is the
+# report contradicting the detector. PR #31 review, finding 4.
+rm -f "$KIPI_LINEAR_CLAIMS"
+HOLDER="$(spawn_holder)"
+run claim ASK-STAT --agent agent-a --session sess-STAT --holder-pid "$HOLDER"
+python3 "$CLAIM" status >"$WORK/out" 2>&1
+if grep -qi "stale" "$WORK/out"; then
+  fail "status called a LIVE holder's claim stale: $(cat "$WORK/out")"
+fi
+ok "status does not call a live holder's claim stale"
+reap "$HOLDER"
+python3 "$CLAIM" status >"$WORK/out" 2>&1
+grep -qi "stale" "$WORK/out" || \
+  fail "status reported a holder with zero processes alive as a live claim: $(cat "$WORK/out")"
+ok "status says so when the holder it reports is provably gone"
+# The note is APPENDED, never substituted: case 20 reads the session token out of
+# this exact line with sed, and a rewritten line would break that reader while
+# every assertion above still passed.
+S_PARSED="$(python3 "$CLAIM" status | sed -n 's/.*session \([^)]*\)).*/\1/p')"
+[ "$S_PARSED" = "sess-STAT" ] || fail "the status line's session field stopped parsing (got '$S_PARSED')"
+ok "the status line still parses for its existing reader"
+rm -f "$KIPI_LINEAR_CLAIMS"
 
 echo "PASS: linear-claim ($PASS checks)"

--- a/q-system/.q-system/scripts/test/test-linear-claim.sh
+++ b/q-system/.q-system/scripts/test/test-linear-claim.sh
@@ -293,7 +293,118 @@ ok "the recorded holder is the claimant that was told it won"
 [ ! -e "${KIPI_LINEAR_CLAIMS}.guard" ] || fail "the O_EXCL guard leaked after the race"
 ok "no guard file leaked after the race"
 
-# --- 21. isolation proof: the live lock was never TOUCHED -----------------
+# --- 21-25. LIVENESS: a claim whose holder is provably gone (ASK-189) ------
+# Measured twice on 2026-07-27: a run was killed, the claim stayed held by a dead
+# session with zero processes alive, and every issue on the board was blocked
+# until a human ran `release --holder`. SIGKILL CANNOT BE TRAPPED, so no
+# in-process cleanup can ever close this -- converge.sh's TERM/INT/HUP trap is
+# real and still never ran. The lock has to be able to tell, ON READ, that its
+# holder is gone.
+#
+# These cases spend most of their weight on the OPPOSITE failure, which is the
+# worse one: a liveness check that reads "dead" for a HEALTHY long-running worker
+# silently disables the mutex while the suite stays green. So every case that
+# proves a reclaim is paired with one that proves a live or unknown holder is
+# still respected.
+spawn_holder() {   # a process that lives until this suite kills it
+  sh -c 'exec sleep 300' >/dev/null 2>&1 &
+  echo $!
+}
+reap() { kill -9 "$1" 2>/dev/null || true; wait "$1" 2>/dev/null || true; }
+
+# --- 21. a LIVE holder is respected; a SIGKILLed one is reclaimable --------
+rm -f "$KIPI_LINEAR_CLAIMS"
+HOLDER="$(spawn_holder)"
+r=$(rc claim ASK-KILL --agent agent-a --session sess-DEAD --holder-pid "$HOLDER")
+[ "$r" = "$EXIT_OK" ] || fail "a claim carrying --holder-pid was refused (exit $r): $(cat "$WORK/err")"
+r=$(rc claim ASK-KILL2 --agent agent-b --session sess-B)
+[ "$r" = "$EXIT_COLLISION" ] || \
+  fail "a claim whose holder pid is ALIVE was reclaimed (exit $r) -- the mutex is off, which is worse than the leak"
+ok "a claim whose holder process is alive is still refused"
+
+kill -9 "$HOLDER" 2>/dev/null || true
+# NOT reaped yet, on purpose. A SIGKILLed child is a ZOMBIE until its parent
+# waits, and `os.kill(pid, 0)` SUCCEEDS on a zombie -- so a pid-only liveness
+# check reads a killed holder as alive and the board stays wedged anyway.
+r=$(rc claim ASK-KILL2 --agent agent-b --session sess-B)
+[ "$r" = "$EXIT_OK" ] || \
+  fail "a SIGKILLed holder that is still an unreaped zombie blocked the tree (exit $r): $(cat "$WORK/err")"
+ok "a claim whose SIGKILLed holder is an unreaped zombie is reclaimable"
+reap "$HOLDER"
+run release ASK-KILL2 --agent agent-b --session sess-B
+
+# --- 22. the measured scar end-state: holder fully gone, no human needed ---
+rm -f "$KIPI_LINEAR_CLAIMS"
+HOLDER="$(spawn_holder)"
+run claim ASK-KILL3 --agent agent-a --session sess-DEAD --holder-pid "$HOLDER"
+reap "$HOLDER"
+r=$(rc claim ASK-KILL4 --agent agent-b --session sess-B)
+[ "$r" = "$EXIT_OK" ] || \
+  fail "a claim held by a session with zero processes alive still needed --break-stale (exit $r); this is the ASK-189 scar"
+grep -qi "reclaim" "$WORK/err" || \
+  fail "the reclaim was SILENT; a mutex that hands a resource to someone else says so out loud"
+ok "a claim whose holder is fully gone is reclaimed without --break-stale, and says so"
+run release ASK-KILL4 --agent agent-b --session sess-B
+
+# --- 23. a record with NO liveness field is still respected ---------------
+# Every claim written before this change, and every claim from a caller that has
+# no long-lived process to name. Missing must read as alive, never as dead.
+rm -f "$KIPI_LINEAR_CLAIMS"
+cat > "$KIPI_LINEAR_CLAIMS" <<'JSON'
+{"issue_id":"ASK-OLD","agent":"agent-a","session":"sess-OLD","acquired_at":"2026-07-01T00:00:00Z"}
+JSON
+r=$(rc claim ASK-NEW --agent agent-b --session sess-B)
+[ "$r" = "$EXIT_COLLISION" ] || \
+  fail "a pre-liveness record with no holder_pid was reclaimed (exit $r); old records must stay respected"
+ok "a claim record with no liveness field is still respected"
+
+# --- 24. THE PID-RECYCLING TRAP -------------------------------------------
+# Pid numbers wrap. An unrelated process that inherits the dead holder's number
+# makes the leak permanent again -- the whole reason the record carries the
+# holder's START TIME and not just its pid.
+rm -f "$KIPI_LINEAR_CLAIMS"
+IMPOSTOR="$(spawn_holder)"
+python3 - "$KIPI_LINEAR_CLAIMS" "$IMPOSTOR" <<'PY'
+import json, sys
+json.dump({"issue_id": "ASK-RECYCLE", "agent": "agent-a", "session": "sess-OLD",
+           "acquired_at": "2026-07-01T00:00:00Z",
+           "holder_pid": int(sys.argv[2]),
+           "holder_pid_start": "Thu Jan  1 00:00:00 1970"}, open(sys.argv[1], "w"))
+PY
+r=$(rc claim ASK-FRESH --agent agent-b --session sess-B)
+[ "$r" = "$EXIT_OK" ] || \
+  fail "a RECYCLED pid impersonated the dead holder and wedged the tree forever (exit $r)"
+ok "a live pid whose start time does not match the record is a recycled pid, not the holder"
+run release ASK-FRESH --agent agent-b --session sess-B
+
+# --- 25. UNKNOWN reads as ALIVE, never as dead ----------------------------
+# holder_pid recorded, holder_pid_start absent (ps could not answer at claim
+# time), holder still running. Nothing here PROVES death, so the claim stands.
+rm -f "$KIPI_LINEAR_CLAIMS"
+python3 - "$KIPI_LINEAR_CLAIMS" "$IMPOSTOR" <<'PY'
+import json, sys
+json.dump({"issue_id": "ASK-NOSTART", "agent": "agent-a", "session": "sess-OLD",
+           "acquired_at": "2026-07-01T00:00:00Z",
+           "holder_pid": int(sys.argv[2])}, open(sys.argv[1], "w"))
+PY
+r=$(rc claim ASK-FRESH2 --agent agent-b --session sess-B)
+[ "$r" = "$EXIT_COLLISION" ] || \
+  fail "a LIVE holder with no recorded start time was reclaimed (exit $r); unknown must read as alive"
+ok "a live holder with no recorded start time is respected (unknown is not proof of death)"
+reap "$IMPOSTOR"
+
+# A --holder-pid that is not a pid is a USAGE error, not a silently dropped
+# field: a caller that thinks it recorded liveness and did not has a mutex that
+# leaks exactly as before, with nothing to show for it.
+rm -f "$KIPI_LINEAR_CLAIMS"
+r=$(rc claim ASK-BADPID --agent agent-a --session sess-A --holder-pid not-a-pid)
+[ "$r" = "$EXIT_USAGE" ] || fail "--holder-pid with a non-integer gave exit $r, want $EXIT_USAGE"
+r=$(rc claim ASK-BADPID --agent agent-a --session sess-A --holder-pid 0)
+[ "$r" = "$EXIT_USAGE" ] || fail "--holder-pid 0 gave exit $r, want $EXIT_USAGE"
+ok "a --holder-pid that is not a usable pid is a usage error, never a silent drop"
+rm -f "$KIPI_LINEAR_CLAIMS"
+
+# --- 26. isolation proof: the live lock was never TOUCHED -----------------
 # Asserts the suite did not CHANGE the live lock, not that no lock exists.
 #
 # Scar 2026-07-27: this used to assert `! -e $ROOT/.linear-claims.json`, which

--- a/q-system/.q-system/scripts/test/test-linear-worker-parallel.sh
+++ b/q-system/.q-system/scripts/test/test-linear-worker-parallel.sh
@@ -182,7 +182,46 @@ grep -qi "claimed by another session" "$WORK/d.out" \
   || fail "the refused run did not report a collision. It said: $(grep -i 'skip\|INFRA' "$WORK/d.out" | head -2)"
 ok "the refused run reports the collision (exit 3), not a generic infra failure"
 
-# --- 5. the script still parses -------------------------------------------
+# --- 5. a reclaim is SAID OUT LOUD in the run log ---------------------------
+# The claim's stderr used to go to /dev/null here, so a tree CHANGING HANDS left
+# the log showing a normal `start ASK-xxx` and nothing else (PR #31 review,
+# finding 2). A mutex that silently moves a resource from one holder to another
+# is indistinguishable from one that never worked, and this line is the only
+# evidence an operator has at 3am. Driven through the real worker, not grepped
+# out of its source: the defect was a shell redirect, which a grep cannot see.
+: > "$WORK/worked.txt"
+ETREE="$WORK/state-e/worktrees/ask-eee"
+mkdir -p "$WORK/state-e/worktrees"
+git -C "$WORK/skel" worktree add -q -b sana/ask-eee "$ETREE" main \
+  || fail "could not create the worktree this case seeds"
+
+# A holder pid that is provably gone: spawned, killed, reaped.
+sh -c 'exec sleep 300' >/dev/null 2>&1 &
+DEADPID=$!
+kill -9 "$DEADPID" 2>/dev/null || true
+wait "$DEADPID" 2>/dev/null || true
+
+# "$REAL_PY", not `python3`: the PATH stub above intercepts `python3 -`.
+"$REAL_PY" - "$ETREE/.linear-claims.json" "$DEADPID" <<'PY'
+import json, sys
+json.dump({"issue_id": "ASK-EEE", "agent": "someone-else", "session": "sess-killed",
+           "acquired_at": "2026-07-27T00:00:00Z", "holder_pid": int(sys.argv[2])},
+          open(sys.argv[1], "w"))
+PY
+
+( cd "$WORK/skel" \
+  && KIPI_SKEL="$WORK/skel" KIPI_STATE_DIR="$WORK/state-e" \
+     bash "$WORKER" --apply --issue ASK-EEE --limit 1 ) >"$WORK/e.out" 2>&1
+
+grep -q "ask-eee" "$WORK/worked.txt" \
+  || fail "the worker never took the tree from the dead holder at all: $(grep -i 'skip\|INFRA' "$WORK/e.out" | head -2)"
+ok "a claim left by a killed holder is reclaimed by the real worker, no human needed"
+
+grep -q "RECLAIMED:" "$WORK/e.out" \
+  || fail "the worker took a tree from a dead holder and said NOTHING in its log. It logged: $(grep -i 'start\|skip\|INFRA' "$WORK/e.out" | head -3)"
+ok "the reclaim is reported in the worker's run log, not swallowed by the redirect"
+
+# --- 6. the script still parses -------------------------------------------
 bash -n "$WORKER" || fail "linear-worker.sh does not parse"
 ok "linear-worker.sh parses (bash -n)"
 


### PR DESCRIPTION
Closes the ASK-189 DoR. **Do not merge without review.**

## The defect

Measured twice on 2026-07-27: a run was killed, the claim stayed held by a session with **zero processes alive**, and every issue on the board was blocked until a human ran `release --holder`. SIGKILL cannot be trapped, so no in-process cleanup can ever close this. The lock has to tell, on READ, that its holder is gone.

## Approach: option 1 (holder pid), and why

The gap was never that pids are useless here. It is that **nothing long-lived was ever written down**. The claiming `python3` exits within milliseconds, which is exactly why the claim record deliberately carried no pid. The worker shell lives for the entire run, and now names itself: `--holder-pid "$$"`.

Smaller than option 2 (lease + TTL) and it reuses `_pid_alive`, which already exists for the critical-section guard. No refresh path to get wrong.

## Pid recycling: addressed, not accepted

The DoR calls this the trap in option 1. The record stores the holder's absolute start time (`ps -o lstart=`), so a process that later inherits the dead holder's pid reads as a *different* holder rather than as the original still running. Residual: `lstart` has 1-second resolution, so a recycled pid would have to land in the same wall-clock second on a pid space that wraps at ~99999.

## Zombies earn the second half of the check

`os.kill(pid, 0)` **succeeds** on a SIGKILLed process until its parent reaps it. A pid-only check would have read the measured scar as "holder alive" and changed nothing. `ps -o state=` catches it. Verified on this machine before the design was written.

## Blast radius: the direction of doubt is one-way

The DoR names the failure to avoid above all: a liveness check that reads "dead" for a HEALTHY long-running worker, because that silently disables the mutex while the suite stays green. So a reclaim happens **only on positive proof of death**. Missing field, unreadable `ps`, permission error, ps timeout, unparseable output: all read as ALIVE and the claim stands.

Leaking a lock wedges a board and a human notices. Reclaiming a live holder's tree hands two workers the same files, which is scar `53f2eeb`, and nobody notices.

**Five of the seven new checks assert the mutex is NOT weakened**, not that it reclaims.

## Reproducer first, observed RED

```
FAIL: a claim carrying --holder-pid was refused (exit 2): linear-claim.py: error: unrecognized arguments: --holder-pid 19937
EXIT=1
```

Then green, 30 -> 37 checks:

```
ok: a claim whose holder process is alive is still refused
ok: a claim whose SIGKILLed holder is an unreaped zombie is reclaimable
ok: a claim whose holder is fully gone is reclaimed without --break-stale, and says so
ok: a claim record with no liveness field is still respected
ok: a live pid whose start time does not match the record is a recycled pid, not the holder
ok: a live holder with no recorded start time is respected (unknown is not proof of death)
ok: a --holder-pid that is not a usable pid is a usage error, never a silent drop
PASS: linear-claim (37 checks)
```

## Regression sweep (real output)

```
=== test-linear-claim.sh rc=0 :: PASS: linear-claim (37 checks)
=== test-linear-worker-parallel.sh rc=0 :: PASS: linear-worker parallel (7 checks)
=== test-linear-worker-fetch.sh rc=0 :: PASS: linear-worker fetch (10 checks)
=== test-converge.sh rc=0 :: PASS: 17/17 converge checks
=== test-severity-floor.sh rc=0 :: PASS: 87/87 severity-floor checks
=== test-linear-wiring.sh rc=0 :: pass=13 fail=0
```

## Two residuals, stated rather than papered over

1. **Orphaned child.** If the worker shell alone is killed and its backgrounded `claude` child is orphaned, the holder reads dead while work continues. That needs a targeted kill of that one pid; a timeout, a killed process group, a slept laptop, or a reboot (every case actually observed) takes the whole tree down together. Documented at the call site.
2. **`$$` not `$BASHPID`.** The claim runs inside a subshell inside the `while` loop's pipeline subshell. `$$` stays the script's pid through both (verified); `$BASHPID` would be the innermost subshell, dead on the next line, and does not exist in the bash 3.2 macOS ships.

## Captured, not fixed here

`sp-763f21b5`: `converge.sh:111` compares `rec.get("issue")` against a record whose key is `issue_id`, so that TERM/INT/HUP trap has been a no-op since it was written (`4b5a7af`). Out of the DoR's file scope.

## Not doing (DoR-binding)

No change to the remote-collision half, no change to the worker's four refusals, no scheduling.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
