### PR TITLE
fix(token-guard): match the git invocation, not the substring, in the ceiling exemption

### DIFF
--- a/q-system/.q-system/capability-manifest.json
+++ b/q-system/.q-system/capability-manifest.json
@@ -372,6 +372,10 @@
       "runner": "python3"
     },
     {
+      "path": "q-system/.q-system/scripts/test_token_guard_commit_forms.py",
+      "runner": "python3"
+    },
+    {
       "path": "q-system/.q-system/scripts/test_token_guard_observation.py",
       "runner": "python3"
     },

--- a/q-system/.q-system/scripts/test_token_guard_commit_forms.py
+++ b/q-system/.q-system/scripts/test_token_guard_commit_forms.py
@@ -255,6 +255,62 @@ check("19. `git -C <wt> commit` DOES reset the volume ceiling",
 check("20. compound cd+add+commit DOES reset the volume ceiling",
       _reset["compound_commit_resets"] is True, str(_reset))
 
+# --- --dry-run belongs to an INVOCATION, not to the command string ----------
+# Round-1 review, MAJOR (sp-9ca7e393): the disqualifier was `"--dry-run" in
+# command`, a global substring test. A real commit whose MESSAGE mentions the
+# flag was read as a dry run and blocked at the ceiling — the exact
+# strands-finished-work failure this whole change exists to remove. shlex
+# collapses a quoted message into ONE token, so exact-token matching scoped to
+# the invocation that carries the flag fixes it.
+check_clears(21, "real commit whose message mentions --dry-run",
+             'git commit -m "fix: honor --dry-run flag"')
+check_clears(22, "real commit after a dry-run probe in the same command",
+             f'git commit --dry-run && git -C {WT} commit -m "msg"')
+check_clears(23, "git commit -n is --no-verify, a REAL commit",
+             'git commit -n -m "msg"')
+check_blocks(24, "git add --dry-run ships nothing", "git add --dry-run .")
+check_blocks(25, "git add -n is add's dry-run spelling", "git add -n .")
+
+# --- Unreachable checkpoints must not earn the exemption --------------------
+# Round-1 review, MINOR. Only the literal always-false/always-true builtins are
+# decided statically; see the comment on _segment_is_reachable for why this is a
+# named narrow case and not general reachability.
+check_blocks(26, "commit unreachable after `false &&`",
+             'false && git commit -m "msg"')
+check_blocks(27, "commit unreachable after `true ||`",
+             'true || git commit -m "msg"')
+check_clears(28, "commit IS reachable after `false ||`",
+             'false || git commit -m "msg"')
+check_clears(29, "commit IS reachable after `true &&`",
+             'true && git commit -m "msg"')
+
+# --- The reset reader must agree on all of the above ------------------------
+_mod2 = subprocess.run(
+    [sys.executable, "-c",
+     "import importlib.util,sys,json;"
+     "s=importlib.util.spec_from_file_location('g',sys.argv[1]);"
+     "m=importlib.util.module_from_spec(s);s.loader.exec_module(m);"
+     "resp={'exit_code':0,'stdout':'1 file changed'};"
+     "print(json.dumps({"
+     "'msg_mentions_dryrun': m._is_successful_commit("
+     "'git commit -m \\\"note about --dry-run\\\"', resp),"
+     "'pure_dry_run': m._is_successful_commit('git commit --dry-run', resp),"
+     "'dryrun_then_real': m._is_successful_commit("
+     "'git commit --dry-run && git -C /w commit -m x', resp),"
+     "'unreachable': m._is_successful_commit("
+     "'false && git commit -m x', resp)}))",
+     str(GUARD)],
+    capture_output=True, text=True, check=True)
+_r2 = json.loads(_mod2.stdout)
+check("30. reset: commit whose message mentions --dry-run DOES reset",
+      _r2["msg_mentions_dryrun"] is True, str(_r2))
+check("31. reset: a pure --dry-run does NOT reset",
+      _r2["pure_dry_run"] is False, str(_r2))
+check("32. reset: dry-run probe then a real commit DOES reset",
+      _r2["dryrun_then_real"] is True, str(_r2))
+check("33. reset: an unreachable commit does NOT reset",
+      _r2["unreachable"] is False, str(_r2))
+
 _tmpdir.cleanup()
 print()
 if failures:

--- a/q-system/.q-system/scripts/test_token_guard_commit_forms.py
+++ b/q-system/.q-system/scripts/test_token_guard_commit_forms.py
@@ -1,0 +1,263 @@
+#!/usr/bin/env python3
+"""Paired test for token-guard.py's volume-ceiling commit exemption
+(_is_commit_command), sp-91a19d16.
+
+WHY THIS EXISTS (scar, 2026-08-01): the exemption matched the raw substring
+"git commit". That is wrong in BOTH directions at once, and both directions
+were observed live:
+
+  - too tight: `git -C <worktree> commit -m ...` carries no "git commit"
+    substring, so a worktree commit was BLOCKED at the ceiling. `git add` was
+    never exempt at all, so the staging step that makes a commit possible was
+    blocked too. An agent finished cross-repo GH_REPO scoping with a passing
+    26-case suite, could not commit any of it, correctly refused to route
+    around the gate, and stopped. Worktrees are the standard dispatch pattern
+    here, so the ceiling effectively never cleared.
+  - too loose: `echo "git commit"` and `grep -r "git commit" .` carry the
+    substring and cleared the ceiling while shipping nothing.
+
+The fix matches the INVOCATION (tokenised), not the substring. This test pins
+both directions so a future "simplification" back to `in cmd` fails loudly.
+
+DRIVES THE REAL SCRIPT. Every case pipes real PreToolUse hook JSON into
+token-guard.py as a subprocess and reads the exit code (2 = block, 0 = allow),
+because the defect lives in the wiring between the matcher and the ceiling
+check, which a pure-function test cannot see.
+
+REF HATCH: TOKEN_GUARD_REF=<git-ref> runs the cases against the copy of
+token-guard.py at that ref instead of the working tree, so the pre-fix failure
+can be re-observed on demand and this test is never a case that has only ever
+been watched pass. Expect the pre-fix ref to FAIL cases 3/7/8/9/10/11/12.
+
+ISOLATION: each case gets its own synthetic session id, so the guard cache is a
+disposable per-case file that no real session can collide with, and it is
+deleted afterwards. CLAUDE_PROJECT_DIR points at a non-repo temp dir so the
+PreToolUse commit valve (reset_volume_if_committed, which shells out to git
+HEAD) cannot mask the result. Case 1 is the built-in control for that: if the
+git valve were doing the work, EVERY form would clear, not just the ones the
+matcher recognises.
+"""
+import json
+import os
+import pathlib
+import subprocess
+import sys
+import tempfile
+import uuid
+
+REPO_ROOT = pathlib.Path(__file__).resolve().parents[3]
+WORKTREE_GUARD = REPO_ROOT / "q-system/.q-system/token-guard.py"
+
+failures = []
+_tmpdir = tempfile.TemporaryDirectory(prefix="tg-commit-forms-")
+SANDBOX = pathlib.Path(_tmpdir.name)
+
+# A directory that is deliberately NOT a git repo: _head_commit_epoch() returns
+# None here, so the PreToolUse git valve is provably not the thing under test.
+NON_REPO = SANDBOX / "not-a-repo"
+NON_REPO.mkdir()
+
+
+def guard_path():
+    """The token-guard.py under test: the working tree, or a ref-extracted copy
+    when TOKEN_GUARD_REF is set (the mutation/pre-fix hatch)."""
+    ref = os.environ.get("TOKEN_GUARD_REF")
+    if not ref:
+        return WORKTREE_GUARD
+    out = subprocess.run(
+        ["git", "-C", str(REPO_ROOT), "show",
+         f"{ref}:q-system/.q-system/token-guard.py"],
+        capture_output=True, text=True)
+    if out.returncode != 0:
+        sys.exit(f"TOKEN_GUARD_REF={ref} could not be read: {out.stderr.strip()}")
+    dest = SANDBOX / f"token-guard-{ref.replace('/', '_')}.py"
+    dest.write_text(out.stdout)
+    return dest
+
+
+GUARD = guard_path()
+
+# Read the ceiling from the guard under test rather than hardcoding 50, so this
+# test pins the BEHAVIOUR and not a constant someone may legitimately retune.
+VOLUME_CEILING = int(subprocess.run(
+    [sys.executable, "-c",
+     "import importlib.util,sys;"
+     "s=importlib.util.spec_from_file_location('g',sys.argv[1]);"
+     "m=importlib.util.module_from_spec(s);s.loader.exec_module(m);"
+     "print(m.VOLUME_CEILING)", str(GUARD)],
+    capture_output=True, text=True, check=True).stdout.strip())
+
+
+def fire(command, calls_before, tool_name="Bash", tool_input=None, session=None,
+         extra_cache=None):
+    """One PreToolUse hook fire against the real script. Returns (exit_code,
+    stderr). Seeds the actor cache to `calls_before` first."""
+    session = session or f"tg-commit-forms-{uuid.uuid4()}"
+    cache = pathlib.Path(f"/tmp/claude-guard-{session}.json")
+    # last_volume_reset=now keeps the git valve inert even if CLAUDE_PROJECT_DIR
+    # ever resolves to a real repo; last_write_time=now keeps the stall warning
+    # quiet so the only signal in the exit code is the volume ceiling.
+    import time
+    seed = {
+        "tool_calls_since_user": calls_before,
+        "last_volume_reset": time.time(),
+        "last_write_time": time.time(),
+    }
+    seed.update(extra_cache or {})
+    cache.write_text(json.dumps(seed))
+    payload = {
+        "hook_event_name": "PreToolUse",
+        "session_id": session,
+        "tool_name": tool_name,
+        "tool_input": tool_input if tool_input is not None else {"command": command},
+    }
+    env = dict(os.environ)
+    env["CLAUDECODE"] = "1"
+    env["CLAUDE_PROJECT_DIR"] = str(NON_REPO)
+    env["KIPI_NOTIFY"] = "/usr/bin/true"
+    proc = subprocess.run(
+        [sys.executable, str(GUARD)], input=json.dumps(payload),
+        capture_output=True, text=True, env=env)
+    cache.unlink(missing_ok=True)
+    return proc.returncode, proc.stderr
+
+
+def check(name, condition, detail=""):
+    if condition:
+        print(f"PASS: {name}")
+    else:
+        failures.append(name)
+        print(f"FAIL: {name}{'  ' + detail if detail else ''}")
+
+
+def at_ceiling(command):
+    """Fire `command` as the call that lands exactly ON the ceiling."""
+    return fire(command, VOLUME_CEILING - 1)
+
+
+def check_clears(num, name, command):
+    code, err = at_ceiling(command)
+    check(f"{num}. clears ceiling: {name}", code == 0,
+          f"exit={code} stderr={err.strip()[:120]!r}")
+
+
+def check_blocks(num, name, command):
+    code, err = at_ceiling(command)
+    check(f"{num}. still BLOCKED: {name}", code == 2, f"exit={code}")
+
+
+WT = "/private/tmp/claude-501/wt-example"
+
+print(f"guard under test: {GUARD}")
+print(f"VOLUME_CEILING={VOLUME_CEILING}\n")
+
+# --- 0. The ceiling is real and reachable through the live path -------------
+# Drive actual calls until the guard blocks. Inputs vary so check_exact_retry
+# (3 identical calls) is not what stops us. Proves the rest of the matrix is
+# testing a ceiling that genuinely fires, not a dead code path.
+# fire() reseeds the cache per call, so driving needs its own loop over a cache
+# that PERSISTS across calls.
+def drive_to_ceiling():
+    session = f"tg-commit-forms-drive-{uuid.uuid4()}"
+    cache = pathlib.Path(f"/tmp/claude-guard-{session}.json")
+    cache.unlink(missing_ok=True)
+    env = dict(os.environ)
+    env["CLAUDECODE"] = "1"
+    env["CLAUDE_PROJECT_DIR"] = str(NON_REPO)
+    env["KIPI_NOTIFY"] = "/usr/bin/true"
+    try:
+        for n in range(1, VOLUME_CEILING + 5):
+            payload = {
+                "hook_event_name": "PreToolUse",
+                "session_id": session,
+                "tool_name": "Read",
+                "tool_input": {"file_path": f"{SANDBOX}/f{n}.txt"},
+            }
+            proc = subprocess.run(
+                [sys.executable, str(GUARD)], input=json.dumps(payload),
+                capture_output=True, text=True, env=env)
+            if proc.returncode == 2:
+                return n, proc.stderr
+        return None, ""
+    finally:
+        cache.unlink(missing_ok=True)
+
+
+blocked_at, block_err = drive_to_ceiling()
+check("0. live path blocks exactly at VOLUME_CEILING",
+      blocked_at == VOLUME_CEILING, f"blocked at {blocked_at}")
+check("0b. and it is the VOLUME ceiling that fired",
+      "tool calls without user input" in block_err, block_err.strip()[:120])
+
+# --- POSITIVE: real-world commit forms must clear the ceiling ---------------
+check_clears(1, "bare git commit (regression guard)", 'git commit -m "msg"')
+check_clears(2, "cd + git add + git commit (&&)",
+             f'cd {WT} && git add -A && git commit -m "msg"')
+check_clears(3, "git -C <worktree> commit", f'git -C {WT} commit -m "msg"')
+check_clears(4, "leading cd then commit", f'cd {WT} && git commit -m "msg"')
+check_clears(5, "newline-separated commit", f'cd {WT}\ngit commit -m "msg"')
+check_clears(6, "semicolon-separated commit", f'cd {WT}; git commit -m "msg"')
+check_clears(7, "bare git add", "git add -A")
+check_clears(8, "git -C <worktree> add", f"git -C {WT} add -A")
+check_clears(9, "cd then git add", f"cd {WT} && git add -A")
+
+# --- NEGATIVE: a mere MENTION must not clear the ceiling --------------------
+# These are the cases that make this a matcher fix and not a policy relaxation.
+check_blocks(10, "echo of the words", 'echo "git commit"')
+check_blocks(11, "grep for the words", 'grep -r "git commit" .')
+check_blocks(12, "-m message body mentioning both verbs",
+             'python3 notify.py -m "remember to git add and git commit"')
+check_blocks(13, "path segment containing commit",
+             "cat /repo/docs/git-commit-guide.md")
+check_blocks(14, "directory named commit", "ls /Users/x/projects/commit/")
+check_blocks(15, "git subcommand that is not a checkpoint", "git log --oneline -20")
+check_blocks(16, "commit --dry-run ships nothing", 'git commit --dry-run -m "msg"')
+
+# --- The other detectors are untouched --------------------------------------
+# A commit is exempt from the VOLUME ceiling ONLY. check_exact_retry runs at
+# priority 2, ahead of the exemption, so an agent re-firing one identical failing
+# commit must still be stopped: the exemption must not become a way to loop
+# forever on a commit that never lands.
+import hashlib as _h
+_cmd = 'git commit -m "looping"'
+_ti = {"command": _cmd}
+_key = "Bash:" + _h.md5(
+    ("Bash" + json.dumps(_ti, sort_keys=True)).encode()).hexdigest()[:12]
+code, err = fire(_cmd, VOLUME_CEILING - 1,
+                 extra_cache={"repeat_map": {_key: 3}})
+check("17. exempt commit still hits the exact-retry detector", code == 2,
+      f"exit={code} stderr={err.strip()[:80]!r}")
+
+# --- The exemption widened; the RESET must not have -------------------------
+# `git add` is exempt from the ceiling but ships nothing, so it must never look
+# like progress. These pin the two readers apart: if a later edit points
+# _invokes_git_commit at GIT_CHECKPOINT_SUBCOMMANDS, `git add` starts resetting
+# the ceiling and an agent can hold the ceiling open forever without committing.
+_mod = subprocess.run(
+    [sys.executable, "-c",
+     "import importlib.util,sys,json;"
+     "s=importlib.util.spec_from_file_location('g',sys.argv[1]);"
+     "m=importlib.util.module_from_spec(s);s.loader.exec_module(m);"
+     "resp={'exit_code':0,'stdout':'1 file changed'};"
+     "print(json.dumps({"
+     "'add_resets': m._is_successful_commit('cd /w && git add -A', resp),"
+     "'wt_commit_resets': m._is_successful_commit("
+     "'git -C /w commit -m x', resp),"
+     "'compound_commit_resets': m._is_successful_commit("
+     "'cd /w && git add -A && git commit -m x', resp)}))",
+     str(GUARD)],
+    capture_output=True, text=True, check=True)
+_reset = json.loads(_mod.stdout)
+check("18. `git add` does NOT reset the volume ceiling",
+      _reset["add_resets"] is False, str(_reset))
+check("19. `git -C <wt> commit` DOES reset the volume ceiling",
+      _reset["wt_commit_resets"] is True, str(_reset))
+check("20. compound cd+add+commit DOES reset the volume ceiling",
+      _reset["compound_commit_resets"] is True, str(_reset))
+
+_tmpdir.cleanup()
+print()
+if failures:
+    print(f"FAILED ({len(failures)}): " + "; ".join(failures))
+    sys.exit(1)
+print("All checks passed.")

--- a/q-system/.q-system/token-guard.py
+++ b/q-system/.q-system/token-guard.py
@@ -489,26 +489,128 @@ def _invokes_git_subcommand(command, subcommands):
     _invokes_git_commit passes commit-only, because there a false positive is the
     expensive one: it mints a grace budget, or resets the ceiling, for a command
     that committed nothing."""
-    if not command or "--dry-run" in command:
+    if not command:
         return False
-    try:
-        tokens = shlex.split(command, comments=True)
-    except ValueError:
-        tokens = command.split()
+    segments = _command_segments(command)
+    for position, (operator, tokens) in enumerate(segments):
+        if position and not _segment_is_reachable(
+                operator, segments[position - 1][1]):
+            continue
+        if _segment_invokes(tokens, subcommands):
+            return True
+    return False
+
+
+# Shell operators that end one command and begin the next.
+_CMD_SEPARATORS = frozenset(("&&", "||", ";", "|", "&"))
+
+# git's global options that swallow the following token as their value.
+_GIT_GLOBAL_TWO_WORD = frozenset(
+    ("-c", "-C", "--git-dir", "--work-tree", "--namespace", "--exec-path"))
+
+# Commands whose exit status is knowable from the text alone. Everything else is
+# runtime-valued, so `foo && git commit` stays reachable.
+_ALWAYS_FALSE = frozenset(("false", "/bin/false", "/usr/bin/false"))
+_ALWAYS_TRUE = frozenset(("true", "/bin/true", "/usr/bin/true", ":"))
+
+# The flag meaning "this invocation ships nothing", per subcommand. `-n` is add's
+# short --dry-run, but commit's -n is --no-verify: a REAL commit. Reading them
+# the same way would refuse a --no-verify checkpoint, which is exactly the
+# strands-finished-work failure this exemption exists to prevent.
+_DRY_RUN_FLAGS = {
+    "commit": frozenset(("--dry-run",)),
+    "add": frozenset(("--dry-run", "-n")),
+}
+
+
+def _command_segments(command):
+    """Every independently-executable command in the string, as
+    (preceding_operator, tokens).
+
+    Newlines are real command separators in shell but plain WHITESPACE to shlex,
+    so lines are split first and `&&`/`||`/`;`/`|`/`&` split what remains. Doing
+    it in that order is what keeps _is_dry_run's argument region from running off
+    the end of one command into the next."""
+    segments = []
+    for line in command.splitlines():
+        if not line.strip():
+            continue
+        try:
+            tokens = shlex.split(line, comments=True)
+        except ValueError:
+            tokens = line.split()
+        operator, current = None, []
+        for token in tokens:
+            if token in _CMD_SEPARATORS:
+                segments.append((operator, current))
+                operator, current = token, []
+            else:
+                current.append(token)
+        segments.append((operator, current))
+    return segments
+
+
+def _segment_is_reachable(operator, previous_tokens):
+    """False only for the two cases decidable from the text alone: a command
+    guarded by `false &&`, or by `true ||`.
+
+    Deliberately NOT general reachability. That needs a real shell parser, and
+    even with one, `foo && git commit` depends on foo's runtime exit status, so
+    it is undecidable here. The error budget forces the narrowness: calling a
+    REACHABLE commit unreachable refuses a real checkpoint and strands finished
+    work, the expensive failure. So only the always-false/always-true builtins,
+    only as a whole command, and only against the IMMEDIATELY preceding segment
+    (`false && a && git commit` leaves the commit reachable — conservative in the
+    safe direction). (Round-1 review, MINOR.)"""
+    guard = previous_tokens[0] if len(previous_tokens) == 1 else None
+    if operator == "&&" and guard in _ALWAYS_FALSE:
+        return False
+    if operator == "||" and guard in _ALWAYS_TRUE:
+        return False
+    return True
+
+
+def _segment_invokes(tokens, subcommands):
+    """Scan one command for `git [global-opts] <subcommand>` that is not a dry
+    run. The scan walks every token rather than assuming position 0, so wrapper
+    prefixes (`env FOO=bar git commit ...`) still match."""
     index = 0
     while index < len(tokens):
         if tokens[index] == "git" or tokens[index].endswith("/git"):
             cursor = index + 1
             while cursor < len(tokens) and tokens[cursor].startswith("-"):
-                # git's global options; the two-word forms swallow their value.
-                if tokens[cursor] in ("-c", "-C", "--git-dir", "--work-tree",
-                                      "--namespace", "--exec-path"):
+                if tokens[cursor] in _GIT_GLOBAL_TWO_WORD:
                     cursor += 2
                 else:
                     cursor += 1
-            if cursor < len(tokens) and tokens[cursor] in subcommands:
+            if (cursor < len(tokens) and tokens[cursor] in subcommands
+                    and not _is_dry_run(tokens, cursor)):
                 return True
+            index = cursor
         index += 1
+    return False
+
+
+def _is_dry_run(tokens, subcommand_index):
+    """True when THIS invocation carries its subcommand's dry-run flag.
+
+    Scoped to the one invocation and matched on WHOLE tokens, never on the
+    command string. Scar (sp-9ca7e393, round-1 review MAJOR): this was
+    `"--dry-run" in command`, so `git commit -m "fix: honor --dry-run flag"` was
+    read as a dry run and blocked at the volume ceiling — a real commit refused,
+    leaving unattended work uncommitted until a human resumed it, the same shape
+    as the worktree strand this file's other scar records. It also masked a real
+    commit that followed a dry-run probe (`git commit --dry-run && git -C x
+    commit -m y`). shlex collapses a quoted message into ONE token, so exact
+    matching inside the invocation's own argument region cannot be fooled by
+    message text."""
+    flags = _DRY_RUN_FLAGS.get(tokens[subcommand_index], frozenset())
+    for token in tokens[subcommand_index + 1:]:
+        # A new `git ...` begins the next invocation; its flags are not ours.
+        if token == "git" or token.endswith("/git"):
+            break
+        if token in flags:
+            return True
     return False
 
 

--- a/q-system/.q-system/token-guard.py
+++ b/q-system/.q-system/token-guard.py
@@ -439,31 +439,56 @@ def warn(message):
     sys.exit(0)
 
 
+# The subcommands that make a checkpoint possible, for the volume-ceiling
+# exemption only. `add` is here because a blocked `git add` makes the commit
+# impossible regardless — staging is part of the checkpoint, not a separate
+# errand. It is deliberately NOT in the reset/grace readers below: `git add`
+# ships nothing, so it must never reset the ceiling or mint a grace budget.
+GIT_CHECKPOINT_SUBCOMMANDS = ("commit", "add")
+
+
 def _is_commit_command(tool_name, tool_input):
-    """A `git commit` invocation, judged from the command alone (PreToolUse has no
-    response yet). Used to EXEMPT a commit from the volume ceiling — a commit is the
-    checkpoint the ceiling is asking for, so blocking it deadlocks the run (the
-    PostToolUse commit-reset can never fire if PreToolUse blocks the commit first)."""
+    """A `git commit`/`git add` invocation, judged from the command alone
+    (PreToolUse has no response yet). Used to EXEMPT the checkpoint from the
+    volume ceiling — a commit is the checkpoint the ceiling is asking for, so
+    blocking it deadlocks the run (the PostToolUse commit-reset can never fire
+    if PreToolUse blocks the commit first).
+
+    Scar (sp-91a19d16, observed live 2026-08-01): this was `"git commit" in cmd`,
+    a raw substring test, and it was wrong in BOTH directions at once. Too tight:
+    `git -C <worktree> commit -m ...` contains no "git commit" substring, and
+    `git add` was never matched at all — so an agent working in a worktree (the
+    standard dispatch pattern here) could never clear the ceiling. One finished
+    cross-repo GH_REPO scoping with a passing 26-case suite, could not commit any
+    of it, correctly refused to route around the gate, and stopped. Too loose:
+    `echo "git commit"` and `grep -r "git commit" .` carried the substring and
+    cleared the ceiling while shipping nothing. Match the INVOCATION, not the
+    substring; the tokeniser below already knew how."""
     if tool_name != "Bash":
         return False
     cmd = (tool_input or {}).get("command", "") or ""
-    return "git commit" in cmd and "--dry-run" not in cmd
+    return _invokes_git_subcommand(cmd, GIT_CHECKPOINT_SUBCOMMANDS)
 
 
-def _invokes_git_commit(command):
-    """True only when the command actually RUNS `git commit`.
+def _invokes_git_subcommand(command, subcommands):
+    """True only when the command actually RUNS `git <subcommand>`, for any
+    subcommand in `subcommands`.
 
     A substring test on the command text is not that: `grep -rn "git commit"
     canonical/` carries the string and ships nothing, and a failing one was read
     as a refused checkpoint (PR #27 review, finding 2). Tokenising drops the
-    quoted mention while keeping `cd x && git commit -m y`.
+    quoted mention (shlex collapses "git commit" into ONE token, which is not
+    `git`) while keeping `cd x && git add -A && git commit -m y`, `git -C x
+    commit`, and the newline/`;`-separated forms — the scan walks every token,
+    so the position of the verb in the command does not matter.
 
-    Deliberately NOT used by _is_commit_command above. There the error costs run
-    the other way: a false negative blocks the checkpoint the ceiling is asking
-    for and deadlocks the run, while a false positive only exempts one harmless
-    call from the ceiling. Here — and in _is_successful_commit — a false positive
-    is the expensive one: it mints a grace budget, or resets the ceiling, for a
-    command that committed nothing. Two readers, two error budgets, on purpose."""
+    Two callers, two subcommand sets, on purpose. The ceiling exemption passes
+    GIT_CHECKPOINT_SUBCOMMANDS, where a false negative is the expensive error: it
+    blocks the checkpoint the ceiling is asking for and deadlocks the run, while
+    a false positive costs one exempted call that still cannot reset anything.
+    _invokes_git_commit passes commit-only, because there a false positive is the
+    expensive one: it mints a grace budget, or resets the ceiling, for a command
+    that committed nothing."""
     if not command or "--dry-run" in command:
         return False
     try:
@@ -481,10 +506,17 @@ def _invokes_git_commit(command):
                     cursor += 2
                 else:
                     cursor += 1
-            if cursor < len(tokens) and tokens[cursor] == "commit":
+            if cursor < len(tokens) and tokens[cursor] in subcommands:
                 return True
         index += 1
     return False
+
+
+def _invokes_git_commit(command):
+    """True only when the command actually RUNS `git commit`. Feeds the
+    volume-counter reset and the gate-grace budget, so it stays commit-only:
+    `git add` ships nothing and must not look like progress."""
+    return _invokes_git_subcommand(command, ("commit",))
 
 
 def _is_successful_commit(command, tool_response):


### PR DESCRIPTION
Fixes the gate defect captured as `sp-91a19d16`. **Do not merge yet.**

## The defect

`token-guard.py`'s volume-ceiling exemption (`_is_commit_command`) tested the raw substring `"git commit" in cmd`. That was wrong in **both** directions at once, and both directions reproduce.

**Too tight.** `git -C <worktree> commit -m ...` carries no `git commit` substring, and `git add` was never matched at all. Worktrees are the standard dispatch pattern here, so the ceiling effectively never cleared. Observed live 2026-08-01: an agent finished cross-repo `GH_REPO` scoping with a passing 26-case suite, could not commit any of it, correctly refused to route around the gate, and stopped.

**Too loose.** `echo "git commit"` and `grep -r "git commit" .` carried the substring and cleared the ceiling while shipping nothing.

## The fix

Matcher only. The tokenising walker already in this file (`_invokes_git_commit`) knew how to do this; it was deliberately not wired to the exemption. Generalised it to `_invokes_git_subcommand(command, subcommands)` and pointed the exemption at `("commit", "add")`.

`shlex` collapses a quoted `"git commit"` into one token that is not `git`, so a mention cannot match. The scan walks every token, so `&&`, `;`, newline, leading `cd`, and `git -C <path>` all work regardless of where the verb sits.

## Not a policy relaxation

- `VOLUME_CEILING` untouched at 50.
- `git add` is exempt from the **ceiling** only. The reset and gate-grace readers stay commit-only (`_invokes_git_commit`), so `git add` can never reset the counter or mint a grace budget. Pinned by cases 18-20.
- exact-retry, edit-spiral, read-spiral, grep-drift and time-stall are untouched. Case 17 proves a repeated failing commit is still stopped by exact-retry, which runs ahead of the exemption.

## Evidence

New test `q-system/.q-system/scripts/test_token_guard_commit_forms.py`, 20 cases, registered in `capability-manifest.json`. It drives the **real script** via subprocess with real PreToolUse hook JSON and reads the exit code, because the defect lives in the wiring between the matcher and the ceiling check.

Case 0 drives actual calls until the guard blocks, asserting it blocks at exactly `VOLUME_CEILING` — so the matrix is testing a ceiling that genuinely fires.

`CLAUDE_PROJECT_DIR` points at a non-repo temp dir so the PreToolUse git valve cannot mask results; case 1 is the control (if the valve were doing the work, every form would clear).

**Mutation via the built-in ref hatch** — `TOKEN_GUARD_REF=c39968b` replays every case against the pre-fix guard:

```
FAIL: 3. clears ceiling: git -C <worktree> commit  exit=2
FAIL: 7. clears ceiling: bare git add  exit=2
FAIL: 8. clears ceiling: git -C <worktree> add  exit=2
FAIL: 9. clears ceiling: cd then git add  exit=2
FAIL: 10. still BLOCKED: echo of the words  exit=0
FAIL: 11. still BLOCKED: grep for the words  exit=0
FAIL: 12. still BLOCKED: -m message body mentioning both verbs  exit=0
FAILED (7)
```

Post-fix: all 20 pass. Siblings green, no regression: `test_token_guard_observation.py`, `test_token_guard_runtime.py`, `test-token-guard-hook-behavior.sh`. `capability-gate.py --check-only`: GREEN. fable-discipline lint: exit 0 on both changed files.

## Correction to the reported symptom

`cd <path> && git add -A && git commit -m ...` was **already** exempt on the old code, because that form does contain the literal substring. The genuinely blocked forms were `git -C <path> commit` and every `git add`. Verified, not assumed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01QsZcVy4GyFFqVtacBfWKEs