### PR TITLE
fix(fleet): a registered instance that receives no skeleton propagation declares it or fails the run (ASK-117)

### DIFF
--- a/instance-registry.json
+++ b/instance-registry.json
@@ -161,7 +161,8 @@
       "type": "standalone",
       "has_git": true,
       "skip_agent_check": true,
-      "note": "Standalone Reddit consensus signal engine for weekly build recommendations. No q-system subtree because local git lacks git-subtree."
+      "skeleton_managed": false,
+      "note": "Standalone Reddit consensus signal engine for weekly build recommendations. No q-system subtree because local git lacks git-subtree. skeleton_managed=false is the deliberate record (ASK-117): it receives zero skeleton propagation, so it carries none of the fleet enforcement layer (no token-guard.py, no .claude/rules/, no capability gate) and must be excluded from fleet-wide governance counts rather than counted as a governed instance."
     },
     {
       "name": "Alice",

--- a/kipi-update.sh
+++ b/kipi-update.sh
@@ -290,6 +290,7 @@ PASS=0
 FAIL=0
 SKIP=0
 GATE_FAIL=""
+UNDECLARED=""
 MODEL_RUN=0
 DRY_MODEL_ROOT=""
 ARCHIVE_TMP=""
@@ -840,7 +841,7 @@ reject_untracked_config_collisions() {
 
 trap cleanup_updater_temps EXIT
 
-while IFS='|' read -r name path prefix itype; do
+while IFS='|' read -r name path prefix itype declared; do
   # Filter INSIDE the loop, not in the feed, so an --only name that matches
   # nothing is caught by the post-loop check rather than reading as an empty
   # registry.
@@ -859,9 +860,26 @@ while IFS='|' read -r name path prefix itype; do
   # Standalone repos have no skeleton subtree; nothing to sync and the updater
   # must not auto-commit or rsync into them. (A null subtree_prefix used to
   # crash the registry parser below -- keep this guard before any mutation.)
+  #
+  # Receiving nothing is legitimate. Receiving nothing SILENTLY is not: this
+  # branch printed one identical line either way, so `reddit-build-radar` sat in
+  # the fleet's 24 governed instances with 0 skeleton capabilities -- no
+  # token-guard, no .claude/rules/, no capability gate -- and every fleet-wide
+  # claim about gates holding had an exception nobody could see (ASK-117). The
+  # declaration is what separates a decision from an oversight, so an entry
+  # without one is a run failure, not a skip.
   if [ "$itype" = "standalone" ] || [ -z "$prefix" ]; then
-    echo "  SKIP: standalone (not skeleton-managed)"
-    SKIP=$((SKIP + 1))
+    if [ "$declared" = "declared" ]; then
+      echo "  SKIP: declared not skeleton-managed (skeleton_managed=false)"
+      SKIP=$((SKIP + 1))
+    else
+      echo "  UNDECLARED NON-PROPAGATING: registered as an instance but receives"
+      echo "    no skeleton propagation, and nothing on record says that is intended."
+      echo "    Add \"skeleton_managed\": false to its instance-registry.json entry"
+      echo "    with a note, or give it a subtree_prefix so it actually syncs."
+      UNDECLARED="$UNDECLARED $name"
+      FAIL=$((FAIL + 1))
+    fi
     echo ""
     continue
   fi
@@ -1491,7 +1509,11 @@ for i in d['instances']:
         continue
     t = i.get('type', 'subtree')
     prefix = i.get('subtree_prefix') or ''
-    print(i['name'] + '|' + i['path'] + '|' + prefix + '|' + t)
+    # Only an explicit false counts as a declaration. A missing key is the
+    # reddit-build-radar state -- registered, receiving nothing, nobody on the
+    # record for it -- and must not read the same as a deliberate opt-out.
+    declared = 'declared' if i.get('skeleton_managed') is False else 'undeclared'
+    print(i['name'] + '|' + i['path'] + '|' + prefix + '|' + t + '|' + declared)
 ")
 
 if [ -n "$ONLY" ] && [ "$((PASS+FAIL+SKIP))" -eq 0 ]; then
@@ -1505,6 +1527,12 @@ echo "  Failed:  $FAIL"
 echo "  Skipped: $SKIP"
 if [ -n "${GATE_FAIL:-}" ]; then
   echo "  CAPABILITY GATE RED in:$GATE_FAIL"
+fi
+# In the summary, not only inline: a real run prints ~40 lines per instance and
+# the summary is what gets read. An ungoverned instance that only appears on
+# line 300 of 900 is still, in practice, silent.
+if [ -n "${UNDECLARED:-}" ]; then
+  echo "  UNDECLARED NON-PROPAGATING:$UNDECLARED"
 fi
 
 [ "$FAIL" -eq 0 ] && [ -z "${GATE_FAIL:-}" ] && exit 0 || exit 1

--- a/q-system/.q-system/capability-manifest.json
+++ b/q-system/.q-system/capability-manifest.json
@@ -82,6 +82,10 @@
       "runner": "bash"
     },
     {
+      "path": "q-system/.q-system/scripts/test/test-kipi-update-unmanaged-instance.sh",
+      "runner": "bash"
+    },
+    {
       "path": "q-system/.q-system/scripts/test/test-lessons-daily-exit.sh",
       "runner": "bash"
     },

--- a/q-system/.q-system/scripts/test/test-kipi-update-unmanaged-instance.sh
+++ b/q-system/.q-system/scripts/test/test-kipi-update-unmanaged-instance.sh
@@ -1,0 +1,187 @@
+#!/usr/bin/env bash
+# A registered instance that receives NOTHING must say so out loud.
+#
+# `reddit-build-radar` sat in instance-registry.json`s `instances` array with 0
+# of its 28 capabilities originating from the skeleton, while every other
+# instance carried 268-281. `kipi update` printed one quiet line -- "SKIP:
+# standalone" -- and exited 0, so the fleet counted 24 governed instances when
+# one of them had no token-guard, no .claude/rules/, no capability gate at all.
+# Silent non-propagation has fleet precedent (the launchd income scanners, 6
+# days). Hence the two properties this file pins:
+#
+#   1. a non-propagating instance that DECLARES itself (skeleton_managed:false)
+#      is skipped quietly and named as declared -- the deliberate case, on the
+#      record and machine-readable;
+#   2. a non-propagating instance that does NOT declare itself is flagged in the
+#      summary and fails the run. Quiet is the failure mode, so the absence of a
+#      declaration cannot be the absence of a message.
+#
+# Property 3 runs against the REAL registry: every entry that receives nothing
+# is declared. That is the assertion ASK-117 actually closes.
+set -euo pipefail
+ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/../../../.." && pwd)"
+fail() { echo "FAIL: $1" >&2; exit 1; }
+G() { git -c user.email=t@t.t -c user.name=test -c commit.gpgsign=false "$@"; }
+
+GATE_REL="q-system/.q-system/scripts/propagation-leak-gate.py"
+BASELINE_REL="q-system/.q-system/state/propagation-leak-baseline.json"
+
+# The smallest skeleton kipi-update.sh will run: enough to clear its preflights
+# and reach the instance loop, nothing more. No real instance directory is
+# needed -- every entry here is one the updater must refuse to sync.
+build_skeleton() {
+  local sk="$1"
+  mkdir -p "$sk/q-system/.q-system/scripts" "$sk/q-system/.q-system/state" \
+           "$sk/q-system/marketing" "$sk/plugins"
+  cp "$ROOT/kipi-update.sh" "$sk/kipi-update.sh"
+  cp "$ROOT/kipi-update-preserve-scan.py" "$sk/kipi-update-preserve-scan.py"
+  cp "$ROOT/$GATE_REL" "$sk/$GATE_REL"
+  cp "$ROOT/q-system/.q-system/scripts/containment-targets.py" \
+     "$sk/q-system/.q-system/scripts/containment-targets.py"
+  cp "$ROOT/validate-separation.py" "$sk/validate-separation.py"
+  # Not the repo's committed baseline: that one is armed against THIS repo's
+  # content and its permits refuse when loaded over a synthetic skeleton.
+  cat > "$sk/$BASELINE_REL" <<'BASELINE_JSON'
+{
+  "schema_version": 1,
+  "blocking_classes": [
+    "case_proof_gap",
+    "client_identity",
+    "dated_interaction",
+    "pricing",
+    "relationship",
+    "source_identity",
+    "sourced_interaction"
+  ],
+  "classifier_sha256": null,
+  "entries": []
+}
+BASELINE_JSON
+  printf 'generic skeleton content\n' > "$sk/q-system/marketing/outreach.md"
+  ( cd "$sk" && G init -q && G add -A -f && G commit -qm skel )
+}
+
+# Runs the updater against a registry written for this case. Exit code is
+# captured, never allowed to abort the test, because both outcomes are data.
+run_with_registry() {
+  local sk="$1" registry_json="$2"
+  printf '%s\n' "$registry_json" > "$sk/instance-registry.json"
+  RUN_OUT="$(bash "$sk/kipi-update.sh" --dry-run 2>&1)" && RUN_RC=0 || RUN_RC=$?
+}
+
+# --------------------------------------------------------------- property 1
+# The deliberate case. A declared entry is not a defect, so it must not shout,
+# but it must be named as DECLARED -- "SKIP: standalone" alone reads the same
+# whether a human decided it or nobody noticed.
+assert_declared_is_quiet_and_named() {
+  local work sk
+  work="$(mktemp -d)"; sk="$work/skel"
+  build_skeleton "$sk"
+  mkdir -p "$work/declared"
+  run_with_registry "$sk" '{"instances":[{"name":"declared","path":"'"$work"'/declared","subtree_prefix":null,"type":"standalone","skeleton_managed":false}]}'
+
+  echo "$RUN_OUT" | grep -q "declared not skeleton-managed" || \
+    fail "a declared non-propagating instance was not named as declared: $RUN_OUT"
+  if echo "$RUN_OUT" | grep -q "UNDECLARED NON-PROPAGATING"; then
+    fail "a declared instance was flagged as undeclared: $RUN_OUT"
+  fi
+  [ "$RUN_RC" -eq 0 ] || fail "a declared instance failed the run (rc=$RUN_RC): $RUN_OUT"
+
+  echo "PASS: a declared non-propagating instance is named as declared and does not fail the run"
+}
+
+# --------------------------------------------------------------- property 2
+# The whole point. An entry that receives nothing and says nothing about it is
+# the reddit-build-radar shape, and it has to be impossible to miss: named in
+# the summary AND non-zero exit. A message alone is not enough -- `kipi update`
+# prints ~40 lines per instance and the founder reads the summary.
+assert_undeclared_is_flagged_and_fails() {
+  local work sk
+  work="$(mktemp -d)"; sk="$work/skel"
+  build_skeleton "$sk"
+  mkdir -p "$work/undeclared"
+  run_with_registry "$sk" '{"instances":[{"name":"undeclared","path":"'"$work"'/undeclared","subtree_prefix":null,"type":"standalone"}]}'
+
+  echo "$RUN_OUT" | grep -q "UNDECLARED NON-PROPAGATING" || \
+    fail "an undeclared non-propagating instance was skipped quietly: $RUN_OUT"
+  echo "$RUN_OUT" | grep -q "undeclared" || \
+    fail "the flag did not name the instance: $RUN_OUT"
+  [ "$RUN_RC" -ne 0 ] || \
+    fail "an undeclared non-propagating instance exited 0: $RUN_OUT"
+
+  echo "PASS: an undeclared non-propagating instance is flagged in the summary and fails the run"
+}
+
+# A missing path is a DIFFERENT skip and must keep its own message. Folding it
+# into the non-propagation flag would make a moved directory read as an
+# ungoverned instance, which is a false alarm on a real and common state.
+assert_missing_path_is_not_the_same_flag() {
+  local work sk
+  work="$(mktemp -d)"; sk="$work/skel"
+  build_skeleton "$sk"
+  run_with_registry "$sk" '{"instances":[{"name":"gone","path":"'"$work"'/does-not-exist","subtree_prefix":"q-system","type":"subtree"}]}'
+
+  echo "$RUN_OUT" | grep -q "does not exist" || \
+    fail "a missing instance path lost its own message: $RUN_OUT"
+  if echo "$RUN_OUT" | grep -q "UNDECLARED NON-PROPAGATING"; then
+    fail "a missing path was misreported as an undeclared non-propagating instance: $RUN_OUT"
+  fi
+
+  echo "PASS: a missing instance path keeps its own message and is not the non-propagation flag"
+}
+
+# --------------------------------------------------------------- property 3
+# The live registry. A fixture proves the mechanism; this proves the fleet is
+# actually clean under it, which is what ASK-117 asked the registry to state.
+assert_real_registry_declares_every_non_propagating_instance() {
+  python3 - "$ROOT/instance-registry.json" <<'PY' || fail "the real registry has an undeclared non-propagating instance (above)"
+import json, sys
+
+registry = json.load(open(sys.argv[1], encoding="utf-8"))
+undeclared = []
+for entry in registry["instances"]:
+    receives_nothing = (
+        entry.get("type", "subtree") == "standalone"
+        or not entry.get("subtree_prefix")
+    )
+    if receives_nothing and entry.get("skeleton_managed") is not False:
+        undeclared.append(entry["name"])
+
+if undeclared:
+    print("undeclared non-propagating instances: " + ", ".join(undeclared))
+    print('Add "skeleton_managed": false to each, or give it a subtree_prefix.')
+    sys.exit(1)
+print("real registry: every non-propagating instance is declared")
+PY
+  echo "PASS: the live instance-registry.json declares every entry that receives no propagation"
+}
+
+# reddit-build-radar by name, because the generic invariant above would also be
+# satisfied by deleting the entry, and deleting it is not the recorded decision.
+assert_reddit_build_radar_is_recorded() {
+  python3 - "$ROOT/instance-registry.json" <<'PY' || fail "reddit-build-radar is not recorded as deliberately unmanaged (above)"
+import json, sys
+
+registry = json.load(open(sys.argv[1], encoding="utf-8"))
+match = [e for e in registry["instances"] if e["name"] == "reddit-build-radar"]
+if not match:
+    print("reddit-build-radar is no longer in instances[]")
+    sys.exit(1)
+entry = match[0]
+if entry.get("skeleton_managed") is not False:
+    print("reddit-build-radar lacks \"skeleton_managed\": false")
+    sys.exit(1)
+if not entry.get("note"):
+    print("reddit-build-radar has no note explaining why it is unmanaged")
+    sys.exit(1)
+print("reddit-build-radar: skeleton_managed=false, reason on the record")
+PY
+  echo "PASS: reddit-build-radar is on the record as deliberately not skeleton-managed"
+}
+
+assert_declared_is_quiet_and_named
+assert_undeclared_is_flagged_and_fails
+assert_missing_path_is_not_the_same_flag
+assert_real_registry_declares_every_non_propagating_instance
+assert_reddit_build_radar_is_recorded
+echo "PASS: a registered instance that receives nothing either declares it or fails the run"


### PR DESCRIPTION
Closes ASK-117 (do not merge until /issue-verify and /issue-closeout run).

## The finding, and which of the two cases it is

`reddit-build-radar` was in `instance-registry.json`'s `instances[]` with **0 of its 28 capabilities originating from the skeleton**, while every other instance carried 268-281.

It is **case 1: deliberate.** Evidence, not assumption:

```
$ python3 q-system/.q-system/scripts/capability-map-gen.py \
    --root ~/projects/cole-gtm/projects/reddit-build-radar \
    --repo reddit-build-radar --out /tmp/rbr.json
reddit-build-radar: 28 capabilities (LIVE=17, UNWIRED=11) [local=28] -> 11 actionable+local
origin_counts = {'local': 28}          # no 'skeleton' key at all
```

The entry already had `subtree_prefix: null`, `type: "standalone"`, and a note saying local git lacks git-subtree. `kipi-update.sh` already refused to sync it. So propagation was never broken; the record was.

## What was actually wrong

The skip was **indistinguishable from an oversight**. One line, `SKIP: standalone (not skeleton-managed)`, exit 0. The fleet counted 24 governed instances while one of them ran with no `token-guard.py`, no `.claude/rules/`, no `auto-commit.py`, no capability gate. Every fleet-wide claim about gates holding had an exception nobody could see.

## The change

**`instance-registry.json`** — `"skeleton_managed": false` on `reddit-build-radar`, note extended to state what it therefore does not carry and that fleet governance counts must exclude it. Machine-readable, so a counter can honor it; prose in `note` could not.

**`kipi-update.sh`** — the standalone skip splits in two:

| State | Output | Run |
|---|---|---|
| `skeleton_managed: false` | `SKIP: declared not skeleton-managed (skeleton_managed=false)` | green |
| no declaration | `UNDECLARED NON-PROPAGATING` inline **and in the summary**, with the fix in the message | **fails** |

Only an explicit `false` counts. A missing key is the reddit-build-radar state and must not read like a deliberate opt-out. A missing instance path keeps its own separate message, so a moved directory is not misreported as ungoverned.

The summary line matters: a real run prints ~40 lines per instance, and a flag that only appears on line 300 of 900 is still, in practice, silent.

## Verification

Reproducer first. RED, before the fix:

```
$ bash q-system/.q-system/scripts/test/test-kipi-update-unmanaged-instance.sh
FAIL: a declared non-propagating instance was not named as declared:
  ...
  --- declared (standalone) ---
    SKIP: standalone (not skeleton-managed)
  === Summary ===
    Updated: 0 / Failed: 0 / Skipped: 1
```

GREEN, after:

```
PASS: a declared non-propagating instance is named as declared and does not fail the run
PASS: an undeclared non-propagating instance is flagged in the summary and fails the run
PASS: a missing instance path keeps its own message and is not the non-propagation flag
PASS: the live instance-registry.json declares every entry that receives no propagation
PASS: reddit-build-radar is on the record as deliberately not skeleton-managed
PASS: a registered instance that receives nothing either declares it or fails the run
```

Two of the five assertions run against the **live** `instance-registry.json`, so a future entry that receives nothing and says nothing fails the suite, not just the updater. Registered in `capability-manifest.json` (77 expected tests).

The real registry entry, through the real updater, in an isolated fixture (no instance touched):

```
--- reddit-build-radar (standalone) ---
  SKIP: declared not skeleton-managed (skeleton_managed=false)
=== Summary ===
  Updated: 0 / Failed: 0 / Skipped: 1        EXIT=0
```

No regression in the adjacent updater suites:

```
$ bash q-system/.q-system/scripts/test/test-kipi-update-leak-preflight.sh
PASS: kipi update leak preflight is fail-closed, version-locked, and explicit when unarmed
$ bash q-system/.q-system/scripts/test/test-kipi-update-safety.sh
PASS: differing config content is protected; identical residue and dot-named dirs are not
```

## Not doing

`kipi update` was not run against any real instance, per the DoR. All updater runs here are `--dry-run` against synthetic skeletons in `mktemp -d`.

## Found, not fixed (captured, `sp-d31681f2`)

The DoR's literal check `./kipi update --dry 2>&1 | grep -i reddit-build-radar` **cannot run on `main` right now**, for a reason that predates this branch:

```
propagation leak gate: ABORT -- baseline was built by classifier cc1bbe24488d, running cb5c31f32e12
  Findings MOVED: added 0, removed 28, recounted 0.
```

The committed baseline is stamped against a classifier that has since changed, so every `kipi update` run, `--dry` included, aborts at preflight before the instance loop. Re-baselining requires per-entry human justification by design, so an agent cannot clear it. Hence the isolated-fixture evidence above. Captured as spillover `sp-d31681f2`, not silently worked around.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
