### PR TITLE
fix(ci): main was RED, blocking every open PR on two defects of mine (ASK-113)

### DIFF
--- a/q-system/.q-system/capability-manifest.json
+++ b/q-system/.q-system/capability-manifest.json
@@ -396,6 +396,11 @@
       "path": "q-system/.q-system/scripts/verify-containment-export.py",
       "reason": "built for prd-skeleton-data-containment's export/quarantine flow and never wired",
       "spillover_id": "sp-0f773063"
+    },
+    {
+      "path": "q-system/.q-system/scripts/linear-collapse-jobmigration.py",
+      "reason": "one-shot family collapse: it absorbed the 32-member job-migration family into ASK-151 on 2026-07-28 and has no second family to run on. ASK-226 generalises it; retire this one when that lands",
+      "spillover_id": "sp-fb332466"
     }
   ],
   "uncovered_known": [

--- a/q-system/.q-system/scripts/com.kipi.dispatch.plist
+++ b/q-system/.q-system/scripts/com.kipi.dispatch.plist
@@ -8,12 +8,12 @@
 	<key>EnvironmentVariables</key>
 	<dict>
 		<key>KIPI_REPO</key>
-		<string>/Users/assafkipnis/projects/kipi-system</string>
+		<string>__KIPI_REPO__</string>
 		<!-- Same PATH as com.kipi.openloops-heartbeat, which is the proven
 		     working `claude -p` under launchd. gh and claude both live in
 		     /opt/homebrew/bin; without it the dispatcher pages and exits. -->
 		<key>PATH</key>
-		<string>/Users/assafkipnis/.local/bin:/opt/homebrew/bin:/usr/bin:/bin:/usr/sbin:/sbin</string>
+		<string>__HOME__/.local/bin:/opt/homebrew/bin:/usr/bin:/bin:/usr/sbin:/sbin</string>
 		<!-- ONE at a time, deliberately. Each run spawns a `claude -p` agent
 		     plus a reviewer, so this is also the spend ceiling -- but the real
 		     reason is conflicts. The dispatcher picks by readiness and has NO
@@ -53,7 +53,7 @@
 	<key>ProgramArguments</key>
 	<array>
 		<string>/bin/bash</string>
-		<string>/Users/assafkipnis/projects/kipi-system/kipi-dispatch.sh</string>
+		<string>__KIPI_REPO__/kipi-dispatch.sh</string>
 	</array>
 
 	<!-- Every 15 minutes. The heartbeat only TOPS UP to the concurrency cap;
@@ -68,8 +68,8 @@
 	<false/>
 
 	<key>StandardOutPath</key>
-	<string>/Users/assafkipnis/.config/kipi/dispatch.out</string>
+	<string>__HOME__/.config/kipi/dispatch.out</string>
 	<key>StandardErrorPath</key>
-	<string>/Users/assafkipnis/.config/kipi/dispatch.err</string>
+	<string>__HOME__/.config/kipi/dispatch.err</string>
 </dict>
 </plist>


### PR DESCRIPTION
`validate` is required, so a red main blocks 100% of PRs. #23, #34, #35 and #36 all failed the same two checks, none of which they caused.

**1. `com.kipi.dispatch.plist` hardcoded `/Users/assafkipnis`** in five places, while the other three templates use `__KIPI_REPO__`/`__HOME__` placeholders that `install-plist.sh` substitutes. On any other machine the job installs and then execs a path that does not exist — launchd reports a failed job, not a bad template.

**2. `linear-collapse-jobmigration.py` was neither wired nor declared.** It is a genuine one-shot (it collapsed the 32-member job-migration family into ASK-151 and has no second family). Declared inert with `sp-fb332466`, which is the plan to delete it when ASK-226's general collapse tool lands.

### Checks (real output, same commands CI runs)

| check | before | after |
|---|---|---|
| `capability-gate.py` | RED (2) | **GREEN**, ran=77, exit 0 |
| `test-install-plist.sh` | FAIL hardcoded home | **PASS** incl. both negative self-tests |
| `plutil -lint` | — | OK |

Appended to `capability-manifest.json`, never re-sorted — it is the magnet file (`sp-f3a2ad81`).

The installed job at `~/Library/LaunchAgents` is untouched and still running; this is the template it renders from.

🤖 Generated with [Claude Code](https://claude.com/claude-code)