### PR TITLE
fix(notify): slack-notify refuses to page a human from a fixture run

### DIFF
--- a/q-system/.q-system/capability-manifest.json
+++ b/q-system/.q-system/capability-manifest.json
@@ -170,6 +170,10 @@
       "runner": "bash"
     },
     {
+      "path": "q-system/.q-system/scripts/test/test-notify-fixture-guard.sh",
+      "runner": "bash"
+    },
+    {
       "path": "q-system/.q-system/scripts/test/test-worker-project-scope.sh",
       "runner": "bash"
     },

--- a/q-system/.q-system/scripts/slack-notify.sh
+++ b/q-system/.q-system/scripts/slack-notify.sh
@@ -50,10 +50,32 @@ MSG="[$LABEL] $MSG"
 # The refused text goes to stderr rather than being dropped: a silently
 # swallowed alert is the precise failure mode founder-notifications.md exists
 # to prevent, and a fixture run still needs its diagnostic to be readable.
+# Two review findings on PR #58 shaped this function, and they point in OPPOSITE
+# directions -- which is why both halves are asserted in the paired suite:
+#
+#   1. A `127.*` shell pattern also matches non-loopback HOSTNAMES beginning
+#      "127.", so `127.example.com` would have been read as a fixture and its
+#      alert SILENTLY SUPPRESSED. That is the same failure class this guard
+#      rejects KIPI_STATE_DIR-under-temp for. The real invariant is the
+#      127.0.0.0/8 block -- four NUMERIC octets in range -- not a string prefix.
+#   2. The comparison was case-sensitive, so `LOCALHOST` reached the webhook
+#      from a fixture run. DNS hostnames are case-insensitive, so that was a
+#      genuine bypass, not a theoretical one.
+#
+# Lowercasing uses tr, not ${var,,}: /bin/bash on macOS is 3.2, where ${var,,}
+# is a syntax error. `[[ =~ ]]` + BASH_REMATCH do exist in 3.2, and the regex
+# must stay in an UNQUOTED variable -- quoting it makes 3.2 match it literally.
 _kipi_loopback_host() {
-  case "$1" in
-    localhost|*.localhost|::1|0.0.0.0|0|127.*) return 0 ;;
+  local h re
+  h="$(printf '%s' "$1" | tr '[:upper:]' '[:lower:]')"
+  case "$h" in
+    localhost|*.localhost|::1|0.0.0.0|0) return 0 ;;
   esac
+  re='^127\.([0-9]{1,3})\.([0-9]{1,3})\.([0-9]{1,3})$'
+  if [[ "$h" =~ $re ]]; then
+    [ "${BASH_REMATCH[1]}" -le 255 ] && [ "${BASH_REMATCH[2]}" -le 255 ] \
+      && [ "${BASH_REMATCH[3]}" -le 255 ] && return 0
+  fi
   return 1
 }
 

--- a/q-system/.q-system/scripts/slack-notify.sh
+++ b/q-system/.q-system/scripts/slack-notify.sh
@@ -23,6 +23,55 @@ if [ -z "$LABEL" ]; then
 fi
 MSG="[$LABEL] $MSG"
 
+# --- fixture-run guard: a test must never be able to page a human -------------
+# SCAR 2026-08-01. Three tests were found paging the founder's real Slack and
+# were fixed by stubbing KIPI_NOTIFY per test (PR #54). While that PR sat open
+# and unmerged, an agent ran test-worker-project-scope.sh from a worktree cut
+# off main -- which carries no stub -- and the founder was paged again, live.
+# Per-test stubbing has three structural holes: it only protects branches that
+# carry it, only tests someone remembered to fix, and its paired lint only fires
+# at write-time on the edited file. A test written tomorrow still pages.
+# This is the one chokepoint that needs none of those things to be remembered.
+#
+# THE SIGNAL. Every test in this repo points the worker at a fixture Linear on
+# loopback (KIPI_LINEAR_API_URL=http://127.0.0.1:$PORT/graphql); production
+# always points at the real Linear API. That asymmetry is total in both
+# directions, which is what makes it safe to key a refusal on. This script is
+# invoked as `bash "$NOTIFY" "msg"` from the worker, so it INHERITS the
+# variable -- verified 2026-08-01 by running the same `env VAR=... bash parent`
+# shape the tests use and reading the variable from the grandchild.
+#
+# DELIBERATELY NOT A SIGNAL: KIPI_STATE_DIR under a temp dir. A production job
+# may legitimately keep state in a temp path (macOS $TMPDIR is exactly that), so
+# keying on it would suppress real pages. A guard that swallows a genuine alert
+# is worse than the bug it fixes, so the guard keys only on the one signal that
+# cannot be true in production.
+#
+# The refused text goes to stderr rather than being dropped: a silently
+# swallowed alert is the precise failure mode founder-notifications.md exists
+# to prevent, and a fixture run still needs its diagnostic to be readable.
+_kipi_loopback_host() {
+  case "$1" in
+    localhost|*.localhost|::1|0.0.0.0|0|127.*) return 0 ;;
+  esac
+  return 1
+}
+
+if [ -n "${KIPI_LINEAR_API_URL:-}" ]; then
+  _KHOST="${KIPI_LINEAR_API_URL#*://}"   # drop scheme
+  _KHOST="${_KHOST%%/*}"                 # drop path
+  _KHOST="${_KHOST##*@}"                 # drop userinfo
+  case "$_KHOST" in
+    \[*\]*) _KHOST="${_KHOST#\[}"; _KHOST="${_KHOST%%\]*}" ;;  # [::1]:8080 -> ::1
+    *)      _KHOST="${_KHOST%%:*}" ;;                          # host:port  -> host
+  esac
+  if _kipi_loopback_host "$_KHOST"; then
+    printf 'slack-notify: REFUSED to page a human -- fixture run (KIPI_LINEAR_API_URL host "%s" is loopback). Message NOT sent: %s\n' \
+           "$_KHOST" "$MSG" >&2
+    exit 0
+  fi
+fi
+
 HOOK="${KIPI_SLACK_WEBHOOK:-}"
 if [ -z "$HOOK" ] && [ -f "$HOME/.config/kipi/slack-webhook" ]; then
   HOOK="$(tr -d '\n\r' < "$HOME/.config/kipi/slack-webhook")"

--- a/q-system/.q-system/scripts/test/test-notify-fixture-guard.sh
+++ b/q-system/.q-system/scripts/test/test-notify-fixture-guard.sh
@@ -1,0 +1,182 @@
+#!/usr/bin/env bash
+# Regression suite for slack-notify.sh's fixture-run guard.
+#
+# THE INVARIANT: a worker running against a FIXTURE Linear API must never be
+# able to page a real human.
+#
+# SCAR 2026-08-01. Three tests were found paging the founder's real Slack and
+# were fixed by stubbing KIPI_NOTIFY per test (PR #54). While that PR sat open
+# and unmerged, an agent ran test-worker-project-scope.sh from a worktree cut
+# off main -- which carries no stub -- and the founder was paged again, live,
+# with "repo identity 'no-such-project-anywhere' matches no Linear project".
+# Per-test stubbing only protects branches that carry it and tests someone
+# remembered to fix. The guard under test here is the chokepoint that protects
+# every test on every branch, including tests nobody has written yet.
+#
+# WHY THE ASSERTIONS RUN IN BOTH DIRECTIONS: a guard that refuses everything
+# would pass a refusal-only suite while silently disabling every real founder
+# alert -- strictly worse than the bug it fixes. So every loopback case is
+# paired with a production case that must still SEND.
+#
+# THIS SUITE NEVER TOUCHES REAL SLACK. It exports KIPI_SLACK_WEBHOOK at its own
+# loopback capture server before the first invocation, and slack-notify.sh
+# checks that variable BEFORE ~/.config/kipi/slack-webhook, so the founder's
+# real hook file is never read even on a machine where it exists.
+#
+# REF HATCH: KIPI_NOTIFY_UNDER_TEST points the suite at a different copy of
+# slack-notify.sh, so the PRE-GUARD copy can be checked out from a git ref and
+# watched to FAIL. A regression case added after its own fix has never been
+# observed red, and an unobserved-red case is an assertion about nothing.
+#
+#   git show <pre-guard-ref>:q-system/.q-system/scripts/slack-notify.sh > /tmp/old.sh
+#   KIPI_NOTIFY_UNDER_TEST=/tmp/old.sh bash test-notify-fixture-guard.sh
+#
+set -uo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+NOTIFY="${KIPI_NOTIFY_UNDER_TEST:-$SCRIPT_DIR/../slack-notify.sh}"
+
+PASS=0; FAIL=0
+ok()  { PASS=$((PASS+1)); printf '  ok   %s\n' "$1"; }
+bad() { FAIL=$((FAIL+1)); printf '  FAIL %s\n     %s\n' "$1" "${2:-}"; }
+
+WORK="$(mktemp -d)"
+trap 'kill "${CAP_PID:-}" 2>/dev/null; rm -rf "$WORK"' EXIT
+
+# --- capture endpoint: stands in for the founder's Incoming Webhook ----------
+# Its stdout/stderr go to FILES, never to the inherited ones. A long-lived child
+# holding this suite's stderr open keeps the pipeline's write end open, so a
+# caller doing `| tail` hangs forever after the script already exited.
+cat > "$WORK/capture.py" <<'PY'
+import os
+from http.server import BaseHTTPRequestHandler, HTTPServer
+CAPTURE_FILE = os.environ["CAPTURE_FILE"]
+class H(BaseHTTPRequestHandler):
+    def log_message(self, *a): pass
+    def do_POST(self):
+        n = int(self.headers.get("Content-Length") or 0)
+        body = self.rfile.read(n).decode("utf-8", "replace")
+        with open(CAPTURE_FILE, "a") as fh:
+            fh.write(body.replace("\n", " ") + "\n")
+        out = b"ok"
+        self.send_response(200)
+        self.send_header("Content-Length", str(len(out)))
+        self.end_headers()
+        self.wfile.write(out)
+srv = HTTPServer(("127.0.0.1", 0), H)
+print(srv.server_port, flush=True)
+srv.serve_forever()
+PY
+
+export CAPTURE_FILE="$WORK/captured.txt"
+: > "$CAPTURE_FILE"
+python3 "$WORK/capture.py" > "$WORK/port" 2> "$WORK/cap.err" &
+CAP_PID=$!
+for _ in $(seq 1 100); do
+  PORT="$(cat "$WORK/port" 2>/dev/null)"; [ -n "${PORT:-}" ] && break; sleep 0.1
+done
+[ -n "${PORT:-}" ] || { echo "capture server did not start: $(cat "$WORK/cap.err" 2>/dev/null)"; exit 1; }
+export KIPI_SLACK_WEBHOOK="http://127.0.0.1:$PORT/capture"
+
+echo "== slack-notify.sh fixture guard (notify under test: $NOTIFY)"
+
+# --- HARNESS SELF-TEST: prove the capture endpoint can register a hit --------
+# Without this, every "0 captured" below is ambiguous between "the guard
+# refused" and "the capture endpoint was broken the whole time". A check that
+# cannot record a hit cannot prove a miss.
+curl -fsS -X POST -H 'Content-type: application/json' \
+     --data '{"text":"harness probe, not a real page"}' "$KIPI_SLACK_WEBHOOK" >/dev/null 2>&1
+if [ "$(wc -l < "$CAPTURE_FILE" | tr -d ' ')" = "1" ]; then
+  ok "harness self-test: capture endpoint records a hit (a later 0 means refusal, not a dead harness)"
+else
+  bad "harness self-test: capture endpoint records a hit" "probe was not captured -- every assertion below is inert"
+  echo "  $PASS passed, $FAIL failed"; exit 1
+fi
+
+# send <env-assignment-or-empty> -> echoes "<captured-count>|<stderr>"
+send() {
+  : > "$CAPTURE_FILE"
+  if [ -n "${1:-}" ]; then
+    env "$1" bash "$NOTIFY" "guard suite probe" 2> "$WORK/err"
+  else
+    env -u KIPI_LINEAR_API_URL bash "$NOTIFY" "guard suite probe" 2> "$WORK/err"
+  fi
+  sleep 0.3
+  printf '%s|%s' "$(wc -l < "$CAPTURE_FILE" | tr -d ' ')" "$(cat "$WORK/err")"
+}
+
+# --- direction 1: fixture API -> REFUSE, and say so on stderr ---------------
+# Every form a loopback fixture server can take. test-worker-project-scope.sh
+# and friends bind 127.0.0.1; the others are here so a future fixture that binds
+# localhost or ::1 is covered before someone writes it.
+for url in "http://127.0.0.1:54321/graphql" \
+           "http://localhost:8080/graphql" \
+           "http://[::1]:8080/graphql" \
+           "http://0.0.0.0:9/graphql" \
+           "http://127.0.0.53/graphql"; do
+  R="$(send "KIPI_LINEAR_API_URL=$url")"
+  N="${R%%|*}"; ERR="${R#*|}"
+  if [ "$N" = "0" ]; then
+    ok "refuses to page from a fixture run ($url)"
+  else
+    bad "refuses to page from a fixture run ($url)" "$N message(s) reached the webhook"
+  fi
+  # A refusal that says nothing is a silently dropped alert -- the exact failure
+  # mode founder-notifications.md exists to prevent. The diagnostic must survive.
+  case "$ERR" in
+    *REFUSED*"guard suite probe"*) ok "refusal writes the unsent message to stderr ($url)" ;;
+    *) bad "refusal writes the unsent message to stderr ($url)" "stderr was: [$ERR]" ;;
+  esac
+done
+
+# --- direction 2: production API -> STILL SENDS -----------------------------
+# The half that keeps this guard from becoming an outage. If these go red, the
+# fleet has lost founder alerting entirely and nobody would be told.
+for url in "https://api.linear.app/graphql" \
+           "https://localhost.evil.example.com/graphql" \
+           "https://1270.0.0.1/graphql"; do
+  R="$(send "KIPI_LINEAR_API_URL=$url")"
+  N="${R%%|*}"
+  if [ "$N" = "1" ]; then
+    ok "still pages from a production run ($url)"
+  else
+    bad "still pages from a production run ($url)" "expected 1 delivered message, got $N -- founder alerting is BROKEN"
+  fi
+done
+
+# The common production shape: the variable is not set at all. A guard keyed on
+# a missing variable would silence every launchd job on the fleet.
+R="$(send "")"
+if [ "${R%%|*}" = "1" ]; then
+  ok "still pages when KIPI_LINEAR_API_URL is unset entirely (the launchd shape)"
+else
+  bad "still pages when KIPI_LINEAR_API_URL is unset entirely" "expected 1 delivered message, got ${R%%|*}"
+fi
+
+# --- NEGATIVE SELF-TEST -----------------------------------------------------
+# Proves this suite can go red. Without it every assertion above is compatible
+# with a notify script that never sends anything, and with a capture file that
+# is never written. Stands in for the PRE-GUARD slack-notify.sh: a copy with no
+# guard at all must be caught by the direction-1 assertion.
+UNGUARDED="$WORK/unguarded-notify.sh"
+cat > "$UNGUARDED" <<'SH'
+#!/bin/bash
+set -uo pipefail
+MSG="${1:-}"; [ -n "$MSG" ] || exit 0
+HOOK="${KIPI_SLACK_WEBHOOK:-}"; [ -n "$HOOK" ] || exit 0
+PAYLOAD="$(python3 -c "import json,sys; print(json.dumps({'text': sys.argv[1]}))" "$MSG" 2>/dev/null)"
+curl -fsS -X POST -H 'Content-type: application/json' --data "$PAYLOAD" "$HOOK" >/dev/null 2>&1 || true
+exit 0
+SH
+: > "$CAPTURE_FILE"
+env KIPI_LINEAR_API_URL="http://127.0.0.1:54321/graphql" bash "$UNGUARDED" "probe" 2>/dev/null
+sleep 0.3
+if [ "$(wc -l < "$CAPTURE_FILE" | tr -d ' ')" = "1" ]; then
+  ok "negative self-test: an UNGUARDED notify does page from a fixture run, so direction-1 is a real check"
+else
+  bad "negative self-test" "an unguarded notify did not page either -- direction-1 passes for the wrong reason"
+fi
+
+echo
+echo "  $PASS passed, $FAIL failed"
+[ "$FAIL" -eq 0 ]

--- a/q-system/.q-system/scripts/test/test-notify-fixture-guard.sh
+++ b/q-system/.q-system/scripts/test/test-notify-fixture-guard.sh
@@ -109,11 +109,18 @@ send() {
 # Every form a loopback fixture server can take. test-worker-project-scope.sh
 # and friends bind 127.0.0.1; the others are here so a future fixture that binds
 # localhost or ::1 is covered before someone writes it.
+#
+# The UPPERCASE forms are a PR #58 review finding, not decoration: the host
+# comparison used to be case-sensitive, so a fixture at LOCALHOST sent a real
+# page. DNS hostnames are case-insensitive, so that was a live bypass.
 for url in "http://127.0.0.1:54321/graphql" \
            "http://localhost:8080/graphql" \
+           "http://LOCALHOST:8080/graphql" \
+           "http://LocalHost:8080/graphql" \
            "http://[::1]:8080/graphql" \
            "http://0.0.0.0:9/graphql" \
-           "http://127.0.0.53/graphql"; do
+           "http://127.0.0.53/graphql" \
+           "http://127.255.255.255/graphql"; do
   R="$(send "KIPI_LINEAR_API_URL=$url")"
   N="${R%%|*}"; ERR="${R#*|}"
   if [ "$N" = "0" ]; then
@@ -132,9 +139,17 @@ done
 # --- direction 2: production API -> STILL SENDS -----------------------------
 # The half that keeps this guard from becoming an outage. If these go red, the
 # fleet has lost founder alerting entirely and nobody would be told.
+#
+# 127.example.com is a PR #58 review finding. The old `127.*` shell pattern
+# classified it as a fixture and SILENTLY SUPPRESSED its alert -- a real page
+# swallowed, the failure mode this guard exists to avoid becoming. Only four
+# numeric octets in range are the 127.0.0.0/8 block; a string prefix is not.
 for url in "https://api.linear.app/graphql" \
+           "https://127.example.com/graphql" \
+           "https://127.EXAMPLE.COM/graphql" \
            "https://localhost.evil.example.com/graphql" \
-           "https://1270.0.0.1/graphql"; do
+           "https://1270.0.0.1/graphql" \
+           "https://127.0.0.999/graphql"; do
   R="$(send "KIPI_LINEAR_API_URL=$url")"
   N="${R%%|*}"
   if [ "$N" = "1" ]; then


### PR DESCRIPTION
## The invariant

A worker running against a **fixture** Linear API must never be able to page a real human.

## Why PR #54 is not enough

#54 stubs `KIPI_NOTIFY` per test. It is correct and should still land. But it has three structural holes:

1. it only protects branches that carry it,
2. it only protects tests someone remembered to fix,
3. its paired lint only fires at write-time on the edited file.

Consequence observed live today: an agent working in a worktree cut from `main` ran `test-worker-project-scope.sh` (which on `main` has no stub) and the founder was paged for real, while #54 sat open and unmerged.

One chokepoint in `slack-notify.sh` protects every test on every branch, including tests nobody has written yet and branches cut before #54 lands. **The per-test stubs and the lint stay as defence in depth.**

## The signal, and what was deliberately excluded

Every test points the worker at a loopback fixture (`KIPI_LINEAR_API_URL=http://127.0.0.1:$PORT/graphql`); production always points at the real Linear API. `slack-notify.sh` runs as `bash "$NOTIFY" "msg"` from the worker, so it **inherits** that variable — verified by running the same `env VAR=... bash parent` shape the tests use and reading the variable from the grandchild, not assumed.

Detection parses the URL **host** (not a substring match), covering `127.0.0.0/8`, `localhost`, `*.localhost`, `::1` (bracketed), `0.0.0.0`.

**Deliberately NOT a signal: `KIPI_STATE_DIR` under a temp dir.** A production job may legitimately keep state in a temp path — macOS `$TMPDIR` is exactly that — so keying on it would suppress real pages. A guard that swallows a genuine alert is worse than the bug it fixes, so the guard keys only on the one signal that cannot be true in production.

The refused text goes to **stderr**, never dropped: a silently swallowed alert is the precise failure mode `founder-notifications.md` exists to prevent.

## Evidence (all captured locally, never real Slack)

Reproducer points `KIPI_SLACK_WEBHOOK` at a local capture endpoint. `KIPI_SLACK_WEBHOOK` is checked before `~/.config/kipi/slack-webhook`, so the real hook is never read. The harness self-tests that it can register a hit, so a `0` means refusal and not a dead capture.

| Check | Result |
|---|---|
| Reproducer on unmodified `main` | **1 page captured** (RED) — test itself reported `14 passed, 0 failed` while paging |
| After guard, same test file unmodified | **0 captured** (GREEN) |
| Production: real API / var unset / `localhost.evil.example.com` / `1270.0.0.1` | **all still deliver** |
| Fixture: `127.0.0.1` / `localhost` / `[::1]` / `0.0.0.0` / `127.0.0.53` | all refused, message on stderr |
| New suite `test-notify-fixture-guard.sh` | **16 passed, 0 failed** |
| Ref hatch vs pre-guard copy (`KIPI_NOTIFY_UNDER_TEST`) | **10 failed, exit 1** — and the production-direction assertions stayed green, so it discriminates |
| Mutation: guard removed from the file | **reproducer pages again** |
| `capability-gate.py --check-only` | GREEN, 95 declared tests |

The captured page is the same defect the founder actually received; only the worktree label differs:

```
[kipi-wt-notify-guard] kipi worker: repo identity 'no-such-project-anywhere' matches no
Linear project, so the queue reads empty and NO work can ever be picked...
```

A green suite is fully compatible with paging a human. That is the gap this closes.

## Merge order

`capability-manifest.json` is also touched by **#57** (terminal-states) and the **fleet-preflight** branch. This PR adds exactly one entry, `test-notify-fixture-guard.sh`, inserted alphabetically between `test-linear-worker-parallel.sh` and `test-worker-project-scope.sh`.

- Order does not matter for correctness; conflicts are additive one-line resolutions (keep all entries).
- Suggested: land this **first** (it is the live-paging stop), then #54, then #57 / fleet-preflight rebase on top.
- This PR touches no file owned by #52, #53, #54, or #57.

## Files

- `q-system/.q-system/scripts/slack-notify.sh` — the guard
- `q-system/.q-system/scripts/test/test-notify-fixture-guard.sh` — new, both directions + negative self-test + ref hatch
- `q-system/.q-system/capability-manifest.json` — one entry

## Known residual (captured, not dropped)

`sp-6ccca729`: `linear-worker.sh` calls `bash "$NOTIFY" ... 2>/dev/null` at all its notify sites, so the refusal diagnostic is discarded **at the caller**. Measured: the guard fired (0 pages) but no `REFUSED` line appeared in the test output. `slack-notify.sh` holds up its end; the fix belongs in `linear-worker.sh`, which is owned by #52 and the fleet-preflight issue, so it is out of scope here.

**DO NOT MERGE** without review.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01QsZcVy4GyFFqVtacBfWKEs