### PR TITLE
feat(claude-changes): safe replace, gated by a census that reads rule content (ASK-290)

### DIFF
--- a/q-system/.q-system/scripts/apply_claude_changes.py
+++ b/q-system/.q-system/scripts/apply_claude_changes.py
@@ -24,17 +24,18 @@ WHY THIS SHAPE (measured 2026-08-01, do not "simplify" any of it away):
 
 THE THREE LAYERS
 
-  L1 additive-only  : the only ops that EXIST are insert_after, insert_before,
-                      append, create_file. There is no replace and no delete, so
-                      "remove a hook entry" is not expressible. Unknown ops and
-                      unknown proposal keys are refused, so a proposal cannot
-                      smuggle in a flag like disables_enforcement.
+  L1 op vocabulary  : insert_after, insert_before, append, create_file, replace.
+                      There is no delete, so "remove a rule file" is not
+                      expressible. Unknown ops and unknown proposal keys are
+                      refused, so a proposal cannot smuggle in a flag like
+                      disables_enforcement.
   L2 ratchet        : census the live enforcement points before and after. Every
                       pre-existing member must still be present and no category
                       may shrink. This catches the technically-additive edit that
                       removes something as a side effect -- e.g. inserting
                       " || true" after a hook command, which deletes nothing but
                       makes the old exact command string vanish from the census.
+                      It ALSO reads rule bodies, which is what makes replace safe.
   L3 verify+revert  : run the gate suite before and after. Any gate that goes
                       pass -> fail auto-restores the backup. The founder must
                       never be the one who notices a regression.
@@ -43,13 +44,29 @@ Everything runs against a COPY of .claude/ first. The live tree is touched only
 after all of L1, L2 and the preconditions pass on that copy, so a refusal never
 half-writes.
 
+WHY `replace` EXISTS (2026-08-02). L1 was additive-only, and that had a cost
+nobody had priced: a whole class of rule work had NO path. Correcting a false
+claim, fixing wrong text, editing a stale line -- all of them are replaces. On
+2026-08-01 three separate PRs each found a rule carrying a FALSE enforcement
+claim, which is the sharp version of the problem: the system could detect the lie
+and could not correct it. The safety property was never "additive"; it is "an
+agent cannot WEAKEN enforcement", and that is L2's job, not L1's.
+
+Admitting replace required L2 to grow FIRST. Until that day the census counted
+rule FILE NAMES and never read a rule body, so a replace that swapped a whole
+rule for "Advisory only. Nothing runs." kept the filename and passed clean --
+observed, `OK applied gut-rule: ... gates held`, before the fix. The census now
+also holds each rule's ENFORCED claim and the executables it names.
+
 OUT OF REACH BY DESIGN (say so, do not pretend otherwise): removing a hook,
-deleting a rule, narrowing a matcher, and widening permissions.allow or
-defaultMode cannot be done through this path at all. Those need a different
-tool and a real conversation. See REFUSED_SURFACES.
+deleting a rule file, narrowing a matcher, dropping a rule's ENFORCED claim,
+dropping the name of an executable that really exists, and widening
+permissions.allow or defaultMode cannot be done through this path at all. Those
+need a different tool and a real conversation. See REFUSED_SURFACES.
 """
 import json
 import os
+import re
 import shutil
 import subprocess
 import sys
@@ -58,9 +75,19 @@ import time
 
 SCHEMA_VERSION = 1
 
-# L1: the entire op vocabulary. Additive only. There is deliberately no
-# "replace" and no "delete" -- a removal is not expressible, not merely gated.
-ADDITIVE_OPS = ("insert_after", "insert_before", "append", "create_file")
+# L1: the entire op vocabulary. There is deliberately no "delete" -- deleting a
+# file is not expressible, not merely gated.
+#
+# `replace` WAS absent here, and its absence was itself a defect (2026-08-02).
+# Additive-only meant a whole class of rule work had no path at all: correcting a
+# false claim, fixing wrong text, editing a stale line. Three PRs in one night
+# found rules carrying FALSE enforcement claims, and fixing a false claim is
+# exactly a replace -- the system could detect the lie and could not correct it.
+# The safety property was never "additive"; it is "an agent cannot WEAKEN
+# enforcement", which is L2's job. So replace is admitted and L2 was widened to
+# see rule CONTENT (see census), because until that day the ratchet counted rule
+# FILE NAMES only and would have waved through a replace that gutted a rule body.
+ALLOWED_OPS = ("insert_after", "insert_before", "append", "create_file", "replace")
 
 ALLOWED_PROPOSAL_KEYS = {"schema_version", "slug", "reason", "requires", "edits"}
 ALLOWED_EDIT_KEYS = {"file", "op", "anchor", "insert", "reason"}
@@ -172,9 +199,9 @@ def load_proposal(path):
         if unknown_e:
             raise Refusal("edit %d has unknown key(s): %s" % (idx, ", ".join(sorted(unknown_e))))
         op = edit.get("op")
-        if op not in ADDITIVE_OPS:
+        if op not in ALLOWED_OPS:
             raise Refusal(
-                "edit %d op %r is not additive (allowed: %s)" % (idx, op, ", ".join(ADDITIVE_OPS))
+                "edit %d op %r is not an allowed op (allowed: %s)" % (idx, op, ", ".join(ALLOWED_OPS))
             )
         for field in ("file", "insert", "reason"):
             if not isinstance(edit.get(field), str) or not edit[field].strip():
@@ -182,7 +209,7 @@ def load_proposal(path):
         # THE boundary. After this line the proposal holds exactly one spelling
         # of each path and no other reader normalizes anything.
         edit["file"] = canonical_rel(edit["file"])
-        if op in ("insert_after", "insert_before"):
+        if op in ("insert_after", "insert_before", "replace"):
             if not isinstance(edit.get("anchor"), str) or not edit["anchor"].strip():
                 raise Refusal("edit %d needs a non-empty anchor for op %s" % (idx, op))
         elif "anchor" in edit:
@@ -335,6 +362,24 @@ def apply_edit(content, edit, rel):
         raise Refusal("create_file target already exists with different content: %s" % rel)
 
     anchor = edit["anchor"]
+
+    if op == "replace":
+        # IDEMPOTENCE IS GUARANTEED HERE, NOT HOPED FOR. Every other op re-runs
+        # safely because it can detect its own output; replace cannot when the
+        # anchor survives inside the replacement (anchor "ENFORCED" -> insert
+        # "ENFORCED by x.py" re-fires on the next run and yields "ENFORCED by
+        # x.py by x.py"). Rather than half-detect that, the overlapping case is
+        # refused outright and the author is pointed at the op that already does
+        # it correctly. Ambiguity gets a refusal here, same as a >1 anchor.
+        if anchor in ins:
+            raise Refusal(
+                "replace anchor appears inside its own replacement in %s (not "
+                "idempotent -- use insert_after/insert_before to extend text): %r"
+                % (rel, _snip(anchor))
+            )
+        if anchor not in content and content.count(ins) == 1:
+            return content, True
+
     hits = content.count(anchor)
     if hits == 0:
         raise Refusal("anchor not found in %s: %r" % (rel, _snip(anchor)))
@@ -342,6 +387,13 @@ def apply_edit(content, edit, rel):
         raise Refusal("anchor matches %d times (must be exactly 1) in %s: %r" % (hits, rel, _snip(anchor)))
 
     pos = content.index(anchor)
+    if op == "replace":
+        # `insert` is validated non-empty upstream, so replace-with-nothing is
+        # not expressible through this path. That is not the safety property
+        # though -- replacing a hook command with "x" deletes it just as well.
+        # The census is what actually holds the line; see L2.
+        return content[:pos] + ins + content[pos + len(anchor):], False
+
     if op == "insert_after":
         cut = pos + len(anchor)
         if content[cut:cut + len(ins)] == ins:
@@ -385,9 +437,100 @@ def _dir_names(path):
     return {n for n in os.listdir(path) if not n.startswith(".")}
 
 
-def census(root):
-    """Count the live enforcement points. Enforcement may only grow."""
+# A leading alphanumeric is REQUIRED. Without it the pattern also matches the
+# literal "<skill>-lint.py" that skill-hook-pairing.md writes as a naming
+# convention, and a template placeholder is not an executable.
+_SCRIPT_NAME_RE = re.compile(r"[A-Za-z0-9][A-Za-z0-9_.-]*\.(?:py|sh)\b")
+
+_REPO_SCRIPTS_CACHE = {}
+
+
+def _repo_script_names(root):
+    """Every .py/.sh basename that actually exists anywhere in the repo.
+
+    Walks dot-directories deliberately: the enforcement scripts live in
+    `q-system/.q-system/scripts/`, and Python's glob `**` silently skips
+    dot-dirs. Measured 2026-08-02 -- a glob-based version of this scan reported
+    38 rule-named scripts as missing when only 4 really were, which would have
+    made the ratchet wave through the removal of 34 live enforcement claims.
+
+    Pruning is deliberately minimal (.git, node_modules). Every directory left in
+    can only make MORE names resolve, and a name that resolves is a name the
+    ratchet protects -- so an over-broad scan errs toward more protection, while
+    an over-narrow one errs toward letting a real claim be deleted.
+    """
+    key = os.path.abspath(root)
+    if key in _REPO_SCRIPTS_CACHE:
+        return _REPO_SCRIPTS_CACHE[key]
+    names = set()
+    for dirpath, dirnames, filenames in os.walk(key):
+        dirnames[:] = [d for d in dirnames if d not in (".git", "node_modules")]
+        for name in filenames:
+            if name.endswith(".py") or name.endswith(".sh"):
+                names.add(name)
+    _REPO_SCRIPTS_CACHE[key] = names
+    return names
+
+
+def _rule_content_claims(root, repo_scripts):
+    """(enforced_claims, named_executables) read from .claude/rules/*.md bodies.
+
+    WHY THIS EXISTS (2026-08-02). The census counted rule FILE NAMES and nothing
+    else, so it could not see inside a rule at all. That was survivable while the
+    op vocabulary was additive-only. The moment `replace` was admitted it stopped
+    being survivable: a replace that swapped a rule's whole body for "Advisory
+    only. Nothing runs." kept the filename, passed the ratchet, and the engine
+    reported `OK applied ... gates held`. That run is the reproducer for this
+    function, and it was watched green-when-it-should-have-been-red first.
+
+    named_executables holds only scripts that RESOLVE to a real file. That
+    qualifier is what keeps `replace` useful rather than merely safe: a rule
+    naming a script that does not exist is a false claim, not enforcement, and
+    correcting it is the exact job replace was added for. A rule naming a script
+    that does exist is a live claim, and dropping the name weakens it.
+
+    KNOWN LIMIT, stated rather than hidden: resolution is repo-only. A hook that
+    lives outside the repo (destructive-op-deny.sh sits in ~/.claude/hooks/) is
+    therefore unprotected prose here. That is acceptable because the enforcement
+    for those is the hook WIRING in settings.json, which the hooks census already
+    holds; the mention in a rule is documentation of it.
+    """
+    enforced = set()
+    named = set()
+    rules_dir = os.path.join(root, ".claude", "rules")
+    if not os.path.isdir(rules_dir):
+        return enforced, named
+    for name in sorted(os.listdir(rules_dir)):
+        if not name.endswith(".md") or name.startswith("."):
+            continue
+        try:
+            with open(os.path.join(rules_dir, name)) as fh:
+                text = fh.read()
+        except (OSError, UnicodeDecodeError):
+            # Unreadable is not "makes no claims". Skipping it silently would let
+            # a rule be emptied behind an encoding error, so it is left out of
+            # BOTH censuses identically and the file-name census still covers it.
+            continue
+        if "ENFORCED" in text:
+            enforced.add(name)
+        for script in _SCRIPT_NAME_RE.findall(text):
+            if script in repo_scripts:
+                named.add("%s|%s" % (name, script))
+    return enforced, named
+
+
+def census(root, resolve_root=None):
+    """Count the live enforcement points. Enforcement may only grow.
+
+    `resolve_root` is where script names are checked for existence, and it is
+    NOT `root`. The "after" census runs against a copy tree that holds only
+    .claude/ and the capability manifest, so resolving there would find zero
+    scripts, every named_executables entry would vanish, and the ratchet would
+    refuse every apply. Existence is a fact about the REPO, identical before and
+    after -- no op in this vocabulary can create a script outside .claude/.
+    """
     c = {}
+    repo_scripts = _repo_script_names(resolve_root or root)
     settings_path = os.path.join(root, ".claude", "settings.json")
     settings = {}
     if os.path.isfile(settings_path):
@@ -415,6 +558,7 @@ def census(root):
         except ValueError:
             pass
     c["manifest_tests"] = tests
+    c["enforced_claims"], c["named_executables"] = _rule_content_claims(root, repo_scripts)
     return c
 
 
@@ -709,8 +853,8 @@ def main(argv):
             with open(dest, "w") as fh:
                 fh.write(content)
 
-        before_census = census(root)
-        after_census = census(copy_root)
+        before_census = census(root, resolve_root=root)
+        after_census = census(copy_root, resolve_root=root)
         ratchet_check(before_census, after_census)
         log.append("ratchet ok: hooks %d->%d, rules %d->%d, deny %d->%d" % (
             len(before_census["hooks"]), len(after_census["hooks"]),

--- a/q-system/.q-system/scripts/test/test-apply-claude-changes.sh
+++ b/q-system/.q-system/scripts/test/test-apply-claude-changes.sh
@@ -224,7 +224,11 @@ rm -r "$T"
 
 # ------------------------- 5. removal / disable is not expressible (no bypass)
 T=$(mktemp -d); mk_fixture "$T"
-for OP in replace delete remove overwrite; do
+# `replace` LEFT this list on 2026-08-02 and is now a first-class op (see the
+# replace section below). Deleting a file is still not expressible. The safety
+# property was never the op vocabulary; it is the ratchet, which had to learn to
+# read rule CONTENT before replace could be admitted.
+for OP in delete remove overwrite; do
   cat > "$T/op.json" <<JSON
 {
   "schema_version": 1, "slug": "op-$OP", "reason": "try to remove a hook",
@@ -233,7 +237,7 @@ for OP in replace delete remove overwrite; do
 }
 JSON
   run_engine "$ENGINE" "$T/op.json" "$T"
-  check "op '$OP' refused as non-additive" 2 "is not additive" "$RC" "$OUT"
+  check "op '$OP' refused as not allowed" 2 "is not an allowed op" "$RC" "$OUT"
 done
 
 # The flag the old design would have used. It must not be a bypass; it must not
@@ -556,6 +560,143 @@ case "$OUT" in
 esac
 rm -r "$T"
 
+# =========================== 15. replace ===================================
+# `replace` exists so that a FALSE claim in a rule can be corrected. Additive-only
+# meant "the system can detect the lie and cannot correct it" (three PRs on
+# 2026-08-01 each found a rule carrying a false enforcement claim).
+#
+# The danger it introduces is exact: under the census as it stood, a replace
+# could gut a rule's whole body and pass, because the census counted rule FILE
+# NAMES and never read inside one. Case 15a is that gap; it was watched RED
+# (the gutting APPLIED, rc=0) before the content census was written.
+
+# A rule that makes a REAL enforcement claim: the token ENFORCED, and a script
+# name that resolves to a file that actually exists in the fixture repo.
+mk_enforced_rule() {  # mk_enforced_rule <root>
+  cat > "$1/.claude/rules/voice-thing.md" <<'MD'
+# Voice Rule (ENFORCED)
+
+Enforced by `existing-lint.py` (PostToolUse on Edit/Write). Bypass per file with
+the marker.
+MD
+}
+
+# ---- 15a. gutting a rule's enforcement claim is refused (THE gap case)
+T=$(mktemp -d); mk_fixture "$T"; mk_enforced_rule "$T"
+cat > "$T/gut.json" <<'JSON'
+{
+  "schema_version": 1, "slug": "gut-rule", "reason": "quietly retire a rule",
+  "edits": [ { "file": ".claude/rules/voice-thing.md", "op": "replace",
+               "anchor": "# Voice Rule (ENFORCED)\n\nEnforced by `existing-lint.py` (PostToolUse on Edit/Write). Bypass per file with\nthe marker.",
+               "insert": "# Voice Rule\n\nAdvisory only. Nothing runs.",
+               "reason": "demote to advisory" } ]
+}
+JSON
+SUM=$(shasum -a 256 "$T/.claude/rules/voice-thing.md" | awk '{print $1}')
+run_engine "$ENGINE" "$T/gut.json" "$T"
+check "replace gutting a rule refused" 2 "enforcement ratchet" "$RC" "$OUT"
+check_one_line "replace gutting a rule" "$OUT"
+if [ "$SUM" = "$(shasum -a 256 "$T/.claude/rules/voice-thing.md" | awk '{print $1}')" ]; then
+  ok "replace gutting a rule wrote nothing"
+else bad "replace gutting a rule mutated the rule file"; fi
+rm -r "$T"
+
+# ---- 15b. dropping ONLY the ENFORCED token is refused
+T=$(mktemp -d); mk_fixture "$T"; mk_enforced_rule "$T"
+cat > "$T/demote.json" <<'JSON'
+{
+  "schema_version": 1, "slug": "demote-rule", "reason": "drop the ENFORCED claim",
+  "edits": [ { "file": ".claude/rules/voice-thing.md", "op": "replace",
+               "anchor": "# Voice Rule (ENFORCED)",
+               "insert": "# Voice Rule (advisory)", "reason": "demote" } ]
+}
+JSON
+run_engine "$ENGINE" "$T/demote.json" "$T"
+check "replace dropping ENFORCED refused" 2 "enforcement ratchet" "$RC" "$OUT"
+rm -r "$T"
+
+# ---- 15c. dropping the name of a script that EXISTS is refused
+T=$(mktemp -d); mk_fixture "$T"; mk_enforced_rule "$T"
+cat > "$T/unname.json" <<'JSON'
+{
+  "schema_version": 1, "slug": "unname-script", "reason": "stop naming the lint",
+  "edits": [ { "file": ".claude/rules/voice-thing.md", "op": "replace",
+               "anchor": "Enforced by `existing-lint.py` (PostToolUse on Edit/Write).",
+               "insert": "Enforced by convention.", "reason": "drop the executable" } ]
+}
+JSON
+run_engine "$ENGINE" "$T/unname.json" "$T"
+check "replace dropping a REAL executable refused" 2 "enforcement ratchet" "$RC" "$OUT"
+rm -r "$T"
+
+# ---- 15d. THE PERMISSIVE HALF: dropping the name of a script that does NOT
+# exist is ALLOWED. Without this the ratchet would forbid the very thing replace
+# was built for -- correcting a false claim. A rule naming a nonexistent script
+# is a lie, not enforcement, so removing the name is a correction. Measured on
+# the real repo: 4 such names exist today (kebab-case.py, kebab-case.sh,
+# destructive-op-deny.sh, and the `<skill>-lint.py` regex artifact).
+T=$(mktemp -d); mk_fixture "$T"
+cat > "$T/.claude/rules/false-claim.md" <<'MD'
+# Some Rule (ENFORCED)
+
+Enforced by `kebab-case.py` on every write.
+MD
+cat > "$T/fix.json" <<'JSON'
+{
+  "schema_version": 1, "slug": "fix-false-claim", "reason": "correct a false enforcement claim",
+  "edits": [ { "file": ".claude/rules/false-claim.md", "op": "replace",
+               "anchor": "Enforced by `kebab-case.py` on every write.",
+               "insert": "No executable enforces this yet; it is advisory until one does.",
+               "reason": "the named script does not exist" } ]
+}
+JSON
+run_engine "$ENGINE" "$T/fix.json" "$T"
+check "replace correcting a FALSE claim allowed" 0 "applied" "$RC" "$OUT"
+if grep -q "kebab-case.py" "$T/.claude/rules/false-claim.md"; then
+  bad "false-claim correction did not land"
+else ok "false-claim correction landed (the lie is gone)"; fi
+
+# ---- 15e. and it is idempotent: re-running the same proposal is not an error
+run_engine "$ENGINE" "$T/fix.json" "$T"
+if [ "$RC" = "0" ]; then ok "replace is idempotent on re-run (rc=0)"
+else bad "replace re-run failed (rc=$RC) :: $OUT"; fi
+rm -r "$T"
+
+# ---- 15f. anchor discipline carries over to replace
+T=$(mktemp -d); mk_fixture "$T"
+printf 'dup\ndup\n' > "$T/.claude/rules/dup.md"
+cat > "$T/dupr.json" <<'JSON'
+{
+  "schema_version": 1, "slug": "dup-replace", "reason": "ambiguous anchor",
+  "edits": [ { "file": ".claude/rules/dup.md", "op": "replace",
+               "anchor": "dup", "insert": "X", "reason": "r" } ]
+}
+JSON
+run_engine "$ENGINE" "$T/dupr.json" "$T"
+check "replace with ambiguous anchor refused" 2 "must be exactly 1" "$RC" "$OUT"
+
+cat > "$T/missr.json" <<'JSON'
+{
+  "schema_version": 1, "slug": "miss-replace", "reason": "anchor absent",
+  "edits": [ { "file": ".claude/rules/dup.md", "op": "replace",
+               "anchor": "nowhere-at-all", "insert": "X", "reason": "r" } ]
+}
+JSON
+run_engine "$ENGINE" "$T/missr.json" "$T"
+check "replace with missing anchor refused" 2 "anchor not found" "$RC" "$OUT"
+
+# An anchor that survives inside its own replacement would re-fire on every run.
+cat > "$T/overlap.json" <<'JSON'
+{
+  "schema_version": 1, "slug": "overlap-replace", "reason": "non-idempotent",
+  "edits": [ { "file": ".claude/rules/dup.md", "op": "replace",
+               "anchor": "dup\ndup", "insert": "dup\ndup extra", "reason": "r" } ]
+}
+JSON
+run_engine "$ENGINE" "$T/overlap.json" "$T"
+check "replace with self-containing anchor refused" 2 "not idempotent" "$RC" "$OUT"
+rm -r "$T"
+
 # ============================ MUTATION =====================================
 # Copy the engine, break ONE guard, prove the matching case goes red. Without
 # this, a green suite only proves the tests run, not that the guards do anything.
@@ -684,6 +825,98 @@ if grep -q 'Bash(:\*)' "$T/.claude/settings.json"; then
   ok "MUTATION normalize: both readers restored -> ./ spelling widened permissions.allow (rc=$MRC), test goes RED as required"
 else
   bad "MUTATION normalize: mutant did not widen permissions - the ./ test is not load-bearing"
+fi
+rm -r "$T"
+
+echo "--- mutation: blind the census to a rule's ENFORCED claim ---"
+T=$(mktemp -d); mk_fixture "$T"; mk_enforced_rule "$T"
+MUT="$T/mutant_enforced.py"
+mutate "$MUT" '        if "ENFORCED" in text:' '        if False and "ENFORCED" in text:'
+python3 -c "import ast,sys; ast.parse(open(sys.argv[1]).read())" "$MUT" \
+  && ok "MUTATION enforced: mutant parses (not a false kill)" \
+  || bad "MUTATION enforced: mutant does not parse"
+cat > "$T/demote.json" <<'JSON'
+{
+  "schema_version": 1, "slug": "demote-rule", "reason": "drop the ENFORCED claim",
+  "edits": [ { "file": ".claude/rules/voice-thing.md", "op": "replace",
+               "anchor": "# Voice Rule (ENFORCED)",
+               "insert": "# Voice Rule (advisory)", "reason": "demote" } ]
+}
+JSON
+set +e
+MOUT=$(python3 "$MUT" "$T/demote.json" --root "$T" 2>&1); MRC=$?
+set -e
+if [ "$MRC" = "2" ]; then
+  bad "MUTATION enforced: mutant still refused - the ENFORCED census is not load-bearing"
+else
+  ok "MUTATION enforced: census blinded -> rule demoted to advisory (rc=$MRC), test goes RED as required"
+fi
+if grep -q "advisory" "$T/.claude/rules/voice-thing.md"; then
+  ok "MUTATION enforced: confirmed the mutant really wrote the demotion"
+else bad "MUTATION enforced: mutant did not write; mutation may be inert"; fi
+rm -r "$T"
+
+echo "--- mutation: blind the census to a rule's named executables ---"
+T=$(mktemp -d); mk_fixture "$T"; mk_enforced_rule "$T"
+MUT="$T/mutant_named.py"
+mutate "$MUT" '            if script in repo_scripts:' '            if False and script in repo_scripts:'
+python3 -c "import ast,sys; ast.parse(open(sys.argv[1]).read())" "$MUT" \
+  && ok "MUTATION named: mutant parses (not a false kill)" \
+  || bad "MUTATION named: mutant does not parse"
+cat > "$T/unname.json" <<'JSON'
+{
+  "schema_version": 1, "slug": "unname-script", "reason": "stop naming the lint",
+  "edits": [ { "file": ".claude/rules/voice-thing.md", "op": "replace",
+               "anchor": "Enforced by `existing-lint.py` (PostToolUse on Edit/Write).",
+               "insert": "Enforced by convention.", "reason": "drop the executable" } ]
+}
+JSON
+set +e
+MOUT=$(python3 "$MUT" "$T/unname.json" --root "$T" 2>&1); MRC=$?
+set -e
+if [ "$MRC" = "2" ]; then
+  bad "MUTATION named: mutant still refused - the named-executable census is not load-bearing"
+else
+  ok "MUTATION named: census blinded -> live executable un-named (rc=$MRC), test goes RED as required"
+fi
+if grep -q "Enforced by convention." "$T/.claude/rules/voice-thing.md"; then
+  ok "MUTATION named: confirmed the mutant really wrote the removal"
+else bad "MUTATION named: mutant did not write; mutation may be inert"; fi
+rm -r "$T"
+
+# The existence qualifier is itself a guard: drop it and named_executables would
+# protect NAMES THAT DO NOT RESOLVE, which forbids the false-claim correction
+# that replace exists to make. This mutation proves the carve-out is load-bearing
+# in the permissive direction -- the direction a ratchet is least likely to be
+# tested in, and the one where over-blocking hides as "safe".
+echo "--- mutation: protect names that do not resolve (over-block) ---"
+T=$(mktemp -d); mk_fixture "$T"
+cat > "$T/.claude/rules/false-claim.md" <<'MD'
+# Some Rule (ENFORCED)
+
+Enforced by `kebab-case.py` on every write.
+MD
+MUT="$T/mutant_exists.py"
+mutate "$MUT" '            if script in repo_scripts:' '            if True or script in repo_scripts:'
+python3 -c "import ast,sys; ast.parse(open(sys.argv[1]).read())" "$MUT" \
+  && ok "MUTATION exists: mutant parses (not a false kill)" \
+  || bad "MUTATION exists: mutant does not parse"
+cat > "$T/fix.json" <<'JSON'
+{
+  "schema_version": 1, "slug": "fix-false-claim", "reason": "correct a false enforcement claim",
+  "edits": [ { "file": ".claude/rules/false-claim.md", "op": "replace",
+               "anchor": "Enforced by `kebab-case.py` on every write.",
+               "insert": "No executable enforces this yet; it is advisory until one does.",
+               "reason": "the named script does not exist" } ]
+}
+JSON
+set +e
+MOUT=$(python3 "$MUT" "$T/fix.json" --root "$T" 2>&1); MRC=$?
+set -e
+if [ "$MRC" = "2" ]; then
+  ok "MUTATION exists: qualifier removed -> false-claim correction wrongly REFUSED, test goes RED as required"
+else
+  bad "MUTATION exists: mutant still allowed the correction - the existence qualifier is not load-bearing"
 fi
 rm -r "$T"
 


### PR DESCRIPTION
## What

Adds a `replace` op to the `.claude/` apply route, and widens the L2 enforcement ratchet to read `.claude/rules/*.md` **content** so the op cannot weaken enforcement.

Closes ASK-290.

## Why

L1 was additive-only, so a whole class of rule work had **no path at all**: correcting a false claim, fixing wrong text, editing a stale line. On 2026-08-01 three PRs (#49, #51, spillover `sp-8a7d358a`) each found a rule carrying a FALSE enforcement claim. Fixing a false claim is exactly a replace. The system could detect the lie and could not correct it.

## The gap, observed rather than theorized

`census()` counted rule FILE NAMES via `_dir_names` and never read a rule body. With the op added and the census untouched, a replace swapping a rule's entire body for `"Advisory only. Nothing runs."` was **applied and reported clean**:

```
FAIL: replace gutting a rule refused (exit 0, wanted 2) :: OK applied gut-rule: 1 edit(s), 1 file(s), hooks 1->1, gates held
```

That RED was watched before the census was written. So the census grew first.

## The fix

Two new census keys over rule content:

- `enforced_claims` — a rule that declared `ENFORCED` must still declare it.
- `named_executables` — `(rule, script)` pairs where the script **resolves to a real file**.

The existence qualifier is load-bearing **in the permissive direction**: a rule naming a script that does not exist is a lie, not enforcement, so correcting it is precisely what `replace` exists for. Without it the ratchet would forbid the very thing the op was added to do.

Two resolution details that are easy to get wrong:
- Script resolution walks dot-directories. A glob-based scan reported 38 of 42 rule-named scripts as missing when only 4 really were, which would have let 34 live enforcement claims be deleted.
- Resolution runs against the **real repo root for both censuses**. The "after" copy tree holds only `.claude/`, so resolving there would empty the set and refuse every apply.

`replace` also guarantees idempotence rather than hoping for it: an anchor that survives inside its own replacement is refused outright, since it would re-fire on every run.

## Verdict: can replace be made safe?

Yes, but **not by the ratchet as it stood**. The safety property is not additivity, it is that an agent cannot weaken enforcement. Admitting `replace` required L2 to grow first. Deleting a rule file is still not expressible.

## Tests

76 pass. Three mutations, each watched RED:

| Mutation | Result |
|---|---|
| Blind the `ENFORCED` census | rule demoted to advisory, rc=0 |
| Blind the named-executable census | live executable un-named, rc=0 |
| Remove the existence qualifier | false-claim correction wrongly REFUSED |

Both directions proven: gutting is refused, and a genuine false-claim correction is allowed and idempotent on re-run.

Adjacent suite `test-claude-write-path.sh` still 78/78 — the ASK-282 harness guard is untouched and no direct shell write path is reopened.