### PR TITLE
test(claim): ASK-224 disproved on the merged head; assert BOTH halves of the ps env pin

### DIFF
--- a/q-system/.q-system/scripts/test/test-linear-claim.sh
+++ b/q-system/.q-system/scripts/test/test-linear-claim.sh
@@ -464,27 +464,76 @@ else
   fail "the suite MUTATED the live lock at repo root; the env override is not honored"
 fi
 
-# --- 26. A TIMEZONE CHANGE IS NOT A RECYCLED PID --------------------------
-# `ps -o lstart=` renders in the READING process's timezone. The claim is written
-# by one process and read by another hours later, so an unpinned render made a
-# LIVE holder read as "the pid was recycled" the moment the system zone moved --
+# --- 26. A TIMEZONE OR LOCALE CHANGE IS NOT A RECYCLED PID ----------------
+# `ps -o lstart=` renders in the READING process's timezone AND locale. The claim
+# is written by one process and read by another hours later, so an unpinned render
+# made a LIVE holder read as "the pid was recycled" the moment either one moved --
 # macOS sets the zone automatically, and a laptop that travels flips it. That is
 # the mutex handing a live worker's tree to a second worker (scar 53f2eeb), the
 # one direction this feature must never go. PR #31 review, finding 1.
-rc_tz() {
-  local z="$1"; shift
-  set +e; TZ="$z" python3 "$CLAIM" "$@" >"$WORK/out" 2>"$WORK/err"; local r=$?; set -e
+#
+# BOTH HALVES OF THE PIN ARE ASSERTED (ASK-224). This case used to vary TZ only.
+# Measured 2026-07-28: deleting `"LC_ALL": "C"` from `_PS_ENV` and running this
+# suite under `LC_ALL=ja_JP.UTF-8` left all 43 checks GREEN, so the locale half of
+# the guard was true by accident and nothing would have caught its removal -- the
+# same class as the zombie fixture that passed with zombie detection deleted.
+# Codex's ASK-224 major named "timezone OR LOCALE"; the locale word is why this
+# case now varies both.
+rc_env() {
+  local z="$1" l="$2"; shift 2
+  set +e
+  TZ="$z" LC_ALL="$l" python3 "$CLAIM" "$@" >"$WORK/out" 2>"$WORK/err"
+  local r=$?
+  set -e
   echo "$r"
 }
-rm -f "$KIPI_LINEAR_CLAIMS"
-HOLDER="$(spawn_holder)"
-r=$(rc_tz UTC claim ASK-TZ --agent agent-a --session sess-A --holder-pid "$HOLDER")
-[ "$r" = "$EXIT_OK" ] || fail "the claim recording the holder's start time was refused (exit $r): $(cat "$WORK/err")"
-r=$(rc_tz Asia/Tokyo claim ASK-TZ2 --agent agent-b --session sess-B)
-[ "$r" = "$EXIT_COLLISION" ] || \
-  fail "a LIVE holder was reclaimed because the timezone changed between claim and read (exit $r): $(cat "$WORK/err")"
+
+# The locale must PROVABLY re-render lstart on this machine, or asserting against
+# it proves nothing. A machine with only C/POSIX cannot express the defect at all,
+# and that is reported as a SKIP, never counted as a passing check -- a green tick
+# for an assertion that never ran is the failure this whole file exists to avoid.
+ALT_LOCALE=""
+C_RENDER="$(TZ=UTC LC_ALL=C ps -p $$ -o lstart=)"
+for cand in ja_JP.UTF-8 de_DE.UTF-8 fr_FR.UTF-8 es_ES.UTF-8 ru_RU.UTF-8; do
+  if [ "$(TZ=UTC LC_ALL="$cand" ps -p $$ -o lstart= 2>/dev/null)" != "$C_RENDER" ]; then
+    ALT_LOCALE="$cand"
+    break
+  fi
+done
+
+# writer env -> reader env; the holder stays alive across both, so any reclaim is
+# a live holder losing its tree.
+tz_locale_case() {
+  local label="$1" wtz="$2" wlc="$3" rtz="$4" rlc="$5"
+  rm -f "$KIPI_LINEAR_CLAIMS"
+  local holder; holder="$(spawn_holder)"
+  local r
+  r=$(rc_env "$wtz" "$wlc" claim ASK-TZ --agent agent-a --session sess-A --holder-pid "$holder")
+  if [ "$r" != "$EXIT_OK" ]; then
+    reap "$holder"
+    fail "[$label] the claim recording the holder's start time was refused (exit $r): $(cat "$WORK/err")"
+  fi
+  r=$(rc_env "$rtz" "$rlc" claim ASK-TZ2 --agent agent-b --session sess-B)
+  if [ "$r" != "$EXIT_COLLISION" ]; then
+    reap "$holder"
+    fail "[$label] a LIVE holder was reclaimed because TZ/locale changed between claim and read (exit $r): $(cat "$WORK/err")"
+  fi
+  reap "$holder"
+}
+
+tz_locale_case "tz-only" UTC C Asia/Tokyo C
 ok "a timezone change between claim and read does not make a live holder look recycled"
-reap "$HOLDER"
+
+if [ -n "$ALT_LOCALE" ]; then
+  tz_locale_case "locale-only" UTC "$ALT_LOCALE" UTC C
+  ok "a locale change between claim and read does not make a live holder look recycled ($ALT_LOCALE)"
+  tz_locale_case "tz+locale" Asia/Tokyo "$ALT_LOCALE" UTC C
+  tz_locale_case "tz+locale reversed" UTC C Asia/Tokyo "$ALT_LOCALE"
+  ok "TZ and locale changing together, in both directions, still respect a live holder"
+else
+  echo "  SKIP: no installed locale re-renders \`ps -o lstart=\`, so the locale half" >&2
+  echo "        of the pin cannot be exercised on this machine (checked: ja_JP de_DE fr_FR es_ES ru_RU)" >&2
+fi
 
 # --- 27. A PRE-PIN RECORD IS NOT READ AS A RECYCLED PID -------------------
 # The layer ABOVE the fix in case 26. Records written before the pin hold a


### PR DESCRIPTION
Closes ASK-224 as **not-a-defect in the merged code**, with a test-only change that closes the assertion gap the investigation exposed.

## Verdict on Codex's major

> **major** — The mutex can reclaim a live holder when two invocations use different timezone or locale settings. `linear-claim.py:241`

Split verdict. Codex was **right about the head it reviewed** and **wrong about the merged head**.

| build | reproducer result |
| -- | -- |
| `7de67d76` (the head Codex reviewed) | **REPRODUCED, 4/4 pairings** — a live holder loses its tree |
| `2936aef` (merged) | **not reproduced, 4/4 pairings** — exit 3, live holder respected |

The `_PS_ENV` pin at `linear-claim.py:110` (`TZ=UTC`, `LC_ALL=C`) landed in the same PR, **after** the head Codex reviewed. So the issue's premise — "PR #31 merged carrying this finding unaddressed" — is not right. The finding was addressed before merge.

Same for all three of Codex's minors, each already fixed in the merged head:

| minor | where it is fixed in `2936aef` |
| -- | -- |
| worker suppresses the reclaim audit message | `linear-worker.sh:813-819` echoes `RECLAIMED:` via `say`, comment cites "PR #31 review, finding 2" |
| zombie test does not create an unreaped zombie | test case 21b, with the zombie preconditions asserted (`ps` says `Z` while `os.kill` still succeeds) |
| `status` reports a provably dead holder as active | `cmd_status` appends `[STALE: ...]`; test case 28 |

**No product fix is warranted. `linear-claim.py` is untouched by this PR.**

## The reproducer

Four writer→reader pairings, holder alive throughout, asserting whether the second claim reclaims:

```
scenario "tz-only"           TZ=Asia/Tokyo LC_ALL=C           ->  TZ=UTC        LC_ALL=C
scenario "locale-only"       TZ=UTC        LC_ALL=ja_JP.UTF-8 ->  TZ=UTC        LC_ALL=C
scenario "tz+locale"         TZ=Asia/Tokyo LC_ALL=ja_JP.UTF-8 ->  TZ=UTC        LC_ALL=C
scenario "reverse tz+locale" TZ=UTC        LC_ALL=C           ->  TZ=Asia/Tokyo LC_ALL=de_DE.UTF-8
```

Against the real historical file (`git cat-file -p 7de67d76:...`), not a mutant:

```
  [locale-only] writer TZ=UTC LC_ALL=ja_JP.UTF-8  ->  reader TZ=UTC LC_ALL=C
    holder pid 98005 is alive: SN
    recorded start time: '火  7/28 15:37:40 2026'
    second claim exit=0  stderr: RECLAIMED: ... pid 98005 now belongs to a process
      started 'Tue Jul 28 15:37:40 2026', not the holder recorded at
      '火  7/28 15:37:40 2026' (the pid was recycled). Taking the tree.
    RESULT: *** LIVE HOLDER RECLAIMED -- REPRODUCED ***
REPRODUCED: this build reclaims a live holder across a TZ/locale difference
```

Against the merged head, all four pairings recorded the identical UTC/C render and refused:

```
  [tz+locale] writer TZ=Asia/Tokyo LC_ALL=ja_JP.UTF-8  ->  reader TZ=UTC LC_ALL=C
    holder pid 96973 is alive: SN
    recorded start time: 'Tue Jul 28 15:36:48 2026'
    second claim exit=3  stderr: REFUSED: this working tree is claimed by agent-a ...
    RESULT: live holder RESPECTED (no repro)
NOT REPRODUCED: this build respects a live holder under every TZ/locale pairing above
```

The mechanism itself is real on this machine, so the "no repro" is not a broken probe — `ps -o lstart=` re-renders under `LC_ALL`, `LC_TIME`, and bare `LANG`:

```
TZ=UTC        -> Tue Jul 28 15:36:15 2026
TZ=Asia/Tokyo -> Wed Jul 29 00:36:15 2026
LC_ALL=de_DE.UTF-8 -> Di. 28 Juli 15:36:15 2026
LC_ALL=ja_JP.UTF-8 -> 火  7/28 15:36:15 2026
```

## What this PR actually changes

The investigation found a real hole, just not the one Codex named. **Case 26 varied `TZ` only.** The locale half of the pin was true by accident and nothing asserted it:

```
MUTATED: dropped LC_ALL from the pin, kept TZ=UTC
PASS: linear-claim (43 checks)
suite exit under mutant = 0
VERDICT: the suite is GREEN with the locale pin removed -- the locale half is UNASSERTED
```

Same class as the zombie fixture that passed with zombie detection deleted (PR #31 review, finding 3).

Case 26 is now extended in place to drive writer/reader pairs across TZ, locale, and both together in both directions. The locale is chosen only if it **provably** re-renders `ps -o lstart=` on the machine; otherwise the case prints `SKIP` on stderr rather than counting a green tick for an assertion that never ran.

## Checks

RED → GREEN proven by mutation, and the TZ case still passes under the mutant, so the new locale case is what catches it:

```
# LC_ALL dropped from _PS_ENV
  ok: a timezone change between claim and read does not make a live holder look recycled
FAIL: [locale-only] a LIVE holder was reclaimed because TZ/locale changed between
  claim and read (exit 0): RECLAIMED: ... not the holder recorded at '火  7/28 15:39:24 2026'
suite exit under mutant = 1
```

```
# shipped code, ambient LC_ALL=C
PASS: linear-claim (45 checks)   exit=0
# shipped code, ambient LC_ALL=ja_JP.UTF-8
PASS: linear-claim (45 checks)   exit=0
```

43 → 45 checks.

## Known RED, not caused by this PR

`capability-gate.py` exits 1 on `test-install-plist.sh`:

```
FAIL com.kipi.dispatch: template hardcodes a /Users/<name> path
```

A launchd plist template, pre-existing on main, unrelated to a diff that touches one test file. Captured as `sp-def86be0` rather than fixed here. The duplicate `--- 26.` case label in the same test file is captured as `sp-b87651c1`.

## Calibration note for ASK-221

This is not "Codex produced a false major". Codex reviewed `7de67d76` and was correct about it; the fix landed later in the same PR. The real lesson is narrower and more useful: **a review verdict is bound to the head it read**, and a finding carried forward without re-checking the merged head reads as an open defect when it is a closed one. Worth encoding when Codex becomes a required gate.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
