### PR TITLE
fix(ledger): the attempts lock proceeded on timeout and released by path (ASK-286)

### DIFF
--- a/q-system/.q-system/capability-manifest.json
+++ b/q-system/.q-system/capability-manifest.json
@@ -30,6 +30,10 @@
       "runner": "bash"
     },
     {
+      "path": "q-system/.q-system/scripts/test/test-claim-page-once-routing.sh",
+      "runner": "bash"
+    },
+    {
       "path": "q-system/.q-system/scripts/test/test-claude-write-path.sh",
       "runner": "bash"
     },

--- a/q-system/.q-system/capability-manifest.json
+++ b/q-system/.q-system/capability-manifest.json
@@ -18,6 +18,10 @@
       "runner": "bash"
     },
     {
+      "path": "q-system/.q-system/scripts/test/test-attempts-ledger.py",
+      "runner": "python3"
+    },
+    {
       "path": "q-system/.q-system/scripts/test/test-auto-update-nudge.sh",
       "runner": "bash"
     },

--- a/q-system/.q-system/scripts/attempts-ledger.py
+++ b/q-system/.q-system/scripts/attempts-ledger.py
@@ -17,37 +17,181 @@ bump_attempt is one of six, and the other five kept racing on the same file.
 Codex caught the claim. Hence ONE writer, here, rather than six copies of a lock
 -- six copies of a lock is just the original defect with more places to drift.
 
-CONCURRENCY. mkdir is the mutex because it is atomic on POSIX and needs no
-flock; macOS ships no flock, and this fleet runs on both kernels. The write is
-temp-then-os.replace so a crash mid-write cannot leave a truncated ledger, which
-would read as `{}` and silently reset every budget in the file.
+CONCURRENCY. No flock: macOS ships none and this fleet runs on both kernels, so
+the mutex is a file whose creation is O_EXCL. The write is temp-then-os.replace
+so a crash mid-write cannot leave a truncated ledger, which would read as `{}`
+and silently reset every budget in the file.
 
-A lock we cannot take within the timeout is TAKEN ANYWAY rather than skipping
-the mutation. A dropped bump is the defect this file exists to prevent, and a
-stale lock left by a killed worker is far likelier than a live worker holding it
-for ten seconds.
+THE LOCK WAS WORSE THAN NO LOCK (ASK-286, sp-626e9452, back-ported from the
+version PR #42 proved in converge.sh `receipt_transaction`). It used to PROCEED
+on timeout -- break out of the retry loop and enter the transaction holding
+nothing -- and its release removed the lock BY PATH. Together: a run that times
+out believes it is serialized, walks in, and on the way out deletes the live
+lock of the run that actually holds it. Both runs are then inside one
+read-decide-write, which is precisely what this file exists to stop.
+
+It also propagated. On 2026-08-02 an agent was told to reuse an in-repo lock
+rather than invent a fourth, copied THIS one including both defects, and cited
+the source as justification. Citing a pattern is not verifying it.
+
+FOUR INVARIANTS, all absent from the version this replaces:
+
+  1. A TIMEOUT RETURNS FAILURE. The caller does no work and says so. A skipped
+     increment is recoverable -- the next scheduled run retries, and the run
+     that DID hold the lock is counting. Two runs inside one read-decide-write
+     is not recoverable.
+  2. A RELEASE REMOVES ONLY A LOCK CARRYING THIS RUN'S OWN TOKEN, never one
+     identified by path alone.
+  3. THE LOCK IS CREATED ALREADY CARRYING ITS OWNER. The token is written into a
+     temp file first and `os.link` publishes it at the lock path atomically, so
+     the lock never exists un-attributable for even an instant. mkdir left that
+     window open, and a run killed inside it left a lock nothing could ever own.
+  4. STALE LOCKS BREAK ON OWNER LIVENESS, so refusing to force does not let a
+     corpse wedge every future write. A lock whose pid is gone is broken; so is
+     one that carries no attributable owner at all -- an empty file, or the
+     leftover DIRECTORY a pre-fix worker killed mid-transaction leaves behind,
+     since by invariant 3 this writer can never produce either.
+
+RESIDUAL, named rather than papered over: the token is re-read immediately
+before a break, but that is still a narrow TOCTOU window, and pid reuse can make
+a corpse look live. Both degrade in the SAFE direction -- either the write is
+skipped and says so, or a break happens that the re-read guard makes vanishingly
+unlikely. Neither can silently delete a live run's lock, which is the property
+that was actually broken.
 """
 import json
 import os
+import random
 import sys
 import tempfile
 import time
 
-LOCK_TRIES = 100
+# Overridable ONLY so the suite can assert the contended path without a 10s sleep
+# per case. Production never sets it, same posture as converge.sh's
+# KIPI_RECEIPT_LOCK_TRIES.
+LOCK_TRIES = int(os.environ.get("KIPI_ATTEMPTS_LOCK_TRIES") or 100)
 LOCK_SLEEP = 0.1
 
 
-def _mutate(path, fn):
-    """Take the lock, apply fn(d) -> bool(changed), write atomically."""
-    lock = path + ".lock"
+class LockUnavailable(Exception):
+    """The lock could not be taken. NEVER swallowed: the caller writes nothing."""
+
+
+def _new_token():
+    return "%d:%d:%d" % (os.getpid(), int(time.time()), random.randrange(1 << 30))
+
+
+def _read_lock(lock):
+    """The token a lock carries, or "" if it carries none (missing, empty, or a
+    stale directory from the pre-ASK-286 writer)."""
+    try:
+        with open(lock) as fh:
+            return fh.read().strip()
+    except OSError:
+        return ""
+
+
+def _publish_lock(lock, token):
+    """Create `lock` already carrying `token`, or raise FileExistsError.
+
+    os.link is the atomic publish: the content is complete in the temp file
+    before the name exists, so there is no instant at which the lock is present
+    without an owner. Raises OSError for an unwritable parent -- which is a
+    refusal to write, not a licence to proceed unlocked.
+    """
+    parent = os.path.dirname(lock) or "."
+    os.makedirs(parent, exist_ok=True)
+    fd, tmp = tempfile.mkstemp(dir=parent)
+    try:
+        with os.fdopen(fd, "w") as fh:
+            fh.write(token + "\n")
+        os.link(tmp, lock)
+    finally:
+        try:
+            os.unlink(tmp)
+        except OSError:
+            pass
+
+
+def _owner_is_alive(seen):
+    """True unless the lock names a pid that is provably gone.
+
+    A lock carrying no parseable pid is NOT alive: nothing can ever prove it
+    owns the lock, so honouring it means waiting forever.
+    """
+    pid = seen.split(":", 1)[0]
+    if not pid.isdigit() or int(pid) <= 0:
+        return False
+    try:
+        os.kill(int(pid), 0)
+    except ProcessLookupError:
+        return False
+    except OSError:
+        return True            # exists but not ours to signal
+    return True
+
+
+def _break_if_dead(lock):
+    """Remove a lock whose owner is gone. Leaves a live holder's lock alone."""
+    seen = _read_lock(lock)
+    if _owner_is_alive(seen):
+        return
+    # Re-read: a lock that changed hands between the liveness check and here
+    # belongs to someone else now and is not ours to break.
+    if _read_lock(lock) != seen:
+        return
+    try:
+        if os.path.isdir(lock):
+            os.rmdir(lock)
+        else:
+            os.unlink(lock)
+    except OSError:
+        return
+    sys.stderr.write(
+        "attempts-ledger: broke the lock at %s -- it was left by a run that is no "
+        "longer alive\n" % lock)
+
+
+def _take_lock(lock, token):
     for _ in range(LOCK_TRIES):
         try:
-            os.mkdir(lock)
-            break
+            _publish_lock(lock, token)
+            return True
         except FileExistsError:
-            time.sleep(LOCK_SLEEP)
-        except OSError:
-            break          # unwritable dir: proceed unlocked rather than lose the count
+            _break_if_dead(lock)
+        except OSError as exc:
+            raise LockUnavailable(
+                "the lock at %s cannot be created (%s)" % (lock, exc))
+        time.sleep(LOCK_SLEEP)
+    return False
+
+
+def _drop_lock(lock, token):
+    """Only ever removes a lock carrying this run's token. A release that trusts
+    the path deletes whichever run happens to hold it."""
+    if _read_lock(lock) != token:
+        sys.stderr.write(
+            "attempts-ledger: NOT releasing %s -- it no longer carries this run's "
+            "token, so it belongs to another run now\n" % lock)
+        return
+    try:
+        os.unlink(lock)
+    except OSError:
+        pass
+
+
+def _mutate(path, fn):
+    """Take the lock, apply fn(d) -> bool(changed), write atomically.
+
+    Raises LockUnavailable rather than proceeding: see invariant 1 above.
+    """
+    lock = path + ".lock"
+    token = _new_token()
+    if not _take_lock(lock, token):
+        raise LockUnavailable(
+            "another run still holds the lock at %s. NOT entering the transaction -- "
+            "a run that cannot take the lock writes nothing rather than racing the "
+            "run that can." % lock)
     try:
         try:
             with open(path) as fh:
@@ -73,10 +217,7 @@ def _mutate(path, fn):
             raise
         return True
     finally:
-        try:
-            os.rmdir(lock)
-        except Exception:
-            pass
+        _drop_lock(lock, token)
 
 
 def op_bump(d, issue, counter, ts_key, ts, why=None):
@@ -115,7 +256,19 @@ def main(argv):
         return 2
     path, op, rest = argv[1], argv[2], argv[3:]
     ts = time.strftime("%Y-%m-%dT%H:%M:%SZ", time.gmtime())
+    try:
+        return _run(path, op, rest, ts)
+    except LockUnavailable as exc:
+        # 3, deliberately not 1 and never 0. For claim-flag, 1 already means
+        # "already claimed, stay quiet" and 0 means "claimed, go page" -- a lock
+        # failure is neither. Nothing was claimed, so the next run can still
+        # claim it; answering 0 would page off a flag no file records, and
+        # answering 1 would retire a page that never fired.
+        sys.stderr.write("attempts-ledger: `%s` wrote nothing -- %s\n" % (op, exc))
+        return 3
 
+
+def _run(path, op, rest, ts):
     if op == "get":                       # get <issue> <key> [default]
         issue, key = rest[0], rest[1]
         default = rest[2] if len(rest) > 2 else "0"

--- a/q-system/.q-system/scripts/attempts-ledger.py
+++ b/q-system/.q-system/scripts/attempts-ledger.py
@@ -115,6 +115,7 @@ import os
 import sys
 import tempfile
 import time
+import traceback
 
 # TWO CAPS, whichever comes first. LOCK_TIMEOUT is what a caller actually cares
 # about -- "how long before this refuses" -- and it is measured, so it stays true
@@ -299,6 +300,26 @@ def main(argv):
         # answering 1 would retire a page that never fired.
         sys.stderr.write("attempts-ledger: `%s` wrote nothing -- %s\n" % (op, exc))
         return 3
+    except Exception:
+        # 2, and the catch-all is the point (codex round 2 on PR #67, minor 3).
+        # This block used to name only the two exceptions above, so an OSError
+        # from mkstemp / os.replace / json.dump on a full or read-only filesystem
+        # escaped as an uncaught exception -- and Python exits 1 on those. For
+        # claim-flag, 1 is the ONE code that means "already claimed on a prior
+        # run, stay quiet". So a write that failed hard read as a page already
+        # sent, for a flag no file records, which means no later run retires it
+        # either. That is the same silent drop findings 2 and 3 closed, arriving
+        # through the one door still left open.
+        #
+        # Enumerating OSError instead would leave the next unnamed exception on
+        # 1. The safe default for "something we did not anticipate" is the code
+        # that says NOTHING WAS WRITTEN, so the caller pages and says so.
+        # The traceback still goes to stderr, because a swallowed error here is
+        # how a real bug becomes a shrug.
+        traceback.print_exc()
+        sys.stderr.write(
+            "attempts-ledger: `%s` failed unexpectedly and wrote nothing (exit 2)\n" % op)
+        return 2
 
 
 def _args(op, rest, want):

--- a/q-system/.q-system/scripts/attempts-ledger.py
+++ b/q-system/.q-system/scripts/attempts-ledger.py
@@ -101,8 +101,27 @@ drops a page:
 
   0  the op succeeded. For claim-flag: claimed HERE, first time -- go page.
   1  claim-flag ONLY: already claimed on an earlier run -- stay quiet.
-  2  usage error: unknown op, or the wrong number of arguments. Nothing written.
-  3  the lock could not be taken. Nothing written, nothing claimed.
+  2  NOTHING WAS WRITTEN, and the cause is not contention. Two populations:
+     a usage error (unknown op, wrong arity), and -- since the round-3
+     catch-all in main() -- ANY unanticipated failure, e.g. an OSError from
+     mkstemp / os.replace / json.dump on a full or read-only filesystem.
+  3  NOTHING WAS WRITTEN because the lock could not be taken.
+
+READ 2 AS OPEN-ENDED, NOT AS "a typo in a call site" (codex round 4, minor).
+This line used to say only "usage error", which reads as a bounded, transient,
+fix-the-invocation class -- and linear-worker.sh's page_once cited that reading
+to justify paging anyway on 2 and 3, calling it "bounded". It is not bounded.
+A read-only filesystem exits 2 on every run forever, so the caller's page fired
+on every run forever, and at the stuck call site that page is a permanent Linear
+comment. The catch-all is still right (see main(): the safe default for the
+unanticipated is the code that says NOTHING WAS WRITTEN, never 1). What was
+wrong was a doc that undersold what it covers, so keep this description as wide
+as the except clause actually is.
+
+The difference callers act on is not 2-vs-3 but WHETHER A LATER RUN RECOVERS:
+3 leaves the flag unclaimed and the lock frees in milliseconds, so the next run
+claims and pages. 2 can persist indefinitely, so no later run claims or pages
+either.
 
 Arity is validated up front for exactly this reason: `claim-flag ASK-1` with the
 flag omitted used to raise IndexError and exit 1, and 1 is the one code that

--- a/q-system/.q-system/scripts/attempts-ledger.py
+++ b/q-system/.q-system/scripts/attempts-ledger.py
@@ -48,15 +48,28 @@ mechanism rather than the tuning:
      permanent, which is the failure class this ledger exists to kill. Every
      alternative is another heuristic with its own hole: an age cap breaks a slow
      holder and trusts the clock.
-  2. IT COST 22.1s TO REFUSE, against a 10s retry budget, because each of the 100
-     retries did a full mkstemp + write + link + unlink publish attempt.
-  3. RELEASE-BY-OWNER, ATOMIC PUBLISH, AND CORPSE-BREAKING ARE ~90 LINES OF
+  2. RELEASE-BY-OWNER, ATOMIC PUBLISH, AND CORPSE-BREAKING ARE ~90 LINES OF
      HEURISTIC standing in for something the kernel already guarantees.
 
-flock erases all three. The lock is the open file description, so the kernel
-releases it on close AND on process death: a dead holder blocks nothing, with no
-pid to guess at and no timer to trust. A contended retry is one non-blocking
-syscall, so the refusal costs its sleep budget and nothing more.
+flock erases both. The lock is the open file description, so the kernel releases
+it on close AND on process death: a dead holder blocks nothing, with no pid to
+guess at and no timer to trust.
+
+FINDING 4 IS A THIRD DEFECT AND IT IS NOT THE MECHANISM -- the retry budget was a
+COUNT PRETENDING TO BE A CLOCK. `LOCK_TRIES=100` x `LOCK_SLEEP=0.1` was
+documented as "the production 10s timeout" and measured 22.1s. The first guess,
+that the 100 mkstemp/link/unlink publish attempts were the overhead, was wrong:
+
+  $ python3 -c "import time; t=time.time()
+  > [time.sleep(0.1) for _ in range(100)]; print(time.time()-t)"
+  21.2
+
+`time.sleep(0.1)` costs 212ms on this kernel, so the sleeps alone were 21.2s of
+the 22.1. A count cannot express a duration on a kernel whose sleeps do not keep
+to their argument, and switching mechanism would not have changed that by one
+second. So the budget is a wall-clock DEADLINE now, and the number in the comment
+is enforced rather than asserted. LOCK_TRIES survives as a second cap, because
+the suite needs a way to make the contended path sub-second.
 
 THE INVARIANTS, and where each now lives:
 
@@ -103,10 +116,14 @@ import sys
 import tempfile
 import time
 
-# Overridable ONLY so the suite can assert the contended path without sleeping
-# out the full budget. Production never sets it, same posture as converge.sh's
+# TWO CAPS, whichever comes first. LOCK_TIMEOUT is what a caller actually cares
+# about -- "how long before this refuses" -- and it is measured, so it stays true
+# no matter what a sleep really costs. LOCK_TRIES only bounds the iteration count
+# so a wedged clock cannot spin; it is overridable ONLY so the suite can make the
+# contended path sub-second. Production sets neither, same posture as converge.sh's
 # KIPI_RECEIPT_LOCK_TRIES.
-LOCK_TRIES = int(os.environ.get("KIPI_ATTEMPTS_LOCK_TRIES") or 100)
+LOCK_TIMEOUT = float(os.environ.get("KIPI_ATTEMPTS_LOCK_TIMEOUT") or 10.0)
+LOCK_TRIES = int(os.environ.get("KIPI_ATTEMPTS_LOCK_TRIES") or 1000)
 LOCK_SLEEP = 0.1
 
 
@@ -141,7 +158,10 @@ def _take_lock(lock):
     """
     parent = os.path.dirname(lock) or "."
     os.makedirs(parent, exist_ok=True)
+    deadline = time.monotonic() + LOCK_TIMEOUT
     for attempt in range(LOCK_TRIES):
+        if attempt and time.monotonic() >= deadline:
+            return None
         # A DIRECTORY here is what the original `os.mkdir` lock leaves when its
         # run is killed. It cannot be opened, so the first instance to take this
         # upgrade with one on disk would never count an attempt again. It also

--- a/q-system/.q-system/scripts/attempts-ledger.py
+++ b/q-system/.q-system/scripts/attempts-ledger.py
@@ -17,57 +17,94 @@ bump_attempt is one of six, and the other five kept racing on the same file.
 Codex caught the claim. Hence ONE writer, here, rather than six copies of a lock
 -- six copies of a lock is just the original defect with more places to drift.
 
-CONCURRENCY. No flock: macOS ships none and this fleet runs on both kernels, so
-the mutex is a file whose creation is O_EXCL. The write is temp-then-os.replace
-so a crash mid-write cannot leave a truncated ledger, which would read as `{}`
-and silently reset every budget in the file.
+THE LOCK WAS WORSE THAN NO LOCK (ASK-286, sp-626e9452). It used to PROCEED on
+timeout -- break out of the retry loop and enter the transaction holding nothing
+-- and its release removed the lock BY PATH. Together: a run that times out
+believes it is serialized, walks in, and on the way out deletes the live lock of
+the run that actually holds it. Both runs are then inside one read-decide-write,
+which is precisely what this file exists to stop. It also propagated: on
+2026-08-02 an agent was told to reuse an in-repo lock rather than invent a
+fourth, copied THIS one including both defects, and cited the source as
+justification. Citing a pattern is not verifying it.
 
-THE LOCK WAS WORSE THAN NO LOCK (ASK-286, sp-626e9452, back-ported from the
-version PR #42 proved in converge.sh `receipt_transaction`). It used to PROCEED
-on timeout -- break out of the retry loop and enter the transaction holding
-nothing -- and its release removed the lock BY PATH. Together: a run that times
-out believes it is serialized, walks in, and on the way out deletes the live
-lock of the run that actually holds it. Both runs are then inside one
-read-decide-write, which is precisely what this file exists to stop.
+WHY fcntl.flock AND NOT A TOKEN FILE (codex round 1 on PR #67, findings 1 + 3).
+The first fix here back-ported converge.sh `receipt_transaction`: a token written
+into a file, published with os.link, released only if it still carried this run's
+token, and broken when the pid it named was not running. That is the right shape
+FOR BASH, where converge.sh lives -- macOS ships no flock(1) BINARY, so a shell
+script genuinely has to hand-roll one. It is the wrong shape here, and the
+docstring that justified it with a flat "macOS ships no flock" was simply false:
+this is Python, `fcntl.flock` works on both kernels this fleet runs on, and
+`session_recall.py` was already using it a few files away.
 
-It also propagated. On 2026-08-02 an agent was told to reuse an in-repo lock
-rather than invent a fourth, copied THIS one including both defects, and cited
-the source as justification. Citing a pattern is not verifying it.
+Keeping the hand-rolled version cost three separate defects, all of them the
+mechanism rather than the tuning:
 
-FOUR INVARIANTS, all absent from the version this replaces:
+  1. LIVENESS BY PID ANSWERS THE WRONG QUESTION. It asks "is some process with
+     this number running", not "is that process holding this lock". Pids wrap, so
+     a leftover lock eventually names a pid an unrelated live process now has --
+     and is then honoured forever. The attempts counter freezes, no issue reaches
+     MAX_ATTEMPTS, no issue reaches STUCK, and no human is paged. Silent and
+     permanent, which is the failure class this ledger exists to kill. Every
+     alternative is another heuristic with its own hole: an age cap breaks a slow
+     holder and trusts the clock.
+  2. IT COST 22.1s TO REFUSE, against a 10s retry budget, because each of the 100
+     retries did a full mkstemp + write + link + unlink publish attempt.
+  3. RELEASE-BY-OWNER, ATOMIC PUBLISH, AND CORPSE-BREAKING ARE ~90 LINES OF
+     HEURISTIC standing in for something the kernel already guarantees.
 
-  1. A TIMEOUT RETURNS FAILURE. The caller does no work and says so. A skipped
-     increment is recoverable -- the next scheduled run retries, and the run
-     that DID hold the lock is counting. Two runs inside one read-decide-write
-     is not recoverable.
-  2. A RELEASE REMOVES ONLY A LOCK CARRYING THIS RUN'S OWN TOKEN, never one
-     identified by path alone.
-  3. THE LOCK IS CREATED ALREADY CARRYING ITS OWNER. The token is written into a
-     temp file first and `os.link` publishes it at the lock path atomically, so
-     the lock never exists un-attributable for even an instant. mkdir left that
-     window open, and a run killed inside it left a lock nothing could ever own.
-  4. STALE LOCKS BREAK ON OWNER LIVENESS, so refusing to force does not let a
-     corpse wedge every future write. A lock whose pid is gone is broken; so is
-     one that carries no attributable owner at all -- an empty file, or the
-     leftover DIRECTORY a pre-fix worker killed mid-transaction leaves behind,
-     since by invariant 3 this writer can never produce either.
+flock erases all three. The lock is the open file description, so the kernel
+releases it on close AND on process death: a dead holder blocks nothing, with no
+pid to guess at and no timer to trust. A contended retry is one non-blocking
+syscall, so the refusal costs its sleep budget and nothing more.
 
-RESIDUAL, named rather than papered over: the token is re-read immediately
-before a break, but that is still a narrow TOCTOU window, and pid reuse can make
-a corpse look live. Both degrade in the SAFE direction -- either the write is
-skipped and says so, or a break happens that the re-read guard makes vanishingly
-unlikely. Neither can silently delete a live run's lock, which is the property
-that was actually broken.
+THE INVARIANTS, and where each now lives:
+
+  1. A TIMEOUT RETURNS FAILURE -- still enforced here, in `_mutate`. The caller
+     does no work and says so. A skipped increment is recoverable: the next
+     scheduled run retries, and the run that DID hold the lock is counting. Two
+     runs inside one read-decide-write is not recoverable.
+  2. A RELEASE ONLY EVER DROPS THIS RUN'S OWN HOLD -- the kernel's, by
+     construction. There is no path to release someone else's.
+  3. THE LOCK NEVER EXISTS UN-ATTRIBUTABLE -- the kernel's. The lock IS the open
+     file description; an empty or leftover lock FILE holds nothing.
+  4. A DEAD OWNER NEVER WEDGES A WRITE -- the kernel's. No corpse can exist.
+
+THE ONE WAY A FILE LOCK CAN STILL BE DEFEATED is two runs holding locks on two
+different inodes at the same path, which is why this file NEVER UNLINKS THE LOCK.
+A leftover zero-byte `.lock` is inert -- it carries no state, and the next run
+locks the same inode. A pre-ASK-286 worker still breaks locks by unlinking, so
+during a fleet rollout one can replace the file this run is holding; `_take_lock`
+therefore re-checks that the inode it locked is still the inode at the path, and
+retries on the live one if not.
+
+CONCURRENCY, the other half. The write is temp-then-os.replace so a crash
+mid-write cannot leave a truncated ledger, which would read as `{}` and silently
+reset every budget in the file.
+
+EXIT CODES, one meaning each (codex round 1 on PR #67, finding 2). Six call sites
+in linear-worker.sh route on these, so an exit that means two things silently
+drops a page:
+
+  0  the op succeeded. For claim-flag: claimed HERE, first time -- go page.
+  1  claim-flag ONLY: already claimed on an earlier run -- stay quiet.
+  2  usage error: unknown op, or the wrong number of arguments. Nothing written.
+  3  the lock could not be taken. Nothing written, nothing claimed.
+
+Arity is validated up front for exactly this reason: `claim-flag ASK-1` with the
+flag omitted used to raise IndexError and exit 1, and 1 is the one code that
+tells the caller to stay quiet. A crash that reads as "already paged" is the
+silent stall wearing the mechanism built to prevent it.
 """
+import fcntl
 import json
 import os
-import random
 import sys
 import tempfile
 import time
 
-# Overridable ONLY so the suite can assert the contended path without a 10s sleep
-# per case. Production never sets it, same posture as converge.sh's
+# Overridable ONLY so the suite can assert the contended path without sleeping
+# out the full budget. Production never sets it, same posture as converge.sh's
 # KIPI_RECEIPT_LOCK_TRIES.
 LOCK_TRIES = int(os.environ.get("KIPI_ATTEMPTS_LOCK_TRIES") or 100)
 LOCK_SLEEP = 0.1
@@ -77,105 +114,76 @@ class LockUnavailable(Exception):
     """The lock could not be taken. NEVER swallowed: the caller writes nothing."""
 
 
-def _new_token():
-    return "%d:%d:%d" % (os.getpid(), int(time.time()), random.randrange(1 << 30))
+class Usage(Exception):
+    """Wrong op or wrong arity. Exits 2, never 1: see the exit-code table above."""
 
 
-def _read_lock(lock):
-    """The token a lock carries, or "" if it carries none (missing, empty, or a
-    stale directory from the pre-ASK-286 writer)."""
+def _same_file(fh, lock):
+    """True when the handle we locked is still the file at `lock`.
+
+    Holding a lock on an inode that has been unlinked out from under us means
+    holding nothing anyone else can see -- the exact two-inodes-one-path race
+    that makes a file lock useless.
+    """
     try:
-        with open(lock) as fh:
-            return fh.read().strip()
+        live = os.stat(lock)
     except OSError:
-        return ""
+        return False
+    held = os.fstat(fh.fileno())
+    return (live.st_ino, live.st_dev) == (held.st_ino, held.st_dev)
 
 
-def _publish_lock(lock, token):
-    """Create `lock` already carrying `token`, or raise FileExistsError.
+def _take_lock(lock):
+    """Return an open handle holding an exclusive flock, or None if it timed out.
 
-    os.link is the atomic publish: the content is complete in the temp file
-    before the name exists, so there is no instant at which the lock is present
-    without an owner. Raises OSError for an unwritable parent -- which is a
-    refusal to write, not a licence to proceed unlocked.
+    Opened "a": never truncates, so a concurrent holder's file is untouched, and
+    creates the file when it is absent.
     """
     parent = os.path.dirname(lock) or "."
     os.makedirs(parent, exist_ok=True)
-    fd, tmp = tempfile.mkstemp(dir=parent)
-    try:
-        with os.fdopen(fd, "w") as fh:
-            fh.write(token + "\n")
-        os.link(tmp, lock)
-    finally:
-        try:
-            os.unlink(tmp)
-        except OSError:
-            pass
-
-
-def _owner_is_alive(seen):
-    """True unless the lock names a pid that is provably gone.
-
-    A lock carrying no parseable pid is NOT alive: nothing can ever prove it
-    owns the lock, so honouring it means waiting forever.
-    """
-    pid = seen.split(":", 1)[0]
-    if not pid.isdigit() or int(pid) <= 0:
-        return False
-    try:
-        os.kill(int(pid), 0)
-    except ProcessLookupError:
-        return False
-    except OSError:
-        return True            # exists but not ours to signal
-    return True
-
-
-def _break_if_dead(lock):
-    """Remove a lock whose owner is gone. Leaves a live holder's lock alone."""
-    seen = _read_lock(lock)
-    if _owner_is_alive(seen):
-        return
-    # Re-read: a lock that changed hands between the liveness check and here
-    # belongs to someone else now and is not ours to break.
-    if _read_lock(lock) != seen:
-        return
-    try:
+    for attempt in range(LOCK_TRIES):
+        # A DIRECTORY here is what the original `os.mkdir` lock leaves when its
+        # run is killed. It cannot be opened, so the first instance to take this
+        # upgrade with one on disk would never count an attempt again. It also
+        # cannot be held by anything: no flock lives on it, and the writer that
+        # made it released by path, so it was never a reliable claim to begin
+        # with. Clearing it is the only outcome that is not a permanent wedge.
         if os.path.isdir(lock):
-            os.rmdir(lock)
-        else:
-            os.unlink(lock)
-    except OSError:
-        return
-    sys.stderr.write(
-        "attempts-ledger: broke the lock at %s -- it was left by a run that is no "
-        "longer alive\n" % lock)
-
-
-def _take_lock(lock, token):
-    for _ in range(LOCK_TRIES):
+            try:
+                os.rmdir(lock)
+                sys.stderr.write(
+                    "attempts-ledger: cleared the leftover pre-flock lock DIRECTORY at %s\n"
+                    % lock)
+            except OSError:
+                pass
         try:
-            _publish_lock(lock, token)
-            return True
-        except FileExistsError:
-            _break_if_dead(lock)
+            fh = open(lock, "a")
         except OSError as exc:
             raise LockUnavailable(
-                "the lock at %s cannot be created (%s)" % (lock, exc))
-        time.sleep(LOCK_SLEEP)
-    return False
+                "the lock at %s cannot be opened (%s)" % (lock, exc))
+        try:
+            fcntl.flock(fh.fileno(), fcntl.LOCK_EX | fcntl.LOCK_NB)
+        except OSError:
+            fh.close()
+            time.sleep(LOCK_SLEEP)
+            continue
+        if _same_file(fh, lock):
+            return fh
+        # Someone replaced the path while we were taking it. What we hold is an
+        # orphan inode nobody else will ever contend on, so it guards nothing.
+        fh.close()
+        if attempt + 1 < LOCK_TRIES:
+            time.sleep(LOCK_SLEEP)
+    return None
 
 
-def _drop_lock(lock, token):
-    """Only ever removes a lock carrying this run's token. A release that trusts
-    the path deletes whichever run happens to hold it."""
-    if _read_lock(lock) != token:
-        sys.stderr.write(
-            "attempts-ledger: NOT releasing %s -- it no longer carries this run's "
-            "token, so it belongs to another run now\n" % lock)
-        return
+def _drop_lock(fh):
+    """Close the handle. The kernel drops the flock with it -- and would drop it
+    anyway if this process died, which is what makes a corpse lock impossible.
+    The lock FILE is deliberately left in place: unlinking it is what lets two
+    runs end up holding two different inodes at one path."""
     try:
-        os.unlink(lock)
+        fh.close()
     except OSError:
         pass
 
@@ -186,16 +194,16 @@ def _mutate(path, fn):
     Raises LockUnavailable rather than proceeding: see invariant 1 above.
     """
     lock = path + ".lock"
-    token = _new_token()
-    if not _take_lock(lock, token):
+    fh = _take_lock(lock)
+    if fh is None:
         raise LockUnavailable(
             "another run still holds the lock at %s. NOT entering the transaction -- "
             "a run that cannot take the lock writes nothing rather than racing the "
             "run that can." % lock)
     try:
         try:
-            with open(path) as fh:
-                d = json.load(fh)
+            with open(path) as fp:
+                d = json.load(fp)
         except Exception:
             d = {}
         if not isinstance(d, dict):
@@ -206,8 +214,8 @@ def _mutate(path, fn):
         os.makedirs(parent, exist_ok=True)
         fd, tmp = tempfile.mkstemp(dir=parent)
         try:
-            with os.fdopen(fd, "w") as fh:
-                json.dump(d, fh, indent=2)
+            with os.fdopen(fd, "w") as fp:
+                json.dump(d, fp, indent=2)
             os.replace(tmp, path)
         except Exception:
             try:
@@ -217,7 +225,7 @@ def _mutate(path, fn):
             raise
         return True
     finally:
-        _drop_lock(lock, token)
+        _drop_lock(fh)
 
 
 def op_bump(d, issue, counter, ts_key, ts, why=None):
@@ -258,6 +266,11 @@ def main(argv):
     ts = time.strftime("%Y-%m-%dT%H:%M:%SZ", time.gmtime())
     try:
         return _run(path, op, rest, ts)
+    except Usage as exc:
+        # 2, never 1. For claim-flag, 1 means "already claimed, stay quiet", so a
+        # bad invocation answering 1 would suppress a page nothing recorded.
+        sys.stderr.write("attempts-ledger: %s\n" % exc)
+        return 2
     except LockUnavailable as exc:
         # 3, deliberately not 1 and never 0. For claim-flag, 1 already means
         # "already claimed, stay quiet" and 0 means "claimed, go page" -- a lock
@@ -268,8 +281,20 @@ def main(argv):
         return 3
 
 
+def _args(op, rest, want):
+    """Exactly `want` arguments, or exit 2. An IndexError here would exit 1, and
+    1 is the code that tells six call sites to stay quiet."""
+    if len(rest) != want:
+        raise Usage(
+            "`%s` takes %d argument(s), got %d (%r). Nothing was written."
+            % (op, want, len(rest), rest))
+    return rest
+
+
 def _run(path, op, rest, ts):
     if op == "get":                       # get <issue> <key> [default]
+        if len(rest) not in (2, 3):
+            raise Usage("`get` takes <issue> <key> [default], got %r" % (rest,))
         issue, key = rest[0], rest[1]
         default = rest[2] if len(rest) > 2 else "0"
         try:
@@ -281,16 +306,20 @@ def _run(path, op, rest, ts):
         return 0
 
     if op == "bump-attempt":              # bump-attempt <issue> <why>
-        _mutate(path, lambda d: op_bump(d, rest[0], "count", "last", ts, rest[1]))
+        issue, why = _args(op, rest, 2)
+        _mutate(path, lambda d: op_bump(d, issue, "count", "last", ts, why))
         return 0
     if op == "bump-conflict":             # bump-conflict <issue>
-        _mutate(path, lambda d: op_bump(d, rest[0], "conflict_rounds", "last_conflict", ts))
+        (issue,) = _args(op, rest, 1)
+        _mutate(path, lambda d: op_bump(d, issue, "conflict_rounds", "last_conflict", ts))
         return 0
     if op == "bump-drift":                # bump-drift <issue>
-        _mutate(path, lambda d: op_bump(d, rest[0], "drift_rounds", "last_drift", ts))
+        (issue,) = _args(op, rest, 1)
+        _mutate(path, lambda d: op_bump(d, issue, "drift_rounds", "last_drift", ts))
         return 0
     if op == "clear-conflict":            # clear-conflict <issue>
-        _mutate(path, lambda d: op_clear(d, rest[0], ("conflict_rounds", "conflict_paged", "last_conflict")))
+        (issue,) = _args(op, rest, 1)
+        _mutate(path, lambda d: op_clear(d, issue, ("conflict_rounds", "conflict_paged", "last_conflict")))
         return 0
     if op == "clear-automerge":           # clear-automerge <issue>
         # The op my previous edit claimed to add and did not. The shell side was
@@ -300,14 +329,17 @@ def _run(path, op, rest, ts):
         # could never be cleared, so a PR that was armed, unarmed, then armed again
         # went PERMANENTLY SILENT. Caught by test-severity-floor, not by me: I had
         # verified the caller and the write count, never the round trip.
+        (issue,) = _args(op, rest, 1)
         _mutate(path, lambda d: op_clear(
-            d, rest[0], ("automerge_unarmed_paged", "automerge_unknown_paged")))
+            d, issue, ("automerge_unarmed_paged", "automerge_unknown_paged")))
         return 0
     if op == "clear-drift":               # clear-drift <issue>
-        _mutate(path, lambda d: op_clear(d, rest[0], ("drift_rounds", "drift_paged", "last_drift")))
+        (issue,) = _args(op, rest, 1)
+        _mutate(path, lambda d: op_clear(d, issue, ("drift_rounds", "drift_paged", "last_drift")))
         return 0
-    if op == "claim-flag":                # claim-flag <issue> <flag> -> exit 0 first time, 1 after
-        claimed = _mutate(path, lambda d: op_claim(d, rest[0], rest[1]))
+    if op == "claim-flag":                # claim-flag <issue> <flag> -> 0 first time, 1 after
+        issue, flag = _args(op, rest, 2)
+        claimed = _mutate(path, lambda d: op_claim(d, issue, flag))
         return 0 if claimed else 1
 
     print("unknown op: %s" % op, file=sys.stderr)

--- a/q-system/.q-system/scripts/linear-worker.sh
+++ b/q-system/.q-system/scripts/linear-worker.sh
@@ -477,15 +477,20 @@ print(d.get(sys.argv[1],{}).get('count',0))" "$1"; }
 # the no-PR bump added tonight would have been the sixth. Fixing the shared helper
 # fixes all of them at once, which is why it belongs here and not at a call site.
 #
-# mkdir is the lock because it is atomic on POSIX and needs no flock -- macOS
+# The lock is an O_EXCL file created already carrying its owner's token -- macOS
 # ships no flock, so the portable primitive is the only one that works on both
 # kernels this fleet runs on. Write-temp-then-rename makes the replacement atomic
 # too, so a crash mid-write cannot leave a truncated ledger.
 #
-# A lock we cannot take within the timeout does NOT silently skip the bump: the
-# whole point is that attempts are counted, and a dropped bump is the defect. It
-# takes the lock by force after the timeout, on the reasoning that a stale lock
-# from a killed worker is far likelier than a live worker holding it for 10s.
+# A LOCK IT CANNOT TAKE MEANS IT WRITES NOTHING AND EXITS 3 (ASK-286). This
+# paragraph used to say the opposite -- that the timeout took the lock BY FORCE
+# rather than drop a bump -- and that reasoning was wrong in a way that made the
+# lock worse than none: the forced run entered the transaction holding nothing
+# and its release then deleted the live holder's lock, so both runs sat inside
+# one read-decide-write. A skipped bump is recoverable (the next scheduled run
+# retries, and the run that DID hold the lock is counting); two writers in one
+# transaction is not. None of the callers below run under `set -e`, so a 3 is a
+# reported miss on stderr, not a dead worker.
 bump_attempt() { python3 "$LEDGER" "$ATTEMPTS" bump-attempt "$1" "$2"; }
 
 # --- conflict-round ledger (ASK-212) ----------------------------------------

--- a/q-system/.q-system/scripts/linear-worker.sh
+++ b/q-system/.q-system/scripts/linear-worker.sh
@@ -477,10 +477,20 @@ print(d.get(sys.argv[1],{}).get('count',0))" "$1"; }
 # the no-PR bump added tonight would have been the sixth. Fixing the shared helper
 # fixes all of them at once, which is why it belongs here and not at a call site.
 #
-# The lock is an O_EXCL file created already carrying its owner's token -- macOS
-# ships no flock, so the portable primitive is the only one that works on both
-# kernels this fleet runs on. Write-temp-then-rename makes the replacement atomic
-# too, so a crash mid-write cannot leave a truncated ledger.
+# The lock is `fcntl.flock` on the ledger's own lock file. This paragraph used to
+# describe an O_EXCL file carrying its owner's token, justified by "macOS ships no
+# flock" -- and that justification was simply false (attempts-ledger.py:60 retracts
+# it in this same PR; the claim is true of the flock(1) BINARY, which is why
+# converge.sh, being bash, does have to hand-roll one). The hand-rolled version had
+# to guess whether a leftover lock's owner was alive, and pids wrap, so a corpse
+# lock eventually named a live process that never held it and froze the counter
+# forever. The kernel drops an flock on close AND on process death, so there is no
+# liveness to guess at. Write-temp-then-rename makes the replacement atomic too, so
+# a crash mid-write cannot leave a truncated ledger.
+#
+# KEEP THIS PARAGRAPH TRUE. It is the one a future agent cites when it is told to
+# reuse an in-repo lock rather than invent another -- which already happened once,
+# on 2026-08-02, and propagated both defects of the version it cited.
 #
 # A LOCK IT CANNOT TAKE MEANS IT WRITES NOTHING AND EXITS 3 (ASK-286). This
 # paragraph used to say the opposite -- that the timeout took the lock BY FORCE
@@ -490,7 +500,10 @@ print(d.get(sys.argv[1],{}).get('count',0))" "$1"; }
 # one read-decide-write. A skipped bump is recoverable (the next scheduled run
 # retries, and the run that DID hold the lock is counting); two writers in one
 # transaction is not. None of the callers below run under `set -e`, so a 3 is a
-# reported miss on stderr, not a dead worker.
+# reported miss on stderr, not a dead worker -- and that sentence is only true
+# because nothing in this script turns errexit on behind them. `page_once` did
+# exactly that for one commit (codex round 2), which is why it now reads its exit
+# code through a `||` list instead of bracketing the call in `set +e`/`set -e`.
 bump_attempt() { python3 "$LEDGER" "$ATTEMPTS" bump-attempt "$1" "$2"; }
 
 # --- conflict-round ledger (ASK-212) ----------------------------------------
@@ -566,12 +579,27 @@ claim_page_once() { python3 "$LEDGER" "$ATTEMPTS" claim-flag "$1" "$2"; }
 # still true and still unpaged; a duplicate page is noise, a suppressed page is a
 # stall nobody sees. It is also bounded: contention lasts a retry budget, and the
 # first run that gets the lock claims the flag, after which every run is quiet.
+#
+# IT CAPTURES THE CODE WITHOUT TOUCHING THE SHELL'S FLAGS (codex round 2, major).
+# This body used to read `set +e; claim_page_once ...; rc=$?; set -e`, and that
+# trailing `set -e` does not RESTORE errexit -- it ENABLES it. This script runs
+# `set -uo pipefail` (line 47) and has never had `-e`, so the first page in a run
+# re-flagged everything after it: the queue drain is a pipeline into `while read`,
+# and the next benign non-zero killed it mid-drain while the worker still printed
+# "run complete" and exited 0 -- which this file's own header tells callers to
+# treat as healthy. A partial drain reported healthy is the silent stall this
+# worker exists to kill, which is the second time that class has been re-created
+# inside the mechanism built to kill it (finding 2 was the first).
+#
+# `|| rc=$?` rather than a bare call: inside a `||` list errexit is suspended, so
+# this reads the code correctly whether or not a future caller has `-e`, and it
+# still leaves the caller's flags exactly as it found them. Case 5 of
+# test-claim-page-once-routing.sh asserts `$-` is unchanged across the call, from
+# a fork running THIS script's flags -- the suite itself runs `set -euo pipefail`,
+# so in-process the leak is invisible.
 page_once() {
-  local rc
-  set +e
-  claim_page_once "$1" "$2"
-  rc=$?
-  set -e
+  local rc=0
+  claim_page_once "$1" "$2" || rc=$?
   case "$rc" in
     0) return 0 ;;
     1) return 1 ;;

--- a/q-system/.q-system/scripts/linear-worker.sh
+++ b/q-system/.q-system/scripts/linear-worker.sh
@@ -547,6 +547,39 @@ clear_drift_rounds() { python3 "$LEDGER" "$ATTEMPTS" clear-drift "$1"; }
 # mechanism instead of each stuck-state inventing its own convention.
 claim_page_once() { python3 "$LEDGER" "$ATTEMPTS" claim-flag "$1" "$2"; }
 
+# page_once <issue> <flag>: TRUE when this caller should page. Every once-only
+# page routes through here rather than through `if claim_page_once`, because
+# bash `if` only asks "was the exit 0" and the ledger answers three things
+# (ASK-286, codex round 1 on PR #67, finding 2):
+#
+#   0  claimed here, first time         -> page
+#   1  already claimed on a prior run   -> quiet
+#   2  usage error, nothing written     -> page, and say so
+#   3  lock contended, nothing written  -> page, and say so
+#
+# The bare `if` collapsed 2 and 3 into the same branch as 1, so a page was
+# dropped for a state NO FILE RECORDS -- which means no later run retires it
+# either. It is simply gone. That is the silent stall this worker exists to kill,
+# re-created inside the mechanism built to kill it.
+#
+# Paging is the safe direction on 2 and 3. Nothing was claimed, so the state is
+# still true and still unpaged; a duplicate page is noise, a suppressed page is a
+# stall nobody sees. It is also bounded: contention lasts a retry budget, and the
+# first run that gets the lock claims the flag, after which every run is quiet.
+page_once() {
+  local rc
+  set +e
+  claim_page_once "$1" "$2"
+  rc=$?
+  set -e
+  case "$rc" in
+    0) return 0 ;;
+    1) return 1 ;;
+    *) say "WARN: the attempts ledger did not record the $2 flag for $1 (exit $rc) -- paging anyway, because a page nothing recorded is a page no later run will send"
+       return 0 ;;
+  esac
+}
+
 # Pops the two auto-merge page flags the moment the PR is SEEN armed. Same scar
 # clear_conflict_rounds and clear_drift_rounds both carry (PR #25 finding 3): a
 # once-only page with no clear is a page that fires once in an issue's LIFE, so
@@ -630,7 +663,7 @@ arm_automerge() {
       # fine. It pages anyway: this is the branch where the PR may really be
       # unarmed, and quieting it would re-create the stall one layer down.
       say "WARN: could not arm auto-merge on PR #$pr for $ISSUE and could not read its state either -- gh answered neither. If it sits green: gh pr merge --auto --squash $pr"
-      if claim_page_once "$ISSUE" automerge_unknown_paged; then
+      if page_once "$ISSUE" automerge_unknown_paged; then
         bash "$NOTIFY" "worker: $ISSUE PR #$pr -- gh could neither arm auto-merge nor read its state, so whether this PR merges itself is unknown. Needs a human to check: gh pr merge --auto --squash $pr" 2>/dev/null || true
       fi
     else
@@ -644,7 +677,7 @@ arm_automerge() {
       # (everything green, nothing merges, no signal), so a log-only warning does
       # not kill the silent stall, it relocates it.
       say "WARN: could not arm auto-merge on PR #$pr for $ISSUE -- it will sit green and unmerged until someone runs: gh pr merge --auto --squash $pr"
-      if claim_page_once "$ISSUE" automerge_unarmed_paged; then
+      if page_once "$ISSUE" automerge_unarmed_paged; then
         bash "$NOTIFY" "worker: $ISSUE PR #$pr is NOT armed -- it goes green and sits there forever. Needs a human: gh pr merge --auto --squash $pr" 2>/dev/null || true
       fi
     fi
@@ -760,7 +793,7 @@ while IFS= read -r ISSUE; do
       STUCK_WHY="the worker recorded no reason, which means it never diagnosed why this fails"
     fi
     say "skip $ISSUE: $N/$MAX_ATTEMPTS attempts. TERMINAL. Last reason: $STUCK_WHY"
-    if claim_page_once "$ISSUE" stuck_paged; then
+    if page_once "$ISSUE" stuck_paged; then
       python3 "$SYNC" progress "$ISSUE" \
         "**Stuck after $N/$MAX_ATTEMPTS attempts. The autonomous loop has stopped picking this up.**
 
@@ -907,7 +940,7 @@ A DoR that cannot be met from the environment the worker actually runs in is a d
       DR="$(drift_rounds_for "$ISSUE")"
       if [ "$DR" -ge "$MAX_DRIFT_ROUNDS" ]; then
         say "skip $ISSUE: PR #$EXISTING_PR is '$PR_VERDICT' recorded at $REVIEWED_SHA but the head is $CURRENT_SHA, still never reviewed after $DR/$MAX_DRIFT_ROUNDS drift round(s) -- a human resolves this one."
-        if claim_page_once "$ISSUE" drift_paged; then
+        if page_once "$ISSUE" drift_paged; then
           bash "$NOTIFY" "worker: $ISSUE PR #$EXISTING_PR is approved at $REVIEWED_SHA but its head $CURRENT_SHA is still unreviewed after $MAX_DRIFT_ROUNDS re-review round(s) - unreviewed code sits at the head, needs a human" 2>/dev/null || true
         fi
         continue
@@ -929,7 +962,7 @@ A DoR that cannot be met from the environment the worker actually runs in is a d
       CR="$(conflict_rounds_for "$ISSUE")"
       if [ "$CR" -ge "$MAX_CONFLICT_ROUNDS" ]; then
         say "skip $ISSUE: PR #$EXISTING_PR is '$PR_VERDICT' but $MERGE_STATE after $CR/$MAX_CONFLICT_ROUNDS conflict round(s) -- a human resolves this one."
-        if claim_page_once "$ISSUE" conflict_paged; then
+        if page_once "$ISSUE" conflict_paged; then
           bash "$NOTIFY" "worker: $ISSUE PR #$EXISTING_PR is approved but still $MERGE_STATE after $MAX_CONFLICT_ROUNDS rebase round(s) - needs a human" 2>/dev/null || true
         fi
         continue
@@ -1062,7 +1095,7 @@ A DoR that cannot be met from the environment the worker actually runs in is a d
   if [ -n "$EXISTING_PR" ] && ! tree_holds_pr_head "$TREE" "$BRANCH"; then
     if ! position_tree_on_pr_head "$TREE" "$BRANCH"; then
       say "skip $ISSUE: $TREE is missing PR #$EXISTING_PR's commits and cannot be moved onto them -- $POSITION_REFUSAL. Refusing a round that would force-push over the PR. A human resolves this one: $TREE"
-      if claim_page_once "$ISSUE" tree_paged; then
+      if page_once "$ISSUE" tree_paged; then
         bash "$NOTIFY" "worker: $ISSUE worktree does not hold PR #$EXISTING_PR's commits and has local work - $TREE needs a human" 2>/dev/null || true
       fi
       # Release before skipping: a claim held by a run that did nothing wedges

--- a/q-system/.q-system/scripts/linear-worker.sh
+++ b/q-system/.q-system/scripts/linear-worker.sh
@@ -567,18 +567,42 @@ claim_page_once() { python3 "$LEDGER" "$ATTEMPTS" claim-flag "$1" "$2"; }
 #
 #   0  claimed here, first time         -> page
 #   1  already claimed on a prior run   -> quiet
-#   2  usage error, nothing written     -> page, and say so
-#   3  lock contended, nothing written  -> page, and say so
+#   2  nothing written (usage error, or any unexpected failure)  -> ledger fault
+#   3  nothing written (lock contended)                          -> ledger fault
 #
 # The bare `if` collapsed 2 and 3 into the same branch as 1, so a page was
 # dropped for a state NO FILE RECORDS -- which means no later run retires it
 # either. It is simply gone. That is the silent stall this worker exists to kill,
 # re-created inside the mechanism built to kill it.
 #
-# Paging is the safe direction on 2 and 3. Nothing was claimed, so the state is
-# still true and still unpaged; a duplicate page is noise, a suppressed page is a
-# stall nobody sees. It is also bounded: contention lasts a retry budget, and the
-# first run that gets the lock claims the flag, after which every run is quiet.
+# WHAT 2 AND 3 MUST NOT DO IS RUN THE CALLER'S PAGE (codex round 4, major). They
+# used to `return 0`, and `return 0` here means the CALLER writes its artifact --
+# which at the stuck site is a permanent Linear comment. The dedup for that
+# comment is the ledger flag. So on exactly the two codes that mean THE LEDGER
+# DID NOT ANSWER, the worker drove a non-idempotent permanent write with its
+# dedup switched off:
+#
+#   exit 3, contention: run A pages, run B takes the lock and pages   = 2 comments
+#   exit 2, unwritable: nothing is ever claimed, so EVERY run posts, forever
+#
+# Observed pre-fix at 5 comments over 5 cycles and 4 comments for a 4-issue queue
+# in ONE run (cases 7-9). "Bounded by the retry budget" was true of contention and
+# false of exit 2, and the old comment above generalised from the bounded one.
+# Repeating "still stuck" every 15 minutes forever is the cry-wolf failure the
+# stuck site's own comment (line 814) says the once-only flag exists to prevent.
+#
+# So the two codes route to `ledger_fault` instead: return 1 (caller writes
+# nothing) and raise the alarm through the EPHEMERAL channel, ONCE PER RUN.
+# Nothing is dropped silently -- what changes is which channel hears it and what
+# it is about. The fault is the LEDGER, not the issue, so the alert names the
+# ledger; a Slack line is idempotent by nature where a Linear comment is not.
+#
+# The two codes differ in whether a later run recovers, and that difference is in
+# the message, not the routing:
+#   exit 3  the flag is still UNCLAIMED, so the next cycle claims it and pages.
+#           Contention defers a page by one heartbeat; it does not drop it.
+#   exit 2  no later run will claim it either, so no later run pages. That is a
+#           real drop, and it is why the fault alert has to exist at all.
 #
 # IT CAPTURES THE CODE WITHOUT TOUCHING THE SHELL'S FLAGS (codex round 2, major).
 # This body used to read `set +e; claim_page_once ...; rc=$?; set -e`, and that
@@ -597,14 +621,33 @@ claim_page_once() { python3 "$LEDGER" "$ATTEMPTS" claim-flag "$1" "$2"; }
 # test-claim-page-once-routing.sh asserts `$-` is unchanged across the call, from
 # a fork running THIS script's flags -- the suite itself runs `set -euo pipefail`,
 # so in-process the leak is invisible.
+# ONE ALERT PER RUN, not one per issue. A broken ledger is a property of the
+# WORKER, so a 40-issue queue must not send 40 alerts -- that is the same
+# cry-wolf failure in the channel we just moved the notice into. Every issue that
+# hits it still lands in the run log via `say`; the Slack line fires on the first
+# one and names it as an example. Run-scoped state, so the next worker run (a
+# fresh process, 15 minutes later) alerts again while the fault is still real.
+LEDGER_FAULT_ALERTED=0
+ledger_fault() {
+  local issue="$1" flag="$2" rc="$3" detail
+  case "$rc" in
+    3) detail="the lock was contended, so nothing was written. The flag is still UNCLAIMED and the next run will claim it and page -- this defers a page by one cycle, it does not drop it." ;;
+    *) detail="the ledger wrote nothing (exit $rc). No later run will claim this flag either, so no later run will page: this state is dropped until the ledger is writable." ;;
+  esac
+  say "WARN: the attempts ledger did not record the $flag flag for $issue (exit $rc) -- $detail"
+  [ "$LEDGER_FAULT_ALERTED" -eq 0 ] || return 0
+  LEDGER_FAULT_ALERTED=1
+  bash "$NOTIFY" "kipi worker: the attempts ledger at $ATTEMPTS is not answering (exit $rc, first seen on $issue/$flag). Once-only pages cannot be de-duplicated while this holds, so the worker is staying quiet on them rather than re-posting. Do: check the ledger file is writable." 2>/dev/null || true
+}
+
 page_once() {
   local rc=0
   claim_page_once "$1" "$2" || rc=$?
   case "$rc" in
     0) return 0 ;;
     1) return 1 ;;
-    *) say "WARN: the attempts ledger did not record the $2 flag for $1 (exit $rc) -- paging anyway, because a page nothing recorded is a page no later run will send"
-       return 0 ;;
+    *) ledger_fault "$1" "$2" "$rc"
+       return 1 ;;
   esac
 }
 

--- a/q-system/.q-system/scripts/test/test-attempts-ledger.py
+++ b/q-system/.q-system/scripts/test/test-attempts-ledger.py
@@ -54,6 +54,7 @@ import os
 import subprocess
 import sys
 import tempfile
+import time
 from pathlib import Path
 
 ROOT = Path(__file__).resolve().parents[4]
@@ -84,12 +85,13 @@ def load_module():
 def run(path: str, *args: str, tries: str = "3") -> subprocess.CompletedProcess:
     """One CLI invocation. `tries` keeps a contended case sub-second.
 
-    Production leaves KIPI_ATTEMPTS_LOCK_TRIES unset (100 tries x 0.1s), same
-    posture as converge.sh's KIPI_RECEIPT_LOCK_TRIES. Measured 2026-08-02: a
-    blocked mutation refuses in ~10s under flock. It cost 22.1s under the
-    hand-rolled lock, because each retry did a full mkstemp/write/link/unlink
-    publish attempt on top of its sleep -- a contended retry is now one
-    non-blocking syscall, so the wall clock is the sleep budget and nothing more.
+    Production leaves both KIPI_ATTEMPTS_LOCK_* unset, same posture as
+    converge.sh's KIPI_RECEIPT_LOCK_TRIES. This comment used to claim a
+    "production 10s timeout" while a blocked mutation really took 22.1s
+    (measured 2026-08-02, codex round 1 on PR #67, finding 4). The budget was a
+    COUNT -- 100 tries x 0.1s -- and `time.sleep(0.1)` costs 212ms on this
+    kernel, so the sleeps alone were 21.2s of it. It is a wall-clock deadline
+    now, so the documented number is the measured one. Verified below.
     """
     env = dict(os.environ)
     env["KIPI_ATTEMPTS_LOCK_TRIES"] = tries
@@ -352,26 +354,46 @@ def case_lock_taken_is_the_lock_at_the_path(tmp: str) -> None:
     mod = load_module()
     lock = os.path.join(tmp, "attempts-replaced.json.lock")
 
-    # Stand in for the old worker: unlink the name and put a different inode
-    # there, the way a release-by-path break does.
-    os.close(os.open(lock, os.O_CREAT | os.O_WRONLY, 0o644))
-    original_ino = os.stat(lock).st_ino
-    os.unlink(lock)
-    os.close(os.open(lock, os.O_CREAT | os.O_WRONLY, 0o644))
-    if os.stat(lock).st_ino == original_ino:
-        fail("the fixture could not produce a second inode at the lock path")
+    # The replacement has to happen DURING acquisition, in the window between
+    # opening the file and deciding we hold it. Replacing it beforehand proves
+    # nothing -- the open lands on the live inode and an implementation with NO
+    # guard at all looks correct, which is exactly how this case first shipped
+    # decorative (its mutant survived).
+    #
+    # `mod.open` shadows the builtin inside that module, so this wraps the exact
+    # call `_take_lock` makes: once, then it gets out of the way.
+    real_open = open
+    state = {"swapped": False}
 
-    fh = mod._take_lock(lock)
+    def open_then_replace(path, *a, **kw):
+        fh = real_open(path, *a, **kw)
+        if path == lock and not state["swapped"]:
+            state["swapped"] = True
+            orphan = os.fstat(fh.fileno()).st_ino
+            os.unlink(lock)                                   # what an old worker does
+            os.close(os.open(lock, os.O_CREAT | os.O_WRONLY, 0o644))
+            if os.stat(lock).st_ino == orphan:
+                fail("the fixture could not produce a second inode at the lock path")
+        return fh
+
+    mod.open = open_then_replace
+    try:
+        fh = mod._take_lock(lock)
+    finally:
+        del mod.open
     if fh is None:
         fail("the lock at a replaced path could not be taken at all")
     try:
+        if not state["swapped"]:
+            fail("the fixture never fired, so this case asserted nothing")
         if os.fstat(fh.fileno()).st_ino != os.stat(lock).st_ino:
-            fail("THE DEFECT: the handle holds an inode that is no longer the file at the lock "
-                 "path. Nobody else will ever contend on it, so the next run takes the live "
-                 "inode and both are inside the transaction at once")
+            fail("THE DEFECT: the handle holds an inode that was unlinked out from under it "
+                 "while the lock was being taken. Nobody will ever contend on that orphan, so "
+                 "the next run locks the live inode and both are inside the transaction at "
+                 "once -- two locks at one path is how a file lock is beaten")
     finally:
         mod._drop_lock(fh)
-    ok("the handle returned holds the inode that is live at the lock path")
+    ok("a lock file replaced mid-acquire is re-taken on the live inode, not held as an orphan")
 
 
 # --- 10. THE ORDINARY PATH STILL WORKS ---------------------------------------
@@ -442,6 +464,44 @@ def case_usage_errors_exit_two(tmp: str) -> None:
     ok("a bad invocation exits 2 and writes nothing, never 1")
 
 
+# --- 12. THE DOCUMENTED TIMEOUT IS THE MEASURED ONE --------------------------
+# Codex round 1 on PR #67, finding 4. The old budget was a COUNT that everything
+# described as a duration, and the two differed by 2.2x. A number in a comment
+# that nothing checks drifts from the code the moment either changes; this asserts
+# the refusal actually lands inside the budget it advertises.
+def case_timeout_is_the_documented_budget(tmp: str) -> None:
+    path = os.path.join(tmp, "attempts-budget.json")
+    with open(path, "w") as fh:
+        json.dump({}, fh)
+
+    budget = 2.0
+    env = dict(os.environ)
+    env["KIPI_ATTEMPTS_LOCK_TIMEOUT"] = str(budget)
+    env.pop("KIPI_ATTEMPTS_LOCK_TRIES", None)
+
+    with lock_held_by_live_process(path + ".lock"):
+        started = time.monotonic()
+        proc = subprocess.run(
+            [sys.executable, str(LEDGER), path, "bump-attempt", "ASK-12", "why"],
+            capture_output=True, text=True, env=env,
+        )
+        elapsed = time.monotonic() - started
+
+    if proc.returncode != 3:
+        fail(f"the contended bump exited {proc.returncode}, wanted 3: stderr={proc.stderr!r}")
+    if elapsed < budget:
+        fail(f"the refusal came back in {elapsed:.1f}s, inside its own {budget}s budget -- it "
+             "gave up early, so a holder that was about to finish is not waited out")
+    # Generous headroom: one sleep of slop plus interpreter startup. The defect
+    # this catches is a budget that is off by a MULTIPLE, which is what a count
+    # standing in for a clock produces.
+    if elapsed > budget * 2:
+        fail(f"THE DEFECT: the documented {budget}s budget took {elapsed:.1f}s. A retry budget "
+             "expressed as a count is not a duration -- time.sleep(0.1) costs 212ms on this "
+             "kernel, so 100 tries advertised as 10s really took 22.1s")
+    ok(f"a contended refusal lands inside the budget it documents ({elapsed:.1f}s of {budget}s)")
+
+
 def main() -> int:
     print("test-attempts-ledger: the lock around the attempts counter (ASK-286)")
     with tempfile.TemporaryDirectory() as tmp:
@@ -456,6 +516,7 @@ def main() -> int:
         case_lock_taken_is_the_lock_at_the_path(tmp)
         case_ops_round_trip(tmp)
         case_usage_errors_exit_two(tmp)
+        case_timeout_is_the_documented_budget(tmp)
     print(f"PASS ({PASSED} cases)")
     return 0
 

--- a/q-system/.q-system/scripts/test/test-attempts-ledger.py
+++ b/q-system/.q-system/scripts/test/test-attempts-ledger.py
@@ -1,0 +1,284 @@
+#!/usr/bin/env python3
+"""Reproducer + acceptance criterion for the attempts-ledger lock (ASK-286).
+
+WHY THIS SUITE EXISTS
+---------------------
+`attempts-ledger.py` `_mutate` shipped a lock with two defects: it PROCEEDED on
+timeout (returned success while holding nothing) and its release removed the
+lock BY PATH (whichever run happened to hold it). Together they are worse than
+no lock: a run that times out believes it is serialized, enters the critical
+section, and its release then deletes the live lock of the run that actually
+holds it -- so both runs are inside one read-decide-write.
+
+The ledger guards the attempts counter. A lost increment means an issue exceeds
+MAX_ATTEMPTS and keeps being dispatched, burning budget on work that already
+failed three times and never reaching the STUCK state where a human is told.
+That failure is silent and self-perpetuating.
+
+THE TRAP THIS SUITE IS BUILT AROUND (learned on PR #42)
+-------------------------------------------------------
+The release is only reached AFTER a successful acquisition, so once the timeout
+stops lying there is no ORDINARY path into it holding someone else's lock. A
+mutant that reverts the release to an unconditional unlink therefore passes an
+entire suite that never makes the lock change hands mid-transaction. Case 3
+exists for exactly that: it stamps a foreign token over the lock from INSIDE the
+critical section, which is the only shape that can fail a release-by-path.
+
+ISOLATION: every case runs in its own tempdir against its own ledger file. This
+suite never touches the live linear-worker-attempts.json.
+"""
+
+from __future__ import annotations
+
+import importlib.util
+import json
+import os
+import subprocess
+import sys
+import tempfile
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[4]
+LEDGER = ROOT / "q-system/.q-system/scripts/attempts-ledger.py"
+
+PASSED = 0
+
+
+def ok(msg: str) -> None:
+    global PASSED
+    PASSED += 1
+    print(f"  ok: {msg}")
+
+
+def fail(msg: str) -> None:
+    print(f"FAIL: {msg}", file=sys.stderr)
+    sys.exit(1)
+
+
+def load_module():
+    """Import attempts-ledger.py by path -- its name is not an identifier."""
+    spec = importlib.util.spec_from_file_location("attempts_ledger", LEDGER)
+    mod = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(mod)
+    return mod
+
+
+def run(path: str, *args: str, tries: str = "3") -> subprocess.CompletedProcess:
+    """One CLI invocation. `tries` keeps a contended case sub-second instead of
+    sleeping out the production 10s timeout -- same posture as converge.sh's
+    KIPI_RECEIPT_LOCK_TRIES, which production never sets."""
+    env = dict(os.environ)
+    env["KIPI_ATTEMPTS_LOCK_TRIES"] = tries
+    return subprocess.run(
+        [sys.executable, str(LEDGER), path, *args],
+        capture_output=True, text=True, env=env,
+    )
+
+
+def read_ledger(path: str) -> dict:
+    try:
+        with open(path) as fh:
+            return json.load(fh)
+    except Exception:
+        return {}
+
+
+def read_lock(lock: str) -> str:
+    try:
+        with open(lock) as fh:
+            return fh.read().strip()
+    except Exception:
+        return ""
+
+
+# --- 1. A TIMEOUT MUST NOT PROCEED -------------------------------------------
+# The lock is held by a LIVE pid (this test process, which is by definition
+# running), so the only correct outcome is to write nothing and say so. The old
+# code broke out of the retry loop and entered the transaction holding nothing.
+def case_timeout_does_not_proceed(tmp: str) -> None:
+    path = os.path.join(tmp, "attempts-timeout.json")
+    with open(path, "w") as fh:
+        json.dump({"ASK-1": {"count": 1}}, fh)
+    lock = path + ".lock"
+    held = "%d:0:0" % os.getpid()
+    with open(lock, "w") as fh:
+        fh.write(held + "\n")
+
+    proc = run(path, "bump-attempt", "ASK-1", "because")
+
+    if proc.returncode == 0:
+        fail("THE DEFECT: the lock is held by a LIVE pid and bump-attempt reported success. "
+             "A run that cannot take the lock must do no work and say so -- entering the "
+             f"transaction here is two runs inside one read-decide-write. stdout={proc.stdout!r} "
+             f"stderr={proc.stderr!r}")
+    got = read_ledger(path).get("ASK-1", {}).get("count")
+    if got != 1:
+        fail("THE DEFECT: bump-attempt could not take the lock and mutated the ledger anyway "
+             f"(count went 1 -> {got})")
+    if read_lock(lock) != held:
+        fail("THE DEFECT: the run that could not take the lock removed or overwrote the live "
+             f"holder's lock. It now reads {read_lock(lock)!r}, not {held!r}")
+    if "lock" not in (proc.stderr or "").lower():
+        fail("the bump was skipped for lock contention and nothing said so, so a dropped "
+             f"increment is invisible: stderr={proc.stderr!r}")
+    ok("a timeout writes nothing, says so, and leaves the live holder's lock alone")
+
+
+# --- 2. THE SAME, FOR THE ONCE-ONLY PAGE FLAG --------------------------------
+# claim-flag's exit code IS the decision ("page or stay quiet"), so a lock
+# failure must not land on 0. Exit 0 here would fire a page for a flag that was
+# never claimed, and every later run would fire it again.
+def case_claim_flag_timeout(tmp: str) -> None:
+    path = os.path.join(tmp, "attempts-claim.json")
+    with open(path, "w") as fh:
+        json.dump({}, fh)
+    lock = path + ".lock"
+    with open(lock, "w") as fh:
+        fh.write("%d:0:0\n" % os.getpid())
+
+    proc = run(path, "claim-flag", "ASK-2", "stuck_paged")
+
+    if proc.returncode == 0:
+        fail("THE DEFECT: claim-flag could not take the lock and answered 'claimed'. The "
+             "caller pages on exit 0, so this is a page for a flag nothing recorded -- it "
+             "fires again on every run after")
+    if read_ledger(path).get("ASK-2", {}).get("stuck_paged"):
+        fail("claim-flag could not take the lock and set the flag anyway")
+    ok("claim-flag under contention neither claims nor reports a claim")
+
+
+# --- 3. THE RELEASE ONLY EVER REMOVES A LOCK THIS RUN OWNS -------------------
+# The mutation-killer. Reached only after a SUCCESSFUL acquisition, so nothing
+# ordinary walks into the release holding a foreign lock: the case has to build
+# that state on purpose. The mutation fn stamps a foreign token over the lock
+# from INSIDE the critical section. A release that trusts the path deletes it;
+# one that checks its own token leaves it.
+def case_release_checks_ownership(tmp: str) -> None:
+    mod = load_module()
+    path = os.path.join(tmp, "attempts-own.json")
+    lock = path + ".lock"
+
+    def steal(d: dict) -> bool:
+        with open(lock, "w") as fh:
+            fh.write("foreign:0:0\n")
+        d["ASK-3"] = {"count": 1}
+        return True
+
+    wrote = mod._mutate(path, steal)
+
+    if not wrote:
+        fail("the transaction itself did not complete; this case can only judge the RELEASE "
+             "if the mutation ran")
+    if not os.path.exists(lock):
+        fail("THE DEFECT: the lock changed hands during the transaction and the release "
+             "deleted it anyway. Releasing by path means whichever run finishes first unlocks "
+             "the run that is still inside its own transaction")
+    if read_lock(lock) != "foreign:0:0":
+        fail("the release removed another run's lock and left something else in its place: "
+             f"{read_lock(lock)!r}")
+    ok("a release refuses to remove a lock that no longer carries this run's token")
+
+
+# --- 4. A CORPSE LOCK DOES NOT WEDGE FUTURE WRITES ---------------------------
+# The other side of refusing to force. Broken on OWNER LIVENESS, not a timer:
+# pid 2147483647 is not running, so honouring its lock would mean no attempt is
+# ever counted again on this ledger.
+def case_corpse_lock(tmp: str) -> None:
+    path = os.path.join(tmp, "attempts-corpse.json")
+    with open(path, "w") as fh:
+        json.dump({}, fh)
+    lock = path + ".lock"
+    with open(lock, "w") as fh:
+        fh.write("2147483647:0:0\n")
+
+    proc = run(path, "bump-attempt", "ASK-4", "because")
+
+    if proc.returncode != 0:
+        fail("a lock left behind by a dead run blocked the increment permanently. Refusing to "
+             "force a LIVE lock is right; honouring a corpse means the attempts counter "
+             f"freezes and no issue ever reaches STUCK. stderr={proc.stderr!r}")
+    if read_ledger(path).get("ASK-4", {}).get("count") != 1:
+        fail(f"the corpse lock was broken but the bump never landed: {read_ledger(path)!r}")
+    if os.path.exists(lock):
+        fail("the run finished its transaction and left its own lock behind, so the next run "
+             "has to break it as a corpse before it can do anything")
+    ok("a lock left by a dead run is broken, written through, and released")
+
+
+# --- 5. AN UNATTRIBUTABLE LOCK IS A CORPSE BY CONSTRUCTION -------------------
+# Two shapes, one rule. A leftover DIRECTORY is what a pre-fix worker killed
+# mid-transaction leaves behind (the old lock was `os.mkdir`), and an EMPTY file
+# is the window a create-then-stamp lock leaves open. Neither can ever be
+# attributed to a live owner, so honouring either wedges this ledger forever on
+# the first upgrade. Both must break.
+def case_unattributable_lock(tmp: str) -> None:
+    for name, make in (("directory", os.mkdir), ("empty file", lambda p: open(p, "w").close())):
+        path = os.path.join(tmp, "attempts-unattr-%s.json" % name.split()[0])
+        with open(path, "w") as fh:
+            json.dump({}, fh)
+        make(path + ".lock")
+
+        proc = run(path, "bump-attempt", "ASK-5", "because")
+
+        if proc.returncode != 0:
+            fail(f"a leftover lock {name} wedged the ledger permanently. Nothing can ever "
+                 "prove it owns that lock, so waiting on it is waiting forever. "
+                 f"stderr={proc.stderr!r}")
+        if read_ledger(path).get("ASK-5", {}).get("count") != 1:
+            fail(f"the leftover lock {name} was cleared but the bump never landed")
+    ok("a lock nothing can ever own (stale mkdir directory, empty file) is broken, not honoured")
+
+
+# --- 6. THE ORDINARY PATH STILL WORKS ----------------------------------------
+# The guard is only worth having if every op still round-trips. clear-automerge
+# is called out by name because it once existed only in the shell caller and
+# exited 2 here, which made a once-only page permanently silent.
+def case_ops_round_trip(tmp: str) -> None:
+    path = os.path.join(tmp, "attempts-ops.json")
+
+    for args, want in (
+        (("bump-attempt", "ASK-6", "why"), 0),
+        (("bump-conflict", "ASK-6"), 0),
+        (("bump-drift", "ASK-6"), 0),
+        (("claim-flag", "ASK-6", "stuck_paged"), 0),
+        (("claim-flag", "ASK-6", "stuck_paged"), 1),   # second claim is refused
+        (("clear-conflict", "ASK-6"), 0),
+        (("clear-drift", "ASK-6"), 0),
+        (("clear-automerge", "ASK-6"), 0),
+    ):
+        proc = run(path, *args)
+        if proc.returncode != want:
+            fail(f"{' '.join(args)} exited {proc.returncode}, wanted {want}: "
+                 f"stdout={proc.stdout!r} stderr={proc.stderr!r}")
+
+    entry = read_ledger(path).get("ASK-6", {})
+    if entry.get("count") != 1 or entry.get("why") != "why":
+        fail(f"bump-attempt did not record the count and reason: {entry!r}")
+    if entry.get("conflict_rounds") is not None or entry.get("drift_rounds") is not None:
+        fail(f"the clear ops left their counters behind: {entry!r}")
+    if not entry.get("stuck_paged"):
+        fail(f"the claimed page flag did not survive the clears: {entry!r}")
+
+    proc = run(path, "get", "ASK-6", "count", "0")
+    if proc.stdout.strip() != "1":
+        fail(f"get read back {proc.stdout!r}, wanted 1")
+    if os.path.exists(path + ".lock"):
+        fail("the ordinary path leaves its lock behind")
+    ok("every op round-trips through the guarded writer and releases its lock")
+
+
+def main() -> int:
+    print("test-attempts-ledger: the lock around the attempts counter (ASK-286)")
+    with tempfile.TemporaryDirectory() as tmp:
+        case_timeout_does_not_proceed(tmp)
+        case_claim_flag_timeout(tmp)
+        case_release_checks_ownership(tmp)
+        case_corpse_lock(tmp)
+        case_unattributable_lock(tmp)
+        case_ops_round_trip(tmp)
+    print(f"PASS ({PASSED} cases)")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/q-system/.q-system/scripts/test/test-attempts-ledger.py
+++ b/q-system/.q-system/scripts/test/test-attempts-ledger.py
@@ -502,6 +502,57 @@ def case_timeout_is_the_documented_budget(tmp: str) -> None:
     ok(f"a contended refusal lands inside the budget it documents ({elapsed:.1f}s of {budget}s)")
 
 
+# --- 13. AN OS ERROR ON THE WRITE PATH MUST NOT ANSWER 1 ---------------------
+# Codex round 2 on PR #67, minor 3. `main` caught `Usage` and `LockUnavailable`
+# and nothing else, so an OSError from mkstemp / os.replace / json.dump escaped
+# as an uncaught exception -- and Python exits 1 on those. For claim-flag, 1 is
+# the ONE code that means "already claimed on a prior run, stay quiet". So a
+# write that failed hard read as a page already sent, for a flag no file records,
+# which means no later run retires it either. Same silent-drop class as findings
+# 2 and 3, arriving through the one door still left open.
+#
+# The trigger here is constructed (a read-only ledger directory); the natural
+# producer is a full disk. That is why the exit code is what gets asserted rather
+# than the specific errno -- the point is that EVERY unexpected failure lands on
+# 2, not that this one does.
+def case_write_failure_is_not_already_claimed(tmp: str) -> None:
+    ro_dir = os.path.join(tmp, "readonly-ledger")
+    os.mkdir(ro_dir)
+    path = os.path.join(ro_dir, "attempts.json")
+    with open(path, "w") as fh:
+        json.dump({}, fh)
+    # PRE-CREATE THE LOCK FILE. Without it the read-only directory stops the run
+    # at lock CREATION, which already answers 3 -- so the fixture would pass
+    # against an implementation that has none of this handling, testing the lock
+    # path instead of the write path. The defect lives after acquisition: flock
+    # opens an existing file fine, and `mkstemp` in the same directory is the
+    # first thing that cannot proceed.
+    open(path + ".lock", "a").close()
+    os.chmod(ro_dir, 0o555)          # writable files, unwritable directory
+    try:
+        proc = subprocess.run(
+            [sys.executable, str(LEDGER), path, "claim-flag", "ASK-13", "stuck_paged"],
+            capture_output=True, text=True,
+        )
+    finally:
+        os.chmod(ro_dir, 0o755)
+
+    if proc.returncode == 0:
+        fail("the failed write answered 0, so the caller pages off a flag no file records")
+    if proc.returncode == 1:
+        fail("THE DEFECT: the ledger write failed with an OSError and the process exited 1 -- "
+             "the same answer as 'already claimed on a prior run'. page_once routes 1 to "
+             "'stay quiet', so the page is dropped for a state nothing recorded and no later "
+             f"run will retire. stderr tail={proc.stderr.strip().splitlines()[-1:]!r}")
+
+    # And the flag really was not written, which is what makes 1 a lie.
+    with open(path) as fh:
+        after = json.load(fh)
+    if after:
+        fail(f"the ledger recorded {after!r} despite the write failing")
+    ok(f"a hard write failure exits {proc.returncode}, not 1 ('already claimed'), and records nothing")
+
+
 def main() -> int:
     print("test-attempts-ledger: the lock around the attempts counter (ASK-286)")
     with tempfile.TemporaryDirectory() as tmp:
@@ -517,6 +568,7 @@ def main() -> int:
         case_ops_round_trip(tmp)
         case_usage_errors_exit_two(tmp)
         case_timeout_is_the_documented_budget(tmp)
+        case_write_failure_is_not_already_claimed(tmp)
     print(f"PASS ({PASSED} cases)")
     return 0
 

--- a/q-system/.q-system/scripts/test/test-attempts-ledger.py
+++ b/q-system/.q-system/scripts/test/test-attempts-ledger.py
@@ -17,12 +17,29 @@ That failure is silent and self-perpetuating.
 
 THE TRAP THIS SUITE IS BUILT AROUND (learned on PR #42)
 -------------------------------------------------------
-The release is only reached AFTER a successful acquisition, so once the timeout
-stops lying there is no ORDINARY path into it holding someone else's lock. A
-mutant that reverts the release to an unconditional unlink therefore passes an
-entire suite that never makes the lock change hands mid-transaction. Case 3
-exists for exactly that: it stamps a foreign token over the lock from INSIDE the
-critical section, which is the only shape that can fail a release-by-path.
+The release is only reached AFTER a successful acquisition, so there is no
+ORDINARY path into it holding someone else's lock. A mutant that reverts the
+release to an unconditional unlink therefore passes an entire suite that never
+makes the lock change hands mid-transaction. Case 3 exists for exactly that.
+
+WHAT CHANGED IN ROUND 2 (codex round 1 on PR #67)
+-------------------------------------------------
+The first fix hand-rolled the lock: a token file, published with os.link,
+released by token, broken when the pid it named was not running. Codex found
+that pid liveness answers the wrong question -- pids wrap, so a leftover lock
+eventually names a live process that never held it and is then honoured forever
+(case 7). The mechanism is now `fcntl.flock`, which the kernel releases on close
+AND on process death, so a corpse lock cannot exist (case 8).
+
+That moves where the fixtures have to bite. A lock is now HELD, not DESCRIBED,
+so the contention cases hold a real flock from a live subprocess instead of
+writing a pid into a file. Two contracts inverted with the mechanism and are
+asserted in their new form rather than dropped:
+
+  * the lock FILE is never unlinked (case 6). Unlinking is what lets two runs
+    hold locks on two different inodes at one path.
+  * a leftover lock file is inert. It carries no state, so nothing about its
+    contents can wedge a write (cases 4, 5, 7).
 
 ISOLATION: every case runs in its own tempdir against its own ledger file. This
 suite never touches the live linear-worker-attempts.json.
@@ -30,6 +47,7 @@ suite never touches the live linear-worker-attempts.json.
 
 from __future__ import annotations
 
+import contextlib
 import importlib.util
 import json
 import os
@@ -64,9 +82,15 @@ def load_module():
 
 
 def run(path: str, *args: str, tries: str = "3") -> subprocess.CompletedProcess:
-    """One CLI invocation. `tries` keeps a contended case sub-second instead of
-    sleeping out the production 10s timeout -- same posture as converge.sh's
-    KIPI_RECEIPT_LOCK_TRIES, which production never sets."""
+    """One CLI invocation. `tries` keeps a contended case sub-second.
+
+    Production leaves KIPI_ATTEMPTS_LOCK_TRIES unset (100 tries x 0.1s), same
+    posture as converge.sh's KIPI_RECEIPT_LOCK_TRIES. Measured 2026-08-02: a
+    blocked mutation refuses in ~10s under flock. It cost 22.1s under the
+    hand-rolled lock, because each retry did a full mkstemp/write/link/unlink
+    publish attempt on top of its sleep -- a contended retry is now one
+    non-blocking syscall, so the wall clock is the sleep budget and nothing more.
+    """
     env = dict(os.environ)
     env["KIPI_ATTEMPTS_LOCK_TRIES"] = tries
     return subprocess.run(
@@ -83,76 +107,91 @@ def read_ledger(path: str) -> dict:
         return {}
 
 
-def read_lock(lock: str) -> str:
+@contextlib.contextmanager
+def lock_held_by_live_process(lock: str):
+    """Hold a real flock on `lock` from a separate live process.
+
+    The lock is now the open file description, so contention has to be produced
+    by actually holding it. Writing a pid into the file would describe a holder
+    without being one, which is precisely the confusion case 7 exists to kill.
+    """
+    holder = subprocess.Popen(
+        [sys.executable, "-c",
+         "import fcntl,sys,time\n"
+         "fh=open(sys.argv[1],'a')\n"
+         "fcntl.flock(fh.fileno(), fcntl.LOCK_EX)\n"
+         "sys.stdout.write('held\\n'); sys.stdout.flush()\n"
+         "time.sleep(300)\n",
+         lock],
+        stdout=subprocess.PIPE, text=True,
+    )
     try:
-        with open(lock) as fh:
-            return fh.read().strip()
-    except Exception:
-        return ""
+        if holder.stdout.readline().strip() != "held":
+            fail("the holder subprocess never reported taking the lock")
+        yield holder
+    finally:
+        holder.kill()
+        holder.wait()
 
 
 # --- 1. A TIMEOUT MUST NOT PROCEED -------------------------------------------
-# The lock is held by a LIVE pid (this test process, which is by definition
-# running), so the only correct outcome is to write nothing and say so. The old
-# code broke out of the retry loop and entered the transaction holding nothing.
+# The lock is held by a live process, so the only correct outcome is to write
+# nothing and say so. The old code broke out of the retry loop and entered the
+# transaction holding nothing.
 def case_timeout_does_not_proceed(tmp: str) -> None:
     path = os.path.join(tmp, "attempts-timeout.json")
     with open(path, "w") as fh:
         json.dump({"ASK-1": {"count": 1}}, fh)
-    lock = path + ".lock"
-    held = "%d:0:0" % os.getpid()
-    with open(lock, "w") as fh:
-        fh.write(held + "\n")
 
-    proc = run(path, "bump-attempt", "ASK-1", "because")
+    with lock_held_by_live_process(path + ".lock"):
+        proc = run(path, "bump-attempt", "ASK-1", "because")
 
-    if proc.returncode == 0:
-        fail("THE DEFECT: the lock is held by a LIVE pid and bump-attempt reported success. "
-             "A run that cannot take the lock must do no work and say so -- entering the "
-             f"transaction here is two runs inside one read-decide-write. stdout={proc.stdout!r} "
-             f"stderr={proc.stderr!r}")
-    got = read_ledger(path).get("ASK-1", {}).get("count")
-    if got != 1:
-        fail("THE DEFECT: bump-attempt could not take the lock and mutated the ledger anyway "
-             f"(count went 1 -> {got})")
-    if read_lock(lock) != held:
-        fail("THE DEFECT: the run that could not take the lock removed or overwrote the live "
-             f"holder's lock. It now reads {read_lock(lock)!r}, not {held!r}")
-    if "lock" not in (proc.stderr or "").lower():
-        fail("the bump was skipped for lock contention and nothing said so, so a dropped "
-             f"increment is invisible: stderr={proc.stderr!r}")
-    ok("a timeout writes nothing, says so, and leaves the live holder's lock alone")
+        if proc.returncode == 0:
+            fail("THE DEFECT: the lock is held by a live process and bump-attempt reported "
+                 "success. A run that cannot take the lock must do no work and say so -- "
+                 f"entering the transaction here is two runs inside one read-decide-write. "
+                 f"stdout={proc.stdout!r} stderr={proc.stderr!r}")
+        got = read_ledger(path).get("ASK-1", {}).get("count")
+        if got != 1:
+            fail("THE DEFECT: bump-attempt could not take the lock and mutated the ledger "
+                 f"anyway (count went 1 -> {got})")
+        if "lock" not in (proc.stderr or "").lower():
+            fail("the bump was skipped for lock contention and nothing said so, so a dropped "
+                 f"increment is invisible: stderr={proc.stderr!r}")
+    ok("a timeout writes nothing and says so, leaving the live holder undisturbed")
 
 
 # --- 2. THE SAME, FOR THE ONCE-ONLY PAGE FLAG --------------------------------
 # claim-flag's exit code IS the decision ("page or stay quiet"), so a lock
-# failure must not land on 0. Exit 0 here would fire a page for a flag that was
-# never claimed, and every later run would fire it again.
+# failure must land on neither 0 nor 1. Exit 0 fires a page for a flag that was
+# never claimed; exit 1 retires a page that never fired.
 def case_claim_flag_timeout(tmp: str) -> None:
     path = os.path.join(tmp, "attempts-claim.json")
     with open(path, "w") as fh:
         json.dump({}, fh)
-    lock = path + ".lock"
-    with open(lock, "w") as fh:
-        fh.write("%d:0:0\n" % os.getpid())
 
-    proc = run(path, "claim-flag", "ASK-2", "stuck_paged")
+    with lock_held_by_live_process(path + ".lock"):
+        proc = run(path, "claim-flag", "ASK-2", "stuck_paged")
 
-    if proc.returncode == 0:
-        fail("THE DEFECT: claim-flag could not take the lock and answered 'claimed'. The "
-             "caller pages on exit 0, so this is a page for a flag nothing recorded -- it "
-             "fires again on every run after")
-    if read_ledger(path).get("ASK-2", {}).get("stuck_paged"):
-        fail("claim-flag could not take the lock and set the flag anyway")
-    ok("claim-flag under contention neither claims nor reports a claim")
+        if proc.returncode == 0:
+            fail("THE DEFECT: claim-flag could not take the lock and answered 'claimed'. The "
+                 "caller pages on exit 0, so this is a page for a flag nothing recorded -- it "
+                 "fires again on every run after")
+        if proc.returncode == 1:
+            fail("THE DEFECT: claim-flag could not take the lock and answered 1, which is the "
+                 "code for 'already claimed on an earlier run'. The caller stays quiet, so a "
+                 "page is dropped for a state no file records and no later run will retire")
+        if read_ledger(path).get("ASK-2", {}).get("stuck_paged"):
+            fail("claim-flag could not take the lock and set the flag anyway")
+    ok("claim-flag under contention neither claims, nor reports a claim, nor reads as claimed")
 
 
-# --- 3. THE RELEASE ONLY EVER REMOVES A LOCK THIS RUN OWNS -------------------
+# --- 3. THE RELEASE NEVER DISTURBS A LOCK THIS RUN DOES NOT OWN --------------
 # The mutation-killer. Reached only after a SUCCESSFUL acquisition, so nothing
 # ordinary walks into the release holding a foreign lock: the case has to build
-# that state on purpose. The mutation fn stamps a foreign token over the lock
-# from INSIDE the critical section. A release that trusts the path deletes it;
-# one that checks its own token leaves it.
+# that state on purpose. It stamps a foreign token over the lock file from INSIDE
+# the critical section. A release that trusts the path unlinks it; the flock
+# release closes a file descriptor and touches no name at all.
 def case_release_checks_ownership(tmp: str) -> None:
     mod = load_module()
     path = os.path.join(tmp, "attempts-own.json")
@@ -171,18 +210,14 @@ def case_release_checks_ownership(tmp: str) -> None:
              "if the mutation ran")
     if not os.path.exists(lock):
         fail("THE DEFECT: the lock changed hands during the transaction and the release "
-             "deleted it anyway. Releasing by path means whichever run finishes first unlocks "
+             "removed it anyway. Releasing by path means whichever run finishes first unlocks "
              "the run that is still inside its own transaction")
-    if read_lock(lock) != "foreign:0:0":
-        fail("the release removed another run's lock and left something else in its place: "
-             f"{read_lock(lock)!r}")
-    ok("a release refuses to remove a lock that no longer carries this run's token")
+    ok("a release removes no name, so it cannot take away a lock another run holds")
 
 
-# --- 4. A CORPSE LOCK DOES NOT WEDGE FUTURE WRITES ---------------------------
-# The other side of refusing to force. Broken on OWNER LIVENESS, not a timer:
-# pid 2147483647 is not running, so honouring its lock would mean no attempt is
-# ever counted again on this ledger.
+# --- 4. A LOCK LEFT BY A DEAD RUN DOES NOT WEDGE FUTURE WRITES ---------------
+# The other side of refusing to force. A leftover lock file naming pid
+# 2147483647 is inert: it holds no flock, so nothing has to reason about it.
 def case_corpse_lock(tmp: str) -> None:
     path = os.path.join(tmp, "attempts-corpse.json")
     with open(path, "w") as fh:
@@ -199,21 +234,17 @@ def case_corpse_lock(tmp: str) -> None:
              f"freezes and no issue ever reaches STUCK. stderr={proc.stderr!r}")
     if read_ledger(path).get("ASK-4", {}).get("count") != 1:
         fail(f"the corpse lock was broken but the bump never landed: {read_ledger(path)!r}")
-    if os.path.exists(lock):
-        fail("the run finished its transaction and left its own lock behind, so the next run "
-             "has to break it as a corpse before it can do anything")
-    ok("a lock left by a dead run is broken, written through, and released")
+    ok("a lock file left by a dead run holds nothing and blocks nothing")
 
 
-# --- 5. AN UNATTRIBUTABLE LOCK IS A CORPSE BY CONSTRUCTION -------------------
-# Two shapes, one rule. A leftover DIRECTORY is what a pre-fix worker killed
-# mid-transaction leaves behind (the old lock was `os.mkdir`), and an EMPTY file
-# is the window a create-then-stamp lock leaves open. Neither can ever be
-# attributed to a live owner, so honouring either wedges this ledger forever on
-# the first upgrade. Both must break.
-def case_unattributable_lock(tmp: str) -> None:
+# --- 5. THE PRE-FLOCK LEFTOVERS ARE BOTH SURVIVED ----------------------------
+# Two shapes a pre-ASK-286 worker leaves at this path. A DIRECTORY is what the
+# original os.mkdir lock leaves when its run is killed, and an EMPTY file is the
+# window the token lock left between create and stamp. Neither can be opened-and-
+# locked as-is, so the first fleet upgrade would wedge every ledger that has one.
+def case_pre_flock_leftovers(tmp: str) -> None:
     for name, make in (("directory", os.mkdir), ("empty file", lambda p: open(p, "w").close())):
-        path = os.path.join(tmp, "attempts-unattr-%s.json" % name.split()[0])
+        path = os.path.join(tmp, "attempts-leftover-%s.json" % name.split()[0])
         with open(path, "w") as fh:
             json.dump({}, fh)
         make(path + ".lock")
@@ -221,15 +252,129 @@ def case_unattributable_lock(tmp: str) -> None:
         proc = run(path, "bump-attempt", "ASK-5", "because")
 
         if proc.returncode != 0:
-            fail(f"a leftover lock {name} wedged the ledger permanently. Nothing can ever "
-                 "prove it owns that lock, so waiting on it is waiting forever. "
-                 f"stderr={proc.stderr!r}")
+            fail(f"a leftover lock {name} from a pre-flock worker wedged the ledger. The first "
+                 "instance to take this upgrade with one on disk never counts an attempt "
+                 f"again. stderr={proc.stderr!r}")
         if read_ledger(path).get("ASK-5", {}).get("count") != 1:
             fail(f"the leftover lock {name} was cleared but the bump never landed")
-    ok("a lock nothing can ever own (stale mkdir directory, empty file) is broken, not honoured")
+    ok("a pre-flock leftover (mkdir directory, empty token file) does not wedge the upgrade")
 
 
-# --- 6. THE ORDINARY PATH STILL WORKS ----------------------------------------
+# --- 6. THE LOCK FILE IS NEVER UNLINKED --------------------------------------
+# Inverted contract, asserted rather than dropped. The old lock deleted its file
+# on release; this one must not. Unlinking is the ONE way a file lock is
+# defeated: run A holds the inode, someone unlinks the name, run B creates a
+# fresh inode at that path and locks it, and both are inside the transaction.
+def case_lock_file_is_never_unlinked(tmp: str) -> None:
+    path = os.path.join(tmp, "attempts-persist.json")
+    lock = path + ".lock"
+
+    if run(path, "bump-attempt", "ASK-10", "why").returncode != 0:
+        fail("the ordinary bump did not succeed, so this case cannot judge the release")
+    if not os.path.exists(lock):
+        fail("THE DEFECT: the release unlinked the lock file. A later run then creates a NEW "
+             "inode at that path while a live run holds the old one, and both believe they "
+             "are alone -- the two-inodes-one-path race a file lock exists to prevent")
+    first = os.stat(lock).st_ino
+
+    if run(path, "bump-attempt", "ASK-10", "why").returncode != 0:
+        fail("the second bump did not succeed against the surviving lock file")
+    if os.stat(lock).st_ino != first:
+        fail("the second run replaced the lock inode instead of locking the one already there")
+    if os.path.getsize(lock) != 0:
+        fail(f"the lock file carries state ({os.path.getsize(lock)} bytes); it must be inert, "
+             "or something will start reasoning about its contents again")
+    ok("the lock file survives the release, is re-locked in place, and carries no state")
+
+
+# --- 7. A LOCK NAMING A LIVE PID THAT IS NOT THE HOLDER MUST NOT WEDGE -------
+# Codex round 1 on PR #67, MAJOR. Liveness-by-pid answers the wrong question: it
+# asks "is some process with this number running", not "is that process holding
+# this lock". Pids wrap, so a leftover lock file eventually names a pid that some
+# unrelated live process now has -- and then it is honoured forever. The attempts
+# counter freezes, no issue reaches MAX_ATTEMPTS, no issue reaches STUCK, and no
+# human is ever paged. Silent and permanent, which is the exact failure class
+# this ledger exists to kill.
+#
+# pid 1 makes it deterministic rather than probabilistic: launchd/init is always
+# alive and is never the holder of this lock.
+def case_live_pid_that_never_held_it(tmp: str) -> None:
+    path = os.path.join(tmp, "attempts-pidreuse.json")
+    with open(path, "w") as fh:
+        json.dump({}, fh)
+    lock = path + ".lock"
+    with open(lock, "w") as fh:
+        fh.write("1:0:0\n")          # pid 1 is alive and never held this lock
+
+    proc = run(path, "bump-attempt", "ASK-7", "because")
+
+    if proc.returncode != 0:
+        fail("THE DEFECT: a leftover lock naming a LIVE pid that never held it froze the "
+             "ledger. Nothing releases that lock, so every future write is refused: the "
+             "attempts counter stops, no issue reaches STUCK, and no human is paged. "
+             f"stderr={proc.stderr!r}")
+    if read_ledger(path).get("ASK-7", {}).get("count") != 1:
+        fail(f"the stale lock was cleared but the bump never landed: {read_ledger(path)!r}")
+    ok("a leftover lock naming a live pid that never held it does not freeze the ledger")
+
+
+# --- 8. THE HOLDER'S DEATH RELEASES THE LOCK, WITH NO HEURISTIC --------------
+# The positive form of case 7, and the reason case 7 is unreachable by
+# construction rather than merely unlikely. A real holder blocks; the moment that
+# holder dies the next run proceeds -- not after a timer, not after guessing at a
+# pid, but because the kernel drops the lock with the process.
+def case_holder_death_releases(tmp: str) -> None:
+    path = os.path.join(tmp, "attempts-death.json")
+    with open(path, "w") as fh:
+        json.dump({}, fh)
+
+    with lock_held_by_live_process(path + ".lock"):
+        proc = run(path, "bump-attempt", "ASK-8", "because")
+        if proc.returncode == 0:
+            fail("THE DEFECT: a run wrote the ledger while another process held the lock. "
+                 f"stderr={proc.stderr!r}")
+
+    proc = run(path, "bump-attempt", "ASK-8", "because")
+    if proc.returncode != 0:
+        fail("the holder is dead and its lock was still honoured, so the ledger is wedged "
+             f"until something outside this program intervenes. stderr={proc.stderr!r}")
+    if read_ledger(path).get("ASK-8", {}).get("count") != 1:
+        fail(f"the dead holder's lock was released but the bump never landed: {read_ledger(path)!r}")
+    ok("a live holder blocks the write and its death releases the lock with no heuristic")
+
+
+# --- 9. THE LOCK TAKEN IS THE LOCK AT THE PATH -------------------------------
+# A pre-ASK-286 worker breaks a lock by UNLINKING it, so during a fleet rollout
+# one can replace the file this run is taking. A handle locked on an orphaned
+# inode guards nothing: nobody else will ever contend on it. Acquiring is
+# therefore not enough -- the inode locked has to still be the inode at the path.
+def case_lock_taken_is_the_lock_at_the_path(tmp: str) -> None:
+    mod = load_module()
+    lock = os.path.join(tmp, "attempts-replaced.json.lock")
+
+    # Stand in for the old worker: unlink the name and put a different inode
+    # there, the way a release-by-path break does.
+    os.close(os.open(lock, os.O_CREAT | os.O_WRONLY, 0o644))
+    original_ino = os.stat(lock).st_ino
+    os.unlink(lock)
+    os.close(os.open(lock, os.O_CREAT | os.O_WRONLY, 0o644))
+    if os.stat(lock).st_ino == original_ino:
+        fail("the fixture could not produce a second inode at the lock path")
+
+    fh = mod._take_lock(lock)
+    if fh is None:
+        fail("the lock at a replaced path could not be taken at all")
+    try:
+        if os.fstat(fh.fileno()).st_ino != os.stat(lock).st_ino:
+            fail("THE DEFECT: the handle holds an inode that is no longer the file at the lock "
+                 "path. Nobody else will ever contend on it, so the next run takes the live "
+                 "inode and both are inside the transaction at once")
+    finally:
+        mod._drop_lock(fh)
+    ok("the handle returned holds the inode that is live at the lock path")
+
+
+# --- 10. THE ORDINARY PATH STILL WORKS ---------------------------------------
 # The guard is only worth having if every op still round-trips. clear-automerge
 # is called out by name because it once existed only in the shell caller and
 # exited 2 here, which made a once-only page permanently silent.
@@ -262,9 +407,39 @@ def case_ops_round_trip(tmp: str) -> None:
     proc = run(path, "get", "ASK-6", "count", "0")
     if proc.stdout.strip() != "1":
         fail(f"get read back {proc.stdout!r}, wanted 1")
-    if os.path.exists(path + ".lock"):
-        fail("the ordinary path leaves its lock behind")
-    ok("every op round-trips through the guarded writer and releases its lock")
+    ok("every op round-trips through the guarded writer")
+
+
+# --- 11. A BAD INVOCATION EXITS 2, NEVER 1 -----------------------------------
+# Codex round 1 on PR #67, finding 2, and the shape it does not name. Exit 1 is
+# claim-flag's "already claimed on an earlier run, stay quiet". `claim-flag ASK-1`
+# with the flag omitted used to raise IndexError, and an uncaught Python exception
+# exits 1 -- so a typo in a call site read as "already paged" and the page was
+# dropped for good. Each exit code has to mean exactly one thing.
+def case_usage_errors_exit_two(tmp: str) -> None:
+    path = os.path.join(tmp, "attempts-usage.json")
+    with open(path, "w") as fh:
+        json.dump({}, fh)
+
+    for args in (
+        ("claim-flag", "ASK-11"),                       # flag omitted
+        ("bump-attempt", "ASK-11"),                     # why omitted
+        ("bump-conflict",),                             # issue omitted
+        ("clear-automerge", "ASK-11", "extra"),         # one too many
+        ("not-an-op", "ASK-11"),                        # unknown op
+    ):
+        proc = run(path, *args)
+        if proc.returncode == 1:
+            fail("THE DEFECT: `%s` exited 1, which is the code for 'already claimed, stay "
+                 "quiet'. Six call sites in linear-worker.sh read that as a page already "
+                 "sent, so a bad invocation silently drops the page. stderr=%r"
+                 % (" ".join(args), proc.stderr))
+        if proc.returncode != 2:
+            fail(f"`{' '.join(args)}` exited {proc.returncode}, wanted 2 (usage): "
+                 f"stderr={proc.stderr!r}")
+    if read_ledger(path):
+        fail(f"a usage error wrote to the ledger: {read_ledger(path)!r}")
+    ok("a bad invocation exits 2 and writes nothing, never 1")
 
 
 def main() -> int:
@@ -274,8 +449,13 @@ def main() -> int:
         case_claim_flag_timeout(tmp)
         case_release_checks_ownership(tmp)
         case_corpse_lock(tmp)
-        case_unattributable_lock(tmp)
+        case_pre_flock_leftovers(tmp)
+        case_lock_file_is_never_unlinked(tmp)
+        case_live_pid_that_never_held_it(tmp)
+        case_holder_death_releases(tmp)
+        case_lock_taken_is_the_lock_at_the_path(tmp)
         case_ops_round_trip(tmp)
+        case_usage_errors_exit_two(tmp)
     print(f"PASS ({PASSED} cases)")
     return 0
 

--- a/q-system/.q-system/scripts/test/test-claim-page-once-routing.sh
+++ b/q-system/.q-system/scripts/test/test-claim-page-once-routing.sh
@@ -56,11 +56,26 @@ extract_page_once() {
   sed -n '/^page_once() {/,/^}/p' "$WORKER"
 }
 
+extract_ledger_fault() {
+  sed -n '/^ledger_fault() {/,/^}/p' "$WORKER"
+}
+
 CLAIM_FN="$(extract_claim_page_once)"
 [ -n "$CLAIM_FN" ] || fail "claim_page_once is no longer a one-line definition in $WORKER; this test has to be re-pointed"
 
 PAGE_FN="$(extract_page_once)"
 [ -n "$PAGE_FN" ] || fail "page_once is no longer a \`page_once() {\` .. \`}\` block in $WORKER; this test has to be re-pointed"
+
+FAULT_FN="$(extract_ledger_fault)"
+[ -n "$FAULT_FN" ] || fail "ledger_fault is no longer a \`ledger_fault() {\` .. \`}\` block in $WORKER; this test has to be re-pointed"
+
+# page_once calls ledger_fault, which pages Slack through \$NOTIFY. Point it at a
+# log inside the temp dir: unstubbed it would run the real slack-notify.sh.
+NOTIFY="$WORK/notify.sh"
+SLACKLOG="$WORK/slack.log"
+printf '#!/usr/bin/env bash\necho "$*" >> "%s"\n' "$SLACKLOG" > "$NOTIFY"
+chmod +x "$NOTIFY"
+: > "$SLACKLOG"
 
 LEDGER="$LEDGER_PY"
 ATTEMPTS="$WORK/attempts.json"
@@ -116,16 +131,19 @@ ok "a failed ledger write is distinguishable from 'already claimed' (rc=$CONTEND
 # running the WORKER'S OWN `page_once`, lifted above, not a copy of it.
 SAYLOG="$WORK/say.log"
 say() { echo "$*" >> "$SAYLOG"; }
+LEDGER_FAULT_ALERTED=0
+eval "$FAULT_FN"
 eval "$PAGE_FN"
 
 # `page_once` answers page/quiet with its exit code and distinguishes the third
 # route by warning through `say`, so the observation has to read both.
 route() {
   : > "$SAYLOG"
+  LEDGER_FAULT_ALERTED=0
   if page_once "$@" 2>/dev/null; then
     if [ -s "$SAYLOG" ]; then echo page-and-warn; else echo page; fi
   else
-    echo quiet
+    if [ -s "$SAYLOG" ]; then echo quiet-and-warn; else echo quiet; fi
   fi
 }
 echo '{}' > "$ATTEMPTS"
@@ -133,13 +151,21 @@ rm -f "$ATTEMPTS.lock"   # case 2 deliberately left a held lock behind
 [ "$(route ASK-3 tree_paged)" = "page" ]  || fail "a first claim did not route to page"
 [ "$(route ASK-3 tree_paged)" = "quiet" ] || fail "a repeat claim did not route to quiet"
 # The third answer: the ledger could not run at all, so nothing was written and
-# nothing was claimed. Stands in for exit 2 (usage) and exit 3 (contention)
-# alike -- what matters is that neither lands on the "quiet" branch.
+# nothing was claimed. Stands in for exit 2 (usage) and exit 3 (contention) alike.
+#
+# THIS USED TO ASSERT `page-and-warn` AND THAT WAS THE ROUND-4 MAJOR. Returning
+# 0 here tells the CALLER to write its artifact, and at the stuck site that
+# artifact is a permanent Linear comment whose only dedup is the ledger flag we
+# just failed to write. The route has to be distinguishable from plain `quiet`
+# -- that is what finding 2 of round 1 was about, and it still holds -- but
+# distinguishable via the WARN, not by driving a non-idempotent permanent write
+# with its dedup switched off. Cases 7-9 below hold the consequence.
 BROKEN_RC="$(LEDGER="$WORK/no-such-ledger.py" route ASK-3 tree_paged)"
-[ "$BROKEN_RC" = "page-and-warn" ] || fail "THE DEFECT: the ledger did not run and the answer
-routed to '$BROKEN_RC'. Nothing was claimed, so a 'quiet' here drops the page for
-a state no file records and no later run will retire."
-ok "page / quiet / page-and-warn are three distinct routes, not one"
+[ "$BROKEN_RC" = "quiet-and-warn" ] || fail "THE DEFECT: the ledger did not run and the answer
+routed to '$BROKEN_RC'. It must be 'quiet-and-warn': audible (a bare 'quiet' drops
+the state silently) but WITHOUT returning 0, because returning 0 makes the caller
+post a permanent Linear comment that nothing can de-duplicate."
+ok "page / quiet / quiet-and-warn are three distinct routes, not one"
 
 # --- 4. EVERY CALL SITE ACTUALLY USES THE ROUTING HELPER --------------------
 # The routing is only real if no call site still writes the collapsing shape.
@@ -217,5 +243,92 @@ worker still exits 0 and says 'run complete', which its own header tells callers
 to treat as healthy. A partial drain reported healthy is a silent stall."
 fi
 ok "a 3-issue queue still drains all 3 after a page fires (drained $DRAINED)"
+
+# --- 7-9. A PAGE THE LEDGER COULD NOT RECORD MUST NOT DRIVE A PERMANENT WRITE -
+# (codex round 4 on PR #67, major.) Exit codes and warn-vs-quiet are internals;
+# the thing that reaches a human is what the CALLER writes when page_once says 0.
+# At the stuck site that is `linear-sync.py progress` -- a permanent Linear
+# comment, and the ledger flag is its only dedup. So `return 0` on the two codes
+# that mean THE LEDGER DID NOT ANSWER drove a non-idempotent write with its dedup
+# switched off. These three cases assert the artifact count, not the exit code.
+#
+# A real worker RUN is a fresh process, so `LEDGER_FAULT_ALERTED` starts at 0.
+# Modelling several runs in one shell means resetting it by hand.
+PERMANENT="$WORK/linear-comments.log"
+: > "$PERMANENT"
+attempt_page() {
+  if page_once "$1" stuck_paged 2>/dev/null; then
+    echo "PERMANENT LINEAR COMMENT on $1" >> "$PERMANENT"
+  fi
+}
+new_run() { LEDGER_FAULT_ALERTED=0; }
+
+# --- 7. CONTENTION PAGES ONCE ACROSS TWO RUNS, NOT TWICE -------------------
+# Run A meets a live holder (exit 3, wrote nothing); run B, one cycle later,
+# finds the lock free and claims. The state is real and deserves exactly one
+# comment. Contention DEFERS the page by a cycle -- it does not drop it, which
+# is why staying quiet here is safe and posting is not.
+echo '{}' > "$ATTEMPTS"
+rm -f "$ATTEMPTS.lock"
+python3 - "$ATTEMPTS.lock" <<'PY' &
+import fcntl, sys, time
+fh = open(sys.argv[1], "a")
+fcntl.flock(fh.fileno(), fcntl.LOCK_EX)
+time.sleep(60)
+PY
+HOLDER=$!
+sleep 1
+new_run; KIPI_ATTEMPTS_LOCK_TRIES=2 attempt_page ASK-CONTEND
+kill "$HOLDER" 2>/dev/null || true
+wait "$HOLDER" 2>/dev/null || true
+new_run; attempt_page ASK-CONTEND
+CONTEND_COMMENTS="$(grep -c 'ASK-CONTEND' "$PERMANENT" || true)"
+if [ "$CONTEND_COMMENTS" -ne 1 ]; then
+  fail "THE DEFECT: one contended cycle plus one successful cycle posted
+$CONTEND_COMMENTS permanent Linear comments for a single state, expected 1. The
+contended run wrote no flag, so paging off it duplicates whatever the run that
+DOES get the lock posts a cycle later."
+fi
+ok "a contended cycle followed by a claiming cycle posts exactly 1 comment"
+
+# --- 8. AN UNWRITABLE LEDGER DOES NOT POST EVERY RUN FOREVER ---------------
+# Exit 2 is NOT self-recovering: nothing is ever claimed, so "bounded by the
+# retry budget" -- true of contention -- is false here. Five cycles stand in for
+# the unbounded series. Repeating "still stuck" every 15 minutes forever is the
+# cry-wolf failure the stuck site's own comment says this flag exists to prevent.
+: > "$PERMANENT"; : > "$SLACKLOG"
+for cycle in 1 2 3 4 5; do
+  new_run
+  LEDGER="$WORK/no-such-ledger.py" attempt_page ASK-BROKEN
+done
+BROKEN_COMMENTS="$(grep -c 'ASK-BROKEN' "$PERMANENT" || true)"
+if [ "$BROKEN_COMMENTS" -ne 0 ]; then
+  fail "THE DEFECT: an unwritable ledger posted $BROKEN_COMMENTS permanent Linear
+comments over 5 cycles, and the series does not terminate -- nothing is ever
+claimed, so every future run posts again. A read-only filesystem exits 2 forever."
+fi
+BROKEN_ALERTS="$(wc -l < "$SLACKLOG" | tr -d ' ')"
+if [ "$BROKEN_ALERTS" -ne 5 ]; then
+  fail "an unwritable ledger raised $BROKEN_ALERTS Slack alerts over 5 runs, expected 5
+(one per run). Silence here would be the drop this whole file exists to prevent:
+the notice moves channel, it does not disappear."
+fi
+ok "5 unwritable cycles post 0 permanent comments and 5 ephemeral alerts"
+
+# --- 9. ONE BROKEN LEDGER, ONE ALERT -- NOT ONE PER QUEUED ISSUE -----------
+# A broken ledger is a property of the WORKER, not of any issue. Alerting per
+# issue re-creates cry-wolf inside the channel the notice was just moved into.
+: > "$PERMANENT"; : > "$SLACKLOG"
+new_run   # ONE run; the four issues below are its queue, not four runs
+for i in ASK-Q1 ASK-Q2 ASK-Q3 ASK-Q4; do
+  LEDGER="$WORK/no-such-ledger.py" attempt_page "$i"
+done
+QUEUE_ALERTS="$(wc -l < "$SLACKLOG" | tr -d ' ')"
+if [ "$QUEUE_ALERTS" -ne 1 ]; then
+  fail "THE DEFECT: a 4-issue queue against one broken ledger raised $QUEUE_ALERTS Slack
+alerts in a single run, expected 1. The fault is the ledger, not the issue."
+fi
+[ ! -s "$PERMANENT" ] || fail "a broken ledger still posted permanent comments for a queued run"
+ok "a 4-issue queue against a broken ledger raises 1 alert, not 4"
 
 echo "PASS ($PASS checks)"

--- a/q-system/.q-system/scripts/test/test-claim-page-once-routing.sh
+++ b/q-system/.q-system/scripts/test/test-claim-page-once-routing.sh
@@ -46,8 +46,21 @@ extract_claim_page_once() {
   awk '/^claim_page_once\(\)/{print; exit}' "$WORKER"
 }
 
+# LIFT THE ROUTER ITSELF, DO NOT RE-WRITE IT (codex round 2 on PR #67, minor 2).
+# Case 3 used to define a local `route()` that reimplemented the routing from the
+# same mental model that wrote `page_once` -- and it happened to omit the very
+# `set -e` that made the shipped function a major defect. A test that reimplements
+# its subject asserts the author's intent, not the code. The function wired to six
+# call sites had zero executed coverage and the suite was green anyway.
+extract_page_once() {
+  sed -n '/^page_once() {/,/^}/p' "$WORKER"
+}
+
 CLAIM_FN="$(extract_claim_page_once)"
 [ -n "$CLAIM_FN" ] || fail "claim_page_once is no longer a one-line definition in $WORKER; this test has to be re-pointed"
+
+PAGE_FN="$(extract_page_once)"
+[ -n "$PAGE_FN" ] || fail "page_once is no longer a \`page_once() {\` .. \`}\` block in $WORKER; this test has to be re-pointed"
 
 LEDGER="$LEDGER_PY"
 ATTEMPTS="$WORK/attempts.json"
@@ -99,17 +112,21 @@ ok "a failed ledger write is distinguishable from 'already claimed' (rc=$CONTEND
 
 # --- 3. THE CALL-SITE SHAPE ROUTES THE THREE ANSWERS TO TWO BRANCHES --------
 # The exit code only matters if the six call sites read it. This asserts the
-# routing the worker actually performs, on the three answers it can get.
+# routing the worker actually performs, on the three answers it can get -- by
+# running the WORKER'S OWN `page_once`, lifted above, not a copy of it.
+SAYLOG="$WORK/say.log"
+say() { echo "$*" >> "$SAYLOG"; }
+eval "$PAGE_FN"
+
+# `page_once` answers page/quiet with its exit code and distinguishes the third
+# route by warning through `say`, so the observation has to read both.
 route() {
-  set +e
-  claim_page_once "$@" >/dev/null 2>&1
-  local rc=$?
-  set -e
-  case "$rc" in
-    0) echo page ;;
-    1) echo quiet ;;
-    *) echo page-and-warn ;;
-  esac
+  : > "$SAYLOG"
+  if page_once "$@" 2>/dev/null; then
+    if [ -s "$SAYLOG" ]; then echo page-and-warn; else echo page; fi
+  else
+    echo quiet
+  fi
 }
 echo '{}' > "$ATTEMPTS"
 rm -f "$ATTEMPTS.lock"   # case 2 deliberately left a held lock behind
@@ -133,5 +150,72 @@ if [ "$BARE" -ne 0 ]; then
 same branch as exit 1 (already claimed). Those pages are silently dropped."
 fi
 ok "no call site uses the bare \`if claim_page_once\` shape that collapses exit 3"
+
+# --- 5. page_once MUST LEAVE THE SHELL FLAGS IT FOUND ----------------------
+# (codex round 2 on PR #67, major.) `page_once` bracketed its call in
+# `set +e` .. `set -e`, which does not RESTORE errexit, it TURNS IT ON. The
+# worker runs `set -uo pipefail` (line 47) and has never had `-e`, so the first
+# page in a run silently re-flags the rest of the script.
+#
+# THIS CASE CANNOT RUN IN-PROCESS. This suite itself runs `set -euo pipefail`,
+# so errexit is already on here and the leak is invisible. The observation only
+# exists under the worker's REAL flags, which is why it forks.
+cat > "$WORK/flags.sh" <<EOF
+set -uo pipefail                       # the worker's flags at linear-worker.sh:47
+LEDGER="$LEDGER_PY"
+ATTEMPTS="$WORK/flags-attempts.json"
+echo '{}' > "\$ATTEMPTS"
+say() { echo "\$*" >&2; }
+$CLAIM_FN
+$PAGE_FN
+BEFORE="\$-"
+page_once ASK-FLAGS stuck_paged >/dev/null 2>&1
+AFTER="\$-"
+echo "\$BEFORE|\$AFTER"
+EOF
+FLAGS="$(bash "$WORK/flags.sh")"
+FLAGS_BEFORE="${FLAGS%%|*}"
+FLAGS_AFTER="${FLAGS##*|}"
+if [ "$FLAGS_BEFORE" != "$FLAGS_AFTER" ]; then
+  fail "THE DEFECT: page_once changed the caller's shell flags from '$FLAGS_BEFORE' to
+'$FLAGS_AFTER'. \`set -e\` at the end of the function does not restore errexit, it
+enables it, and linear-worker.sh never had it. Every command after the first page
+in a run is now fatal."
+fi
+ok "page_once leaves the shell flags unchanged ($FLAGS_BEFORE -> $FLAGS_AFTER)"
+
+# --- 6. THE 3AM CONSEQUENCE: A PARTIAL QUEUE DRAIN THAT EXITS 0 -------------
+# Flags are only worth asserting because of what they do to the drain. The
+# worker's queue is a pipeline into `while read`, and it ends by saying
+# "run complete" and exiting 0 -- its header documents that as "a caller may
+# treat this as healthy". With errexit leaked, the first benign non-zero after
+# the first page kills the loop and the worker still reports healthy: issues
+# silently never processed, which is the stall class this file exists to kill.
+cat > "$WORK/drain.sh" <<EOF
+set -uo pipefail
+LEDGER="$LEDGER_PY"
+ATTEMPTS="$WORK/drain-attempts.json"
+echo '{}' > "\$ATTEMPTS"
+say() { echo "\$*" >&2; }
+$CLAIM_FN
+$PAGE_FN
+printf 'ASK-1\nASK-2\nASK-3\n' | while read -r I; do
+  echo "processing \$I"
+  page_once "\$I" stuck_paged >/dev/null 2>&1 || true
+  # A benign non-zero the worker runs constantly: a grep that matches nothing.
+  grep -q 'no-such-pattern' /dev/null || true
+  [ -f "$WORK/no-such-file" ]        # unguarded, exits 1, harmless without -e
+  echo "finished \$I"
+done
+echo "LOOP DONE"
+EOF
+DRAINED="$(bash "$WORK/drain.sh" 2>/dev/null | grep -c '^processing ' || true)"
+if [ "$DRAINED" -ne 3 ]; then
+  fail "THE DEFECT: the queue drained $DRAINED of 3 issues. page_once leaked errexit,
+so the first benign non-zero after the first page killed the drain -- and the
+worker still exits 0 and says 'run complete', which its own header tells callers
+to treat as healthy. A partial drain reported healthy is a silent stall."
+fi
+ok "a 3-issue queue still drains all 3 after a page fires (drained $DRAINED)"
 
 echo "PASS ($PASS checks)"

--- a/q-system/.q-system/scripts/test/test-claim-page-once-routing.sh
+++ b/q-system/.q-system/scripts/test/test-claim-page-once-routing.sh
@@ -1,0 +1,137 @@
+#!/usr/bin/env bash
+# Reproducer + acceptance criterion for how linear-worker.sh routes the ledger's
+# exit codes (ASK-286, codex round 1 on PR #67, finding 2).
+#
+# THE DEFECT
+# ----------
+# `claim_page_once` is the once-only page gate for six states in linear-worker.sh
+# (stuck, drift, conflict, tree, and both auto-merge shapes). Every call site is
+# `if claim_page_once "$ISSUE" <flag>; then <page>; fi`, and bash `if` only ever
+# asks "was the exit 0". So THREE different answers collapse into one branch:
+#
+#   0  claimed, this is the first time     -> page          (correct)
+#   1  already claimed on an earlier run   -> stay quiet     (correct)
+#   3  the ledger could not be written     -> stay quiet     (WRONG)
+#   2  unknown op / bad usage              -> stay quiet     (WRONG)
+#
+# Exit 3 means NOTHING WAS CLAIMED. Reading it as "already claimed" suppresses a
+# page for a state no file records, so it will not be retired by a later run
+# either -- it is simply gone. That is the silent-stall failure class this whole
+# worker exists to kill, re-created inside the mechanism built to kill it.
+#
+# WHICH DIRECTION IS SAFE
+# -----------------------
+# A duplicate page is noise; a suppressed page is a stall nobody sees. Under
+# contention nothing was claimed, so the state is still true and still unpaged:
+# the worker pages. Lock contention is bounded (the retry budget), so this is
+# a page or two during a collision, not a page every cycle forever -- the first
+# run that gets the lock claims the flag and every run after it is quiet again.
+#
+# ISOLATION: runs against a temp ledger. Never touches linear-worker-attempts.json.
+set -euo pipefail
+ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/../../../.." && pwd)"
+WORKER="$ROOT/q-system/.q-system/scripts/linear-worker.sh"
+LEDGER_PY="$ROOT/q-system/.q-system/scripts/attempts-ledger.py"
+
+PASS=0
+fail() { echo "FAIL: $1" >&2; exit 1; }
+ok()   { PASS=$((PASS + 1)); echo "  ok: $1"; }
+
+WORK="$(mktemp -d)"
+trap 'rm -rf "$WORK"' EXIT
+
+# Lift the one function under test out of the worker rather than sourcing the
+# whole script, which runs a dispatch loop against live Linear on load.
+extract_claim_page_once() {
+  awk '/^claim_page_once\(\)/{print; exit}' "$WORKER"
+}
+
+CLAIM_FN="$(extract_claim_page_once)"
+[ -n "$CLAIM_FN" ] || fail "claim_page_once is no longer a one-line definition in $WORKER; this test has to be re-pointed"
+
+LEDGER="$LEDGER_PY"
+ATTEMPTS="$WORK/attempts.json"
+echo '{}' > "$ATTEMPTS"
+eval "$CLAIM_FN"
+
+# --- 1. THE FIRST CLAIM PAGES, THE SECOND DOES NOT -------------------------
+if claim_page_once "ASK-1" stuck_paged 2>/dev/null; then :; else
+  fail "the first claim of a flag did not page"
+fi
+if claim_page_once "ASK-1" stuck_paged 2>/dev/null; then
+  fail "the second claim of the same flag paged again, so the page is not once-only"
+fi
+ok "the first claim pages and the second stays quiet"
+
+# --- 2. A LEDGER WRITE THAT FAILED MUST NOT READ AS 'ALREADY CLAIMED' -------
+# Hold the lock from a live process so the claim exits 3 (wrote nothing). The
+# call site's `if` must not treat that as "quiet": nothing was claimed, so the
+# state is unpaged and still true.
+python3 - "$ATTEMPTS.lock" <<'PY' &
+import fcntl, sys, time
+fh = open(sys.argv[1], "a")
+fcntl.flock(fh.fileno(), fcntl.LOCK_EX)
+sys.stdout.write("held\n"); sys.stdout.flush()
+time.sleep(60)
+PY
+HOLDER=$!
+# Also stamp the pre-flock token shape, so this case is meaningful against both
+# the old hand-rolled lock and the flock one.
+printf '%s\n' "$$:0:0" > "$ATTEMPTS.lock" 2>/dev/null || true
+sleep 1
+
+set +e
+KIPI_ATTEMPTS_LOCK_TRIES=2 claim_page_once "ASK-2" conflict_paged >/dev/null 2>&1
+CONTENDED_RC=$?
+set -e
+kill "$HOLDER" 2>/dev/null || true
+wait "$HOLDER" 2>/dev/null || true
+
+[ "$CONTENDED_RC" -ne 0 ] || fail "the contended claim exited 0, so it reported a claim it never made"
+
+if [ "$CONTENDED_RC" -eq 1 ]; then
+  fail "THE DEFECT: the ledger could not be written and the claim answered 1 -- the same
+answer as 'already claimed on an earlier run'. Every call site is
+\`if claim_page_once ...; then page; fi\`, so the page is silently dropped for a
+state no file records and no later run will retire. rc=$CONTENDED_RC"
+fi
+ok "a failed ledger write is distinguishable from 'already claimed' (rc=$CONTENDED_RC)"
+
+# --- 3. THE CALL-SITE SHAPE ROUTES THE THREE ANSWERS TO TWO BRANCHES --------
+# The exit code only matters if the six call sites read it. This asserts the
+# routing the worker actually performs, on the three answers it can get.
+route() {
+  set +e
+  claim_page_once "$@" >/dev/null 2>&1
+  local rc=$?
+  set -e
+  case "$rc" in
+    0) echo page ;;
+    1) echo quiet ;;
+    *) echo page-and-warn ;;
+  esac
+}
+echo '{}' > "$ATTEMPTS"
+rm -f "$ATTEMPTS.lock"   # case 2 deliberately left a held lock behind
+[ "$(route ASK-3 tree_paged)" = "page" ]  || fail "a first claim did not route to page"
+[ "$(route ASK-3 tree_paged)" = "quiet" ] || fail "a repeat claim did not route to quiet"
+# The third answer: the ledger could not run at all, so nothing was written and
+# nothing was claimed. Stands in for exit 2 (usage) and exit 3 (contention)
+# alike -- what matters is that neither lands on the "quiet" branch.
+BROKEN_RC="$(LEDGER="$WORK/no-such-ledger.py" route ASK-3 tree_paged)"
+[ "$BROKEN_RC" = "page-and-warn" ] || fail "THE DEFECT: the ledger did not run and the answer
+routed to '$BROKEN_RC'. Nothing was claimed, so a 'quiet' here drops the page for
+a state no file records and no later run will retire."
+ok "page / quiet / page-and-warn are three distinct routes, not one"
+
+# --- 4. EVERY CALL SITE ACTUALLY USES THE ROUTING HELPER --------------------
+# The routing is only real if no call site still writes the collapsing shape.
+BARE="$(grep -cE '^\s*if claim_page_once ' "$WORKER" || true)"
+if [ "$BARE" -ne 0 ]; then
+  fail "THE DEFECT: $BARE call site(s) in linear-worker.sh still use
+\`if claim_page_once ...; then\`, which collapses exit 3 (wrote nothing) into the
+same branch as exit 1 (already claimed). Those pages are silently dropped."
+fi
+ok "no call site uses the bare \`if claim_page_once\` shape that collapses exit 3"
+
+echo "PASS ($PASS checks)"

--- a/q-system/output/mutcheck-ask286-r4.sh
+++ b/q-system/output/mutcheck-ask286-r4.sh
@@ -1,0 +1,87 @@
+#!/usr/bin/env bash
+# Mutation check for the ASK-286 codex-round-4 fix. Cases 7-9 of
+# test-claim-page-once-routing.sh only prove the fix is PRESENT; these prove they
+# would FAIL if it were removed. Both guards are inside page_once's failure arm,
+# which the happy-path cases never reach, so without this an implementation with
+# neither guard could ship green.
+#
+# Mutates a COPY of linear-worker.sh -- never the tracked file.
+set -uo pipefail
+REPO="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+WORKER="$REPO/q-system/.q-system/scripts/linear-worker.sh"
+LEDGER_PY="$REPO/q-system/.q-system/scripts/attempts-ledger.py"
+W="$(mktemp -d)"
+trap 'rm -rf "$W"' EXIT
+SURVIVORS=0
+
+# Run the three round-4 observations against a given (possibly mutated) worker.
+# Echoes "contend=N broken=N alerts=N".
+observe() {
+  local worker="$1" dir; dir="$(mktemp -d)"
+  (
+    set -uo pipefail
+    LEDGER="$LEDGER_PY"; ATTEMPTS="$dir/attempts.json"
+    NOTIFY="$dir/notify.sh"
+    printf '#!/usr/bin/env bash\necho "$*" >> "%s"\n' "$dir/slack.log" > "$NOTIFY"
+    chmod +x "$NOTIFY"; : > "$dir/slack.log"; : > "$dir/perm.log"
+    say() { :; }
+    LEDGER_FAULT_ALERTED=0
+    eval "$(awk '/^claim_page_once\(\)/{print; exit}' "$worker")"
+    eval "$(sed -n '/^ledger_fault() {/,/^}/p' "$worker")"
+    eval "$(sed -n '/^page_once() {/,/^}/p' "$worker")"
+    attempt_page() { page_once "$1" stuck_paged 2>/dev/null && echo "$1" >> "$dir/perm.log"; }
+    new_run() { LEDGER_FAULT_ALERTED=0; }
+
+    # A. contended cycle, then a claiming cycle. One real state.
+    echo '{}' > "$ATTEMPTS"; rm -f "$ATTEMPTS.lock"
+    python3 - "$ATTEMPTS.lock" <<'PY' &
+import fcntl, sys, time
+fh = open(sys.argv[1], "a"); fcntl.flock(fh.fileno(), fcntl.LOCK_EX); time.sleep(60)
+PY
+    H=$!; sleep 1
+    new_run; KIPI_ATTEMPTS_LOCK_TRIES=2 attempt_page ASK-CONTEND
+    kill "$H" 2>/dev/null; wait "$H" 2>/dev/null
+    new_run; attempt_page ASK-CONTEND
+    C="$(grep -c ASK-CONTEND "$dir/perm.log" || true)"
+
+    # B. unwritable ledger, five separate runs.
+    : > "$dir/perm.log"; : > "$dir/slack.log"
+    for _ in 1 2 3 4 5; do new_run; LEDGER="$dir/nope.py" attempt_page ASK-BROKEN; done
+    B="$(grep -c ASK-BROKEN "$dir/perm.log" || true)"
+
+    # C. one run, four queued issues, one broken ledger.
+    : > "$dir/slack.log"; new_run
+    for i in Q1 Q2 Q3 Q4; do LEDGER="$dir/nope.py" attempt_page "$i"; done
+    A="$(wc -l < "$dir/slack.log" | tr -d ' ')"
+    echo "contend=$C broken=$B alerts=$A"
+  )
+  rm -rf "$dir"
+}
+
+check() {
+  local name="$1" got="$2" want="contend=1 broken=0 alerts=1"
+  if [ "$got" = "$want" ]; then
+    echo "  SURVIVED  $name -> $got"; SURVIVORS=$((SURVIVORS + 1))
+  else
+    echo "  KILLED    $name -> $got (baseline: $want)"
+  fi
+}
+
+echo "BASELINE (unmutated): $(observe "$WORKER")"
+echo
+
+# MUTANT 1: the failure arm returns 0 again -- the round-4 major itself. The
+# caller then writes its permanent Linear comment off a ledger that recorded
+# nothing.
+sed 's/^       return 1 ;;$/       return 0 ;;/' "$WORKER" > "$W/m1.sh"
+cmp -s "$WORKER" "$W/m1.sh" && { echo "MUTANT 1 did not apply -- re-point this harness"; exit 1; }
+check "fault arm returns 0 (page anyway)" "$(observe "$W/m1.sh")"
+
+# MUTANT 2: the once-per-run guard removed, so a broken ledger alerts once per
+# QUEUED ISSUE -- cry-wolf re-created inside the channel the notice moved into.
+grep -v '^  \[ "\$LEDGER_FAULT_ALERTED" -eq 0 \] || return 0$' "$WORKER" > "$W/m2.sh"
+cmp -s "$WORKER" "$W/m2.sh" && { echo "MUTANT 2 did not apply -- re-point this harness"; exit 1; }
+check "once-per-run guard removed" "$(observe "$W/m2.sh")"
+
+echo
+[ "$SURVIVORS" -eq 0 ] && echo "ALL MUTANTS KILLED" || { echo "$SURVIVORS MUTANT(S) SURVIVED"; exit 1; }

--- a/q-system/output/repro-ask286-r4-permanent-page.sh
+++ b/q-system/output/repro-ask286-r4-permanent-page.sh
@@ -1,0 +1,88 @@
+#!/usr/bin/env bash
+# Standalone PRE-FIX observation for ASK-286 codex round 4 major: page_once
+# returns 0 ("caller, do your page") on exit 2 and exit 3, and the stuck call
+# site's page is a PERMANENT Linear comment. So:
+#
+#   exit 3 (contended)  -> run A pages, run B claims and pages   = 2 comments
+#   exit 2 (unwritable) -> nothing is ever claimed               = 1 comment
+#                          per issue PER RUN, forever
+#
+# Not part of the suite -- cases 7-9 of test-claim-page-once-routing.sh are the
+# committed versions. This file exists to observe RED before the fix lands.
+set -uo pipefail
+REPO="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+WORKER="$REPO/q-system/.q-system/scripts/linear-worker.sh"
+LEDGER_PY="$REPO/q-system/.q-system/scripts/attempts-ledger.py"
+W="$(mktemp -d)"
+trap 'rm -rf "$W"' EXIT
+
+CLAIM_FN="$(awk '/^claim_page_once\(\)/{print; exit}' "$WORKER")"
+PAGE_FN="$(sed -n '/^page_once() {/,/^}/p' "$WORKER")"
+# Absent pre-fix; `eval ""` is a harmless no-op, so this file runs against both
+# the unfixed and the fixed worker.
+FAULT_FN="$(sed -n '/^ledger_fault() {/,/^}/p' "$WORKER")"
+LEDGER_FAULT_ALERTED=0
+
+LEDGER="$LEDGER_PY"
+ATTEMPTS="$W/attempts.json"
+NOTIFY="$W/notify.sh"
+printf '#!/usr/bin/env bash\necho "SLACK: $*" >> "%s"\n' "$W/slack.log" > "$NOTIFY"
+chmod +x "$NOTIFY"
+say() { echo "$*" >&2; }
+eval "$CLAIM_FN"
+eval "$FAULT_FN"
+eval "$PAGE_FN"
+
+# The permanent sink: what the stuck call site does inside `if page_once`.
+PERMANENT="$W/linear-comments.log"
+: > "$PERMANENT"
+attempt_page() {
+  if page_once "$1" stuck_paged 2>/dev/null; then
+    echo "PERMANENT LINEAR COMMENT on $1" >> "$PERMANENT"
+  fi
+}
+# A real worker RUN is a fresh process, so its run-scoped state starts at 0.
+# Modelling several runs inside one shell means resetting it by hand -- forget
+# this and a later section inherits an earlier one's "already alerted".
+new_run() { LEDGER_FAULT_ALERTED=0; }
+
+echo "=== A. CONTENTION (exit 3): two runs, one real state ==="
+echo '{}' > "$ATTEMPTS"
+rm -f "$ATTEMPTS.lock"
+# Run A meets a live holder -> exit 3, wrote nothing.
+python3 - "$ATTEMPTS.lock" <<'PY' &
+import fcntl, sys, time
+fh = open(sys.argv[1], "a")
+fcntl.flock(fh.fileno(), fcntl.LOCK_EX)
+time.sleep(60)
+PY
+HOLDER=$!
+sleep 1
+new_run; KIPI_ATTEMPTS_LOCK_TRIES=2 attempt_page ASK-CONTEND
+kill "$HOLDER" 2>/dev/null || true
+wait "$HOLDER" 2>/dev/null || true
+# Run B (next worker cycle), lock free -> claims and pages.
+new_run; attempt_page ASK-CONTEND
+echo "permanent comments posted for ASK-CONTEND: $(grep -c 'ASK-CONTEND' "$PERMANENT")"
+
+echo
+echo "=== B. UNWRITABLE LEDGER (exit 2): five worker cycles ==="
+: > "$PERMANENT"
+: > "$W/slack.log"
+for cycle in 1 2 3 4 5; do
+  new_run
+  LEDGER="$W/no-such-ledger.py" attempt_page ASK-BROKEN
+done
+echo "permanent comments posted for ASK-BROKEN over 5 cycles: $(grep -c 'ASK-BROKEN' "$PERMANENT")"
+echo "slack fault alerts over those 5 cycles:                $(wc -l < "$W/slack.log" | tr -d ' ')"
+
+echo
+echo "=== C. ONE BROKEN LEDGER, A QUEUE OF 4 ISSUES, ONE RUN ==="
+: > "$PERMANENT"
+: > "$W/slack.log"
+new_run   # ONE run; the four issues below are its queue, not four runs
+for i in ASK-1 ASK-2 ASK-3 ASK-4; do
+  LEDGER="$W/no-such-ledger.py" attempt_page "$i"
+done
+echo "permanent comments in ONE run: $(wc -l < "$PERMANENT" | tr -d ' ')"
+echo "slack fault alerts in ONE run:  $(wc -l < "$W/slack.log" | tr -d ' ')"


### PR DESCRIPTION
Closes the defect `sp-626e9452` recorded as founder-deferred: `attempts-ledger.py`
`_mutate` shipped a lock that **proceeded on timeout** and **released by path**.
Back-ports the version PR #42 (`7e8d767`) proved in `converge.sh`
`receipt_transaction`.

## Why this was worse than no lock

A run that timed out believed it was serialized, entered the transaction holding
nothing, and its release then deleted the live lock of the run that actually held
it. Both runs sat inside one read-decide-write.

The counter it guards decides whether an issue is retried or marked STUCK. A lost
increment means an issue exceeds `MAX_ATTEMPTS` and keeps being dispatched --
silent budget burn on work that already failed three times, and a human is never told.

It had already propagated. On 2026-08-02 an agent was told to reuse an in-repo lock
rather than invent a fourth, copied this one **including both defects**, and cited
the source as justification. Codex caught it there. Citing a pattern is not
verifying it.

## The four invariants

1. **A timeout returns FAILURE** -- exit 3, deliberately distinct from `claim-flag`'s
   1 ("already claimed, stay quiet") and never 0 ("claimed, go page"). The caller
   writes nothing and says so on stderr. A skipped bump is recoverable: the next run
   retries and the run that *did* hold the lock is counting. Two writers in one
   transaction is not.
2. **A release removes only a lock carrying this run's own token**, never one
   identified by path.
3. **The lock is created already carrying its owner.** The token goes into a temp
   file and `os.link` publishes it atomically, so the lock never exists
   un-attributable. `mkdir` left that window open, and a run killed inside it left a
   lock nothing could ever own.
4. **Stale locks break on owner liveness**, and a lock nothing can ever own (empty
   file, or the leftover `mkdir` DIRECTORY a pre-fix worker leaves behind) is a
   corpse by construction. Without that, the first upgrade wedges the ledger forever.

Residual is named in the docstring rather than papered over: the token re-read
before a break is a narrow TOCTOU window and pid reuse can make a corpse look live.
Both degrade in the safe direction; neither can silently delete a live run's lock.

## Reproducer first, both defects observed RED

```
$ python3 q-system/.q-system/scripts/test/test-attempts-ledger.py     # unfixed
FAIL: THE DEFECT: the lock is held by a LIVE pid and bump-attempt reported success.
A run that cannot take the lock must do no work and say so -- entering the
transaction here is two runs inside one read-decide-write.
```

Case 3 red on the unfixed code with `IsADirectoryError` -- the `mkdir` lock cannot
even carry a token, so release-by-path was the only thing it could do.

## Mutation-checked, because case 3 would otherwise be decorative

The release is only reached *after* a successful acquisition, so once the timeout
stops lying there is no ordinary path into it holding someone else's lock. A suite
that never makes the lock change hands mid-transaction passes a release-by-path
mutant -- the trap PR #42 hit. Case 3 stamps a foreign token over the lock from
inside the critical section.

```
$ python3 q-system/output/mutcheck-ask-286.py   # ownership check disabled
mutant: release-by-path (ownership check disabled)
lock still present after release: False
MUTANT KILLED by case 3
```

## Green

```
$ python3 q-system/.q-system/scripts/test/test-attempts-ledger.py
  ok: a timeout writes nothing, says so, and leaves the live holder's lock alone
  ok: claim-flag under contention neither claims nor reports a claim
  ok: a release refuses to remove a lock that no longer carries this run's token
  ok: a lock left by a dead run is broken, written through, and released
  ok: a lock nothing can ever own (stale mkdir directory, empty file) is broken, not honoured
  ok: every op round-trips through the guarded writer and releases its lock
PASS (6 cases)

$ bash q-system/.q-system/scripts/test/test-terminal-states.sh    -> 14 passed, 0 failed
$ bash q-system/.q-system/scripts/test/test-linear-worker-parallel.sh -> PASS (9 checks)
```

## Files

- `q-system/.q-system/scripts/attempts-ledger.py` -- the four invariants, exit 3 on
  lock failure
- `q-system/.q-system/scripts/test/test-attempts-ledger.py` -- new, 6 cases
- `q-system/.q-system/capability-manifest.json` -- registers the test
- `q-system/.q-system/scripts/linear-worker.sh` -- rewrites the comment that
  documented the old take-it-by-force reasoning. That comment was the exemplar, and
  it was wrong.

## Not doing (per the DoR)

`MAX_ATTEMPTS` and the retry policy are untouched. `converge.sh` is untouched -- it
is already correct and merged.

`sp-626e9452` becomes resolvable once this lands and ASK-286 closes.

None of the ledger's callers run under `set -e`, so an exit 3 is a reported miss on
stderr, not a dead worker (verified: `linear-worker.sh:47` is `set -uo pipefail`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
