### PR TITLE
fix(ops): launchd was killing every converge the instant it was dispatched (ASK-113)

### DIFF
--- a/kipi-dispatch.sh
+++ b/kipi-dispatch.sh
@@ -184,9 +184,68 @@ fi
 printf '%s' "$((DISPATCHED_TODAY + 1))" > "$COUNT_FILE"
 
 say "dispatching $NEXT (live=$LIVE cap=$MAX_CONCURRENT rounds=$MAX_ROUNDS budget=$((DISPATCHED_TODAY + 1))/$DAILY_MAX)"
-nohup ./kipi converge --issue "$NEXT" --max-rounds "$MAX_ROUNDS" \
-  > "$HOME/.config/kipi/converge-$NEXT.log" 2>&1 &
-disown
 
-say "dispatched $NEXT"
+# THE CHILD NEEDS ITS OWN SESSION, AND THIS IS NOT A STYLE CHOICE.
+#
+# This was `nohup ... & disown`, which is correct in an interactive shell and
+# WRONG under launchd. launchd reaps the job's whole process group when the main
+# process exits; nohup only blocks SIGHUP, so the converge was killed the instant
+# this script returned. Every launchd dispatch since the dispatcher was installed
+# died that way, and the failure was invisible by construction: the log file is
+# created by the redirect before the child dies, so it exists and is 0 bytes,
+# `say "dispatched $NEXT"` still runs, and the budget counter is already spent.
+# The loop reported four healthy dispatches of ASK-224 on 2026-07-28 and did no
+# work at all -- it only spent the subscription.
+#
+# PROVEN, not reasoned about. A launchd job whose only act was
+# `nohup bash -c "sleep 25; touch F" & disown; exit`:
+#     under launchd   F never written  (child killed)
+#     same script from an interactive shell   F written (child survived)
+# and with the setsid form below, under launchd, F is written.
+#
+# macOS ships no setsid(1), so python3 is how setsid(2) gets called. A new
+# session means a new process group with no controlling terminal, which is
+# outside the group launchd tears down.
+python3 - "$HOME/.config/kipi/converge-$NEXT.log" \
+         ./kipi converge --issue "$NEXT" --max-rounds "$MAX_ROUNDS" <<'PY'
+import subprocess, sys
+log_path, argv = sys.argv[1], sys.argv[2:]
+# Append, never truncate: a re-dispatch of the same issue must not erase the
+# evidence of the previous run (the burst incident truncated a live log with >).
+log = open(log_path, "ab", buffering=0)
+subprocess.Popen(argv, stdout=log, stderr=log, start_new_session=True)
+PY
+RC=$?
+if [ "$RC" -ne 0 ]; then
+  # A launch that failed must NOT report success -- that is the same shape as
+  # the bug above. The budget slot is already spent, so say so plainly.
+  say "FAILED to launch converge for $NEXT (rc=$RC); the budget slot is spent"
+  page "kipi dispatch: could not launch the converge run for $NEXT, so NO work is happening even though the loop looks alive. Do: run \`bash kipi-dispatch.sh\` by hand and read the error."
+  exit 1
+fi
+
+# PROVE IT IS ALIVE BEFORE CLAIMING IT. The whole defect above was a dispatch
+# that reported success into a void, so the report is now evidence-backed: the
+# process either shows up in the table or the founder hears about it.
+#
+# NOT `pgrep -f "...$NEXT\b"`. \b is a GNU regex extension and BSD pgrep (macOS,
+# where this actually runs under launchd) does not honour it, so that pattern
+# never matches and a HEALTHY run gets reported as died -- a false alarm is how
+# an alert earns itself muted. The boundary is done in grep, which does support
+# it, against `pgrep -fl` output.
+DISPATCH_OK=0
+for _ in 1 2 3 4 5 6 7 8 9 10; do
+  if pgrep -fl "converge.sh --issue" 2>/dev/null \
+       | grep -qE "[[:space:]]${NEXT}([[:space:]]|\$)"; then
+    DISPATCH_OK=1; break
+  fi
+  sleep 1
+done
+if [ "$DISPATCH_OK" -eq 1 ]; then
+  say "dispatched $NEXT (confirmed running)"
+else
+  say "DISPATCH DIED: $NEXT was launched but no converge process is alive after 10s"
+  page "kipi dispatch: $NEXT was launched but died immediately -- the loop is spending budget and doing no work. Do: check ~/.config/kipi/converge-$NEXT.log and whether launchd is reaping the child."
+  exit 1
+fi
 exit 0

--- a/kipi-dispatch.sh
+++ b/kipi-dispatch.sh
@@ -174,7 +174,15 @@ fi
 
 # Belt and braces against the race between dispatch and the In Progress
 # transition: two converge runs on one issue would fight over one worktree.
-if pgrep -f "converge.sh --issue $NEXT\b" >/dev/null 2>&1; then
+#
+# NOT pgrep, and NOT \b (PR #39 review, finding 2). BSD pgrep reads `\b` as a
+# literal `b`, so this guard has never fired on macOS -- the only platform it
+# runs on. It was harmless while every dispatched child was being reaped
+# instantly; the moment children survive (the fix below), it becomes reachable
+# and lets a second converge start on an issue that already has one. Same
+# `ps -Ao args=` form and same [c] self-match guard as the liveness check.
+if ps -Ao args= 2>/dev/null \
+     | grep -qE "[c]onverge\.sh --issue ${NEXT}([[:space:]]|\$)"; then
   say "skip $NEXT: a converge run for it is already live"
   exit 0
 fi
@@ -206,15 +214,28 @@ say "dispatching $NEXT (live=$LIVE cap=$MAX_CONCURRENT rounds=$MAX_ROUNDS budget
 # macOS ships no setsid(1), so python3 is how setsid(2) gets called. A new
 # session means a new process group with no controlling terminal, which is
 # outside the group launchd tears down.
-python3 - "$HOME/.config/kipi/converge-$NEXT.log" \
+CONVERGE_LOG="$HOME/.config/kipi/converge-$NEXT.log"
+# A RUN BOUNDARY, because the log is appended (PR #39 review, finding 3). The
+# failure page points the operator at this file; without a marker they cannot
+# tell where a re-dispatch's output starts and are reading the previous run's
+# tail as if it were this one's.
+printf '\n===== dispatch %s  %s  rounds=%s =====\n' \
+  "$NEXT" "$(date -u +%Y-%m-%dT%H:%M:%SZ)" "$MAX_ROUNDS" >> "$CONVERGE_LOG"
+
+CHILD_PID="$(python3 - "$CONVERGE_LOG" \
          ./kipi converge --issue "$NEXT" --max-rounds "$MAX_ROUNDS" <<'PY'
 import subprocess, sys
 log_path, argv = sys.argv[1], sys.argv[2:]
 # Append, never truncate: a re-dispatch of the same issue must not erase the
 # evidence of the previous run (the burst incident truncated a live log with >).
 log = open(log_path, "ab", buffering=0)
-subprocess.Popen(argv, stdout=log, stderr=log, start_new_session=True)
+p = subprocess.Popen(argv, stdout=log, stderr=log, start_new_session=True)
+# The PID is the whole point: the caller has to watch THE CHILD IT LAUNCHED,
+# not "some converge for this issue". `kipi` runs converge.sh with bash rather
+# than exec, so this pid stays alive exactly as long as the run does.
+print(p.pid)
 PY
+)"
 RC=$?
 if [ "$RC" -ne 0 ]; then
   # A launch that failed must NOT report success -- that is the same shape as
@@ -234,23 +255,32 @@ fi
 # an alert earns itself muted. The boundary is done in grep, which does support
 # it, against `pgrep -fl` output.
 #
-# NOR `pgrep -fl`. Its -l means two different things: on macOS it prints the full
-# command line, on Linux (procps) it prints only the process NAME, so the issue
-# id is simply not in the output there and a healthy run reads as died. That is
-# not academic -- it failed exactly that way on CI.
+# WATCH THE PID, NOT THE PROCESS TABLE (PR #39 review, finding 1). Asking "is
+# some converge for this issue running?" lets an UNRELATED live converge answer
+# on the dead child's behalf -- which is the exact silent-success hole this
+# check exists to close, rebuilt one layer up. The reachable chain the reviewer
+# walked: the duplicate guard above was dead on macOS, so a second converge
+# started while one was live, converge.sh refused the claim and that child died
+# instantly, and the table still held converge #1. Success reported, budget
+# spent, nobody paged.
 #
-# `ps -Ao args=` prints full command lines on both. The [c] bracket is the
-# standard trick to stop this grep from matching ITSELF: the pattern matches the
-# text "converge", while this process's own command line contains the literal
-# "[c]onverge", which does not.
+# `kill -0` sends no signal; it only asks whether the pid is still there.
+# Checked every second rather than once, so a child that dies at t+4 is caught
+# too -- "alive at least once" would pass a run that fell over immediately after
+# starting, which is most of the ways this actually fails.
 DISPATCH_OK=0
-for _ in 1 2 3 4 5 6 7 8 9 10; do
-  if ps -Ao args= 2>/dev/null \
-       | grep -qE "[c]onverge\.sh --issue ${NEXT}([[:space:]]|\$)"; then
-    DISPATCH_OK=1; break
-  fi
-  sleep 1
-done
+case "$CHILD_PID" in
+  ''|*[!0-9]*)
+    say "DISPATCH DIED: no child pid was returned for $NEXT"
+    ;;
+  *)
+    DISPATCH_OK=1
+    for _ in 1 2 3 4 5 6 7 8 9 10; do
+      if ! kill -0 "$CHILD_PID" 2>/dev/null; then DISPATCH_OK=0; break; fi
+      sleep 1
+    done
+    ;;
+esac
 if [ "$DISPATCH_OK" -eq 1 ]; then
   say "dispatched $NEXT (confirmed running)"
 else

--- a/kipi-dispatch.sh
+++ b/kipi-dispatch.sh
@@ -233,10 +233,20 @@ fi
 # never matches and a HEALTHY run gets reported as died -- a false alarm is how
 # an alert earns itself muted. The boundary is done in grep, which does support
 # it, against `pgrep -fl` output.
+#
+# NOR `pgrep -fl`. Its -l means two different things: on macOS it prints the full
+# command line, on Linux (procps) it prints only the process NAME, so the issue
+# id is simply not in the output there and a healthy run reads as died. That is
+# not academic -- it failed exactly that way on CI.
+#
+# `ps -Ao args=` prints full command lines on both. The [c] bracket is the
+# standard trick to stop this grep from matching ITSELF: the pattern matches the
+# text "converge", while this process's own command line contains the literal
+# "[c]onverge", which does not.
 DISPATCH_OK=0
 for _ in 1 2 3 4 5 6 7 8 9 10; do
-  if pgrep -fl "converge.sh --issue" 2>/dev/null \
-       | grep -qE "[[:space:]]${NEXT}([[:space:]]|\$)"; then
+  if ps -Ao args= 2>/dev/null \
+       | grep -qE "[c]onverge\.sh --issue ${NEXT}([[:space:]]|\$)"; then
     DISPATCH_OK=1; break
   fi
   sleep 1

--- a/kipi-dispatch.sh
+++ b/kipi-dispatch.sh
@@ -181,8 +181,20 @@ fi
 # instantly; the moment children survive (the fix below), it becomes reachable
 # and lets a second converge start on an issue that already has one. Same
 # `ps -Ao args=` form and same [c] self-match guard as the liveness check.
-if ps -Ao args= 2>/dev/null \
-     | grep -qE "[c]onverge\.sh --issue ${NEXT}([[:space:]]|\$)"; then
+# NO PIPE INTO grep -q, and that is the whole point (PR #39 review r3,
+# finding 1). `ps ... | grep -q` under `set -o pipefail` fires only sometimes:
+# grep -q exits the instant it matches, ps then takes SIGPIPE and dies 141, and
+# pipefail makes 141 the status of the whole pipeline -- so the `if` does NOT
+# run its body. Whether ps has finished writing before grep leaves is a race,
+# so the guard worked load-dependently, which is worse than never working
+# because it looks fine when you test it by hand.
+#
+# A snapshot into a variable plus bash's own =~ removes the pipeline entirely,
+# so there is nothing to SIGPIPE and nothing for pipefail to poison. It also
+# removes the need for the [c] self-match trick: with no grep process there is
+# no grep command line in the table to match.
+PS_SNAPSHOT="$(ps -Ao args= 2>/dev/null || true)"
+if [[ "$PS_SNAPSHOT" =~ converge\.sh\ --issue\ ${NEXT}([[:space:]]|$) ]]; then
   say "skip $NEXT: a converge run for it is already live"
   exit 0
 fi

--- a/q-system/.q-system/capability-manifest.json
+++ b/q-system/.q-system/capability-manifest.json
@@ -396,6 +396,11 @@
       "path": "q-system/.q-system/scripts/verify-containment-export.py",
       "reason": "built for prd-skeleton-data-containment's export/quarantine flow and never wired",
       "spillover_id": "sp-0f773063"
+    },
+    {
+      "path": "q-system/.q-system/scripts/linear-collapse-jobmigration.py",
+      "reason": "one-shot family collapse: it absorbed the 32-member job-migration family into ASK-151 on 2026-07-28 and has no second family to run on. ASK-226 generalises it; retire this one when that lands",
+      "spillover_id": "sp-fb332466"
     }
   ],
   "uncovered_known": [

--- a/q-system/.q-system/capability-manifest.json
+++ b/q-system/.q-system/capability-manifest.json
@@ -309,6 +309,10 @@
     {
       "path": "q-system/.q-system/test_token_guard_runtime.py",
       "runner": "python3"
+    },
+    {
+      "path": "q-system/.q-system/scripts/test/test-dispatch-liveness.sh",
+      "runner": "bash"
     }
   ],
   "required_data": [],

--- a/q-system/.q-system/scripts/com.kipi.dispatch.plist
+++ b/q-system/.q-system/scripts/com.kipi.dispatch.plist
@@ -8,12 +8,12 @@
 	<key>EnvironmentVariables</key>
 	<dict>
 		<key>KIPI_REPO</key>
-		<string>/Users/assafkipnis/projects/kipi-system</string>
+		<string>__KIPI_REPO__</string>
 		<!-- Same PATH as com.kipi.openloops-heartbeat, which is the proven
 		     working `claude -p` under launchd. gh and claude both live in
 		     /opt/homebrew/bin; without it the dispatcher pages and exits. -->
 		<key>PATH</key>
-		<string>/Users/assafkipnis/.local/bin:/opt/homebrew/bin:/usr/bin:/bin:/usr/sbin:/sbin</string>
+		<string>__HOME__/.local/bin:/opt/homebrew/bin:/usr/bin:/bin:/usr/sbin:/sbin</string>
 		<!-- ONE at a time, deliberately. Each run spawns a `claude -p` agent
 		     plus a reviewer, so this is also the spend ceiling -- but the real
 		     reason is conflicts. The dispatcher picks by readiness and has NO
@@ -53,7 +53,7 @@
 	<key>ProgramArguments</key>
 	<array>
 		<string>/bin/bash</string>
-		<string>/Users/assafkipnis/projects/kipi-system/kipi-dispatch.sh</string>
+		<string>__KIPI_REPO__/kipi-dispatch.sh</string>
 	</array>
 
 	<!-- Every 15 minutes. The heartbeat only TOPS UP to the concurrency cap;
@@ -68,8 +68,8 @@
 	<false/>
 
 	<key>StandardOutPath</key>
-	<string>/Users/assafkipnis/.config/kipi/dispatch.out</string>
+	<string>__HOME__/.config/kipi/dispatch.out</string>
 	<key>StandardErrorPath</key>
-	<string>/Users/assafkipnis/.config/kipi/dispatch.err</string>
+	<string>__HOME__/.config/kipi/dispatch.err</string>
 </dict>
 </plist>

--- a/q-system/.q-system/scripts/test/test-dispatch-liveness.sh
+++ b/q-system/.q-system/scripts/test/test-dispatch-liveness.sh
@@ -1,0 +1,195 @@
+#!/usr/bin/env bash
+# Pairs with kipi-dispatch.sh: a dispatch that DIED must not report success.
+#
+# THE SCAR (2026-07-28)
+# ---------------------
+# kipi-dispatch.sh launched converge with `nohup ... & disown`. That is right in
+# an interactive shell and wrong under launchd, which reaps the job's whole
+# process group when the main process exits -- nohup only blocks SIGHUP. Every
+# launchd dispatch was killed the instant the dispatcher returned.
+#
+# It was invisible by construction, and every visible signal said healthy:
+#   - the log file exists, because the redirect creates it before the child dies
+#   - it is 0 bytes, which reads as "just started"
+#   - `say "dispatched $NEXT"` runs unconditionally, so the log claims success
+#   - the budget counter is already spent, because it is spent before launching
+# The loop reported four healthy dispatches of ASK-224 and did no work at all.
+#
+# Proven with a launchd probe: a job whose only act was
+#   nohup bash -c "sleep 25; touch F" & disown; exit
+# never wrote F under launchd, wrote it from an interactive shell, and wrote it
+# under launchd once the child was given its own session via setsid(2).
+#
+# WHAT THIS FILE CAN AND CANNOT TEST
+# ----------------------------------
+# It cannot reproduce the launchd reap: CI is Linux and has no launchd. So it
+# tests the thing that makes the class of failure LOUD instead of silent -- the
+# dispatcher must confirm the process is actually alive before claiming it
+# dispatched, and must page and exit non-zero when it is not. That check fires
+# for a reaped child, a converge that crashes on startup, a bad PATH, or any
+# other reason the run does not survive: the assertion is on the outcome, not on
+# one cause.
+#
+# A structural check that `start_new_session` is still there guards the specific
+# fix from a silent revert (see the merge that restored RESET_HOUR for why that
+# is not paranoia).
+set -uo pipefail
+
+PASS=0; FAIL=0
+ok()  { printf '  PASS %s\n' "$1"; PASS=$((PASS + 1)); }
+bad() { printf '  FAIL %s\n     %s\n' "$1" "${2:-}"; FAIL=$((FAIL + 1)); }
+check() { if [ "$2" = "$3" ]; then ok "$1"; else bad "$1" "expected [$3] got [$2]"; fi; }
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+# FOUR levels: this file is <repo>/q-system/.q-system/scripts/test/, so the repo
+# root is test -> scripts -> .q-system -> q-system -> repo. Three resolves to
+# q-system/ and the dispatcher is not there. The assert below is what turns that
+# into a loud failure instead of a suite that grades its own error message
+# (the exact shape of the token-guard fixture bug fixed earlier the same day).
+REPO_ROOT="$(cd "$SCRIPT_DIR/../../../.." && pwd)"
+DISPATCH="$REPO_ROOT/kipi-dispatch.sh"
+[ -f "$DISPATCH" ] || { echo "FATAL: kipi-dispatch.sh not found at $DISPATCH" >&2; exit 1; }
+
+ROOT="$(mktemp -d)"
+trap 'pkill -f "$ROOT/converge.sh" 2>/dev/null; rm -r -- "$ROOT" 2>/dev/null' EXIT
+
+# --- the sandbox ------------------------------------------------------------
+# A fake repo whose `kipi` responds to `work` with one ready issue, and to
+# `converge` in whichever way the case under test needs.
+FAKE_REPO="$ROOT/repo"
+mkdir -p "$FAKE_REPO" "$ROOT/home/.config/kipi" "$ROOT/bin"
+
+# gh must merely exist; the dispatcher only checks `command -v gh`.
+printf '#!/bin/sh\nexit 0\n' > "$ROOT/bin/gh"; chmod +x "$ROOT/bin/gh"
+
+# The page sink, so an alert is asserted on a file rather than on prose.
+PAGES="$ROOT/pages.txt"
+printf '#!/bin/sh\nprintf "%%s\\n" "$1" >> "%s"\n' "$PAGES" > "$ROOT/notify.sh"
+chmod +x "$ROOT/notify.sh"
+
+# A stand-in for the real converge.sh. Named so `pgrep -f "converge.sh --issue"`
+# matches it exactly as it matches the real one -- the dispatcher's liveness
+# check greps the process table, so the fixture has to be visible there.
+cat > "$ROOT/converge.sh" <<'SH'
+#!/usr/bin/env bash
+sleep 30
+SH
+chmod +x "$ROOT/converge.sh"
+
+make_kipi() {  # make_kipi <alive|dead>
+  cat > "$FAKE_REPO/kipi" <<SH
+#!/usr/bin/env bash
+case "\$1" in
+  work) printf '1 ready issue\n[dry] would work ASK-930\n' ;;
+  converge)
+    if [ "$1" = "alive" ]; then
+      exec bash "$ROOT/converge.sh" --issue ASK-930 --max-rounds 3
+    fi
+    # "dead": exit immediately, exactly like a child launchd has reaped.
+    exit 0
+    ;;
+esac
+SH
+  chmod +x "$FAKE_REPO/kipi"
+}
+
+run_dispatch() {
+  ( cd "$FAKE_REPO" && HOME="$ROOT/home" PATH="$ROOT/bin:$PATH" \
+      KIPI_REPO="$FAKE_REPO" KIPI_NOTIFY="$ROOT/notify.sh" \
+      KIPI_DISPATCH_DAILY_MAX=9 \
+      bash "$DISPATCH" 2>&1 )
+}
+
+# `say` writes to the dispatch LOG, not to stdout, so every assertion about what
+# the dispatcher reported has to read the log. Asserting on stdout would pass
+# vacuously against an empty string -- which is how a check ends up grading
+# nothing at all.
+dlog() { cat "$ROOT/home/.config/kipi/dispatch.log" 2>/dev/null; }
+
+reset_state() {
+  rm -r -- "$ROOT/home/.config/kipi" 2>/dev/null
+  mkdir -p "$ROOT/home/.config/kipi"
+  # Seed the liveness beacon so the one-off "heartbeat STARTED" page does not
+  # fire and get mistaken for a fault page by the assertions below.
+  date -u +%s > "$ROOT/home/.config/kipi/dispatch-lastbeat"
+  : > "$PAGES"
+  pkill -f "$ROOT/converge.sh" 2>/dev/null
+}
+
+echo "test-dispatch-liveness.sh"
+
+# --- 1. a dispatch that dies immediately is reported as DIED ----------------
+# THE REGRESSION. With the old code this case printed "dispatched ASK-930" and
+# exited 0 while nothing ran.
+reset_state
+make_kipi dead
+run_dispatch >/dev/null; RC=$?
+
+check "1a a died dispatch exits non-zero" "$RC" "1"
+
+if dlog | grep -q "DISPATCH DIED"; then
+  ok "1b the log says the dispatch died"
+else
+  bad "1b the log says the dispatch died" "$(dlog)"
+fi
+
+if dlog | grep -q "dispatched ASK-930 (confirmed running)"; then
+  bad "1c it does NOT claim the run is confirmed" "$(dlog)"
+else
+  ok "1c it does NOT claim the run is confirmed"
+fi
+
+# LOUD MEANS THE FOUNDER HEARS IT. A dead loop that only writes its own log is
+# the silent failure again, one layer down: nobody reads dispatch.log.
+if grep -q "died immediately" "$PAGES" 2>/dev/null; then
+  ok "1d the founder is paged, naming the symptom"
+else
+  bad "1d the founder is paged, naming the symptom" "$(cat "$PAGES" 2>/dev/null)"
+fi
+
+if grep -q "spending budget and doing no work" "$PAGES" 2>/dev/null; then
+  ok "1e the page says the cost is real, not just that something is wrong"
+else
+  bad "1e the page says the cost is real" "$(cat "$PAGES" 2>/dev/null)"
+fi
+
+# --- 2. control: a dispatch that survives is reported as running ------------
+# Without this the suite would pass by simply always failing, which is the
+# no-teeth shape the reviewer keeps catching.
+reset_state
+make_kipi alive
+run_dispatch >/dev/null; RC=$?
+
+check "2a a surviving dispatch exits 0" "$RC" "0"
+
+if dlog | grep -q "confirmed running"; then
+  ok "2b it reports the run as confirmed"
+else
+  bad "2b it reports the run as confirmed" "$(dlog)"
+fi
+
+check "2c no page is sent on the healthy path" \
+  "$([ -s "$PAGES" ] && echo paged || echo silent)" "silent"
+
+pkill -f "$ROOT/converge.sh" 2>/dev/null
+
+# --- 3. the child is still given its own session ----------------------------
+# Structural, and deliberately so: the launchd reap cannot be reproduced on CI
+# (Linux, no launchd), so this is what stops a rewrite quietly restoring
+# `nohup ... & disown` and taking the loop back down to zero work per night.
+if grep -q "start_new_session=True" "$DISPATCH"; then
+  ok "3a the converge child is launched in a new session (setsid)"
+else
+  bad "3a the converge child is launched in a new session (setsid)" \
+    "start_new_session=True is gone from kipi-dispatch.sh; launchd will reap every run"
+fi
+
+if grep -qE '^\s*nohup \./kipi converge' "$DISPATCH"; then
+  bad "3b the reaped nohup form has not come back" "nohup ./kipi converge is back in kipi-dispatch.sh"
+else
+  ok "3b the reaped nohup form has not come back"
+fi
+
+echo
+printf '== %s passed, %s failed\n' "$PASS" "$FAIL"
+[ "$FAIL" -eq 0 ] || exit 1

--- a/q-system/.q-system/scripts/test/test-dispatch-liveness.sh
+++ b/q-system/.q-system/scripts/test/test-dispatch-liveness.sh
@@ -50,6 +50,14 @@ REPO_ROOT="$(cd "$SCRIPT_DIR/../../../.." && pwd)"
 DISPATCH="$REPO_ROOT/kipi-dispatch.sh"
 [ -f "$DISPATCH" ] || { echo "FATAL: kipi-dispatch.sh not found at $DISPATCH" >&2; exit 1; }
 
+# A UNIQUE issue id per run. Every assertion here goes through the GLOBAL
+# process table, so a hardcoded id makes two concurrent runs of this suite (the
+# capability gate runs the fleet's tests together) see each other's decoys: one
+# run's live converge satisfies the other run's duplicate guard, and cases fail
+# for a reason that has nothing to do with the code under test. Observed exactly
+# that way on 2026-07-28 -- 17/17 standalone, 15/17 under the gate.
+ISS="ASK-9$$"
+
 ROOT="$(mktemp -d)"
 trap 'pkill -f "$ROOT/converge.sh" 2>/dev/null; rm -r -- "$ROOT" 2>/dev/null' EXIT
 
@@ -80,10 +88,10 @@ make_kipi() {  # make_kipi <alive|dead>
   cat > "$FAKE_REPO/kipi" <<SH
 #!/usr/bin/env bash
 case "\$1" in
-  work) printf '1 ready issue\n[dry] would work ASK-930\n' ;;
+  work) printf '1 ready issue\n[dry] would work $ISS\n' ;;
   converge)
     if [ "$1" = "alive" ]; then
-      exec bash "$ROOT/converge.sh" --issue ASK-930 --max-rounds 3
+      exec bash "$ROOT/converge.sh" --issue $ISS --max-rounds 3
     fi
     # "dead": exit immediately, exactly like a child launchd has reaped.
     exit 0
@@ -119,7 +127,7 @@ reset_state() {
 echo "test-dispatch-liveness.sh"
 
 # --- 1. a dispatch that dies immediately is reported as DIED ----------------
-# THE REGRESSION. With the old code this case printed "dispatched ASK-930" and
+# THE REGRESSION. With the old code this case printed "dispatched $ISS" and
 # exited 0 while nothing ran.
 reset_state
 make_kipi dead
@@ -133,7 +141,7 @@ else
   bad "1b the log says the dispatch died" "$(dlog)"
 fi
 
-if dlog | grep -q "dispatched ASK-930 (confirmed running)"; then
+if dlog | grep -q "dispatched $ISS (confirmed running)"; then
   bad "1c it does NOT claim the run is confirmed" "$(dlog)"
 else
   ok "1c it does NOT claim the run is confirmed"
@@ -188,6 +196,97 @@ if grep -qE '^\s*nohup \./kipi converge' "$DISPATCH"; then
   bad "3b the reaped nohup form has not come back" "nohup ./kipi converge is back in kipi-dispatch.sh"
 else
   ok "3b the reaped nohup form has not come back"
+fi
+
+# --- 4. an unrelated live converge must not vouch for a dead child ----------
+# PR #39 review, finding 1. The first cut of this liveness check asked "is SOME
+# converge for this issue in the process table?" -- so any other converge on the
+# same issue answered on the dead child's behalf, rebuilding the exact
+# silent-success hole one layer up.
+#
+# The reviewer's chain, reproduced here: the child is launched, it spawns a
+# DECOY that matches the process-table pattern and then dies itself. A
+# table-grep sees the decoy and reports "confirmed running". A pid-bound check
+# sees the child it actually launched is gone and reports DIED.
+#
+# The decoy is started by the child rather than beforehand on purpose: started
+# beforehand, the duplicate-dispatch guard would skip the issue and the
+# liveness check would never run at all.
+reset_state
+cat > "$FAKE_REPO/kipi" <<SH
+#!/usr/bin/env bash
+case "\$1" in
+  work) printf '1 ready issue\n[dry] would work $ISS\n' ;;
+  converge)
+    # Spawn something that LOOKS like a live converge for this issue...
+    # Plain background, not setsid: macOS ships no setsid(1), so that spelling
+    # is a command-not-found and the decoy never starts, which would make this
+    # whole case pass for the wrong reason. The child is already in its own
+    # session (the dispatcher put it there), so its children survive anyway.
+    # NOTE: no backticks anywhere in this heredoc -- it is unquoted (<<SH) so
+    # backticks would run as command substitution while the stub is WRITTEN.
+    bash "$ROOT/converge.sh" --issue $ISS --max-rounds 3 >/dev/null 2>&1 &
+    disown 2>/dev/null || true
+    # ...then die, exactly as a reaped child does.
+    exit 0
+    ;;
+esac
+SH
+chmod +x "$FAKE_REPO/kipi"
+run_dispatch >/dev/null; RC=$?
+
+check "4a a decoy converge does not make a dead dispatch succeed" "$RC" "1"
+
+if dlog | grep -q "DISPATCH DIED"; then
+  ok "4b the dead child is still reported as died"
+else
+  bad "4b the dead child is still reported as died" "$(dlog)"
+fi
+
+if grep -q "died immediately" "$PAGES" 2>/dev/null; then
+  ok "4c the founder is still paged"
+else
+  bad "4c the founder is still paged" "$(cat "$PAGES" 2>/dev/null)"
+fi
+
+pkill -f "$ROOT/converge.sh" 2>/dev/null
+
+# The check must be bound to the launched pid, not to a table search. Structural
+# because the race above is the only behavioural way in, and it is easy to
+# "simplify" this back to a grep while every case still passes.
+if grep -q 'kill -0 "$CHILD_PID"' "$DISPATCH"; then
+  ok "4d the liveness check watches the pid it launched"
+else
+  bad "4d the liveness check watches the pid it launched" \
+    "kill -0 \$CHILD_PID is gone; an unrelated converge can vouch for a dead child again"
+fi
+
+# --- 5. the duplicate guard no longer uses the \b that never fires ---------
+# PR #39 review, finding 2. The guard used `pgrep -f "...ASK-n\b"`, and BSD
+# pgrep reads \b as a literal b, so it has never fired on macOS -- the only
+# platform it runs on. Harmless only while every child was being reaped anyway;
+# children surviving is exactly what makes it reachable.
+#
+# STRUCTURAL, NOT BEHAVIOURAL, AND THAT IS A DELIBERATE LIMIT. Driving it for
+# real means putting a decoy converge in the GLOBAL process table and asserting
+# the dispatcher sees it -- which races against any other run of this suite and
+# against real converge runs on the machine. That version was written first and
+# was flaky under the capability gate (17/17 alone, 15/17 alongside the fleet's
+# other tests), and a flaky gate is worse than a narrow one: it teaches everyone
+# to re-run until green. The regex itself is verified by hand against a live
+# process; this pins the spelling so the \b cannot come back.
+# A non-racy behavioural version is captured as spillover.
+if grep -qE 'pgrep -f "converge\.sh --issue \$NEXT' "$DISPATCH"; then
+  bad "5a the duplicate guard does not use the \\b that BSD pgrep ignores" \
+    "the pgrep+\\b form is back in kipi-dispatch.sh; the guard will never fire on macOS"
+else
+  ok "5a the duplicate guard does not use the \\b that BSD pgrep ignores"
+fi
+
+if grep -c 'ps -Ao args=' "$DISPATCH" | grep -q '[1-9]'; then
+  ok "5b the guard matches on full command lines, portably"
+else
+  bad "5b the guard matches on full command lines, portably" "ps -Ao args= is gone from kipi-dispatch.sh"
 fi
 
 echo

--- a/q-system/.q-system/scripts/test/test-dispatch-liveness.sh
+++ b/q-system/.q-system/scripts/test/test-dispatch-liveness.sh
@@ -101,10 +101,16 @@ SH
   chmod +x "$FAKE_REPO/kipi"
 }
 
+# KIPI_DISPATCH_MAX IS PINNED HIGH ON PURPOSE (PR #39 review r3, finding 2).
+# The dispatcher's concurrency cap counts live converge runs from the GLOBAL
+# process table, so without this the suite is at the mercy of whatever else is
+# running on the box: two unrelated converge runs and the dispatcher skips
+# before it reaches anything under test, taking 8 of 16 cases red. That is the
+# flakiness previously blamed on one case; it was the cap all along.
 run_dispatch() {
   ( cd "$FAKE_REPO" && HOME="$ROOT/home" PATH="$ROOT/bin:$PATH" \
       KIPI_REPO="$FAKE_REPO" KIPI_NOTIFY="$ROOT/notify.sh" \
-      KIPI_DISPATCH_DAILY_MAX=9 \
+      KIPI_DISPATCH_DAILY_MAX=9 KIPI_DISPATCH_MAX=999 \
       bash "$DISPATCH" 2>&1 )
 }
 
@@ -288,6 +294,44 @@ if grep -c 'ps -Ao args=' "$DISPATCH" | grep -q '[1-9]'; then
 else
   bad "5b the guard matches on full command lines, portably" "ps -Ao args= is gone from kipi-dispatch.sh"
 fi
+
+# --- 6. the duplicate guard actually fires, driven for real -----------------
+# The behavioural half of case 5, restored once BOTH causes of its earlier
+# flakiness were understood and fixed: the issue id is unique per run (so two
+# runs of this suite cannot see each other's decoy) and run_dispatch pins
+# KIPI_DISPATCH_MAX (so the concurrency cap cannot skip before the guard is
+# reached). Blaming the process table was wrong; it was the cap.
+#
+# THIS IS THE CASE THAT CATCHES THE SIGPIPE BUG. A structural grep cannot: the
+# `ps ... | grep -q` spelling looked correct and failed ~35% of the time because
+# pipefail turned grep -q's early exit into a 141 for the whole pipeline. Only
+# running it can tell.
+reset_state
+make_kipi alive
+bash "$ROOT/converge.sh" --issue "$ISS" --max-rounds 3 >/dev/null 2>&1 &
+DECOY2=$!
+disown "$DECOY2" 2>/dev/null || true
+sleep 1
+
+# Run it several times: the SIGPIPE race is load-dependent, so a single green
+# pass proves nothing. Every one of them must skip.
+GUARD_FIRED=0; GUARD_RUNS=5
+for _ in $(seq 1 "$GUARD_RUNS"); do
+  run_dispatch >/dev/null
+  if dlog | grep -q "skip $ISS: a converge run for it is already live"; then
+    GUARD_FIRED=$((GUARD_FIRED + 1))
+  fi
+  : > "$ROOT/home/.config/kipi/dispatch.log"
+done
+
+check "6a the guard fires on EVERY attempt, not most of them" \
+  "$GUARD_FIRED" "$GUARD_RUNS"
+
+check "6b no budget slot is spent while the issue is already live" \
+  "$(cat "$ROOT/home/.config/kipi/dispatch-count-"* 2>/dev/null || echo 0)" "0"
+
+kill "$DECOY2" 2>/dev/null
+pkill -f "$ROOT/converge.sh" 2>/dev/null
 
 echo
 printf '== %s passed, %s failed\n' "$PASS" "$FAIL"


### PR DESCRIPTION
**The autonomous loop has been dispatching and doing no work. Not slowly — zero.**

`kipi-dispatch.sh` launched with `nohup ./kipi converge ... & disown`. Correct in an interactive shell, wrong under launchd, which reaps the job's whole process group when the main process exits. `nohup` only blocks SIGHUP.

### Why nothing caught it — every visible signal said healthy
- the converge log **exists** (the redirect creates it before the child dies) and is **0 bytes**, which reads as "just started"
- `say "dispatched $NEXT"` ran unconditionally, so the log claimed success
- the budget counter was already spent, because it is spent *before* launching
- the liveness beacon kept reporting a healthy heartbeat

Observed 2026-07-28: ASK-224 dispatched at 15:01, 15:16, 15:31 — three budget slots spent, three 0-byte logs, no converge process alive at any point.

### Proven, not reasoned about
A launchd job whose only act was `nohup bash -c "sleep 25; touch F" & disown`:

| context | result |
|---|---|
| under launchd | F never written (**reaped**) |
| identical script, interactive shell | F written (survived) |
| under launchd, with `setsid(2)` | F written (**fix confirmed**) |

### The fix
Give the child its own session, outside the group launchd tears down. macOS ships no `setsid(1)`, so `python3`'s `start_new_session=True` calls `setsid(2)`. Log opened append-only so a re-dispatch cannot erase the previous run's evidence.

**And the dispatch is now proved alive before it is claimed** — the process shows up in the table within 10s, or the founder is paged and the run exits non-zero. Asserts the outcome, not one cause.

The liveness match deliberately avoids `pgrep -f "...$NEXT\b"`: `\b` is a GNU extension BSD pgrep ignores, so on the platform this runs on it would never match and a *healthy* run would report as died.

### Checks (real output)
```
bash -n kipi-dispatch.sh          OK
test-dispatch-liveness.sh         10 passed, 0 failed
capability-gate.py                GREEN, ran=78, exit 0
```

Section 3 of the test is structural on purpose: CI is Linux, no launchd, so the reap cannot be reproduced there. It stops a rewrite quietly restoring `nohup ... & disown` — the same silent-revert shape that dropped `RESET_HOUR` from this file earlier today.

Includes #37 (merged in) so this stands alone.

🤖 Generated with [Claude Code](https://claude.com/claude-code)