### PR TITLE
fix(test): stop three test suites from paging the founder, and lint the class shut

### DIFF
--- a/plugins/prd-os/.claude-plugin/plugin.json
+++ b/plugins/prd-os/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "prd-os",
-  "version": "0.7.4",
+  "version": "0.8.0",
   "description": "PRD operating system: capture rough ideas, draft reviewable PRDs, run standard and adversarial review (Codex or a Claude senior-staff-engineer subagent, recorded truthfully), triage findings, decompose approved PRDs into atomic issue specs, and execute those issues with scope enforcement, stop-gate receipts, and reviewer-attributed findings.",
   "author": {
     "name": "Assaf Kipnis"

--- a/plugins/prd-os/.claude-plugin/plugin.json
+++ b/plugins/prd-os/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "prd-os",
-  "version": "0.8.0",
+  "version": "0.9.0",
   "description": "PRD operating system: capture rough ideas, draft reviewable PRDs, run standard and adversarial review (Codex or a Claude senior-staff-engineer subagent, recorded truthfully), triage findings, decompose approved PRDs into atomic issue specs, and execute those issues with scope enforcement, stop-gate receipts, and reviewer-attributed findings.",
   "author": {
     "name": "Assaf Kipnis"

--- a/plugins/prd-os/.claude-plugin/plugin.json
+++ b/plugins/prd-os/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "prd-os",
-  "version": "0.9.0",
+  "version": "0.9.1",
   "description": "PRD operating system: capture rough ideas, draft reviewable PRDs, run standard and adversarial review (Codex or a Claude senior-staff-engineer subagent, recorded truthfully), triage findings, decompose approved PRDs into atomic issue specs, and execute those issues with scope enforcement, stop-gate receipts, and reviewer-attributed findings.",
   "author": {
     "name": "Assaf Kipnis"

--- a/plugins/prd-os/skills/fable-discipline/scripts/fable-discipline-lint.py
+++ b/plugins/prd-os/skills/fable-discipline/scripts/fable-discipline-lint.py
@@ -65,13 +65,22 @@ Outbound-channel detector coverage (third detector, same enumeration rule):
              branch, reached the real slack-notify.sh, and paged the founder's
              phone twice on 2026-08-01 while reporting 14/14 green. A live
              channel is a live resource.
-    CATCHES  a file under a test directory that (a) names a runner script which
-             resolves on disk and itself reaches slack-notify.sh, and (b) hands
-             that runner to an interpreter, with (c) no notifier stub anywhere
-             in its non-comment lines. The notify-capable set is DERIVED by
-             reading the referenced runner, never hardcoded, so a new
-             pager-capable script is covered the day it is written and there is
-             no list to remember to update.
+    CATCHES  (test side) a file under a test directory that (a) names a runner
+             script which resolves on disk and itself reaches slack-notify.sh on
+             a LIVE line, and (b) hands that runner to an interpreter, with (c)
+             no notifier stub in THAT COMMAND. Isolation is judged per
+             invocation, joined across backslash continuations, because a stub
+             three commands earlier protects nothing: the real
+             test-severity-floor.sh stubbed 5 reviewer call sites and left 2
+             unstubbed, and a file-wide check called it clean.
+             (runner side) editing a pager-capable runner re-checks every test
+             in its sibling test/ directory and blocks if any drives it
+             unstubbed. Adding a page to a runner turns those tests into leaks,
+             and the edit touches none of them, so the edited file alone can
+             never reveal it.
+             The notify-capable set is DERIVED by reading the referenced runner,
+             never hardcoded, so a new pager-capable script is covered the day it
+             is written and there is no list to remember to update.
     SKIPS    a test that only greps/parses the runner (no interpreter line), and
              any test that stubs the notifier one of the three ways the fleet
              actually uses: KIPI_NOTIFY=... (the env seam), a NOTIFY_SCRIPT
@@ -79,16 +88,21 @@ Outbound-channel detector coverage (third detector, same enumeration rule):
              sandbox skeleton (the seam for runners like lessons-daily.sh that
              hardcode $SKEL/.../slack-notify.sh and expose no env override).
              `bash -n` parses without executing and is not an invocation.
-    MISSES   (documented deferrals): a stub named only in a COMMENT does not
-             count, but a bare mention on a live line does, so an unused
-             KIPI_NOTIFY assignment reads as isolation; a runner reached only
-             through a PATH-shadowed binary, or one whose filename the test
-             never spells out; a runner imported as a Python MODULE instead of
-             executed (no interpreter line to see); a runner living somewhere
-             other than the test's own directory or its parent; and outbound
-             channels other than slack-notify.sh (a raw curl to a webhook,
-             sendmail, gh) -- this detector is scoped to the one channel that
-             actually wakes a human.
+    MISSES   (documented deferrals): ENV INHERITANCE to a grandchild -- a test
+             that sets KIPI_NOTIFY on a parent command whose CHILD execs the
+             runner reads as unstubbed, because the invocation line cannot name
+             the parent. test-dispatch-liveness.sh hit this; the fix there was
+             to `export` the stub, which is both correct for that topology and
+             what the global carve-out recognises. Also: a stub named only in a
+             COMMENT does not count, but a bare mention on the command does, so
+             an unused KIPI_NOTIFY assignment reads as isolation; a runner
+             reached only through a PATH-shadowed binary, or one whose filename
+             the test never spells out; a runner imported as a Python MODULE
+             instead of executed (no interpreter line to see); a runner living
+             somewhere other than the test's own directory or its parent; and
+             outbound channels other than slack-notify.sh (a raw curl to a
+             webhook, sendmail, gh) -- this detector is scoped to the one
+             channel that actually wakes a human.
 
 Scope (fast-exit otherwise, token discipline):
     Three detectors, three scopes, evaluated in this order:
@@ -241,8 +255,29 @@ _SYNTAX_ONLY = re.compile(r"\b(?:bash|sh|zsh)\s+-n\b")
 # ${FOO:-default} forms alike, because the name only has to appear on the line.
 _ASSIGN = re.compile(r"^\s*(?:export\s+)?([A-Za-z_][A-Za-z0-9_]*)=")
 
-# The three stub shapes the fleet actually uses.
-_NOTIFY_STUB = re.compile(r"KIPI_NOTIFY|NOTIFY_SCRIPT|slack-notify\.sh")
+# A stub that genuinely covers EVERY later invocation in the file. Only these
+# three shapes do: an exported shell var, a module-level rebind of the Python
+# seam, and writing your own notifier into the sandbox skeleton a runner
+# resolves. Anything else is per-command and protects only its own command.
+_GLOBAL_STUB = re.compile(
+    r"^\s*export\s+KIPI_NOTIFY=|"
+    r"NOTIFY_SCRIPT\s*=|"
+    r"os\.environ\[[\"']KIPI_NOTIFY[\"']\]\s*=|"
+    r"setenv\(\s*[\"']KIPI_NOTIFY[\"']|"
+    r">\s*[\"']?[^\s\"']*slack-notify\.sh"
+)
+
+# A stub attached to one command. Must appear in the SAME logical line as the
+# invocation it protects.
+_PER_CALL_STUB = re.compile(r"KIPI_NOTIFY|NOTIFY_SCRIPT")
+
+# Resolution is disk I/O and the runner-change scan re-checks every sibling test,
+# so memoise per (test dir, runner name).
+_REACH_CACHE = {}
+
+# A runaway bracket count (an unbalanced brace inside a string) must not swallow
+# the rest of the file into one logical line and hide every later invocation.
+_MAX_JOIN = 30
 
 
 _ENV_ASSIGN_TOK = re.compile(r"^[A-Za-z_][A-Za-z0-9_]*=")
@@ -306,6 +341,10 @@ def _notifier_reachable(test_path, name):
     if name == NOTIFIER_BASENAME:
         return False
     d = Path(str(test_path)).resolve().parent
+    key = (str(d), name)
+    if key in _REACH_CACHE:
+        return _REACH_CACHE[key]
+    result = False
     for cand in (d.parent / name, d / name):
         try:
             if cand.is_file():
@@ -313,21 +352,54 @@ def _notifier_reachable(test_path, name):
                 # a comment about an unrelated defect and never invokes it; a
                 # whole-text match made two innocent suites look like leaks.
                 body = cand.read_text(encoding="utf-8", errors="replace")
-                return any(NOTIFIER_BASENAME in line
-                           for _, line in _live_lines(body))
+                result = any(NOTIFIER_BASENAME in line
+                             for _, line in _live_lines(body))
+                break
         except Exception:
-            return False
-    return False
+            result = False
+            break
+    _REACH_CACHE[key] = result
+    return result
+
+
+def _logical_lines(text, python=False):
+    """[(first_line_no, joined_command)] -- the isolation UNIT.
+
+    `KIPI_NOTIFY=... \\` + `bash "$RUNNER"` is ONE command, so the stub has to be
+    joined to the invocation it protects. Checking the file instead certified the
+    real test-severity-floor.sh clean: it stubbed 5 reviewer call sites and left 2
+    unstubbed, and one file-wide match suppressed detection for all 7.
+    """
+    out, buf, start, depth = [], [], None, 0
+    for i, raw in enumerate(text.splitlines(), 1):
+        if raw.lstrip().startswith("#"):
+            continue
+        if start is None:
+            start = i
+        buf.append(raw)
+        cont = raw.rstrip().endswith("\\")
+        if python:
+            depth += raw.count("(") + raw.count("[") + raw.count("{")
+            depth -= raw.count(")") + raw.count("]") + raw.count("}")
+            depth = max(depth, 0)
+        if (cont or (python and depth > 0)) and len(buf) < _MAX_JOIN:
+            continue
+        out.append((start, " ".join(b.rstrip().rstrip("\\") for b in buf)))
+        buf, start, depth = [], None, 0
+    if buf:
+        out.append((start, " ".join(b.rstrip().rstrip("\\") for b in buf)))
+    return out
 
 
 def find_notify_leaks(file_path, text):
     """[(line_no, runner_name)] per notify-capable runner this test EXECUTES
     while stubbing nothing."""
     live = _live_lines(text)
-    if any(_NOTIFY_STUB.search(line) for _, line in live):
-        return []                      # isolated by one of the three seams
+    if any(_GLOBAL_STUB.search(line) for _, line in live):
+        return []                      # one stub genuinely covers the whole file
 
     self_name = Path(str(file_path)).name
+    is_py = Path(str(file_path)).suffix == ".py"
     reachable = {}                     # runner name -> bool, resolved once
     var_to_runner = {}                 # shell var -> runner name assigned to it
 
@@ -345,21 +417,80 @@ def find_notify_leaks(file_path, text):
 
     hits = []
     seen = set()
-    for ln, line in live:
-        if _SYNTAX_ONLY.search(line):
+    for ln, cmd in _logical_lines(text, python=is_py):
+        if _SYNTAX_ONLY.search(cmd):
             continue
-        for tok in _interpreter_args(line):
+        here = []
+        for tok in _interpreter_args(cmd):
             for name in _SCRIPT_NAME.findall(tok):
-                if name != self_name and reachable.get(name) and name not in seen:
-                    seen.add(name)
-                    hits.append((ln, name))
+                if name != self_name and reachable.get(name):
+                    here.append(name)
             for var, name in var_to_runner.items():
-                if name in seen:
-                    continue
                 if re.search(r"\$\{?" + re.escape(var) + r"\b", tok):
-                    seen.add(name)
-                    hits.append((ln, name))
+                    here.append(name)
+        if not here:
+            continue
+        # The stub must ride along with THIS command, not merely exist somewhere
+        # above it in the file.
+        if _PER_CALL_STUB.search(cmd):
+            continue
+        for name in here:
+            if (ln, name) not in seen:
+                seen.add((ln, name))
+                hits.append((ln, name))
     return hits
+
+
+def find_runner_change_leaks(runner_path):
+    """[(test_path, line, runner)] -- tests that drive THIS runner unstubbed.
+
+    A PostToolUse hook that only ever reads the edited file cannot see the other
+    half of the contract. Adding a page to a runner turns every unstubbed test
+    that executes it into a leak, and the edit touched none of those files, so
+    editing the runner used to exit 0 while editing any of its tests exited 2.
+    """
+    p = Path(str(runner_path)).resolve()
+    if p.suffix not in _TEST_SUFFIXES or is_test_dir_file(str(p)):
+        return []
+    try:
+        body = p.read_text(encoding="utf-8", errors="replace")
+    except Exception:
+        return []
+    if not any(NOTIFIER_BASENAME in line for _, line in _live_lines(body)):
+        return []
+    hits = []
+    for d in (p.parent / "test", p.parent / "tests"):
+        if not d.is_dir():
+            continue
+        for t in sorted(d.iterdir()):
+            if t.suffix not in _TEST_SUFFIXES:
+                continue
+            if not t.name.startswith(("test-", "test_")):
+                continue
+            try:
+                ttext = t.read_text(encoding="utf-8", errors="replace")
+            except Exception:
+                continue
+            if SKIP_MARKER in ttext:
+                continue
+            for ln, name in find_notify_leaks(str(t), ttext):
+                if name == p.name:
+                    hits.append((str(t), ln, name))
+    return hits
+
+
+def format_runner_report(runner_path, hits):
+    lines = [f"fable-discipline-lint: {runner_path} reaches {NOTIFIER_BASENAME}, "
+             f"and {len(hits)} test invocation(s) drive it unstubbed:"]
+    for tp, ln, _ in hits:
+        lines.append(f"  {tp}:{ln}")
+    lines.append(
+        "Editing a pager-capable runner makes every unstubbed test that executes "
+        "it a live-channel leak. Stub the notifier at those call sites "
+        "(KIPI_NOTIFY=/usr/bin/true), or add  # " + SKIP_MARKER + "  to a test to "
+        "bypass it."
+    )
+    return "\n".join(lines)
 
 
 def format_notify_report(file_path, hits):
@@ -420,6 +551,12 @@ def hook_mode():
         if deferrals:
             print(format_deferral_report(file_path, deferrals), file=sys.stderr)
             sys.exit(2)
+    # Runner side of the contract: editing a pager-capable runner re-checks the
+    # tests that execute it, which the edited file alone can never reveal.
+    runner_hits = find_runner_change_leaks(file_path)
+    if runner_hits:
+        print(format_runner_report(file_path, runner_hits), file=sys.stderr)
+        sys.exit(2)
     # Outbound-channel isolation: any test-dir file that can reach the pager.
     if is_test_dir_file(file_path):
         try:
@@ -451,6 +588,10 @@ def cli_mode(file_path):
         if deferrals:
             print(format_deferral_report(file_path, deferrals))
             sys.exit(2)
+    runner_hits = find_runner_change_leaks(file_path)
+    if runner_hits:
+        print(format_runner_report(file_path, runner_hits))
+        sys.exit(2)
     if is_test_dir_file(file_path):
         try:
             text = Path(file_path).read_text(encoding="utf-8")

--- a/plugins/prd-os/skills/fable-discipline/scripts/fable-discipline-lint.py
+++ b/plugins/prd-os/skills/fable-discipline/scripts/fable-discipline-lint.py
@@ -88,12 +88,14 @@ Outbound-channel detector coverage (third detector, same enumeration rule):
              sandbox skeleton (the seam for runners like lessons-daily.sh that
              hardcode $SKEL/.../slack-notify.sh and expose no env override).
              `bash -n` parses without executing and is not an invocation.
-    MISSES   (documented deferrals): ENV INHERITANCE to a grandchild -- a test
-             that sets KIPI_NOTIFY on a parent command whose CHILD execs the
-             runner reads as unstubbed, because the invocation line cannot name
-             the parent. test-dispatch-liveness.sh hit this; the fix there was
-             to `export` the stub, which is both correct for that topology and
-             what the global carve-out recognises. Also: a stub named only in a
+    MISSES   (deliberate, because this is DEFENCE IN DEPTH): an executed path
+             that cannot be placed in this checkout is NOT flagged -- see
+             _classify_path. PR #58 made slack-notify.sh refuse to send when the
+             Linear API host is loopback, so a miss here is caught downstream while a false
+             positive is caught by nobody and gets the lint switched off.
+             Also missed: ENV INHERITANCE to a grandchild, where a test sets
+             KIPI_NOTIFY on a parent command whose CHILD execs the runner; the
+             invocation line cannot name the parent. Also: a stub named only in a
              COMMENT does not count, but a bare mention on the command does, so
              an unused KIPI_NOTIFY assignment reads as isolation; a runner
              reached only through a PATH-shadowed binary, or one whose filename
@@ -271,6 +273,22 @@ _GLOBAL_STUB = re.compile(
 # invocation it protects.
 _PER_CALL_STUB = re.compile(r"KIPI_NOTIFY|NOTIFY_SCRIPT")
 
+# Any assignment, so an executed path can be traced back through the variables
+# that built it. Basename alone is not identity: test-dispatch-liveness.sh runs
+# "$ROOT/converge.sh" where ROOT is a mktemp dir, i.e. a sandbox stub that cannot
+# page anyone, and matching on "converge.sh" called it a production leak.
+_ANY_ASSIGN = re.compile(r"^\s*(?:export\s+|local\s+)?([A-Za-z_]\w*)=(.*)$")
+
+# Positive proof the path is a throwaway copy.
+_SANDBOX_EVIDENCE = re.compile(
+    r"\bmktemp\b|\$\{?TMPDIR\b|(?:^|[\s\"'=:])/tmp/|/private/tmp/")
+
+# Positive proof the path is anchored at THIS checkout: the shell idioms that
+# mean "next to this file" or "where we are".
+_HERE_ANCHOR = re.compile(r"BASH_SOURCE|\bdirname\b|\$\{?PWD\b|(?:^|[\"'\s])\./")
+
+_MAX_EXPAND = 6
+
 # Resolution is disk I/O and the runner-change scan re-checks every sibling test,
 # so memoise per (test dir, runner name).
 _REACH_CACHE = {}
@@ -362,6 +380,56 @@ def _notifier_reachable(test_path, name):
     return result
 
 
+def _collect_assignments(live):
+    out = {}
+    for _, line in live:
+        m = _ANY_ASSIGN.match(line)
+        if m and m.group(1) not in out:
+            out[m.group(1)] = m.group(2)
+    return out
+
+
+def _expand(tok, assigns, depth=0):
+    """Substitute the file's own variables into an executed path token."""
+    if depth > _MAX_EXPAND:
+        return tok
+    s = tok.strip("\"'")
+    # ${VAR:-default} keeps the DEFAULT: that is the ref-hatch shape
+    # (`${KIPI_WORKER_UNDER_TEST:-$REPO_SCRIPTS/linear-worker.sh}`), where the
+    # default is the production path the suite normally drives.
+    s = re.sub(r"\$\{[A-Za-z_]\w*:-([^}]*)\}", r"\1", s)
+
+    def sub(m):
+        name = m.group(1)
+        if name in assigns:
+            return _expand(assigns[name], assigns, depth + 1)
+        return m.group(0)
+
+    return re.sub(r"\$\{?([A-Za-z_]\w*)\}?", sub, s)
+
+
+def _classify_path(tok, assigns):
+    """'sandbox' | 'production' | 'unknown' for an executed path token.
+
+    PRECISION FIRST, deliberately. This lint is defence in depth: PR #58 made
+    slack-notify.sh refuse to send when the Linear API host is loopback, which
+    is a chokepoint covering every test on every branch, including the
+    grandchild-process case this detector documents as a structural miss.
+    So a MISS here is caught downstream, while a FALSE POSITIVE is caught by
+    nobody and gets the whole lint switched off by the next person it blocks.
+    'unknown' therefore does NOT flag: when the executed path cannot be placed
+    in this checkout with evidence, stay quiet.
+    """
+    full = _expand(tok, assigns)
+    if _SANDBOX_EVIDENCE.search(full):
+        return "sandbox"
+    if _HERE_ANCHOR.search(full):
+        return "production"
+    if full.startswith("/"):
+        return "production"
+    return "unknown"
+
+
 def _logical_lines(text, python=False):
     """[(first_line_no, joined_command)] -- the isolation UNIT.
 
@@ -395,9 +463,18 @@ def find_notify_leaks(file_path, text):
     """[(line_no, runner_name)] per notify-capable runner this test EXECUTES
     while stubbing nothing."""
     live = _live_lines(text)
-    if any(_GLOBAL_STUB.search(line) for _, line in live):
-        return []                      # one stub genuinely covers the whole file
+    # An exemption cannot apply BACKWARDS in time. An `export KIPI_NOTIFY` on
+    # line 500 says nothing about an invocation on line 100, which ran with the
+    # real notifier. Same shape as the file-wide bug this detector already fixed,
+    # one level up. Record WHERE the global stub starts and exempt only what
+    # follows it.
+    gstub = None
+    for ln, line in live:
+        if _GLOBAL_STUB.search(line):
+            gstub = ln
+            break
 
+    assigns = _collect_assignments(live)
     self_name = Path(str(file_path)).name
     is_py = Path(str(file_path)).suffix == ".py"
     reachable = {}                     # runner name -> bool, resolved once
@@ -420,8 +497,13 @@ def find_notify_leaks(file_path, text):
     for ln, cmd in _logical_lines(text, python=is_py):
         if _SYNTAX_ONLY.search(cmd):
             continue
+        if gstub is not None and ln >= gstub:
+            continue                   # covered by a global stub set EARLIER
         here = []
         for tok in _interpreter_args(cmd):
+            # Identity is the resolved PATH, not the basename.
+            if _classify_path(tok, assigns) != "production":
+                continue
             for name in _SCRIPT_NAME.findall(tok):
                 if name != self_name and reachable.get(name):
                     here.append(name)

--- a/plugins/prd-os/skills/fable-discipline/scripts/fable-discipline-lint.py
+++ b/plugins/prd-os/skills/fable-discipline/scripts/fable-discipline-lint.py
@@ -57,11 +57,48 @@ Deferral-capture detector coverage (second detector, same enumeration rule):
              and non-English phrasing. Your standing gate / CI is the
              enforcement of last resort; this detector is the write-time nudge.
 
+Outbound-channel detector coverage (third detector, same enumeration rule):
+    WHY      The DB-path detector above reads "live data path" as "a file on
+             disk". A test that fires the founder's real Slack webhook is the
+             same defect through a different resource, and this lint missed it:
+             test-worker-project-scope.sh drove the worker into its MISCONFIG
+             branch, reached the real slack-notify.sh, and paged the founder's
+             phone twice on 2026-08-01 while reporting 14/14 green. A live
+             channel is a live resource.
+    CATCHES  a file under a test directory that (a) names a runner script which
+             resolves on disk and itself reaches slack-notify.sh, and (b) hands
+             that runner to an interpreter, with (c) no notifier stub anywhere
+             in its non-comment lines. The notify-capable set is DERIVED by
+             reading the referenced runner, never hardcoded, so a new
+             pager-capable script is covered the day it is written and there is
+             no list to remember to update.
+    SKIPS    a test that only greps/parses the runner (no interpreter line), and
+             any test that stubs the notifier one of the three ways the fleet
+             actually uses: KIPI_NOTIFY=... (the env seam), a NOTIFY_SCRIPT
+             rebind (the Python seam), or writing its own slack-notify.sh into a
+             sandbox skeleton (the seam for runners like lessons-daily.sh that
+             hardcode $SKEL/.../slack-notify.sh and expose no env override).
+             `bash -n` parses without executing and is not an invocation.
+    MISSES   (documented deferrals): a stub named only in a COMMENT does not
+             count, but a bare mention on a live line does, so an unused
+             KIPI_NOTIFY assignment reads as isolation; a runner reached only
+             through a PATH-shadowed binary, or one whose filename the test
+             never spells out; a runner imported as a Python MODULE instead of
+             executed (no interpreter line to see); a runner living somewhere
+             other than the test's own directory or its parent; and outbound
+             channels other than slack-notify.sh (a raw curl to a webhook,
+             sendmail, gh) -- this detector is scoped to the one channel that
+             actually wakes a human.
+
 Scope (fast-exit otherwise, token discipline):
-    Two detectors, two scopes, evaluated in this order:
+    Three detectors, three scopes, evaluated in this order:
     1. Deferral capture runs on ANY code file (suffix allowlist in
        _CODE_SUFFIXES) and can exit 2 on its own.
-    2. Test isolation then runs only on a Python TEST file, detected by
+    2. Outbound-channel isolation runs on any .sh/.py file under a TEST
+       directory (or named test-* / test_*), so it covers SHELL suites, which
+       the Python-only detector below structurally cannot see. That blind spot
+       is why the 2026-08-01 leak lived in a .sh file this lint already ran on.
+    3. Test isolation then runs only on a Python TEST file, detected by
        basename test_*.py / *_test.py or a path under a /tests/ directory.
     A non-code, non-test edit (markdown, JSON, config) exits 0 untouched.
 """
@@ -174,6 +211,172 @@ def find_violations(text):
     return violations
 
 
+# --- Detector 3: outbound-channel isolation ---------------------------------
+# A test that reaches slack-notify.sh rings the founder's actual phone. That is
+# a live resource in exactly the sense the DB-path detector already guards, so
+# it belongs in this lint rather than in a second one.
+NOTIFIER_BASENAME = "slack-notify.sh"
+_TEST_DIR_NAMES = {"test", "tests", "testing"}
+_TEST_SUFFIXES = {".sh", ".py"}
+
+# A script filename as it appears anywhere in a test: in a VAR= assignment, in a
+# quoted path, or bare on an interpreter line.
+_SCRIPT_NAME = re.compile(r"[\w][\w.-]*\.(?:sh|py)")
+
+# Interpreter words that actually RUN a file. `env` is in the set because the
+# 2026-08-01 leak shipped as `env KIPI_SKEL=... bash "$WORKER"`.
+#
+# The interpreter must be a COMMAND WORD: preceded by start-of-line, whitespace
+# or a shell separator, and FOLLOWED BY WHITESPACE. A plain \b...\b here matches
+# the "sh" inside the extension of `AGENT="$DIR/pr-review-agent.sh"`, which made
+# every line that merely NAMES a .sh runner look like an invocation and flagged
+# three grep-only suites. Caught by cross-checking the detector against a
+# measured run rather than trusting its own output.
+_INTERP = re.compile(r"(?:^|[;&|(]|\s)(?:bash|sh|zsh|python3|python|env)\s")
+
+# `bash -n` parses a script without executing it, so it cannot page anyone.
+_SYNTAX_ONLY = re.compile(r"\b(?:bash|sh|zsh)\s+-n\b")
+
+# VAR=... on a line that also names the runner. Covers plain, exported and
+# ${FOO:-default} forms alike, because the name only has to appear on the line.
+_ASSIGN = re.compile(r"^\s*(?:export\s+)?([A-Za-z_][A-Za-z0-9_]*)=")
+
+# The three stub shapes the fleet actually uses.
+_NOTIFY_STUB = re.compile(r"KIPI_NOTIFY|NOTIFY_SCRIPT|slack-notify\.sh")
+
+
+_ENV_ASSIGN_TOK = re.compile(r"^[A-Za-z_][A-Za-z0-9_]*=")
+_INTERP_WORDS = {"bash", "sh", "zsh", "python3", "python", "env"}
+
+
+def _interpreter_args(line):
+    """The FIRST real argument handed to each interpreter on this line.
+
+    Being NAMED on an interpreter line is not being RUN by it. The discriminator
+    is position: `bash "$WORKER"` runs the worker, while
+    `bash -c '... grep "$AGENT" ...'` hands $AGENT to grep. Skipping leading
+    env-assignments and flags is what makes `env A=B bash "$WORKER"` resolve to
+    "$WORKER" rather than to `bash`.
+    """
+    args = []
+    for m in _INTERP.finditer(line):
+        for tok in line[m.end():].split():
+            bare = tok.strip("\"'")
+            if _ENV_ASSIGN_TOK.match(bare) or bare in _INTERP_WORDS:
+                continue
+            if tok.startswith("-"):
+                continue
+            args.append(tok)
+            break
+    return args
+
+
+def is_test_dir_file(file_path):
+    p = Path(str(file_path))
+    if p.suffix not in _TEST_SUFFIXES:
+        return False
+    posix = p.as_posix()
+    if any(part in _TEST_DIR_NAMES for part in posix.split("/")[:-1]):
+        return True
+    name = p.name
+    return name.startswith(("test-", "test_")) or "_test." in name
+
+
+def _live_lines(text):
+    """(line_no, line) for every line that is not a whole-line comment.
+
+    A stub named only in a comment is prose, not isolation. That distinction is
+    what stops a test whose ONLY mention of slack-notify.sh is an explanatory
+    comment from certifying itself clean.
+    """
+    out = []
+    for i, line in enumerate(text.splitlines(), 1):
+        if line.lstrip().startswith("#"):
+            continue
+        out.append((i, line))
+    return out
+
+
+def _notifier_reachable(test_path, name):
+    """True when `name` resolves next to the test and itself reaches the notifier.
+
+    Derived, never hardcoded: the day someone writes a new pager-capable runner,
+    the tests that drive it are covered without editing a list in this file.
+    """
+    if name == NOTIFIER_BASENAME:
+        return False
+    d = Path(str(test_path)).resolve().parent
+    for cand in (d.parent / name, d / name):
+        try:
+            if cand.is_file():
+                # Non-comment lines only. linear-sync.py NAMES slack-notify.sh in
+                # a comment about an unrelated defect and never invokes it; a
+                # whole-text match made two innocent suites look like leaks.
+                body = cand.read_text(encoding="utf-8", errors="replace")
+                return any(NOTIFIER_BASENAME in line
+                           for _, line in _live_lines(body))
+        except Exception:
+            return False
+    return False
+
+
+def find_notify_leaks(file_path, text):
+    """[(line_no, runner_name)] per notify-capable runner this test EXECUTES
+    while stubbing nothing."""
+    live = _live_lines(text)
+    if any(_NOTIFY_STUB.search(line) for _, line in live):
+        return []                      # isolated by one of the three seams
+
+    self_name = Path(str(file_path)).name
+    reachable = {}                     # runner name -> bool, resolved once
+    var_to_runner = {}                 # shell var -> runner name assigned to it
+
+    for _, line in live:
+        for name in _SCRIPT_NAME.findall(line):
+            if name == self_name:
+                continue
+            if name not in reachable:
+                reachable[name] = _notifier_reachable(file_path, name)
+            if not reachable[name]:
+                continue
+            m = _ASSIGN.match(line)
+            if m:
+                var_to_runner[m.group(1)] = name
+
+    hits = []
+    seen = set()
+    for ln, line in live:
+        if _SYNTAX_ONLY.search(line):
+            continue
+        for tok in _interpreter_args(line):
+            for name in _SCRIPT_NAME.findall(tok):
+                if name != self_name and reachable.get(name) and name not in seen:
+                    seen.add(name)
+                    hits.append((ln, name))
+            for var, name in var_to_runner.items():
+                if name in seen:
+                    continue
+                if re.search(r"\$\{?" + re.escape(var) + r"\b", tok):
+                    seen.add(name)
+                    hits.append((ln, name))
+    return hits
+
+
+def format_notify_report(file_path, hits):
+    lines = [f"fable-discipline-lint: {len(hits)} unstubbed outbound-channel "
+             f"invocation(s) in {file_path}:"]
+    for ln, name in hits:
+        lines.append(f"  line {ln}: runs {name}, which reaches {NOTIFIER_BASENAME}")
+    lines.append(
+        "This test can page the founder's real phone. Stub the notifier: pass "
+        "KIPI_NOTIFY=/usr/bin/true in the runner's env, or rebind NOTIFY_SCRIPT, "
+        "or write your own slack-notify.sh into the sandbox skeleton for runners "
+        "with no env seam. Scar: 2026-08-01, a suite reporting 14/14 green paged "
+        f"the founder twice. Or add  # {SKIP_MARKER}  to bypass."
+    )
+    return "\n".join(lines)
+
+
 def lint_file(file_path):
     try:
         text = Path(file_path).read_text(encoding="utf-8")
@@ -217,6 +420,17 @@ def hook_mode():
         if deferrals:
             print(format_deferral_report(file_path, deferrals), file=sys.stderr)
             sys.exit(2)
+    # Outbound-channel isolation: any test-dir file that can reach the pager.
+    if is_test_dir_file(file_path):
+        try:
+            text = Path(file_path).read_text(encoding="utf-8")
+        except Exception:
+            text = ""
+        if text and SKIP_MARKER not in text:
+            leaks = find_notify_leaks(file_path, text)
+            if leaks:
+                print(format_notify_report(file_path, leaks), file=sys.stderr)
+                sys.exit(2)
     # Test isolation: only on test files.
     if not is_test_file(file_path):
         sys.exit(0)
@@ -237,8 +451,18 @@ def cli_mode(file_path):
         if deferrals:
             print(format_deferral_report(file_path, deferrals))
             sys.exit(2)
+    if is_test_dir_file(file_path):
+        try:
+            text = Path(file_path).read_text(encoding="utf-8")
+        except Exception:
+            text = ""
+        if text and SKIP_MARKER not in text:
+            leaks = find_notify_leaks(file_path, text)
+            if leaks:
+                print(format_notify_report(file_path, leaks))
+                sys.exit(2)
     if not is_test_file(file_path):
-        print(f"fable-discipline-lint: not a test file (deferral-checked only): {file_path}")
+        print(f"fable-discipline-lint: clean, no unstubbed outbound channel ({file_path})")
         sys.exit(0)
     violations = lint_file(file_path)
     if not violations:

--- a/plugins/prd-os/skills/fable-discipline/scripts/test_fable_discipline_lint.py
+++ b/plugins/prd-os/skills/fable-discipline/scripts/test_fable_discipline_lint.py
@@ -98,7 +98,11 @@ QUIET_RUNNER = (
     'echo ok\n'
 )
 
-_HEAD = 'RUNNER="$SCRIPT_DIR/../pager-runner.sh"\n'
+# Real suites anchor themselves with BASH_SOURCE; the fixtures must too, or
+# the detector cannot place the executed path in this checkout and (correctly)
+# stays quiet, which would make every positive case below vacuously green.
+_ANCHOR = 'SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"\n'
+_HEAD = _ANCHOR + 'RUNNER="$SCRIPT_DIR/../pager-runner.sh"\n'
 
 # (case name, test-file body, target: "test"|"runner", expected exit)
 CHANNEL_CASES = [
@@ -134,6 +138,23 @@ CHANNEL_CASES = [
      "test", 0),
     # Editing the RUNNER must re-check the tests that drive it. The edited file
     # alone can never show this: the leak lives in files the edit did not touch.
+    # Identity is the resolved PATH. A sandbox copy of a pager-capable runner
+    # cannot page anyone, and flagging it is the false positive that gets a lint
+    # switched off. test-dispatch-liveness.sh runs "$ROOT/converge.sh" from a
+    # mktemp dir and was wrongly blocked.
+    ("sandbox copy of the runner is not the production runner",
+     _ANCHOR + 'SB="$(mktemp -d)"\nRUNNER="$SB/pager-runner.sh"\n'
+               'bash "$RUNNER" --go\n', "test", 0),
+    # Precision first: this lint is defence in depth behind the slack-notify.sh
+    # loopback refusal, so an unplaceable path stays quiet rather than crying wolf.
+    ("unplaceable path is not flagged",
+     'RUNNER="$MYSTERY_DIR/pager-runner.sh"\nbash "$RUNNER" --go\n', "test", 0),
+    # An exemption cannot reach backwards: the early call already ran with the
+    # real notifier.
+    ("a LATER export does not exempt an EARLIER invocation",
+     _HEAD + 'bash "$RUNNER" --early\n'
+             'export KIPI_NOTIFY=/usr/bin/true\n'
+             'bash "$RUNNER" --late\n', "test", 2),
     ("editing the runner sees its unstubbed test",
      _HEAD + 'bash "$RUNNER" --go\n', "runner", 2),
     ("editing the runner is clean when its test is stubbed",

--- a/plugins/prd-os/skills/fable-discipline/scripts/test_fable_discipline_lint.py
+++ b/plugins/prd-os/skills/fable-discipline/scripts/test_fable_discipline_lint.py
@@ -6,12 +6,24 @@ Dogfoods the fable-discipline skill: every fixture is written under a TemporaryD
 (isolation), never a real path. Run from this directory:
     python3 test_fable_discipline_lint.py
 """
+import os
 import subprocess
 import sys
 import tempfile
 from pathlib import Path
 
-LINT = str(Path(__file__).resolve().parent / "fable-discipline-lint.py")
+# REF HATCH: point the suite at a DIFFERENT copy of the lint, so the pre-feature
+# lint can be checked out from a git ref and watched to FAIL. A regression case
+# added after its own fix has never been observed red, and an unobserved-red case
+# is an assertion about nothing. This suite used to pass unchanged against the
+# lint from a5ac9c1 -- deleting the whole outbound-channel detector left its own
+# regression suite green.
+#
+#   git show <pre-feature-ref>:plugins/prd-os/skills/fable-discipline/scripts/\
+#     fable-discipline-lint.py > /tmp/old-lint.py
+#   FABLE_LINT_UNDER_TEST=/tmp/old-lint.py python3 test_fable_discipline_lint.py
+LINT = (os.environ.get("FABLE_LINT_UNDER_TEST")
+        or str(Path(__file__).resolve().parent / "fable-discipline-lint.py"))
 
 # (filename, content, expected_exit)
 CASES = [
@@ -64,6 +76,83 @@ CASES = [
 ]
 
 
+# --- outbound-channel cases -------------------------------------------------
+# These are TREE-SHAPED on purpose. The detector resolves a runner NEXT TO the
+# test (../<name> or ./<name>), so a flat tempdir makes every runner
+# unresolvable and the whole detector reports green on a leaking fixture. The
+# first version of this suite had no channel cases at all: it passed unchanged
+# against the pre-feature lint, which means deleting the detector outright left
+# its own regression suite green. A self-test that cannot detect its own
+# removal is decoration.
+
+# Reaches the pager on a LIVE line -> notify-capable.
+PAGER_RUNNER = (
+    '#!/usr/bin/env bash\n'
+    'NOTIFY="${KIPI_NOTIFY:-$SCRIPT_DIR/slack-notify.sh}"\n'
+    'bash "$NOTIFY" "a human needs to look at this"\n'
+)
+# Names the notifier only in PROSE -> not notify-capable, must not be flagged.
+QUIET_RUNNER = (
+    '#!/usr/bin/env bash\n'
+    '# historical note: this used to call slack-notify.sh, it no longer does\n'
+    'echo ok\n'
+)
+
+_HEAD = 'RUNNER="$SCRIPT_DIR/../pager-runner.sh"\n'
+
+# (case name, test-file body, target: "test"|"runner", expected exit)
+CHANNEL_CASES = [
+    ("unstubbed invocation",
+     _HEAD + 'bash "$RUNNER" --go\n', "test", 2),
+    ("per-command stub on the same line",
+     _HEAD + 'KIPI_NOTIFY=/usr/bin/true bash "$RUNNER" --go\n', "test", 0),
+    ("stub carried across a backslash continuation",
+     _HEAD + 'env FOO=1 \\\n    KIPI_NOTIFY=/usr/bin/true \\\n'
+             '    bash "$RUNNER" --go\n', "test", 0),
+    # THE regression for the file-wide-stub defect. One stubbed site used to
+    # suppress detection for every other site in the file; the real
+    # test-severity-floor.sh had 5 stubbed and 2 unstubbed and passed.
+    ("PARTIAL stub: one site covered, one not",
+     _HEAD + 'KIPI_NOTIFY=/usr/bin/true bash "$RUNNER" --first\n'
+             'bash "$RUNNER" --second\n', "test", 2),
+    ("exported stub covers the whole file",
+     'export KIPI_NOTIFY=/usr/bin/true\n' + _HEAD + 'bash "$RUNNER" --go\n',
+     "test", 0),
+    ("writing your own notifier into a sandbox skeleton",
+     _HEAD + 'printf "exit 0\\n" > "$WORK/skel/scripts/slack-notify.sh"\n'
+             'bash "$RUNNER" --go\n', "test", 0),
+    ("grep-only reference is not an invocation",
+     _HEAD + 'grep -q needle "$RUNNER"\n', "test", 0),
+    ("bash -n is a parse, not a run",
+     _HEAD + 'bash -n "$RUNNER"\n', "test", 0),
+    ("bash -c handing the runner to grep is not an invocation",
+     _HEAD + 'OUT="$(bash -c \'grep -c x \'"\'$RUNNER\'")"\n', "test", 0),
+    ("runner that only NAMES the notifier in a comment",
+     'RUNNER="$SCRIPT_DIR/../quiet-runner.sh"\nbash "$RUNNER" --go\n', "test", 0),
+    ("skip marker bypasses",
+     '# fable-discipline-lint-skip\n' + _HEAD + 'bash "$RUNNER" --go\n',
+     "test", 0),
+    # Editing the RUNNER must re-check the tests that drive it. The edited file
+    # alone can never show this: the leak lives in files the edit did not touch.
+    ("editing the runner sees its unstubbed test",
+     _HEAD + 'bash "$RUNNER" --go\n', "runner", 2),
+    ("editing the runner is clean when its test is stubbed",
+     _HEAD + 'KIPI_NOTIFY=/usr/bin/true bash "$RUNNER" --go\n', "runner", 0),
+]
+
+
+def run_channel_case(base, name, body, target):
+    """Build <base>/scripts/{pager,quiet}-runner.sh + scripts/test/test-x.sh."""
+    scripts = base / "scripts"
+    tdir = scripts / "test"
+    tdir.mkdir(parents=True, exist_ok=True)
+    (scripts / "pager-runner.sh").write_text(PAGER_RUNNER)
+    (scripts / "quiet-runner.sh").write_text(QUIET_RUNNER)
+    test_file = tdir / "test-channel-case.sh"
+    test_file.write_text(body)
+    return run(test_file if target == "test" else scripts / "pager-runner.sh")
+
+
 def run(path):
     return subprocess.run([sys.executable, LINT, str(path)],
                           capture_output=True, text=True).returncode
@@ -81,10 +170,23 @@ def main():
             print(f"  [{'PASS' if ok else 'FAIL'}] {name}: exit {got} (want {want})")
             if not ok:
                 failures += 1
+
+    for name, body, target, want in CHANNEL_CASES:
+        # Each case gets its OWN tree; a shared one lets a previous fixture's
+        # stub file satisfy the next case and every assertion goes soft.
+        with tempfile.TemporaryDirectory() as d:
+            got = run_channel_case(Path(d), name, body, target)
+        ok = got == want
+        print(f"  [{'PASS' if ok else 'FAIL'}] channel/{target}: {name}: "
+              f"exit {got} (want {want})")
+        if not ok:
+            failures += 1
+
+    total = len(CASES) + len(CHANNEL_CASES)
     if failures:
         print(f"fable-discipline-lint self-test: {failures} FAILED")
         sys.exit(1)
-    print(f"fable-discipline-lint self-test: all {len(CASES)} cases passed")
+    print(f"fable-discipline-lint self-test: all {total} cases passed")
     sys.exit(0)
 
 

--- a/q-system/.q-system/scripts/test/test-dispatch-liveness.sh
+++ b/q-system/.q-system/scripts/test/test-dispatch-liveness.sh
@@ -59,13 +59,6 @@ DISPATCH="$REPO_ROOT/kipi-dispatch.sh"
 ISS="ASK-9$$"
 
 ROOT="$(mktemp -d)"
-
-# EXPORTED, not per-command. This suite runs converge.sh from inside generated
-# stub scripts, so the pager is reached by a grandchild the invocation line
-# cannot name. An exported default covers every descendant; the per-command
-# KIPI_NOTIFY="$ROOT/notify.sh" further down still wins where a case needs to
-# RECORD what was paged.
-export KIPI_NOTIFY="/usr/bin/true"
 trap 'pkill -f "$ROOT/converge.sh" 2>/dev/null; rm -r -- "$ROOT" 2>/dev/null' EXIT
 
 # --- the sandbox ------------------------------------------------------------

--- a/q-system/.q-system/scripts/test/test-dispatch-liveness.sh
+++ b/q-system/.q-system/scripts/test/test-dispatch-liveness.sh
@@ -59,6 +59,13 @@ DISPATCH="$REPO_ROOT/kipi-dispatch.sh"
 ISS="ASK-9$$"
 
 ROOT="$(mktemp -d)"
+
+# EXPORTED, not per-command. This suite runs converge.sh from inside generated
+# stub scripts, so the pager is reached by a grandchild the invocation line
+# cannot name. An exported default covers every descendant; the per-command
+# KIPI_NOTIFY="$ROOT/notify.sh" further down still wins where a case needs to
+# RECORD what was paged.
+export KIPI_NOTIFY="/usr/bin/true"
 trap 'pkill -f "$ROOT/converge.sh" 2>/dev/null; rm -r -- "$ROOT" 2>/dev/null' EXIT
 
 # --- the sandbox ------------------------------------------------------------

--- a/q-system/.q-system/scripts/test/test-linear-worker-fetch.sh
+++ b/q-system/.q-system/scripts/test/test-linear-worker-fetch.sh
@@ -147,6 +147,7 @@ picker_stub '{"ready":[{"id":"ASK-AAA","title":"t","project":"p"}],"total_open":
 # cwd is the skeleton, which is where launchd runs this from.
 ( cd "$WORK/skel" \
   && HOME="$WORK/home" KIPI_SKEL="$WORK/skel" KIPI_STATE_DIR="$WORK/state" \
+     KIPI_NOTIFY="/usr/bin/true" \
      bash "$WORKER" --apply --issue ASK-AAA --limit 1 ) >"$WORK/run.out" 2>&1
 RC=$?
 
@@ -186,6 +187,7 @@ picker_stub '{"ready":[{"id":"ASK-AAA","title":"t","project":"p"},{"id":"ASK-BBB
 
 ( cd "$WORK/skel" \
   && PATH="$CSTUB:$PATH" HOME="$WORK/home" KIPI_SKEL="$WORK/skel" KIPI_STATE_DIR="$WORK/state2" \
+     KIPI_NOTIFY="/usr/bin/true" \
      bash "$WORKER" --apply --limit 2 ) >"$WORK/run2.out" 2>&1
 
 # `grep -c` exits 1 on a zero count, so the old `|| echo 0` idiom printed "0\n0"

--- a/q-system/.q-system/scripts/test/test-linear-worker-parallel.sh
+++ b/q-system/.q-system/scripts/test/test-linear-worker-parallel.sh
@@ -114,10 +114,15 @@ export PATH="$STUB:$PATH"
 # run_worker <issue> <run-label> [hold-token]
 # cwd is the skeleton on purpose: that is where launchd runs this from, and it
 # is the cwd that made every issue share one lock.
+# KIPI_NOTIFY is stubbed at every --apply site below. --apply drives the real
+# worker, and several of its branches page the founder. The PATH-stubbed python3
+# happens to short-circuit the picker today so nothing escapes -- that is luck
+# about a stub, not isolation, and the stub is one edit away from changing.
 run_worker() {
   local issue="$1" label="$2" hold="${3:-}"
   ( cd "$WORK/skel" \
     && KIPI_SKEL="$WORK/skel" KIPI_STATE_DIR="$WORK/state-$label" STUB_HOLD="$hold" \
+       KIPI_NOTIFY="/usr/bin/true" \
        bash "$WORKER" --apply --issue "$issue" --limit 1 ) \
     >"$WORK/$label.out" 2>&1
   echo "$?" > "$WORK/$label.rc"
@@ -193,6 +198,7 @@ done
 # d shares c's state dir, so it lands on the SAME worktree for the same issue.
 ( cd "$WORK/skel" \
   && KIPI_SKEL="$WORK/skel" KIPI_STATE_DIR="$WORK/state-c" \
+     KIPI_NOTIFY="/usr/bin/true" \
      bash "$WORKER" --apply --issue ASK-CCC --limit 1 ) >"$WORK/d.out" 2>&1
 touch "$HOLD2.go"
 wait "$C_PID"
@@ -234,6 +240,7 @@ PY
 
 ( cd "$WORK/skel" \
   && KIPI_SKEL="$WORK/skel" KIPI_STATE_DIR="$WORK/state-e" \
+     KIPI_NOTIFY="/usr/bin/true" \
      bash "$WORKER" --apply --issue ASK-EEE --limit 1 ) >"$WORK/e.out" 2>&1
 
 grep -q "ask-eee" "$WORK/worked.txt" \

--- a/q-system/.q-system/scripts/test/test-severity-floor.sh
+++ b/q-system/.q-system/scripts/test/test-severity-floor.sh
@@ -857,7 +857,13 @@ printf '## VERDICT: APPROVE\n\nNothing survived reproduction.\n\nFINDINGS:\nEND 
 EOF
 chmod +x "$SW/python3" "$SW/gh" "$SW/claude"
 
-( PATH="$SW:$PATH" HOME="$W2/home-writer" bash "$REVIEWER" 901 ) >"$W2/writer.out" 2>&1
+# KIPI_NOTIFY is isolation, not decoration: $REVIEWER pages the founder on a
+# degraded-review verdict. The sandboxed HOME below only HIDES that -- it makes
+# slack-notify.sh find no webhook file -- so the moment KIPI_SLACK_WEBHOOK is set
+# in the environment this suite rings a real phone. Measured 2026-08-01: it sent
+# "codex is not producing an independent review (PR #901)" to a capture endpoint.
+( PATH="$SW:$PATH" HOME="$W2/home-writer" KIPI_NOTIFY="/usr/bin/true" \
+  bash "$REVIEWER" 901 ) >"$W2/writer.out" 2>&1
 REC="$W2/home-writer/.config/kipi/pr-reviews/pr-901.verdict.json"
 [ -s "$REC" ] \
   || fail "the reviewer wrote no verdict record at all. It said:
@@ -950,7 +956,9 @@ EOF
 RC=0
 run_status_reviewer() {
   local d="$1"; shift
-  ( PATH="$d/bin:$PATH" HOME="$d/home" bash "$REVIEWER" 901 "$@" ) \
+  # Same reason as the writer case above: stub the pager, do not rely on $HOME.
+  ( PATH="$d/bin:$PATH" HOME="$d/home" KIPI_NOTIFY="/usr/bin/true" \
+    bash "$REVIEWER" 901 "$@" ) \
     >"$d/out.txt" 2>"$d/err.txt"
   RC=$?
 }

--- a/q-system/.q-system/scripts/test/test-worker-project-scope.sh
+++ b/q-system/.q-system/scripts/test/test-worker-project-scope.sh
@@ -136,12 +136,22 @@ setup_skel() {
 # been filtered were simply never reached. The budget was doing the filter's job
 # and the assertion could not tell the two apart. Assert on the pool, then, not
 # on the truncated tail of it: `ready_count` below reads the picker's own number.
+#
+# KIPI_NOTIFY is part of the isolation, not a nicety. Case 3 deliberately drives
+# the worker into MISCONFIG, and MISCONFIG pages the founder (linear-worker.sh:384).
+# Without this line the suite reaches the real slack-notify.sh and rings the
+# founder's actual phone on every run -- which it did, twice on 2026-08-01, during
+# ASK-281 verification and again under `kipi check`. A test that fires a real
+# outbound channel is not isolated no matter how good its assertions are.
+# The assertion is unaffected: case 3 greps the worker's own stdout for MISCONFIG,
+# and that line is written by $LOG, not by $NOTIFY.
 run_worker() {  # run_worker <skel-dir> [extra env assignments...]
   local skel="$1"; shift
   env KIPI_SKEL="$skel" \
       KIPI_STATE_DIR="$WORK/state" \
       KIPI_LINEAR_API_URL="http://127.0.0.1:$PORT/graphql" \
       KIPI_LINEAR_API_KEY="fixture-key-not-a-secret" \
+      KIPI_NOTIFY="/usr/bin/true" \
       "$@" bash "$WORKER" --limit 99 2>&1
 }
 


### PR DESCRIPTION
## The leak

`test-worker-project-scope.sh` case 3 misconfigures the worker on purpose to prove it fails loud. Its `run_worker()` set `KIPI_SKEL`, `KIPI_STATE_DIR`, `KIPI_LINEAR_API_URL` and `KIPI_LINEAR_API_KEY` but not `KIPI_NOTIFY`, so the worker reached the real `slack-notify.sh`. The founder was paged twice on 2026-08-01 by a suite reporting 14/14 green.

## Reproducer first, RED observed

A local HTTP capture endpoint stands in for the Slack webhook via `KIPI_SLACK_WEBHOOK` (read ahead of `~/.config/kipi/slack-webhook`, and no test in the directory does `env -i` or unsets it, so nothing escapes the interception). The harness self-tests the wire on every run — a capture that never captures would report "0 notifications" for a leaking test and certify the suite clean.

| | exit | notifications |
|---|---|---|
| before | 0 (14/14 pass) | **1** — the exact MISCONFIG page the founder received |
| after | 0 (14/14 pass) | **0** |

No real Slack message was sent at any point.

## Full-directory audit: measured, not read

All 64 tests were run through the capture harness. Static reading tells you which tests *look* like they reach the notifier; this tells you which ones do. Two more of the same class:

- **`test-severity-floor.sh`** — ran the review agent unstubbed at two sites and emitted a real *"codex is not producing an independent review (PR #901)"* page. In production it is shielded only by a sandboxed `HOME`, which stops shielding the moment `KIPI_SLACK_WEBHOOK` is set in the environment. Now 169/169 with 0 notifications.
- **`test-linear-worker-parallel.sh`** — drives `--apply` at three sites. A PATH-stubbed `python3` happens to short-circuit the picker today; that is luck about a stub, not isolation. Now exit 0 with 0 notifications.

Already clean and left alone: `test-converge.sh` (file-wide `export KIPI_NOTIFY`), `test-linear-worker-fetch.sh` (notify *recorder*, asserts the page happened), `test-review-tree-guard.sh`, `test-dispatch-liveness.sh`, `test-lessons-daily-exit.sh` and `test-open-loops-heartbeat-exit.sh` (stub `slack-notify.sh` inside a sandbox skeleton — the seam for runners that hardcode `$SKEL/.../slack-notify.sh`), `test-linear-dor-failure-reporting.py` (`NOTIFY_SCRIPT` rebind), and `test-worker-refusal.sh` (untouched, ASK-281 is live on it).

## Closing the class deterministically

`fable-discipline-lint.py` gains a third detector. A file under a test directory that hands a notify-capable runner to an interpreter, with no notifier stub, is exit 2.

The notify-capable set is **derived** by reading the referenced runner, never hardcoded — a new pager-capable script is covered the day it is written.

- RED against the pre-fix file (placed in the real test dir, since the runner has to resolve), green against the fixed one.
- **Mutation check:** drop the `KIPI_NOTIFY` line and the lint goes 0 → 2. It is not decorative.
- Both existing detectors (DB-path, deferral-capture) re-verified still firing.

Cross-checking the lint against the measured run caught two false-positive sources in my own detector, both fixed: `\bsh\b` matched the `.sh` *extension* (so every line merely naming a runner looked like an invocation), and reachability matched `slack-notify.sh` inside a *comment* in `linear-sync.py`. Sweep is now 0 blocks across all 64 tests.

## Nothing was weakened

Case 3 still asserts the worker says MISCONFIG. That line is written by `$LOG`, not `$NOTIFY`, so stubbing the notifier cannot touch it.

## Findings captured, not fixed here

The spillover ledger is gitignored, so recording them here too:

1. **Stale plugin cache runs an old gate.** `~/.claude/plugins/cache/kipi/prd-os/0.1.0/hooks/scope_hook.py` lacks the `_outside_repo` escape its own newer copies carry. Verified: identical payload, rc=2 on 0.1.0, rc=0 on current `kipi-dsse`. It blocks writes to the session scratchpad and to sibling worktrees. (`sp-8b6e75bb`)
2. **DSSE active-issue state is global, not per-session.** A second concurrent session inherits the first's active issue and gets scope-blocked against an `allowed_files` list it has nothing to do with. Hit live while another session held `needs-scope-redrive`. (`sp-ec5905a9`)
3. **This detector misses a partial stub.** Any live-line `KIPI_NOTIFY` mention reads as file-wide isolation. `test-severity-floor.sh` had 5 stubbed sites and 2 unstubbed, and only the measured run caught it. Per-invocation checking with an `export` carve-out would close it. (`sp-ab706cb3`)
4. **`slack-notify.sh` no-ops silently with no webhook**, so `HOME`-sandboxing shields tests by accident. Any test relying on that instead of `KIPI_NOTIFY` is a latent pager. (`sp-a79e18c3`)
5. **Fable mirror drift.** `export-fable-mirror.sh --check` reports drift on the lint after this change; the public mirror needs a deliberate export pass. (`sp-06be93ad`)

## Load path

`plugins/prd-os` version bumped 0.7.4 → 0.8.0 — the `plugin-version-bump` gate blocked the first commit for exactly the stale-cache reason in finding 1. The running lint is the marketplace clone of this repo; the new detector is **inert until that clone pulls this merge**.

## Not touched

`linear-worker.sh`, `test-worker-refusal.sh` (ASK-281 in flight), `linear-dor-drafter.py` and its tests (another session in flight).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
