### PR TITLE
fix(ops): the round cap was one short, so issues died with one major left (ASK-113)

### DIFF
--- a/kipi-dispatch.sh
+++ b/kipi-dispatch.sh
@@ -103,8 +103,11 @@ fi
 # runs. An unbounded heartbeat is a runaway-bill loop, which is exactly the
 # thing loop-exits.md says an autonomous loop must not be.
 #
-# One issue costs up to MAX_ROUNDS x (1 agent + 1 reviewer) = 6 sessions.
-# So DAILY_MAX is roughly "sessions per day / 6".
+# One issue costs up to MAX_ROUNDS x (1 agent + 1 reviewer) sessions, so at the
+# current cap of 4 that is 8, and DAILY_MAX is roughly "sessions per day / 8".
+#
+# The two dials move TOGETHER. Raising the round cap without lowering DAILY_MAX
+# raises the bill; the plist sets 4 rounds x 3 issues to hold it flat at 24.
 DAILY_MAX="${KIPI_DISPATCH_DAILY_MAX:-4}"
 # The budget day starts at RESET_HOUR LOCAL, not at midnight and not at UTC.
 # Founder-set 2026-07-28, and the reasoning is safety, not tidiness:

--- a/q-system/.q-system/scripts/com.kipi.dispatch.plist
+++ b/q-system/.q-system/scripts/com.kipi.dispatch.plist
@@ -37,6 +37,31 @@
 		       launchctl unload ~/Library/LaunchAgents/com.kipi.dispatch.plist
 		       launchctl load   ~/Library/LaunchAgents/com.kipi.dispatch.plist -->
 		<key>KIPI_DISPATCH_DAILY_MAX</key>
+		<string>3</string>
+
+		<!-- ROUND CAP: 4, raised from 3 on 2026-07-28, and DAILY_MAX dropped
+		     4 -> 3 in the same breath so the spend is UNCHANGED:
+		         3 rounds x 2 sessions x 4 issues = 24
+		         4 rounds x 2 sessions x 3 issues = 24
+
+		     WHY, measured rather than guessed. Two issues capped out at 3
+		     rounds the same day. Their review histories say the cap was the
+		     problem, not the work:
+
+		       - NO finding was ever repeated across rounds, on either issue.
+		         Every round surfaced different lines and different bugs, so
+		         the agent WAS fixing what it was told; the reviewer kept
+		         finding new, deeper problems underneath.
+		       - Majors decline toward zero, and that is the convergence
+		         signal: PR #39 went 2 majors -> 2 majors -> 0 majors, and the
+		         third round returned APPROVE WITH NITS and merged. Minors
+		         never block.
+		       - PR #40 was at ONE major when the cap stopped it.
+
+		     A cap-out is the most expensive possible outcome: it spends the
+		     whole cost of the issue and produces nothing mergeable. Three
+		     issues that LAND beat four that die one round short. -->
+		<key>KIPI_DISPATCH_ROUNDS</key>
 		<string>4</string>
 
 		<!-- WHEN THE ALLOWANCE REFILLS, local hour. Founder-set 2026-07-28,


### PR DESCRIPTION
Two issues capped out at 3 rounds today. The review histories rule out both obvious explanations.

### Measured, from the reviews on disk

**No finding was ever repeated across rounds, on either issue.** PR #40:

| round | findings |
|---|---|
| 1 | draft PRs · stranded_issue · transient gh failure · 2 doc minors |
| 2 | fractional-second timestamps · sequential gh calls |
| 3 | verdict ledger unread · SILENT_STATES · clipped-page guard |

Different lines, different bugs, every round — the agent **was** fixing what it was told. The reviewer kept finding new, deeper problems underneath.

**Majors declining to zero is the convergence signal.** PR #39, the one that converged:

| round | result |
|---|---|
| 1 | 2 majors + 1 minor |
| 2 | 2 majors + 1 minor |
| 3 | **0 majors** + 3 minors → APPROVE WITH NITS → merged |

Minors never block. PR #40 was at **one major** when the cap stopped it.

### Why this costs nothing

A cap-out is the most expensive outcome available: it spends the full cost of the issue and produces nothing mergeable. Three issues that land beat four that die one round short.

```
3 rounds x 2 sessions x 4 issues = 24
4 rounds x 2 sessions x 3 issues = 24
```

Both dials move together. The old comment hardcoded the cap into its arithmetic ("= 6 sessions"), which is how the two drift apart; it now names the relationship.

### Checks
```
plutil -lint com.kipi.dispatch.plist   OK
bash -n kipi-dispatch.sh               OK
capability-gate.py                     GREEN, ran=78, exit 0
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)