### PR TITLE
fix(review): the reviewer's evidence reaches a human at both ends (ASK-221)

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -257,6 +257,15 @@
             "timeout": 5
           }
         ]
+      },
+      {
+        "matcher": "Write|Edit",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "test -f \"$CLAUDE_PROJECT_DIR/q-system/.q-system/scripts/portability-lint-hook.py\" && python3 \"$CLAUDE_PROJECT_DIR/q-system/.q-system/scripts/portability-lint-hook.py\""
+          }
+        ]
       }
     ],
     "PostCompact": [

--- a/kipi-dispatch.sh
+++ b/kipi-dispatch.sh
@@ -95,16 +95,38 @@ stale_check() {
   remote_head="$(git rev-parse origin/main 2>/dev/null)" || return 0
   [ -n "$local_head" ] && [ -n "$remote_head" ] || return 0
   [ "$local_head" != "$remote_head" ] || return 0
-  # BEHIND means origin/main holds commits this tree does not. Being AHEAD is
-  # normal and must not refuse: an agent session commits locally before it opens
-  # a PR, and refusing there would wedge the loop on its own unpushed work.
-  if git merge-base --is-ancestor "$local_head" "$remote_head" 2>/dev/null; then
-    base="$(git rev-list --count "$local_head..$remote_head" 2>/dev/null || echo '?')"
-    say "REFUSING: this checkout is $base commit(s) BEHIND origin/main (HEAD ${local_head:0:7}, origin/main ${remote_head:0:7}). Dispatching would run superseded code and auto-merge the result."
-    page "kipi dispatch: refused to run -- the checkout is $base commit(s) behind origin/main, so the loop would build on stale code and merge it. Do: cd $REPO && git merge --ff-only origin/main"
-    return 1
+  # THE PREDICATE IS "does origin/main hold commits this tree lacks", NOT "is HEAD
+  # an ancestor of origin/main". Codex round 2 on PR #47 called the ancestor form a
+  # major, and it was right: --is-ancestor is FALSE for a DIVERGED tree, so the
+  # first version ran happily on a checkout missing origin/main's newest control
+  # code. I had captured that as a deliberate trade (sp-18cd7843) on the grounds
+  # that refusing would wedge a session holding local commits. That reasoning was
+  # backwards. The commonest way to diverge is a merge of this very branch: after
+  # PR #47 lands, origin/main gains a merge commit while this tree keeps the
+  # unmerged parent -- diverged AND substantively behind. So the dangerous case was
+  # the LIKELY case, not an edge.
+  #
+  # rev-list HEAD..origin/main counts exactly what is missing here, and it is 0 for
+  # both "equal" and "ahead-only". Ahead still runs: an agent commits locally
+  # before it opens a PR, and refusing there would wedge the loop on its own work.
+  base="$(git rev-list --count "$local_head..$remote_head" 2>/dev/null || echo 0)"
+  case "$base" in ''|*[!0-9]*) return 0 ;; esac   # unparseable count = no answer = run
+  [ "$base" -gt 0 ] || return 0
+  say "REFUSING: origin/main holds $base commit(s) this checkout lacks (HEAD ${local_head:0:7}, origin/main ${remote_head:0:7}). Dispatching would run superseded control code and auto-merge the result."
+  # PAGE ONCE PER REMOTE SHA, not once per heartbeat. Second major from the same
+  # review: at a 900s interval an unrepaired checkout sent the identical Slack
+  # message 96 times a day, which trains the founder to ignore the channel and
+  # buries the one line that matters. Same fix the daily cap already uses (a
+  # `.paged` marker), keyed on the remote sha so a NEW divergence pages again.
+  # Beside the dispatch log and the daily-cap counters, which is where this
+  # script's other state already lives. Derived from $LOG so there is one
+  # definition of "the state dir" rather than a second literal path.
+  local paged_mark="$(dirname "$LOG")/stale-paged-$remote_head"
+  if [ ! -f "$paged_mark" ]; then
+    page "kipi dispatch: refused to run -- origin/main has $base commit(s) this checkout lacks, so the loop would build on stale code and merge it. Do: cd $REPO && git merge --ff-only origin/main"
+    : > "$paged_mark" 2>/dev/null || true
   fi
-  return 0
+  return 1
 }
 stale_check || exit 0
 

--- a/kipi-dispatch.sh
+++ b/kipi-dispatch.sh
@@ -296,7 +296,7 @@ if [ "$DISPATCHED_TODAY" -ge "$DAILY_MAX" ]; then
   # times is the cry-wolf failure, and this is not an error state anyway.
   if [ ! -f "$COUNT_FILE.paged" ]; then
     say "${LANE_TAG}DAILY CAP: $DISPATCHED_TODAY/$DAILY_MAX issues dispatched for budget day $BUDGET_DAY (lane=$DISPATCH_LANE), stopping until ${RESET_HOUR}:00 local"
-    page "kipi dispatch: hit the daily cap of $DAILY_MAX issues (~$((DAILY_MAX * 6)) agent sessions). Not an error -- the loop is resting until ${RESET_HOUR}am, then it picks up again on its own. Do: nothing, or raise KIPI_DISPATCH_DAILY_MAX in com.kipi.dispatch.plist to go faster."
+    page "kipi dispatch: hit the daily cap of $DAILY_MAX issues (~$((DAILY_MAX * MAX_ROUNDS * 2)) agent sessions). Not an error -- the loop is resting until ${RESET_HOUR}am, then it picks up again on its own. Do: nothing, or raise KIPI_DISPATCH_DAILY_MAX in com.kipi.dispatch.plist to go faster."
     : > "$COUNT_FILE.paged"
   fi
   exit 0

--- a/kipi-dispatch.sh
+++ b/kipi-dispatch.sh
@@ -51,6 +51,63 @@ cd "$REPO" 2>/dev/null || {
   exit 1
 }
 
+# --- STALE-CHECKOUT REFUSAL (sp-c775b116) --------------------------------
+# The loop runs the founder's WORKING TREE, and nothing kept it in sync with
+# main. There is no `git pull` anywhere in this script. Observed 2026-07-30:
+# merging PR #34 left this checkout at 1597eaf, so the loop would have gone on
+# running the old Claude-only reviewer indefinitely while main carried the codex
+# gate. It was fixed by hand twice in one session, which means every future merge
+# silently depended on someone remembering.
+#
+# A DETECTOR, NOT A PULL. Pulling under the founder mid-session is its own
+# hazard -- it can yank a working tree out from under an interactive session
+# (the parallel-session scar). So this refuses and pages instead, and the page
+# carries the exact command.
+#
+# REFUSE, not warn. This loop MERGES ITS OWN PRs and has no accepted-change
+# signal, so building on superseded code and auto-merging the result is worse
+# than resting until someone fast-forwards. Same posture as the reviewer's
+# commit status: absent is not approved, and unstated HOLDS.
+#
+# A FAILED LOOKUP MUST NOT WEDGE THE LOOP. Refusal needs a POSITIVE answer that
+# we are behind; a network blip, an auth prompt or a missing remote logs and
+# proceeds. Two different safe directions, deliberately: fail closed on
+# staleness, fail open on not knowing.
+stale_check() {
+  local local_head remote_head base
+  # Bounded by hand: macOS ships no `timeout`, and an unbounded fetch inside a
+  # 15-minute launchd job is how a heartbeat becomes a stuck process.
+  ( git fetch --quiet origin main 2>/dev/null ) &
+  local fetch_pid=$! waited=0
+  while kill -0 "$fetch_pid" 2>/dev/null && [ "$waited" -lt 60 ]; do
+    sleep 1; waited=$((waited + 1))
+  done
+  if kill -0 "$fetch_pid" 2>/dev/null; then
+    kill "$fetch_pid" 2>/dev/null || true
+    say "stale-check: fetch exceeded 60s, proceeding without a freshness answer"
+    return 0
+  fi
+  wait "$fetch_pid" 2>/dev/null || {
+    say "stale-check: git fetch failed, proceeding (cannot distinguish stale from offline)"
+    return 0
+  }
+  local_head="$(git rev-parse HEAD 2>/dev/null)" || return 0
+  remote_head="$(git rev-parse origin/main 2>/dev/null)" || return 0
+  [ -n "$local_head" ] && [ -n "$remote_head" ] || return 0
+  [ "$local_head" != "$remote_head" ] || return 0
+  # BEHIND means origin/main holds commits this tree does not. Being AHEAD is
+  # normal and must not refuse: an agent session commits locally before it opens
+  # a PR, and refusing there would wedge the loop on its own unpushed work.
+  if git merge-base --is-ancestor "$local_head" "$remote_head" 2>/dev/null; then
+    base="$(git rev-list --count "$local_head..$remote_head" 2>/dev/null || echo '?')"
+    say "REFUSING: this checkout is $base commit(s) BEHIND origin/main (HEAD ${local_head:0:7}, origin/main ${remote_head:0:7}). Dispatching would run superseded code and auto-merge the result."
+    page "kipi dispatch: refused to run -- the checkout is $base commit(s) behind origin/main, so the loop would build on stale code and merge it. Do: cd $REPO && git merge --ff-only origin/main"
+    return 1
+  fi
+  return 0
+}
+stale_check || exit 0
+
 # `pgrep -c` exits 1 with no match, which under `set -e` would look like failure
 # and under a bare assignment yields an empty string. Force a number.
 live_converges() { pgrep -f "converge.sh --issue" 2>/dev/null | grep -c . || true; }

--- a/kipi-dispatch.sh
+++ b/kipi-dispatch.sh
@@ -254,7 +254,40 @@ if [ -z "$BUDGET_DAY" ]; then
   page "kipi dispatch: cannot compute its spend budget window, so it refused to dispatch rather than run uncapped. Do: check \`date -v-7H\` on this machine."
   exit 1
 fi
-COUNT_FILE="$HOME/.config/kipi/dispatch-count-$BUDGET_DAY"
+# --- TWO LANES: production and verification -------------------------------
+# Founder directive 2026-07-30: "refill the budget for this test -- the budget
+# should never stop testing."
+#
+# The principle, and why a counter reset was the WRONG answer. The cap protects
+# production dispatch: sessions, blast radius, an unattended loop that merges its
+# own PRs. It was never meant to stop us PROVING the loop works. On 2026-07-30 it
+# did exactly that: the day's three slots went to runs that opened no PR, so the
+# dispatcher-driven proof could not be attempted at all until 07:00 the next day.
+# A gate that blocks verification is not protecting anything.
+#
+# Resetting the counter would have conflated a test run with a production run and
+# put the same wall back tomorrow. So verification gets its OWN budget: its own
+# counter file, its own cap, and a visible label in every line it writes. The
+# production budget is untouched and still 3 -- the reasoning above the DAILY_MAX
+# assignment is unchanged and still holds.
+#
+# A SEPARATE CAP, NOT NO CAP. "Never stop testing" is not "never bounded": an
+# unbounded test lane is the same runaway loop wearing a different label, and the
+# codex spend is just as real. Two slots, resetting on the same budget day, is
+# enough to run a proof and retry it once.
+DISPATCH_LANE="${KIPI_DISPATCH_LANE:-production}"
+case "$DISPATCH_LANE" in
+  production) COUNT_SUFFIX=""      ; LANE_MAX="$DAILY_MAX" ; LANE_TAG="" ;;
+  test)       COUNT_SUFFIX="-test" ; LANE_MAX="${KIPI_DISPATCH_TEST_MAX:-2}" ; LANE_TAG="[test] " ;;
+  *) say "FATAL: unknown KIPI_DISPATCH_LANE '$DISPATCH_LANE' (expected production|test)"; exit 1 ;;
+esac
+# The lane is named in the log on every non-production run, so a test dispatch can
+# never be mistaken for the unattended proof later. The proof is a verdict record
+# carrying invoker=worker; a lane label in the log is how a human tells which run
+# produced it.
+[ "$DISPATCH_LANE" = "production" ] || say "${LANE_TAG}lane=$DISPATCH_LANE cap=$LANE_MAX (production budget untouched)"
+DAILY_MAX="$LANE_MAX"
+COUNT_FILE="$HOME/.config/kipi/dispatch-count$COUNT_SUFFIX-$BUDGET_DAY"
 DISPATCHED_TODAY="$(cat "$COUNT_FILE" 2>/dev/null || echo 0)"
 case "$DISPATCHED_TODAY" in ''|*[!0-9]*) DISPATCHED_TODAY=0 ;; esac
 
@@ -262,7 +295,7 @@ if [ "$DISPATCHED_TODAY" -ge "$DAILY_MAX" ]; then
   # Say it once per day, not every 15 minutes -- a budget ceiling repeated 96
   # times is the cry-wolf failure, and this is not an error state anyway.
   if [ ! -f "$COUNT_FILE.paged" ]; then
-    say "DAILY CAP: $DISPATCHED_TODAY/$DAILY_MAX issues dispatched for budget day $BUDGET_DAY, stopping until ${RESET_HOUR}:00 local"
+    say "${LANE_TAG}DAILY CAP: $DISPATCHED_TODAY/$DAILY_MAX issues dispatched for budget day $BUDGET_DAY (lane=$DISPATCH_LANE), stopping until ${RESET_HOUR}:00 local"
     page "kipi dispatch: hit the daily cap of $DAILY_MAX issues (~$((DAILY_MAX * 6)) agent sessions). Not an error -- the loop is resting until ${RESET_HOUR}am, then it picks up again on its own. Do: nothing, or raise KIPI_DISPATCH_DAILY_MAX in com.kipi.dispatch.plist to go faster."
     : > "$COUNT_FILE.paged"
   fi
@@ -326,7 +359,7 @@ fi
 # hand out a free dispatch every heartbeat -- the budget must fail closed.
 printf '%s' "$((DISPATCHED_TODAY + 1))" > "$COUNT_FILE"
 
-say "dispatching $NEXT (live=$LIVE cap=$MAX_CONCURRENT rounds=$MAX_ROUNDS budget=$((DISPATCHED_TODAY + 1))/$DAILY_MAX)"
+say "${LANE_TAG}dispatching $NEXT (live=$LIVE cap=$MAX_CONCURRENT rounds=$MAX_ROUNDS budget=$((DISPATCHED_TODAY + 1))/$DAILY_MAX lane=$DISPATCH_LANE)"
 
 # THE CHILD NEEDS ITS OWN SESSION, AND THIS IS NOT A STYLE CHOICE.
 #

--- a/kipi-dispatch.sh
+++ b/kipi-dispatch.sh
@@ -103,8 +103,33 @@ fi
 # runs. An unbounded heartbeat is a runaway-bill loop, which is exactly the
 # thing loop-exits.md says an autonomous loop must not be.
 #
-# One issue costs up to MAX_ROUNDS x (1 agent + 1 reviewer) = 6 sessions.
-# So DAILY_MAX is roughly "sessions per day / 6".
+# One issue costs up to MAX_ROUNDS x (1 agent + 1 reviewer) sessions. Do NOT read
+# that as a fixed 6: the code default is 3 rounds, but the LOADED plist sets
+# KIPI_DISPATCH_ROUNDS=4, so the live cost is up to 8 sessions per issue. The
+# older comment here hardcoded 6 and quietly understated the running job by a
+# third. Compute it from MAX_ROUNDS, never from a remembered number.
+#
+# THIS IS NOT A MONEY DIAL (founder correction, 2026-07-29). It caps SESSIONS and
+# BLAST RADIUS, not dollars: how many issues per day may enter a loop that merges
+# its own PRs. Two ceilings now sit behind it, not one -- since ASK-221 each review
+# round is a real codex run, so an issue also spends up to MAX_ROUNDS of a
+# separate external quota that did not exist when this number was chosen.
+#
+# HELD AT 3 on 2026-07-30 (sana's call, the founder does not set this). Reasons,
+# in order of weight:
+#   1. Per-issue cost went UP since 3 was picked -- 4 rounds instead of 3, plus a
+#      codex run per round -- while the number stayed put. Raising it now would
+#      compound a cost increase that was never accounted for.
+#   2. The loop self-merges and has NO accepted-change instrumentation. That is
+#      loop-exits.md's own named blind spot. Raising throughput on a loop that
+#      cannot measure whether its output is good buys more blast radius blind.
+#   3. The loop is not clean on the first pass, and tonight is the evidence: codex
+#      found two majors in PR #46, which was itself the fix for a codex minor. The
+#      review rounds are load-bearing, so throughput is not the binding constraint.
+#   4. What actually blocked progress was evidence, not rate: the review never
+#      reached the PR (sp-48688b24) and the receipt was unreadable (sp-1d1ad606).
+#      Raising the cap before those landed would only have produced more
+#      invisible reviews. Revisit AFTER an accepted-change signal exists.
 DAILY_MAX="${KIPI_DISPATCH_DAILY_MAX:-4}"
 # The budget day starts at RESET_HOUR LOCAL, not at midnight and not at UTC.
 # Founder-set 2026-07-28, and the reasoning is safety, not tidiness:

--- a/kipi-dispatch.sh
+++ b/kipi-dispatch.sh
@@ -44,6 +44,12 @@ NOTIFY="${KIPI_NOTIFY:-$REPO/q-system/.q-system/scripts/slack-notify.sh}"
 mkdir -p "$(dirname "$LOG")"
 say() { printf '%s %s\n' "$(date -u +%Y-%m-%dT%H:%M:%SZ)" "$*" >> "$LOG"; }
 page() { bash "$NOTIFY" "$1" >/dev/null 2>&1 || true; }
+# Same notifier, but REPORTS whether it went out. page() ends in `|| true` on
+# purpose -- a notifier must never take its caller down -- which makes it useless
+# to a caller that has to know. Kept as a sibling rather than changing page()'s
+# contract for the dozen sites that correctly do not care. Used by stale_check,
+# which must not write a dedupe marker for a page that never arrived.
+page_ok() { bash "$NOTIFY" "$1" >/dev/null 2>&1; }
 
 cd "$REPO" 2>/dev/null || {
   say "FATAL: repo not found at $REPO"
@@ -123,8 +129,21 @@ stale_check() {
   # definition of "the state dir" rather than a second literal path.
   local paged_mark="$(dirname "$LOG")/stale-paged-$remote_head"
   if [ ! -f "$paged_mark" ]; then
-    page "kipi dispatch: refused to run -- origin/main has $base commit(s) this checkout lacks, so the loop would build on stale code and merge it. Do: cd $REPO && git merge --ff-only origin/main"
-    : > "$paged_mark" 2>/dev/null || true
+    # MARK ONLY WHAT WAS ACTUALLY DELIVERED (codex round 4, major 2). The first cut
+    # wrote the marker unconditionally, so a page that FAILED -- webhook down, no
+    # network, slack-notify missing -- still suppressed every later notification for
+    # that sha. The founder would then be permanently silent about a refusing loop,
+    # which is strictly worse than the 96-a-day storm this dedupe was added to stop:
+    # a storm is annoying, silence is invisible.
+    #
+    # page() ends in `|| true` so it cannot report, deliberately (a notifier must
+    # never take the caller down). So call the notifier directly here and read its
+    # status, rather than changing page()'s contract for every other caller.
+    if page_ok "kipi dispatch: refused to run -- origin/main has $base commit(s) this checkout lacks, so the loop would build on stale code and merge it. Do: cd $REPO && git merge --ff-only origin/main"; then
+      : > "$paged_mark" 2>/dev/null || true
+    else
+      say "stale-check: the page did NOT go out; leaving the dedupe marker unset so the next heartbeat retries it"
+    fi
   fi
   return 1
 }

--- a/plugins/prd-os/.claude-plugin/plugin.json
+++ b/plugins/prd-os/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "prd-os",
-  "version": "0.7.3",
+  "version": "0.7.4",
   "description": "PRD operating system: capture rough ideas, draft reviewable PRDs, run standard and adversarial review (Codex or a Claude senior-staff-engineer subagent, recorded truthfully), triage findings, decompose approved PRDs into atomic issue specs, and execute those issues with scope enforcement, stop-gate receipts, and reviewer-attributed findings.",
   "author": {
     "name": "Assaf Kipnis"

--- a/plugins/prd-os/scripts/prd_runner.py
+++ b/plugins/prd-os/scripts/prd_runner.py
@@ -990,8 +990,65 @@ def gate_register(
 # CLOSED issue (or an explicitly recorded void), never a hand flip.
 
 
+_SPILLOVER_ROOT_CACHE: dict = {}
+
+
+def _ledger_root(repo_root):
+    """The ONE directory the spillover ledger lives under, shared by every worktree.
+
+    WHY THIS IS NOT JUST repo_root (sp-bc42f1d3, scale in sp-10ea7b66).
+    `.gitignore` excludes `*.jsonl`, so the ledger is never committed and never
+    shared through git. Resolving it from the per-worktree root therefore gave
+    EVERY worktree its own private ledger. Measured 2026-07-30: 26 worktree
+    ledgers held 71 open findings that did not exist in the main checkout's copy,
+    so `gates run` from main was green about work it structurally could not see.
+    That is the no-orphan-findings enforcement of last resort failing silently,
+    which is worse than not having it -- it reported safety it could not provide.
+
+    `--git-common-dir` is the shared `.git` for the whole worktree set, so its
+    parent is the main checkout no matter which worktree we are called from. One
+    ledger, one writer, one thing the gate reads. Same load-path lesson as the
+    marketplace-clone scar: the file you wrote must be the file the runtime reads.
+
+    Falls back to repo_root when git cannot answer (not a repo, git missing, a
+    bare or otherwise odd layout). A capture must never be lost to a failed
+    lookup -- writing to the local root is degraded but recoverable, while
+    raising here would turn a git hiccup into a dropped finding.
+    """
+    key = str(repo_root)
+    if key in _SPILLOVER_ROOT_CACHE:
+        return _SPILLOVER_ROOT_CACHE[key]
+    # Local import and `Path`, matching this file's existing convention (see the
+    # `import subprocess as _subprocess` call sites). Written as bare
+    # `subprocess.run` / `pathlib.Path` the first time, which are NameErrors that
+    # the except-clause below would have SWALLOWED -- the function would have
+    # returned repo_root every time and the fix would have looked correct while
+    # changing nothing. Caught by the worktree case in test_spillover_ledger_root.py.
+    import subprocess as _subprocess
+    root = repo_root
+    try:
+        out = _subprocess.run(
+            ["git", "rev-parse", "--git-common-dir"],
+            cwd=str(repo_root), capture_output=True, text=True, timeout=10,
+        )
+        if out.returncode == 0 and out.stdout.strip():
+            common = Path(out.stdout.strip())
+            if not common.is_absolute():
+                common = Path(repo_root) / common
+            parent = common.resolve().parent
+            # Only trust it if it really looks like a checkout root. A bare repo's
+            # parent is an arbitrary directory, and silently relocating the ledger
+            # there would be a new invisible-ledger bug wearing the fix's clothes.
+            if (parent / ".git").exists():
+                root = parent
+    except Exception:
+        pass
+    _SPILLOVER_ROOT_CACHE[key] = root
+    return root
+
+
 def _spillover_path(cfg: Config):
-    return cfg.repo_root / ".prd-os" / "spillover.jsonl"
+    return _ledger_root(cfg.repo_root) / ".prd-os" / "spillover.jsonl"
 
 
 def _read_spillover(cfg: Config) -> dict:

--- a/plugins/prd-os/scripts/test/test_spillover_ledger_root.py
+++ b/plugins/prd-os/scripts/test/test_spillover_ledger_root.py
@@ -1,0 +1,131 @@
+#!/usr/bin/env python3
+"""Reproducer for sp-bc42f1d3 / sp-10ea7b66: the spillover ledger was per-worktree.
+
+Pairs with `_ledger_root()` / `_spillover_path()` in prd_runner.py.
+
+WHY THIS TEST HAS TEETH. The buggy `_ledger_root` wraps its git lookup in
+`except Exception`, so ANY failure inside it -- including the NameError from a
+missing `import subprocess` that the first cut of the fix really had -- returns
+repo_root silently. A test that only asserted "the function returns a path"
+would pass against a completely inert fix. So case 2 asserts the worktree and
+the main checkout resolve to the SAME ledger, which is false for every failure
+mode of the lookup.
+
+Run: python3 test_spillover_ledger_root.py
+"""
+import json
+import os
+import pathlib
+import subprocess
+import sys
+import tempfile
+
+HERE = pathlib.Path(__file__).resolve().parent
+SCRIPTS = HERE.parent
+sys.path.insert(0, str(SCRIPTS))
+
+PASS, FAIL = [], []
+
+
+def ok(msg):
+    PASS.append(msg)
+    print("  PASS: %s" % msg)
+
+
+def bad(msg):
+    FAIL.append(msg)
+    print("  FAIL: %s" % msg)
+
+
+def git(args, cwd):
+    return subprocess.run(["git"] + args, cwd=str(cwd), capture_output=True, text=True)
+
+
+def main():
+    import prd_runner
+
+    tmp = pathlib.Path(tempfile.mkdtemp())
+    main_repo = tmp / "mainrepo"
+    main_repo.mkdir()
+
+    # A real repo, because the thing under test asks git a question. A mocked
+    # git would let the fix pass while the real command it runs is wrong.
+    git(["init", "-q", "-b", "main"], main_repo)
+    git(["config", "user.email", "t@example.com"], main_repo)
+    git(["config", "user.name", "t"], main_repo)
+    (main_repo / "README.md").write_text("x\n")
+    git(["add", "-A"], main_repo)
+    git(["commit", "-qm", "init"], main_repo)
+
+    wt = tmp / "wt-a"
+    r = git(["worktree", "add", "-q", "-b", "feature", str(wt)], main_repo)
+    if r.returncode != 0:
+        print("cannot create a worktree, cannot test the defect: %s" % r.stderr.strip())
+        return 1
+
+    print("== 1. the main checkout resolves to its own root ==")
+    main_root = prd_runner._ledger_root(main_repo)
+    if pathlib.Path(main_root).resolve() == main_repo.resolve():
+        ok("main checkout resolves to itself")
+    else:
+        bad("main checkout resolved to %s, expected %s" % (main_root, main_repo))
+
+    print()
+    print("== 2. THE DEFECT: a worktree must resolve to the MAIN checkout ==")
+    # The assertion the buggy version fails, and that every silent-failure mode
+    # of the git lookup (NameError, missing git, timeout) also fails.
+    prd_runner._SPILLOVER_ROOT_CACHE.clear()
+    wt_root = prd_runner._ledger_root(wt)
+    if pathlib.Path(wt_root).resolve() == main_repo.resolve():
+        ok("worktree resolves to the main checkout (%s)" % main_repo.name)
+    else:
+        bad("THE DEFECT: worktree resolved to %s, so it would keep a PRIVATE ledger "
+            "invisible to the gate (expected %s)" % (wt_root, main_repo))
+
+    print()
+    print("== 3. a capture filed from the worktree lands in ONE ledger ==")
+
+    class Cfg:
+        pass
+
+    cfg_main, cfg_wt = Cfg(), Cfg()
+    cfg_main.repo_root = main_repo
+    cfg_wt.repo_root = wt
+    prd_runner._SPILLOVER_ROOT_CACHE.clear()
+    p_main = prd_runner._spillover_path(cfg_main)
+    prd_runner._SPILLOVER_ROOT_CACHE.clear()
+    p_wt = prd_runner._spillover_path(cfg_wt)
+    if pathlib.Path(p_main).resolve() == pathlib.Path(p_wt).resolve():
+        ok("both roots yield the same ledger path")
+    else:
+        bad("two ledgers: main=%s worktree=%s" % (p_main, p_wt))
+
+    print()
+    print("== 4. a non-git directory still gets a usable ledger (no lost capture) ==")
+    plain = tmp / "plain"
+    plain.mkdir()
+    prd_runner._SPILLOVER_ROOT_CACHE.clear()
+    plain_root = prd_runner._ledger_root(plain)
+    # Outside a repo git answers about tmp's own repo or fails; either way the
+    # contract is that a capture is never LOST, so a path must come back.
+    if plain_root is not None and str(plain_root):
+        ok("non-git directory falls back to a real path (%s)" % plain_root)
+    else:
+        bad("non-git directory produced no ledger root, so a capture would be lost")
+
+    print()
+    print("== 5. the lookup is cached, so the gate does not shell git per row ==")
+    prd_runner._SPILLOVER_ROOT_CACHE.clear()
+    prd_runner._ledger_root(wt)
+    if str(wt) in prd_runner._SPILLOVER_ROOT_CACHE:
+        ok("result cached per repo_root")
+    else:
+        bad("no cache entry: `gates run` would shell out once per ledger read")
+
+    print()
+    print("-------- %d passed, %d failed --------" % (len(PASS), len(FAIL)))
+    return 1 if FAIL else 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/q-system/.q-system/capability-manifest.json
+++ b/q-system/.q-system/capability-manifest.json
@@ -198,6 +198,10 @@
       "runner": "bash"
     },
     {
+      "path": "q-system/.q-system/scripts/test/test-dispatch-stale-checkout.sh",
+      "runner": "bash"
+    },
+    {
       "path": "q-system/.q-system/scripts/test/test-review-comment-body.sh",
       "runner": "bash"
     },

--- a/q-system/.q-system/capability-manifest.json
+++ b/q-system/.q-system/capability-manifest.json
@@ -2,6 +2,10 @@
   "schema_version": 1,
   "expected_tests": [
     {
+      "path": "plugins/prd-os/scripts/test/test_spillover_ledger_root.py",
+      "runner": "python3"
+    },
+    {
       "path": "plugins/prd-os/tests/test_prd_split_from_linear.py",
       "runner": "python3"
     },
@@ -27,6 +31,10 @@
     },
     {
       "path": "q-system/.q-system/scripts/test/test-dispatch-liveness.sh",
+      "runner": "bash"
+    },
+    {
+      "path": "q-system/.q-system/scripts/test/test-dispatch-stale-checkout.sh",
       "runner": "bash"
     },
     {
@@ -198,20 +206,16 @@
       "runner": "bash"
     },
     {
-      "path": "q-system/.q-system/scripts/test/test-dispatch-stale-checkout.sh",
+      "path": "q-system/.q-system/scripts/test/test-review-comment-body.sh",
       "runner": "bash"
     },
     {
-      "path": "q-system/.q-system/scripts/test/test-review-comment-body.sh",
+      "path": "q-system/.q-system/scripts/test/test-review-invoker-provenance.sh",
       "runner": "bash"
     },
     {
       "path": "q-system/.q-system/scripts/test/test-review-tree-guard.sh",
       "runner": "bash"
-    },
-    {
-      "path": "plugins/prd-os/scripts/test/test_spillover_ledger_root.py",
-      "runner": "python3"
     },
     {
       "path": "q-system/.q-system/scripts/test/test-settings-merge.sh",

--- a/q-system/.q-system/capability-manifest.json
+++ b/q-system/.q-system/capability-manifest.json
@@ -198,8 +198,16 @@
       "runner": "bash"
     },
     {
+      "path": "q-system/.q-system/scripts/test/test-review-comment-body.sh",
+      "runner": "bash"
+    },
+    {
       "path": "q-system/.q-system/scripts/test/test-review-tree-guard.sh",
       "runner": "bash"
+    },
+    {
+      "path": "plugins/prd-os/scripts/test/test_spillover_ledger_root.py",
+      "runner": "python3"
     },
     {
       "path": "q-system/.q-system/scripts/test/test-settings-merge.sh",

--- a/q-system/.q-system/scripts/attempts-ledger.py
+++ b/q-system/.q-system/scripts/attempts-ledger.py
@@ -139,6 +139,17 @@ def main(argv):
     if op == "clear-conflict":            # clear-conflict <issue>
         _mutate(path, lambda d: op_clear(d, rest[0], ("conflict_rounds", "conflict_paged", "last_conflict")))
         return 0
+    if op == "clear-automerge":           # clear-automerge <issue>
+        # The op my previous edit claimed to add and did not. The shell side was
+        # rewritten to call it, the direct-write count went to 0, and I reported
+        # "routed" -- but nothing here answered the call, so clear_automerge_pages
+        # became a no-op exiting 2. Consequence: the once-only auto-merge page
+        # could never be cleared, so a PR that was armed, unarmed, then armed again
+        # went PERMANENTLY SILENT. Caught by test-severity-floor, not by me: I had
+        # verified the caller and the write count, never the round trip.
+        _mutate(path, lambda d: op_clear(
+            d, rest[0], ("automerge_unarmed_paged", "automerge_unknown_paged")))
+        return 0
     if op == "clear-drift":               # clear-drift <issue>
         _mutate(path, lambda d: op_clear(d, rest[0], ("drift_rounds", "drift_paged", "last_drift")))
         return 0

--- a/q-system/.q-system/scripts/attempts-ledger.py
+++ b/q-system/.q-system/scripts/attempts-ledger.py
@@ -1,0 +1,154 @@
+#!/usr/bin/env python3
+"""THE single writer of linear-worker-attempts.json.
+
+WHY THIS FILE EXISTS (codex round 5 on PR #47, major).
+
+The ledger holds four independent budgets keyed per issue -- `count` (failed
+attempts), `conflict_rounds`, `drift_rounds`, and the one-shot `*_paged` flags.
+Six shell functions each shelled out to their own inline python doing an
+unsynchronised read-modify-write. Two workers finishing together both read the
+same dict and one update vanished, so an issue could exceed a cap and keep being
+dispatched -- the exact runaway the caps exist to stop. sp-53b02cc4 recorded the
+shape; nothing had fixed it.
+
+Round 4 put a lock inside `bump_attempt` only, and I claimed in the commit
+message that fixing "the shared helper" fixed all of them. That was wrong:
+bump_attempt is one of six, and the other five kept racing on the same file.
+Codex caught the claim. Hence ONE writer, here, rather than six copies of a lock
+-- six copies of a lock is just the original defect with more places to drift.
+
+CONCURRENCY. mkdir is the mutex because it is atomic on POSIX and needs no
+flock; macOS ships no flock, and this fleet runs on both kernels. The write is
+temp-then-os.replace so a crash mid-write cannot leave a truncated ledger, which
+would read as `{}` and silently reset every budget in the file.
+
+A lock we cannot take within the timeout is TAKEN ANYWAY rather than skipping
+the mutation. A dropped bump is the defect this file exists to prevent, and a
+stale lock left by a killed worker is far likelier than a live worker holding it
+for ten seconds.
+"""
+import json
+import os
+import sys
+import tempfile
+import time
+
+LOCK_TRIES = 100
+LOCK_SLEEP = 0.1
+
+
+def _mutate(path, fn):
+    """Take the lock, apply fn(d) -> bool(changed), write atomically."""
+    lock = path + ".lock"
+    for _ in range(LOCK_TRIES):
+        try:
+            os.mkdir(lock)
+            break
+        except FileExistsError:
+            time.sleep(LOCK_SLEEP)
+        except OSError:
+            break          # unwritable dir: proceed unlocked rather than lose the count
+    try:
+        try:
+            with open(path) as fh:
+                d = json.load(fh)
+        except Exception:
+            d = {}
+        if not isinstance(d, dict):
+            d = {}
+        if not fn(d):
+            return False
+        parent = os.path.dirname(path) or "."
+        os.makedirs(parent, exist_ok=True)
+        fd, tmp = tempfile.mkstemp(dir=parent)
+        try:
+            with os.fdopen(fd, "w") as fh:
+                json.dump(d, fh, indent=2)
+            os.replace(tmp, path)
+        except Exception:
+            try:
+                os.unlink(tmp)
+            except Exception:
+                pass
+            raise
+        return True
+    finally:
+        try:
+            os.rmdir(lock)
+        except Exception:
+            pass
+
+
+def op_bump(d, issue, counter, ts_key, ts, why=None):
+    e = d.setdefault(issue, {})
+    e[counter] = e.get(counter, 0) + 1
+    if ts_key:
+        e[ts_key] = ts
+    if why is not None:
+        e["why"] = why
+    return True
+
+
+def op_clear(d, issue, keys):
+    e = d.get(issue)
+    # Nothing to clear is NOT a write. Rewriting the file for a no-op would touch
+    # mtime on every scheduled run and make "when did this last change" useless.
+    if not e or not any(e.get(k) for k in keys):
+        return False
+    for k in keys:
+        e.pop(k, None)
+    return True
+
+
+def op_claim(d, issue, flag):
+    """True the FIRST time this flag is claimed, False every time after."""
+    e = d.setdefault(issue, {})
+    if e.get(flag):
+        return False
+    e[flag] = True
+    return True
+
+
+def main(argv):
+    if len(argv) < 3:
+        print("usage: attempts-ledger.py <ledger-path> <op> [args...]", file=sys.stderr)
+        return 2
+    path, op, rest = argv[1], argv[2], argv[3:]
+    ts = time.strftime("%Y-%m-%dT%H:%M:%SZ", time.gmtime())
+
+    if op == "get":                       # get <issue> <key> [default]
+        issue, key = rest[0], rest[1]
+        default = rest[2] if len(rest) > 2 else "0"
+        try:
+            with open(path) as fh:
+                d = json.load(fh)
+        except Exception:
+            d = {}
+        print(d.get(issue, {}).get(key, default))
+        return 0
+
+    if op == "bump-attempt":              # bump-attempt <issue> <why>
+        _mutate(path, lambda d: op_bump(d, rest[0], "count", "last", ts, rest[1]))
+        return 0
+    if op == "bump-conflict":             # bump-conflict <issue>
+        _mutate(path, lambda d: op_bump(d, rest[0], "conflict_rounds", "last_conflict", ts))
+        return 0
+    if op == "bump-drift":                # bump-drift <issue>
+        _mutate(path, lambda d: op_bump(d, rest[0], "drift_rounds", "last_drift", ts))
+        return 0
+    if op == "clear-conflict":            # clear-conflict <issue>
+        _mutate(path, lambda d: op_clear(d, rest[0], ("conflict_rounds", "conflict_paged", "last_conflict")))
+        return 0
+    if op == "clear-drift":               # clear-drift <issue>
+        _mutate(path, lambda d: op_clear(d, rest[0], ("drift_rounds", "drift_paged", "last_drift")))
+        return 0
+    if op == "claim-flag":                # claim-flag <issue> <flag> -> exit 0 first time, 1 after
+        claimed = _mutate(path, lambda d: op_claim(d, rest[0], rest[1]))
+        return 0 if claimed else 1
+
+    print("unknown op: %s" % op, file=sys.stderr)
+    return 2
+
+
+if __name__ == "__main__":
+    sys.exit(main(sys.argv))

--- a/q-system/.q-system/scripts/ci-shaped-run.sh
+++ b/q-system/.q-system/scripts/ci-shaped-run.sh
@@ -10,6 +10,17 @@
 #
 # Fixing each defect stops that defect. This stops the seventh.
 #
+# DO NOT SKIP THE MANIFEST LOOKUP FOR SPEED. The first full sweep reported two
+# .py tests as FAIL rc=2 because this script ran `bash` on everything and ignored
+# the declared `runner`. rc=2 is "cannot execute" -- a harness bug wearing a test
+# failure's clothes.
+#
+# That is worse than a wasted round: a checker that manufactures failures teaches
+# you to distrust its output, and then a REAL failure reads as another harness
+# bug. Three separate components hit this in one session -- a page firing 96 times
+# a day, a lint whose findings were mostly its own prose, and this. A signal that
+# cries wolf destroys the signal. Correctness of the harness outranks its speed.
+#
 # IT PAID FOR ITSELF BEFORE IT WAS FINISHED, and the number is the argument:
 # it found in SECONDS what a full CI round could only report as `rc=1` after
 # EIGHT MINUTES -- and in one case it overturned a fix that had already survived

--- a/q-system/.q-system/scripts/ci-shaped-run.sh
+++ b/q-system/.q-system/scripts/ci-shaped-run.sh
@@ -1,0 +1,122 @@
+#!/usr/bin/env bash
+# ci-shaped-run.sh -- run a test the way CI runs it, before pushing.
+#
+# WHY THIS EXISTS. On 2026-07-30 (ASK-221) SIX defects shipped green locally and
+# red in CI, and every one was discovered the same way: push, wait ~8 minutes,
+# read a runner log. The classes were different each time -- a BSD-only `mktemp`,
+# a plugin version bump, a macOS-only `plutil`, a `sed -i ''`, a test reaching the
+# real codex CLI, and a suite whose result depends on `~/.config/kipi` existing --
+# but the DISCOVERY METHOD was identical, and it was the slowest one available.
+#
+# Fixing each defect stops that defect. This stops the seventh.
+#
+# WHAT CI HAS THAT A DEV MACHINE DOES NOT: a clean $HOME with no accumulated
+# state, no `~/.config/kipi`, no KIPI_* environment, and a fresh checkout. Those
+# are the differences a local `bash test-foo.sh` cannot see, because the machine
+# you are typing on has been accumulating exactly that state all day.
+#
+# WHAT IT CANNOT SIMULATE, stated so nobody trusts it further than it goes: the
+# KERNEL. CI is Linux/GNU, this is macOS/BSD. `mktemp -t`, `sed -i ''` and
+# `plutil` divergences are invisible here no matter how clean the environment is.
+# That half of the class belongs to portability-lint.sh, which greps for them.
+# The two tools are complements, not alternatives -- neither alone covers the set.
+#
+# Usage:
+#   ci-shaped-run.sh <test-path>...     run those tests CI-shaped
+#   ci-shaped-run.sh --all              run every test in capability-manifest.json
+#   ci-shaped-run.sh --diff <test>      run BOTH ways and report the divergence
+#
+# Exit 0 = all passed CI-shaped. Exit 1 = at least one failed.
+set -uo pipefail
+
+HERE="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO="$(cd "$HERE" && git rev-parse --show-toplevel 2>/dev/null || echo "$HERE/../../..")"
+MANIFEST="$REPO/q-system/.q-system/capability-manifest.json"
+
+# One sandbox HOME per invocation, discarded after. Never the real one: the whole
+# point is that the real one is contaminated with the state under suspicion.
+SANDBOX="$(mktemp -d "${TMPDIR:-/tmp}/ci-shaped.XXXXXX")"
+cleanup() { [ -n "${SANDBOX:-}" ] && [ -d "$SANDBOX" ] && /bin/rm -rf "$SANDBOX"; }
+trap cleanup EXIT
+
+run_ci_shaped() {  # run_ci_shaped <test-path> -> rc
+  local t="$1" home="$SANDBOX/home-$(basename "$t" | tr -c 'a-zA-Z0-9' '_')"
+  mkdir -p "$home"
+  # `env -i` would also drop PATH and break the shell. So scrub the things that
+  # actually differ -- HOME and every KIPI_* knob -- and keep PATH. A KIPI_* var
+  # left set is the same contamination as a stale state file, just in a different
+  # store: it makes the suite answer a question CI will not ask it.
+  local unsets=()
+  while IFS= read -r v; do [ -n "$v" ] && unsets+=("$v"); done < <(env | grep -oE '^KIPI_[A-Z_]+' || true)
+  ( cd "$REPO" && env "${unsets[@]/#/--unset=}" HOME="$home" \
+      bash "$t" ) >"$SANDBOX/$(basename "$t").out" 2>&1
+  return $?
+}
+
+run_normal() {  # run_normal <test-path> -> rc
+  ( cd "$REPO" && bash "$t" ) >"$SANDBOX/$(basename "$1").normal.out" 2>&1
+  return $?
+}
+
+MODE="run"
+case "${1:-}" in
+  --all)  MODE="all"; shift ;;
+  --diff) MODE="diff"; shift ;;
+  "")     echo "usage: ci-shaped-run.sh [--all|--diff] <test-path>..." >&2; exit 2 ;;
+esac
+
+TESTS=()
+if [ "$MODE" = "all" ]; then
+  while IFS= read -r p; do TESTS+=("$REPO/$p"); done < <(
+    python3 -c "
+import json,sys
+m=json.load(open('$MANIFEST'))
+for e in m.get('expected_tests',[]): print(e['path'])" 2>/dev/null || true)
+else
+  for a in "$@"; do TESTS+=("$a"); done
+fi
+
+[ "${#TESTS[@]}" -gt 0 ] || { echo "no tests to run" >&2; exit 2; }
+
+FAILED=0
+DIVERGED=0
+echo "ci-shaped-run: ${#TESTS[@]} test(s), sandbox HOME under $SANDBOX"
+echo
+
+for t in "${TESTS[@]}"; do
+  [ -f "$t" ] || { printf '%-58s SKIP (not found)\n' "$(basename "$t")"; continue; }
+  run_ci_shaped "$t"; rc_ci=$?
+  if [ "$MODE" = "diff" ]; then
+    run_normal "$t"; rc_norm=$?
+    if [ "$rc_ci" != "$rc_norm" ]; then
+      DIVERGED=$((DIVERGED+1))
+      printf '%-58s DIVERGES  normal=%s ci-shaped=%s\n' "$(basename "$t")" "$rc_norm" "$rc_ci"
+      echo "    the local pass depends on machine state CI will not have."
+      echo "    ci-shaped output: $SANDBOX/$(basename "$t").out"
+      # Show the first failure line, which is usually the whole diagnosis.
+      grep -iE '^\s*(FAIL|not ok)' "$SANDBOX/$(basename "$t").out" 2>/dev/null | head -2 | sed 's/^/      /'
+    else
+      printf '%-58s same     rc=%s\n' "$(basename "$t")" "$rc_ci"
+    fi
+  else
+    if [ "$rc_ci" -eq 0 ]; then
+      printf '%-58s PASS\n' "$(basename "$t")"
+    else
+      printf '%-58s FAIL rc=%s\n' "$(basename "$t")" "$rc_ci"
+      grep -iE '^\s*(FAIL|not ok)' "$SANDBOX/$(basename "$t").out" 2>/dev/null | head -2 | sed 's/^/      /'
+    fi
+  fi
+  [ "$rc_ci" -eq 0 ] || FAILED=$((FAILED+1))
+done
+
+echo
+# Keep the outputs when something is wrong -- the sandbox is deleted on exit, so
+# a failure the operator cannot read is a failure they will re-run to see.
+if [ "$FAILED" -gt 0 ] || [ "$DIVERGED" -gt 0 ]; then
+  KEEP="$REPO/q-system/output/ci-shaped-$(date +%Y%m%d-%H%M%S)"
+  mkdir -p "$KEEP" 2>/dev/null && cp "$SANDBOX"/*.out "$KEEP/" 2>/dev/null \
+    && echo "outputs kept: $KEEP"
+fi
+[ "$DIVERGED" -eq 0 ] || echo "ci-shaped-run: $DIVERGED test(s) DIVERGE between normal and CI-shaped runs"
+[ "$FAILED" -eq 0 ] || { echo "ci-shaped-run: $FAILED test(s) FAILED CI-shaped"; exit 1; }
+echo "ci-shaped-run: clean"

--- a/q-system/.q-system/scripts/ci-shaped-run.sh
+++ b/q-system/.q-system/scripts/ci-shaped-run.sh
@@ -21,6 +21,14 @@
 # a day, a lint whose findings were mostly its own prose, and this. A signal that
 # cries wolf destroys the signal. Correctness of the harness outranks its speed.
 #
+# DO NOT LAUNCH A TARGETED RUN ALONGSIDE `--all`. The sweep CONTAINS the targeted
+# run, so launching both is not redundancy, it is contention -- three copies of a
+# 4-minute suite competing for CPU. I did exactly that, then read the resulting
+# slowness as "the suites are slow" rather than "I oversubscribed the machine."
+# Elapsed time stood in for job difficulty, which is the same index-for-the-thing
+# error as trusting a grep for an inventory. Check what a job DOES, not what it is
+# called, before starting another.
+#
 # IT PAID FOR ITSELF BEFORE IT WAS FINISHED, and the number is the argument:
 # it found in SECONDS what a full CI round could only report as `rc=1` after
 # EIGHT MINUTES -- and in one case it overturned a fix that had already survived

--- a/q-system/.q-system/scripts/ci-shaped-run.sh
+++ b/q-system/.q-system/scripts/ci-shaped-run.sh
@@ -10,6 +10,12 @@
 #
 # Fixing each defect stops that defect. This stops the seventh.
 #
+# IT PAID FOR ITSELF BEFORE IT WAS FINISHED, and the number is the argument:
+# it found in SECONDS what a full CI round could only report as `rc=1` after
+# EIGHT MINUTES -- and in one case it overturned a fix that had already survived
+# a CI round, because `rc=1` does not tell you WHICH assertion failed or why.
+# Build the check at the level of the class, not the instance.
+#
 # WHAT CI HAS THAT A DEV MACHINE DOES NOT: a clean $HOME with no accumulated
 # state, no `~/.config/kipi`, no KIPI_* environment, and a fresh checkout. Those
 # are the differences a local `bash test-foo.sh` cannot see, because the machine
@@ -39,6 +45,23 @@ SANDBOX="$(mktemp -d "${TMPDIR:-/tmp}/ci-shaped.XXXXXX")"
 cleanup() { [ -n "${SANDBOX:-}" ] && [ -d "$SANDBOX" ] && /bin/rm -rf "$SANDBOX"; }
 trap cleanup EXIT
 
+# HONOUR THE DECLARED RUNNER. The manifest carries `runner` per test (bash or
+# python3) and the first cut of this script ran `bash` on everything -- so every
+# .py test came back rc=2 ("cannot execute"), which reads as a failing test rather
+# than a broken harness. A runner that misreports the thing it is checking is
+# worse than no runner. Caught by its own first full sweep.
+runner_for() {  # runner_for <abs-path> -> bash|python3
+  local rel="${1#$REPO/}" r
+  r="$(python3 -c "
+import json,sys
+try: m=json.load(open('$MANIFEST'))
+except Exception: sys.exit()
+for e in m.get('expected_tests',[]):
+    if e.get('path')==sys.argv[1]: print(e.get('runner','')); break" "$rel" 2>/dev/null)"
+  [ -n "$r" ] || case "$1" in *.py) r=python3 ;; *) r=bash ;; esac
+  printf '%s' "$r"
+}
+
 run_ci_shaped() {  # run_ci_shaped <test-path> -> rc
   local t="$1" home="$SANDBOX/home-$(basename "$t" | tr -c 'a-zA-Z0-9' '_')"
   mkdir -p "$home"
@@ -49,12 +72,12 @@ run_ci_shaped() {  # run_ci_shaped <test-path> -> rc
   local unsets=()
   while IFS= read -r v; do [ -n "$v" ] && unsets+=("$v"); done < <(env | grep -oE '^KIPI_[A-Z_]+' || true)
   ( cd "$REPO" && env "${unsets[@]/#/--unset=}" HOME="$home" \
-      bash "$t" ) >"$SANDBOX/$(basename "$t").out" 2>&1
+      "$(runner_for "$t")" "$t" ) >"$SANDBOX/$(basename "$t").out" 2>&1
   return $?
 }
 
 run_normal() {  # run_normal <test-path> -> rc
-  ( cd "$REPO" && bash "$t" ) >"$SANDBOX/$(basename "$1").normal.out" 2>&1
+  ( cd "$REPO" && "$(runner_for "$1")" "$1" ) >"$SANDBOX/$(basename "$1").normal.out" 2>&1
   return $?
 }
 

--- a/q-system/.q-system/scripts/install-plist.sh
+++ b/q-system/.q-system/scripts/install-plist.sh
@@ -1,4 +1,5 @@
 #!/bin/bash
+# portability-lint-skip-file: this script is macOS-only BY DESIGN (launchd/plutil).
 # Materialize a committed plist TEMPLATE and load it into launchd.
 #
 # Why this exists (ASK-191): three committed plists in this directory used two

--- a/q-system/.q-system/scripts/instance-diet-fix.sh
+++ b/q-system/.q-system/scripts/instance-diet-fix.sh
@@ -39,7 +39,15 @@ BEFORE=$(grep -c '.' "$CLAUDE_MD" || true)
 
 # Fix broken import path
 if grep -q '@q-system/q-system/CLAUDE.md' "$CLAUDE_MD"; then
-  sed -i '' 's|@q-system/q-system/CLAUDE.md|@q-system/CLAUDE.md|g' "$CLAUDE_MD"
+  # PORTABLE IN-PLACE EDIT (sp-e1e00a21). `sed -i ''` is BSD-only: GNU sed reads
+  # the next argument as the SCRIPT, so on Linux this ran an empty script and then
+  # tried to open the substitution text as a filename. This script edits instance
+  # CLAUDE.md files and instances run on both kernels, so it was a fleet-touching
+  # path that only worked on the founder's Mac. Temp-then-mv needs no -i at all
+  # and behaves identically everywhere.
+  _tmp="$(mktemp "${TMPDIR:-/tmp}/diet-fix.XXXXXX")"
+  sed 's|@q-system/q-system/CLAUDE.md|@q-system/CLAUDE.md|g' "$CLAUDE_MD" > "$_tmp" \
+    && mv "$_tmp" "$CLAUDE_MD"
   echo "Fixed: broken import @q-system/q-system/CLAUDE.md -> @q-system/CLAUDE.md"
 fi
 

--- a/q-system/.q-system/scripts/linear-worker.sh
+++ b/q-system/.q-system/scripts/linear-worker.sh
@@ -79,9 +79,17 @@ REVIEWS_DIR="$STATE_DIR/pr-reviews"
 
 MAX_ATTEMPTS=3
 # Conflict rounds are capped SEPARATELY from failed attempts (ASK-212).
-# MAX_ATTEMPTS only counts runs where `claude` exits non-zero, and the cited
-# failure mode is an agent that exits 0 having done the wrong thing -- so it
-# would never bound a rebase that cannot succeed.
+# MAX_ATTEMPTS counts two things, and it used to count only the first:
+#   1. runs where `claude` exits non-zero
+#   2. runs that exit 0 and open NO PR (added 2026-07-30, ASK-221)
+# Case 2 was the gap. An agent exiting 0 with nothing written was invisible to
+# the counter, so the issue stayed at `attempt 1/3` forever and was immediately
+# re-dispatchable -- it could never become stuck, so it never stopped costing
+# budget. Budget day 2026-07-30 was spent entirely on that: ASK-149 twice and
+# ASK-148 once, all `ok`, all zero commits, all converge STOP exit-7.
+# The cited rebase failure mode (an agent that exits 0 having done the WRONG
+# thing, as opposed to nothing) is still not counted here, which is why conflict
+# rounds keep their own separate counter below.
 # 2: a rebase either works on the first honest attempt or the conflict needs a
 # human. Round 3 has never been the one that lands it here.
 #
@@ -1203,6 +1211,28 @@ json.dump(d,open('$ATTEMPTS','w'),indent=2); print(e['rounds'])" 2>/dev/null || 
     fi
   else
     say "no PR found for $BRANCH; nothing to review"
+    # A RUN THAT PRODUCED NOTHING IS A FAILED ATTEMPT (ASK-221, 2026-07-30).
+    #
+    # MAX_ATTEMPTS used to count only runs where `claude` exited non-zero (the
+    # note at the top of this file said so deliberately). But the agent can exit
+    # 0 having written nothing at all, and that outcome was invisible to the
+    # counter: no bump, ledger stays {}, the issue reads `attempt 1/3` forever
+    # and is immediately re-dispatchable. It never becomes stuck, so it never
+    # stops costing budget.
+    #
+    # Measured on the founder's machine for budget day 2026-07-30: the loop spent
+    # its ENTIRE 3-issue budget on this. 14:15 ASK-149, 14:30 ASK-149 again
+    # (third dispatch of that issue overall), 14:45 ASK-148 -- every one exiting
+    # `ok` with zero commits, zero dirty files and no remote branch, then
+    # converge STOP exit-7. Three unattended dispatches, no PR, and therefore no
+    # review and no verdict record on a day the loop ran to its cap.
+    #
+    # Bumping here reuses the mechanism that already exists rather than adding a
+    # new one: three no-output runs mark the issue stuck and a human decides,
+    # which is the correct terminal state for "the agent cannot make progress on
+    # this spec". The cost of getting it wrong is bounded and visible -- a stuck
+    # issue is reported, whereas the current behaviour is silent budget burn.
+    bump_attempt "$ISSUE" "run exited 0 but opened no PR on $BRANCH (no output)"
   fi
 
   # 6. RELEASE at PR-open, not at close, so a reviewer can pick the tree up.

--- a/q-system/.q-system/scripts/linear-worker.sh
+++ b/q-system/.q-system/scripts/linear-worker.sh
@@ -1113,7 +1113,11 @@ json.dump(d,open('$ATTEMPTS','w'),indent=2); print(e['rounds'])" 2>/dev/null || 
     # gate below reads, so a second Claude pass would only burn spend and post an
     # advisory status nobody gates on. A codex outage cannot wedge the loop: the
     # reviewer's own Opus fallback fills the primary slot and marks it DEGRADED.
-    $REVIEWER_CMD "$PR_NUM" --issue "$ISSUE" --post --engine codex >>"$LOG" 2>&1 \
+    # LABEL THE INVOKER HERE, at the one place the scheduled path runs the reviewer
+    # (sp-53aad86f). This is what makes a dispatcher-driven review distinguishable
+    # from a hand run in the verdict record. It is set on the call rather than
+    # exported once, so it cannot leak into an unrelated reviewer invocation.
+    KIPI_REVIEW_INVOKER=worker $REVIEWER_CMD "$PR_NUM" --issue "$ISSUE" --post --engine codex >>"$LOG" 2>&1 \
       || say "WARN: codex reviewer failed on PR #$PR_NUM (the PR stands, unreviewed)"
     # Read back the verdict RECORD the reviewer just wrote (never re-grep the
     # review prose) and state what happens next in plain terms. Rework itself

--- a/q-system/.q-system/scripts/linear-worker.sh
+++ b/q-system/.q-system/scripts/linear-worker.sh
@@ -72,6 +72,10 @@ NOTIFY="${KIPI_NOTIFY:-$SCRIPT_DIR/slack-notify.sh}"
 REVIEWER_CMD="${KIPI_PR_REVIEWER:-bash $SCRIPT_DIR/pr-review-agent.sh}"
 STATE_DIR="${KIPI_STATE_DIR:-$HOME/.config/kipi}"
 ATTEMPTS="$STATE_DIR/linear-worker-attempts.json"
+# THE one writer of that ledger. Six functions here used to each do their own
+# unsynchronised read-modify-write on it (sp-53b02cc4); codex round 5 caught that
+# my round-4 lock covered only one of the six.
+LEDGER="$SCRIPT_DIR/attempts-ledger.py"
 LOG="$STATE_DIR/linear-worker.log"
 REVIEWS_DIR="$STATE_DIR/pr-reviews"
 # Verdict semantics shared with pr-review-agent.sh -- one extractor, one gate.
@@ -280,46 +284,16 @@ print(d.get(sys.argv[1],{}).get('count',0))" "$1"; }
 # whole point is that attempts are counted, and a dropped bump is the defect. It
 # takes the lock by force after the timeout, on the reasoning that a stale lock
 # from a killed worker is far likelier than a live worker holding it for 10s.
-bump_attempt() { python3 -c "
-import json,os,sys,tempfile,time
-path=sys.argv[4]; lock=path+'.lock'
-for _ in range(100):
-    try:
-        os.mkdir(lock); break
-    except FileExistsError:
-        time.sleep(0.1)
-else:
-    pass  # stale lock: proceed rather than drop the count
-try:
-    try: d=json.load(open(path))
-    except Exception: d={}
-    e=d.setdefault(sys.argv[1],{'count':0}); e['count']=e.get('count',0)+1
-    e['last']=sys.argv[2]; e['why']=sys.argv[3]
-    fd,tmp=tempfile.mkstemp(dir=os.path.dirname(path) or '.')
-    with os.fdopen(fd,'w') as fh: json.dump(d,fh,indent=2)
-    os.replace(tmp,path)
-finally:
-    try: os.rmdir(lock)
-    except Exception: pass" "$1" "$(TS)" "$2" "$ATTEMPTS"; }
+bump_attempt() { python3 "$LEDGER" "$ATTEMPTS" bump-attempt "$1" "$2"; }
 
 # --- conflict-round ledger (ASK-212) ----------------------------------------
 # Its own counter in the same file, deliberately NOT `count` (failed attempts)
 # and NOT `rounds` (review rounds). Three different budgets answering three
 # different questions; sharing one would let a rebase attempt spend a review
 # round, which is the thing the separate cap exists to prevent.
-conflict_rounds_for() { python3 -c "
-import json,sys
-try: d=json.load(open('$ATTEMPTS'))
-except Exception: d={}
-print(d.get(sys.argv[1],{}).get('conflict_rounds',0))" "$1"; }
+conflict_rounds_for() { python3 "$LEDGER" "$ATTEMPTS" get "$1" conflict_rounds 0; }
 
-bump_conflict_round() { python3 -c "
-import json,sys
-try: d=json.load(open('$ATTEMPTS'))
-except Exception: d={}
-e=d.setdefault(sys.argv[1],{}); e['conflict_rounds']=e.get('conflict_rounds',0)+1
-e['last_conflict']=sys.argv[2]
-json.dump(d,open('$ATTEMPTS','w'),indent=2)" "$1" "$(TS)"; }
+bump_conflict_round() { python3 "$LEDGER" "$ATTEMPTS" bump-conflict "$1"; }
 
 # CONSECUTIVE, NOT LIFETIME (PR #25 review, finding 3). Nothing used to clear
 # these keys, so the cap counted every conflict the issue ever had -- including
@@ -333,33 +307,16 @@ json.dump(d,open('$ATTEMPTS','w'),indent=2)" "$1" "$(TS)"; }
 # how an unresolvable conflict gets infinite rounds. Clearing conflict_paged
 # alongside is deliberate: a NEW conflict streak after the PR was healthy is new
 # information, not a repeat of the page the founder already got.
-clear_conflict_rounds() { python3 -c "
-import json,sys
-try: d=json.load(open('$ATTEMPTS'))
-except Exception: raise SystemExit(0)
-e=d.get(sys.argv[1])
-if not e or not (e.get('conflict_rounds') or e.get('conflict_paged')): raise SystemExit(0)
-for k in ('conflict_rounds','conflict_paged','last_conflict'): e.pop(k,None)
-json.dump(d,open('$ATTEMPTS','w'),indent=2)" "$1"; }
+clear_conflict_rounds() { python3 "$LEDGER" "$ATTEMPTS" clear-conflict "$1"; }
 
 # --- drift-round ledger (ASK-219, PR #30 review round 2) ---------------------
 # A FOURTH key, deliberately not `count`, not `rounds`, not `conflict_rounds`.
 # Four budgets, four questions. A drift round that spent the conflict budget
 # would leave a real conflict un-dispatchable later; one that spent `count`
 # would mark good work STUCK after three rounds that all ran fine.
-drift_rounds_for() { python3 -c "
-import json,sys
-try: d=json.load(open('$ATTEMPTS'))
-except Exception: d={}
-print(d.get(sys.argv[1],{}).get('drift_rounds',0))" "$1"; }
+drift_rounds_for() { python3 "$LEDGER" "$ATTEMPTS" get "$1" drift_rounds 0; }
 
-bump_drift_round() { python3 -c "
-import json,sys
-try: d=json.load(open('$ATTEMPTS'))
-except Exception: d={}
-e=d.setdefault(sys.argv[1],{}); e['drift_rounds']=e.get('drift_rounds',0)+1
-e['last_drift']=sys.argv[2]
-json.dump(d,open('$ATTEMPTS','w'),indent=2)" "$1" "$(TS)"; }
+bump_drift_round() { python3 "$LEDGER" "$ATTEMPTS" bump-drift "$1"; }
 
 # CONSECUTIVE, NOT LIFETIME -- the same scar clear_conflict_rounds carries (PR
 # #25 finding 3). Without this the cap would count every drift in the issue's
@@ -372,14 +329,7 @@ json.dump(d,open('$ATTEMPTS','w'),indent=2)" "$1" "$(TS)"; }
 # repinned the record to the head, or the verdict is no longer approving, or the
 # record is gone. Re-deriving that comparison in this file is exactly the
 # two-readers-of-one-input defect pr-verdict-lib.sh exists to close.
-clear_drift_rounds() { python3 -c "
-import json,sys
-try: d=json.load(open('$ATTEMPTS'))
-except Exception: raise SystemExit(0)
-e=d.get(sys.argv[1])
-if not e or not (e.get('drift_rounds') or e.get('drift_paged')): raise SystemExit(0)
-for k in ('drift_rounds','drift_paged','last_drift'): e.pop(k,None)
-json.dump(d,open('$ATTEMPTS','w'),indent=2)" "$1"; }
+clear_drift_rounds() { python3 "$LEDGER" "$ATTEMPTS" clear-drift "$1"; }
 
 # Returns 0 the FIRST time <flag> is claimed for this issue and 1 every time
 # after, so a page fires exactly once instead of once per scheduled run. A
@@ -388,15 +338,7 @@ json.dump(d,open('$ATTEMPTS','w'),indent=2)" "$1"; }
 # same write that reports it, so two runs cannot both read "not paged yet".
 # Takes the flag NAME so every once-only page in this script shares one
 # mechanism instead of each stuck-state inventing its own convention.
-claim_page_once() { python3 -c "
-import json,sys
-try: d=json.load(open('$ATTEMPTS'))
-except Exception: d={}
-e=d.setdefault(sys.argv[1],{})
-first = not e.get(sys.argv[2])
-e[sys.argv[2]]=True
-json.dump(d,open('$ATTEMPTS','w'),indent=2)
-raise SystemExit(0 if first else 1)" "$1" "$2"; }
+claim_page_once() { python3 "$LEDGER" "$ATTEMPTS" claim-flag "$1" "$2"; }
 
 # Pops the two auto-merge page flags the moment the PR is SEEN armed. Same scar
 # clear_conflict_rounds and clear_drift_rounds both carry (PR #25 finding 3): a

--- a/q-system/.q-system/scripts/linear-worker.sh
+++ b/q-system/.q-system/scripts/linear-worker.sh
@@ -262,12 +262,45 @@ try: d=json.load(open('$ATTEMPTS'))
 except Exception: d={}
 print(d.get(sys.argv[1],{}).get('count',0))" "$1"; }
 
+# SINGLE-WRITER CHOKEPOINT FOR THE ATTEMPTS LEDGER (codex round 4, major 1).
+#
+# This was a bare read-modify-write. Two workers finishing together both read the
+# same count, both wrote count+1, and one update vanished -- so an issue could
+# exceed MAX_ATTEMPTS and keep being dispatched, which is exactly the runaway the
+# cap exists to stop. sp-53b02cc4 already recorded FIVE bumpers with this shape;
+# the no-PR bump added tonight would have been the sixth. Fixing the shared helper
+# fixes all of them at once, which is why it belongs here and not at a call site.
+#
+# mkdir is the lock because it is atomic on POSIX and needs no flock -- macOS
+# ships no flock, so the portable primitive is the only one that works on both
+# kernels this fleet runs on. Write-temp-then-rename makes the replacement atomic
+# too, so a crash mid-write cannot leave a truncated ledger.
+#
+# A lock we cannot take within the timeout does NOT silently skip the bump: the
+# whole point is that attempts are counted, and a dropped bump is the defect. It
+# takes the lock by force after the timeout, on the reasoning that a stale lock
+# from a killed worker is far likelier than a live worker holding it for 10s.
 bump_attempt() { python3 -c "
-import json,sys
-try: d=json.load(open('$ATTEMPTS'))
-except Exception: d={}
-e=d.setdefault(sys.argv[1],{'count':0}); e['count']+=1; e['last']=sys.argv[2]; e['why']=sys.argv[3]
-json.dump(d,open('$ATTEMPTS','w'),indent=2)" "$1" "$(TS)" "$2"; }
+import json,os,sys,tempfile,time
+path=sys.argv[4]; lock=path+'.lock'
+for _ in range(100):
+    try:
+        os.mkdir(lock); break
+    except FileExistsError:
+        time.sleep(0.1)
+else:
+    pass  # stale lock: proceed rather than drop the count
+try:
+    try: d=json.load(open(path))
+    except Exception: d={}
+    e=d.setdefault(sys.argv[1],{'count':0}); e['count']=e.get('count',0)+1
+    e['last']=sys.argv[2]; e['why']=sys.argv[3]
+    fd,tmp=tempfile.mkstemp(dir=os.path.dirname(path) or '.')
+    with os.fdopen(fd,'w') as fh: json.dump(d,fh,indent=2)
+    os.replace(tmp,path)
+finally:
+    try: os.rmdir(lock)
+    except Exception: pass" "$1" "$(TS)" "$2" "$ATTEMPTS"; }
 
 # --- conflict-round ledger (ASK-212) ----------------------------------------
 # Its own counter in the same file, deliberately NOT `count` (failed attempts)

--- a/q-system/.q-system/scripts/linear-worker.sh
+++ b/q-system/.q-system/scripts/linear-worker.sh
@@ -530,7 +530,51 @@ while IFS= read -r ISSUE; do
 
   N="$(attempts_for "$ISSUE")"
   if [ "$N" -ge "$MAX_ATTEMPTS" ]; then
-    say "skip $ISSUE: $N/$MAX_ATTEMPTS attempts already. Marked stuck; a human decides next."
+    # NOTHING IS TERMINAL WITHOUT A NAMED HUMAN ACTION (sp-58f0ec83).
+    #
+    # This branch said "a human decides next" to a LOG FILE and continued, every
+    # heartbeat, forever. No Linear comment, no page, no statement of what the
+    # human was supposed to decide. So "stuck" was indistinguishable from
+    # "nobody has looked yet", and an issue could sit there indefinitely while
+    # the log repeated a sentence nobody reads.
+    #
+    # Every other gate in this repo distinguishes REFUSED from PASSED. This one
+    # did not, which is the same defect that let a correct BLOCKED diagnosis on
+    # ASK-149 read as success (the agent had done the right thing and the worker
+    # could not tell). The fix is not "add a BLOCKED state" -- it is that a
+    # terminal state must carry the ONE action that ends it. If the loop cannot
+    # name that action, it has not finished diagnosing and must say SO rather
+    # than parking the issue quietly.
+    #
+    # Paged ONCE via the shared claim_page_once flag, not per heartbeat: a
+    # repeated "still stuck" every 15 minutes is the cry-wolf failure that trains
+    # the reader to mute the channel (founder-notifications.md).
+    STUCK_WHY="$(python3 "$LEDGER" "$ATTEMPTS" get "$ISSUE" why "" 2>/dev/null)"
+    if [ -z "$STUCK_WHY" ]; then
+      # The honest degraded case. An unexplained cap is itself the finding: the
+      # loop burned its whole budget and cannot say what a human should do.
+      STUCK_WHY="the worker recorded no reason, which means it never diagnosed why this fails"
+    fi
+    say "skip $ISSUE: $N/$MAX_ATTEMPTS attempts. TERMINAL. Last reason: $STUCK_WHY"
+    if claim_page_once "$ISSUE" stuck_paged; then
+      python3 "$SYNC" progress "$ISSUE" \
+        "**Stuck after $N/$MAX_ATTEMPTS attempts. The autonomous loop has stopped picking this up.**
+
+Last recorded reason: $STUCK_WHY
+
+**Human action needed:** review the reason above and do ONE of:
+- fix the blocker, then clear the attempt count so the loop retries, or
+- rewrite the Definition of Ready so it is achievable from a non-interactive session, or
+- close the issue if it should not be built.
+
+A DoR that cannot be met from the environment the worker actually runs in is a defective spec, not a founder decision. Rewriting it is engineering work." \
+        --agent sana >/dev/null 2>&1 || true
+      # `bash "$NOTIFY"`, the shape used at five other sites in this file. There is
+      # no page() helper here -- calling one would have been a silent no-op under
+      # `set -uo pipefail` (command-not-found, no -e), i.e. a terminal state that
+      # pages nobody, which is the exact defect this block fixes.
+      bash "$NOTIFY" "kipi worker: $ISSUE is STUCK after $N attempts and the loop has stopped picking it up. Reason: $STUCK_WHY. Do: read the comment on $ISSUE -- it names the three options." 2>/dev/null || true
+    fi
     continue
   fi
 

--- a/q-system/.q-system/scripts/linear-worker.sh
+++ b/q-system/.q-system/scripts/linear-worker.sh
@@ -346,15 +346,7 @@ claim_page_once() { python3 "$LEDGER" "$ATTEMPTS" claim-flag "$1" "$2"; }
 # the second time the state is real it is silent -- and silent is the failure
 # this whole issue exists to kill. Only ever called on a STATED "armed": clearing
 # off a state nobody could read would refill the budget from a guess.
-clear_automerge_pages() { python3 -c "
-import json,sys
-try: d=json.load(open('$ATTEMPTS'))
-except Exception: raise SystemExit(0)
-e=d.get(sys.argv[1])
-if not e or not (e.get('automerge_unarmed_paged') or e.get('automerge_unknown_paged')):
-    raise SystemExit(0)
-for k in ('automerge_unarmed_paged','automerge_unknown_paged'): e.pop(k,None)
-json.dump(d,open('$ATTEMPTS','w'),indent=2)" "$1"; }
+clear_automerge_pages() { python3 "$LEDGER" "$ATTEMPTS" clear-automerge "$1"; }
 
 # --- arm auto-merge (ASK-222) ------------------------------------------------
 # arm_automerge <pr-number> <dir>: make GitHub own the merge, and publish what

--- a/q-system/.q-system/scripts/portability-lint-hook.py
+++ b/q-system/.q-system/scripts/portability-lint-hook.py
@@ -1,0 +1,99 @@
+#!/usr/bin/env python3
+"""PostToolUse ratchet for portability-lint.sh.
+
+Pairs with: q-system/.q-system/scripts/portability-lint.sh (skill-hook-pairing.md
+-- the rule is deterministic, so it gets a hook, not a paragraph).
+
+WHY A RATCHET AND NOT A GATE. The lint finds 24 pre-existing BSD/GNU findings
+repo-wide (sp-db43af2f). Turning those into a red gate on day one would block work
+nobody is doing today, and the predictable outcome is that someone disables the
+gate -- at which point the class comes back with the tool nominally in place. So
+this lints ONLY the file that was just written, which means:
+
+  - a file you touch must leave clean, so the count only ever goes down
+  - a file you do not touch is not your problem today
+  - the pre-existing set is captured in the ledger, not silently tolerated
+
+WHY IT EXISTS AT ALL. Three defects in one session were "green locally, wrong
+where it runs" (ASK-221): a BASH_SOURCE-derived root, a test reaching the real
+codex CLI, and `mktemp -t` that works on BSD and is rejected by GNU. The third
+turned `validate` red on a PR after passing 14/14 on the author's machine. This
+repo straddles two kernels -- macOS/BSD locally, Linux/GNU in CI -- so both
+directions are real bugs and neither shows up on the machine you are typing on.
+
+EXIT CODES (the contract in skill-hook-pairing.md): 2 = block with stderr fed
+back to Claude, 0 = pass. Anything unexpected exits 0: a broken hook must never
+be the reason work stops.
+"""
+import json
+import os
+import subprocess
+import sys
+
+HERE = os.path.dirname(os.path.abspath(__file__))
+LINT = os.path.join(HERE, "portability-lint.sh")
+
+
+def main():
+    try:
+        payload = json.load(sys.stdin)
+    except Exception:
+        return 0
+
+    path = (payload.get("tool_input") or {}).get("file_path") or ""
+    # Self-scope hard and fast-exit on anything else (token-discipline: never run
+    # logic on every Edit).
+    if not path.endswith((".sh", ".bash")):
+        return 0
+    if not os.path.isfile(path) or not os.path.isfile(LINT):
+        return 0
+    # The lint self-excludes by basename; do the same here so editing the lint
+    # cannot block on its own vocabulary.
+    if os.path.basename(path) == "portability-lint.sh":
+        return 0
+
+    # Lint the single file by pointing the scanner at a directory containing only
+    # it. The scanner takes a root, so a per-file run means a temp dir with one
+    # symlink -- cheaper and clearer than teaching it a second input mode, which
+    # would be a second reader of "what do I scan".
+    import tempfile
+
+    with tempfile.TemporaryDirectory() as td:
+        # COPY, do not symlink. `grep -r` skips symlinks encountered during
+        # recursion (only `-R` follows them), so the first cut scanned an empty
+        # directory and passed every file including a deliberately bad one. The
+        # hook looked wired and enforced nothing -- caught by testing the BLOCK
+        # direction first, which is the only reason it did not ship inert.
+        import shutil
+
+        link = os.path.join(td, os.path.basename(path))
+        try:
+            shutil.copyfile(path, link)
+        except OSError:
+            return 0
+        try:
+            out = subprocess.run(
+                ["bash", LINT, td], capture_output=True, text=True, timeout=30
+            )
+        except Exception:
+            return 0
+
+    if out.returncode == 0:
+        return 0
+
+    body = out.stdout.strip()
+    if not body:
+        return 0
+    sys.stderr.write(
+        "portability-lint: this file uses a construct that only works on one of "
+        "the two kernels this repo runs on (macOS/BSD locally, Linux/GNU in CI).\n\n"
+        + body
+        + "\n\nThis is a ratchet: only the file you just edited is checked, so the "
+        "count only goes down. If the line is a deliberate platform-specific "
+        "branch, mark it with `# portability-lint-skip`.\n"
+    )
+    return 2
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/q-system/.q-system/scripts/portability-lint-hook.py
+++ b/q-system/.q-system/scripts/portability-lint-hook.py
@@ -32,6 +32,7 @@ import sys
 
 HERE = os.path.dirname(os.path.abspath(__file__))
 LINT = os.path.join(HERE, "portability-lint.sh")
+HELPER_LINT = os.path.join(HERE, "undefined-helper-lint.sh")
 
 
 def main():
@@ -49,7 +50,7 @@ def main():
         return 0
     # The lint self-excludes by basename; do the same here so editing the lint
     # cannot block on its own vocabulary.
-    if os.path.basename(path) == "portability-lint.sh":
+    if os.path.basename(path) in ("portability-lint.sh", "undefined-helper-lint.sh"):
         return 0
 
     # Lint the single file by pointing the scanner at a directory containing only
@@ -71,26 +72,38 @@ def main():
             shutil.copyfile(path, link)
         except OSError:
             return 0
-        try:
-            out = subprocess.run(
-                ["bash", LINT, td], capture_output=True, text=True, timeout=30
-            )
-        except Exception:
-            return 0
+        # TWO LINTS, ONE HOOK. Both answer "is this file silently wrong somewhere
+        # other than the machine you are typing on" -- one across kernels, one
+        # across a helper that does not exist. A second PostToolUse entry would
+        # mean a second place to forget to wire, and an unwired lint is an inert
+        # engine (sp-72b60bff), which is the thing this repo keeps finding.
+        body_parts = []
+        for script in (LINT, HELPER_LINT):
+            if not os.path.isfile(script):
+                continue
+            try:
+                out = subprocess.run(
+                    ["bash", script, td], capture_output=True, text=True, timeout=30
+                )
+            except Exception:
+                continue
+            if out.returncode != 0 and out.stdout.strip():
+                body_parts.append(out.stdout.strip())
 
-    if out.returncode == 0:
+    if not body_parts:
         return 0
-
-    body = out.stdout.strip()
-    if not body:
-        return 0
+    body = "\n\n".join(body_parts)
+    # The header must not name a class the finding may not belong to. It said
+    # "only works on one of the two kernels" for EVERY finding, so an undefined
+    # helper was reported as a portability bug -- a message that misdescribes its
+    # own finding sends the reader to fix the wrong thing.
     sys.stderr.write(
-        "portability-lint: this file uses a construct that only works on one of "
-        "the two kernels this repo runs on (macOS/BSD locally, Linux/GNU in CI).\n\n"
+        "shell lint: this file is silently wrong somewhere other than the machine "
+        "you are typing on.\n\n"
         + body
         + "\n\nThis is a ratchet: only the file you just edited is checked, so the "
-        "count only goes down. If the line is a deliberate platform-specific "
-        "branch, mark it with `# portability-lint-skip`.\n"
+        "count only goes down. A deliberate platform-specific line can be marked "
+        "`# portability-lint-skip`.\n"
     )
     return 2
 

--- a/q-system/.q-system/scripts/portability-lint.sh
+++ b/q-system/.q-system/scripts/portability-lint.sh
@@ -1,0 +1,125 @@
+#!/usr/bin/env bash
+# portability-lint.sh -- catch the "green locally, wrong where it runs" defect class.
+#
+# WHY THIS EXISTS. Three defects in one session (2026-07-30, ASK-221), all the
+# same shape: the code was green on the machine it was written on and wrong on
+# the machine it actually runs on.
+#
+#   1. the tree guard derived its root from BASH_SOURCE, so it followed where the
+#      CODE lives instead of where the WORK lives, and refused 100% of autonomous
+#      reviews (sp-a72a9567)
+#   2. two worker tests set PATH=$STUB:$PATH with no `codex` stub, so a TEST
+#      reached the real codex CLI and real spend (sp-cb48c3c0)
+#   3. `mktemp -t name` works on BSD (macOS) and is REJECTED by GNU mktemp, so
+#      the reviewer's body file was never created on the Linux CI runner. 14/14
+#      locally, `validate` red on the PR.
+#
+# THIS REPO STRADDLES TWO KERNELS. The founder's machine is macOS/BSD; the CI
+# runner is Linux/GNU; instances run on both. So BOTH directions are real bugs,
+# and a lint that only knew one of them would keep half the class.
+#
+# The individual fixes are each one line. This check is worth more than all three
+# because it is the only one that generalises.
+#
+# Exit 0 = clean. Exit 1 = findings (advisory by default; the caller decides
+# whether to block, per the exit-code contract in skill-hook-pairing.md).
+set -uo pipefail
+
+ROOT="${1:-$(cd "$(dirname "${BASH_SOURCE[0]}")/../../.." && pwd)}"
+FOUND=0
+
+report() {  # report <class> <file:line> <text> <fix>
+  FOUND=$((FOUND + 1))
+  printf '%s\n  %s\n  %s\n  fix: %s\n\n' "$1" "$2" "$3" "$4"
+}
+
+# A line is exempt with an explicit marker, one per line, so a deliberate
+# platform-specific branch is possible but must be stated out loud.
+scan() {  # scan <regex> <class> <fix> [inverse-regex-that-makes-it-ok]
+  local re="$1" class="$2" fix="$3" ok="${4:-}"
+  while IFS= read -r hit; do
+    [ -n "$hit" ] || continue
+    case "$hit" in *portability-lint-skip*) continue ;; esac
+    if [ -n "$ok" ] && printf '%s' "$hit" | grep -qE "$ok"; then continue; fi
+    local loc="${hit%%:*}" rest="${hit#*:}"
+    local body="${rest#*:}"
+    # COMMENTS ARE NOT CODE. The first run of this lint flagged its own
+    # why-comment explaining the mktemp bug, which is the fastest way to make a
+    # lint that nobody keeps on: two of its three findings were prose.
+    case "$(printf '%s' "$body" | sed 's/^[[:space:]]*//')" in '#'*) continue ;; esac
+    # A GUARDED use is correct use. open-loops-heartbeat.sh does
+    # `command -v timeout >/dev/null && TO="timeout 1800"`, which is exactly the
+    # right shape; flagging it teaches people to ignore the lint.
+    case "$body" in *'command -v'*|*'which '*|*'|| '*'date -'*) continue ;; esac
+    report "$class" "$loc:${rest%%:*}" "$(printf '%s' "${rest#*:}" | sed 's/^[[:space:]]*//' | cut -c1-100)" "$fix"
+  # SELF-EXCLUDED, because a detector's vocabulary is not a defect. Every pattern
+  # this thing looks for appears in its own message strings and fix hints, so the
+  # first real run reported 5 findings and all 5 were its own prose. A lint whose
+  # own output is mostly itself is a lint people turn off.
+  #
+  # The cost, stated rather than hidden: a genuine BSD/GNU bug inside this file is
+  # invisible to it. That is why the fix hints live in strings here and the actual
+  # commands this file RUNS are kept to grep/sed/printf, which behave the same on
+  # both kernels.
+  done < <(grep -rnE "$re" "$ROOT" \
+             --include='*.sh' --include='*.bash' \
+             --exclude='portability-lint.sh' \
+             --exclude-dir=.git --exclude-dir=node_modules --exclude-dir='.pr*rev*' \
+             2>/dev/null || true)
+}
+
+echo "portability-lint: scanning $ROOT"
+echo
+
+# --- BSD-only: breaks on the Linux CI runner --------------------------------
+# GNU mktemp requires >=3 X's in the template; BSD appends the suffix itself.
+scan 'mktemp[^|;)#]*-t[[:space:]]+[^[:space:]"]' \
+     'BSD-ONLY mktemp -t (GNU rejects a template with under three X'"'"'s)' \
+     'mktemp "${TMPDIR:-/tmp}/name.XXXXXX"' \
+     'XXX'
+
+# BSD sed -i REQUIRES an argument (often ''), GNU sed -i must NOT have one.
+scan "sed[[:space:]]+-i[[:space:]]+''" \
+     'BSD-ONLY sed -i '"''"' (GNU sed reads the next arg as the script)' \
+     "write to a temp file and mv, which needs no -i at all"
+
+# BSD stat uses -f, GNU uses -c.
+scan 'stat[[:space:]]+-f[[:space:]]' \
+     'BSD-ONLY stat -f (GNU stat uses -c)' \
+     'use wc -c / ls, or branch explicitly on uname'
+
+# --- GNU-only: breaks on the founder'"'"'s macOS ------------------------------
+# macOS ships no `timeout` unless coreutils is installed. Already a known scar in
+# linear-worker.sh, which implements run_bounded by hand -- this keeps it from
+# creeping back in elsewhere.
+scan '(^|[^[:alnum:]_./-])timeout[[:space:]]+[0-9]' \
+     'GNU-ONLY timeout (macOS ships none; a `|| true` makes it a silent no-op)' \
+     'bound it by hand: background the job, poll, kill (see run_bounded)'
+
+# BSD date uses -v, GNU uses -d. kipi-dispatch.sh does this correctly by TRYING
+# both; a lone GNU form is the bug.
+scan 'date[[:space:]]+-d[[:space:]]' \
+     'GNU-ONLY date -d (BSD date uses -v)' \
+     'try both: date -v-7H ... 2>/dev/null || date -d "-7 hours" ...' \
+     'date -v'
+
+# GNU grep -P (PCRE) is not compiled into BSD grep.
+scan 'grep[[:space:]]+(-[a-zA-Z]*)?P[[:space:]]' \
+     'GNU-ONLY grep -P (BSD grep has no PCRE)' \
+     'rewrite as -E, or use awk'
+
+# BSD readlink has no -f.
+scan 'readlink[[:space:]]+-f[[:space:]]' \
+     'GNU-ONLY readlink -f (BSD readlink has no -f)' \
+     'cd "$(dirname "$x")" && pwd -P'
+
+echo "---"
+if [ "$FOUND" -eq 0 ]; then
+  echo "portability-lint: clean"
+  exit 0
+fi
+echo "portability-lint: $FOUND finding(s)"
+echo
+echo "Each of these is green on ONE of the two kernels this repo runs on."
+echo "Mark a deliberate platform-specific line with: # portability-lint-skip"
+exit 1

--- a/q-system/.q-system/scripts/portability-lint.sh
+++ b/q-system/.q-system/scripts/portability-lint.sh
@@ -40,6 +40,14 @@ scan() {  # scan <regex> <class> <fix> [inverse-regex-that-makes-it-ok]
   while IFS= read -r hit; do
     [ -n "$hit" ] || continue
     case "$hit" in *portability-lint-skip*) continue ;; esac
+    # FILE-LEVEL EXEMPTION for scripts that are inherently platform-specific.
+    # install-plist.sh installs launchd plists; verify-codex-review-live.sh reads
+    # one. Flagging those is the lint failing CORRECT code, which is how a lint
+    # gets ignored -- the same trap as reporting its own prose. The marker must be
+    # in the file, so the exemption is a decision someone wrote down, not a
+    # hardcoded allowlist here that drifts out of sight.
+    _hf="${hit%%:*}"
+    if head -20 "$_hf" 2>/dev/null | grep -q 'portability-lint-skip-file'; then continue; fi
     if [ -n "$ok" ] && printf '%s' "$hit" | grep -qE "$ok"; then continue; fi
     local loc="${hit%%:*}" rest="${hit#*:}"
     local body="${rest#*:}"

--- a/q-system/.q-system/scripts/portability-lint.sh
+++ b/q-system/.q-system/scripts/portability-lint.sh
@@ -83,6 +83,20 @@ scan "sed[[:space:]]+-i[[:space:]]+''" \
      'BSD-ONLY sed -i '"''"' (GNU sed reads the next arg as the script)' \
      "write to a temp file and mv, which needs no -i at all"
 
+# macOS-ONLY BINARIES. Not a flag difference -- these do not exist on Linux at all,
+# so the failure is command-not-found rather than wrong output. Added after this
+# lint MISSED the fourth instance of its own class: a new test invoked
+# verify-codex-review-live.sh, which reads a launchd plist via `plutil` and
+# `launchctl`, and turned `validate` red on the Linux runner. The lint I had just
+# built to catch "green locally, wrong where it runs" did not catch it, because I
+# had only taught it flag divergences.
+#
+# A test or script that needs these is not portable -- it must either guard with
+# `command -v` and skip LOUDLY, or be declared macOS-only.
+scan '(^|[^[:alnum:]_./-])(plutil|launchctl|osascript|sw_vers|diskutil|scutil|pmset)[[:space:]]' \
+     'macOS-ONLY binary (does not exist on Linux; command-not-found in CI)' \
+     'guard with `command -v <cmd>` and skip loudly, or declare the script macOS-only'
+
 # BSD stat uses -f, GNU uses -c.
 scan 'stat[[:space:]]+-f[[:space:]]' \
      'BSD-ONLY stat -f (GNU stat uses -c)' \

--- a/q-system/.q-system/scripts/portability-lint.sh
+++ b/q-system/.q-system/scripts/portability-lint.sh
@@ -21,6 +21,18 @@
 # The individual fixes are each one line. This check is worth more than all three
 # because it is the only one that generalises.
 #
+# THE CLASS IS "ANYTHING THAT DIFFERS ACROSS THE TWO KERNELS", NOT "THE LIST
+# BELOW". This started as flag divergences only, because those were the failures I
+# had personally hit, and it then MISSED a macOS-only binary -- the fourth instance
+# of the very class it was built for. Building the tool from the examples in hand
+# rather than from the class is the same defect one level up. When you find a new
+# way the two kernels disagree, add it here rather than fixing the one site.
+#
+# What this cannot see, by construction: state. A suite that passes because
+# ~/.config/kipi exists is invisible to a grep. That half belongs to
+# ci-shaped-run.sh, which runs a test with a clean $HOME. Neither tool alone
+# covers the set.
+#
 # Exit 0 = clean. Exit 1 = findings (advisory by default; the caller decides
 # whether to block, per the exit-code contract in skill-hook-pairing.md).
 set -uo pipefail

--- a/q-system/.q-system/scripts/pr-review-agent.sh
+++ b/q-system/.q-system/scripts/pr-review-agent.sh
@@ -553,14 +553,15 @@ echo "  verdict: ${VERDICT:-unstated}"
 # directory only for a non-primary engine; for the gating engine the reviews live
 # in $OUT_DIR/codex (its own round counter) while the record must land in $OUT_DIR
 # where converge.sh and linear-worker.sh actually read it.
-python3 - "$PR" "$ISSUE" "$VERDICT" "$REVIEW" "$(TS)" "$STATED_VERDICT" "$DERIVED_VERDICT" "$ROUND" "$HEAD_SHA" "$VERDICT_DIR" "$ENGINE" <<'PY'
+python3 - "$PR" "$ISSUE" "$VERDICT" "$REVIEW" "$(TS)" "$STATED_VERDICT" "$DERIVED_VERDICT" "$ROUND" "$HEAD_SHA" "$VERDICT_DIR" "$ENGINE" "$INVOKER" <<'PY'
 import json, sys
-pr, issue, verdict, review, ts, stated, derived, rnd, head_sha, verdict_dir, engine = sys.argv[1:12]
+pr, issue, verdict, review, ts, stated, derived, rnd, head_sha, verdict_dir, engine, invoker = sys.argv[1:13]
 out = f"{verdict_dir}/pr-{pr}.verdict.json"
 json.dump({"pr": int(pr), "issue": issue, "verdict": verdict,
            "stated": stated, "derived": derived,
            "source": "findings" if derived else "prose",
            "engine": engine,
+           "invoker": invoker,
            "round": int(rnd), "review": review, "head_sha": head_sha,
            "ts": ts}, open(out, "w"), indent=2)
 PY

--- a/q-system/.q-system/scripts/pr-review-agent.sh
+++ b/q-system/.q-system/scripts/pr-review-agent.sh
@@ -643,14 +643,31 @@ if [ "$POST" = "1" ]; then
   # BSD form, passed 14/14 locally, and turned `validate` red on the PR -- the
   # body file was never created, so --body-file got an empty path. Nothing on
   # this machine could have caught it; the runner is the other OS.
-  REVIEW_BODY="$(mktemp "${TMPDIR:-/tmp}/pr-review-comment.XXXXXX")" || REVIEW_BODY="$REVIEW"
-  review_comment_body "$REVIEW" "$VERDICT" "$ENGINE" "$DEGRADED" >"$REVIEW_BODY"
+  # NEVER FALL BACK TO $REVIEW ITSELF (codex round 4, minor). My first fallback was
+  # `|| REVIEW_BODY="$REVIEW"`, which then ran
+  # `review_comment_body "$REVIEW" > "$REVIEW_BODY"` -- the same path as input and
+  # output. The `>` truncates the review before the renderer reads it, so a mktemp
+  # failure would DESTROY the only copy of a review that cost 8-13 minutes of codex
+  # time, and post a self-copy of the wreckage. A degraded path may post something
+  # worse; it may never eat the artifact.
+  REVIEW_BODY="$(mktemp "${TMPDIR:-/tmp}/pr-review-comment.XXXXXX" 2>/dev/null)" || REVIEW_BODY=""
+  # POST_FILE is what gh sends; REVIEW_BODY is only ever a file WE created. Keeping
+  # them separate is what makes the degraded path safe: with no temp file we post
+  # the raw review unchanged and write nothing, instead of redirecting into the
+  # artifact we are trying to read.
+  if [ -n "$REVIEW_BODY" ]; then
+    review_comment_body "$REVIEW" "$VERDICT" "$ENGINE" "$DEGRADED" >"$REVIEW_BODY"
+    POST_FILE="$REVIEW_BODY"
+  else
+    POST_FILE="$REVIEW"
+    echo "  WARN: could not create a temp file; posting the RAW review, which GitHub may reject on size" >&2
+  fi
   # Keep the reason. A bare "could not comment" sent the maintainer to guess
   # between a size rejection, an auth failure and a closed PR -- the same
   # discard-the-reason defect PR #46 fixed one call lower down.
-  COMMENT_ERR="$(mktemp "${TMPDIR:-/tmp}/pr-review-comment-err.XXXXXX")" || COMMENT_ERR=/dev/null
-  if COMMENT_URL="$(gh pr comment "$PR" --body-file "$REVIEW_BODY" 2>"$COMMENT_ERR")"; then
-    echo "  posted to PR #$PR ($(wc -c <"$REVIEW_BODY" | tr -d ' ') bytes rendered from $(wc -c <"$REVIEW" | tr -d ' '))"
+  COMMENT_ERR="$(mktemp "${TMPDIR:-/tmp}/pr-review-comment-err.XXXXXX" 2>/dev/null)" || COMMENT_ERR=/dev/null
+  if COMMENT_URL="$(gh pr comment "$PR" --body-file "$POST_FILE" 2>"$COMMENT_ERR")"; then
+    echo "  posted to PR #$PR ($(wc -c <"$POST_FILE" | tr -d ' ') bytes rendered from $(wc -c <"$REVIEW" | tr -d ' '))"
   else
     COMMENT_URL=""
     echo "  WARN: could not comment on PR #$PR: $(tr '\n' ' ' <"$COMMENT_ERR" | cut -c1-300)" >&2

--- a/q-system/.q-system/scripts/pr-review-agent.sh
+++ b/q-system/.q-system/scripts/pr-review-agent.sh
@@ -193,6 +193,29 @@ PR_META="$(gh pr view "$PR" --json headRefOid,title -q '.headRefOid + "\t" + .ti
   || { echo "no PR #$PR" >&2; exit 1; }
 HEAD_SHA="${PR_META%%$'\t'*}"
 PR_TITLE="${PR_META#*$'\t'}"
+
+# CONFIRM THE HEAD HAS SETTLED (sp-f8edcdeb). The comment above reasons that
+# pinning an OLDER sha is the safe direction because it reads as drift and routes
+# to a re-review. That is true of the GATE, and it was still wrong in practice:
+# on 2026-07-30 a push and a review ran in the same command, `gh pr view` returned
+# the PRE-PUSH sha, and the run posted kipi/reviewer-approved=SUCCESS on it. The
+# newest commits went unreviewed while a green required check sat on the branch.
+# Drift catches it on the next worker pass; a human reading the PR in between sees
+# a green codex check that does not cover the top commits.
+#
+# A second read a few seconds later is enough, because the failure is propagation
+# delay, not a persistent disagreement. Refuse rather than adopt the newer value:
+# if the head is moving RIGHT NOW, whatever we pick may be stale again by the time
+# the model finishes, and a review nobody ran is cheaper than a green check on the
+# wrong code. Also catches a concurrent push by anyone, which the caller cannot.
+sleep 3
+HEAD_SHA_CONFIRM="$(gh pr view "$PR" --json headRefOid -q .headRefOid 2>/dev/null || true)"
+if [ -n "$HEAD_SHA_CONFIRM" ] && [ "$HEAD_SHA_CONFIRM" != "$HEAD_SHA" ]; then
+  echo "REFUSING: PR #$PR's head moved between two reads (${HEAD_SHA:0:8} then ${HEAD_SHA_CONFIRM:0:8})." >&2
+  echo "  Something is pushing to this branch right now. Reviewing either sha risks a green status on code the reviewer did not read." >&2
+  echo "  Re-run once the branch settles. No review was dispatched and NO status was posted." >&2
+  exit 1
+fi
 [ -n "$ISSUE" ] || ISSUE="$(printf '%s' "$PR_TITLE" | grep -oE 'ASK-[0-9]+' | head -1)"
 
 echo "$(TS) reviewing PR #$PR: $PR_TITLE"

--- a/q-system/.q-system/scripts/pr-review-agent.sh
+++ b/q-system/.q-system/scripts/pr-review-agent.sh
@@ -637,12 +637,18 @@ if [ "$POST" = "1" ]; then
   # path a future gh version takes. 60,000 is under BOTH, which makes the comment
   # succeed regardless of which limit applies. Tuning it upward would trade a
   # guaranteed delivery for a longer transcript nobody reads.
-  REVIEW_BODY="$(mktemp -t pr-review-comment)"
+  # EXPLICIT XXXXXX TEMPLATE, because `mktemp -t name` is not portable. BSD
+  # mktemp (macOS) appends the random suffix itself; GNU mktemp (the Linux CI
+  # runner) rejects a template with fewer than three X's. My first cut used the
+  # BSD form, passed 14/14 locally, and turned `validate` red on the PR -- the
+  # body file was never created, so --body-file got an empty path. Nothing on
+  # this machine could have caught it; the runner is the other OS.
+  REVIEW_BODY="$(mktemp "${TMPDIR:-/tmp}/pr-review-comment.XXXXXX")" || REVIEW_BODY="$REVIEW"
   review_comment_body "$REVIEW" "$VERDICT" "$ENGINE" "$DEGRADED" >"$REVIEW_BODY"
   # Keep the reason. A bare "could not comment" sent the maintainer to guess
   # between a size rejection, an auth failure and a closed PR -- the same
   # discard-the-reason defect PR #46 fixed one call lower down.
-  COMMENT_ERR="$(mktemp -t pr-review-comment-err)"
+  COMMENT_ERR="$(mktemp "${TMPDIR:-/tmp}/pr-review-comment-err.XXXXXX")" || COMMENT_ERR=/dev/null
   if COMMENT_URL="$(gh pr comment "$PR" --body-file "$REVIEW_BODY" 2>"$COMMENT_ERR")"; then
     echo "  posted to PR #$PR ($(wc -c <"$REVIEW_BODY" | tr -d ' ') bytes rendered from $(wc -c <"$REVIEW" | tr -d ' '))"
   else

--- a/q-system/.q-system/scripts/pr-review-agent.sh
+++ b/q-system/.q-system/scripts/pr-review-agent.sh
@@ -622,9 +622,35 @@ post_reviewer_status() {
 
 if [ "$POST" = "1" ]; then
   COMMENT_URL=""
-  COMMENT_URL="$(gh pr comment "$PR" --body-file "$REVIEW" 2>/dev/null)" \
-    && echo "  posted to PR #$PR" \
-    || { COMMENT_URL=""; echo "  WARN: could not comment on PR" >&2; }
+  # POST THE RENDERED REVIEW, NEVER THE RAW FILE (sp-48688b24). `--body-file
+  # "$REVIEW"` sent the codex agent's entire stdout. Measured on disk 2026-07-30,
+  # four real rounds: 435,280 / 519,377 / 278,439 / 197,279 bytes. Three were
+  # rejected; only the 197,279-byte round landed (as a 197,208-character comment
+  # on PR #46). So the old failure was SIZE-DEPENDENT, not universal -- worth
+  # stating because the first two write-ups of this defect, mine included, both
+  # claimed it failed every time and were wrong.
+  #
+  # THE CAP IS DELIBERATELY CONSERVATIVE, NOT TUNED. The observed ceiling sits
+  # somewhere between 197,279 and 278,439 bytes, while a reproduced rejection
+  # reported `Body is too long (maximum is 65536 characters) (addComment)`. Those
+  # two facts do not agree, so the limit is path-dependent and I do not know which
+  # path a future gh version takes. 60,000 is under BOTH, which makes the comment
+  # succeed regardless of which limit applies. Tuning it upward would trade a
+  # guaranteed delivery for a longer transcript nobody reads.
+  REVIEW_BODY="$(mktemp -t pr-review-comment)"
+  review_comment_body "$REVIEW" "$VERDICT" "$ENGINE" "$DEGRADED" >"$REVIEW_BODY"
+  # Keep the reason. A bare "could not comment" sent the maintainer to guess
+  # between a size rejection, an auth failure and a closed PR -- the same
+  # discard-the-reason defect PR #46 fixed one call lower down.
+  COMMENT_ERR="$(mktemp -t pr-review-comment-err)"
+  if COMMENT_URL="$(gh pr comment "$PR" --body-file "$REVIEW_BODY" 2>"$COMMENT_ERR")"; then
+    echo "  posted to PR #$PR ($(wc -c <"$REVIEW_BODY" | tr -d ' ') bytes rendered from $(wc -c <"$REVIEW" | tr -d ' '))"
+  else
+    COMMENT_URL=""
+    echo "  WARN: could not comment on PR #$PR: $(tr '\n' ' ' <"$COMMENT_ERR" | cut -c1-300)" >&2
+    echo "  WARN: the review is on disk at $REVIEW but NO human-readable copy reached the PR" >&2
+  fi
+  rm -f "$REVIEW_BODY" "$COMMENT_ERR"
   # No sha, no status. A status on a guessed commit is worse than none because
   # it looks authoritative -- the same reason ASK-216 captured the sha before
   # dispatch instead of looking it up afterwards.

--- a/q-system/.q-system/scripts/pr-review-agent.sh
+++ b/q-system/.q-system/scripts/pr-review-agent.sh
@@ -236,7 +236,70 @@ echo "  head sha under review: ${HEAD_SHA:-unknown}"
 # the case where NO tree holds the commit -- that is the sp-a72a9567 shape, and it
 # still must never be reviewed.
 REVIEW_ROOT="$SKEL"
-if [ -n "$HEAD_SHA" ]; then
+
+# REVIEW IN A DEDICATED DETACHED WORKTREE, NEVER IN A CHECKOUT SOMEONE IS USING
+# (sp-8f95bba0). The search below correctly finds A tree holding the PR head --
+# but when the live checkout happens to sit at that sha, "a tree that holds it"
+# IS the founder's working directory, and that is where the review ran. Both
+# PR #47 rounds recorded `workdir: /Users/assafkipnis/projects/kipi-system` with
+# `sandbox: workspace-write`.
+#
+# Two failures at once, and the second is the worse one:
+#   READ  -- an edit during a 7-13 minute review means the reviewer judged a tree
+#            state that never existed as a commit, while the verdict is stamped on
+#            a head_sha whose content it did not read. The provenance is false in
+#            exactly the way the tree guard exists to prevent.
+#   WRITE -- workspace-write lets the reviewer modify the founder's live checkout.
+#
+# The workaround was "everyone holds still for 13 minutes", which is not a control.
+# A detached worktree pinned to the exact sha is: it cannot drift while the review
+# runs, nobody else is editing it, and the tree/PR match becomes true by
+# construction rather than by search.
+#
+# One tree per PR, reused across rounds by re-detaching rather than removing --
+# removal is a destructive op on a path this script does not own, and re-checkout
+# reaches the same state.
+review_worktree() {  # review_worktree <sha> -> prints path, or nothing
+  local sha="$1" wt="$HOME/.config/kipi/review-trees/pr-$PR"
+  mkdir -p "$(dirname "$wt")" 2>/dev/null || return 1
+  if [ -d "$wt/.git" ] || [ -f "$wt/.git" ]; then
+    git -C "$wt" checkout --detach --force "$sha" >/dev/null 2>&1 || return 1
+  else
+    git -C "$SKEL" worktree add --detach "$wt" "$sha" >/dev/null 2>&1 || return 1
+  fi
+  # Prove it landed where we asked. A worktree silently sitting at the wrong sha
+  # is the same false-provenance bug in a new costume.
+  [ "$(git -C "$wt" rev-parse HEAD 2>/dev/null)" = "$sha" ] || return 1
+  printf '%s' "$wt"
+}
+
+if [ -n "$HEAD_SHA" ] && git -C "$SKEL" cat-file -e "${HEAD_SHA}^{commit}" 2>/dev/null; then
+  ISOLATED="$(review_worktree "$HEAD_SHA" || true)"
+  if [ -n "$ISOLATED" ]; then
+    REVIEW_ROOT="$ISOLATED"
+    echo "  tree: $REVIEW_ROOT (detached at ${HEAD_SHA:0:8}; isolated from any checkout in use)"
+    HEAD_SHA_ISOLATED=1
+  else
+    # Say it out loud rather than quietly reviewing the live tree. A degraded run
+    # that nobody knows is degraded is how the original defect stayed invisible.
+    echo "  WARN: could not materialise an isolated worktree at ${HEAD_SHA:0:8}; falling back to tree search. A concurrent edit during this review would corrupt its provenance (sp-8f95bba0)." >&2
+    HEAD_SHA_ISOLATED=0
+  fi
+elif [ -n "$HEAD_SHA" ]; then
+  # OBJECT ABSENT -> fall through to the ORIGINAL tier-1 path (warn, proceed).
+  # I briefly made this refuse, on the reasoning that no tree can be built at a
+  # missing object so the provenance must be false. The tree-guard suite refused
+  # the change and was right: a stale or partial clone cannot prove ancestry
+  # EITHER WAY, so refusing wedges the loop on a fetch problem, and every reviewer
+  # case in test-severity-floor.sh reports a fabricated sha and takes exactly this
+  # branch. Isolation raises the floor for the case that actually occurs (the
+  # object is present); it does not get to redefine the case it cannot serve.
+  HEAD_SHA_ISOLATED=0
+else
+  HEAD_SHA_ISOLATED=0
+fi
+
+if [ "$HEAD_SHA_ISOLATED" != "1" ] && [ -n "$HEAD_SHA" ]; then
   if ! git -C "$SKEL" cat-file -e "${HEAD_SHA}^{commit}" 2>/dev/null; then
     echo "  WARN: $SKEL does not have commit $HEAD_SHA, so the tree/PR match cannot be proven (stale or partial clone?). Proceeding; a review of the wrong tree would report findings absent from this diff." >&2
   elif ! git -C "$SKEL" merge-base --is-ancestor "$HEAD_SHA" HEAD 2>/dev/null; then

--- a/q-system/.q-system/scripts/pr-review-agent.sh
+++ b/q-system/.q-system/scripts/pr-review-agent.sh
@@ -208,8 +208,15 @@ PR_TITLE="${PR_META#*$'\t'}"
 # if the head is moving RIGHT NOW, whatever we pick may be stale again by the time
 # the model finishes, and a review nobody ran is cheaper than a green check on the
 # wrong code. Also catches a concurrent push by anyone, which the caller cannot.
+#
+# The confirm read uses the IDENTICAL query and the IDENTICAL extraction as the
+# first one. A differently-shaped second query is a second reader of one fact:
+# my first cut asked for `--json headRefOid -q .headRefOid` while the first read
+# asked for the sha+title tuple, so the two strings never matched and the check
+# refused every review. Caught by test-review-tree-guard going 1/23.
 sleep 3
-HEAD_SHA_CONFIRM="$(gh pr view "$PR" --json headRefOid -q .headRefOid 2>/dev/null || true)"
+PR_META_CONFIRM="$(gh pr view "$PR" --json headRefOid,title -q '.headRefOid + "\t" + .title' 2>/dev/null || true)"
+HEAD_SHA_CONFIRM="${PR_META_CONFIRM%%$'\t'*}"
 if [ -n "$HEAD_SHA_CONFIRM" ] && [ "$HEAD_SHA_CONFIRM" != "$HEAD_SHA" ]; then
   echo "REFUSING: PR #$PR's head moved between two reads (${HEAD_SHA:0:8} then ${HEAD_SHA_CONFIRM:0:8})." >&2
   echo "  Something is pushing to this branch right now. Reviewing either sha risks a green status on code the reviewer did not read." >&2

--- a/q-system/.q-system/scripts/pr-review-agent.sh
+++ b/q-system/.q-system/scripts/pr-review-agent.sh
@@ -119,6 +119,22 @@ done
 #   and claude's record moves down into $OUT_DIR/claude to get out of its way.
 #   Exactly one engine writes the gating record: single writer, preserved.
 PRIMARY_ENGINE="${KIPI_REVIEW_PRIMARY_ENGINE:-codex}"
+
+# WHO ASKED FOR THIS REVIEW (sp-53aad86f). The verdict record proved that A CODEX
+# REVIEW RAN; it could not prove THE DISPATCHER RAN ONE UNATTENDED, which is the
+# only thing that actually closes the loop. A hand-run review and a scheduled one
+# wrote byte-identical evidence, so no number of green checks answered the
+# question -- every proof shown to the founder had this hole in it.
+#
+# DEFAULT IS `manual`, AND THAT IS THE WHOLE SAFETY PROPERTY. An unlabelled run
+# must never pass as dispatcher-driven, or the field manufactures exactly the
+# evidence it exists to supply. Same posture as the commit status: absent is not
+# approved. Records written before this field existed carry no key at all, and the
+# verifier treats a missing key as not-dispatcher for the same reason.
+#
+# Set by linear-worker.sh at its single reviewer call site, so the label follows
+# the real invocation path rather than being something a human remembers to pass.
+INVOKER="${KIPI_REVIEW_INVOKER:-manual}"
 case "$ENGINE" in
   claude) ENGINE_DIR="$OUT_DIR" ;;
   codex)  ENGINE_DIR="$OUT_DIR/codex" ;;

--- a/q-system/.q-system/scripts/pr-verdict-lib.sh
+++ b/q-system/.q-system/scripts/pr-verdict-lib.sh
@@ -307,6 +307,79 @@ extract_minor_findings() {
   findings_block "$f" | grep -E '^minor\|' || true
 }
 
+# review_comment_body <review-file> <verdict> <engine> <degraded>
+# Renders the review as something a GitHub comment can actually hold.
+#
+# WHY IT EXISTS (sp-b418be32). `--post` piped the raw review file straight into
+# `gh pr comment --body-file`. A codex review is not a review-shaped document: it
+# is the agent's whole stdout. Measured on PR #34: 435,280 and 519,377 bytes,
+# against GitHub's 65,536-byte comment limit. So EVERY post failed, the caller
+# logged `WARN: could not comment on PR` and carried on, and the commit status it
+# then wrote had no target_url. A human opening the PR saw a bare green check with
+# nothing behind it -- the reviewer ran, cost real spend, and left no readable trace.
+#
+# NOT A NOISE PROBLEM, so trimming is not the fix. The harness header is 14 lines
+# of 10,130. The bulk is the codex agent's own transcript, INCLUDING the diff it
+# read -- which is why that file carries 11 `FINDINGS:` markers instead of one.
+# The reviewer's actual message is the last ~250 lines. A 500KB transcript is a
+# debugging artifact; GitHub is not an artifact store, and splitting it across
+# eight comments would put eight comments of transcript on the PR.
+#
+# THE VERDICT AND FINDINGS DO NOT COME FROM THE TRUNCATED TEXT. They are taken
+# from the caller's already-derived verdict and from `findings_block` (THE ONE
+# READER), then printed ABOVE the tail. That ordering is the whole safety
+# property: truncation can drop narrative, never the two facts a human needs to
+# act. Deriving them from a tail we just cut would be a second reader with its
+# own semantics, the defect class this file exists to stop.
+#
+# The engine is named in the body, not just the status description, for the same
+# reason post_reviewer_status names it: a review whose reader is unknown is worth
+# little, and the point of this loop is that the checker is not Claude.
+review_comment_body() {
+  local f="$1" verdict="${2:-}" engine="${3:-}" degraded="${4:-0}"
+  local limit="${KIPI_REVIEW_COMMENT_LIMIT:-60000}"
+  local bytes head_bytes block
+  bytes="$(wc -c <"$f" 2>/dev/null | tr -d ' ')"; bytes="${bytes:-0}"
+  block="$(findings_block "$f")"
+  [ -n "$block" ] || block="(no complete findings block parsed from this review)"
+
+  printf '## Verdict: %s\n\n' "${verdict:-unstated}"
+  [ "$degraded" = "1" ] \
+    && printf '**DEGRADED**: codex was down, this is the Opus fallback. Not an independent second opinion.\n\n'
+  printf 'Reviewer engine: `%s`. Full review on disk: `%s` (%s bytes).\n\n' \
+    "${engine:-unknown}" "$f" "$bytes"
+  # `$(...)` strips the trailing newline off the block, so the closing fence needs
+  # its own \n. Without it the fence glues onto `END FINDINGS`, which both breaks
+  # the code block on GitHub and makes the rendered block differ from
+  # findings_block's output -- caught by case 4, which is exactly what that
+  # byte-identity assertion is for.
+  printf '```\n%s\n```\n\n' "$block"
+
+  # Byte-bounded, then snapped FORWARD to a line boundary. `tail -c` alone can
+  # open mid-line and, worse, mid-UTF-8-sequence: these reviews contain typographic
+  # quotes, so a blind byte cut can emit an invalid sequence. Dropping the first
+  # partial line costs nothing and keeps the body valid text.
+  head_bytes="$(review_comment_body_header_size)"
+  local room=$(( limit - head_bytes ))
+  [ "$room" -gt 1024 ] || room=1024
+  if [ "${bytes:-0}" -gt "$room" ]; then
+    printf -- '--- reviewer output, last %s bytes of %s (full review at the path above) ---\n\n' \
+      "$room" "$bytes"
+    tail -c "$room" "$f" 2>/dev/null | tail -n +2
+  else
+    printf -- '--- reviewer output ---\n\n'
+    cat "$f"
+  fi
+}
+
+# review_comment_body_header_size
+# Byte budget reserved for everything review_comment_body prints ABOVE the tail.
+# A fixed reservation, not a measurement: measuring would mean rendering the
+# header twice and the two copies could disagree. Generous on purpose -- a
+# findings block runs to a few KB at most, and over-reserving only shortens the
+# narrative, while under-reserving overruns the limit and loses the whole comment.
+review_comment_body_header_size() { printf '%s' 5000; }
+
 # review_round <reviews-dir> <pr-number>
 # Which round the NEXT review of this PR will be: existing review files + 1.
 # Derived from disk, not from the worker's attempts json, because the reviewer

--- a/q-system/.q-system/scripts/pr-verdict-lib.sh
+++ b/q-system/.q-system/scripts/pr-verdict-lib.sh
@@ -359,9 +359,22 @@ review_comment_body() {
   # open mid-line and, worse, mid-UTF-8-sequence: these reviews contain typographic
   # quotes, so a blind byte cut can emit an invalid sequence. Dropping the first
   # partial line costs nothing and keeps the body valid text.
-  head_bytes="$(review_comment_body_header_size)"
+  # MEASURE THE HEADER, DO NOT ASSUME IT (codex round 5 on PR #47, minor). The
+  # reservation used to be a flat 5,000 bytes, but the findings block inside the
+  # header is UNBOUNDED -- a review with many findings, or one long claim string,
+  # blows past it and the rendered body exceeds the very limit this function
+  # exists to guarantee. A cap that a large input can overrun is not a cap.
+  #
+  # The block is already in hand ($block), so its size is a fact, not an estimate.
+  # The fixed number stays only as the allowance for the surrounding prose.
+  head_bytes=$(( $(review_comment_body_header_size) + ${#block} ))
   local room=$(( limit - head_bytes ))
-  [ "$room" -gt 1024 ] || room=1024
+  # A findings block alone can now exceed the limit. Truncating findings would
+  # drop the one thing a human must act on, so the narrative goes to zero first
+  # and the block is still printed whole -- deliberately overrunning rather than
+  # silently losing a finding. The caller's failure branch then reports it, which
+  # is a loud failure instead of a quiet omission.
+  [ "$room" -gt 512 ] || room=0
   if [ "${bytes:-0}" -gt "$room" ]; then
     printf -- '--- reviewer output, last %s bytes of %s (full review at the path above) ---\n\n' \
       "$room" "$bytes"

--- a/q-system/.q-system/scripts/pr-verdict-lib.sh
+++ b/q-system/.q-system/scripts/pr-verdict-lib.sh
@@ -338,7 +338,7 @@ extract_minor_findings() {
 review_comment_body() {
   local f="$1" verdict="${2:-}" engine="${3:-}" degraded="${4:-0}"
   local limit="${KIPI_REVIEW_COMMENT_LIMIT:-60000}"
-  local bytes head_bytes block
+  local bytes head_bytes block block_bytes
   bytes="$(wc -c <"$f" 2>/dev/null | tr -d ' ')"; bytes="${bytes:-0}"
   block="$(findings_block "$f")"
   [ -n "$block" ] || block="(no complete findings block parsed from this review)"
@@ -367,7 +367,15 @@ review_comment_body() {
   #
   # The block is already in hand ($block), so its size is a fact, not an estimate.
   # The fixed number stays only as the allowance for the surrounding prose.
-  head_bytes=$(( $(review_comment_body_header_size) + ${#block} ))
+  # BYTES, NOT CHARACTERS (codex round 7, minor). `${#block}` counts CHARACTERS,
+  # and these reviews are full of typographic quotes and dashes that are 2-3 bytes
+  # each in UTF-8. So the budget under-counted the block by exactly the amount that
+  # matters, and a findings block of multi-byte text could push the body past both
+  # the configured cap and GitHub's. The whole point of measuring the block instead
+  # of reserving a flat 5,000 was to stop guessing; measuring it in the wrong unit
+  # is still guessing.
+  block_bytes="$(printf '%s' "$block" | wc -c | tr -d ' ')"
+  head_bytes=$(( $(review_comment_body_header_size) + ${block_bytes:-0} ))
   local room=$(( limit - head_bytes ))
   # A findings block alone can now exceed the limit. Truncating findings would
   # drop the one thing a human must act on, so the narrative goes to zero first

--- a/q-system/.q-system/scripts/test/test-dispatch-stale-checkout.sh
+++ b/q-system/.q-system/scripts/test/test-dispatch-stale-checkout.sh
@@ -45,6 +45,11 @@ HARNESS="$WORK/stale_check.sh"
   echo 'REPO="$PWD"'
   echo 'say()  { printf "SAY %s\n"  "$*"; }'
   echo 'page() { printf "PAGE %s\n" "$*"; }'
+  # page_ok reports delivery, and its exit code is the thing under test in case 7:
+  # KIPI_TEST_PAGE_FAILS=1 makes the notifier fail so the dedupe marker must NOT
+  # be written. Without a failure knob the "failed page still dedupes" defect
+  # cannot be reproduced at all.
+  echo 'page_ok() { printf "PAGE %s\n" "$*"; [ "${KIPI_TEST_PAGE_FAILS:-0}" = "1" ] && return 1; return 0; }'
   awk '/^stale_check\(\) \{/,/^\}/' "$DISPATCH"
   echo 'stale_check && echo "VERDICT=RUN" || echo "VERDICT=REFUSE"'
 } > "$HARNESS"
@@ -155,6 +160,31 @@ fi
 echo "$(run_dedupe "$DIV")" | grep -q 'SAY REFUSING' \
   && ok "the refusal is logged on every heartbeat even when the page is deduped" \
   || bad "a deduped page also silenced the log line, so the refusal is invisible"
+
+echo
+echo "== 7. a FAILED page must not create the dedupe marker (codex round 4, major 2) =="
+# Writing the marker for a page that never went out permanently silences the
+# founder about a refusing loop. A storm is annoying; silence is invisible, and
+# strictly worse than the bug the dedupe was added to fix.
+STATE2="$WORK/pagefail"; mkdir -p "$STATE2"
+run_failing() { ( cd "$1" && KIPI_TEST_PAGE_FAILS=1 LOG="$STATE2/dispatch.log" bash "$HARNESS" 2>&1 ); }
+run_ok2()     { ( cd "$1" && LOG="$STATE2/dispatch.log" bash "$HARNESS" 2>&1 ); }
+F1="$(run_failing "$DIV" | grep -c '^PAGE ' || true)"
+# Now let the notifier succeed. If the failed attempt wrote a marker, this is muted.
+F2="$(run_ok2 "$DIV" | grep -c '^PAGE ' || true)"
+if [ "${F1:-0}" -ge 1 ] && [ "${F2:-0}" -ge 1 ]; then
+  ok "a failed page leaves the marker unset, so the next heartbeat retries it ($F1 then $F2)"
+else
+  bad "THE DEFECT: failed page still deduped -- founder goes permanently silent ($F1 then $F2)"
+fi
+# FRESH state dir. The successful page above wrote a marker, so re-running against
+# the same dir skips the whole block and emits nothing -- which is correct
+# behaviour and a broken assertion. Caught by this case failing on its first run.
+STATE3="$WORK/pagefail-log"; mkdir -p "$STATE3"
+LOGLINE="$( cd "$DIV" && KIPI_TEST_PAGE_FAILS=1 LOG="$STATE3/dispatch.log" bash "$HARNESS" 2>&1 )"
+echo "$LOGLINE" | grep -q 'did NOT go out' \
+  && ok "the undelivered page is logged" \
+  || bad "an undelivered page is not logged, so the silence has no trace"
 
 echo
 echo "-------- $PASS passed, $FAIL failed --------"

--- a/q-system/.q-system/scripts/test/test-dispatch-stale-checkout.sh
+++ b/q-system/.q-system/scripts/test/test-dispatch-stale-checkout.sh
@@ -1,0 +1,116 @@
+#!/usr/bin/env bash
+# Reproducer for sp-c775b116: the dispatcher ran the founder's working tree with
+# no freshness check, so a merge alone never reached the running loop.
+#
+# Pairs with: stale_check() in kipi-dispatch.sh.
+#
+# The four states that matter, and only ONE of them may refuse:
+#   behind  -> REFUSE (would build on superseded code and auto-merge it)
+#   ahead   -> RUN    (an agent commits locally before opening a PR)
+#   equal   -> RUN
+#   no answer (fetch fails / offline) -> RUN, because a network blip must not
+#             wedge the loop. Fail closed on staleness, fail open on not knowing.
+#
+# The ahead and offline cases are the point. A check that refuses whenever HEAD
+# differs from origin/main passes a naive behind-test and wedges the loop on its
+# own unpushed work, which is a worse bug than the one being fixed.
+set -uo pipefail
+
+HERE="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+# Derive the repo from the SCRIPT, never from $PWD -- a test that asks the
+# checkout it happens to run in proves nothing about the caller.
+REPO="$(cd "$HERE" && git rev-parse --show-toplevel)"
+DISPATCH="$REPO/kipi-dispatch.sh"
+WORK="$(mktemp -d)"
+trap 'rm -rf "$WORK"' EXIT
+
+PASS=0; FAIL=0
+ok()  { PASS=$((PASS+1)); echo "  PASS: $1"; }
+bad() { FAIL=$((FAIL+1)); echo "  FAIL: $1"; }
+
+[ -f "$DISPATCH" ] || { echo "no kipi-dispatch.sh at $DISPATCH"; exit 1; }
+
+if ! grep -q 'stale_check' "$DISPATCH"; then
+  echo "  FAIL: THE DEFECT: kipi-dispatch.sh has no stale_check, so a merge never reaches the running loop"
+  echo "-------- 0 passed, 1 failed --------"
+  exit 1
+fi
+
+# Extract stale_check and drive it directly. Running the whole dispatcher would
+# reach Linear and could dispatch REAL work -- never let a test touch a live
+# data path (fable-discipline lint blocks it, and this is why).
+HARNESS="$WORK/stale_check.sh"
+{
+  echo 'set -uo pipefail'
+  echo 'REPO="$PWD"'
+  echo 'say()  { printf "SAY %s\n"  "$*"; }'
+  echo 'page() { printf "PAGE %s\n" "$*"; }'
+  awk '/^stale_check\(\) \{/,/^\}/' "$DISPATCH"
+  echo 'stale_check && echo "VERDICT=RUN" || echo "VERDICT=REFUSE"'
+} > "$HARNESS"
+
+# --- a real origin + clone, because stale_check asks git real questions ------
+ORIGIN="$WORK/origin.git"; CLONE="$WORK/clone"
+git init -q --bare -b main "$ORIGIN"
+git init -q -b main "$WORK/seed"
+( cd "$WORK/seed"
+  git config user.email t@e.com; git config user.name t
+  echo one > f.txt; git add -A; git commit -qm one
+  git remote add origin "$ORIGIN"; git push -q origin main ) >/dev/null 2>&1
+git clone -q "$ORIGIN" "$CLONE" >/dev/null 2>&1
+( cd "$CLONE"; git config user.email t@e.com; git config user.name t )
+
+run_check() { ( cd "$1" && bash "$HARNESS" 2>&1 ); }
+
+echo "== 1. equal: HEAD == origin/main -> RUN =="
+OUT="$(run_check "$CLONE")"
+echo "$OUT" | grep -q 'VERDICT=RUN' \
+  && ok "an up-to-date checkout runs" \
+  || bad "an up-to-date checkout was refused: $(echo "$OUT" | tr '\n' ' ')"
+
+echo
+echo "== 2. THE DEFECT: behind -> REFUSE and PAGE =="
+( cd "$WORK/seed"; echo two >> f.txt; git commit -qam two; git push -q origin main ) >/dev/null 2>&1
+OUT="$(run_check "$CLONE")"
+if echo "$OUT" | grep -q 'VERDICT=REFUSE'; then
+  ok "a checkout behind origin/main refuses to dispatch"
+else
+  bad "THE DEFECT: a checkout 1 commit behind origin/main still dispatched"
+fi
+echo "$OUT" | grep -q '^PAGE ' \
+  && ok "the refusal pages the founder" \
+  || bad "refused silently: an unattended refusal nobody is told about is a dead loop"
+echo "$OUT" | grep -q 'git merge --ff-only' \
+  && ok "the page carries the fix command" \
+  || bad "the page does not say what to do"
+
+echo
+echo "== 3. ahead: local commits not yet pushed -> RUN (must not wedge) =="
+( cd "$CLONE"; git merge -q --ff-only origin/main; echo three >> f.txt; git commit -qam three ) >/dev/null 2>&1
+OUT="$(run_check "$CLONE")"
+echo "$OUT" | grep -q 'VERDICT=RUN' \
+  && ok "a checkout AHEAD of origin/main still runs" \
+  || bad "being ahead was treated as stale, which wedges the loop on its own unpushed work"
+
+echo
+echo "== 4. no answer: fetch fails -> RUN (fail open on not knowing) =="
+# A repo with no reachable remote is the offline case without needing the network.
+BROKEN="$WORK/broken"
+git init -q -b main "$BROKEN"
+( cd "$BROKEN"; git config user.email t@e.com; git config user.name t
+  echo x > f.txt; git add -A; git commit -qm x
+  git remote add origin "$WORK/does-not-exist.git" ) >/dev/null 2>&1
+OUT="$(run_check "$BROKEN")"
+if echo "$OUT" | grep -q 'VERDICT=RUN'; then
+  ok "an unanswerable freshness check proceeds instead of wedging"
+else
+  bad "a failed fetch refused to dispatch, so an offline machine kills the loop"
+fi
+echo "$OUT" | grep -q 'SAY stale-check' \
+  && ok "the unanswered check is logged, not silent" \
+  || bad "the check failed with no log line, so the blind spot is invisible"
+
+echo
+echo "-------- $PASS passed, $FAIL failed --------"
+[ "$FAIL" -eq 0 ] || exit 1
+echo "PASS: stale_check refuses only when genuinely behind"

--- a/q-system/.q-system/scripts/test/test-dispatch-stale-checkout.sh
+++ b/q-system/.q-system/scripts/test/test-dispatch-stale-checkout.sh
@@ -111,6 +111,52 @@ echo "$OUT" | grep -q 'SAY stale-check' \
   || bad "the check failed with no log line, so the blind spot is invisible"
 
 echo
+echo "== 5. DIVERGED must REFUSE (codex round 2, major 1) =="
+# The case the first cut got wrong, and the one a merge of this very branch
+# produces: origin/main gains a commit while this tree keeps local commits of its
+# own. --is-ancestor is FALSE here, so an ancestry test runs on a checkout missing
+# origin/main's newest control code. This is the LIKELY divergence, not an edge.
+DIV="$WORK/diverged"
+git clone -q "$ORIGIN" "$DIV" >/dev/null 2>&1
+( cd "$DIV"; git config user.email t@e.com; git config user.name t
+  echo local-only >> f.txt; git commit -qam "local only" ) >/dev/null 2>&1
+( cd "$WORK/seed"; echo remote-only >> f.txt; git commit -qam "remote only"; git push -q origin main ) >/dev/null 2>&1
+OUT="$(run_check "$DIV")"
+if echo "$OUT" | grep -q 'VERDICT=REFUSE'; then
+  ok "a DIVERGED checkout refuses (origin/main holds commits it lacks)"
+else
+  bad "THE DEFECT: a diverged checkout dispatched, so superseded control code runs after a concurrent merge"
+fi
+
+echo
+echo "== 6. the page is deduped per remote sha (codex round 2, major 2) =="
+# At a 900s interval an unrepaired checkout paged 96 times a day with the
+# identical message, which trains the founder to ignore the channel.
+STATE="$WORK/pagestate"; mkdir -p "$STATE"
+# Point the function's state dir at a scratch dir by overriding $LOG, which is
+# what the marker path is derived from.
+run_dedupe() { ( cd "$1" && LOG="$STATE/dispatch.log" bash "$HARNESS" 2>&1 ); }
+P1="$(run_dedupe "$DIV" | grep -c '^PAGE ' || true)"
+P2="$(run_dedupe "$DIV" | grep -c '^PAGE ' || true)"
+if [ "${P1:-0}" -ge 1 ] && [ "${P2:-0}" -eq 0 ]; then
+  ok "pages once for a given origin/main sha, silent on the repeat ($P1 then $P2)"
+else
+  bad "THE DEFECT: paged $P1 then $P2 for the same remote sha -- 96 identical pages a day"
+fi
+# A NEW divergence must page again, or a second, different staleness goes unreported.
+( cd "$WORK/seed"; echo remote-two >> f.txt; git commit -qam "remote two"; git push -q origin main ) >/dev/null 2>&1
+P3="$(run_dedupe "$DIV" | grep -c '^PAGE ' || true)"
+if [ "${P3:-0}" -ge 1 ]; then
+  ok "a NEW origin/main sha pages again (dedupe is per-sha, not permanent)"
+else
+  bad "dedupe is permanent: a second, different divergence would never be reported"
+fi
+# The refusal itself must still be logged every time, even when the page is muted.
+echo "$(run_dedupe "$DIV")" | grep -q 'SAY REFUSING' \
+  && ok "the refusal is logged on every heartbeat even when the page is deduped" \
+  || bad "a deduped page also silenced the log line, so the refusal is invisible"
+
+echo
 echo "-------- $PASS passed, $FAIL failed --------"
 [ "$FAIL" -eq 0 ] || exit 1
-echo "PASS: stale_check refuses only when genuinely behind"
+echo "PASS: stale_check refuses whenever origin/main holds commits this tree lacks, and pages once per sha"

--- a/q-system/.q-system/scripts/test/test-linear-worker-fetch.sh
+++ b/q-system/.q-system/scripts/test/test-linear-worker-fetch.sh
@@ -60,6 +60,29 @@ unset KIPI_LINEAR_CLAIMS KIPI_SESSION_ID CLAUDE_SESSION_ID 2>/dev/null || true
 G() { git -c user.email=t@t.t -c user.name=t "$@"; }
 
 STUB="$WORK/bin"; mkdir -p "$STUB" "$WORK/home"
+
+# NEVER LET A TEST REACH THE REAL REVIEWER (sp-cb48c3c0). This suite drives
+# linear-worker.sh for real, and the worker's review step shells
+# pr-review-agent.sh, whose DEFAULT ENGINE IS CODEX. $STUB carries no `codex`, so
+# the call fell through to /opt/homebrew/bin/codex: real spend, real `gh --post`
+# attempts against a PR number that does not exist, and codex running
+# workspace-write inside the founder's live checkout. Caught live 2026-07-30 by
+# finding `pr-review-agent.sh 807 --issue ASK-AAA --post --engine codex` in ps.
+#
+# KIPI_PR_REVIEWER is the override linear-worker.sh:72 already exposes, so one
+# export closes the whole path -- strictly better than adding a `codex` stub,
+# which would still run the real reviewer script against real `gh`.
+KIPI_PR_REVIEWER="$STUB/reviewer-noop"
+export KIPI_PR_REVIEWER
+cat > "$STUB/reviewer-noop" <<'NOOP'
+#!/usr/bin/env bash
+# Stands in for pr-review-agent.sh. Prints what it was asked to do so a test can
+# assert the worker TRIED to review, and exits 0 without touching any network.
+echo "  [stub reviewer] would review PR $1 ($*)"
+exit 0
+NOOP
+chmod +x "$STUB/reviewer-noop"
+
 # No PR exists and none may be created.
 printf '#!/usr/bin/env bash\nexit 0\n' > "$STUB/gh"
 chmod +x "$STUB/gh"

--- a/q-system/.q-system/scripts/test/test-linear-worker-parallel.sh
+++ b/q-system/.q-system/scripts/test/test-linear-worker-parallel.sh
@@ -58,6 +58,29 @@ git -C "$WORK/skel" push -q -u origin main
 # Everything else -- crucially linear-claim.py, the subject of this test --
 # is the real interpreter running the real script.
 STUB="$WORK/bin"; mkdir -p "$STUB"
+
+# NEVER LET A TEST REACH THE REAL REVIEWER (sp-cb48c3c0). This suite drives
+# linear-worker.sh for real, and the worker's review step shells
+# pr-review-agent.sh, whose DEFAULT ENGINE IS CODEX. $STUB carries no `codex`, so
+# the call fell through to /opt/homebrew/bin/codex: real spend, real `gh --post`
+# attempts against a PR number that does not exist, and codex running
+# workspace-write inside the founder's live checkout. Caught live 2026-07-30 by
+# finding `pr-review-agent.sh 807 --issue ASK-AAA --post --engine codex` in ps.
+#
+# KIPI_PR_REVIEWER is the override linear-worker.sh:72 already exposes, so one
+# export closes the whole path -- strictly better than adding a `codex` stub,
+# which would still run the real reviewer script against real `gh`.
+KIPI_PR_REVIEWER="$STUB/reviewer-noop"
+export KIPI_PR_REVIEWER
+cat > "$STUB/reviewer-noop" <<'NOOP'
+#!/usr/bin/env bash
+# Stands in for pr-review-agent.sh. Prints what it was asked to do so a test can
+# assert the worker TRIED to review, and exits 0 without touching any network.
+echo "  [stub reviewer] would review PR $1 ($*)"
+exit 0
+NOOP
+chmod +x "$STUB/reviewer-noop"
+
 cat > "$STUB/python3" <<EOF
 #!/usr/bin/env bash
 case "\${1:-}" in

--- a/q-system/.q-system/scripts/test/test-review-comment-body.sh
+++ b/q-system/.q-system/scripts/test/test-review-comment-body.sh
@@ -1,0 +1,170 @@
+#!/usr/bin/env bash
+# Reproducer for sp-b418be32: a codex review is too large for a GitHub comment,
+# so `--post` never delivered the review to the PR.
+#
+# Pairs with: review_comment_body() in pr-verdict-lib.sh, and the --post call
+# site in pr-review-agent.sh.
+#
+# WHY THE REF HATCH. Every case here must be watched FAIL before it is trusted.
+# KIPI_TEST_REVIEWER_REF loads the lib from a pre-fix git ref, where
+# review_comment_body does not exist at all -- so the harness asserts the
+# ABSENCE is what fails, not a rewritten assertion. Same hatch and same reason
+# as test-review-tree-guard.sh case 5.
+#
+#   KIPI_TEST_REVIEWER_REF=f277389 bash test-review-comment-body.sh   -> FAIL
+#   bash test-review-comment-body.sh                                  -> PASS
+set -uo pipefail
+
+HERE="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+SCRIPTS="$(cd "$HERE/.." && pwd)"
+WORK="$(mktemp -d)"
+trap 'rm -rf "$WORK"' EXIT
+
+PASS=0; FAIL=0
+ok()   { PASS=$((PASS+1)); echo "  PASS: $1"; }
+bad()  { FAIL=$((FAIL+1)); echo "  FAIL: $1"; }
+
+# ---- load the lib under test (live tree, or a pre-fix ref) -------------------
+LIB="$SCRIPTS/pr-verdict-lib.sh"
+if [ -n "${KIPI_TEST_REVIEWER_REF:-}" ]; then
+  # Resolve the repo from the SCRIPT's own location, never from $PWD: a refuse-path
+  # test that asks the checkout it is running in proves nothing about the caller.
+  REPO="$(cd "$SCRIPTS" && git rev-parse --show-toplevel)"
+  REL="$(cd "$SCRIPTS" && git ls-files --full-name pr-verdict-lib.sh)"
+  LIB="$WORK/lib-at-ref.sh"
+  git -C "$REPO" show "$KIPI_TEST_REVIEWER_REF:$REL" >"$LIB" 2>/dev/null \
+    || { echo "cannot load pr-verdict-lib.sh at ref $KIPI_TEST_REVIEWER_REF"; exit 1; }
+  echo "== lib loaded from ref $KIPI_TEST_REVIEWER_REF (expect FAILs) =="
+fi
+# shellcheck disable=SC1090
+. "$LIB"
+
+# GitHub's hard limit on an issue-comment body. The thing the defect violated.
+GH_LIMIT=65536
+
+# ---- the fixture IS the real payload ----------------------------------------
+# A synthesized 500KB blob would not carry the properties that broke this: the
+# codex header, a transcript that echoes the diff (so MULTIPLE FINDINGS: blocks),
+# typographic quotes that a blind byte cut can split, and the real trailing
+# block. Prefer the captured review; fall back to a shaped stand-in so the test
+# still runs on a machine that never ran a review.
+REAL="$HOME/.config/kipi/pr-reviews/codex/pr-34-20260729-210606.md"
+BIG="$WORK/big-review.md"
+if [ -s "$REAL" ]; then
+  cp "$REAL" "$BIG"; echo "== fixture: captured review $(wc -c <"$BIG" | tr -d ' ') bytes =="
+else
+  {
+    echo "Reading additional input from stdin..."
+    echo "OpenAI Codex v0.145.0"
+    # A quoted PRIOR block, so "take the last complete block" is under test too.
+    echo "FINDINGS:"; echo "major|a quoted prior-round finding that must NOT win|a.sh:1"; echo "END FINDINGS"
+    # Bulk, with typographic quotes so a blind byte cut could split a sequence.
+    for _ in $(seq 1 12000); do echo "transcript line with a \xe2\x80\x99 curly quote and padding to make this long"; done
+    echo "## VERDICT"; echo "APPROVE WITH NITS."
+    echo "FINDINGS:"
+    echo "minor|the real trailing finding the human has to act on|q-system/.q-system/scripts/pr-review-agent.sh:660"
+    echo "END FINDINGS"
+  } >"$BIG"
+  echo "== fixture: synthesized $(wc -c <"$BIG" | tr -d ' ') bytes =="
+fi
+
+echo
+echo "== 1. the defect itself: the raw file cannot be a comment =="
+RAW_BYTES="$(wc -c <"$BIG" | tr -d ' ')"
+# NEGATIVE SELF-TEST. This is the assertion the fix has to satisfy, aimed at the
+# UNFIXED input. If it ever passes, the fixture stopped reproducing the defect and
+# every result below is meaningless.
+if [ "$RAW_BYTES" -gt "$GH_LIMIT" ]; then
+  ok "fixture reproduces the defect: raw review is $RAW_BYTES bytes > $GH_LIMIT"
+else
+  bad "fixture no longer reproduces the defect ($RAW_BYTES <= $GH_LIMIT); every case below is void"
+fi
+
+echo
+echo "== 2. the rendered body fits a GitHub comment =="
+if ! type review_comment_body >/dev/null 2>&1; then
+  bad "THE DEFECT: no review_comment_body exists, so --post can only send the raw $RAW_BYTES-byte file"
+else
+  BODY="$WORK/body.md"
+  review_comment_body "$BIG" "APPROVE WITH NITS" "codex" 0 >"$BODY" 2>/dev/null
+  B="$(wc -c <"$BODY" | tr -d ' ')"
+  [ "$B" -le "$GH_LIMIT" ] \
+    && ok "rendered body is $B bytes <= $GH_LIMIT" \
+    || bad "rendered body is $B bytes, still over the $GH_LIMIT limit"
+  [ "$B" -gt 200 ] \
+    && ok "rendered body is not empty ($B bytes)" \
+    || bad "rendered body is $B bytes, effectively empty"
+
+  echo
+  echo "== 3. truncation cannot drop the verdict or the findings =="
+  grep -q 'APPROVE WITH NITS' "$BODY" \
+    && ok "verdict survives truncation" \
+    || bad "verdict is missing from the rendered body"
+  grep -q '^FINDINGS:' "$BODY" && grep -q '^END FINDINGS' "$BODY" \
+    && ok "a complete findings block survives truncation" \
+    || bad "no complete findings block in the rendered body"
+
+  echo
+  echo "== 4. the findings come from the ONE READER, not from the cut text =="
+  # The fixture's FIRST block is a decoy. If the rendered block carries it, the
+  # renderer grew its own extractor instead of going through findings_block.
+  EXPECTED="$(findings_block "$BIG")"
+  RENDERED="$(awk '/^FINDINGS:/{f=1} f{print} /^END FINDINGS/{if(f) exit}' "$BODY")"
+  [ -n "$EXPECTED" ] && [ "$RENDERED" = "$EXPECTED" ] \
+    && ok "rendered block is byte-identical to findings_block output" \
+    || bad "rendered block differs from findings_block (a second reader)"
+
+  echo
+  echo "== 5. the full artifact is still reachable =="
+  grep -q "$BIG" "$BODY" \
+    && ok "body names the on-disk review path" \
+    || bad "body does not name the full review path, so the transcript is unreachable"
+
+  echo
+  echo "== 6. the body says which engine reviewed =="
+  grep -q 'codex' "$BODY" \
+    && ok "body names the engine" \
+    || bad "body does not name the reviewing engine"
+
+  echo
+  echo "== 7. a DEGRADED review says so in the body =="
+  review_comment_body "$BIG" "APPROVE" "codex" 1 >"$WORK/deg.md" 2>/dev/null
+  grep -qi 'DEGRADED' "$WORK/deg.md" \
+    && ok "degraded review is marked in the body" \
+    || bad "degraded review is not marked, so a fallback reads as a second opinion"
+
+  echo
+  echo "== 8. a small review is passed through whole, not truncated =="
+  SMALL="$WORK/small.md"
+  { echo "## VERDICT"; echo "APPROVE"; echo "a short narrative line";
+    echo "FINDINGS:"; echo "END FINDINGS"; } >"$SMALL"
+  review_comment_body "$SMALL" "APPROVE" "codex" 0 >"$WORK/small-body.md" 2>/dev/null
+  grep -q 'a short narrative line' "$WORK/small-body.md" \
+    && ok "small review keeps its narrative" \
+    || bad "small review lost its narrative"
+
+  echo
+  echo "== 9. valid UTF-8 after the cut =="
+  if iconv -f UTF-8 -t UTF-8 "$BODY" >/dev/null 2>&1; then
+    ok "rendered body is valid UTF-8 (the byte cut did not split a sequence)"
+  else
+    bad "rendered body is invalid UTF-8: the byte cut split a multi-byte sequence"
+  fi
+
+  echo
+  echo "== 10. an unusable review does not render a fake findings block =="
+  TRUNC="$WORK/trunc.md"
+  { echo "## VERDICT"; echo "REQUEST CHANGES"; echo "FINDINGS:";
+    echo "major|a block that never closes|x.sh:1"; } >"$TRUNC"
+  review_comment_body "$TRUNC" "REQUEST CHANGES" "codex" 0 >"$WORK/trunc-body.md" 2>/dev/null
+  # findings_block VOIDS a review whose block is open at EOF, so the renderer must
+  # say "no complete block" rather than print the withdrawn one as if it counted.
+  grep -q 'no complete findings block' "$WORK/trunc-body.md" \
+    && ok "truncated review renders as 'no complete findings block'" \
+    || bad "truncated review rendered a findings block findings_block had voided"
+fi
+
+echo
+echo "-------- $PASS passed, $FAIL failed --------"
+[ "$FAIL" -eq 0 ] || exit 1
+echo "PASS: review_comment_body keeps a codex review inside a GitHub comment"

--- a/q-system/.q-system/scripts/test/test-review-comment-body.sh
+++ b/q-system/.q-system/scripts/test/test-review-comment-body.sh
@@ -165,6 +165,37 @@ else
 fi
 
 echo
+echo "== 11. THE CALL SITE actually uses the renderer =="
+# Codex round 1 on PR #47, minor 2: every case above tests the LIBRARY. Mutate
+# pr-review-agent.sh back to `gh pr comment --body-file "$REVIEW"` and all ten
+# still pass, because none of them ever asks what the reviewer posts. A renderer
+# nothing calls is the same dead code as a hook nothing wires -- this repo's
+# load-path lesson, applied to its own test.
+#
+# Structural, not behavioural: driving the real --post path would need a live PR
+# and a real gh. So assert the two things a revert would break, on the file the
+# scripts dir actually holds.
+AGENT="$SCRIPTS/pr-review-agent.sh"
+if [ ! -f "$AGENT" ]; then
+  bad "no pr-review-agent.sh next to the lib, so the call site cannot be checked"
+else
+  POST_BLOCK="$WORK/post-block.txt"
+  # From the `--post` guard to the end: the only region that comments on a PR.
+  awk '/^if \[ "\$POST" = "1" \]; then/,0' "$AGENT" > "$POST_BLOCK"
+  if grep -q 'review_comment_body' "$POST_BLOCK"; then
+    ok "the --post path calls review_comment_body"
+  else
+    bad "THE DEFECT: the --post path does not call review_comment_body, so the raw review is still what gets posted"
+  fi
+  # The mutation this case exists to catch: --body-file pointed straight at $REVIEW.
+  if grep -qE '(gh|GH) pr comment[^|]*--body-file[[:space:]]*"?\$REVIEW"?([[:space:]]|$)' "$POST_BLOCK"; then
+    bad "THE DEFECT: gh pr comment still posts --body-file \$REVIEW (the raw transcript)"
+  else
+    ok "gh pr comment does not post the raw \$REVIEW file"
+  fi
+fi
+
+echo
 echo "-------- $PASS passed, $FAIL failed --------"
 [ "$FAIL" -eq 0 ] || exit 1
-echo "PASS: review_comment_body keeps a codex review inside a GitHub comment"
+echo "PASS: review_comment_body keeps a codex review inside a GitHub comment, and the reviewer uses it"

--- a/q-system/.q-system/scripts/test/test-review-comment-body.sh
+++ b/q-system/.q-system/scripts/test/test-review-comment-body.sh
@@ -196,6 +196,38 @@ else
 fi
 
 echo
+echo "== 12. no BSD-only mktemp form (portability, caught by CI not by me) =="
+# `mktemp -t name` appends a random suffix on BSD (macOS) and is REJECTED by GNU
+# mktemp (the Linux runner) unless the template carries three or more X's. My
+# first cut used the BSD form: 14/14 here, `validate` red on the PR, because the
+# body file was never created and --body-file got an empty path.
+#
+# A grep, deliberately. The behavioural test cannot see this -- it passes on the
+# developer's OS by construction, and the only machine that disagrees is the one
+# nobody runs the suite on by hand.
+if [ -f "$AGENT" ]; then
+  # Per LINE, not per line-ending. The first cut anchored the template with `$`,
+  # which never matched because the real line continues with `)" || ...` -- so the
+  # guard passed with the BSD form reintroduced. Caught by running the negative
+  # self-test, which is the entire reason for running it: a check that cannot
+  # fail is not a check, and this one could not.
+  BAD="$(grep -n 'mktemp' "$AGENT" | grep -E 'mktemp[^|;)]*-t[[:space:]]' | grep -v 'XXX' || true)"
+  if [ -z "$BAD" ]; then
+    ok "no BSD-only 'mktemp -t' form in the reviewer"
+  else
+    bad "THE DEFECT: BSD-only mktemp form, fails on the GNU/Linux runner: $BAD"
+  fi
+  # And the positive: every mktemp here must carry an explicit template.
+  MKT="$(grep -c 'mktemp' "$AGENT" || true)"
+  MKX="$(grep -c 'mktemp.*XXXXXX' "$AGENT" || true)"
+  if [ "${MKT:-0}" -eq 0 ] || [ "${MKX:-0}" -ge 1 ]; then
+    ok "mktemp calls carry an explicit XXXXXX template ($MKX of $MKT)"
+  else
+    bad "mktemp used without an XXXXXX template ($MKX of $MKT)"
+  fi
+fi
+
+echo
 echo "-------- $PASS passed, $FAIL failed --------"
 [ "$FAIL" -eq 0 ] || exit 1
 echo "PASS: review_comment_body keeps a codex review inside a GitHub comment, and the reviewer uses it"

--- a/q-system/.q-system/scripts/test/test-review-comment-body.sh
+++ b/q-system/.q-system/scripts/test/test-review-comment-body.sh
@@ -196,6 +196,40 @@ else
 fi
 
 echo
+echo "== 13. a LARGE findings block cannot overrun the limit (codex round 5, minor) =="
+# The header reservation was a flat 5,000 bytes while the findings block inside
+# it is unbounded, so a review with many findings blew past the cap this function
+# exists to guarantee. Build a block bigger than the old reservation and assert
+# the body still fits AND still carries every finding.
+BIGF="$WORK/big-findings.md"
+{
+  echo "## VERDICT"; echo "REQUEST CHANGES"
+  # The padding must push the review PAST the byte budget, or the renderer takes
+  # the "small review, pass it through whole" branch and the reservation is never
+  # exercised. My first fixture was ~30KB, so case 13 passed against the OLD flat
+  # reservation too -- it proved nothing until the negative self-test said so.
+  for _ in $(seq 1 3000); do echo "narrative padding line to give the tail something to eat and push this review well past the sixty-thousand-byte budget"; done
+  echo "FINDINGS:"
+  for i in $(seq 1 90); do
+    printf 'major|finding %s with a deliberately long claim string so the block alone exceeds the old flat five-thousand-byte header reservation|q-system/.q-system/scripts/some-file-%s.sh:%s\n' "$i" "$i" "$i"
+  done
+  echo "END FINDINGS"
+} >"$BIGF"
+BLOCK_BYTES="$(findings_block "$BIGF" | wc -c | tr -d ' ')"
+review_comment_body "$BIGF" "REQUEST CHANGES" "codex" 0 >"$WORK/bigf-body.md" 2>/dev/null
+BB="$(wc -c <"$WORK/bigf-body.md" | tr -d ' ')"
+[ "${BLOCK_BYTES:-0}" -gt 5000 ] \
+  && ok "fixture reproduces the case: findings block alone is $BLOCK_BYTES bytes > the old 5000 reservation" \
+  || bad "fixture too small ($BLOCK_BYTES bytes); case 13 proves nothing"
+[ "$BB" -le "$GH_LIMIT" ] \
+  && ok "body with a $BLOCK_BYTES-byte findings block still fits ($BB <= $GH_LIMIT)" \
+  || bad "THE DEFECT: body is $BB bytes, over the $GH_LIMIT limit the renderer guarantees"
+RENDERED_N="$(awk '/^FINDINGS:/{f=1} f&&/^major\|/{n++} /^END FINDINGS/{if(f){print n; exit}}' "$WORK/bigf-body.md")"
+[ "${RENDERED_N:-0}" -eq 90 ] \
+  && ok "all 90 findings survive (narrative is sacrificed first, never a finding)" \
+  || bad "only ${RENDERED_N:-0} of 90 findings rendered -- truncation ate a finding"
+
+echo
 echo "== 12. no BSD-only mktemp form (portability, caught by CI not by me) =="
 # `mktemp -t name` appends a random suffix on BSD (macOS) and is REJECTED by GNU
 # mktemp (the Linux runner) unless the template carries three or more X's. My

--- a/q-system/.q-system/scripts/test/test-review-invoker-provenance.sh
+++ b/q-system/.q-system/scripts/test/test-review-invoker-provenance.sh
@@ -1,0 +1,122 @@
+#!/usr/bin/env bash
+# Reproducer for sp-53aad86f: the verdict record could not distinguish a
+# DISPATCHER-driven review from a hand-run one.
+#
+# Pairs with: the invoker field written by pr-review-agent.sh, set by
+# linear-worker.sh, and reported by verify-codex-review-live.sh check 8.
+#
+# WHY THIS IS THE PROOF THAT MATTERS. Every green check so far proves "a codex
+# review ran". The founder asked for something stricter: that the DISPATCHER ran
+# one, unattended, on a PR nobody reviewed by hand. Without provenance in the
+# record, a hand-run review and an unattended one are byte-identical evidence, so
+# no amount of green proves the thing he asked about.
+#
+# THE FAIL-SAFE DIRECTION IS THE WHOLE DESIGN. An unlabelled review must read as
+# hand-run, never as dispatcher-driven. Absent is not approved -- the same posture
+# the reviewer's commit status takes. Case 3 is that assertion, and it is the one
+# a careless default would break.
+set -uo pipefail
+
+HERE="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+SCRIPTS="$(cd "$HERE/.." && pwd)"
+WORK="$(mktemp -d)"
+trap 'rm -rf "$WORK"' EXIT
+
+PASS=0; FAIL=0
+ok()  { PASS=$((PASS+1)); echo "  PASS: $1"; }
+bad() { FAIL=$((FAIL+1)); echo "  FAIL: $1"; }
+
+AGENT="$SCRIPTS/pr-review-agent.sh"
+WORKER="$SCRIPTS/linear-worker.sh"
+VERIFIER="$SCRIPTS/verify-codex-review-live.sh"
+
+echo "== 1. the reviewer records an invoker at all =="
+if grep -q 'KIPI_REVIEW_INVOKER' "$AGENT"; then
+  ok "pr-review-agent.sh reads KIPI_REVIEW_INVOKER"
+else
+  bad "THE DEFECT: pr-review-agent.sh has no invoker concept, so no record can name its caller"
+fi
+if grep -qE '"invoker"' "$AGENT"; then
+  ok "the verdict record carries an invoker field"
+else
+  bad "THE DEFECT: the verdict record has no invoker field"
+fi
+
+echo
+echo "== 2. the WORKER labels itself, so a dispatcher run is identifiable =="
+# The label has to be on the worker's call, not merely available as an env var
+# nobody sets -- an unset knob is the same as no feature.
+if grep -nE 'KIPI_REVIEW_INVOKER=(worker|dispatcher)' "$WORKER" >/dev/null 2>&1; then
+  ok "linear-worker.sh labels its reviewer invocation"
+else
+  bad "THE DEFECT: linear-worker.sh does not set KIPI_REVIEW_INVOKER, so its runs are indistinguishable from hand runs"
+fi
+
+echo
+echo "== 3. THE FAIL-SAFE: an unlabelled run must NOT read as dispatcher-driven =="
+# Drive the default straight out of the script rather than trusting a comment.
+DEFAULT="$(bash -c 'unset KIPI_REVIEW_INVOKER; grep -oE "KIPI_REVIEW_INVOKER:-[a-z]+" '"'$AGENT'"' | head -1 | cut -d- -f2')"
+case "$DEFAULT" in
+  worker|dispatcher)
+    bad "THE DEFECT: the default invoker is '$DEFAULT', so every hand-run review would count as dispatcher proof" ;;
+  "")
+    bad "could not read the default invoker out of $AGENT" ;;
+  *)
+    ok "the default invoker is '$DEFAULT', so an unlabelled run cannot pass as dispatcher-driven" ;;
+esac
+
+echo
+echo "== 4. a record with NO invoker key reads as not-dispatcher =="
+# Every record written before this change lacks the key entirely. Those must not
+# be counted either -- a missing field is the same unknown as a manual label.
+STATE="$WORK/state"; mkdir -p "$STATE/pr-reviews"
+cat > "$STATE/pr-reviews/pr-900.verdict.json" <<'JSON'
+{"pr":900,"issue":"ASK-900","verdict":"APPROVE","engine":"codex",
+ "round":1,"head_sha":"deadbeefdeadbeef","ts":"2026-07-30T00:00:00Z"}
+JSON
+OUT="$(KIPI_STATE_DIR="$STATE" bash "$VERIFIER" 2>&1 | grep -E 'RECEIPT|dispatcher' || true)"
+if echo "$OUT" | grep -qi 'dispatcher-driven'; then
+  # It may legitimately report "no dispatcher-driven receipt"; only a positive claim is wrong.
+  if echo "$OUT" | grep -qiE 'no dispatcher-driven|not dispatcher-driven|hand-run'; then
+    ok "a legacy record without an invoker is not claimed as dispatcher-driven"
+  else
+    bad "THE DEFECT: a legacy record with no invoker was reported as dispatcher-driven proof"
+  fi
+else
+  ok "the verifier makes no dispatcher claim for a record without an invoker"
+fi
+
+echo
+echo "== 5. a worker-labelled record IS reported as dispatcher-driven =="
+cat > "$STATE/pr-reviews/pr-901.verdict.json" <<'JSON'
+{"pr":901,"issue":"ASK-901","verdict":"APPROVE","engine":"codex","invoker":"worker",
+ "round":1,"head_sha":"cafebabecafebabe","ts":"2026-07-30T01:00:00Z"}
+JSON
+OUT="$(KIPI_STATE_DIR="$STATE" bash "$VERIFIER" 2>&1 | grep -E 'RECEIPT|dispatcher' || true)"
+# Require the PR NUMBER, not just the phrase. The phrase also appears in the
+# NO-receipt message, so the loose form passed against a crashed verifier.
+if echo "$OUT" | grep -qi 'DISPATCHER-DRIVEN RECEIPT FOUND' && echo "$OUT" | grep -q '901'; then
+  ok "a worker-labelled record is reported as the dispatcher-driven receipt"
+else
+  bad "a worker-labelled record was NOT reported as dispatcher-driven, so the proof stays invisible"
+fi
+
+echo
+echo "== 6. the newest worker record wins, not the newest record overall =="
+# A later HAND run must not displace the dispatcher receipt in the report: the
+# question "has the dispatcher ever done this" is not answered by recency.
+cat > "$STATE/pr-reviews/pr-902.verdict.json" <<'JSON'
+{"pr":902,"issue":"ASK-902","verdict":"APPROVE","engine":"codex","invoker":"manual",
+ "round":1,"head_sha":"0123456789abcdef","ts":"2026-07-30T02:00:00Z"}
+JSON
+OUT="$(KIPI_STATE_DIR="$STATE" bash "$VERIFIER" 2>&1 | grep -iE 'dispatcher-driven' || true)"
+if echo "$OUT" | grep -q '901'; then
+  ok "a newer hand run does not hide the dispatcher receipt (PR #901 still named)"
+else
+  bad "a newer manual review displaced the dispatcher receipt in the report"
+fi
+
+echo
+echo "-------- $PASS passed, $FAIL failed --------"
+[ "$FAIL" -eq 0 ] || exit 1
+echo "PASS: the record distinguishes a dispatcher-driven review from a hand run"

--- a/q-system/.q-system/scripts/test/test-review-invoker-provenance.sh
+++ b/q-system/.q-system/scripts/test/test-review-invoker-provenance.sh
@@ -65,6 +65,27 @@ case "$DEFAULT" in
     ok "the default invoker is '$DEFAULT', so an unlabelled run cannot pass as dispatcher-driven" ;;
 esac
 
+
+# --- cases 1-3 are static and run anywhere. 4-6 drive the VERIFIER, which reads a
+# launchd plist with `plutil` and `launchctl` -- both macOS-only. On the Linux CI
+# runner those do not exist, so the verifier cannot answer and the assertions below
+# would fail for a reason that has nothing to do with the invoker field. That is the
+# same caller's-environment class as the mktemp defect, one level up: the test itself
+# was only ever runnable on the machine it was written on.
+#
+# SKIPPED LOUDLY, never silently. A quiet skip is how a suite reports green about
+# checks it did not run, which is the defect this repo keeps finding. The skip prints,
+# and it does NOT count as a pass.
+if ! command -v plutil >/dev/null 2>&1 || ! command -v launchctl >/dev/null 2>&1; then
+  echo
+  echo "== 4-6 SKIPPED: this host has no plutil/launchctl, so the verifier cannot run =="
+  echo "   (cases 1-3 above are static and DID run; the invoker wiring is still asserted)"
+  echo
+  echo "-------- $PASS passed, $FAIL failed, 3 case(s) skipped --------"
+  [ "$FAIL" -eq 0 ] || exit 1
+  echo "PASS (partial): invoker wiring asserted; verifier-dependent cases need macOS"
+  exit 0
+fi
 echo
 echo "== 4. a record with NO invoker key reads as not-dispatcher =="
 # Every record written before this change lacks the key entirely. Those must not

--- a/q-system/.q-system/scripts/test/test-review-invoker-provenance.sh
+++ b/q-system/.q-system/scripts/test/test-review-invoker-provenance.sh
@@ -76,9 +76,17 @@ esac
 # SKIPPED LOUDLY, never silently. A quiet skip is how a suite reports green about
 # checks it did not run, which is the defect this repo keeps finding. The skip prints,
 # and it does NOT count as a pass.
-if ! command -v plutil >/dev/null 2>&1 || ! command -v launchctl >/dev/null 2>&1; then
+# GUARD ON THE REAL PRECONDITION, not on the binaries. My first guard checked
+# `command -v plutil/launchctl`, which is true on any Mac -- including a CI-shaped
+# run with a sandbox $HOME. But the verifier reads
+# $HOME/Library/LaunchAgents/com.kipi.dispatch.plist, so what it actually needs is
+# THAT FILE, and a clean $HOME does not have it. The binary check passed and the
+# cases still failed. Found by ci-shaped-run.sh in seconds, having survived a full
+# CI round that only reported rc=1.
+if ! command -v plutil >/dev/null 2>&1 || ! command -v launchctl >/dev/null 2>&1 \
+   || [ ! -f "$HOME/Library/LaunchAgents/com.kipi.dispatch.plist" ]; then
   echo
-  echo "== 4-6 SKIPPED: this host has no plutil/launchctl, so the verifier cannot run =="
+  echo "== 4-6 SKIPPED: no launchd plist at \$HOME/Library/LaunchAgents/com.kipi.dispatch.plist, so the verifier cannot run =="
   echo "   (cases 1-3 above are static and DID run; the invoker wiring is still asserted)"
   echo
   echo "-------- $PASS passed, $FAIL failed, 3 case(s) skipped --------"

--- a/q-system/.q-system/scripts/test/test-review-tree-guard.sh
+++ b/q-system/.q-system/scripts/test/test-review-tree-guard.sh
@@ -44,7 +44,7 @@ command -v git >/dev/null 2>&1 || fail "git not on PATH"
 command -v python3 >/dev/null 2>&1 || fail "python3 not on PATH (the record writer is a real python3 heredoc)"
 
 W="$(mktemp -d)"
-trap 'rm -rf "$W"' EXIT
+trap 'git -C "$REPO" worktree prune >/dev/null 2>&1 || true; rm -rf "$W"' EXIT
 REPO="$W/repo"
 S="$REPO/q-system/.q-system/scripts"
 mkdir -p "$S/test" "$W/bin" "$W/home"
@@ -144,37 +144,39 @@ record() { echo "$1/home/.config/kipi/pr-reviews/pr-901.verdict.json"; }
 
 # --- case 1: the defect. A real object that is not in this tree's history. -----
 run_case refuse "$ORPHAN"
-[ "$RC" -ne 0 ] || fail "THE DEFECT: the reviewer exited 0 on PR #901 whose head $ORPHAN is NOT in
-      this tree's history. Every finding it produced would cite code absent from that PR's diff,
-      stamped with that PR's sha. stdout was:
-$(sed 's/^/        /' "$CASE_DIR/out.txt")"
-ok "a PR head that is not an ancestor of the tree exits non-zero"
-
-grep -q 'REFUSING' "$CASE_DIR/err.txt" \
-  || fail "it failed but never said why. stderr was:
+# CONTRACT INVERTED BY sp-8f95bba0 (2026-07-30). The reviewer now materialises a
+# DETACHED WORKTREE at the exact PR head before reading anything, so "a real object
+# not in this tree's history" is no longer a reason to refuse -- a tree holding
+# that commit is built on demand, and the provenance is correct by construction
+# rather than by search. The refusal that remains is for a MISSING object, which is
+# the only case where no tree can be built (case 1b below).
+#
+# The original assertion is kept, inverted, rather than deleted: it is the record
+# of what the guard used to have to do and why it no longer does.
+[ "$RC" -eq 0 ] || fail "REGRESSION: the reviewer refused PR #901 at $ORPHAN, but that object EXISTS
+      locally, so a detached worktree can be built at it and the provenance is correct by
+      construction. Refusing here wastes a reviewable PR. stderr was:
 $(sed 's/^/        /' "$CASE_DIR/err.txt")"
-ok "the refusal names itself on stderr"
+ok "a present-but-unreachable head is reviewed, not refused (worktree built on demand)"
 
-[ ! -f "$CASE_DIR/codex-ran" ] \
-  || fail "THE EXPENSIVE HALF OF THE DEFECT: codex was DISPATCHED against the wrong tree before
-      anything refused. The live 2026-07-29 run reported codex_ran=yes and verdict APPROVE this
-      way. Refusing after the model has already spoken is not a guard."
-ok "codex is never dispatched (the guard refuses BEFORE the model runs)"
+grep -q 'detached at' "$CASE_DIR/out.txt" \
+  || fail "the reviewer did not report an isolated worktree, so it read SOME tree it happened to be
+      standing in -- the sp-8f95bba0 defect. stdout was:
+$(sed 's/^/        /' "$CASE_DIR/out.txt")"
+ok "the review runs in a detached worktree, named on stdout"
 
-[ ! -f "$CASE_DIR/claude-ran" ] \
-  || fail "the Opus fallback ran on a refused tree, which would fill the required status slot with
-      a review of the wrong code."
-ok "the Opus fallback is not reached either"
+grep -q 'review-trees' "$CASE_DIR/out.txt" \
+  || fail "the tree is not under review-trees/, so it may be a checkout someone else is using"
+ok "the tree is a dedicated review tree, not a live checkout"
 
-[ ! -f "$(record "$CASE_DIR")" ] \
-  || fail "a verdict record was written for a review that must not have happened:
-      $(cat "$(record "$CASE_DIR")")"
-ok "no verdict record is written"
+[ -f "$CASE_DIR/codex-ran" ] \
+  || fail "codex never ran on a PR whose head is materialisable, so the PR goes unreviewed"
+ok "codex IS dispatched once the tree is isolated"
 
-grep -q 'statuses/' "$CASE_DIR/gh-calls.log" 2>/dev/null \
-  && fail "a commit status was posted on a refused review. gh calls were:
-$(sed 's/^/        /' "$CASE_DIR/gh-calls.log")"
-ok "no commit status is posted (absent is not approved)"
+# case 1b removed: it asserted a refusal on a MISSING object that this suite's own
+# case 3 correctly forbids (a stale clone cannot prove ancestry either way, and
+# every test-severity-floor.sh reviewer case reports a fabricated sha). Isolation
+# improves the present-object path; the absent-object path keeps tier 1.
 
 # --- case 2: the negative self-test. The guard must let a real head through. ---
 run_case allow "$REAL_HEAD"
@@ -256,9 +258,14 @@ ok "a PR head held by a linked worktree is not refused"
 $(sed 's/^/        /' "$CASE_DIR/out.txt")"
 ok "codex is dispatched for the worktree-held head"
 
-grep -q "$W/wt" "$CASE_DIR/out.txt" \
-  || fail "codex ran but the reviewer never named the tree it resolved to. Without that line there
-      is no way to tell from a log whether it read the PR's files or main's. stdout was:
+# The tree it names is now its OWN detached review tree, not whichever existing
+# worktree happened to hold the sha (sp-8f95bba0). The assertion's intent is
+# unchanged -- a log reader must be able to tell which tree was read -- but naming
+# $W/wt specifically was over-specified once the reviewer stopped borrowing other
+# people's checkouts.
+grep -qE 'tree: .*review-trees.*detached at' "$CASE_DIR/out.txt" \
+  || fail "codex ran but the reviewer never named an isolated tree. Without that line there is no
+      way to tell from a log whether it read the PR's files or someone's working copy. stdout was:
 $(sed 's/^/        /' "$CASE_DIR/out.txt")"
 ok "the resolved tree is named on stdout (provenance is auditable in the worker log)"
 

--- a/q-system/.q-system/scripts/undefined-helper-lint.sh
+++ b/q-system/.q-system/scripts/undefined-helper-lint.sh
@@ -1,0 +1,73 @@
+#!/usr/bin/env bash
+# undefined-helper-lint.sh -- catch a helper that is CALLED but never DEFINED.
+#
+# WHY. Under `set -uo pipefail` (no `-e`, which is this fleet's house style) a
+# call to a function that does not exist is a command-not-found: it prints to
+# stderr and the script CARRIES ON. In a scheduled job whose stderr goes to a log
+# nobody reads, that is a silent no-op.
+#
+# The scar, 2026-07-30 (ASK-221): the fix for "a terminal state that pages nobody"
+# called `page "..."` inside linear-worker.sh. That file has no `page()` -- it uses
+# `bash "$NOTIFY" ...`, the shape at five other call sites. So the fix for terminal
+# states that page nobody would itself have paged nobody. The class eating its own
+# tail, and nothing would have reported it.
+#
+# SCOPE, deliberately narrow. Resolving every bare word against PATH, builtins,
+# aliases and functions is a shell-parsing problem, and a lint with false
+# positives gets turned off (the portability lint learned that the hard way in the
+# same session). So this checks a SMALL ALLOWLIST of helper names this fleet
+# actually uses for cross-cutting concerns -- the ones whose absence is silent and
+# consequential. It will miss others. Missing some is fine; crying wolf is not.
+#
+# Exit 0 = clean, 1 = findings.
+set -uo pipefail
+
+ROOT="${1:-.}"
+# Helpers whose silent absence changes behaviour rather than just erroring loudly.
+HELPERS="page page_ok say notify warn fail ok info die"
+FOUND=0
+
+while IFS= read -r f; do
+  [ -f "$f" ] || continue
+  case "$(basename "$f")" in undefined-helper-lint.sh) continue ;; esac
+  for h in $HELPERS; do
+    # Called: the name at the start of a command position. Not `foo_page`, not
+    # `--page`, not inside a longer word.
+    calls="$(grep -nE "(^|[;&|(]|then |else |do |\{ )[[:space:]]*${h}[[:space:]]+[\"'\$-]" "$f" 2>/dev/null \
+             | grep -v "^[0-9]*:[[:space:]]*#" || true)"
+    [ -n "$calls" ] || continue
+    # Defined here, or inherited by being sourced into a file that defines it.
+    # Both `h() {` and `function h` count.
+    if grep -qE "^[[:space:]]*(function[[:space:]]+)?${h}[[:space:]]*\(\)" "$f" 2>/dev/null; then
+      continue
+    fi
+    # A file that sources another may legitimately inherit the helper. Only flag
+    # when nothing it sources defines it either -- checked shallowly, one level,
+    # because a deeper chain is rare here and guessing costs false positives.
+    inherited=0
+    while IFS= read -r src; do
+      cand="$(dirname "$f")/$(basename "$src")"
+      [ -f "$cand" ] || continue
+      if grep -qE "^[[:space:]]*(function[[:space:]]+)?${h}[[:space:]]*\(\)" "$cand" 2>/dev/null; then
+        inherited=1; break
+      fi
+    done < <(grep -oE '(^|[[:space:]])(\.|source)[[:space:]]+[^[:space:]]+' "$f" 2>/dev/null \
+             | awk '{print $NF}' || true)
+    [ "$inherited" = "1" ] && continue
+
+    FOUND=$((FOUND + 1))
+    printf 'UNDEFINED HELPER: %s() is called but never defined\n' "$h"
+    printf '  %s\n' "$f"
+    printf '%s\n' "$calls" | head -3 | sed 's/^/    /'
+    printf '  why it matters: under `set -uo pipefail` this is command-not-found on stderr and the script CONTINUES.\n'
+    printf '  fix: define it, or use the shape this file already uses for that concern.\n\n'
+  done
+done < <(find "$ROOT" -name '*.sh' -type f \
+           -not -path '*/.git/*' -not -path '*/node_modules/*' -not -path '*/.pr*rev*/*' 2>/dev/null)
+
+if [ "$FOUND" -eq 0 ]; then
+  echo "undefined-helper-lint: clean"
+  exit 0
+fi
+echo "undefined-helper-lint: $FOUND finding(s)"
+exit 1

--- a/q-system/.q-system/scripts/verify-codex-review-live.sh
+++ b/q-system/.q-system/scripts/verify-codex-review-live.sh
@@ -19,8 +19,14 @@
 # scheduler will execute -- never a repo-relative path, never this branch's copy.
 #
 # WHAT IT CANNOT TELL YOU: that a review RAN. Wiring is a precondition, not a
-# receipt. The receipt is a dispatch-log line showing a codex verdict on a real PR.
-# Check 8 reads that log rather than asserting from the wiring.
+# receipt. The receipt is a VERDICT RECORD (pr-<N>.verdict.json carrying
+# engine=codex), which is the artifact the reviewer actually writes. Check 8 reads
+# those records rather than asserting from the wiring.
+#
+# This header used to say the receipt was a dispatch-log line, and said it for a
+# while after check 8 stopped reading one -- codex round 1 on PR #47 flagged the
+# drift. Worth the note: the wrong doc was more convincing than the code, because
+# a header is what a reader trusts when they are deciding whether to look further.
 #
 # Exit 0 = codex is wired into the next run. Non-zero = it is not, with the reason.
 set -uo pipefail

--- a/q-system/.q-system/scripts/verify-codex-review-live.sh
+++ b/q-system/.q-system/scripts/verify-codex-review-live.sh
@@ -189,6 +189,12 @@ STATE_DIR="${KIPI_STATE_DIR:-$HOME/.config/kipi}"
 RECEIPT="$(python3 - "$STATE_DIR/pr-reviews" <<'PY' 2>/dev/null
 import glob, json, os, sys
 newest = None
+# Initialised beside `newest`, because the first cut did NOT initialise it: the loop
+# raised NameError, the `2>/dev/null` on the command substitution swallowed it, and
+# the verifier silently reported NO receipt at all. A test greping for
+# 'dispatcher-driven receipt' then PASSED against the failure message. Same
+# swallowed-exception shape as the ledger-root fix earlier tonight.
+worker = None
 # Both layouts: the PRIMARY engine writes pr-<N>.verdict.json to the parent dir,
 # a secondary engine to <dir>/<engine>/. Globbing only one would miss the receipt
 # the moment KIPI_REVIEW_PRIMARY_ENGINE changes.
@@ -202,16 +208,40 @@ for p in glob.glob(os.path.join(sys.argv[1], "*.verdict.json")) + \
         continue
     if newest is None or str(r.get("ts", "")) > str(newest.get("ts", "")):
         newest = r
+    # THE DISPATCHER-DRIVEN RECEIPT IS TRACKED SEPARATELY, not as "the newest one
+    # that happens to be a worker run" (sp-53aad86f). A later HAND review must not
+    # hide it: "has the dispatcher ever done this unattended" is not a question
+    # about recency. A MISSING invoker key counts as manual -- every record written
+    # before the field existed lacks it, and treating those as proof would
+    # manufacture exactly the evidence this check exists to supply.
+    if r.get("invoker") == "worker":
+        if worker is None or str(r.get("ts", "")) > str(worker.get("ts", "")):
+            worker = r
+def line(r):
+    return "PR #%s %s verdict=%s head=%.12s at %s (invoker=%s)" % (
+        r.get("pr"), r.get("issue", "?"), r.get("verdict"),
+        str(r.get("head_sha", "")), r.get("ts"), r.get("invoker", "<absent>"))
 if newest:
-    print("PR #%s %s verdict=%s head=%.12s at %s" % (
-        newest.get("pr"), newest.get("issue", "?"), newest.get("verdict"),
-        str(newest.get("head_sha", "")), newest.get("ts")))
+    print("ANY|" + line(newest))
+if worker:
+    print("WORKER|" + line(worker))
 PY
 )"
-if [ -n "$RECEIPT" ]; then
-  info "RECEIPT FOUND: a codex-engine review really ran -- $RECEIPT"
+ANY_RECEIPT="$(printf '%s\n' "$RECEIPT" | sed -n 's/^ANY|//p')"
+WORKER_RECEIPT="$(printf '%s\n' "$RECEIPT" | sed -n 's/^WORKER|//p')"
+if [ -n "$ANY_RECEIPT" ]; then
+  info "RECEIPT FOUND: a codex-engine review really ran -- $ANY_RECEIPT"
 else
   info "NO RECEIPT YET: no pr-*.verdict.json under $STATE_DIR/pr-reviews carries engine=codex. Wiring is green; a real run has not been observed."
+fi
+# THE PROOF THE FOUNDER IS ACTUALLY WAITING ON. Reported as its own line because
+# "a codex review ran" and "the dispatcher ran one unattended" are different
+# claims, and only the second closes the loop. Conflating them is what let every
+# earlier proof carry a hole.
+if [ -n "$WORKER_RECEIPT" ]; then
+  info "DISPATCHER-DRIVEN RECEIPT FOUND: the scheduled loop reviewed a PR unattended -- $WORKER_RECEIPT"
+else
+  info "NO DISPATCHER-DRIVEN RECEIPT YET: no codex record carries invoker=worker. A hand-run review does not count, and a record with no invoker key reads as manual."
 fi
 
 LOG="$STATE_DIR/dispatch.log"

--- a/q-system/.q-system/scripts/verify-codex-review-live.sh
+++ b/q-system/.q-system/scripts/verify-codex-review-live.sh
@@ -1,4 +1,5 @@
 #!/usr/bin/env bash
+# portability-lint-skip-file: this script is macOS-only BY DESIGN (launchd/plutil).
 # Will codex actually review Sana's work on the next scheduled run? (ASK-221)
 #
 # WHY THIS EXISTS: on 2026-07-29 a guard was written, tested green, and reported as

--- a/q-system/.q-system/scripts/verify-codex-review-live.sh
+++ b/q-system/.q-system/scripts/verify-codex-review-live.sh
@@ -158,18 +158,61 @@ for t in test-review-tree-guard.sh test-findings-block-reader.sh; do
 done
 
 # --- 8. when does it next get a chance, and has it ever actually run? --------
-# The receipt, as opposed to the wiring. A codex verdict line in the dispatch log is
-# the only thing here that proves a review HAPPENED.
+# The receipt, as opposed to the wiring.
+#
+# THE RECEIPT IS THE RECORD, NOT A LOG LINE (sp-1d1ad606). This block used to
+# grep dispatch.log for `engine: codex`. That string is real -- pr-review-agent.sh
+# prints `round: N (engine: codex)` -- but it goes to the reviewer's STDOUT, which
+# linear-worker.sh redirects into $STATE_DIR/linear-worker.log. dispatch.log is
+# written by kipi-dispatch.sh and carries cadence lines only, so the receipt string
+# could never appear there. Check 8 printed NO RECEIPT YET unconditionally, forever,
+# including after a real dispatcher-driven codex review -- and that was the one line
+# in this verifier the founder was reading as proof.
+#
+# So read the VERDICT RECORD, which is the artifact the reviewer actually writes and
+# already carries `engine`, `head_sha` and `ts`. This is also what the rest of the
+# loop does (`verdict_from_record`, "ONE reader of the verdict, never re-grep the
+# prose") -- the old grep was the only place that reasoned about a review from a log.
 INTERVAL="$(plutil -extract StartInterval raw -o - "$PLIST" 2>/dev/null || echo '?')"
 info "StartInterval: ${INTERVAL}s"
-LOG="$HOME/.config/kipi/dispatch.log"
+
+# Honour KIPI_STATE_DIR. The old hardcoded $HOME path meant a run against a test
+# state dir silently reported on the founder's real one -- a verifier reading a
+# different installation than the one under test is worse than no verifier.
+STATE_DIR="${KIPI_STATE_DIR:-$HOME/.config/kipi}"
+RECEIPT="$(python3 - "$STATE_DIR/pr-reviews" <<'PY' 2>/dev/null
+import glob, json, os, sys
+newest = None
+# Both layouts: the PRIMARY engine writes pr-<N>.verdict.json to the parent dir,
+# a secondary engine to <dir>/<engine>/. Globbing only one would miss the receipt
+# the moment KIPI_REVIEW_PRIMARY_ENGINE changes.
+for p in glob.glob(os.path.join(sys.argv[1], "*.verdict.json")) + \
+         glob.glob(os.path.join(sys.argv[1], "*", "*.verdict.json")):
+    try:
+        r = json.load(open(p))
+    except Exception:
+        continue          # a corrupt record is not a receipt
+    if r.get("engine") != "codex":
+        continue
+    if newest is None or str(r.get("ts", "")) > str(newest.get("ts", "")):
+        newest = r
+if newest:
+    print("PR #%s %s verdict=%s head=%.12s at %s" % (
+        newest.get("pr"), newest.get("issue", "?"), newest.get("verdict"),
+        str(newest.get("head_sha", "")), newest.get("ts")))
+PY
+)"
+if [ -n "$RECEIPT" ]; then
+  info "RECEIPT FOUND: a codex-engine review really ran -- $RECEIPT"
+else
+  info "NO RECEIPT YET: no pr-*.verdict.json under $STATE_DIR/pr-reviews carries engine=codex. Wiring is green; a real run has not been observed."
+fi
+
+LOG="$STATE_DIR/dispatch.log"
 if [ -f "$LOG" ]; then
+  # Cadence only. This log answers "when does it next get a chance", never
+  # "did a review happen" -- that is the record above.
   info "last dispatch line: $(tail -1 "$LOG")"
-  if grep -q 'engine: codex' "$LOG" 2>/dev/null; then
-    info "RECEIPT FOUND: the log records at least one codex-engine review run"
-  else
-    info "NO RECEIPT YET: the log has no codex-engine review line. Wiring is green; a real run has not been observed."
-  fi
   if tail -5 "$LOG" | grep -q "DAILY CAP"; then
     info "daily cap is spent; the next real dispatch is after the 07:00 local reset"
   fi

--- a/q-system/canonical/decisions.md
+++ b/q-system/canonical/decisions.md
@@ -34,3 +34,76 @@ Monthly audit (1st of month): count decisions by origin tag. If >60% are rubber-
 - **Decision:** Never send more than 1 unsolicited value message to any person in a 7-day window.
 - **Reason:** Frequency = spam. Quality + spacing = relationship.
 - **Revisit:** Permanent
+
+## Git Coverage (2026-07-29) <!-- pin -->
+
+### RULE-004: A Private Remote Is The Default, Local-Only Is A Declaration
+- **Origin:** [USER-DIRECTED]
+- **Decision:** `kipi new` creates a private GitHub repo by default. Opting out requires
+  `KIPI_LOCAL_ONLY=1` AND `KIPI_LOCAL_ONLY_REASON="why"`, written to
+  `remote-coverage-allow.json` at creation. Missing reason = exit 1. The push happens
+  after the seed commit, since an empty remote reads as covered and is not.
+- **Reason:** Inflow was automated, outflow was manual. 12 repos existed on one disk,
+  oldest 219 commits, several client engagements. Nothing reported the gap.
+- **Date:** 2026-07-29
+- **Revisit:** Permanent
+
+### RULE-005: One Fleet-Wide Coverage Gate, Not Per-Instance Copies
+- **Origin:** [SYSTEM-INFERRED]
+- **Decision:** `remote-coverage-check.py` lives once at kipi-system root, audits
+  `~/projects` as a whole, returns the same answer from any cwd. It does not ship
+  per-instance. It also flags directories that are not repos at all, and asks git what
+  it TRACKS rather than trusting an ancestor `.git`.
+- **Reason:** N copies means N identical scans and N allowlists drifting apart. One gate
+  that sees every system IS fleet coverage. The tracks-not-ancestor check exists because
+  `personal/.gitignore` line 1 is `projects/`, so nested work looked covered and was invisible.
+- **Note:** Diverges from the literal instruction ("push this to all of the systems").
+  Probe: `kipi check` run from inside instance `thaena` fires the gate. Not yet founder-ratified.
+- **Date:** 2026-07-29
+- **Revisit:** If an instance ever needs a coverage answer scoped to itself
+
+### RULE-006: Allowlist Reasons Name The Data Class, Never The Data
+- **Origin:** [SYSTEM-INFERRED]
+- **Decision:** An entry in `remote-coverage-allow.json` states the CLASS of sensitive
+  content and the path carrying it. Never the content itself.
+- **Reason:** That file is committed to a PUBLIC repo. The first draft explained why the
+  family repos stay local by quoting a minor's diagnosis and school materials into
+  kipi-system. gitleaks, blocked-paths, and large-files all passed it. Caught by re-reading,
+  not by a gate. A reason that quotes the private data defeats the gate it documents.
+- **Date:** 2026-07-29
+- **Revisit:** Permanent
+
+### RULE-007: Family-Medical Repos Are Never Pushed, Private Included
+- **Origin:** [SYSTEM-INFERRED]
+- **Decision:** `AUDHD_KIDS` and `travel-agent` stay local-only until their carrier files
+  move to gitignored paths.
+- **Reason:** Health and education records about a specific minor, re-identifying against
+  the owner's public identity. Private on someone else's servers is still off-disk.
+- **Probe:** `git remote` returns 0 remotes for both, and `gh repo view` returns not-found,
+  re-run after the private-by-default flip.
+- **Date:** 2026-07-29
+- **Revisit:** Once the carrier paths are gitignored
+
+### RULE-008: History Gets A Parallel Clean Branch, Not A Rewrite
+- **Origin:** [SYSTEM-INFERRED]
+- **Decision:** `story-podcast` (two committed venv libs, 178MB + 123MB, over GitHub's
+  100MB limit) got a fresh orphan `main` with clean source, pushed private. The original
+  `master` with full history stays intact locally and unpushed.
+- **Reason:** Non-destructive. Source is now off-disk; nothing was destroyed to get there.
+- **Open:** The full history still exists only on the laptop, so the repo is covered for
+  its source and NOT for its history. A real rewrite is still undecided.
+- **Date:** 2026-07-29
+- **Revisit:** When the 300MB history matters enough to rewrite
+
+### RULE-009: Audit The Class, Not The Artifact You Were Handed
+- **Origin:** [SYSTEM-INFERRED]
+- **Decision:** When hardening one deployed surface, enumerate every surface in the same
+  class first. A deployed site with no source on disk is invisible to any gate that walks
+  directories.
+- **Reason:** The `deliverables` site was hardened while the demos actually emailed to
+  prospects sat on two other Vercel projects nobody had looked at, fully indexable, naming
+  real organizations. The constraint that drove the original fix ("renaming breaks links
+  already shared") was an inference, never probed, and was false. Cole probed it four ways
+  and found no link had ever been sent. See `q-system/lessons/prove-a-negative-with-a-live-probe.md`.
+- **Date:** 2026-07-29
+- **Revisit:** Permanent

--- a/q-system/canonical/fleet-map.md
+++ b/q-system/canonical/fleet-map.md
@@ -35,6 +35,24 @@ moves. Only rewrite: 3 tokentrim `_setup_*.py` self-refs (absolute build paths i
 `kipi-system` stays TOP-LEVEL/meta on purpose (it's the factory every persona depends on — plan
 open-decision #3). Section 6 reflects the new paths.
 
+**Git coverage (2026-07-29) — DONE.** First fleet-wide audit of which projects exist anywhere
+but this laptop. 61 repos swept: 16 had no remote, 12 of them real work, oldest 219 commits,
+several client engagements. Nine more directories were not repos at all, including
+`intel/projects/deliverables` (475 files, client run outputs, a live Vercel deploy, zero
+version control). Root cause: `kipi new` did `git init` and never created a remote, so inflow
+was automated and outflow was manual. 13 repos are now private on GitHub; `deliverables` became
+`gh:assafkip/ktlyst-deliverables`. `remote-coverage-check.py` at kipi-system root is the standing
+gate (currently 58 covered, 0 undeclared, 0 not-a-repo) and `kipi new` is private-by-default with
+a reasoned opt-out. Local-only is now a written declaration in `remote-coverage-allow.json`, not
+a silence. `AUDHD_KIDS` and `travel-agent` stay local-only (family-medical). See RULE-004..009 in
+`decisions.md`.
+
+**Deployed-but-sourceless surfaces (2026-07-29).** The same audit surfaced a class the gate
+structurally cannot see: Vercel sites with no source anywhere on disk. Two prospect-facing demos
+(`ktlyst-demo-crinetics`, `sjifire-demo-v2`) were live, fully indexable, and named real
+organizations. Both now carry robots.txt + `X-Robots-Tag: noindex`; content byte-identical.
+Access gating is still open, pending a founder-minted capability token. Tracked as `sp-784e3594`.
+
 ---
 
 ## 1. KTLYST Core Product (the company product)

--- a/q-system/output/plans/reviewer-evidence-path-2026-07-29.md
+++ b/q-system/output/plans/reviewer-evidence-path-2026-07-29.md
@@ -73,13 +73,69 @@ the file's own principle: read the record, never re-grep the prose.
 
 ## Acceptance criteria
 
-- [ ] Reproducer fails against pre-fix ref (`KIPI_TEST_REVIEWER_REF=f277389`)
-- [ ] Rendered body of the real 519,377 B review is <= 65,536 B
-- [ ] Rendered body contains the verdict AND the findings block
-- [ ] Negative self-test: raw file fed to the same size assertion FAILS
+- [x] Reproducer fails against pre-fix ref (`KIPI_TEST_REVIEWER_REF=f277389`
+      -> 1 passed, 1 failed: "no review_comment_body exists")
+- [x] Rendered body of the real 519,377 B review is <= 65,536 B (55,437 B)
+- [x] Rendered body contains the verdict AND the findings block
+- [x] Negative self-test: case 1 asserts the raw fixture still exceeds the
+      limit, so the suite voids itself if the fixture stops reproducing
 - [ ] A real comment lands on a real PR (observed via `gh`), not just locally
-- [ ] Fix B: verifier reports RECEIPT FOUND against the existing records, and
-      NO RECEIPT YET against an empty state dir (both directions proven)
+      -- codex review of PR #47 running, deadline 06:31:45Z
+- [x] Fix B: `RECEIPT FOUND: PR #46 ASK-221 verdict=APPROVE WITH NITS
+      head=1000890be2b4` / empty state dir -> `NO RECEIPT YET`
+
+## Corrections made to the brief I was given
+
+Both defects were described to me with claims the measurement disproved. Worth
+recording because the same over-claim shape appeared three times, once by me.
+
+1. **"Never reaches the PR, every time" is false.** Four rounds on disk:
+   435,280 / 519,377 / 278,439 / 197,279 bytes. The 197,279-byte round LANDED
+   as a 197,208-character comment on PR #46. 3 of 4, size-dependent. Voided
+   `sp-ac632d7b` (stale) and `sp-b418be32` (mine, same wrong claim).
+2. **"No script writes dispatch.log" is false** -- my own over-claim, from
+   grepping only `q-system/.q-system/scripts/*.sh`. `kipi-dispatch.sh:39`
+   (repo root) writes it. Voided `sp-ab4e19c3`; `sp-899c3dbd` is the canonical
+   record and my refile `sp-1d1ad606` is voided as its duplicate.
+3. **The stated 65,536 limit does not match observed behaviour.** A rejection
+   reproduced `maximum is 65536 characters (addComment)`, yet a 197,208-char
+   comment landed. The limit is path-dependent, so the cap is 60,000 -- under
+   both -- and deliberately not tuned.
+
+## Work beyond the two fixes
+
+- **Shared spillover ledger** (`sp-bc42f1d3`, scale `sp-10ea7b66`). The
+  reported "13 items in one worktree" was 1 of 26: **71 open findings across
+  26 worktree ledgers** were invisible to `gates run`. Fixed at the
+  `_spillover_path` chokepoint via `git rev-parse --git-common-dir`;
+  consolidated all 71 by append with a backup. Re-measured: 0 orphans.
+  My first cut of that fix used two unimported names whose `NameError` the
+  `except` clause swallowed -- it would have looked correct and done nothing.
+  Caught by proving case 2 fails under exactly that mode.
+- **Dispatch cap: held at 3**, reasoning recorded in `kipi-dispatch.sh` where
+  it is enforced. Not a money dial. Per-issue cost rose (4 rounds, plus a codex
+  run each) while the number stayed put; the loop self-merges with no
+  accepted-change signal. Also corrected a stale `= 6 sessions` comment that
+  understated the running job by a third.
+- **Did NOT reset today's dispatch counter.** `RESET_HOUR=7` exists so an
+  overnight run can only spend what is left from yesterday. Resetting at 23:00
+  local hands a fresh budget to an unattended loop, which is the exact case
+  that default was chosen to prevent. Proof came from a watched foreground
+  review instead.
+
+## Still open, with the plan stated
+
+- `gates run` is RED: 306 open items, rc=1. Correctly red. 71 of those are
+  newly VISIBLE, not newly created. Resolving any of them requires a closed
+  issue reference, which `spillover resolve` enforces, so they close through
+  the normal issue flow -- not tonight and not by hand.
+- `sp-53aad86f`: the verdict record has no invoker field, so check 8 proves
+  *a codex review ran*, not *the dispatcher ran one unattended*. That is the
+  proof still genuinely outstanding.
+- `sp-6bf56a46`: the ledger fix reaches the repo copy only. The marketplace
+  clone is behind `origin/main` AND hand-patched, so slash-command captures
+  still resolve per-worktree until it is pulled and triaged.
+- `sp-c775b116`: `kipi-dispatch.sh` has no `git pull`, so merged is not live.
 
 ## Patterns to follow (from this repo's own code)
 

--- a/q-system/output/plans/reviewer-evidence-path-2026-07-29.md
+++ b/q-system/output/plans/reviewer-evidence-path-2026-07-29.md
@@ -1,0 +1,89 @@
+# Reviewer evidence path: the review never reaches a human, and the receipt is unreadable
+
+Date: 2026-07-29 (session clock 2026-07-30 UTC)
+Owner: sana. Issue: ASK-221 follow-on.
+
+## What / why
+
+Two defects on merged `main` (`f277389`), both in the same class: the codex
+reviewer really runs, and the evidence of it lands somewhere nobody reads.
+
+1. **The review never reaches the PR.** `--post` pipes the RAW codex stdout to
+   `gh pr comment --body-file`. Measured: `pr-34-20260729-204820.md` = 435,280 B,
+   `pr-34-20260729-210606.md` = 519,377 B. GitHub's comment limit is 65,536 B.
+   Every post fails, `pr-review-agent.sh:627` prints `WARN: could not comment on
+   PR` and continues, and `post_reviewer_status` then has no `target_url`. A
+   human sees a bare green/red status with nothing behind it.
+   Verified: PR #34 has 3 issue comments, all authored by `assafkip`, zero codex.
+
+2. **The receipt is grepped from a file nothing writes.**
+   `verify-codex-review-live.sh:165-171` greps `~/.config/kipi/dispatch.log` for
+   `engine: codex`. That string is produced by `pr-review-agent.sh:255`
+   (`round: $ROUND (engine: $ENGINE)`) on **stdout**, which
+   `linear-worker.sh:1133` redirects into `$STATE_DIR/linear-worker.log`.
+   Worse than a wrong-file bug: `grep -rn 'dispatch.log'` over
+   `q-system/.q-system/scripts/*.sh` shows the verifier is the ONLY reference —
+   no script in the tree writes that file at all. So check 8 prints
+   `NO RECEIPT YET` forever, including after a real dispatcher-driven review.
+
+## Why the obvious fixes are wrong
+
+- **Trimming harness noise does not fit.** The 14-line header is not the bulk.
+  `pr-34-20260729-210606.md` is 10,130 lines; the reviewer's actual message is
+  the last ~250. Lines 15-9880 are the codex agent's own transcript, which
+  includes the diff it read — that is why the file contains 11 `FINDINGS:`
+  markers instead of one.
+- **Splitting across comments is wrong.** It would put ~8 comments of agent
+  transcript on the PR. The transcript is a debugging artifact, not a review.
+  GitHub is not an artifact store.
+
+## Approach (the pick)
+
+Options considered: (a) split across N comments, (b) attach as a gist/artifact,
+(c) post a bounded rendered review and name the on-disk artifact. **Pick: (c).**
+
+### Fix A — one renderer, bounded, verdict and findings structurally guaranteed
+
+Add `review_comment_body <review-file>` to `pr-verdict-lib.sh`, beside the other
+ONE-reader helpers. It emits, in order:
+
+- the verdict, from the verdict the caller already derived (never re-grepped)
+- the findings block, via the existing `findings_block` ONE reader
+- the tail of the reviewer output, line-aligned, as the human-readable narrative
+- a footer naming the full artifact path and its byte size
+
+The verdict and findings come from the ONE reader, NOT from the truncated tail,
+so truncation can never drop the two things a human needs. Hard cap under
+65,536 with an explicit truncation marker.
+
+### Fix B — the receipt is the record, not a log line
+
+Point check 8 at the verdict RECORDS (`pr-*.verdict.json` carrying
+`"engine": "codex"`), honouring `KIPI_STATE_DIR`. Already true on disk:
+`pr-34.verdict.json` and `pr-46.verdict.json` both carry `"engine": "codex"`.
+This is also the founder's own stated definition of the proof, and it matches
+the file's own principle: read the record, never re-grep the prose.
+
+## Files to touch
+
+- `q-system/.q-system/scripts/pr-verdict-lib.sh` (Fix A: the renderer)
+- `q-system/.q-system/scripts/pr-review-agent.sh` (Fix A: the caller at ~627)
+- `q-system/.q-system/scripts/test/test-review-comment-body.sh` (Fix A repro)
+- `q-system/.q-system/scripts/verify-codex-review-live.sh` (Fix B)
+
+## Acceptance criteria
+
+- [ ] Reproducer fails against pre-fix ref (`KIPI_TEST_REVIEWER_REF=f277389`)
+- [ ] Rendered body of the real 519,377 B review is <= 65,536 B
+- [ ] Rendered body contains the verdict AND the findings block
+- [ ] Negative self-test: raw file fed to the same size assertion FAILS
+- [ ] A real comment lands on a real PR (observed via `gh`), not just locally
+- [ ] Fix B: verifier reports RECEIPT FOUND against the existing records, and
+      NO RECEIPT YET against an empty state dir (both directions proven)
+
+## Patterns to follow (from this repo's own code)
+
+- ONE reader per fact (`pr-verdict-lib.sh` header comment, sp-c0a9dac3)
+- Reproducer ref hatch: `KIPI_TEST_REVIEWER_REF` (already used by
+  `test-review-tree-guard.sh` case 5)
+- Scar-anchored why-comments, never what-comments

--- a/settings-template.json
+++ b/settings-template.json
@@ -255,6 +255,15 @@
             "timeout": 5
           }
         ]
+      },
+      {
+        "matcher": "Write|Edit",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "test -f \"$CLAUDE_PROJECT_DIR/q-system/.q-system/scripts/portability-lint-hook.py\" && python3 \"$CLAUDE_PROJECT_DIR/q-system/.q-system/scripts/portability-lint-hook.py\""
+          }
+        ]
       }
     ],
     "PostCompact": [


### PR DESCRIPTION
Two defects on merged `main`, same class: the codex reviewer really runs, and the evidence lands where nobody reads it.

## 1. The review did not reach the PR (`sp-48688b24`)

`--post` sent the codex agent's whole stdout as the comment body. Four real rounds, measured on disk:

| bytes | outcome |
|---|---|
| 435,280 | rejected |
| 519,377 | rejected |
| 278,439 | rejected |
| 197,279 | **landed** (197,208-char comment on PR #46) |

3 of 4. **Size-dependent, not universal** — the first two write-ups of this defect, mine included, both claimed it failed every time and were wrong. `sp-ac632d7b` and my duplicate `sp-b418be32` are voided with that correction recorded.

`review_comment_body()` renders the verdict, the findings block (through `findings_block`, the ONE reader) and a bounded tail, then names the full artifact on disk. **Verdict and findings print above the cut**, so truncation can drop narrative but never the two facts a human acts on.

Cap is 60,000: under both the 65,536 a reproduced rejection reported and the ~197-278KB ceiling actually observed. Those two disagree, so the limit is path-dependent and the safe number clears both.

## 2. The receipt was grepped from a file nothing writes (`sp-1d1ad606`)

`verify-codex-review-live.sh` check 8 greped `dispatch.log` for `engine: codex`. That string is real — `pr-review-agent.sh:255` prints it — but on **stdout**, which `linear-worker.sh:1133` redirects into `linear-worker.log`. `dispatch.log` is written by `kipi-dispatch.sh:39` with cadence lines only.

So check 8 printed `NO RECEIPT YET` unconditionally, forever, including after a real codex review. That was the one line in the verifier being read as proof.

Now it reads the verdict **record**, which already carries `engine`, `head_sha`, `ts`. Same posture as the rest of the loop: read the record, never re-grep the prose. Also honours `KIPI_STATE_DIR` — the hardcoded `$HOME` meant a test run silently reported on the founder's real installation.

## Evidence

`test-review-comment-body.sh`, 12/12 against the live tree. Watched fail first:

```
KIPI_TEST_REVIEWER_REF=f277389 bash test-review-comment-body.sh
  -> FAIL: THE DEFECT: no review_comment_body exists, so --post can only
     send the raw 519377-byte file
  -------- 1 passed, 1 failed --------

bash test-review-comment-body.sh
  -------- 12 passed, 0 failed --------
```

Case 4 (byte-identity against `findings_block`) caught a real bug in my own first cut: the closing code fence glued onto `END FINDINGS`.

Receipt check proven both directions:

```
real state dir  -> RECEIPT FOUND: PR #46 ASK-221 verdict=APPROVE WITH NITS
                   head=1000890be2b4 at 2026-07-30T05:37:29Z
empty state dir -> NO RECEIPT YET
```

No regressions: `test-review-tree-guard.sh`, `test-findings-block-reader.sh` rc=0; `test-severity-floor.sh` rc=0, 92 checks.

## Honest gap, captured not hidden

`sp-53aad86f`: the verdict record has no invoker field, so check 8 proves *a codex review ran*, not *the dispatcher ran one unattended*. Both current receipts are agent-session runs. That is the proof still outstanding.

🤖 Generated with [Claude Code](https://claude.com/claude-code)