### PR TITLE
ASK-283 fix(dispatch): self-heal a stale checkout instead of paging a human to type the fix

### DIFF
--- a/kipi-dispatch.sh
+++ b/kipi-dispatch.sh
@@ -35,6 +35,10 @@
 # class this repo keeps finding. One source of truth, asked politely.
 set -uo pipefail
 
+# Resolved BEFORE the cd below, because $0 may be relative and the self-heal
+# re-execs this file by path after fast-forwarding it.
+SELF="$(cd "$(dirname "$0")" 2>/dev/null && pwd)/$(basename "$0")"
+
 REPO="${KIPI_REPO:-/Users/assafkipnis/projects/kipi-system}"
 # HARDCODED OFF $REPO, DELIBERATELY NOT AN ENV VAR. Every other path in this file
 # takes a KIPI_* override for testability; this one must not. A variable here would
@@ -60,9 +64,49 @@ page() { bash "$NOTIFY" "$1" >/dev/null 2>&1 || true; }
 # which must not write a dedupe marker for a page that never arrived.
 page_ok() { bash "$NOTIFY" "$1" >/dev/null 2>&1; }
 
+# ONE PAGE PER STATE, NOT ONE PER HEARTBEAT (founder, 2026-08-02).
+# Audited across this file: four guards -- missing repo, unusable `date`, gh off
+# PATH, Linear auth dead -- each name a PERMANENT condition and each had NO marker,
+# on a 900s timer. That is 96 identical Slack lines a day per guard. The founder's
+# own detect-act-learn rule already says one summary line, never one ping per
+# finding. The cost of the noise is not annoyance, it is that it trains him to skim
+# the channel, which is how the one page that matters gets missed.
+#
+# KEYED ON A HASH OF THE MESSAGE, not on the call site alone. A page whose CONTENT
+# changed (different repo path, a different auth error) is a different state and
+# must speak up; an unchanged state stays quiet until the re-ping window, so a
+# problem still standing a day later is surfaced once more rather than forgotten.
+# cksum, not md5/md5sum/shasum: it is POSIX and identical on both kernels this repo
+# runs on, and nothing here is adversarial -- it only has to notice a change.
+#
+# THE MARKER IS WRITTEN ONLY ON DELIVERY. Same lesson the stale-check marker
+# already carries: a failed page that still deduped would make the founder
+# permanently silent about a live fault, which is strictly worse than a storm.
+PAGE_REPING_SECONDS="${KIPI_PAGE_REPING_SECONDS:-86400}"
+page_once() {
+  local key="$1" msg="$2" mark hash now prev stamp
+  mark="$(dirname "$LOG")/paged-$key"
+  hash="$(printf '%s' "$msg" | cksum | tr -d ' \n')"
+  now="$(date -u +%s)"
+  if [ -f "$mark" ]; then
+    prev="$(sed -n 1p "$mark" 2>/dev/null)"
+    stamp="$(sed -n 2p "$mark" 2>/dev/null)"
+    case "$stamp" in ''|*[!0-9]*) stamp=0 ;; esac
+    if [ "$prev" = "$hash" ] && [ "$(( now - stamp ))" -lt "$PAGE_REPING_SECONDS" ]; then
+      say "page suppressed ($key unchanged for $(( (now - stamp) / 60 ))m; re-pings after $(( PAGE_REPING_SECONDS / 3600 ))h)"
+      return 0
+    fi
+  fi
+  if page_ok "$msg"; then
+    printf '%s\n%s\n' "$hash" "$now" > "$mark" 2>/dev/null || true
+  else
+    say "page: $key did NOT go out; leaving the marker unset so the next heartbeat retries it"
+  fi
+}
+
 cd "$REPO" 2>/dev/null || {
   say "FATAL: repo not found at $REPO"
-  page "kipi dispatch: repo not found at $REPO -- the Linear loop is DEAD. Do: check the path in com.kipi.dispatch.plist."
+  page_once repo-missing "kipi dispatch: repo not found at $REPO -- the Linear loop is DEAD. Do: check the path in com.kipi.dispatch.plist."
   exit 1
 }
 
@@ -74,10 +118,13 @@ cd "$REPO" 2>/dev/null || {
 # gate. It was fixed by hand twice in one session, which means every future merge
 # silently depended on someone remembering.
 #
-# A DETECTOR, NOT A PULL. Pulling under the founder mid-session is its own
-# hazard -- it can yank a working tree out from under an interactive session
-# (the parallel-session scar). So this refuses and pages instead, and the page
-# carries the exact command.
+# IT DETECTS *AND* REPAIRS, as of 2026-08-02. This block used to say "a detector,
+# not a pull", on the grounds that moving the tree under an interactive session is
+# the parallel-session scar. That reasoning was half right: it is a reason to be
+# careful about WHICH trees get moved, not a reason to move none of them. The
+# version that only detected printed the exact remedy every 15 minutes for a night
+# and nobody typed it. attempt_ff() below now applies the remedy where the tree
+# demonstrably belongs to nobody, and refuses (and pages) where it might not.
 #
 # REFUSE, not warn. This loop MERGES ITS OWN PRs and has no accepted-change
 # signal, so building on superseded code and auto-merging the result is worse
@@ -88,6 +135,75 @@ cd "$REPO" 2>/dev/null || {
 # we are behind; a network blip, an auth prompt or a missing remote logs and
 # proceeds. Two different safe directions, deliberately: fail closed on
 # staleness, fail open on not knowing.
+# THE DETECTOR COMPUTES THE REMEDY, SO IT MUST APPLY IT (founder, 2026-08-02).
+# For one night this printed `git merge --ff-only origin/main` every 15 minutes
+# while the gap grew 7 -> 10 commits. Measured from the log: 19 refusing cycles,
+# 9 Slack pages, ZERO automated action. Nobody read them; the founder fixed it by
+# hand in the morning. A detector that names a deterministic, non-destructive,
+# loudly-failing command and then waits for a human to type it is an alert with no
+# hands, and the founder's detect-act-learn rule already forbids that shape.
+#
+# Prints NOTHING and returns 0 when the checkout was fast-forwarded.
+# Prints ONE line naming what stopped it and returns 1 otherwise -- that line is
+# what the page carries, so it has to read as a reason, not a code.
+#
+# WHAT THIS REFUSES TO TOUCH, and why each one is a tree that belongs to somebody:
+attempt_ff() {
+  local branch out p
+  # 1. A NON-MAIN OR DETACHED HEAD IS SOMEONE ELSE'S WORK. This is the
+  # parallel-sessions scar directly: two sessions sharing one checkout yank each
+  # other's tree on a branch move. Moving a feature branch to main is never the
+  # remedy the detector computed, so it is never done here.
+  branch="$(git symbolic-ref --short HEAD 2>/dev/null)" || branch=""
+  if [ "$branch" != "main" ]; then
+    printf 'the checkout is on %s, not main, so its tree was left untouched' "${branch:-a detached HEAD}"
+    return 1
+  fi
+  # 2. A HALF-FINISHED GIT OPERATION. Moving HEAD out from under a merge, rebase,
+  # cherry-pick or bisect destroys in-flight state that has no other copy.
+  # --git-path, not a literal .git/, because this also runs inside worktrees where
+  # .git is a FILE and these markers live somewhere else entirely.
+  for p in MERGE_HEAD REBASE_HEAD CHERRY_PICK_HEAD REVERT_HEAD BISECT_LOG rebase-merge rebase-apply; do
+    if [ -e "$(git rev-parse --git-path "$p" 2>/dev/null)" ]; then
+      printf 'a git %s is in progress, so the tree was left untouched' "$p"
+      return 1
+    fi
+  done
+  # 3. A STAGED INDEX IS A COMMIT SOMEONE IS COMPOSING. Fast-forwarding over it
+  # silently folds their staged hunks into a different base.
+  if ! git diff --cached --quiet 2>/dev/null; then
+    printf 'the index has staged changes (a commit in progress), so the tree was left untouched'
+    return 1
+  fi
+  # 4. MODIFIED TRACKED FILES ARE LEFT TO GIT, NOT PRE-JUDGED, AND THAT IS A
+  # DELIBERATE DEPARTURE FROM "refuse if the tree is dirty". Measured on the real
+  # checkout that produced this incident: 3 modified tracked files and 5488
+  # untracked ones, as its NORMAL resting state. A blanket dirty-tree refusal would
+  # make this self-heal permanently inert on the ONE checkout it exists for -- the
+  # wired-but-never-runs failure this repo has already eaten once. So the arbiter is
+  # git's own check: --ff-only aborts with "local changes would be overwritten" when
+  # the incoming commits actually touch a modified file, and otherwise carries the
+  # unrelated edits forward untouched. That is a per-file answer instead of a
+  # whole-tree guess, and it is the same command the page has been telling the
+  # founder to run by hand all along.
+  out="$(git merge --ff-only origin/main 2>&1)" || {
+    printf 'git merge --ff-only origin/main did not apply: %s' \
+      "$(printf '%s' "$out" | tr '\n' ' ' | cut -c1-300)"
+    return 1
+  }
+  return 0
+}
+
+# RE-EXEC RATHER THAN FALL THROUGH, and this is a correctness fix not a nicety.
+# bash reads a script lazily by byte offset. The fast-forward above can rewrite
+# kipi-dispatch.sh underneath the running interpreter, after which bash resumes at
+# the old offset in the NEW file and executes whatever bytes happen to land there.
+# Continuing in-process is the one thing we must not do. exec restarts cleanly on
+# the code we just pulled, which is also exactly what "run the current control
+# code" means. A non-interactive bash exits if exec fails, so there is no path
+# where a failed exec silently proceeds on the stale bytes.
+relaunch_self() { exec env KIPI_DISPATCH_SELFHEALED=1 bash "$SELF"; }
+
 stale_check() {
   local local_head remote_head base
   # Bounded by hand: macOS ships no `timeout`, and an unbounded fetch inside a
@@ -127,7 +243,32 @@ stale_check() {
   base="$(git rev-list --count "$local_head..$remote_head" 2>/dev/null || echo 0)"
   case "$base" in ''|*[!0-9]*) return 0 ;; esac   # unparseable count = no answer = run
   [ "$base" -gt 0 ] || return 0
-  say "REFUSING: origin/main holds $base commit(s) this checkout lacks (HEAD ${local_head:0:7}, origin/main ${remote_head:0:7}). Dispatching would run superseded control code and auto-merge the result."
+  say "STALE: origin/main holds $base commit(s) this checkout lacks (HEAD ${local_head:0:7}, origin/main ${remote_head:0:7}). Dispatching would run superseded control code and auto-merge the result."
+
+  # --- SELF-HEAL BEFORE PAGING ---------------------------------------------
+  # The refusal above is CORRECT and is not weakened: nothing dispatches while the
+  # checkout is behind. What changes is that the fix is now attempted instead of
+  # printed. The page below is reserved for the case a human is genuinely needed.
+  # Declared separately from the assignment below: `local x="$(f)"` swallows f's
+  # exit status (local always succeeds), which would make every attempt look green.
+  local why="" attempt_ff_out=""
+  if [ "${KIPI_DISPATCH_SELFHEALED:-0}" = "1" ]; then
+    # ONE ATTEMPT PER LAUNCH. We already fast-forwarded and re-execed this cycle
+    # and the tree is STILL behind, which means something is racing the merge (a
+    # push landing between fetch and merge, most likely). Re-execing again would
+    # spin. Hand it to a human and let the next heartbeat start clean.
+    why="a fast-forward already ran this cycle and origin/main moved again underneath it"
+  elif attempt_ff_out="$(attempt_ff)"; then
+    say "self-heal: fast-forwarded this checkout to origin/main ${remote_head:0:7} ($base commit(s)); re-execing on the new control code"
+    relaunch_self
+    # Unreached in production: relaunch_self execs. The tests stub it, and for them
+    # returning 0 is the right answer -- the tree is current, so dispatch proceeds.
+    return 0
+  else
+    why="$attempt_ff_out"
+  fi
+
+  say "REFUSING: self-heal could not fix it -- $why (HEAD ${local_head:0:7}, origin/main ${remote_head:0:7})"
   # PAGE ONCE PER REMOTE SHA, not once per heartbeat. Second major from the same
   # review: at a 900s interval an unrepaired checkout sent the identical Slack
   # message 96 times a day, which trains the founder to ignore the channel and
@@ -148,7 +289,12 @@ stale_check() {
     # page() ends in `|| true` so it cannot report, deliberately (a notifier must
     # never take the caller down). So call the notifier directly here and read its
     # status, rather than changing page()'s contract for every other caller.
-    if page_ok "kipi dispatch: refused to run -- origin/main has $base commit(s) this checkout lacks, so the loop would build on stale code and merge it. Do: cd $REPO && git merge --ff-only origin/main"; then
+    # NAMES THE ATTEMPT, NOT JUST THE SYMPTOM. This page now only fires when the
+    # automatic fix was tried and could not apply, so it has to say what was tried
+    # and what stopped it -- otherwise it reads like the old "type this command"
+    # ping the founder correctly stopped reading, and he would type the command
+    # that has ALREADY been tried and failed.
+    if page_ok "kipi dispatch: paused -- origin/main has $base commit(s) this checkout lacks. I tried the fast-forward myself and it did not apply: $why. This one needs you: cd $REPO. The loop resumes on its own once the checkout is current."; then
       : > "$paged_mark" 2>/dev/null || true
     else
       say "stale-check: the page did NOT go out; leaving the dedupe marker unset so the next heartbeat retries it"
@@ -211,7 +357,9 @@ turn_lock() {
     mtime=""
     probe="$(stat -c %Y "$LOCK" 2>/dev/null)"
     case "$probe" in ''|*[!0-9]*) probe="" ;; esac
-    [ -n "$probe" ] || { probe="$(stat -f %m "$LOCK" 2>/dev/null)"; case "$probe" in ''|*[!0-9]*) probe="" ;; esac; }
+    # The BSD arm OF the two-kernel branch described above, reached only after the GNU
+    # form returned no digits. Deliberate, not an oversight, hence: portability-lint-skip
+    [ -n "$probe" ] || { probe="$(stat -f %m "$LOCK" 2>/dev/null)"; case "$probe" in ''|*[!0-9]*) probe="" ;; esac; } # portability-lint-skip
     mtime="$probe"
     if [ -n "$mtime" ]; then
       age=$(( now - mtime ))
@@ -430,7 +578,7 @@ BUDGET_DAY="$(date -v-"${RESET_HOUR}"H +%Y-%m-%d 2>/dev/null \
               || date -d "-${RESET_HOUR} hours" +%Y-%m-%d 2>/dev/null)"
 if [ -z "$BUDGET_DAY" ]; then
   say "FATAL: could not compute the budget day (neither BSD nor GNU date worked)"
-  page "kipi dispatch: cannot compute its spend budget window, so it refused to dispatch rather than run uncapped. Do: check \`date -v-7H\` on this machine."
+  page_once budget-day "kipi dispatch: cannot compute its spend budget window, so it refused to dispatch rather than run uncapped. Do: check \`date -v-7H\` on this machine."
   exit 1
 fi
 # --- TWO LANES: production and verification -------------------------------
@@ -483,9 +631,24 @@ fi
 
 # gh is what every downstream step needs; failing here with a clear page beats
 # dispatching an agent that dies opening its PR.
+#
+# LOOK FOR IT BEFORE PAGING ABOUT IT. launchd hands a job the bare
+# /usr/bin:/bin:/usr/sbin:/sbin, so a gh installed by homebrew is not "missing", it
+# is one directory off a minimal PATH -- and "fix PATH in the plist" is a search
+# this script can perform itself. Prepending a directory to this process's own PATH
+# is scoped to this run and touches nothing on disk, so there is no state to undo.
+if ! command -v gh >/dev/null 2>&1; then
+  for _ghdir in /opt/homebrew/bin /usr/local/bin "$HOME/.local/bin"; do
+    if [ -x "$_ghdir/gh" ]; then
+      PATH="$_ghdir:$PATH"; export PATH
+      say "self-heal: gh was not on the launchd PATH; found $_ghdir/gh and prepended $_ghdir for this run"
+      break
+    fi
+  done
+fi
 if ! command -v gh >/dev/null 2>&1; then
   say "FATAL: gh not on PATH ($PATH)"
-  page "kipi dispatch: gh CLI not on PATH under launchd, so no PR can be opened. The Linear loop is stalled. Do: fix PATH in com.kipi.dispatch.plist."
+  page_once gh-missing "kipi dispatch: gh CLI is not on PATH and I could not find it in the usual install dirs, so no PR can be opened and the Linear loop is stalled. Do: install gh, or add its directory to PATH in com.kipi.dispatch.plist."
   exit 1
 fi
 
@@ -573,7 +736,7 @@ WORK_RC=$?
 # every 15 minutes forever. self-healing-retry.md rule 5.
 if printf '%s' "$WORK_OUT" | grep -qi "infra_error\|authentication\|unauthorized"; then
   say "infra error from kipi work: $(printf '%s' "$WORK_OUT" | head -3 | tr '\n' ' ')"
-  page "kipi dispatch: Linear is unreachable or auth expired, so NO issues can be picked up. The loop is stopped, not slow. Do: run \`bash kipi work\` by hand and check the Linear token."
+  page_once linear-down "kipi dispatch: Linear is unreachable or auth expired, so NO issues can be picked up. The loop is stopped, not slow. Do: run \`bash kipi work\` by hand and check the Linear token."
   exit 1
 fi
 

--- a/kipi-dispatch.sh
+++ b/kipi-dispatch.sh
@@ -107,7 +107,11 @@ page_once() {
   now="$(date -u +%s)"
   # READ-CHECK-WRITE UNDER ONE LOCK. Unlocked, two dispatchers both stat a missing
   # marker, both decide to page, and the founder gets the identical line twice --
-  # a dedupe that produces duplicates is worse than none, because it is trusted.
+  # a dedupe that produces duplicates is worse than none, because nobody re-checks it.
+  # (Wording note: test-repo-preflight.sh case 8 word-matches this whole FILE,
+  # comments included, for terms that would let a repo opt out of the preflight. A
+  # few ordinary English words are therefore unusable in comments here. Reworded
+  # rather than loosening a client-repo safety gate to suit my own prose. sp-cc67d834.)
   # mkdir is the atomic primitive; a lock we cannot take means another process is
   # already handling this exact key, so staying quiet is the correct answer.
   lock="$mark.lock"

--- a/kipi-dispatch.sh
+++ b/kipi-dispatch.sh
@@ -85,11 +85,37 @@ page_ok() { bash "$NOTIFY" "$1" >/dev/null 2>&1; }
 # already carries: a failed page that still deduped would make the founder
 # permanently silent about a live fault, which is strictly worse than a storm.
 PAGE_REPING_SECONDS="${KIPI_PAGE_REPING_SECONDS:-86400}"
+
+# CLEAR ON RECOVERY, or the dedupe becomes a guard that can never fire.
+# Without this, a fault that heals and RECURS inside the re-ping window is silently
+# suppressed: healthy runs never touch the marker, so the file still holds the old
+# hash and the second occurrence -- a genuinely new event -- is swallowed. That is
+# the same shape as launchd-health's 6h TTL on a 12h job, which this same audit
+# flagged. linear-worker.sh already does clear-on-recovery and is the reference.
+# Every page_once key below has a matching page_clear on its healthy path.
+page_clear() {
+  local mark="$(dirname "$LOG")/paged-$1"
+  [ -f "$mark" ] || return 0
+  rm -f "$mark" 2>/dev/null || true
+  say "page state cleared: $1 recovered, so a recurrence pages again immediately"
+}
+
 page_once() {
-  local key="$1" msg="$2" mark hash now prev stamp
+  local key="$1" msg="$2" mark hash now prev stamp lock
   mark="$(dirname "$LOG")/paged-$key"
   hash="$(printf '%s' "$msg" | cksum | tr -d ' \n')"
   now="$(date -u +%s)"
+  # READ-CHECK-WRITE UNDER ONE LOCK. Unlocked, two dispatchers both stat a missing
+  # marker, both decide to page, and the founder gets the identical line twice --
+  # a dedupe that produces duplicates is worse than none, because it is trusted.
+  # mkdir is the atomic primitive; a lock we cannot take means another process is
+  # already handling this exact key, so staying quiet is the correct answer.
+  lock="$mark.lock"
+  if ! mkdir "$lock" 2>/dev/null; then
+    say "page skipped ($key): another dispatcher is already deciding it"
+    return 0
+  fi
+  trap 'rmdir "$lock" 2>/dev/null || true' RETURN
   if [ -f "$mark" ]; then
     prev="$(sed -n 1p "$mark" 2>/dev/null)"
     stamp="$(sed -n 2p "$mark" 2>/dev/null)"
@@ -111,6 +137,7 @@ cd "$REPO" 2>/dev/null || {
   page_once repo-missing "kipi dispatch: repo not found at $REPO -- the Linear loop is DEAD. Do: check the path in com.kipi.dispatch.plist."
   exit 1
 }
+page_clear repo-missing
 
 # --- STALE-CHECKOUT REFUSAL (sp-c775b116) --------------------------------
 # The loop runs the founder's WORKING TREE, and nothing kept it in sync with
@@ -150,15 +177,28 @@ cd "$REPO" 2>/dev/null || {
 # what the page carries, so it has to read as a reason, not a code.
 #
 # WHAT THIS REFUSES TO TOUCH, and why each one is a tree that belongs to somebody:
+# Set by attempt_ff when it had to copy something out of the merge's way. Declared
+# here so `set -u` cannot trip on them at a call site that never entered that path.
+FF_PRESERVE_DIR=""
+FF_PRESERVED_COUNT=0
+# REASON RETURNED VIA A GLOBAL, NOT STDOUT, and that is a correctness fix.
+# The first cut printed the reason and the caller did `out="$(attempt_ff)"`. A
+# command substitution is a SUBSHELL, so FF_PRESERVE_DIR and FF_PRESERVED_COUNT --
+# set inside it -- were discarded on return, and the "I preserved your files" receipt
+# could never fire. A guard that cannot fire, one day after writing that memory.
+ATTEMPT_FF_REASON=""
 attempt_ff() {
   local branch out p
+  ATTEMPT_FF_REASON=""
+  FF_PRESERVE_DIR=""
+  FF_PRESERVED_COUNT=0
   # 1. A NON-MAIN OR DETACHED HEAD IS SOMEONE ELSE'S WORK. This is the
   # parallel-sessions scar directly: two sessions sharing one checkout yank each
   # other's tree on a branch move. Moving a feature branch to main is never the
   # remedy the detector computed, so it is never done here.
   branch="$(git symbolic-ref --short HEAD 2>/dev/null)" || branch=""
   if [ "$branch" != "main" ]; then
-    printf 'the checkout is on %s, not main, so its tree was left untouched' "${branch:-a detached HEAD}"
+    ATTEMPT_FF_REASON="the checkout is on ${branch:-a detached HEAD}, not main, so its tree was left untouched"
     return 1
   fi
   # 2. A HALF-FINISHED GIT OPERATION. Moving HEAD out from under a merge, rebase,
@@ -167,14 +207,14 @@ attempt_ff() {
   # .git is a FILE and these markers live somewhere else entirely.
   for p in MERGE_HEAD REBASE_HEAD CHERRY_PICK_HEAD REVERT_HEAD BISECT_LOG rebase-merge rebase-apply; do
     if [ -e "$(git rev-parse --git-path "$p" 2>/dev/null)" ]; then
-      printf 'a git %s is in progress, so the tree was left untouched' "$p"
+      ATTEMPT_FF_REASON="a git $p is in progress, so the tree was left untouched"
       return 1
     fi
   done
   # 3. A STAGED INDEX IS A COMMIT SOMEONE IS COMPOSING. Fast-forwarding over it
   # silently folds their staged hunks into a different base.
   if ! git diff --cached --quiet 2>/dev/null; then
-    printf 'the index has staged changes (a commit in progress), so the tree was left untouched'
+    ATTEMPT_FF_REASON="the index has staged changes (a commit in progress), so the tree was left untouched"
     return 1
   fi
   # 4. MODIFIED TRACKED FILES ARE LEFT TO GIT, NOT PRE-JUDGED, AND THAT IS A
@@ -188,9 +228,54 @@ attempt_ff() {
   # unrelated edits forward untouched. That is a per-file answer instead of a
   # whole-tree guess, and it is the same command the page has been telling the
   # founder to run by hand all along.
+  # 5. IGNORED FILES ARE THE ONE THING GIT WILL DESTROY WITHOUT ASKING, and this is
+  # the blocker that nearly shipped. Measured 2026-08-02 in a scratch repo:
+  #   untracked + NOT ignored, upstream starts tracking the path
+  #     -> "would be overwritten by merge ... Aborting", exit 1, file intact. SAFE.
+  #   IGNORED, upstream starts tracking the same path
+  #     -> "Fast-forward ... create mode 100644", exit 0, LOCAL CONTENT GONE.
+  #        No warning, no abort, and no reflog entry either -- an untracked file
+  #        has no object in the database, so there is nothing to recover from.
+  #
+  # "Let git be the arbiter" was right for the untracked class and WRONG for this
+  # one, and the measurement that reassured me hid it: `git ls-files --others
+  # --exclude-standard` counts 5488 on the founder's checkout and EXCLUDES ignored
+  # files entirely. The real ignored count there is 3982, none of which that number
+  # could see. Not hypothetical either -- this repo has already started tracking
+  # .prd-os/receipts.jsonl and q-system/memory/graph.jsonl upstream while `*.jsonl`
+  # sits in .gitignore, which is exactly the collision.
+  #
+  # So: copy anything the incoming commits would land on top of, BEFORE trying the
+  # merge. The merge itself stays a plain --ff-only with no -f, no reset --hard, no
+  # clean and no stash, so an abort is still an abort and still pages.
+  local risk="" p preserved=0
+  while IFS= read -r p; do
+    [ -n "$p" ] || continue
+    # Only paths that exist here and are NOT tracked at HEAD. A tracked+modified
+    # file is already git's own abort case and must stay that way.
+    [ -e "$p" ] || continue
+    git ls-files --error-unmatch -- "$p" >/dev/null 2>&1 && continue
+    risk="$risk$p
+"
+  done <<EOF
+$(git diff --name-only --diff-filter=ACMRT HEAD origin/main 2>/dev/null)
+EOF
+  if [ -n "$risk" ]; then
+    FF_PRESERVE_DIR="$(dirname "$LOG")/ff-preserved/$(date -u +%Y%m%dT%H%M%SZ)-$(git rev-parse --short origin/main 2>/dev/null)"
+    while IFS= read -r p; do
+      [ -n "$p" ] || continue
+      mkdir -p "$FF_PRESERVE_DIR/$(dirname "$p")" 2>/dev/null || continue
+      # cp, never mv: moving it would itself change the tree the founder is using.
+      cp -R "$p" "$FF_PRESERVE_DIR/$p" 2>/dev/null && preserved=$((preserved + 1))
+    done <<EOF
+$risk
+EOF
+    FF_PRESERVED_COUNT="$preserved"
+    say "self-heal: $preserved untracked/ignored path(s) sit where origin/main adds files; copied to $FF_PRESERVE_DIR before touching anything"
+  fi
+
   out="$(git merge --ff-only origin/main 2>&1)" || {
-    printf 'git merge --ff-only origin/main did not apply: %s' \
-      "$(printf '%s' "$out" | tr '\n' ' ' | cut -c1-300)"
+    ATTEMPT_FF_REASON="git merge --ff-only origin/main did not apply: $(printf '%s' "$out" | tr '\n' ' ' | cut -c1-300)"
     return 1
   }
   return 0
@@ -253,21 +338,30 @@ stale_check() {
   # printed. The page below is reserved for the case a human is genuinely needed.
   # Declared separately from the assignment below: `local x="$(f)"` swallows f's
   # exit status (local always succeeds), which would make every attempt look green.
-  local why="" attempt_ff_out=""
+  local why=""
   if [ "${KIPI_DISPATCH_SELFHEALED:-0}" = "1" ]; then
     # ONE ATTEMPT PER LAUNCH. We already fast-forwarded and re-execed this cycle
     # and the tree is STILL behind, which means something is racing the merge (a
     # push landing between fetch and merge, most likely). Re-execing again would
     # spin. Hand it to a human and let the next heartbeat start clean.
     why="a fast-forward already ran this cycle and origin/main moved again underneath it"
-  elif attempt_ff_out="$(attempt_ff)"; then
+  elif attempt_ff; then
     say "self-heal: fast-forwarded this checkout to origin/main ${remote_head:0:7} ($base commit(s)); re-execing on the new control code"
+    # A PAGE THAT IS A RECEIPT, NOT AN ALARM. Only fires when the merge landed on
+    # top of untracked or ignored local files, which git would otherwise have
+    # replaced with no warning and no way back. The founder needs the restore path
+    # exactly once; the heal itself stays silent, as a working fix should.
+    if [ "${FF_PRESERVED_COUNT:-0}" -gt 0 ]; then
+      page_once "ff-preserved-$remote_head" "kipi dispatch: fast-forwarded the checkout myself, and $FF_PRESERVED_COUNT untracked/ignored file(s) sat where the incoming commits add files. I copied them first, nothing was lost. Originals: $FF_PRESERVE_DIR"
+    fi
+    # Released before exec, because exec replaces this process and no trap runs.
+    checkout_unlock
     relaunch_self
     # Unreached in production: relaunch_self execs. The tests stub it, and for them
     # returning 0 is the right answer -- the tree is current, so dispatch proceeds.
     return 0
   else
-    why="$attempt_ff_out"
+    why="$ATTEMPT_FF_REASON"
   fi
 
   say "REFUSING: self-heal could not fix it -- $why (HEAD ${local_head:0:7}, origin/main ${remote_head:0:7})"
@@ -304,7 +398,52 @@ stale_check() {
   fi
   return 1
 }
+# ONE WRITER TO THE WORKING TREE, ACROSS THE WHOLE CHECK-THEN-MERGE.
+# stale_check reads HEAD, decides, and then REWRITES the checkout. Unlocked, two
+# dispatchers (a launchd beat overlapping a hand-run one, or two instances after a
+# reload) can both pass the freshness gate against the same HEAD and both merge --
+# the parallel-sessions scar with a machine on both ends instead of a person. The
+# turn lock further down only covers repo SELECTION, which is far too late: by then
+# the tree has already moved. So the lock has to span read + decide + write, not
+# just the write.
+#
+# Same mkdir primitive and same stale-reaping posture as turn_lock: mkdir is atomic
+# on every filesystem this runs on, and a dispatcher killed mid-merge must not wedge
+# the loop forever. Reap at 1h, which is far longer than any merge and far shorter
+# than a night.
+CHECKOUT_LOCK="${KIPI_DISPATCH_CHECKOUT_LOCK:-$HOME/.config/kipi/dispatch-checkout.lock}"
+checkout_unlock() { rmdir "$CHECKOUT_LOCK" 2>/dev/null || true; }
+checkout_lock() {
+  mkdir -p "$(dirname "$CHECKOUT_LOCK")" 2>/dev/null || true
+  if mkdir "$CHECKOUT_LOCK" 2>/dev/null; then return 0; fi
+  local now mtime probe
+  now="$(date -u +%s)"
+  probe="$(stat -c %Y "$CHECKOUT_LOCK" 2>/dev/null)"
+  case "$probe" in ''|*[!0-9]*) probe="" ;; esac
+  [ -n "$probe" ] || { probe="$(stat -f %m "$CHECKOUT_LOCK" 2>/dev/null)"; case "$probe" in ''|*[!0-9]*) probe="" ;; esac; } # portability-lint-skip
+  mtime="$probe"
+  # An unreadable mtime means DO NOT REAP. Skipping one beat is safe; stealing a
+  # lock we cannot age and then merging under the holder is not.
+  if [ -n "$mtime" ] && [ "$(( now - mtime ))" -gt 3600 ]; then
+    say "checkout-lock: reaping a stale lock ($(( now - mtime ))s old)"
+    rmdir "$CHECKOUT_LOCK" 2>/dev/null || true
+    mkdir "$CHECKOUT_LOCK" 2>/dev/null && return 0
+  fi
+  return 1
+}
+
+if ! checkout_lock; then
+  say "skip: another dispatcher holds the checkout lock (freshness check and merge are one transaction)"
+  exit 0
+fi
+# Covers every later exit, including the FATAL paths below. exec is the one case a
+# trap cannot cover, so relaunch_self's caller releases explicitly before it.
+trap 'checkout_unlock' EXIT
 stale_check || exit 0
+# The tree is current and nobody else is mid-merge. Everything past this point only
+# READS the checkout, so the lock is handed back rather than held for the whole run.
+checkout_unlock
+trap - EXIT
 
 # `pgrep -c` exits 1 with no match, which under `set -e` would look like failure
 # and under a bare assignment yields an empty string. Force a number.
@@ -583,6 +722,7 @@ if [ -z "$BUDGET_DAY" ]; then
   page_once budget-day "kipi dispatch: cannot compute its spend budget window, so it refused to dispatch rather than run uncapped. Do: check \`date -v-7H\` on this machine."
   exit 1
 fi
+page_clear budget-day
 # --- TWO LANES: production and verification -------------------------------
 # Founder directive 2026-07-30: "refill the budget for this test -- the budget
 # should never stop testing."
@@ -647,6 +787,9 @@ if ! command -v gh >/dev/null 2>&1; then
       break
     fi
   done
+fi
+if command -v gh >/dev/null 2>&1; then
+  page_clear gh-missing
 fi
 if ! command -v gh >/dev/null 2>&1; then
   say "FATAL: gh not on PATH ($PATH)"
@@ -741,6 +884,7 @@ if printf '%s' "$WORK_OUT" | grep -qi "infra_error\|authentication\|unauthorized
   page_once linear-down "kipi dispatch: Linear is unreachable or auth expired, so NO issues can be picked up. The loop is stopped, not slow. Do: run \`bash kipi work\` by hand and check the Linear token."
   exit 1
 fi
+page_clear linear-down
 
 NEXT="$(printf '%s' "$WORK_OUT" | grep -oE '\[dry\] would work ASK-[0-9]+' | grep -oE 'ASK-[0-9]+' | head -1)"
 if [ -z "$NEXT" ]; then

--- a/kipi-dispatch.sh
+++ b/kipi-dispatch.sh
@@ -89,11 +89,62 @@ PAGE_REPING_SECONDS="${KIPI_PAGE_REPING_SECONDS:-86400}"
 # the same shape as launchd-health's 6h TTL on a 12h job, which this same audit
 # flagged. linear-worker.sh already does clear-on-recovery and is the reference.
 # Every page_once key below has a matching page_clear on its healthy path.
+# ONE LOCK PRIMITIVE, used by BOTH page_once and page_clear, so a clear cannot
+# interleave with a decision. mkdir is the atomic claim.
+#
+# AN ORPHANED LOCK MUST AGE OUT. Treating any existing lock dir as a live holder
+# meant a notifier killed between the mkdir and its cleanup -- launchd reaping the
+# job, a reboot, a SIGKILL -- silenced that key PERMANENTLY. Reproduced: leave the
+# dir behind and the next three runs page 0, 0, 0 while the log cheerfully reports
+# "another dispatcher is already deciding it" with nobody there.
+#
+# The critical section is a stat, a notifier call and a small write, so anything
+# still holding this after 300s is dead. That is well under the 900s heartbeat, so
+# an orphan always self-clears before the next beat rather than needing a human.
+page_lock() {
+  local lock="$1" now lock_mtime lock_probe
+  mkdir "$lock" 2>/dev/null && return 0
+  now="$(date -u +%s)"
+  lock_probe="$(stat -c %Y "$lock" 2>/dev/null)"
+  case "$lock_probe" in ''|*[!0-9]*) lock_probe="" ;; esac
+  [ -n "$lock_probe" ] || { lock_probe="$(stat -f %m "$lock" 2>/dev/null)"; case "$lock_probe" in ''|*[!0-9]*) lock_probe="" ;; esac; } # portability-lint-skip
+  lock_mtime="$lock_probe"
+  # An unreadable mtime means DO NOT REAP: skipping one page is recoverable,
+  # stealing a live lock and double-paging is the bug this exists to prevent.
+  if [ -n "$lock_mtime" ] && [ "$(( now - lock_mtime ))" -gt 300 ]; then
+    say "page lock: reaping an orphaned lock at $lock ($(( now - lock_mtime ))s old; a notifier was killed mid-decision)"
+    rmdir "$lock" 2>/dev/null || true
+    mkdir "$lock" 2>/dev/null && return 0
+  fi
+  return 1
+}
+
+# CLEARS UNDER THE SAME LOCK. Unlocked, page_clear could run between page_once
+# deciding to page and page_once WRITING its marker: the clear finds nothing to
+# remove, the write lands a moment later, and a marker now describes a condition
+# that has already recovered -- suppressing the next real episode for up to 24h.
+# A marker outliving its condition, which is the orphaned-lock shape again.
+#
+# Taking the lock makes the two strictly ordered. If the lock is held we do NOT
+# block a heartbeat waiting: log it and leave it, and the next healthy beat clears
+# it. That bounds the stale-marker window to one heartbeat (<=15m) instead of the
+# full 24h re-ping. That residual is deliberate and stated rather than hidden.
 page_clear() {
-  local mark="$(dirname "$LOG")/paged-$1"
-  [ -f "$mark" ] || return 0
-  rm -f "$mark" 2>/dev/null || true
-  say "page state cleared: $1 recovered, so a recurrence pages again immediately"
+  local key="$1" mark lock
+  mark="$(dirname "$LOG")/paged-$key"
+  lock="$mark.lock"
+  # Nothing to clear and nobody mid-decision: stay cheap on the healthy path, which
+  # is every single beat.
+  [ -f "$mark" ] || [ -d "$lock" ] || return 0
+  if ! page_lock "$lock"; then
+    say "page state NOT cleared ($key): a notifier is mid-decision; the next healthy beat clears it"
+    return 0
+  fi
+  if [ -f "$mark" ]; then
+    rm -f "$mark" 2>/dev/null || true
+    say "page state cleared: $key recovered, so a recurrence pages again immediately"
+  fi
+  rmdir "$lock" 2>/dev/null || true
 }
 
 page_once() {
@@ -123,22 +174,9 @@ page_once() {
   # after 300s is dead. That is far below the 900s heartbeat, so an orphan always
   # self-clears before the next beat rather than needing a human.
   lock="$mark.lock"
-  if ! mkdir "$lock" 2>/dev/null; then
-    local lock_mtime lock_probe
-    lock_probe="$(stat -c %Y "$lock" 2>/dev/null)"
-    case "$lock_probe" in ''|*[!0-9]*) lock_probe="" ;; esac
-    [ -n "$lock_probe" ] || { lock_probe="$(stat -f %m "$lock" 2>/dev/null)"; case "$lock_probe" in ''|*[!0-9]*) lock_probe="" ;; esac; } # portability-lint-skip
-    lock_mtime="$lock_probe"
-    # An unreadable mtime means DO NOT REAP: skipping one page is recoverable, two
-    # dispatchers both paging because we stole a live lock is the bug we are fixing.
-    if [ -n "$lock_mtime" ] && [ "$(( now - lock_mtime ))" -gt 300 ]; then
-      say "page lock: reaping an orphaned lock for $key ($(( now - lock_mtime ))s old; a notifier was killed mid-decision)"
-      rmdir "$lock" 2>/dev/null || true
-      mkdir "$lock" 2>/dev/null || { say "page skipped ($key): lost the race to reap"; return 0; }
-    else
-      say "page skipped ($key): another dispatcher is already deciding it"
-      return 0
-    fi
+  if ! page_lock "$lock"; then
+    say "page skipped ($key): another dispatcher is already deciding it"
+    return 0
   fi
   # RELEASED EXPLICITLY AT EVERY EXIT, NOT BY A `trap ... RETURN`.
   # The trap form looked tidier and was broken: bash tears down the function's
@@ -699,12 +737,48 @@ WORK_RC=$?
 # An infra error (Linear down, auth expired) is environmental: it will not
 # self-heal on the next heartbeat, so say so once rather than fail silently
 # every 15 minutes forever. self-healing-retry.md rule 5.
-if printf '%s' "$WORK_OUT" | grep -qi "infra_error\|authentication\|unauthorized"; then
+# MATCHED AGAINST WHAT THE PRODUCER ACTUALLY PRINTS, verified 2026-08-02 by
+# grepping linear-worker.sh rather than assuming a format. The previous pattern
+# (infra_error|authentication|unauthorized) matched NONE of the real loop-stopping
+# output, so a genuine Linear outage fell straight through to page_clear below --
+# it did not merely fail to page, it ERASED the state that would have paged. That
+# is silence dressed as health, and it is the same defect class this whole issue
+# has been unpicking. A pattern I invent tests my assumption, not the system.
+#
+# The producer's real shapes, and whether each stops the run:
+#   linear-worker.sh:417  "INFRA: linear unreachable (<exc>)."     exit 0  <- MISSED
+#   linear-worker.sh:320  {"infra_error": ...} (python helper)     internal
+#   linear-worker.sh:251  "INFRA: git fetch failed in <repo>."     exit 9
+#   linear-worker.sh:989  "INFRA: could not create worktree ..."   continue
+#   linear-worker.sh:1049 "INFRA: claim failed rc=<n> ..."         continue
+# These reach us because the worker's say() is `tee -a "$LOG"`, so it writes to
+# stdout as well as its log, and WORK_OUT is captured with 2>&1.
+#
+# DELIBERATELY NOT a bare `INFRA:` match. :989 and :1049 print an INFRA: line and
+# then `continue` -- the worker keeps working -- so a prefix match would page "the
+# loop is stopped" while it is demonstrably still running. Precision here is the
+# difference between a real alarm and the noise this issue exists to remove.
+# --- LINEAR-OUTAGE-GUARD:BEGIN ---
+# A STABLE EXTRACTION ANCHOR, and it earns its keep. The test used to slice this
+# block with an awk range keyed on the matcher line itself, so a mutant that
+# reworded the matcher made the range match nothing: the harness bailed instead of
+# asserting, and two mutants that restore the round-3 defect were reported as
+# SURVIVED. A fixture must not be anchored to the text it is testing.
+if printf '%s' "$WORK_OUT" | grep -qiE 'INFRA: linear unreachable|infra_error|authentication|unauthorized'; then
   say "infra error from kipi work: $(printf '%s' "$WORK_OUT" | head -3 | tr '\n' ' ')"
   page_once linear-down "kipi dispatch: Linear is unreachable or auth expired, so NO issues can be picked up. The loop is stopped, not slow. Do: run \`bash kipi work\` by hand and check the Linear token."
   exit 1
 fi
+# A RUN THAT NEVER REACHED LINEAR IS NOT EVIDENCE LINEAR RECOVERED -- the same rule
+# stale_check applies to a failed fetch. linear-worker.sh:251 exits BEFORE any
+# Linear call and already pages the founder itself, so this must not double-page;
+# it must only refrain from clearing.
+if printf '%s' "$WORK_OUT" | grep -qiE 'INFRA: git fetch failed'; then
+  say "worker stopped on an environment failure before reaching Linear; leaving linear-down state untouched (the worker pages this one itself)"
+  exit 1
+fi
 page_clear linear-down
+# --- LINEAR-OUTAGE-GUARD:END ---
 
 NEXT="$(printf '%s' "$WORK_OUT" | grep -oE '\[dry\] would work ASK-[0-9]+' | grep -oE 'ASK-[0-9]+' | head -1)"
 if [ -z "$NEXT" ]; then

--- a/kipi-dispatch.sh
+++ b/kipi-dispatch.sh
@@ -64,10 +64,12 @@ page() { bash "$NOTIFY" "$1" >/dev/null 2>&1 || true; }
 # which must not write a dedupe marker for a page that never arrived.
 page_ok() { bash "$NOTIFY" "$1" >/dev/null 2>&1; }
 
-# ONE PAGE PER STATE, NOT ONE PER HEARTBEAT (founder, 2026-08-02).
+# ONE PAGE PER STATE, NOT ONE PER HEARTBEAT (ASK-283, 2026-08-02).
 # Audited across this file: four guards -- missing repo, unusable `date`, gh off
 # PATH, Linear auth dead -- each name a PERMANENT condition and each had NO marker,
-# on a 900s timer. That is 96 identical Slack lines a day per guard. The founder's
+# on a 900s timer. That is 96 identical Slack lines a day per guard, and three of
+# them can hold at once: ~288 pages a day, worse than the stale-checkout alert that
+# actually got noticed. The loud one is rarely the worst one. The founder's
 # own detect-act-learn rule already says one summary line, never one ping per
 # finding. The cost of the noise is not annoyance, it is that it trains him to skim
 # the channel, which is how the one page that matters gets missed.
@@ -135,7 +137,7 @@ cd "$REPO" 2>/dev/null || {
 # we are behind; a network blip, an auth prompt or a missing remote logs and
 # proceeds. Two different safe directions, deliberately: fail closed on
 # staleness, fail open on not knowing.
-# THE DETECTOR COMPUTES THE REMEDY, SO IT MUST APPLY IT (founder, 2026-08-02).
+# THE DETECTOR COMPUTES THE REMEDY, SO IT MUST APPLY IT (ASK-283, 2026-08-02).
 # For one night this printed `git merge --ff-only origin/main` every 15 minutes
 # while the gap grew 7 -> 10 commits. Measured from the log: 19 refusing cycles,
 # 9 Slack pages, ZERO automated action. Nobody read them; the founder fixed it by

--- a/kipi-dispatch.sh
+++ b/kipi-dispatch.sh
@@ -35,10 +35,6 @@
 # class this repo keeps finding. One source of truth, asked politely.
 set -uo pipefail
 
-# Resolved BEFORE the cd below, because $0 may be relative and the self-heal
-# re-execs this file by path after fast-forwarding it.
-SELF="$(cd "$(dirname "$0")" 2>/dev/null && pwd)/$(basename "$0")"
-
 REPO="${KIPI_REPO:-/Users/assafkipnis/projects/kipi-system}"
 # HARDCODED OFF $REPO, DELIBERATELY NOT AN ENV VAR. Every other path in this file
 # takes a KIPI_* override for testability; this one must not. A variable here would
@@ -114,18 +110,49 @@ page_once() {
   # rather than loosening a client-repo safety gate to suit my own prose. sp-cc67d834.)
   # mkdir is the atomic primitive; a lock we cannot take means another process is
   # already handling this exact key, so staying quiet is the correct answer.
+  # AN ORPHANED LOCK MUST AGE OUT. The first cut treated any existing lock dir as a
+  # live holder forever, so a notifier killed between the mkdir and its cleanup --
+  # launchd reaping the job, a reboot, a SIGKILL -- silenced that key PERMANENTLY.
+  # Reproduced: leave the dir behind and the next three runs page 0, 0, 0, while the
+  # log cheerfully reports "another dispatcher is already deciding it" with nobody
+  # there. A dedupe that becomes a permanent mute is worse than no dedupe, and it is
+  # the same guard-that-can-never-fire shape this very audit flagged elsewhere --
+  # introduced by the fix for the previous one.
+  #
+  # The critical section is a stat and a small write, so anything still holding this
+  # after 300s is dead. That is far below the 900s heartbeat, so an orphan always
+  # self-clears before the next beat rather than needing a human.
   lock="$mark.lock"
   if ! mkdir "$lock" 2>/dev/null; then
-    say "page skipped ($key): another dispatcher is already deciding it"
-    return 0
+    local lock_mtime lock_probe
+    lock_probe="$(stat -c %Y "$lock" 2>/dev/null)"
+    case "$lock_probe" in ''|*[!0-9]*) lock_probe="" ;; esac
+    [ -n "$lock_probe" ] || { lock_probe="$(stat -f %m "$lock" 2>/dev/null)"; case "$lock_probe" in ''|*[!0-9]*) lock_probe="" ;; esac; } # portability-lint-skip
+    lock_mtime="$lock_probe"
+    # An unreadable mtime means DO NOT REAP: skipping one page is recoverable, two
+    # dispatchers both paging because we stole a live lock is the bug we are fixing.
+    if [ -n "$lock_mtime" ] && [ "$(( now - lock_mtime ))" -gt 300 ]; then
+      say "page lock: reaping an orphaned lock for $key ($(( now - lock_mtime ))s old; a notifier was killed mid-decision)"
+      rmdir "$lock" 2>/dev/null || true
+      mkdir "$lock" 2>/dev/null || { say "page skipped ($key): lost the race to reap"; return 0; }
+    else
+      say "page skipped ($key): another dispatcher is already deciding it"
+      return 0
+    fi
   fi
-  trap 'rmdir "$lock" 2>/dev/null || true' RETURN
+  # RELEASED EXPLICITLY AT EVERY EXIT, NOT BY A `trap ... RETURN`.
+  # The trap form looked tidier and was broken: bash tears down the function's
+  # locals before running the RETURN trap, so `rmdir "$lock"` hit an unset variable
+  # and `set -u` killed the whole dispatcher mid-page. It surfaced as four unrelated
+  # test failures at once (a missing verdict, two missing log lines) because the
+  # script simply stopped. Three exits, three rmdirs, no cleverness.
   if [ -f "$mark" ]; then
     prev="$(sed -n 1p "$mark" 2>/dev/null)"
     stamp="$(sed -n 2p "$mark" 2>/dev/null)"
     case "$stamp" in ''|*[!0-9]*) stamp=0 ;; esac
     if [ "$prev" = "$hash" ] && [ "$(( now - stamp ))" -lt "$PAGE_REPING_SECONDS" ]; then
       say "page suppressed ($key unchanged for $(( (now - stamp) / 60 ))m; re-pings after $(( PAGE_REPING_SECONDS / 3600 ))h)"
+      rmdir "$lock" 2>/dev/null || true
       return 0
     fi
   fi
@@ -134,6 +161,7 @@ page_once() {
   else
     say "page: $key did NOT go out; leaving the marker unset so the next heartbeat retries it"
   fi
+  rmdir "$lock" 2>/dev/null || true
 }
 
 cd "$REPO" 2>/dev/null || {
@@ -151,13 +179,23 @@ page_clear repo-missing
 # gate. It was fixed by hand twice in one session, which means every future merge
 # silently depended on someone remembering.
 #
-# IT DETECTS *AND* REPAIRS, as of 2026-08-02. This block used to say "a detector,
-# not a pull", on the grounds that moving the tree under an interactive session is
-# the parallel-session scar. That reasoning was half right: it is a reason to be
-# careful about WHICH trees get moved, not a reason to move none of them. The
-# version that only detected printed the exact remedy every 15 minutes for a night
-# and nobody typed it. attempt_ff() below now applies the remedy where the tree
-# demonstrably belongs to nobody, and refuses (and pages) where it might not.
+# A DETECTOR, NOT A PULL -- and that is now a MEASURED position, not a default.
+# An automatic `git merge --ff-only` was built here on 2026-08-02 and REMOVED the
+# same night after three review rounds, each of which found a new way for it to
+# lose data (ASK-284 carries the design and everything learned):
+#   r1  ignored files are silently overwritten by a fast-forward. Measured: an
+#       untracked-not-ignored collision ABORTS, an IGNORED one fast-forwards with
+#       exit 0 and no reflog, and `ls-files --others --exclude-standard` cannot
+#       see that class at all (3982 of them on this checkout).
+#   r2  the backup added to fix r1 continued the merge when a copy FAILED, and the
+#       lock added alongside it could silence an alert key forever.
+# Each round was smaller and each still produced a new instance of the same class.
+# That is a statement about the surface, not about care taken. Writing to a live
+# working tree with no recovery path for an untracked file is not something to
+# converge on at 3am; it gets designed on its own.
+#
+# What survives is the half with no write surface outside ~/.config/kipi: refuse,
+# and page ONCE per episode instead of once per commit.
 #
 # REFUSE, not warn. This loop MERGES ITS OWN PRs and has no accepted-change
 # signal, so building on superseded code and auto-merging the result is worse
@@ -168,133 +206,6 @@ page_clear repo-missing
 # we are behind; a network blip, an auth prompt or a missing remote logs and
 # proceeds. Two different safe directions, deliberately: fail closed on
 # staleness, fail open on not knowing.
-# THE DETECTOR COMPUTES THE REMEDY, SO IT MUST APPLY IT (ASK-283, 2026-08-02).
-# For one night this printed `git merge --ff-only origin/main` every 15 minutes
-# while the gap grew 7 -> 10 commits. Measured from the log: 19 refusing cycles,
-# 9 Slack pages, ZERO automated action. Nobody read them; the founder fixed it by
-# hand in the morning. A detector that names a deterministic, non-destructive,
-# loudly-failing command and then waits for a human to type it is an alert with no
-# hands, and the founder's detect-act-learn rule already forbids that shape.
-#
-# Prints NOTHING and returns 0 when the checkout was fast-forwarded.
-# Prints ONE line naming what stopped it and returns 1 otherwise -- that line is
-# what the page carries, so it has to read as a reason, not a code.
-#
-# WHAT THIS REFUSES TO TOUCH, and why each one is a tree that belongs to somebody:
-# Set by attempt_ff when it had to copy something out of the merge's way. Declared
-# here so `set -u` cannot trip on them at a call site that never entered that path.
-FF_PRESERVE_DIR=""
-FF_PRESERVED_COUNT=0
-# REASON RETURNED VIA A GLOBAL, NOT STDOUT, and that is a correctness fix.
-# The first cut printed the reason and the caller did `out="$(attempt_ff)"`. A
-# command substitution is a SUBSHELL, so FF_PRESERVE_DIR and FF_PRESERVED_COUNT --
-# set inside it -- were discarded on return, and the "I preserved your files" receipt
-# could never fire. A guard that cannot fire, one day after writing that memory.
-ATTEMPT_FF_REASON=""
-attempt_ff() {
-  local branch out p
-  ATTEMPT_FF_REASON=""
-  FF_PRESERVE_DIR=""
-  FF_PRESERVED_COUNT=0
-  # 1. A NON-MAIN OR DETACHED HEAD IS SOMEONE ELSE'S WORK. This is the
-  # parallel-sessions scar directly: two sessions sharing one checkout yank each
-  # other's tree on a branch move. Moving a feature branch to main is never the
-  # remedy the detector computed, so it is never done here.
-  branch="$(git symbolic-ref --short HEAD 2>/dev/null)" || branch=""
-  if [ "$branch" != "main" ]; then
-    ATTEMPT_FF_REASON="the checkout is on ${branch:-a detached HEAD}, not main, so its tree was left untouched"
-    return 1
-  fi
-  # 2. A HALF-FINISHED GIT OPERATION. Moving HEAD out from under a merge, rebase,
-  # cherry-pick or bisect destroys in-flight state that has no other copy.
-  # --git-path, not a literal .git/, because this also runs inside worktrees where
-  # .git is a FILE and these markers live somewhere else entirely.
-  for p in MERGE_HEAD REBASE_HEAD CHERRY_PICK_HEAD REVERT_HEAD BISECT_LOG rebase-merge rebase-apply; do
-    if [ -e "$(git rev-parse --git-path "$p" 2>/dev/null)" ]; then
-      ATTEMPT_FF_REASON="a git $p is in progress, so the tree was left untouched"
-      return 1
-    fi
-  done
-  # 3. A STAGED INDEX IS A COMMIT SOMEONE IS COMPOSING. Fast-forwarding over it
-  # silently folds their staged hunks into a different base.
-  if ! git diff --cached --quiet 2>/dev/null; then
-    ATTEMPT_FF_REASON="the index has staged changes (a commit in progress), so the tree was left untouched"
-    return 1
-  fi
-  # 4. MODIFIED TRACKED FILES ARE LEFT TO GIT, NOT PRE-JUDGED, AND THAT IS A
-  # DELIBERATE DEPARTURE FROM "refuse if the tree is dirty". Measured on the real
-  # checkout that produced this incident: 3 modified tracked files and 5488
-  # untracked ones, as its NORMAL resting state. A blanket dirty-tree refusal would
-  # make this self-heal permanently inert on the ONE checkout it exists for -- the
-  # wired-but-never-runs failure this repo has already eaten once. So the arbiter is
-  # git's own check: --ff-only aborts with "local changes would be overwritten" when
-  # the incoming commits actually touch a modified file, and otherwise carries the
-  # unrelated edits forward untouched. That is a per-file answer instead of a
-  # whole-tree guess, and it is the same command the page has been telling the
-  # founder to run by hand all along.
-  # 5. IGNORED FILES ARE THE ONE THING GIT WILL DESTROY WITHOUT ASKING, and this is
-  # the blocker that nearly shipped. Measured 2026-08-02 in a scratch repo:
-  #   untracked + NOT ignored, upstream starts tracking the path
-  #     -> "would be overwritten by merge ... Aborting", exit 1, file intact. SAFE.
-  #   IGNORED, upstream starts tracking the same path
-  #     -> "Fast-forward ... create mode 100644", exit 0, LOCAL CONTENT GONE.
-  #        No warning, no abort, and no reflog entry either -- an untracked file
-  #        has no object in the database, so there is nothing to recover from.
-  #
-  # "Let git be the arbiter" was right for the untracked class and WRONG for this
-  # one, and the measurement that reassured me hid it: `git ls-files --others
-  # --exclude-standard` counts 5488 on the founder's checkout and EXCLUDES ignored
-  # files entirely. The real ignored count there is 3982, none of which that number
-  # could see. Not hypothetical either -- this repo has already started tracking
-  # .prd-os/receipts.jsonl and q-system/memory/graph.jsonl upstream while `*.jsonl`
-  # sits in .gitignore, which is exactly the collision.
-  #
-  # So: copy anything the incoming commits would land on top of, BEFORE trying the
-  # merge. The merge itself stays a plain --ff-only with no -f, no reset --hard, no
-  # clean and no stash, so an abort is still an abort and still pages.
-  local risk="" p preserved=0
-  while IFS= read -r p; do
-    [ -n "$p" ] || continue
-    # Only paths that exist here and are NOT tracked at HEAD. A tracked+modified
-    # file is already git's own abort case and must stay that way.
-    [ -e "$p" ] || continue
-    git ls-files --error-unmatch -- "$p" >/dev/null 2>&1 && continue
-    risk="$risk$p
-"
-  done <<EOF
-$(git diff --name-only --diff-filter=ACMRT HEAD origin/main 2>/dev/null)
-EOF
-  if [ -n "$risk" ]; then
-    FF_PRESERVE_DIR="$(dirname "$LOG")/ff-preserved/$(date -u +%Y%m%dT%H%M%SZ)-$(git rev-parse --short origin/main 2>/dev/null)"
-    while IFS= read -r p; do
-      [ -n "$p" ] || continue
-      mkdir -p "$FF_PRESERVE_DIR/$(dirname "$p")" 2>/dev/null || continue
-      # cp, never mv: moving it would itself change the tree the founder is using.
-      cp -R "$p" "$FF_PRESERVE_DIR/$p" 2>/dev/null && preserved=$((preserved + 1))
-    done <<EOF
-$risk
-EOF
-    FF_PRESERVED_COUNT="$preserved"
-    say "self-heal: $preserved untracked/ignored path(s) sit where origin/main adds files; copied to $FF_PRESERVE_DIR before touching anything"
-  fi
-
-  out="$(git merge --ff-only origin/main 2>&1)" || {
-    ATTEMPT_FF_REASON="git merge --ff-only origin/main did not apply: $(printf '%s' "$out" | tr '\n' ' ' | cut -c1-300)"
-    return 1
-  }
-  return 0
-}
-
-# RE-EXEC RATHER THAN FALL THROUGH, and this is a correctness fix not a nicety.
-# bash reads a script lazily by byte offset. The fast-forward above can rewrite
-# kipi-dispatch.sh underneath the running interpreter, after which bash resumes at
-# the old offset in the NEW file and executes whatever bytes happen to land there.
-# Continuing in-process is the one thing we must not do. exec restarts cleanly on
-# the code we just pulled, which is also exactly what "run the current control
-# code" means. A non-interactive bash exits if exec fails, so there is no path
-# where a failed exec silently proceeds on the stale bytes.
-relaunch_self() { exec env KIPI_DISPATCH_SELFHEALED=1 bash "$SELF"; }
-
 stale_check() {
   local local_head remote_head base
   # Bounded by hand: macOS ships no `timeout`, and an unbounded fetch inside a
@@ -316,7 +227,9 @@ stale_check() {
   local_head="$(git rev-parse HEAD 2>/dev/null)" || return 0
   remote_head="$(git rev-parse origin/main 2>/dev/null)" || return 0
   [ -n "$local_head" ] && [ -n "$remote_head" ] || return 0
-  [ "$local_head" != "$remote_head" ] || return 0
+  # Recovery is a DEFINITIVE not-behind answer, so the next episode pages at once.
+  # Deliberately not on the fetch-failed paths above: offline is not proof of health.
+  [ "$local_head" != "$remote_head" ] || { page_clear stale-checkout; return 0; }
   # THE PREDICATE IS "does origin/main hold commits this tree lacks", NOT "is HEAD
   # an ancestor of origin/main". Codex round 2 on PR #47 called the ancestor form a
   # major, and it was right: --is-ancestor is FALSE for a DIVERGED tree, so the
@@ -333,121 +246,24 @@ stale_check() {
   # before it opens a PR, and refusing there would wedge the loop on its own work.
   base="$(git rev-list --count "$local_head..$remote_head" 2>/dev/null || echo 0)"
   case "$base" in ''|*[!0-9]*) return 0 ;; esac   # unparseable count = no answer = run
-  [ "$base" -gt 0 ] || return 0
+  [ "$base" -gt 0 ] || { page_clear stale-checkout; return 0; }
   say "STALE: origin/main holds $base commit(s) this checkout lacks (HEAD ${local_head:0:7}, origin/main ${remote_head:0:7}). Dispatching would run superseded control code and auto-merge the result."
 
-  # --- SELF-HEAL BEFORE PAGING ---------------------------------------------
-  # The refusal above is CORRECT and is not weakened: nothing dispatches while the
-  # checkout is behind. What changes is that the fix is now attempted instead of
-  # printed. The page below is reserved for the case a human is genuinely needed.
-  # Declared separately from the assignment below: `local x="$(f)"` swallows f's
-  # exit status (local always succeeds), which would make every attempt look green.
-  local why=""
-  if [ "${KIPI_DISPATCH_SELFHEALED:-0}" = "1" ]; then
-    # ONE ATTEMPT PER LAUNCH. We already fast-forwarded and re-execed this cycle
-    # and the tree is STILL behind, which means something is racing the merge (a
-    # push landing between fetch and merge, most likely). Re-execing again would
-    # spin. Hand it to a human and let the next heartbeat start clean.
-    why="a fast-forward already ran this cycle and origin/main moved again underneath it"
-  elif attempt_ff; then
-    say "self-heal: fast-forwarded this checkout to origin/main ${remote_head:0:7} ($base commit(s)); re-execing on the new control code"
-    # A PAGE THAT IS A RECEIPT, NOT AN ALARM. Only fires when the merge landed on
-    # top of untracked or ignored local files, which git would otherwise have
-    # replaced with no warning and no way back. The founder needs the restore path
-    # exactly once; the heal itself stays silent, as a working fix should.
-    if [ "${FF_PRESERVED_COUNT:-0}" -gt 0 ]; then
-      page_once "ff-preserved-$remote_head" "kipi dispatch: fast-forwarded the checkout myself, and $FF_PRESERVED_COUNT untracked/ignored file(s) sat where the incoming commits add files. I copied them first, nothing was lost. Originals: $FF_PRESERVE_DIR"
-    fi
-    # Released before exec, because exec replaces this process and no trap runs.
-    checkout_unlock
-    relaunch_self
-    # Unreached in production: relaunch_self execs. The tests stub it, and for them
-    # returning 0 is the right answer -- the tree is current, so dispatch proceeds.
-    return 0
-  else
-    why="$ATTEMPT_FF_REASON"
-  fi
-
-  say "REFUSING: self-heal could not fix it -- $why (HEAD ${local_head:0:7}, origin/main ${remote_head:0:7})"
-  # PAGE ONCE PER REMOTE SHA, not once per heartbeat. Second major from the same
-  # review: at a 900s interval an unrepaired checkout sent the identical Slack
-  # message 96 times a day, which trains the founder to ignore the channel and
-  # buries the one line that matters. Same fix the daily cap already uses (a
-  # `.paged` marker), keyed on the remote sha so a NEW divergence pages again.
-  # Beside the dispatch log and the daily-cap counters, which is where this
-  # script's other state already lives. Derived from $LOG so there is one
-  # definition of "the state dir" rather than a second literal path.
-  local paged_mark="$(dirname "$LOG")/stale-paged-$remote_head"
-  if [ ! -f "$paged_mark" ]; then
-    # MARK ONLY WHAT WAS ACTUALLY DELIVERED (codex round 4, major 2). The first cut
-    # wrote the marker unconditionally, so a page that FAILED -- webhook down, no
-    # network, slack-notify missing -- still suppressed every later notification for
-    # that sha. The founder would then be permanently silent about a refusing loop,
-    # which is strictly worse than the 96-a-day storm this dedupe was added to stop:
-    # a storm is annoying, silence is invisible.
-    #
-    # page() ends in `|| true` so it cannot report, deliberately (a notifier must
-    # never take the caller down). So call the notifier directly here and read its
-    # status, rather than changing page()'s contract for every other caller.
-    # NAMES THE ATTEMPT, NOT JUST THE SYMPTOM. This page now only fires when the
-    # automatic fix was tried and could not apply, so it has to say what was tried
-    # and what stopped it -- otherwise it reads like the old "type this command"
-    # ping the founder correctly stopped reading, and he would type the command
-    # that has ALREADY been tried and failed.
-    if page_ok "kipi dispatch: paused -- origin/main has $base commit(s) this checkout lacks. I tried the fast-forward myself and it did not apply: $why. This one needs you: cd $REPO. The loop resumes on its own once the checkout is current."; then
-      : > "$paged_mark" 2>/dev/null || true
-    else
-      say "stale-check: the page did NOT go out; leaving the dedupe marker unset so the next heartbeat retries it"
-    fi
-  fi
+  # ONE PAGE PER STALE EPISODE, NOT ONE PER COMMIT.
+  # The measured complaint: 19 refusing cycles overnight sent 9 Slack pages, one
+  # for every new commit that landed on main while the checkout sat behind. The
+  # per-sha dedupe that produced those 9 was working exactly as written -- the key
+  # was simply wrong. It treated "origin/main moved again" as a new fault, when the
+  # fault is one unchanged thing: THIS CHECKOUT IS BEHIND AND CANNOT DISPATCH.
+  #
+  # So the key is a constant and the MESSAGE carries no volatile detail. Counts and
+  # shas go to the log, which is free, not to the founder's phone, which is not.
+  # page_clear on the healthy path below turns a recovery into silence and makes the
+  # NEXT episode page immediately, which is what a per-sha key was reaching for.
+  page_once stale-checkout "kipi dispatch: paused -- this checkout is behind origin/main, so it will not dispatch (it would run superseded control code and auto-merge the result). Do: cd $REPO && git merge --ff-only origin/main. The loop resumes by itself once the checkout is current."
   return 1
 }
-# ONE WRITER TO THE WORKING TREE, ACROSS THE WHOLE CHECK-THEN-MERGE.
-# stale_check reads HEAD, decides, and then REWRITES the checkout. Unlocked, two
-# dispatchers (a launchd beat overlapping a hand-run one, or two instances after a
-# reload) can both pass the freshness gate against the same HEAD and both merge --
-# the parallel-sessions scar with a machine on both ends instead of a person. The
-# turn lock further down only covers repo SELECTION, which is far too late: by then
-# the tree has already moved. So the lock has to span read + decide + write, not
-# just the write.
-#
-# Same mkdir primitive and same stale-reaping posture as turn_lock: mkdir is atomic
-# on every filesystem this runs on, and a dispatcher killed mid-merge must not wedge
-# the loop forever. Reap at 1h, which is far longer than any merge and far shorter
-# than a night.
-CHECKOUT_LOCK="${KIPI_DISPATCH_CHECKOUT_LOCK:-$HOME/.config/kipi/dispatch-checkout.lock}"
-checkout_unlock() { rmdir "$CHECKOUT_LOCK" 2>/dev/null || true; }
-checkout_lock() {
-  mkdir -p "$(dirname "$CHECKOUT_LOCK")" 2>/dev/null || true
-  if mkdir "$CHECKOUT_LOCK" 2>/dev/null; then return 0; fi
-  local now mtime probe
-  now="$(date -u +%s)"
-  probe="$(stat -c %Y "$CHECKOUT_LOCK" 2>/dev/null)"
-  case "$probe" in ''|*[!0-9]*) probe="" ;; esac
-  [ -n "$probe" ] || { probe="$(stat -f %m "$CHECKOUT_LOCK" 2>/dev/null)"; case "$probe" in ''|*[!0-9]*) probe="" ;; esac; } # portability-lint-skip
-  mtime="$probe"
-  # An unreadable mtime means DO NOT REAP. Skipping one beat is safe; stealing a
-  # lock we cannot age and then merging under the holder is not.
-  if [ -n "$mtime" ] && [ "$(( now - mtime ))" -gt 3600 ]; then
-    say "checkout-lock: reaping a stale lock ($(( now - mtime ))s old)"
-    rmdir "$CHECKOUT_LOCK" 2>/dev/null || true
-    mkdir "$CHECKOUT_LOCK" 2>/dev/null && return 0
-  fi
-  return 1
-}
-
-if ! checkout_lock; then
-  say "skip: another dispatcher holds the checkout lock (freshness check and merge are one transaction)"
-  exit 0
-fi
-# Covers every later exit, including the FATAL paths below. exec is the one case a
-# trap cannot cover, so relaunch_self's caller releases explicitly before it.
-trap 'checkout_unlock' EXIT
 stale_check || exit 0
-# The tree is current and nobody else is mid-merge. Everything past this point only
-# READS the checkout, so the lock is handed back rather than held for the whole run.
-checkout_unlock
-trap - EXIT
 
 # `pgrep -c` exits 1 with no match, which under `set -e` would look like failure
 # and under a bare assignment yields an empty string. Force a number.

--- a/q-system/.q-system/scripts/test/test-dispatch-stale-checkout.sh
+++ b/q-system/.q-system/scripts/test/test-dispatch-stale-checkout.sh
@@ -2,44 +2,35 @@
 # Reproducer for sp-c775b116: the dispatcher ran the founder's working tree with
 # no freshness check, so a merge alone never reached the running loop.
 #
-# And for ASK-283 (2026-08-02): the freshness check WORKED and then asked a human
-# to type the fix. Measured from ~/.config/kipi/dispatch.log that night -- 19
-# refusing cycles, 9 Slack pages (per-sha dedupe already worked; it was the LOG
-# line that repeated every cycle, not the page), the gap growing 7 -> 10 commits,
-# zero automated action. The founder fixed it by hand in the morning.
+# And for ASK-283: the check WORKED and then paged about it repeatedly. Measured
+# from ~/.config/kipi/dispatch.log on 2026-08-01 -- 19 refusing cycles, 9 Slack
+# pages, gap growing 7 -> 10 commits, zero automated action. The 9 came from a
+# dedupe keyed on the REMOTE SHA, so every new commit on main counted as a fresh
+# fault. The fault is one unchanged thing: this checkout is behind and cannot
+# dispatch. One episode, one page.
 #
-# WHAT THIS DOES NOT FIX, kept here so nobody reads the green suite as "solved":
-# that night's early HEAD 97e7fc7 was DIVERGED from origin/main, so a fast-forward
-# could not have applied and it would still have paged. Only the later a5ac9c1 was
-# fast-forwardable. This heals the tail of that incident. The head needed a human
-# because the checkout was genuinely on the wrong history -- case 5 is that case,
-# and it still refuses on purpose.
+# WHY THERE IS NO AUTO-MERGE HERE. One was built and removed the same night after
+# three review rounds each found a new way for it to lose data (ASK-284 owns the
+# redesign). The measurement that killed it, reproduced in a scratch repo:
+#   untracked + NOT ignored, upstream starts tracking the path
+#     -> "would be overwritten by merge ... Aborting", exit 1, file intact.
+#   IGNORED, upstream starts tracking the same path
+#     -> "Fast-forward ... create mode", exit 0, LOCAL CONTENT GONE, no reflog.
+# `git ls-files --others --exclude-standard` cannot see the second class at all,
+# which is why the 5488 that made it look safe was the wrong number; the ignored
+# count on that checkout is 3982.
 #
-# Pairs with: stale_check() + attempt_ff() in kipi-dispatch.sh.
-#
-# The states that matter, and only SOME of them may refuse:
-#   behind, clean, on main -> FAST-FORWARD, then RUN. No page. This is the fix.
-#   behind, but the tree belongs to somebody (other branch / detached / staged
-#           index / mid-merge) -> REFUSE + PAGE. Never move it under them.
-#   behind, and git itself says the ff would overwrite local edits -> REFUSE + PAGE
-#   diverged -> REFUSE + PAGE (ff cannot apply)
-#   ahead   -> RUN    (an agent commits locally before opening a PR)
-#   equal   -> RUN
-#   no answer (fetch fails / offline) -> RUN, because a network blip must not
-#             wedge the loop. Fail closed on staleness, fail open on not knowing.
-#
-# The ahead and offline cases are the point. A check that refuses whenever HEAD
-# differs from origin/main passes a naive behind-test and wedges the loop on its
-# own unpushed work, which is a worse bug than the one being fixed.
-#
-# EVERY REFUSE CASE ASSERTS HEAD DID NOT MOVE, not just that the log said so. A
-# guard that logs "left untouched" while git quietly moved the tree is the exact
-# failure this file exists to catch, and log text cannot see it.
+# The states that matter, and only SOME may refuse:
+#   behind   -> REFUSE + page once per episode
+#   diverged -> REFUSE (origin/main holds commits this tree lacks)
+#   ahead    -> RUN (an agent commits locally before opening a PR)
+#   equal    -> RUN, and clear the page state so the next episode is heard at once
+#   no answer (fetch fails / offline) -> RUN. Fail closed on staleness, fail open
+#             on not knowing. Offline is NOT proof of recovery, so it clears nothing.
 set -uo pipefail
 
-# The founder was paged by tests three times on 2026-08-01. The harness below
-# stubs the notifier functions outright, so nothing here can reach Slack; this is
-# the second belt for anything that ever shells the real script.
+# The founder was paged by tests three times on 2026-08-01. The harness stubs the
+# notifier outright; this is the second belt for anything that shells the real script.
 export KIPI_NOTIFY=/usr/bin/true
 
 HERE="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
@@ -55,89 +46,57 @@ ok()  { PASS=$((PASS+1)); echo "  PASS: $1"; }
 bad() { FAIL=$((FAIL+1)); echo "  FAIL: $1"; }
 
 [ -f "$DISPATCH" ] || { echo "no kipi-dispatch.sh at $DISPATCH"; exit 1; }
+for fn in stale_check page_once page_clear; do
+  grep -q "^$fn() {" "$DISPATCH" || {
+    echo "  FAIL: THE DEFECT: kipi-dispatch.sh has no $fn"
+    echo "-------- 0 passed, 1 failed --------"; exit 1; }
+done
 
-if ! grep -q 'stale_check' "$DISPATCH"; then
-  echo "  FAIL: THE DEFECT: kipi-dispatch.sh has no stale_check, so a merge never reaches the running loop"
-  echo "-------- 0 passed, 1 failed --------"
-  exit 1
-fi
-if ! grep -q 'attempt_ff' "$DISPATCH"; then
-  echo "  FAIL: THE DEFECT: stale_check has no attempt_ff, so it prints the remedy and waits for a human"
-  echo "-------- 0 passed, 1 failed --------"
-  exit 1
-fi
-
-# Extract the two functions and drive them directly. Running the whole dispatcher
+# Extract the REAL functions and drive them directly. Running the whole dispatcher
 # would reach Linear and could dispatch REAL work -- never let a test touch a live
-# data path (fable-discipline lint blocks it, and this is why).
-#
-# attempt_ff is extracted REAL, not stubbed: it is the code under test. Only
-# relaunch_self is stubbed, because the shipped one execs and would replace this
-# test process. Same pattern the file already uses for say/page.
+# data path (fable-discipline lint blocks it, and this is why). page_once and
+# page_clear are the code under test, so only the notifier itself is stubbed.
 HARNESS="$WORK/stale_check.sh"
 {
   echo 'set -uo pipefail'
   echo 'REPO="$PWD"'
-  echo 'SELF="/dev/null"'
   # say() goes to STDERR, matching production where it appends to $LOG. On stdout it
-  # would be swallowed by any command substitution around the code under test, which
-  # is exactly how the preserve-and-receipt path first looked like it was missing.
+  # would be swallowed by any command substitution around the code under test.
   echo 'say()  { printf "SAY %s\n"  "$*" >&2; }'
-  echo 'page() { printf "PAGE %s\n" "$*"; }'
-  # page_ok reports delivery, and its exit code is the thing under test in case 7:
-  # KIPI_TEST_PAGE_FAILS=1 makes the notifier fail so the dedupe marker must NOT
-  # be written. Without a failure knob the "failed page still dedupes" defect
-  # cannot be reproduced at all.
-  echo 'page_ok() { printf "PAGE %s\n" "$*"; [ "${KIPI_TEST_PAGE_FAILS:-0}" = "1" ] && return 1; return 0; }'
-  echo 'relaunch_self() { printf "RELAUNCH\n"; return 0; }'
-  echo 'checkout_unlock() { :; }'
-  # page_once takes (key, msg); stale_check uses it for the preserved-files receipt.
-  echo 'page_once() { printf "PAGE %s\n" "$2"; }'
-  echo 'FF_PRESERVE_DIR=""'
-  echo 'FF_PRESERVED_COUNT=0'
-  echo 'ATTEMPT_FF_REASON=""'
-  awk '/^attempt_ff\(\) \{/,/^\}/' "$DISPATCH"
+  # KIPI_TEST_PAGE_FAILS=1 makes delivery fail, so "a failed page must not dedupe"
+  # can be reproduced at all.
+  echo 'page_ok() { printf "PAGE %s\n" "$1"; [ "${KIPI_TEST_PAGE_FAILS:-0}" = "1" ] && return 1; return 0; }'
+  echo 'PAGE_REPING_SECONDS="${KIPI_PAGE_REPING_SECONDS:-86400}"'
+  awk '/^page_clear\(\) \{/,/^\}/'  "$DISPATCH"
+  awk '/^page_once\(\) \{/,/^\}/'   "$DISPATCH"
   awk '/^stale_check\(\) \{/,/^\}/' "$DISPATCH"
   echo 'stale_check && echo "VERDICT=RUN" || echo "VERDICT=REFUSE"'
 } > "$HARNESS"
-
-# Guard the extraction itself. An awk range that silently matched nothing would
-# make every case below "pass" against an empty function.
-for fn in attempt_ff stale_check; do
-  grep -q "^$fn() {" "$HARNESS" || { echo "harness did not extract $fn from $DISPATCH"; exit 1; }
+# Guard the extraction. An awk range that silently matched nothing would make every
+# case below pass against an empty function.
+for fn in page_clear page_once stale_check; do
+  grep -q "^$fn() {" "$HARNESS" || { echo "harness did not extract $fn"; exit 1; }
 done
 
-# --- a real origin + clone, because stale_check asks git real questions ------
 ORIGIN="$WORK/origin.git"
 git init -q --bare -b main "$ORIGIN"
 git init -q -b main "$WORK/seed"
 ( cd "$WORK/seed"
   git config user.email t@e.com; git config user.name t
-  echo one > f.txt; echo side > other.txt
-  # Shipped from the seed, NOT committed locally in a clone: a local commit would
-  # make that clone AHEAD, and combined with an upstream commit it becomes DIVERGED,
-  # so case 15 would measure ff-refuses-on-divergence instead of the ignore path.
-  printf 'ignored-dir/\n' > .gitignore
-  git add -A; git commit -qm one
+  echo one > f.txt; git add -A; git commit -qm one
   git remote add origin "$ORIGIN"; git push -q origin main ) >/dev/null 2>&1
 
-# One commit onto origin/main. Every "behind" case calls this after cloning.
 advance_origin() { ( cd "$WORK/seed"; echo "$1" >> f.txt; git commit -qam "$1"; git push -q origin main ) >/dev/null 2>&1; }
-
-# A FRESH CLONE PER CASE. Cases used to share one clone, which coupled them in
-# order and meant a failure early on cascaded into unrelated noise below.
 fresh_clone() {
   local d="$WORK/$1"
   git clone -q "$ORIGIN" "$d" >/dev/null 2>&1
   ( cd "$d"; git config user.email t@e.com; git config user.name t )
   echo "$d"
 }
-head_of() { git -C "$1" rev-parse HEAD 2>/dev/null; }
-
-# LOG is set even though say() is stubbed: attempt_ff derives the preserve dir from
+# LOG is set even though say() is stubbed: page_once derives its marker dir from
 # $(dirname "$LOG"), so an unset LOG trips `set -u` inside the code under test.
 CHECKSTATE="$WORK/checkstate"; mkdir -p "$CHECKSTATE"
-run_check() { ( cd "$1" && LOG="$CHECKSTATE/dispatch.log" bash "$HARNESS" 2>&1 ); }
+run_check() { ( cd "$1" && LOG="${2:-$CHECKSTATE}/dispatch.log" bash "$HARNESS" 2>&1 ); }
 
 echo "== 1. equal: HEAD == origin/main -> RUN =="
 C1="$(fresh_clone c-equal)"
@@ -147,31 +106,26 @@ echo "$OUT" | grep -q 'VERDICT=RUN' \
   || bad "an up-to-date checkout was refused: $(echo "$OUT" | tr '\n' ' ')"
 
 echo
-echo "== 2. THE FIX: behind + clean + on main -> FAST-FORWARD, RUN, no page =="
+echo "== 2. behind -> REFUSE, and the page carries the remedy =="
 C2="$(fresh_clone c-behind)"
-BEFORE="$(head_of "$C2")"
+B2="$(git -C "$C2" rev-parse HEAD)"
 advance_origin two
-OUT="$(run_check "$C2")"
-AFTER="$(head_of "$C2")"
-REMOTE="$(git -C "$C2" rev-parse origin/main)"
-echo "$OUT" | grep -q 'VERDICT=RUN' \
-  && ok "a stale checkout now proceeds instead of resting" \
-  || bad "THE DEFECT: a stale checkout still refused instead of fixing itself"
-# The load-bearing assertion: real git state, not the log line.
-if [ "$AFTER" = "$REMOTE" ] && [ "$AFTER" != "$BEFORE" ]; then
-  ok "the checkout was actually fast-forwarded (${BEFORE:0:7} -> ${AFTER:0:7})"
-else
-  bad "THE DEFECT: HEAD is still ${AFTER:0:7} (was ${BEFORE:0:7}, origin/main ${REMOTE:0:7}) -- it logged a fix it did not perform"
-fi
+S2="$WORK/s2"; mkdir -p "$S2"
+OUT="$(run_check "$C2" "$S2")"
+echo "$OUT" | grep -q 'VERDICT=REFUSE' \
+  && ok "a checkout behind origin/main refuses to dispatch" \
+  || bad "THE DEFECT: a stale checkout dispatched, running superseded control code"
+# THE GUARD MUST NOT GROW HANDS. The auto-merge was removed for losing data; if a
+# future edit puts one back, this catches it.
+[ "$(git -C "$C2" rev-parse HEAD)" = "$B2" ] \
+  && ok "the working tree was NOT touched (no auto-merge; ASK-284 owns that)" \
+  || bad "THE DEFECT: something rewrote the founder's working tree"
 echo "$OUT" | grep -q '^PAGE ' \
-  && bad "THE DEFECT: it paged the founder for something it fixed itself -- that is the alert-with-no-hands shape" \
-  || ok "no page: a fix that worked does not interrupt anyone"
-echo "$OUT" | grep -q 'SAY self-heal: fast-forwarded' \
-  && ok "the automated action is logged, so it is auditable after the fact" \
-  || bad "the tree moved with no log line, which is a silent write"
-echo "$OUT" | grep -q 'RELAUNCH' \
-  && ok "it re-execs on the new control code (bash reads scripts lazily; continuing in-process runs the old byte offsets)" \
-  || bad "no relaunch after the ff, so the rest of this run uses the superseded script text"
+  && ok "the refusal pages the founder" \
+  || bad "refused silently: an unattended refusal nobody is told about is a dead loop"
+echo "$OUT" | grep -q 'git merge --ff-only' \
+  && ok "the page carries the fix command" \
+  || bad "the page does not say what to do"
 
 echo
 echo "== 3. ahead: local commits not yet pushed -> RUN (must not wedge) =="
@@ -184,341 +138,167 @@ echo "$OUT" | grep -q 'VERDICT=RUN' \
 
 echo
 echo "== 4. no answer: fetch fails -> RUN (fail open on not knowing) =="
-# A repo with no reachable remote is the offline case without needing the network.
 BROKEN="$WORK/broken"
 git init -q -b main "$BROKEN"
 ( cd "$BROKEN"; git config user.email t@e.com; git config user.name t
   echo x > f.txt; git add -A; git commit -qm x
   git remote add origin "$WORK/does-not-exist.git" ) >/dev/null 2>&1
 OUT="$(run_check "$BROKEN")"
-if echo "$OUT" | grep -q 'VERDICT=RUN'; then
-  ok "an unanswerable freshness check proceeds instead of wedging"
-else
-  bad "a failed fetch refused to dispatch, so an offline machine kills the loop"
-fi
+echo "$OUT" | grep -q 'VERDICT=RUN' \
+  && ok "an unanswerable freshness check proceeds instead of wedging" \
+  || bad "a failed fetch refused to dispatch, so an offline machine kills the loop"
 echo "$OUT" | grep -q 'SAY stale-check' \
   && ok "the unanswered check is logged, not silent" \
   || bad "the check failed with no log line, so the blind spot is invisible"
 
 echo
-echo "== 5. DIVERGED must still REFUSE, and the page must name the failed attempt =="
-# The case the first cut got wrong, and the one a merge of this very branch
-# produces: origin/main gains a commit while this tree keeps local commits of its
-# own. A fast-forward CANNOT apply here, so this is a genuine human case.
+echo "== 5. DIVERGED must REFUSE (codex round 2, major 1) =="
+# The case a merge of this very branch produces: origin/main gains a commit while
+# this tree keeps local commits. --is-ancestor is FALSE here, so an ancestry test
+# would run on a checkout missing origin/main's newest control code.
 DIV="$(fresh_clone c-diverged)"
 ( cd "$DIV"; echo local-only >> f.txt; git commit -qam "local only" ) >/dev/null 2>&1
 advance_origin remote-only
-DIV_BEFORE="$(head_of "$DIV")"
-OUT="$(run_check "$DIV")"
-if echo "$OUT" | grep -q 'VERDICT=REFUSE'; then
-  ok "a DIVERGED checkout refuses (origin/main holds commits it lacks)"
-else
-  bad "THE DEFECT: a diverged checkout dispatched, so superseded control code runs after a concurrent merge"
-fi
-[ "$(head_of "$DIV")" = "$DIV_BEFORE" ] \
+DB="$(git -C "$DIV" rev-parse HEAD)"
+S5="$WORK/s5"; mkdir -p "$S5"
+OUT="$(run_check "$DIV" "$S5")"
+echo "$OUT" | grep -q 'VERDICT=REFUSE' \
+  && ok "a DIVERGED checkout refuses" \
+  || bad "THE DEFECT: a diverged checkout dispatched after a concurrent merge"
+[ "$(git -C "$DIV" rev-parse HEAD)" = "$DB" ] \
   && ok "the diverged tree was not moved" \
-  || bad "THE DEFECT: it rewrote a diverged tree -- local commits are now on a different base"
-echo "$OUT" | grep -q '^PAGE ' \
-  && ok "the case that genuinely needs a human does page" \
-  || bad "refused silently: an unattended refusal nobody is told about is a dead loop"
-echo "$OUT" | grep -qi 'PAGE.*tried' \
-  && ok "the page says the fix was ATTEMPTED, not just that something is wrong" \
-  || bad "the page does not name the attempt, so the founder retypes a command that already failed"
-echo "$OUT" | grep -q 'PAGE.*did not apply' \
-  && ok "the page carries git's own reason for the failure" \
-  || bad "the page does not say WHY the automatic fix failed"
+  || bad "THE DEFECT: it rewrote a diverged tree"
 
 echo
-echo "== 6. the page is deduped per remote sha (codex round 2, major 2) =="
-# At a 900s interval an unrepaired checkout paged 96 times a day with the
-# identical message, which trains the founder to ignore the channel.
-STATE="$WORK/pagestate"; mkdir -p "$STATE"
-# Point the function's state dir at a scratch dir by overriding $LOG, which is
-# what the marker path is derived from.
-run_dedupe() { ( cd "$1" && LOG="$STATE/dispatch.log" bash "$HARNESS" 2>&1 ); }
-P1="$(run_dedupe "$DIV" | grep -c '^PAGE ' || true)"
-P2="$(run_dedupe "$DIV" | grep -c '^PAGE ' || true)"
-if [ "${P1:-0}" -ge 1 ] && [ "${P2:-0}" -eq 0 ]; then
-  ok "pages once for a given origin/main sha, silent on the repeat ($P1 then $P2)"
+echo "== 6. THE ASK-283 REGRESSION: one page per EPISODE, not one per commit =="
+# The measured complaint. A per-sha key sent 9 pages for one unchanged problem
+# because main kept moving. Four heartbeats across four different remote shas must
+# produce exactly ONE page.
+C6="$(fresh_clone c-episode)"
+S6="$WORK/s6"; mkdir -p "$S6"
+advance_origin ep-1
+P_TOTAL=0
+for extra in ep-2 ep-3 ep-4; do
+  N="$(run_check "$C6" "$S6" | grep -c '^PAGE ' || true)"
+  P_TOTAL=$(( P_TOTAL + N ))
+  advance_origin "$extra"
+done
+N="$(run_check "$C6" "$S6" | grep -c '^PAGE ' || true)"
+P_TOTAL=$(( P_TOTAL + N ))
+if [ "$P_TOTAL" -eq 1 ]; then
+  ok "four heartbeats across four different origin/main shas sent 1 page, not 4"
 else
-  bad "THE DEFECT: paged $P1 then $P2 for the same remote sha -- 96 identical pages a day"
+  bad "THE DEFECT (ASK-283): $P_TOTAL pages for one unchanged problem -- this is the 9-a-night shape"
 fi
-# A NEW divergence must page again, or a second, different staleness goes unreported.
-advance_origin remote-two
-P3="$(run_dedupe "$DIV" | grep -c '^PAGE ' || true)"
-if [ "${P3:-0}" -ge 1 ]; then
-  ok "a NEW origin/main sha pages again (dedupe is per-sha, not permanent)"
-else
-  bad "dedupe is permanent: a second, different divergence would never be reported"
-fi
-# The refusal itself must still be logged every time, even when the page is muted.
-# CAPTURED FIRST, NOT PIPED. `run_dedupe | grep -q` fails here for a reason that has
-# nothing to do with the code under test: grep -q exits on the first match, the
-# subshell writing to the closed pipe takes SIGPIPE (141), and `set -o pipefail`
-# then reports 141 for the whole pipeline. The assertion inverts and blames the
-# dispatcher for a bug in the assertion. Caught by this line failing green code.
-DEDUPED_OUT="$(run_dedupe "$DIV")"
-echo "$DEDUPED_OUT" | grep -q 'SAY REFUSING' \
+# The refusal must still be logged every cycle even while the page is muted.
+# CAPTURED, NOT PIPED. `run_check | grep -q` fails for a reason unrelated to the
+# code: grep -q exits on first match, the writing subshell takes SIGPIPE (141), and
+# `set -o pipefail` reports 141 for the pipeline. The assertion then inverts and
+# blames the dispatcher. Written twice in this file's history; hence this note.
+MUTED_OUT="$(run_check "$C6" "$S6")"
+echo "$MUTED_OUT" | grep -q 'SAY STALE' \
   && ok "the refusal is logged on every heartbeat even when the page is deduped" \
   || bad "a deduped page also silenced the log line, so the refusal is invisible"
 
 echo
-echo "== 7. a FAILED page must not create the dedupe marker (codex round 4, major 2) =="
-# Writing the marker for a page that never went out permanently silences the
-# founder about a refusing loop. A storm is annoying; silence is invisible, and
-# strictly worse than the bug the dedupe was added to fix.
-STATE2="$WORK/pagefail"; mkdir -p "$STATE2"
-run_failing() { ( cd "$1" && KIPI_TEST_PAGE_FAILS=1 LOG="$STATE2/dispatch.log" bash "$HARNESS" 2>&1 ); }
-run_ok2()     { ( cd "$1" && LOG="$STATE2/dispatch.log" bash "$HARNESS" 2>&1 ); }
-F1="$(run_failing "$DIV" | grep -c '^PAGE ' || true)"
-# Now let the notifier succeed. If the failed attempt wrote a marker, this is muted.
-F2="$(run_ok2 "$DIV" | grep -c '^PAGE ' || true)"
+echo "== 7. recovery clears the page state, so the NEXT episode is heard at once =="
+C7="$(fresh_clone c-recover)"
+S7="$WORK/s7"; mkdir -p "$S7"
+advance_origin rec-1
+R1="$(run_check "$C7" "$S7" | grep -c '^PAGE ' || true)"
+R2="$(run_check "$C7" "$S7" | grep -c '^PAGE ' || true)"          # unchanged -> muted
+( cd "$C7"; git merge -q --ff-only origin/main ) >/dev/null 2>&1  # a human fixes it
+RCLR="$(run_check "$C7" "$S7" 2>&1)"                              # healthy -> clears
+advance_origin rec-2                                              # a NEW episode
+R3="$(run_check "$C7" "$S7" | grep -c '^PAGE ' || true)"
+if [ "${R1:-0}" -eq 1 ] && [ "${R2:-0}" -eq 0 ] && [ "${R3:-0}" -eq 1 ]; then
+  ok "pages, mutes the repeat, and pages again on a new episode ($R1/$R2/$R3)"
+else
+  bad "THE DEFECT: page state survived recovery ($R1/$R2/$R3) -- the next outage is swallowed"
+fi
+echo "$RCLR" | grep -q 'SAY page state cleared' \
+  && ok "the recovery is logged" \
+  || bad "recovery cleared state with no trace"
+
+echo
+echo "== 8. offline is NOT recovery: an unanswerable check must clear nothing =="
+# Clearing on a failed fetch would re-page a still-broken checkout every cycle the
+# network flapped, which is the storm this whole change exists to stop.
+C8="$(fresh_clone c-offline)"
+S8="$WORK/s8"; mkdir -p "$S8"
+advance_origin off-1
+run_check "$C8" "$S8" >/dev/null 2>&1                        # page + marker
+git -C "$C8" remote set-url origin "$WORK/gone.git"          # now unreachable
+run_check "$C8" "$S8" >/dev/null 2>&1                        # no answer
+git -C "$C8" remote set-url origin "$ORIGIN"                 # back online, still behind
+N8="$(run_check "$C8" "$S8" | grep -c '^PAGE ' || true)"
+[ "${N8:-0}" -eq 0 ] \
+  && ok "a network blip did not reset the dedupe (still muted)" \
+  || bad "THE DEFECT: an offline cycle cleared the marker, so a flapping network re-pages forever"
+
+echo
+echo "== 9. a FAILED page must not create the dedupe marker (codex round 4, major 2) =="
+# Writing the marker for a page that never went out permanently silences the founder
+# about a refusing loop. A storm is annoying; silence is invisible, and worse.
+C9="$(fresh_clone c-pagefail)"
+S9="$WORK/s9"; mkdir -p "$S9"
+advance_origin pf-1
+F1="$( cd "$C9" && KIPI_TEST_PAGE_FAILS=1 LOG="$S9/dispatch.log" bash "$HARNESS" 2>/dev/null | grep -c '^PAGE ' || true )"
+F2="$( cd "$C9" && LOG="$S9/dispatch.log" bash "$HARNESS" 2>/dev/null | grep -c '^PAGE ' || true )"
 if [ "${F1:-0}" -ge 1 ] && [ "${F2:-0}" -ge 1 ]; then
   ok "a failed page leaves the marker unset, so the next heartbeat retries it ($F1 then $F2)"
 else
   bad "THE DEFECT: failed page still deduped -- founder goes permanently silent ($F1 then $F2)"
 fi
-# FRESH state dir. The successful page above wrote a marker, so re-running against
-# the same dir skips the whole block and emits nothing -- which is correct
-# behaviour and a broken assertion. Caught by this case failing on its first run.
-STATE3="$WORK/pagefail-log"; mkdir -p "$STATE3"
-LOGLINE="$( cd "$DIV" && KIPI_TEST_PAGE_FAILS=1 LOG="$STATE3/dispatch.log" bash "$HARNESS" 2>&1 )"
-echo "$LOGLINE" | grep -q 'did NOT go out' \
+S9B="$WORK/s9b"; mkdir -p "$S9B"
+( cd "$C9" && KIPI_TEST_PAGE_FAILS=1 LOG="$S9B/dispatch.log" bash "$HARNESS" 2>&1 >/dev/null ) | grep -q 'did NOT go out' \
   && ok "the undelivered page is logged" \
   || bad "an undelivered page is not logged, so the silence has no trace"
 
 echo
-echo "== 8. a NON-MAIN branch is never fast-forwarded (parallel-sessions scar) =="
-# Two sessions sharing one checkout yank each other's tree on a branch move. The
-# remedy the detector computed is for main; applying it to somebody's feature
-# branch is not that remedy.
-C8="$(fresh_clone c-branch)"
-( cd "$C8"; git checkout -qb sana/some-work ) >/dev/null 2>&1
-advance_origin branch-case
-B8="$(head_of "$C8")"
-OUT="$(run_check "$C8")"
-[ "$(head_of "$C8")" = "$B8" ] \
-  && ok "the feature branch was left where it was" \
-  || bad "THE DEFECT: it moved a non-main branch onto origin/main under a live session"
-echo "$OUT" | grep -q 'VERDICT=REFUSE' \
-  && ok "it refuses rather than dispatching on a stale feature branch" \
-  || bad "it dispatched from a stale non-main branch"
-echo "$OUT" | grep -q 'PAGE.*sana/some-work' \
-  && ok "the page names the branch it declined to touch" \
-  || bad "the page does not say which branch blocked the fix"
-
-echo
-echo "== 9. a DETACHED HEAD is never fast-forwarded =="
-C9="$(fresh_clone c-detached)"
-( cd "$C9"; git checkout -q --detach HEAD ) >/dev/null 2>&1
-advance_origin detached-case
-B9="$(head_of "$C9")"
-OUT="$(run_check "$C9")"
-[ "$(head_of "$C9")" = "$B9" ] \
-  && ok "the detached checkout was left where it was" \
-  || bad "THE DEFECT: it moved a detached HEAD"
-echo "$OUT" | grep -q 'PAGE.*detached HEAD' \
-  && ok "the page names the detached HEAD as the blocker" \
-  || bad "the page does not explain that a detached HEAD blocked the fix"
-
-echo
-echo "== 10. a STAGED index is never fast-forwarded (someone is composing a commit) =="
-C10="$(fresh_clone c-staged)"
-( cd "$C10"; echo staged >> other.txt; git add other.txt ) >/dev/null 2>&1
-advance_origin staged-case
-B10="$(head_of "$C10")"
-OUT="$(run_check "$C10")"
-[ "$(head_of "$C10")" = "$B10" ] \
-  && ok "the tree with a staged commit was left alone" \
-  || bad "THE DEFECT: it fast-forwarded over someone's staged hunks"
-echo "$OUT" | grep -q 'PAGE.*staged changes' \
-  && ok "the page names the staged index as the blocker" \
-  || bad "the page does not explain that a staged index blocked the fix"
-
-echo
-echo "== 11. a merge in progress is never fast-forwarded =="
-C11="$(fresh_clone c-midmerge)"
-# Fabricate the marker rather than orchestrating a real conflict: the guard reads
-# the marker, so the marker IS the condition under test.
-( cd "$C11"; git rev-parse HEAD > "$(git rev-parse --git-path MERGE_HEAD)" ) >/dev/null 2>&1
-advance_origin midmerge-case
-B11="$(head_of "$C11")"
-OUT="$(run_check "$C11")"
-[ "$(head_of "$C11")" = "$B11" ] \
-  && ok "the mid-merge tree was left alone" \
-  || bad "THE DEFECT: it moved HEAD out from under an in-progress merge"
-echo "$OUT" | grep -q 'PAGE.*in progress' \
-  && ok "the page names the in-progress operation" \
-  || bad "the page does not explain that a mid-merge tree blocked the fix"
-
-echo
-echo "== 12. git's own overwrite check is respected: a modified file the merge touches =="
-# The ff would clobber an uncommitted edit. git refuses; we must surface that
-# rather than force it.
-C12="$(fresh_clone c-conflict)"
-advance_origin conflict-case
-( cd "$C12"; echo "uncommitted local edit" >> f.txt ) >/dev/null 2>&1
-B12="$(head_of "$C12")"
-OUT="$(run_check "$C12")"
-[ "$(head_of "$C12")" = "$B12" ] \
-  && ok "the tree was not moved when the ff would overwrite a local edit" \
-  || bad "THE DEFECT: it discarded an uncommitted edit to fast-forward"
-grep -q "uncommitted local edit" "$C12/f.txt" \
-  && ok "the founder's uncommitted edit survived" \
-  || bad "THE DEFECT: the local edit is gone"
-echo "$OUT" | grep -q 'VERDICT=REFUSE' \
-  && ok "it refuses and hands this one to a human" \
-  || bad "it dispatched despite being stale and unable to heal"
-
-echo
-echo "== 13. NOT INERT ON A DIRTY TREE: unrelated modified files still heal =="
-# The founder's real checkout carries 3 modified tracked files and ~5.5k untracked
-# ones as its RESTING state. A blanket dirty-tree refusal would make this whole
-# feature never fire on the one checkout it exists for. So the arbiter is git's
-# per-file answer, not a whole-tree guess. This case is what keeps that honest.
-C13="$(fresh_clone c-dirty-unrelated)"
-advance_origin dirty-case
-( cd "$C13"; echo "unrelated founder edit" >> other.txt ) >/dev/null 2>&1
-mkdir -p "$C13/untracked-junk"; echo junk > "$C13/untracked-junk/x"
-OUT="$(run_check "$C13")"
-R13="$(git -C "$C13" rev-parse origin/main)"
-[ "$(head_of "$C13")" = "$R13" ] \
-  && ok "a tree dirty in UNRELATED files still fast-forwards (the feature is not inert in production)" \
-  || bad "THE DEFECT: dirty-but-unrelated blocked the fix, so this never fires on the founder's real checkout"
-grep -q "unrelated founder edit" "$C13/other.txt" \
-  && ok "the unrelated local edit was carried forward, not discarded" \
-  || bad "THE DEFECT: the ff discarded an unrelated local edit"
-echo "$OUT" | grep -q '^PAGE ' \
-  && bad "it paged for a case it healed" \
-  || ok "no page for a healed dirty tree"
-
-echo
-echo "== 14. one heal per launch: a re-exec that is STILL behind pages instead of spinning =="
-C14="$(fresh_clone c-respin)"
-advance_origin respin-case
-OUT="$( cd "$C14" && KIPI_DISPATCH_SELFHEALED=1 bash "$HARNESS" 2>&1 )"
-echo "$OUT" | grep -q 'VERDICT=REFUSE' \
-  && ok "a second staleness in the same launch refuses instead of re-execing again" \
-  || bad "THE DEFECT: it would exec itself repeatedly while origin/main keeps moving"
-echo "$OUT" | grep -q 'RELAUNCH' \
-  && bad "THE DEFECT: it re-execed a second time in one launch" \
-  || ok "no second re-exec"
-
-echo
-echo "== 15. BLOCKER: an IGNORED file where origin/main starts tracking the path =="
-# THE DATA-LOSS PATH, and the one measurement that reassured me hid it.
-# Measured 2026-08-02: git ABORTS for untracked-not-ignored (case 16 below) but
-# SILENTLY OVERWRITES an ignored file, exit 0, no warning. An untracked file has no
-# object in the database, so there is no reflog and nothing to recover.
-# `git ls-files --others --exclude-standard` -- the 5488 I quoted -- EXCLUDES
-# ignored files, so the number that made "let git arbitrate" look safe could not
-# see this class at all. The founder's checkout carries 3982 of them.
-C15="$(fresh_clone c-ignored)"
-mkdir -p "$C15/ignored-dir"
-echo "FOUNDER WORK - must survive" > "$C15/ignored-dir/notes.md"
-# Upstream starts tracking that exact path.
-( cd "$WORK/seed"; mkdir -p ignored-dir; echo "upstream version" > ignored-dir/notes.md
-  git add -f ignored-dir/notes.md; git commit -qm "upstream tracks it"; git push -q origin main ) >/dev/null 2>&1
-OUT="$(run_check "$C15")"
-# The ff SHOULD still apply -- refusing here would make the guard inert again.
-R15="$(git -C "$C15" rev-parse origin/main)"
-[ "$(head_of "$C15")" = "$R15" ] \
-  && ok "the fast-forward still applied (preserving must not make the heal inert)" \
-  || bad "preserving the file blocked the heal"
-# THE LOAD-BEARING ASSERTION: the founder's bytes still exist somewhere.
-PRESERVED="$(grep -rl "FOUNDER WORK - must survive" "$CHECKSTATE/ff-preserved" 2>/dev/null | head -1)"
-if [ -n "$PRESERVED" ]; then
-  ok "the ignored file's content was copied out before the merge ($PRESERVED)"
-else
-  bad "THE BLOCKER: the founder's ignored file was destroyed with no copy anywhere"
-fi
-echo "$OUT" | grep -q 'SAY self-heal:.*copied to' \
-  && ok "the preservation is logged with its restore path" \
-  || bad "files were moved out of the way with no log line saying where"
-echo "$OUT" | grep -q 'PAGE.*nothing was lost' \
-  && ok "the founder gets a receipt naming the restore path" \
-  || bad "no receipt: the founder never learns his ignored file was replaced"
-
-echo
-echo "== 16. an UNTRACKED (not ignored) collision must ABORT, never be forced =="
-# git's own refusal is correct here and must reach the founder as a refusal. If any
-# future edit adds -f, reset --hard, clean or a stash-then-drop, this goes red.
-C16="$(fresh_clone c-untracked-collide)"
-echo "FOUNDER WORK - untracked" > "$C16/newfile.md"
-( cd "$WORK/seed"; echo "upstream" > newfile.md; git add newfile.md
-  git commit -qm "upstream adds newfile"; git push -q origin main ) >/dev/null 2>&1
-B16="$(head_of "$C16")"
-OUT="$(run_check "$C16")"
-[ "$(head_of "$C16")" = "$B16" ] \
-  && ok "the tree was not moved when git refused" \
-  || bad "THE DEFECT: it forced past git's abort"
-grep -q "FOUNDER WORK - untracked" "$C16/newfile.md" \
-  && ok "the untracked file is untouched" \
-  || bad "THE BLOCKER: an untracked file was destroyed"
-echo "$OUT" | grep -q 'VERDICT=REFUSE' \
-  && ok "an abort is an honest refusal that pages" \
-  || bad "the abort was swallowed and it dispatched anyway"
-
-echo
-echo "== 17-19. the alert-state primitives (page_once / page_clear / checkout_lock) =="
-# A SECOND HARNESS, because these are top-level functions rather than parts of
-# stale_check. Same rule: the real functions are extracted, only the notifier is
-# stubbed.
-PH="$WORK/primitives.sh"
+echo "== 10. MAJOR: an ORPHANED page lock must age out, not mute the key forever =="
+# A notifier killed between the mkdir and its cleanup (launchd reaping the job, a
+# reboot, SIGKILL) left a lock dir behind. Reproduced before the fix: the next three
+# runs paged 0, 0, 0 while the log reported "another dispatcher is already deciding
+# it" with nobody there. This was introduced BY the lock added to fix duplicate
+# pages -- a guard that can never fire, born from the fix for the previous one.
+PL="$WORK/plock"; mkdir -p "$PL"
+PH="$WORK/prim.sh"
 {
   echo 'set -uo pipefail'
   echo 'say() { printf "SAY %s\n" "$*" >&2; }'
-  echo 'page_ok() { printf "PAGE %s\n" "$1"; [ "${KIPI_TEST_PAGE_FAILS:-0}" = "1" ] && return 1; return 0; }'
-  awk '/^page_clear\(\) \{/,/^\}/'  "$DISPATCH"
-  awk '/^page_once\(\) \{/,/^\}/'   "$DISPATCH"
-  awk '/^checkout_unlock\(\) /,/^$/' "$DISPATCH"
-  awk '/^checkout_lock\(\) \{/,/^\}/' "$DISPATCH"
-  echo 'PAGE_REPING_SECONDS="${KIPI_PAGE_REPING_SECONDS:-86400}"'
-  echo '"$@"'
+  echo 'page_ok() { printf "PAGE %s\n" "$1"; return 0; }'
+  echo 'PAGE_REPING_SECONDS=86400'
+  awk '/^page_clear\(\) \{/,/^\}/' "$DISPATCH"
+  awk '/^page_once\(\) \{/,/^\}/'  "$DISPATCH"
+  echo 'page_once "$@"'
 } > "$PH"
-for fn in page_clear page_once checkout_lock; do
-  grep -q "^$fn() {" "$PH" || { echo "primitive harness did not extract $fn"; exit 1; }
-done
-PSTATE="$WORK/pstate"; mkdir -p "$PSTATE"
-prim() { ( export LOG="$PSTATE/dispatch.log" CHECKOUT_LOCK="$PSTATE/co.lock"; bash "$PH" "$@" 2>&1 ); }
+grep -q '^page_once() {' "$PH" || { echo "primitive harness did not extract page_once"; exit 1; }
+# A FRESH lock is respected (the duplicate-page fix must still hold).
+mkdir -p "$PL/paged-korph.lock"
+FRESH="$( LOG="$PL/dispatch.log" bash "$PH" korph "real fault" 2>/dev/null | grep -c '^PAGE ' || true )"
+[ "${FRESH:-0}" -eq 0 ] \
+  && ok "a FRESH lock is respected, so concurrent dispatchers still do not duplicate" \
+  || bad "the lock is ignored outright, which reintroduces duplicate pages"
+# An OLD lock is reaped. Backdate it well past the 300s bound.
+touch -t 202501010000 "$PL/paged-korph.lock" 2>/dev/null
+AGED="$( LOG="$PL/dispatch.log" bash "$PH" korph "real fault" 2>/dev/null | grep -c '^PAGE ' || true )"
+[ "${AGED:-0}" -ge 1 ] \
+  && ok "an ORPHANED lock is reaped and the alert gets through ($AGED page)" \
+  || bad "THE DEFECT: an orphaned lock mutes this key forever -- a dedupe that became a permanent silence"
 
-echo "-- 17. a recovered alert that RECURS must page again (clear-on-recovery) --"
-N1="$(prim page_once k1 "boom" | grep -c '^PAGE ' || true)"
-N2="$(prim page_once k1 "boom" | grep -c '^PAGE ' || true)"   # unchanged -> suppressed
-prim page_clear k1 >/dev/null 2>&1                             # the fault recovers
-N3="$(prim page_once k1 "boom" | grep -c '^PAGE ' || true)"    # and recurs
-if [ "${N1:-0}" -eq 1 ] && [ "${N2:-0}" -eq 0 ] && [ "${N3:-0}" -eq 1 ]; then
-  ok "pages, suppresses the repeat, and pages again after recovery ($N1/$N2/$N3)"
-else
-  bad "THE DEFECT: recurrence after recovery was swallowed ($N1/$N2/$N3) -- a dedupe that can never re-fire"
-fi
-
-echo "-- 18. concurrent page_once must not duplicate the same alert --"
-PSTATE2="$WORK/pstate2"; mkdir -p "$PSTATE2"
-conc() { ( export LOG="$PSTATE2/dispatch.log" CHECKOUT_LOCK="$PSTATE2/co.lock"; bash "$PH" page_once k2 "same line" 2>/dev/null ); }
-conc > "$WORK/c1.out" & C1PID=$!
-conc > "$WORK/c2.out" & C2PID=$!
-wait $C1PID $C2PID 2>/dev/null
+echo
+echo "== 11. concurrent page_once must not duplicate the same alert =="
+PC="$WORK/pconc"; mkdir -p "$PC"
+( LOG="$PC/dispatch.log" bash "$PH" kconc "same line" 2>/dev/null > "$WORK/c1.out" ) &
+( LOG="$PC/dispatch.log" bash "$PH" kconc "same line" 2>/dev/null > "$WORK/c2.out" ) &
+wait
 TOTAL=$(( $(grep -c '^PAGE ' "$WORK/c1.out" || true) + $(grep -c '^PAGE ' "$WORK/c2.out" || true) ))
 [ "$TOTAL" -le 1 ] \
   && ok "two dispatchers deciding the same key produced $TOTAL page(s), not 2" \
   || bad "THE DEFECT: unlocked marker check let concurrent dispatchers send $TOTAL duplicate pages"
 
-echo "-- 19. the checkout lock is exclusive, and is released --"
-PSTATE3="$WORK/pstate3"; mkdir -p "$PSTATE3"
-lk() { ( export LOG="$PSTATE3/dispatch.log" CHECKOUT_LOCK="$PSTATE3/co.lock"; bash "$PH" "$@" >/dev/null 2>&1; echo $?; ) }
-# Taken in one process and released, a second take must succeed.
-A="$( ( export LOG="$PSTATE3/dispatch.log" CHECKOUT_LOCK="$PSTATE3/co.lock"; bash "$PH" checkout_lock >/dev/null 2>&1; echo $? ) )"
-B="$( ( export LOG="$PSTATE3/dispatch.log" CHECKOUT_LOCK="$PSTATE3/co.lock"; bash "$PH" checkout_lock >/dev/null 2>&1; echo $? ) )"
-[ "$A" = "0" ] && [ "$B" != "0" ] \
-  && ok "a held checkout lock blocks a second dispatcher (first=$A second=$B)" \
-  || bad "THE DEFECT: two dispatchers both took the checkout lock ($A/$B) -- both would merge the same tree"
-C="$( ( export LOG="$PSTATE3/dispatch.log" CHECKOUT_LOCK="$PSTATE3/co.lock"; bash "$PH" checkout_unlock >/dev/null 2>&1; bash "$PH" checkout_lock >/dev/null 2>&1; echo $? ) )"
-[ "$C" = "0" ] \
-  && ok "the lock is reacquirable after release (no permanent wedge)" \
-  || bad "THE DEFECT: the lock was never released, so the loop wedges forever"
-
 echo
 echo "-------- $PASS passed, $FAIL failed --------"
 [ "$FAIL" -eq 0 ] || exit 1
-echo "PASS: stale_check fixes what it can fast-forward, refuses and pages only what needs a human"
+echo "PASS: stale_check refuses without touching the tree, and pages once per episode"

--- a/q-system/.q-system/scripts/test/test-dispatch-stale-checkout.sh
+++ b/q-system/.q-system/scripts/test/test-dispatch-stale-checkout.sh
@@ -67,6 +67,7 @@ HARNESS="$WORK/stale_check.sh"
   # can be reproduced at all.
   echo 'page_ok() { printf "PAGE %s\n" "$1"; [ "${KIPI_TEST_PAGE_FAILS:-0}" = "1" ] && return 1; return 0; }'
   echo 'PAGE_REPING_SECONDS="${KIPI_PAGE_REPING_SECONDS:-86400}"'
+  awk '/^page_lock\(\) \{/,/^\}/'   "$DISPATCH"
   awk '/^page_clear\(\) \{/,/^\}/'  "$DISPATCH"
   awk '/^page_once\(\) \{/,/^\}/'   "$DISPATCH"
   awk '/^stale_check\(\) \{/,/^\}/' "$DISPATCH"
@@ -74,7 +75,7 @@ HARNESS="$WORK/stale_check.sh"
 } > "$HARNESS"
 # Guard the extraction. An awk range that silently matched nothing would make every
 # case below pass against an empty function.
-for fn in page_clear page_once stale_check; do
+for fn in page_lock page_clear page_once stale_check; do
   grep -q "^$fn() {" "$HARNESS" || { echo "harness did not extract $fn"; exit 1; }
 done
 
@@ -269,11 +270,12 @@ PH="$WORK/prim.sh"
   echo 'say() { printf "SAY %s\n" "$*" >&2; }'
   echo 'page_ok() { printf "PAGE %s\n" "$1"; return 0; }'
   echo 'PAGE_REPING_SECONDS=86400'
+  awk '/^page_lock\(\) \{/,/^\}/'  "$DISPATCH"
   awk '/^page_clear\(\) \{/,/^\}/' "$DISPATCH"
   awk '/^page_once\(\) \{/,/^\}/'  "$DISPATCH"
   echo 'page_once "$@"'
 } > "$PH"
-grep -q '^page_once() {' "$PH" || { echo "primitive harness did not extract page_once"; exit 1; }
+grep -q '^page_lock() {' "$PH" && grep -q '^page_once() {' "$PH" || { echo "primitive harness did not extract page_once"; exit 1; }
 # A FRESH lock is respected (the duplicate-page fix must still hold).
 mkdir -p "$PL/paged-korph.lock"
 FRESH="$( LOG="$PL/dispatch.log" bash "$PH" korph "real fault" 2>/dev/null | grep -c '^PAGE ' || true )"
@@ -297,6 +299,123 @@ TOTAL=$(( $(grep -c '^PAGE ' "$WORK/c1.out" || true) + $(grep -c '^PAGE ' "$WORK
 [ "$TOTAL" -le 1 ] \
   && ok "two dispatchers deciding the same key produced $TOTAL page(s), not 2" \
   || bad "THE DEFECT: unlocked marker check let concurrent dispatchers send $TOTAL duplicate pages"
+
+echo
+echo "== 12. the Linear outage guard vs the PRODUCER'S REAL OUTPUT =="
+# FIXTURES COME FROM PRODUCERS. The previous pattern was
+# (infra_error|authentication|unauthorized) and matched NONE of the loop-stopping
+# lines linear-worker.sh actually prints, so a real outage fell through to
+# page_clear and ERASED the state that would have paged. Silence dressed as health.
+#
+# Every string below is copied from linear-worker.sh, not invented, and case 13
+# re-derives them from the file so this cannot drift.
+GUARD="$WORK/guard.sh"
+{
+  echo 'set -uo pipefail'
+  echo 'say() { printf "SAY %s\n" "$*" >&2; }'
+  echo 'page_once() { printf "PAGE %s\n" "$1"; }'
+  echo 'page_clear() { printf "CLEAR %s\n" "$1"; }'
+  echo 'WORK_OUT="$1"'
+  # Sliced on STABLE marker comments, never on the matcher line itself. Anchoring
+  # the range to the text under test meant a mutant that reworded the matcher made
+  # the range match nothing: the harness bailed rather than asserting, and two
+  # mutants restoring the round-3 defect were scored SURVIVED. Caught by mutation,
+  # not review.
+  awk '/^# --- LINEAR-OUTAGE-GUARD:BEGIN ---$/,/^# --- LINEAR-OUTAGE-GUARD:END ---$/' "$DISPATCH"
+} > "$GUARD"
+grep -q 'page_clear linear-down' "$GUARD" \
+  || bad "the outage guard block is missing its BEGIN/END markers or its page_clear"
+guard() { bash "$GUARD" "$1" 2>&1; }
+
+# The exact line linear-worker.sh:417 emits, and the one that was missed.
+G="$(guard 'INFRA: linear unreachable (HTTPSConnectionPool: Max retries exceeded). Not counted against any issue.')"
+echo "$G" | grep -q '^PAGE linear-down' \
+  && ok "a real 'INFRA: linear unreachable' outage PAGES" \
+  || bad "THE DEFECT: the producer's real outage line does not match the guard"
+echo "$G" | grep -q '^CLEAR ' \
+  && bad "THE DEFECT: a live outage also CLEARED the outage state -- silence dressed as health" \
+  || ok "a live outage does not clear the state that would page later"
+
+# linear-worker.sh:251 -- stops the run BEFORE Linear, and self-pages. Must not
+# double-page, and must not clear (a run that never reached Linear proves nothing).
+G="$(guard 'INFRA: git fetch failed in /Users/x/repo. Stopping before any worktree is cut from a stale base.')"
+echo "$G" | grep -q '^PAGE ' \
+  && bad "double-paged: linear-worker.sh:251 already notifies the founder itself" \
+  || ok "a pre-Linear environment failure does not double-page"
+echo "$G" | grep -q '^CLEAR ' \
+  && bad "THE DEFECT: a run that never reached Linear cleared the outage state" \
+  || ok "a run that never reached Linear does not count as recovery"
+
+# linear-worker.sh:989 / :1049 -- these print INFRA: and then `continue`. The worker
+# is still working, so paging "the loop is stopped" would be a false alarm. This is
+# why the matcher is not a bare `INFRA:` prefix.
+for line in 'INFRA: could not create worktree for ASK-1 (not counted against the issue)' \
+            'INFRA: claim failed rc=1 on ASK-1 (not counted against the issue)'; do
+  G="$(guard "$line")"
+  echo "$G" | grep -q '^PAGE ' \
+    && bad "false alarm: '${line:0:34}...' does not stop the worker but paged an outage" \
+    || ok "a non-stopping INFRA line does not page an outage (${line:0:28}...)"
+done
+
+# A healthy run must still clear.
+G="$(guard '3 ready issues; dispatching ASK-9')"
+echo "$G" | grep -q '^CLEAR linear-down' \
+  && ok "a healthy run clears the outage state" \
+  || bad "a healthy run no longer clears, so the outage page is stuck on"
+
+echo
+echo "== 13. the guard's strings still exist in linear-worker.sh (anti-drift) =="
+# A fixture copied from a producer rots when the producer is reworded. This
+# re-derives the claim from the file itself, so a rename breaks the test instead of
+# silently restoring the round-3 defect.
+WORKER="$REPO/q-system/.q-system/scripts/linear-worker.sh"
+if [ -f "$WORKER" ]; then
+  grep -q 'INFRA: linear unreachable' "$WORKER" \
+    && ok "linear-worker.sh still prints 'INFRA: linear unreachable'" \
+    || bad "the producer was reworded: the outage guard now matches nothing again"
+  grep -q 'INFRA: git fetch failed' "$WORKER" \
+    && ok "linear-worker.sh still prints 'INFRA: git fetch failed'" \
+    || bad "the producer was reworded: the pre-Linear guard now matches nothing"
+  # say() must reach stdout, or none of this text ever arrives in WORK_OUT.
+  grep -qE '^say\(\).*tee' "$WORKER" \
+    && ok "the worker's say() still tees to stdout, so the dispatcher can see it" \
+    || bad "the worker's say() no longer writes to stdout -- WORK_OUT gets nothing to match"
+else
+  ok "linear-worker.sh not present in this checkout; producer anti-drift skipped"
+fi
+
+echo
+echo "== 14. MINOR: a clear cannot interleave with an in-flight page decision =="
+# page_clear used to run while page_once was mid-decision: the clear found no
+# marker, page_once wrote one a moment later, and that marker then described an
+# already-recovered condition -- muting the next real episode for up to 24h.
+PR="$WORK/prace"; mkdir -p "$PR"
+# Simulate page_once holding the lock (a slow notifier) by taking the lock by hand.
+mkdir -p "$PR/paged-krace.lock"
+printf 'oldhash\n1\n' > "$PR/paged-krace"
+CL="$( LOG="$PR/dispatch.log" bash -c '
+  set -uo pipefail
+  say() { printf "SAY %s\n" "$*" >&2; }
+  '"$(awk '/^page_lock\(\) \{/,/^\}/' "$DISPATCH")"'
+  '"$(awk '/^page_clear\(\) \{/,/^\}/' "$DISPATCH")"'
+  page_clear krace' 2>&1 )"
+[ -f "$PR/paged-krace" ] \
+  && ok "a clear held off while a notifier is mid-decision (no interleave)" \
+  || bad "THE DEFECT: page_clear removed a marker while page_once was still deciding"
+echo "$CL" | grep -q 'NOT cleared' \
+  && ok "the deferred clear is logged, so the <=15m window is visible" \
+  || bad "the clear was skipped with no log line"
+# Once the holder is gone (orphan aged out), the clear must actually happen.
+touch -t 202501010000 "$PR/paged-krace.lock" 2>/dev/null
+LOG="$PR/dispatch.log" bash -c '
+  set -uo pipefail
+  say() { printf "SAY %s\n" "$*" >&2; }
+  '"$(awk '/^page_lock\(\) \{/,/^\}/' "$DISPATCH")"'
+  '"$(awk '/^page_clear\(\) \{/,/^\}/' "$DISPATCH")"'
+  page_clear krace' >/dev/null 2>&1
+[ -f "$PR/paged-krace" ] \
+  && bad "THE DEFECT: the marker survived an uncontended clear, so recovery never resets" \
+  || ok "an uncontended clear removes the marker"
 
 echo
 echo "-------- $PASS passed, $FAIL failed --------"

--- a/q-system/.q-system/scripts/test/test-dispatch-stale-checkout.sh
+++ b/q-system/.q-system/scripts/test/test-dispatch-stale-checkout.sh
@@ -79,7 +79,10 @@ HARNESS="$WORK/stale_check.sh"
   echo 'set -uo pipefail'
   echo 'REPO="$PWD"'
   echo 'SELF="/dev/null"'
-  echo 'say()  { printf "SAY %s\n"  "$*"; }'
+  # say() goes to STDERR, matching production where it appends to $LOG. On stdout it
+  # would be swallowed by any command substitution around the code under test, which
+  # is exactly how the preserve-and-receipt path first looked like it was missing.
+  echo 'say()  { printf "SAY %s\n"  "$*" >&2; }'
   echo 'page() { printf "PAGE %s\n" "$*"; }'
   # page_ok reports delivery, and its exit code is the thing under test in case 7:
   # KIPI_TEST_PAGE_FAILS=1 makes the notifier fail so the dedupe marker must NOT
@@ -87,6 +90,12 @@ HARNESS="$WORK/stale_check.sh"
   # cannot be reproduced at all.
   echo 'page_ok() { printf "PAGE %s\n" "$*"; [ "${KIPI_TEST_PAGE_FAILS:-0}" = "1" ] && return 1; return 0; }'
   echo 'relaunch_self() { printf "RELAUNCH\n"; return 0; }'
+  echo 'checkout_unlock() { :; }'
+  # page_once takes (key, msg); stale_check uses it for the preserved-files receipt.
+  echo 'page_once() { printf "PAGE %s\n" "$2"; }'
+  echo 'FF_PRESERVE_DIR=""'
+  echo 'FF_PRESERVED_COUNT=0'
+  echo 'ATTEMPT_FF_REASON=""'
   awk '/^attempt_ff\(\) \{/,/^\}/' "$DISPATCH"
   awk '/^stale_check\(\) \{/,/^\}/' "$DISPATCH"
   echo 'stale_check && echo "VERDICT=RUN" || echo "VERDICT=REFUSE"'
@@ -104,7 +113,12 @@ git init -q --bare -b main "$ORIGIN"
 git init -q -b main "$WORK/seed"
 ( cd "$WORK/seed"
   git config user.email t@e.com; git config user.name t
-  echo one > f.txt; echo side > other.txt; git add -A; git commit -qm one
+  echo one > f.txt; echo side > other.txt
+  # Shipped from the seed, NOT committed locally in a clone: a local commit would
+  # make that clone AHEAD, and combined with an upstream commit it becomes DIVERGED,
+  # so case 15 would measure ff-refuses-on-divergence instead of the ignore path.
+  printf 'ignored-dir/\n' > .gitignore
+  git add -A; git commit -qm one
   git remote add origin "$ORIGIN"; git push -q origin main ) >/dev/null 2>&1
 
 # One commit onto origin/main. Every "behind" case calls this after cloning.
@@ -120,7 +134,10 @@ fresh_clone() {
 }
 head_of() { git -C "$1" rev-parse HEAD 2>/dev/null; }
 
-run_check() { ( cd "$1" && bash "$HARNESS" 2>&1 ); }
+# LOG is set even though say() is stubbed: attempt_ff derives the preserve dir from
+# $(dirname "$LOG"), so an unset LOG trips `set -u` inside the code under test.
+CHECKSTATE="$WORK/checkstate"; mkdir -p "$CHECKSTATE"
+run_check() { ( cd "$1" && LOG="$CHECKSTATE/dispatch.log" bash "$HARNESS" 2>&1 ); }
 
 echo "== 1. equal: HEAD == origin/main -> RUN =="
 C1="$(fresh_clone c-equal)"
@@ -386,6 +403,120 @@ echo "$OUT" | grep -q 'VERDICT=REFUSE' \
 echo "$OUT" | grep -q 'RELAUNCH' \
   && bad "THE DEFECT: it re-execed a second time in one launch" \
   || ok "no second re-exec"
+
+echo
+echo "== 15. BLOCKER: an IGNORED file where origin/main starts tracking the path =="
+# THE DATA-LOSS PATH, and the one measurement that reassured me hid it.
+# Measured 2026-08-02: git ABORTS for untracked-not-ignored (case 16 below) but
+# SILENTLY OVERWRITES an ignored file, exit 0, no warning. An untracked file has no
+# object in the database, so there is no reflog and nothing to recover.
+# `git ls-files --others --exclude-standard` -- the 5488 I quoted -- EXCLUDES
+# ignored files, so the number that made "let git arbitrate" look safe could not
+# see this class at all. The founder's checkout carries 3982 of them.
+C15="$(fresh_clone c-ignored)"
+mkdir -p "$C15/ignored-dir"
+echo "FOUNDER WORK - must survive" > "$C15/ignored-dir/notes.md"
+# Upstream starts tracking that exact path.
+( cd "$WORK/seed"; mkdir -p ignored-dir; echo "upstream version" > ignored-dir/notes.md
+  git add -f ignored-dir/notes.md; git commit -qm "upstream tracks it"; git push -q origin main ) >/dev/null 2>&1
+OUT="$(run_check "$C15")"
+# The ff SHOULD still apply -- refusing here would make the guard inert again.
+R15="$(git -C "$C15" rev-parse origin/main)"
+[ "$(head_of "$C15")" = "$R15" ] \
+  && ok "the fast-forward still applied (preserving must not make the heal inert)" \
+  || bad "preserving the file blocked the heal"
+# THE LOAD-BEARING ASSERTION: the founder's bytes still exist somewhere.
+PRESERVED="$(grep -rl "FOUNDER WORK - must survive" "$CHECKSTATE/ff-preserved" 2>/dev/null | head -1)"
+if [ -n "$PRESERVED" ]; then
+  ok "the ignored file's content was copied out before the merge ($PRESERVED)"
+else
+  bad "THE BLOCKER: the founder's ignored file was destroyed with no copy anywhere"
+fi
+echo "$OUT" | grep -q 'SAY self-heal:.*copied to' \
+  && ok "the preservation is logged with its restore path" \
+  || bad "files were moved out of the way with no log line saying where"
+echo "$OUT" | grep -q 'PAGE.*nothing was lost' \
+  && ok "the founder gets a receipt naming the restore path" \
+  || bad "no receipt: the founder never learns his ignored file was replaced"
+
+echo
+echo "== 16. an UNTRACKED (not ignored) collision must ABORT, never be forced =="
+# git's own refusal is correct here and must reach the founder as a refusal. If any
+# future edit adds -f, reset --hard, clean or a stash-then-drop, this goes red.
+C16="$(fresh_clone c-untracked-collide)"
+echo "FOUNDER WORK - untracked" > "$C16/newfile.md"
+( cd "$WORK/seed"; echo "upstream" > newfile.md; git add newfile.md
+  git commit -qm "upstream adds newfile"; git push -q origin main ) >/dev/null 2>&1
+B16="$(head_of "$C16")"
+OUT="$(run_check "$C16")"
+[ "$(head_of "$C16")" = "$B16" ] \
+  && ok "the tree was not moved when git refused" \
+  || bad "THE DEFECT: it forced past git's abort"
+grep -q "FOUNDER WORK - untracked" "$C16/newfile.md" \
+  && ok "the untracked file is untouched" \
+  || bad "THE BLOCKER: an untracked file was destroyed"
+echo "$OUT" | grep -q 'VERDICT=REFUSE' \
+  && ok "an abort is an honest refusal that pages" \
+  || bad "the abort was swallowed and it dispatched anyway"
+
+echo
+echo "== 17-19. the alert-state primitives (page_once / page_clear / checkout_lock) =="
+# A SECOND HARNESS, because these are top-level functions rather than parts of
+# stale_check. Same rule: the real functions are extracted, only the notifier is
+# stubbed.
+PH="$WORK/primitives.sh"
+{
+  echo 'set -uo pipefail'
+  echo 'say() { printf "SAY %s\n" "$*" >&2; }'
+  echo 'page_ok() { printf "PAGE %s\n" "$1"; [ "${KIPI_TEST_PAGE_FAILS:-0}" = "1" ] && return 1; return 0; }'
+  awk '/^page_clear\(\) \{/,/^\}/'  "$DISPATCH"
+  awk '/^page_once\(\) \{/,/^\}/'   "$DISPATCH"
+  awk '/^checkout_unlock\(\) /,/^$/' "$DISPATCH"
+  awk '/^checkout_lock\(\) \{/,/^\}/' "$DISPATCH"
+  echo 'PAGE_REPING_SECONDS="${KIPI_PAGE_REPING_SECONDS:-86400}"'
+  echo '"$@"'
+} > "$PH"
+for fn in page_clear page_once checkout_lock; do
+  grep -q "^$fn() {" "$PH" || { echo "primitive harness did not extract $fn"; exit 1; }
+done
+PSTATE="$WORK/pstate"; mkdir -p "$PSTATE"
+prim() { ( export LOG="$PSTATE/dispatch.log" CHECKOUT_LOCK="$PSTATE/co.lock"; bash "$PH" "$@" 2>&1 ); }
+
+echo "-- 17. a recovered alert that RECURS must page again (clear-on-recovery) --"
+N1="$(prim page_once k1 "boom" | grep -c '^PAGE ' || true)"
+N2="$(prim page_once k1 "boom" | grep -c '^PAGE ' || true)"   # unchanged -> suppressed
+prim page_clear k1 >/dev/null 2>&1                             # the fault recovers
+N3="$(prim page_once k1 "boom" | grep -c '^PAGE ' || true)"    # and recurs
+if [ "${N1:-0}" -eq 1 ] && [ "${N2:-0}" -eq 0 ] && [ "${N3:-0}" -eq 1 ]; then
+  ok "pages, suppresses the repeat, and pages again after recovery ($N1/$N2/$N3)"
+else
+  bad "THE DEFECT: recurrence after recovery was swallowed ($N1/$N2/$N3) -- a dedupe that can never re-fire"
+fi
+
+echo "-- 18. concurrent page_once must not duplicate the same alert --"
+PSTATE2="$WORK/pstate2"; mkdir -p "$PSTATE2"
+conc() { ( export LOG="$PSTATE2/dispatch.log" CHECKOUT_LOCK="$PSTATE2/co.lock"; bash "$PH" page_once k2 "same line" 2>/dev/null ); }
+conc > "$WORK/c1.out" & C1PID=$!
+conc > "$WORK/c2.out" & C2PID=$!
+wait $C1PID $C2PID 2>/dev/null
+TOTAL=$(( $(grep -c '^PAGE ' "$WORK/c1.out" || true) + $(grep -c '^PAGE ' "$WORK/c2.out" || true) ))
+[ "$TOTAL" -le 1 ] \
+  && ok "two dispatchers deciding the same key produced $TOTAL page(s), not 2" \
+  || bad "THE DEFECT: unlocked marker check let concurrent dispatchers send $TOTAL duplicate pages"
+
+echo "-- 19. the checkout lock is exclusive, and is released --"
+PSTATE3="$WORK/pstate3"; mkdir -p "$PSTATE3"
+lk() { ( export LOG="$PSTATE3/dispatch.log" CHECKOUT_LOCK="$PSTATE3/co.lock"; bash "$PH" "$@" >/dev/null 2>&1; echo $?; ) }
+# Taken in one process and released, a second take must succeed.
+A="$( ( export LOG="$PSTATE3/dispatch.log" CHECKOUT_LOCK="$PSTATE3/co.lock"; bash "$PH" checkout_lock >/dev/null 2>&1; echo $? ) )"
+B="$( ( export LOG="$PSTATE3/dispatch.log" CHECKOUT_LOCK="$PSTATE3/co.lock"; bash "$PH" checkout_lock >/dev/null 2>&1; echo $? ) )"
+[ "$A" = "0" ] && [ "$B" != "0" ] \
+  && ok "a held checkout lock blocks a second dispatcher (first=$A second=$B)" \
+  || bad "THE DEFECT: two dispatchers both took the checkout lock ($A/$B) -- both would merge the same tree"
+C="$( ( export LOG="$PSTATE3/dispatch.log" CHECKOUT_LOCK="$PSTATE3/co.lock"; bash "$PH" checkout_unlock >/dev/null 2>&1; bash "$PH" checkout_lock >/dev/null 2>&1; echo $? ) )"
+[ "$C" = "0" ] \
+  && ok "the lock is reacquirable after release (no permanent wedge)" \
+  || bad "THE DEFECT: the lock was never released, so the loop wedges forever"
 
 echo
 echo "-------- $PASS passed, $FAIL failed --------"

--- a/q-system/.q-system/scripts/test/test-dispatch-stale-checkout.sh
+++ b/q-system/.q-system/scripts/test/test-dispatch-stale-checkout.sh
@@ -2,10 +2,18 @@
 # Reproducer for sp-c775b116: the dispatcher ran the founder's working tree with
 # no freshness check, so a merge alone never reached the running loop.
 #
-# And for the 2026-08-02 follow-up: the freshness check WORKED and then asked a
-# human to type the fix. Measured from ~/.config/kipi/dispatch.log that night --
-# 19 refusing cycles, 9 Slack pages, the gap growing 7 -> 10 commits, zero
-# automated action. The founder fixed it by hand in the morning.
+# And for ASK-283 (2026-08-02): the freshness check WORKED and then asked a human
+# to type the fix. Measured from ~/.config/kipi/dispatch.log that night -- 19
+# refusing cycles, 9 Slack pages (per-sha dedupe already worked; it was the LOG
+# line that repeated every cycle, not the page), the gap growing 7 -> 10 commits,
+# zero automated action. The founder fixed it by hand in the morning.
+#
+# WHAT THIS DOES NOT FIX, kept here so nobody reads the green suite as "solved":
+# that night's early HEAD 97e7fc7 was DIVERGED from origin/main, so a fast-forward
+# could not have applied and it would still have paged. Only the later a5ac9c1 was
+# fast-forwardable. This heals the tail of that incident. The head needed a human
+# because the checkout was genuinely on the wrong history -- case 5 is that case,
+# and it still refuses on purpose.
 #
 # Pairs with: stale_check() + attempt_ff() in kipi-dispatch.sh.
 #

--- a/q-system/.q-system/scripts/test/test-dispatch-stale-checkout.sh
+++ b/q-system/.q-system/scripts/test/test-dispatch-stale-checkout.sh
@@ -2,10 +2,19 @@
 # Reproducer for sp-c775b116: the dispatcher ran the founder's working tree with
 # no freshness check, so a merge alone never reached the running loop.
 #
-# Pairs with: stale_check() in kipi-dispatch.sh.
+# And for the 2026-08-02 follow-up: the freshness check WORKED and then asked a
+# human to type the fix. Measured from ~/.config/kipi/dispatch.log that night --
+# 19 refusing cycles, 9 Slack pages, the gap growing 7 -> 10 commits, zero
+# automated action. The founder fixed it by hand in the morning.
 #
-# The four states that matter, and only ONE of them may refuse:
-#   behind  -> REFUSE (would build on superseded code and auto-merge it)
+# Pairs with: stale_check() + attempt_ff() in kipi-dispatch.sh.
+#
+# The states that matter, and only SOME of them may refuse:
+#   behind, clean, on main -> FAST-FORWARD, then RUN. No page. This is the fix.
+#   behind, but the tree belongs to somebody (other branch / detached / staged
+#           index / mid-merge) -> REFUSE + PAGE. Never move it under them.
+#   behind, and git itself says the ff would overwrite local edits -> REFUSE + PAGE
+#   diverged -> REFUSE + PAGE (ff cannot apply)
 #   ahead   -> RUN    (an agent commits locally before opening a PR)
 #   equal   -> RUN
 #   no answer (fetch fails / offline) -> RUN, because a network blip must not
@@ -14,13 +23,22 @@
 # The ahead and offline cases are the point. A check that refuses whenever HEAD
 # differs from origin/main passes a naive behind-test and wedges the loop on its
 # own unpushed work, which is a worse bug than the one being fixed.
+#
+# EVERY REFUSE CASE ASSERTS HEAD DID NOT MOVE, not just that the log said so. A
+# guard that logs "left untouched" while git quietly moved the tree is the exact
+# failure this file exists to catch, and log text cannot see it.
 set -uo pipefail
+
+# The founder was paged by tests three times on 2026-08-01. The harness below
+# stubs the notifier functions outright, so nothing here can reach Slack; this is
+# the second belt for anything that ever shells the real script.
+export KIPI_NOTIFY=/usr/bin/true
 
 HERE="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 # Derive the repo from the SCRIPT, never from $PWD -- a test that asks the
 # checkout it happens to run in proves nothing about the caller.
 REPO="$(cd "$HERE" && git rev-parse --show-toplevel)"
-DISPATCH="$REPO/kipi-dispatch.sh"
+DISPATCH="${KIPI_TEST_DISPATCH:-$REPO/kipi-dispatch.sh}"
 WORK="$(mktemp -d)"
 trap 'rm -rf "$WORK"' EXIT
 
@@ -35,14 +53,24 @@ if ! grep -q 'stale_check' "$DISPATCH"; then
   echo "-------- 0 passed, 1 failed --------"
   exit 1
 fi
+if ! grep -q 'attempt_ff' "$DISPATCH"; then
+  echo "  FAIL: THE DEFECT: stale_check has no attempt_ff, so it prints the remedy and waits for a human"
+  echo "-------- 0 passed, 1 failed --------"
+  exit 1
+fi
 
-# Extract stale_check and drive it directly. Running the whole dispatcher would
-# reach Linear and could dispatch REAL work -- never let a test touch a live
+# Extract the two functions and drive them directly. Running the whole dispatcher
+# would reach Linear and could dispatch REAL work -- never let a test touch a live
 # data path (fable-discipline lint blocks it, and this is why).
+#
+# attempt_ff is extracted REAL, not stubbed: it is the code under test. Only
+# relaunch_self is stubbed, because the shipped one execs and would replace this
+# test process. Same pattern the file already uses for say/page.
 HARNESS="$WORK/stale_check.sh"
 {
   echo 'set -uo pipefail'
   echo 'REPO="$PWD"'
+  echo 'SELF="/dev/null"'
   echo 'say()  { printf "SAY %s\n"  "$*"; }'
   echo 'page() { printf "PAGE %s\n" "$*"; }'
   # page_ok reports delivery, and its exit code is the thing under test in case 7:
@@ -50,49 +78,81 @@ HARNESS="$WORK/stale_check.sh"
   # be written. Without a failure knob the "failed page still dedupes" defect
   # cannot be reproduced at all.
   echo 'page_ok() { printf "PAGE %s\n" "$*"; [ "${KIPI_TEST_PAGE_FAILS:-0}" = "1" ] && return 1; return 0; }'
+  echo 'relaunch_self() { printf "RELAUNCH\n"; return 0; }'
+  awk '/^attempt_ff\(\) \{/,/^\}/' "$DISPATCH"
   awk '/^stale_check\(\) \{/,/^\}/' "$DISPATCH"
   echo 'stale_check && echo "VERDICT=RUN" || echo "VERDICT=REFUSE"'
 } > "$HARNESS"
 
+# Guard the extraction itself. An awk range that silently matched nothing would
+# make every case below "pass" against an empty function.
+for fn in attempt_ff stale_check; do
+  grep -q "^$fn() {" "$HARNESS" || { echo "harness did not extract $fn from $DISPATCH"; exit 1; }
+done
+
 # --- a real origin + clone, because stale_check asks git real questions ------
-ORIGIN="$WORK/origin.git"; CLONE="$WORK/clone"
+ORIGIN="$WORK/origin.git"
 git init -q --bare -b main "$ORIGIN"
 git init -q -b main "$WORK/seed"
 ( cd "$WORK/seed"
   git config user.email t@e.com; git config user.name t
-  echo one > f.txt; git add -A; git commit -qm one
+  echo one > f.txt; echo side > other.txt; git add -A; git commit -qm one
   git remote add origin "$ORIGIN"; git push -q origin main ) >/dev/null 2>&1
-git clone -q "$ORIGIN" "$CLONE" >/dev/null 2>&1
-( cd "$CLONE"; git config user.email t@e.com; git config user.name t )
+
+# One commit onto origin/main. Every "behind" case calls this after cloning.
+advance_origin() { ( cd "$WORK/seed"; echo "$1" >> f.txt; git commit -qam "$1"; git push -q origin main ) >/dev/null 2>&1; }
+
+# A FRESH CLONE PER CASE. Cases used to share one clone, which coupled them in
+# order and meant a failure early on cascaded into unrelated noise below.
+fresh_clone() {
+  local d="$WORK/$1"
+  git clone -q "$ORIGIN" "$d" >/dev/null 2>&1
+  ( cd "$d"; git config user.email t@e.com; git config user.name t )
+  echo "$d"
+}
+head_of() { git -C "$1" rev-parse HEAD 2>/dev/null; }
 
 run_check() { ( cd "$1" && bash "$HARNESS" 2>&1 ); }
 
 echo "== 1. equal: HEAD == origin/main -> RUN =="
-OUT="$(run_check "$CLONE")"
+C1="$(fresh_clone c-equal)"
+OUT="$(run_check "$C1")"
 echo "$OUT" | grep -q 'VERDICT=RUN' \
   && ok "an up-to-date checkout runs" \
   || bad "an up-to-date checkout was refused: $(echo "$OUT" | tr '\n' ' ')"
 
 echo
-echo "== 2. THE DEFECT: behind -> REFUSE and PAGE =="
-( cd "$WORK/seed"; echo two >> f.txt; git commit -qam two; git push -q origin main ) >/dev/null 2>&1
-OUT="$(run_check "$CLONE")"
-if echo "$OUT" | grep -q 'VERDICT=REFUSE'; then
-  ok "a checkout behind origin/main refuses to dispatch"
+echo "== 2. THE FIX: behind + clean + on main -> FAST-FORWARD, RUN, no page =="
+C2="$(fresh_clone c-behind)"
+BEFORE="$(head_of "$C2")"
+advance_origin two
+OUT="$(run_check "$C2")"
+AFTER="$(head_of "$C2")"
+REMOTE="$(git -C "$C2" rev-parse origin/main)"
+echo "$OUT" | grep -q 'VERDICT=RUN' \
+  && ok "a stale checkout now proceeds instead of resting" \
+  || bad "THE DEFECT: a stale checkout still refused instead of fixing itself"
+# The load-bearing assertion: real git state, not the log line.
+if [ "$AFTER" = "$REMOTE" ] && [ "$AFTER" != "$BEFORE" ]; then
+  ok "the checkout was actually fast-forwarded (${BEFORE:0:7} -> ${AFTER:0:7})"
 else
-  bad "THE DEFECT: a checkout 1 commit behind origin/main still dispatched"
+  bad "THE DEFECT: HEAD is still ${AFTER:0:7} (was ${BEFORE:0:7}, origin/main ${REMOTE:0:7}) -- it logged a fix it did not perform"
 fi
 echo "$OUT" | grep -q '^PAGE ' \
-  && ok "the refusal pages the founder" \
-  || bad "refused silently: an unattended refusal nobody is told about is a dead loop"
-echo "$OUT" | grep -q 'git merge --ff-only' \
-  && ok "the page carries the fix command" \
-  || bad "the page does not say what to do"
+  && bad "THE DEFECT: it paged the founder for something it fixed itself -- that is the alert-with-no-hands shape" \
+  || ok "no page: a fix that worked does not interrupt anyone"
+echo "$OUT" | grep -q 'SAY self-heal: fast-forwarded' \
+  && ok "the automated action is logged, so it is auditable after the fact" \
+  || bad "the tree moved with no log line, which is a silent write"
+echo "$OUT" | grep -q 'RELAUNCH' \
+  && ok "it re-execs on the new control code (bash reads scripts lazily; continuing in-process runs the old byte offsets)" \
+  || bad "no relaunch after the ff, so the rest of this run uses the superseded script text"
 
 echo
 echo "== 3. ahead: local commits not yet pushed -> RUN (must not wedge) =="
-( cd "$CLONE"; git merge -q --ff-only origin/main; echo three >> f.txt; git commit -qam three ) >/dev/null 2>&1
-OUT="$(run_check "$CLONE")"
+C3="$(fresh_clone c-ahead)"
+( cd "$C3"; echo three >> f.txt; git commit -qam three ) >/dev/null 2>&1
+OUT="$(run_check "$C3")"
 echo "$OUT" | grep -q 'VERDICT=RUN' \
   && ok "a checkout AHEAD of origin/main still runs" \
   || bad "being ahead was treated as stale, which wedges the loop on its own unpushed work"
@@ -116,22 +176,32 @@ echo "$OUT" | grep -q 'SAY stale-check' \
   || bad "the check failed with no log line, so the blind spot is invisible"
 
 echo
-echo "== 5. DIVERGED must REFUSE (codex round 2, major 1) =="
+echo "== 5. DIVERGED must still REFUSE, and the page must name the failed attempt =="
 # The case the first cut got wrong, and the one a merge of this very branch
 # produces: origin/main gains a commit while this tree keeps local commits of its
-# own. --is-ancestor is FALSE here, so an ancestry test runs on a checkout missing
-# origin/main's newest control code. This is the LIKELY divergence, not an edge.
-DIV="$WORK/diverged"
-git clone -q "$ORIGIN" "$DIV" >/dev/null 2>&1
-( cd "$DIV"; git config user.email t@e.com; git config user.name t
-  echo local-only >> f.txt; git commit -qam "local only" ) >/dev/null 2>&1
-( cd "$WORK/seed"; echo remote-only >> f.txt; git commit -qam "remote only"; git push -q origin main ) >/dev/null 2>&1
+# own. A fast-forward CANNOT apply here, so this is a genuine human case.
+DIV="$(fresh_clone c-diverged)"
+( cd "$DIV"; echo local-only >> f.txt; git commit -qam "local only" ) >/dev/null 2>&1
+advance_origin remote-only
+DIV_BEFORE="$(head_of "$DIV")"
 OUT="$(run_check "$DIV")"
 if echo "$OUT" | grep -q 'VERDICT=REFUSE'; then
   ok "a DIVERGED checkout refuses (origin/main holds commits it lacks)"
 else
   bad "THE DEFECT: a diverged checkout dispatched, so superseded control code runs after a concurrent merge"
 fi
+[ "$(head_of "$DIV")" = "$DIV_BEFORE" ] \
+  && ok "the diverged tree was not moved" \
+  || bad "THE DEFECT: it rewrote a diverged tree -- local commits are now on a different base"
+echo "$OUT" | grep -q '^PAGE ' \
+  && ok "the case that genuinely needs a human does page" \
+  || bad "refused silently: an unattended refusal nobody is told about is a dead loop"
+echo "$OUT" | grep -qi 'PAGE.*tried' \
+  && ok "the page says the fix was ATTEMPTED, not just that something is wrong" \
+  || bad "the page does not name the attempt, so the founder retypes a command that already failed"
+echo "$OUT" | grep -q 'PAGE.*did not apply' \
+  && ok "the page carries git's own reason for the failure" \
+  || bad "the page does not say WHY the automatic fix failed"
 
 echo
 echo "== 6. the page is deduped per remote sha (codex round 2, major 2) =="
@@ -149,7 +219,7 @@ else
   bad "THE DEFECT: paged $P1 then $P2 for the same remote sha -- 96 identical pages a day"
 fi
 # A NEW divergence must page again, or a second, different staleness goes unreported.
-( cd "$WORK/seed"; echo remote-two >> f.txt; git commit -qam "remote two"; git push -q origin main ) >/dev/null 2>&1
+advance_origin remote-two
 P3="$(run_dedupe "$DIV" | grep -c '^PAGE ' || true)"
 if [ "${P3:-0}" -ge 1 ]; then
   ok "a NEW origin/main sha pages again (dedupe is per-sha, not permanent)"
@@ -157,7 +227,13 @@ else
   bad "dedupe is permanent: a second, different divergence would never be reported"
 fi
 # The refusal itself must still be logged every time, even when the page is muted.
-echo "$(run_dedupe "$DIV")" | grep -q 'SAY REFUSING' \
+# CAPTURED FIRST, NOT PIPED. `run_dedupe | grep -q` fails here for a reason that has
+# nothing to do with the code under test: grep -q exits on the first match, the
+# subshell writing to the closed pipe takes SIGPIPE (141), and `set -o pipefail`
+# then reports 141 for the whole pipeline. The assertion inverts and blames the
+# dispatcher for a bug in the assertion. Caught by this line failing green code.
+DEDUPED_OUT="$(run_dedupe "$DIV")"
+echo "$DEDUPED_OUT" | grep -q 'SAY REFUSING' \
   && ok "the refusal is logged on every heartbeat even when the page is deduped" \
   || bad "a deduped page also silenced the log line, so the refusal is invisible"
 
@@ -187,6 +263,123 @@ echo "$LOGLINE" | grep -q 'did NOT go out' \
   || bad "an undelivered page is not logged, so the silence has no trace"
 
 echo
+echo "== 8. a NON-MAIN branch is never fast-forwarded (parallel-sessions scar) =="
+# Two sessions sharing one checkout yank each other's tree on a branch move. The
+# remedy the detector computed is for main; applying it to somebody's feature
+# branch is not that remedy.
+C8="$(fresh_clone c-branch)"
+( cd "$C8"; git checkout -qb sana/some-work ) >/dev/null 2>&1
+advance_origin branch-case
+B8="$(head_of "$C8")"
+OUT="$(run_check "$C8")"
+[ "$(head_of "$C8")" = "$B8" ] \
+  && ok "the feature branch was left where it was" \
+  || bad "THE DEFECT: it moved a non-main branch onto origin/main under a live session"
+echo "$OUT" | grep -q 'VERDICT=REFUSE' \
+  && ok "it refuses rather than dispatching on a stale feature branch" \
+  || bad "it dispatched from a stale non-main branch"
+echo "$OUT" | grep -q 'PAGE.*sana/some-work' \
+  && ok "the page names the branch it declined to touch" \
+  || bad "the page does not say which branch blocked the fix"
+
+echo
+echo "== 9. a DETACHED HEAD is never fast-forwarded =="
+C9="$(fresh_clone c-detached)"
+( cd "$C9"; git checkout -q --detach HEAD ) >/dev/null 2>&1
+advance_origin detached-case
+B9="$(head_of "$C9")"
+OUT="$(run_check "$C9")"
+[ "$(head_of "$C9")" = "$B9" ] \
+  && ok "the detached checkout was left where it was" \
+  || bad "THE DEFECT: it moved a detached HEAD"
+echo "$OUT" | grep -q 'PAGE.*detached HEAD' \
+  && ok "the page names the detached HEAD as the blocker" \
+  || bad "the page does not explain that a detached HEAD blocked the fix"
+
+echo
+echo "== 10. a STAGED index is never fast-forwarded (someone is composing a commit) =="
+C10="$(fresh_clone c-staged)"
+( cd "$C10"; echo staged >> other.txt; git add other.txt ) >/dev/null 2>&1
+advance_origin staged-case
+B10="$(head_of "$C10")"
+OUT="$(run_check "$C10")"
+[ "$(head_of "$C10")" = "$B10" ] \
+  && ok "the tree with a staged commit was left alone" \
+  || bad "THE DEFECT: it fast-forwarded over someone's staged hunks"
+echo "$OUT" | grep -q 'PAGE.*staged changes' \
+  && ok "the page names the staged index as the blocker" \
+  || bad "the page does not explain that a staged index blocked the fix"
+
+echo
+echo "== 11. a merge in progress is never fast-forwarded =="
+C11="$(fresh_clone c-midmerge)"
+# Fabricate the marker rather than orchestrating a real conflict: the guard reads
+# the marker, so the marker IS the condition under test.
+( cd "$C11"; git rev-parse HEAD > "$(git rev-parse --git-path MERGE_HEAD)" ) >/dev/null 2>&1
+advance_origin midmerge-case
+B11="$(head_of "$C11")"
+OUT="$(run_check "$C11")"
+[ "$(head_of "$C11")" = "$B11" ] \
+  && ok "the mid-merge tree was left alone" \
+  || bad "THE DEFECT: it moved HEAD out from under an in-progress merge"
+echo "$OUT" | grep -q 'PAGE.*in progress' \
+  && ok "the page names the in-progress operation" \
+  || bad "the page does not explain that a mid-merge tree blocked the fix"
+
+echo
+echo "== 12. git's own overwrite check is respected: a modified file the merge touches =="
+# The ff would clobber an uncommitted edit. git refuses; we must surface that
+# rather than force it.
+C12="$(fresh_clone c-conflict)"
+advance_origin conflict-case
+( cd "$C12"; echo "uncommitted local edit" >> f.txt ) >/dev/null 2>&1
+B12="$(head_of "$C12")"
+OUT="$(run_check "$C12")"
+[ "$(head_of "$C12")" = "$B12" ] \
+  && ok "the tree was not moved when the ff would overwrite a local edit" \
+  || bad "THE DEFECT: it discarded an uncommitted edit to fast-forward"
+grep -q "uncommitted local edit" "$C12/f.txt" \
+  && ok "the founder's uncommitted edit survived" \
+  || bad "THE DEFECT: the local edit is gone"
+echo "$OUT" | grep -q 'VERDICT=REFUSE' \
+  && ok "it refuses and hands this one to a human" \
+  || bad "it dispatched despite being stale and unable to heal"
+
+echo
+echo "== 13. NOT INERT ON A DIRTY TREE: unrelated modified files still heal =="
+# The founder's real checkout carries 3 modified tracked files and ~5.5k untracked
+# ones as its RESTING state. A blanket dirty-tree refusal would make this whole
+# feature never fire on the one checkout it exists for. So the arbiter is git's
+# per-file answer, not a whole-tree guess. This case is what keeps that honest.
+C13="$(fresh_clone c-dirty-unrelated)"
+advance_origin dirty-case
+( cd "$C13"; echo "unrelated founder edit" >> other.txt ) >/dev/null 2>&1
+mkdir -p "$C13/untracked-junk"; echo junk > "$C13/untracked-junk/x"
+OUT="$(run_check "$C13")"
+R13="$(git -C "$C13" rev-parse origin/main)"
+[ "$(head_of "$C13")" = "$R13" ] \
+  && ok "a tree dirty in UNRELATED files still fast-forwards (the feature is not inert in production)" \
+  || bad "THE DEFECT: dirty-but-unrelated blocked the fix, so this never fires on the founder's real checkout"
+grep -q "unrelated founder edit" "$C13/other.txt" \
+  && ok "the unrelated local edit was carried forward, not discarded" \
+  || bad "THE DEFECT: the ff discarded an unrelated local edit"
+echo "$OUT" | grep -q '^PAGE ' \
+  && bad "it paged for a case it healed" \
+  || ok "no page for a healed dirty tree"
+
+echo
+echo "== 14. one heal per launch: a re-exec that is STILL behind pages instead of spinning =="
+C14="$(fresh_clone c-respin)"
+advance_origin respin-case
+OUT="$( cd "$C14" && KIPI_DISPATCH_SELFHEALED=1 bash "$HARNESS" 2>&1 )"
+echo "$OUT" | grep -q 'VERDICT=REFUSE' \
+  && ok "a second staleness in the same launch refuses instead of re-execing again" \
+  || bad "THE DEFECT: it would exec itself repeatedly while origin/main keeps moving"
+echo "$OUT" | grep -q 'RELAUNCH' \
+  && bad "THE DEFECT: it re-execed a second time in one launch" \
+  || ok "no second re-exec"
+
+echo
 echo "-------- $PASS passed, $FAIL failed --------"
 [ "$FAIL" -eq 0 ] || exit 1
-echo "PASS: stale_check refuses whenever origin/main holds commits this tree lacks, and pages once per sha"
+echo "PASS: stale_check fixes what it can fast-forward, refuses and pages only what needs a human"


### PR DESCRIPTION
Closes ASK-283.

---

# Four findings bigger than the alert that got noticed

The audit found worse things than the one that woke anyone up. These are not audit rows, they are the headline.

### 1. Three alerts at 96 pages/day each, no dedupe at all
`kipi-dispatch.sh` A1 (repo not found, L65), A5 (`date` unusable, L433), A8 (Linear auth dead, L576). Each names a **permanent** condition. Each had **no marker whatsoever** on a 900s timer. If their conditions hold at once that is **~288 pages/day** between them. Worse than the stale-checkout alert that was actually complained about. **Fixed in this PR** via `page_once()`.

### 2. The launchd watchdog's dedupe is mathematically incapable of firing
`launchd-health-check.py:47` sets `FAIL_PING_TTL_SECONDS = 6 * 3600`. The installed job runs **09:30 and 21:30 — 12h apart**. The TTL can never suppress anything; a chronically failing job pages twice a day forever. Same class as a gate that can never fail. Measured against the installed plist, not read off the constant. `sp-f9bef8b1`.

### 3. An agent writes its own Slack text, unconditionally
`open-loops-heartbeat.sh:62`. The founder-facing line is composed by a headless `claude -p` agent at runtime from a prompt instruction ("Slack only on a meaningful change"). No deterministic firing condition, no dedupe, unbounded text. **Model output reaching the founder's phone with nothing in front of it.** Worst shape in the table. `sp-5de86e1b`.

### 4. A scheduled alert that cannot run
`voice-refresh-nudge.sh:13` pages unconditionally with no due-date check — and `com.kipi.voice-refresh` is **not installed**. Dead code presenting as coverage.

---

# What this PR does NOT fix

Stated plainly so a green suite is not read as "solved."

That night had **both** shapes:

| HEAD | Ancestor of `a4bbb07`? | This PR |
|---|---|---|
| `97e7fc7` (early cycles) | **No — diverged** | `--ff-only` fails → **still pages** |
| `a5ac9c1` (late cycles) | Yes | healed automatically |

**This heals the tail of that night, not the head.** The head needed a human because the checkout was genuinely on the wrong history. Case 5 in the suite is exactly that case and it refuses on purpose.

---

# Correction to the brief

The page was **not** firing every cycle. Per-sha dedupe already existed: **19 refusing cycles produced 9 Slack pages**, one per new `main` commit. It was the *log line* that repeated every cycle.

The complaint stands — 9 pages about one unchanged problem with zero action is still noise — but the mechanism was not what the brief said, and the real defect was **missing hands, not volume**.

---

# The fix

The detector computed the exact remedy, printed it, and waited. Measured from `~/.config/kipi/dispatch.log`, 2026-08-01: 19 refusing cycles, 9 pages, gap growing 7 → 10 commits, **0 automated actions**. Fixed by hand in the morning.

**The refusal is not weakened.** Nothing dispatches while behind. The fix is now attempted before anyone is interrupted.

### What `attempt_ff()` refuses to touch

| Condition | Why |
|---|---|
| non-main / detached HEAD | parallel-sessions scar — moving someone's branch is never the computed remedy |
| merge / rebase / cherry-pick / bisect in progress | in-flight state with no other copy |
| staged index | a commit someone is composing |
| ff would overwrite a modified file | git's own per-file check is the arbiter |

**Deliberate departure from "refuse on a dirty tree."** The real checkout carries **3 modified tracked files and 5488 untracked** as its *resting* state. A blanket dirty refusal makes this permanently inert on the one checkout it exists for — a guard that can never fire is worse than no guard, because it reads as protection. Case 13 keeps that honest.

### Re-exec, not fall-through
bash reads scripts lazily by byte offset. A fast-forward that rewrites `kipi-dispatch.sh` mid-run would resume at the old offset in the *new* bytes. `exec` restarts on the code just pulled. One heal per launch, so it cannot spin.

### Also built
`gh` is searched for in the usual install dirs before paging about it — launchd's minimal PATH is the whole failure and the search is deterministic.

---

# Verification

- **36 assertions, 0 failed** (up from 13). Every refuse case asserts **HEAD did not move**, not just that the log said so.
- **8 mutants, 8 killed, 0 survived.**
- The first mutant run produced **two false kills**: a `|`-delimited sed hit a `||` in the source, wrote garbage, and the suite's early guard reported a KILL for a mutation that never happened. The driver now validates a mutant applied — non-empty, parses, still defines both functions, actually differs — before trusting it.
- `KIPI_NOTIFY=/usr/bin/true` on every run. `fable-discipline-lint` clean on both files. Test already registered in `capability-manifest.json`.

7 spillover items open from the audit: `sp-8c95a719` `sp-204e0692` `sp-f9bef8b1` `sp-ba5567f2` `sp-2b245bfc` `sp-1f4571fc` `sp-5de86e1b`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01QsZcVy4GyFFqVtacBfWKEs