### PR TITLE
feat(claude-changes): replace rule text through the safe path, ratcheted on rule content (ASK-289)

### DIFF
--- a/q-system/.q-system/scripts/apply_claude_changes.py
+++ b/q-system/.q-system/scripts/apply_claude_changes.py
@@ -39,10 +39,12 @@ THE THREE LAYERS
                       removes something as a side effect -- e.g. inserting
                       " || true" after a hook command, which deletes nothing but
                       makes the old exact command string vanish from the census.
-                      The census reads rule CONTENT, not just the rules/ listing
-                      (_rule_marks): an (ENFORCED marker or a pointer to a named
-                      enforcer may not vanish from a rule, and a rule's count of
-                      substantive lines may not shrink. Filenames alone were
+                      The census reads rule CONTENT at any depth under rules/,
+                      not just the rules/ listing (_rule_marks): an (ENFORCED
+                      marker may not lose an occurrence NOR leave the heading it
+                      sits on, a pointer to a named enforcer may not vanish or be
+                      rerouted, and a rule's count of substantive lines may not
+                      shrink. Filenames alone were
                       blind to everything a replace does inside a file, which is
                       exactly why replace could not exist before that census; the
                       line floor is there because 5 of 34 rules carry no token at
@@ -57,17 +59,21 @@ half-writes.
 
 OUT OF REACH BY DESIGN (say so, do not pretend otherwise): removing a hook,
 deleting a rule, narrowing a matcher, widening permissions.allow or defaultMode,
-stripping a rule's (ENFORCED marker or its pointer to a named enforcer, changing
-a rule's frontmatter (the keys that decide whether it loads at all), and
-shortening a rule's body, cannot be done through this path at all. Those need a
-different tool and a real conversation. See REFUSED_SURFACES.
+dropping an occurrence of a rule's (ENFORCED marker or moving it off the heading
+it sits on, dropping or rerouting a rule's pointer to a named enforcer, changing
+a rule's frontmatter (the keys that decide whether it loads at all) by ANY op
+including the additive ones, and shortening a rule's body, cannot be done through
+this path at all. Those need a different tool and a real conversation. See
+REFUSED_SURFACES.
 
 WHAT STILL GETS THROUGH (the honest residue, do not read the list above as
-wider than it is): the census counts markers, executable references and line
-COUNT -- never meaning. A replace that rewrites a rule into something vaguer
-while keeping its (ENFORCED marker, every script name and its line count passes.
-That is the deliberate trade: a ratchet that judged prose would refuse the
-honest corrections this op exists to enable.
+wider than it is): the census counts markers, the routes to executables, and
+line COUNT -- never meaning. A replace that rewrites a rule into something vaguer
+while keeping its (ENFORCED marker on the same heading, every script route and
+its line count passes. Marker placement is checked at heading granularity only:
+moving it between two headings of the same file is invisible here. That is the
+deliberate trade: a ratchet that judged prose would refuse the honest
+corrections this op exists to enable.
 """
 import json
 import os
@@ -96,6 +102,14 @@ RULES_DIR = os.path.join(".claude", "rules")
 # A rule's pointer to the thing that actually enforces it. Census member, so a
 # replace cannot quietly cut a reader's route to the enforcer.
 #
+# The DIRECTORY PREFIX is part of the mark, not decoration. Matching the
+# basename alone let a replace keep `existing-lint.py` while moving its route to
+# `q-system/retired/hooks/existing-lint.py` -- the census saw the same member and
+# the reader's route pointed at nothing (PR #70 round 4, minor). The route as the
+# rule WRITES it is the census member, so moving it is a removal. The leading
+# lookbehind stops the match from starting mid-token, which is what keeps a
+# prefixed route from also registering as its own bare basename.
+#
 # The trailing boundary is load-bearing and is NOT a plain \b. Without it,
 # rewriting `voice-lint.py` to `voice-lint.py.retired` left the mark
 # `voice-lint.py` intact -- the pattern simply matched the prefix -- while the
@@ -104,13 +118,21 @@ RULES_DIR = os.path.join(".claude", "rules")
 # "... is voice-lint.py.", and rejecting a following "." would quietly drop
 # every one of those from the census. So the lookaheads reject exactly two
 # things: more filename characters, and a dot that STARTS another extension.
-_EXEC_REF = re.compile(r"[A-Za-z0-9_][A-Za-z0-9_.-]*\.(?:py|sh)(?![A-Za-z0-9_-])(?!\.[A-Za-z0-9_])")
+_EXEC_REF = re.compile(r"(?<![A-Za-z0-9_./-])(?:[A-Za-z0-9_.-]+/)*[A-Za-z0-9_][A-Za-z0-9_.-]*\.(?:py|sh)(?![A-Za-z0-9_-])(?!\.[A-Za-z0-9_])")
+
+# A markdown heading line. Used only to ask WHERE an (ENFORCED marker sits; see
+# _rule_marks for why the location and not just the presence has to be counted.
+_HEADING = re.compile(r"[ ]{0,3}#{1,6}[ \t]")
 
 # A rule's frontmatter decides whether the rule LOADS. Narrowing paths:/globs:
 # leaves the body, the tokens and the line count all identical while switching
 # the rule off, so no content census can see it (PR #70 round 3, major).
-# `replace` therefore may not move this block at all -- same standing as removing
-# a hook: a different tool and a real conversation.
+# NO op may move this block -- same standing as removing a hook: a different tool
+# and a real conversation. Pinning it to `replace` alone was itself a hole:
+# insert_before wedged a never-matching paths: block ABOVE the H1 of any rule
+# that had no frontmatter yet, which deletes nothing and switches the rule off
+# just the same (PR #70 round 4, major). "Additive" is a claim about the text,
+# not about the effect.
 _FRONTMATTER = re.compile(r"\A---\n.*?\n---(?:\n|\Z)", re.S)
 
 ALLOWED_PROPOSAL_KEYS = {"schema_version", "slug", "reason", "requires", "edits"}
@@ -310,6 +332,22 @@ def resolve_special_keys(root, prop):
     return settings_key, template_key
 
 
+def is_rule_text(rel):
+    """The SHAPE half of "is this rule text", in one place.
+
+    Two callers ask it -- the `replace` scope pin and the frontmatter pin -- and
+    two spellings of one question is the drift class round 2 found in the path
+    normalization and round 3 found again between the token census and the
+    frontmatter nobody was reading.
+
+    Depth-permissive on purpose, and that is now safe: _rule_marks walks the
+    whole rules/ tree, so a rule in a subdirectory is inside the content census
+    and inside these pins together. It used to be inside replace's reach and
+    outside the census at the same time (PR #70 round 4, minor).
+    """
+    return rel.startswith(RULES_DIR + os.sep) and rel.endswith(".md")
+
+
 def rule_text_only(root, rel, settings_key, template_key):
     """`replace` is the only non-additive op, so its reach is pinned to rule TEXT.
 
@@ -331,7 +369,7 @@ def rule_text_only(root, rel, settings_key, template_key):
     """
     if rel == settings_key or rel == template_key:
         raise Refusal("replace may not target %s (rule text only)" % rel)
-    if not (rel.startswith(RULES_DIR + os.sep) and rel.endswith(".md")):
+    if not is_rule_text(rel):
         raise Refusal("replace is only permitted on %s%s*.md, got %s" % (RULES_DIR, os.sep, rel))
     rules_dir = os.path.realpath(os.path.join(root, RULES_DIR))
     real = os.path.realpath(os.path.join(root, rel))
@@ -416,26 +454,53 @@ def _unique_anchor_hits(content, anchor, rel):
     return hits
 
 
+def _guard_frontmatter(rel, before, after):
+    """A rule's frontmatter block may not move, whatever op moved it.
+
+    Compared before/after rather than "is the anchor inside the block": that
+    also catches an insert that ADDS or CLOSES a --- fence, which moves the
+    frontmatter boundary without the anchor ever sitting in it. Equality is
+    transitive, so checking each edit holds across a whole proposal.
+
+    Called for EVERY op with prior content, not just `replace`. The round-3 fix
+    lived inside the replace branch, which left insert_before free to wedge a
+    never-matching paths: block above the H1 of a rule that had no frontmatter
+    yet -- additive text, dead rule, rc=0 (PR #70 round 4, major).
+    """
+    if not is_rule_text(rel):
+        return
+    if _frontmatter(after) != _frontmatter(before):
+        raise Refusal(
+            "edit may not change the frontmatter of %s; the scoping keys "
+            "decide whether the rule loads at all" % rel)
+
+
 def apply_edit(content, edit, rel):
-    """Return (new_content, already_satisfied). Pure; never touches disk."""
+    """Return (new_content, already_satisfied). Pure; never touches disk.
+
+    Every op that has prior content leaves through the single _guard_frontmatter
+    call at the bottom. One exit on purpose: a per-branch guard is what round 4
+    found missing on three of the four branches.
+    """
     op = edit["op"]
     ins = edit["insert"]
 
-    if op == "append":
-        if content.endswith(ins):
-            return content, True
-        return content + ins, False
-
     if op == "create_file":
+        # No prior content, so there is no frontmatter to preserve. A brand-new
+        # rule declaring its own scope is an addition, not a narrowing.
         if content is None:
             return ins, False
         if content == ins:
             return content, True
         raise Refusal("create_file target already exists with different content: %s" % rel)
 
-    anchor = edit["anchor"]
+    if op == "append":
+        if content.endswith(ins):
+            return content, True
+        new = content + ins
 
-    if op == "replace":
+    elif op == "replace":
+        anchor = edit["anchor"]
         # An anchor that survives into its own replacement never converges: the
         # next run finds it again, inserts again, and the file grows forever
         # while "already applied" stays undetectable. Refused, not tolerated --
@@ -452,31 +517,24 @@ def apply_edit(content, edit, rel):
                 return content, True
             raise Refusal("anchor not found in %s: %r" % (rel, _snip(anchor)))
         new = content.replace(anchor, ins, 1)
-        # Compared before/after rather than "is the anchor inside the block":
-        # that also catches an insert that ADDS or CLOSES a --- fence, which
-        # would move the frontmatter boundary without the anchor ever sitting in
-        # it. Equality is transitive, so checking each edit is enough to hold
-        # across a whole proposal.
-        if _frontmatter(new) != _frontmatter(content):
-            raise Refusal(
-                "replace may not change the frontmatter of %s; the scoping keys "
-                "decide whether the rule loads at all" % rel)
-        return new, False
 
-    if _unique_anchor_hits(content, anchor, rel) == 0:
-        raise Refusal("anchor not found in %s: %r" % (rel, _snip(anchor)))
+    else:
+        anchor = edit["anchor"]
+        if _unique_anchor_hits(content, anchor, rel) == 0:
+            raise Refusal("anchor not found in %s: %r" % (rel, _snip(anchor)))
+        pos = content.index(anchor)
+        if op == "insert_after":
+            cut = pos + len(anchor)
+            if content[cut:cut + len(ins)] == ins:
+                return content, True
+            new = content[:cut] + ins + content[cut:]
+        else:  # insert_before
+            if content[max(0, pos - len(ins)):pos] == ins:
+                return content, True
+            new = content[:pos] + ins + content[pos:]
 
-    pos = content.index(anchor)
-    if op == "insert_after":
-        cut = pos + len(anchor)
-        if content[cut:cut + len(ins)] == ins:
-            return content, True
-        return content[:cut] + ins + content[cut:], False
-
-    # insert_before
-    if content[max(0, pos - len(ins)):pos] == ins:
-        return content, True
-    return content[:pos] + ins + content[pos:], False
+    _guard_frontmatter(rel, content, new)
+    return new, False
 
 
 def _snip(text, n=60):
@@ -565,21 +623,47 @@ def _rule_marks(rules_dir):
     line_marks = set()
     if not os.path.isdir(rules_dir):
         return token_marks, line_marks
-    for name in sorted(os.listdir(rules_dir)):
-        if name.startswith(".") or not name.endswith(".md"):
-            continue
-        try:
-            with open(os.path.join(rules_dir, name)) as fh:
-                text = fh.read()
-        except (OSError, UnicodeDecodeError):
-            continue
-        for ref in set(_EXEC_REF.findall(text)):
-            token_marks.add("%s|exec|%s" % (name, ref))
-        if "(ENFORCED" in text:
-            token_marks.add("%s|enforced" % name)
-        substantive = sum(1 for line in text.splitlines() if line.strip())
-        for index in range(substantive):
-            line_marks.add("%s|line|%d" % (name, index))
+    # os.walk, not os.listdir. rule_text_only permits a rule at any depth under
+    # rules/, so a one-level census left a subdirectory rule inside replace's
+    # reach and outside every content check at once (PR #70 round 4, minor). The
+    # mark key is the path relative to rules/, which is identical to the old
+    # filename for every top-level rule, so nothing that was censused stops being.
+    for dirpath, dirnames, filenames in os.walk(rules_dir):
+        dirnames[:] = sorted(d for d in dirnames if not d.startswith("."))
+        for filename in sorted(filenames):
+            if filename.startswith(".") or not filename.endswith(".md"):
+                continue
+            full = os.path.join(dirpath, filename)
+            name = os.path.relpath(full, rules_dir)
+            try:
+                with open(full) as fh:
+                    text = fh.read()
+            except (OSError, UnicodeDecodeError):
+                continue
+            for ref in set(_EXEC_REF.findall(text)):
+                token_marks.add("%s|exec|%s" % (name, ref))
+            # (ENFORCED is counted twice, and the second count is the one that
+            # closes the hole. A whole-file presence boolean let a replace lift
+            # the marker off the heading that DECLARES the rule enforced and park
+            # the token in a sentence saying the rule is advisory -- the token was
+            # still in the file, so the census reported clean (PR #70 round 4).
+            #   occurrences      : total, so losing one anywhere is visible.
+            #   enforced-heading : how many HEADING lines carry it, so moving it
+            #                      out of a heading and into prose drops a mark.
+            # Counts encoded as sets, never positions: rewording a heading and
+            # adding a section above it both have to stay free, and only a count
+            # survives both. Same encode-a-count-as-a-set trick as line marks,
+            # for the same reason -- ratchet_check compares sets.
+            for index in range(text.count("(ENFORCED")):
+                token_marks.add("%s|enforced|%d" % (name, index))
+            lines = text.splitlines()
+            headings = sum(1 for line in lines
+                           if _HEADING.match(line) and "(ENFORCED" in line)
+            for index in range(headings):
+                token_marks.add("%s|enforced-heading|%d" % (name, index))
+            substantive = sum(1 for line in lines if line.strip())
+            for index in range(substantive):
+                line_marks.add("%s|line|%d" % (name, index))
     return token_marks, line_marks
 
 

--- a/q-system/.q-system/scripts/apply_claude_changes.py
+++ b/q-system/.q-system/scripts/apply_claude_changes.py
@@ -40,10 +40,13 @@ THE THREE LAYERS
                       " || true" after a hook command, which deletes nothing but
                       makes the old exact command string vanish from the census.
                       The census reads rule CONTENT, not just the rules/ listing
-                      (_rule_content_marks): an (ENFORCED marker or a pointer to a
-                      named enforcer may not vanish from a rule. Filenames alone
-                      were blind to everything a replace does inside a file, which
-                      is exactly why replace could not exist before that census.
+                      (_rule_marks): an (ENFORCED marker or a pointer to a named
+                      enforcer may not vanish from a rule, and a rule's count of
+                      substantive lines may not shrink. Filenames alone were
+                      blind to everything a replace does inside a file, which is
+                      exactly why replace could not exist before that census; the
+                      line floor is there because 5 of 34 rules carry no token at
+                      all, so tokens alone left them free to be gutted.
   L3 verify+revert  : run the gate suite before and after. Any gate that goes
                       pass -> fail auto-restores the backup. The founder must
                       never be the one who notices a regression.
@@ -54,9 +57,17 @@ half-writes.
 
 OUT OF REACH BY DESIGN (say so, do not pretend otherwise): removing a hook,
 deleting a rule, narrowing a matcher, widening permissions.allow or defaultMode,
-and stripping a rule's (ENFORCED marker or its pointer to a named enforcer,
-cannot be done through this path at all. Those need a different tool and a real
-conversation. See REFUSED_SURFACES.
+stripping a rule's (ENFORCED marker or its pointer to a named enforcer, changing
+a rule's frontmatter (the keys that decide whether it loads at all), and
+shortening a rule's body, cannot be done through this path at all. Those need a
+different tool and a real conversation. See REFUSED_SURFACES.
+
+WHAT STILL GETS THROUGH (the honest residue, do not read the list above as
+wider than it is): the census counts markers, executable references and line
+COUNT -- never meaning. A replace that rewrites a rule into something vaguer
+while keeping its (ENFORCED marker, every script name and its line count passes.
+That is the deliberate trade: a ratchet that judged prose would refuse the
+honest corrections this op exists to enable.
 """
 import json
 import os
@@ -84,7 +95,23 @@ RULES_DIR = os.path.join(".claude", "rules")
 
 # A rule's pointer to the thing that actually enforces it. Census member, so a
 # replace cannot quietly cut a reader's route to the enforcer.
-_EXEC_REF = re.compile(r"[A-Za-z0-9_][A-Za-z0-9_.-]*\.(?:py|sh)")
+#
+# The trailing boundary is load-bearing and is NOT a plain \b. Without it,
+# rewriting `voice-lint.py` to `voice-lint.py.retired` left the mark
+# `voice-lint.py` intact -- the pattern simply matched the prefix -- while the
+# reader's route to the enforcer was dead (PR #70 round 3, minor). But a plain
+# boundary over-corrects the other way: rules routinely end a sentence with
+# "... is voice-lint.py.", and rejecting a following "." would quietly drop
+# every one of those from the census. So the lookaheads reject exactly two
+# things: more filename characters, and a dot that STARTS another extension.
+_EXEC_REF = re.compile(r"[A-Za-z0-9_][A-Za-z0-9_.-]*\.(?:py|sh)(?![A-Za-z0-9_-])(?!\.[A-Za-z0-9_])")
+
+# A rule's frontmatter decides whether the rule LOADS. Narrowing paths:/globs:
+# leaves the body, the tokens and the line count all identical while switching
+# the rule off, so no content census can see it (PR #70 round 3, major).
+# `replace` therefore may not move this block at all -- same standing as removing
+# a hook: a different tool and a real conversation.
+_FRONTMATTER = re.compile(r"\A---\n.*?\n---(?:\n|\Z)", re.S)
 
 ALLOWED_PROPOSAL_KEYS = {"schema_version", "slug", "reason", "requires", "edits"}
 ALLOWED_EDIT_KEYS = {"file", "op", "anchor", "insert", "reason"}
@@ -424,7 +451,17 @@ def apply_edit(content, edit, rel):
             if content.count(ins) == 1:
                 return content, True
             raise Refusal("anchor not found in %s: %r" % (rel, _snip(anchor)))
-        return content.replace(anchor, ins, 1), False
+        new = content.replace(anchor, ins, 1)
+        # Compared before/after rather than "is the anchor inside the block":
+        # that also catches an insert that ADDS or CLOSES a --- fence, which
+        # would move the frontmatter boundary without the anchor ever sitting in
+        # it. Equality is transitive, so checking each edit is enough to hold
+        # across a whole proposal.
+        if _frontmatter(new) != _frontmatter(content):
+            raise Refusal(
+                "replace may not change the frontmatter of %s; the scoping keys "
+                "decide whether the rule loads at all" % rel)
+        return new, False
 
     if _unique_anchor_hits(content, anchor, rel) == 0:
         raise Refusal("anchor not found in %s: %r" % (rel, _snip(anchor)))
@@ -473,8 +510,19 @@ def _dir_names(path):
     return {n for n in os.listdir(path) if not n.startswith(".")}
 
 
-def _rule_content_marks(rules_dir):
-    """Enforcement-bearing tokens INSIDE rule text, keyed by rule file.
+def _frontmatter(text):
+    """The leading --- block, or "" when the file has none. See _FRONTMATTER."""
+    match = _FRONTMATTER.match(text or "")
+    return match.group(0) if match else ""
+
+
+def _rule_marks(rules_dir):
+    """Read every rule ONCE and return (token_marks, line_marks).
+
+    One walk and one read per file on purpose. Two functions each opening the
+    same rules is two readers free to drift -- the defect class round 2 found in
+    the path normalization and round 3 found again between the token census and
+    the frontmatter it never looked at.
 
     The rules census used to be _dir_names -- a directory listing, which is
     blind to everything that happens inside a file. That was fine while every op
@@ -493,12 +541,30 @@ def _rule_content_marks(rules_dir):
       exec     : a named .py/.sh the rule routes a reader to. A rule whose
                  pointer to its enforcer vanishes is a rule nobody can act on.
 
-    Deliberately NOT counted: prose meaning, tone, length. A ratchet that tried
-    to judge those would refuse the honest corrections this op exists to enable.
+    Deliberately NOT counted: prose meaning and tone. A ratchet that tried to
+    judge those would refuse the honest corrections this op exists to enable.
+
+    LINE MARKS are the second half, and they exist because tokens alone are not
+    enough: 5 of this repo's 34 rules carry NEITHER token class (security.md has
+    no (ENFORCED marker and names no script), so a replace swapped the whole
+    475-char body of one for a single sentence while the token census reported
+    rule_marks 113 -> 113 and the tool exited OK applied. Measured 2026-08-02,
+    PR #70 round 3 major.
+
+    A count only becomes visible to ratchet_check's set-difference when it is
+    encoded as a SET, hence one mark per substantive line INDEX. Dropping a line
+    drops the highest index, which is exactly the refusal wanted.
+
+    Lines, not words or characters: rewording a line has to stay free, because
+    that IS the correction this op exists for, while deleting lines must not. So
+    a replace may reword a rule and may grow it; it may never shorten it. The
+    residue is named in the module docstring rather than papered over: a rewrite
+    that keeps the shape and hollows out the meaning still passes.
     """
-    marks = set()
+    token_marks = set()
+    line_marks = set()
     if not os.path.isdir(rules_dir):
-        return marks
+        return token_marks, line_marks
     for name in sorted(os.listdir(rules_dir)):
         if name.startswith(".") or not name.endswith(".md"):
             continue
@@ -508,10 +574,13 @@ def _rule_content_marks(rules_dir):
         except (OSError, UnicodeDecodeError):
             continue
         for ref in set(_EXEC_REF.findall(text)):
-            marks.add("%s|exec|%s" % (name, ref))
+            token_marks.add("%s|exec|%s" % (name, ref))
         if "(ENFORCED" in text:
-            marks.add("%s|enforced" % name)
-    return marks
+            token_marks.add("%s|enforced" % name)
+        substantive = sum(1 for line in text.splitlines() if line.strip())
+        for index in range(substantive):
+            line_marks.add("%s|line|%d" % (name, index))
+    return token_marks, line_marks
 
 
 def census(root):
@@ -529,7 +598,7 @@ def census(root):
     perms = settings.get("permissions") or {}
     c["deny"] = set(perms.get("deny") or [])
     c["rules"] = _dir_names(os.path.join(root, ".claude", "rules"))
-    c["rule_marks"] = _rule_content_marks(os.path.join(root, ".claude", "rules"))
+    c["rule_marks"], c["rule_lines"] = _rule_marks(os.path.join(root, ".claude", "rules"))
     c["agents"] = _dir_names(os.path.join(root, ".claude", "agents"))
     c["output_styles"] = _dir_names(os.path.join(root, ".claude", "output-styles"))
 

--- a/q-system/.q-system/scripts/apply_claude_changes.py
+++ b/q-system/.q-system/scripts/apply_claude_changes.py
@@ -313,6 +313,52 @@ def _same_file(root, rel, target):
         return False
 
 
+def refuse_duplicate_spellings(root, prop):
+    """One name per file in the proposal, or no run.
+
+    canonical_rel collapses the spellings a STRING can collapse ("./", "..",
+    doubled slashes). It cannot see the two normpath is blind to: a case variant
+    on a case-insensitive filesystem, and a symlinked parent directory. Those
+    arrive as two distinct keys naming one inode, and two keys means two readers:
+    each is read from disk independently, each is written back to the same inode
+    in sorted() order, so the LAST spelling's content lands while an earlier
+    spelling is what a single-key guard inspected.
+
+    PR #70 round 5 found the live consequence. `.claude/Settings.json` became
+    settings_key (resolve_special_keys picks the FIRST match), so
+    permission_surface_check read that copy while `.claude/settings.json` sorted
+    last and its content is what hit disk. A proposal widening permissions.allow
+    exited `0 OK applied` with the ratchet and the gates reporting clean, and it
+    reported "2 edit(s)" for one edit's worth of surviving content.
+
+    The fix belongs HERE and not in another guard, because the defect is not that
+    some particular guard read the wrong key -- it is that two keys existed at
+    all. Every guard downstream is correct once the input holds one name per file.
+
+    HONEST BOUNDARY: identity comes from st_dev/st_ino for a file that exists,
+    and from realpath for one that does not. So two case-variant spellings of a
+    path that exists under NEITHER case (two create_file edits racing to make one
+    new file) are not caught. That is a reporting defect, not an enforcement one:
+    nothing pre-existing can be weakened by it, and every guarded file this
+    engine knows about already exists.
+    """
+    seen = {}
+    for edit in prop["edits"]:
+        rel = edit["file"]
+        full = os.path.join(root, rel)
+        try:
+            st = os.stat(full)
+            identity = ("inode", st.st_dev, st.st_ino)
+        except OSError:
+            identity = ("path", os.path.realpath(full))
+        first = seen.setdefault(identity, rel)
+        if first != rel:
+            raise Refusal(
+                "edits name one file under two spellings (%s and %s resolve to the "
+                "same file); use one spelling per file" % (first, rel)
+            )
+
+
 def resolve_special_keys(root, prop):
     """Resolve, ONCE, which canonical edit keys are the guarded files.
 
@@ -354,9 +400,11 @@ def rule_text_only(root, rel, settings_key, template_key):
     Three checks, because each alone has a hole the other two cover:
 
       identity : rel IS .claude/settings.json or settings-template.json under
-                 some spelling. Already collapsed to one key by inode upstream
-                 (resolve_special_keys), so a case variant or a ./ spelling
-                 arrives here as the same key rather than as a new name.
+                 some spelling. resolve_special_keys matches by inode, not by
+                 string, so a case variant or a ./ spelling of a guarded file is
+                 recognised here. It does NOT merge two keys into one -- that is
+                 refuse_duplicate_spellings' job, upstream, and round 5 found the
+                 hole left when this docstring claimed otherwise.
       shape    : anything that is not .claude/rules/<name>.md is out. agents/ and
                  output-styles/ keep the additive-only guarantee they had before
                  this op existed; widening to them is a separate decision with a
@@ -933,6 +981,10 @@ def main(argv):
     check_requires(root, prop, log)
 
     # ---- stage every edit against an in-memory COPY. Nothing on disk yet.
+    # One name per file FIRST: every check below assumes a key it resolves is the
+    # key whose content lands, and that is only true when no second spelling of
+    # the same file is still in the proposal (round 5).
+    refuse_duplicate_spellings(root, prop)
     # Resolved ONCE by inode; every check below reads these, never a string.
     settings_key, template_key = resolve_special_keys(root, prop)
     touches_settings = settings_key is not None

--- a/q-system/.q-system/scripts/apply_claude_changes.py
+++ b/q-system/.q-system/scripts/apply_claude_changes.py
@@ -24,17 +24,26 @@ WHY THIS SHAPE (measured 2026-08-01, do not "simplify" any of it away):
 
 THE THREE LAYERS
 
-  L1 additive-only  : the only ops that EXIST are insert_after, insert_before,
-                      append, create_file. There is no replace and no delete, so
-                      "remove a hook entry" is not expressible. Unknown ops and
-                      unknown proposal keys are refused, so a proposal cannot
-                      smuggle in a flag like disables_enforcement.
+  L1 op vocabulary  : insert_after, insert_before, append, create_file reach
+                      anything under .claude/. `replace` reaches RULE TEXT ONLY
+                      (.claude/rules/*.md) -- see rule_text_only. There is still
+                      no delete: insert must be a non-empty string, so "replace
+                      this paragraph with nothing" is refused, and "remove a hook
+                      entry" is not expressible at all because the config surface
+                      is out of replace's reach. Unknown ops and unknown proposal
+                      keys are refused, so a proposal cannot smuggle in a flag
+                      like disables_enforcement.
   L2 ratchet        : census the live enforcement points before and after. Every
                       pre-existing member must still be present and no category
                       may shrink. This catches the technically-additive edit that
                       removes something as a side effect -- e.g. inserting
                       " || true" after a hook command, which deletes nothing but
                       makes the old exact command string vanish from the census.
+                      The census reads rule CONTENT, not just the rules/ listing
+                      (_rule_content_marks): an (ENFORCED marker or a pointer to a
+                      named enforcer may not vanish from a rule. Filenames alone
+                      were blind to everything a replace does inside a file, which
+                      is exactly why replace could not exist before that census.
   L3 verify+revert  : run the gate suite before and after. Any gate that goes
                       pass -> fail auto-restores the backup. The founder must
                       never be the one who notices a regression.
@@ -44,12 +53,14 @@ after all of L1, L2 and the preconditions pass on that copy, so a refusal never
 half-writes.
 
 OUT OF REACH BY DESIGN (say so, do not pretend otherwise): removing a hook,
-deleting a rule, narrowing a matcher, and widening permissions.allow or
-defaultMode cannot be done through this path at all. Those need a different
-tool and a real conversation. See REFUSED_SURFACES.
+deleting a rule, narrowing a matcher, widening permissions.allow or defaultMode,
+and stripping a rule's (ENFORCED marker or its pointer to a named enforcer,
+cannot be done through this path at all. Those need a different tool and a real
+conversation. See REFUSED_SURFACES.
 """
 import json
 import os
+import re
 import shutil
 import subprocess
 import sys
@@ -58,9 +69,22 @@ import time
 
 SCHEMA_VERSION = 1
 
-# L1: the entire op vocabulary. Additive only. There is deliberately no
-# "replace" and no "delete" -- a removal is not expressible, not merely gated.
+# L1: the op vocabulary. Additive ops reach anything under .claude/.
 ADDITIVE_OPS = ("insert_after", "insert_before", "append", "create_file")
+# The one non-additive op. ASK-289: additive-only meant a wrong sentence in a
+# rule could be BURIED but never corrected -- design-auto-invoke.md still carries
+# its narrowing paragraph wedged ABOVE its own H1 because insert_before was the
+# only thing expressible. replace is pinned to rule text (rule_text_only) and
+# watched by the rule-content census, so it cannot reach the config surface.
+REPLACE_OPS = ("replace",)
+ALL_OPS = ADDITIVE_OPS + REPLACE_OPS
+ANCHOR_OPS = ("insert_after", "insert_before", "replace")
+
+RULES_DIR = os.path.join(".claude", "rules")
+
+# A rule's pointer to the thing that actually enforces it. Census member, so a
+# replace cannot quietly cut a reader's route to the enforcer.
+_EXEC_REF = re.compile(r"[A-Za-z0-9_][A-Za-z0-9_.-]*\.(?:py|sh)")
 
 ALLOWED_PROPOSAL_KEYS = {"schema_version", "slug", "reason", "requires", "edits"}
 ALLOWED_EDIT_KEYS = {"file", "op", "anchor", "insert", "reason"}
@@ -172,17 +196,21 @@ def load_proposal(path):
         if unknown_e:
             raise Refusal("edit %d has unknown key(s): %s" % (idx, ", ".join(sorted(unknown_e))))
         op = edit.get("op")
-        if op not in ADDITIVE_OPS:
+        if op not in ALL_OPS:
             raise Refusal(
-                "edit %d op %r is not additive (allowed: %s)" % (idx, op, ", ".join(ADDITIVE_OPS))
+                "edit %d op %r is not a permitted op (allowed: %s)" % (idx, op, ", ".join(ALL_OPS))
             )
+        # insert must be non-empty AND non-blank for every op including replace.
+        # That is what keeps "delete this paragraph" inexpressible now that a
+        # non-additive op exists: a replace with an empty (or whitespace-only)
+        # insert IS a delete, and it is refused here rather than downstream.
         for field in ("file", "insert", "reason"):
             if not isinstance(edit.get(field), str) or not edit[field].strip():
                 raise Refusal("edit %d.%s must be a non-empty string" % (idx, field))
         # THE boundary. After this line the proposal holds exactly one spelling
         # of each path and no other reader normalizes anything.
         edit["file"] = canonical_rel(edit["file"])
-        if op in ("insert_after", "insert_before"):
+        if op in ANCHOR_OPS:
             if not isinstance(edit.get("anchor"), str) or not edit["anchor"].strip():
                 raise Refusal("edit %d needs a non-empty anchor for op %s" % (idx, op))
         elif "anchor" in edit:
@@ -255,6 +283,35 @@ def resolve_special_keys(root, prop):
     return settings_key, template_key
 
 
+def rule_text_only(root, rel, settings_key, template_key):
+    """`replace` is the only non-additive op, so its reach is pinned to rule TEXT.
+
+    Three checks, because each alone has a hole the other two cover:
+
+      identity : rel IS .claude/settings.json or settings-template.json under
+                 some spelling. Already collapsed to one key by inode upstream
+                 (resolve_special_keys), so a case variant or a ./ spelling
+                 arrives here as the same key rather than as a new name.
+      shape    : anything that is not .claude/rules/<name>.md is out. agents/ and
+                 output-styles/ keep the additive-only guarantee they had before
+                 this op existed; widening to them is a separate decision with a
+                 separate blast radius, not a side effect of ASK-289.
+      realpath : a symlink parked at .claude/rules/x.md pointing somewhere else.
+                 scoped_path permits that today -- it only asks that the target
+                 stay under .claude/ -- so a string-shape check alone waves it
+                 through. Same class as settings.local.json (round 1) and the
+                 "./" spelling (round 2): a second name only some guards see.
+    """
+    if rel == settings_key or rel == template_key:
+        raise Refusal("replace may not target %s (rule text only)" % rel)
+    if not (rel.startswith(RULES_DIR + os.sep) and rel.endswith(".md")):
+        raise Refusal("replace is only permitted on %s%s*.md, got %s" % (RULES_DIR, os.sep, rel))
+    rules_dir = os.path.realpath(os.path.join(root, RULES_DIR))
+    real = os.path.realpath(os.path.join(root, rel))
+    if not real.startswith(rules_dir + os.sep):
+        raise Refusal("replace target resolves outside %s%s: %s" % (RULES_DIR, os.sep, rel))
+
+
 def scoped_path(root, rel, paired_ok=False):
     """Resolve rel under root/.claude, refusing anything that escapes it.
 
@@ -317,6 +374,21 @@ def scoped_path(root, rel, paired_ok=False):
 
 # ------------------------------------------------------------------- editing
 
+def _unique_anchor_hits(content, anchor, rel):
+    """Anchor arithmetic, shared by every anchored op.
+
+    One copy on purpose: when `replace` arrived it grew a second ambiguity check
+    beside this one, and the mutation case that proves the check is load-bearing
+    then matched two lines and aborted the suite. Two copies of a guard is also
+    two chances for them to drift apart -- the same two-readers defect round 2
+    found in the path normalization.
+    """
+    hits = content.count(anchor)
+    if hits > 1:
+        raise Refusal("anchor matches %d times (must be exactly 1) in %s: %r" % (hits, rel, _snip(anchor)))
+    return hits
+
+
 def apply_edit(content, edit, rel):
     """Return (new_content, already_satisfied). Pure; never touches disk."""
     op = edit["op"]
@@ -335,11 +407,27 @@ def apply_edit(content, edit, rel):
         raise Refusal("create_file target already exists with different content: %s" % rel)
 
     anchor = edit["anchor"]
-    hits = content.count(anchor)
-    if hits == 0:
+
+    if op == "replace":
+        # An anchor that survives into its own replacement never converges: the
+        # next run finds it again, inserts again, and the file grows forever
+        # while "already applied" stays undetectable. Refused, not tolerated --
+        # extending text is what the additive ops are for.
+        if anchor in ins:
+            raise Refusal(
+                "replace anchor is contained in the insert, so it never converges in %s; "
+                "use insert_after/insert_before to extend text" % rel)
+        if _unique_anchor_hits(content, anchor, rel) == 0:
+            # Anchor gone AND the replacement sitting there exactly once is the
+            # signature of a completed earlier run, not of a bad proposal. Same
+            # already-satisfied contract the insert ops report.
+            if content.count(ins) == 1:
+                return content, True
+            raise Refusal("anchor not found in %s: %r" % (rel, _snip(anchor)))
+        return content.replace(anchor, ins, 1), False
+
+    if _unique_anchor_hits(content, anchor, rel) == 0:
         raise Refusal("anchor not found in %s: %r" % (rel, _snip(anchor)))
-    if hits > 1:
-        raise Refusal("anchor matches %d times (must be exactly 1) in %s: %r" % (hits, rel, _snip(anchor)))
 
     pos = content.index(anchor)
     if op == "insert_after":
@@ -385,6 +473,47 @@ def _dir_names(path):
     return {n for n in os.listdir(path) if not n.startswith(".")}
 
 
+def _rule_content_marks(rules_dir):
+    """Enforcement-bearing tokens INSIDE rule text, keyed by rule file.
+
+    The rules census used to be _dir_names -- a directory listing, which is
+    blind to everything that happens inside a file. That was fine while every op
+    was additive. It is not fine now that `replace` exists: a replace keeps the
+    filename and can gut what the file says, and the listing would report clean.
+
+    Two token classes are countable without judgement, which is the bar for a
+    ratchet member:
+
+      enforced : the file claims (ENFORCED anywhere. Demoting a rule to advisory
+                 is enforcement-weakening whether or not the prose is honest. If
+                 the claim is genuinely false, the fix is to correct the SCOPE
+                 (which replace now allows) or to take the marker off through a
+                 different tool and a real conversation -- same standing as
+                 removing a hook.
+      exec     : a named .py/.sh the rule routes a reader to. A rule whose
+                 pointer to its enforcer vanishes is a rule nobody can act on.
+
+    Deliberately NOT counted: prose meaning, tone, length. A ratchet that tried
+    to judge those would refuse the honest corrections this op exists to enable.
+    """
+    marks = set()
+    if not os.path.isdir(rules_dir):
+        return marks
+    for name in sorted(os.listdir(rules_dir)):
+        if name.startswith(".") or not name.endswith(".md"):
+            continue
+        try:
+            with open(os.path.join(rules_dir, name)) as fh:
+                text = fh.read()
+        except (OSError, UnicodeDecodeError):
+            continue
+        for ref in set(_EXEC_REF.findall(text)):
+            marks.add("%s|exec|%s" % (name, ref))
+        if "(ENFORCED" in text:
+            marks.add("%s|enforced" % name)
+    return marks
+
+
 def census(root):
     """Count the live enforcement points. Enforcement may only grow."""
     c = {}
@@ -400,6 +529,7 @@ def census(root):
     perms = settings.get("permissions") or {}
     c["deny"] = set(perms.get("deny") or [])
     c["rules"] = _dir_names(os.path.join(root, ".claude", "rules"))
+    c["rule_marks"] = _rule_content_marks(os.path.join(root, ".claude", "rules"))
     c["agents"] = _dir_names(os.path.join(root, ".claude", "agents"))
     c["output_styles"] = _dir_names(os.path.join(root, ".claude", "output-styles"))
 
@@ -462,7 +592,6 @@ def permission_surface_check(root, staged_settings_text):
 
 def _hook_script_paths(settings):
     """Every $CLAUDE_PROJECT_DIR-relative script a hook command references."""
-    import re
     found = set()
     pat = re.compile(r'\$CLAUDE_PROJECT_DIR/([A-Za-z0-9_./-]+\.(?:py|sh))')
     for entry in _hook_entries(settings):
@@ -667,6 +796,8 @@ def main(argv):
     for idx, edit in enumerate(prop["edits"]):
         rel = edit["file"]
         full = scoped_path(root, rel, paired_ok=touches_settings)
+        if edit["op"] in REPLACE_OPS:
+            rule_text_only(root, rel, settings_key, template_key)
         if rel in staged:
             current = staged[rel]
         elif os.path.isfile(full):
@@ -712,9 +843,10 @@ def main(argv):
         before_census = census(root)
         after_census = census(copy_root)
         ratchet_check(before_census, after_census)
-        log.append("ratchet ok: hooks %d->%d, rules %d->%d, deny %d->%d" % (
+        log.append("ratchet ok: hooks %d->%d, rules %d->%d, rule-marks %d->%d, deny %d->%d" % (
             len(before_census["hooks"]), len(after_census["hooks"]),
             len(before_census["rules"]), len(after_census["rules"]),
+            len(before_census["rule_marks"]), len(after_census["rule_marks"]),
             len(before_census["deny"]), len(after_census["deny"])))
 
         if settings_key is not None:

--- a/q-system/.q-system/scripts/test/test-apply-claude-changes.sh
+++ b/q-system/.q-system/scripts/test/test-apply-claude-changes.sh
@@ -1065,6 +1065,105 @@ run_engine "$ENGINE" "$T/retitle.json" "$T"
 check "rewording an (ENFORCED heading still succeeds" 0 "OK applied retitle-rule" "$RC" "$OUT"
 rm -r "$T"
 
+echo
+echo "--- 15p: one file under two spellings in one proposal ---"
+# Round-5 MAJOR. canonical_rel collapses the spellings a STRING can collapse; a
+# symlink and a case variant survive it as a SECOND key naming one inode. Two
+# keys means two readers: resolve_special_keys picks the first as settings_key
+# and permission_surface_check inspects that copy, while sorted() writes the
+# other one last and ITS content is what lands. Widening permissions.allow came
+# back `0 OK applied`.
+#
+# The symlink spelling is used for the deterministic case because it holds on
+# any filesystem; the case-variant spelling only exists as a second name where
+# the filesystem is case-insensitive, so it is probed for below.
+mk_two_spellings() {  # mk_two_spellings <root> <second-spelling> <outfile>
+  cat > "$3" <<JSON
+{
+  "schema_version": 1, "slug": "two-spellings",
+  "reason": "one file, two keys, only one of them permission-checked",
+  "requires": { "template_pairs": ["existing-lint.py"] },
+  "edits": [
+    { "file": "$2", "op": "insert_after",
+      "anchor": "      \"Read(.env)\"",
+      "insert": ",\n      \"Read(.secret)\"",
+      "reason": "decoy: sorts first, becomes settings_key, never lands" },
+    { "file": ".claude/settings.json", "op": "insert_after",
+      "anchor": "      \"Bash(ls:*)\"",
+      "insert": ",\n      \"Bash(:*)\"",
+      "reason": "THE ATTACK: widen allow in the copy that actually lands" }
+  ]
+}
+JSON
+}
+
+T=$(mktemp -d); mk_fixture "$T"
+ln -s settings.json "$T/.claude/aliased-settings.json"
+mk_two_spellings "$T" ".claude/aliased-settings.json" "$T/two-spellings.json"
+run_engine "$ENGINE" "$T/two-spellings.json" "$T"
+check "a symlinked second spelling of settings.json refused" 2 "two spellings" "$RC" "$OUT"
+if grep -q 'Bash(:\*)' "$T/.claude/settings.json"; then
+  bad "the refused proposal still widened permissions.allow"
+else
+  ok "permissions.allow untouched by the refused proposal"
+fi
+check_one_line "two-spellings refusal" "$OUT"
+
+# The same class through a case variant. Only a second name where the filesystem
+# says so, so the case is probed rather than assumed -- a case-sensitive FS makes
+# these two genuinely different files and the assertion would be wrong there.
+if [ -f "$T/.claude/SETTINGS.json" ]; then
+  mk_two_spellings "$T" ".claude/Settings.json" "$T/case-variant.json"
+  run_engine "$ENGINE" "$T/case-variant.json" "$T"
+  check "a case-variant spelling of settings.json refused" 2 "two spellings" "$RC" "$OUT"
+else
+  echo "  (case-insensitive-FS case not applicable on this filesystem)"
+fi
+rm -r "$T"
+
+# Not only the guarded config surface: two names for ONE rule file is the same
+# defect, and it reports "2 edit(s)" for one edit's worth of surviving content.
+T=$(mktemp -d); mk_fixture "$T"
+ln -s enforced-rule.md "$T/.claude/rules/aliased-rule.md"
+cat > "$T/dup-rule.json" <<'JSON'
+{
+  "schema_version": 1, "slug": "dup-rule",
+  "reason": "one rule file addressed under two names",
+  "edits": [
+    { "file": ".claude/rules/aliased-rule.md", "op": "insert_after",
+      "anchor": "# Sample Rule (ENFORCED)", "insert": "\n\nFirst edit.", "reason": "a" },
+    { "file": ".claude/rules/enforced-rule.md", "op": "insert_after",
+      "anchor": "# Sample Rule (ENFORCED)", "insert": "\n\nSecond edit.", "reason": "b" }
+  ]
+}
+JSON
+run_engine "$ENGINE" "$T/dup-rule.json" "$T"
+check "two spellings of one rule file refused" 2 "two spellings" "$RC" "$OUT"
+
+# ...and the check is on the FILE, not on the edit count: chaining two edits onto
+# one file under ONE spelling is the supported case and stays supported.
+cat > "$T/chained.json" <<'JSON'
+{
+  "schema_version": 1, "slug": "chained-edits",
+  "reason": "two edits, one spelling, one file",
+  "edits": [
+    { "file": ".claude/rules/enforced-rule.md", "op": "insert_after",
+      "anchor": "# Sample Rule (ENFORCED)", "insert": "\n\nFirst edit.", "reason": "a" },
+    { "file": ".claude/rules/enforced-rule.md", "op": "insert_after",
+      "anchor": "First edit.", "insert": "\n\nSecond edit.", "reason": "b" }
+  ]
+}
+JSON
+run_engine "$ENGINE" "$T/chained.json" "$T"
+check "two edits on one spelling still succeed" 0 "OK applied chained-edits" "$RC" "$OUT"
+if grep -q "First edit." "$T/.claude/rules/enforced-rule.md" \
+   && grep -q "Second edit." "$T/.claude/rules/enforced-rule.md"; then
+  ok "both chained edits landed"
+else
+  bad "a chained edit was lost - the spelling check is over-blocking"
+fi
+rm -r "$T"
+
 # ============================ MUTATION =====================================
 # Copy the engine, break ONE guard, prove the matching case goes red. Without
 # this, a green suite only proves the tests run, not that the guards do anything.
@@ -1424,6 +1523,27 @@ if grep -q '"type": "cmd"' "$T/.claude/settings.json"; then
   ok "MUTATION scope: pin removed -> replace reached settings.json and broke a hook (rc=$MRC), test goes RED as required"
 else
   bad "MUTATION scope: pin removed but settings.json is untouched - case 15d is not load-bearing"
+fi
+rm -r "$T"
+
+echo
+echo "--- mutation: let one file keep two spellings ---"
+# Round 5's finding, restored. With the collapse gone the decoy spelling becomes
+# settings_key and gets permission-checked while the real spelling sorts last and
+# lands, so permissions.allow widens at exit 0. If the mutant is still refused,
+# case 15p is passing on some other guard and proves nothing.
+T=$(mktemp -d); mk_fixture "$T"
+ln -s settings.json "$T/.claude/aliased-settings.json"
+mk_two_spellings "$T" ".claude/aliased-settings.json" "$T/two-spellings.json"
+MUT="$T/mutant_spelling.py"
+mutate "$MUT" '    refuse_duplicate_spellings(root, prop)' '    pass'
+set +e
+python3 "$MUT" "$T/two-spellings.json" --root "$T" >/dev/null 2>&1; MRC=$?
+set -e
+if grep -q 'Bash(:\*)' "$T/.claude/settings.json"; then
+  ok "MUTATION spelling: collapse removed -> the unchecked spelling widened permissions.allow (rc=$MRC), test goes RED as required"
+else
+  bad "MUTATION spelling: mutant did not widen permissions - case 15p is not load-bearing"
 fi
 rm -r "$T"
 

--- a/q-system/.q-system/scripts/test/test-apply-claude-changes.sh
+++ b/q-system/.q-system/scripts/test/test-apply-claude-changes.sh
@@ -61,6 +61,25 @@ The deterministic half is `existing-lint.py`, wired PostToolUse on Edit|Write.
 This rule is enforced end to end and covers every path in the repo.
 MD
   echo "print('lint')" > "$r/q-system/.q-system/scripts/existing-lint.py"
+  # A rule carrying NEITHER token class the content census counts, plus the
+  # frontmatter that decides whether it loads at all. 5 of this repo's 34 real
+  # rules look exactly like this (security.md, content-output.md, ...), so it is
+  # the shape a token-only census is blind to.
+  cat > "$r/.claude/rules/advisory-rule.md" <<'MD'
+---
+description: Advisory guidance for generated output
+paths:
+  - "q-system/output/**"
+---
+
+# Advisory Rule
+
+Never publish a number whose source is not in this repo.
+
+Every claim traces to a file a reader can open.
+
+Ambiguity is preserved with an explicit marker, never smoothed over.
+MD
   cat > "$r/.claude/settings.json" <<'JSON'
 {
   "permissions": {
@@ -772,6 +791,120 @@ run_engine "$ENGINE" "$T/repabs.json" "$T"
 check "absent replace anchor refused" 2 "anchor not found" "$RC" "$OUT"
 rm -r "$T"
 
+# 15i. gutting a rule that carries NO enforcement tokens (PR #70 round 3, major).
+# A token-only census reports rule_marks unchanged while the whole body goes,
+# because a rule with no (ENFORCED marker and no named script has nothing to
+# count. The body-line floor is the layer that has to refuse this.
+T=$(mktemp -d); mk_fixture "$T"
+cat > "$T/gut.json" <<'JSON'
+{
+  "schema_version": 1, "slug": "gut-advisory",
+  "reason": "swap an entire rule body for one sentence",
+  "edits": [ { "file": ".claude/rules/advisory-rule.md", "op": "replace",
+               "anchor": "Never publish a number whose source is not in this repo.\n\nEvery claim traces to a file a reader can open.\n\nAmbiguity is preserved with an explicit marker, never smoothed over.",
+               "insert": "Use your judgement.", "reason": "r" } ]
+}
+JSON
+SUM=$(shasum -a 256 "$T/.claude/rules/advisory-rule.md" | awk '{print $1}')
+run_engine "$ENGINE" "$T/gut.json" "$T"
+check "gutting a zero-token rule refused" 2 "enforcement ratchet" "$RC" "$OUT"
+check_one_line "gutting a zero-token rule" "$OUT"
+if [ "$SUM" = "$(shasum -a 256 "$T/.claude/rules/advisory-rule.md" | awk '{print $1}')" ]; then
+  ok "gutting a zero-token rule wrote nothing"
+else bad "gutting a zero-token rule REMOVED the body"; fi
+
+# Rewording at the same body length stays allowed -- that is the correction this
+# op exists for, and a floor that refused it would refuse the whole feature.
+cat > "$T/reword.json" <<'JSON'
+{
+  "schema_version": 1, "slug": "reword-advisory",
+  "reason": "correct one sentence without shortening the rule",
+  "edits": [ { "file": ".claude/rules/advisory-rule.md", "op": "replace",
+               "anchor": "Never publish a number whose source is not in this repo.",
+               "insert": "Never publish a number whose source is not a file in this repo.",
+               "reason": "r" } ]
+}
+JSON
+run_engine "$ENGINE" "$T/reword.json" "$T"
+check "same-length reword still succeeds" 0 "OK applied reword-advisory" "$RC" "$OUT"
+rm -r "$T"
+
+# 15j. narrowing frontmatter so the rule never loads (PR #70 round 3, major).
+# Same body, same tokens, same line count -- every content check sees no change,
+# and the rule is dead because its paths: no longer match anything.
+T=$(mktemp -d); mk_fixture "$T"
+cat > "$T/unload.json" <<'JSON'
+{
+  "schema_version": 1, "slug": "unload-rule",
+  "reason": "narrow the scoping key so the rule stops loading",
+  "edits": [ { "file": ".claude/rules/advisory-rule.md", "op": "replace",
+               "anchor": "  - \"q-system/output/**\"",
+               "insert": "  - \"q-system/output/__never__/**\"", "reason": "r" } ]
+}
+JSON
+SUM=$(shasum -a 256 "$T/.claude/rules/advisory-rule.md" | awk '{print $1}')
+run_engine "$ENGINE" "$T/unload.json" "$T"
+check "narrowing frontmatter refused" 2 "frontmatter" "$RC" "$OUT"
+check_one_line "narrowing frontmatter" "$OUT"
+if [ "$SUM" = "$(shasum -a 256 "$T/.claude/rules/advisory-rule.md" | awk '{print $1}')" ]; then
+  ok "narrowing frontmatter wrote nothing"
+else bad "narrowing frontmatter MUTATED the scoping key"; fi
+
+# The body of a rule that HAS frontmatter is still reachable; the refusal above
+# is about the frontmatter block, not about the file carrying one.
+cat > "$T/body-ok.json" <<'JSON'
+{
+  "schema_version": 1, "slug": "fix-body",
+  "reason": "correct body text in a rule that has frontmatter",
+  "edits": [ { "file": ".claude/rules/advisory-rule.md", "op": "replace",
+               "anchor": "Every claim traces to a file a reader can open.",
+               "insert": "Every claim traces to a file any reader can open.", "reason": "r" } ]
+}
+JSON
+run_engine "$ENGINE" "$T/body-ok.json" "$T"
+check "body of a frontmattered rule still editable" 0 "OK applied fix-body" "$RC" "$OUT"
+rm -r "$T"
+
+# 15k. renaming a rule's enforcer to a dead name (PR #70 round 3, minor).
+# `existing-lint.py.retired` still CONTAINS `existing-lint.py`, so an exec-ref
+# pattern with no trailing boundary reports the mark intact while the reader's
+# route to the enforcer is dead.
+T=$(mktemp -d); mk_fixture "$T"
+cat > "$T/retire.json" <<'JSON'
+{
+  "schema_version": 1, "slug": "retire-enforcer",
+  "reason": "point the rule at a name that does not run",
+  "edits": [ { "file": ".claude/rules/enforced-rule.md", "op": "replace",
+               "anchor": "The deterministic half is `existing-lint.py`, wired PostToolUse on Edit|Write.",
+               "insert": "The deterministic half was `existing-lint.py.retired`, now unwired.",
+               "reason": "r" } ]
+}
+JSON
+SUM=$(shasum -a 256 "$T/.claude/rules/enforced-rule.md" | awk '{print $1}')
+run_engine "$ENGINE" "$T/retire.json" "$T"
+check "renaming the enforcer to a dead name refused" 2 "enforcement ratchet" "$RC" "$OUT"
+if [ "$SUM" = "$(shasum -a 256 "$T/.claude/rules/enforced-rule.md" | awk '{print $1}')" ]; then
+  ok "renaming the enforcer wrote nothing"
+else bad "renaming the enforcer left a dead pointer in the rule"; fi
+
+# A ref at the end of a sentence is still a ref: the boundary must reject a
+# LONGER filename, not a following period. Otherwise every "see foo.py." line in
+# the real rules silently stops being a census member.
+printf -- '---\ndescription: d\n---\n\n# Sentence End (ENFORCED)\n\nThe gate is q-system/.q-system/scripts/existing-lint.py.\n\nIt runs on write.\n' \
+  > "$T/.claude/rules/sentence-end.md"
+cat > "$T/sentence.json" <<'JSON'
+{
+  "schema_version": 1, "slug": "drop-sentence-end-ref",
+  "reason": "drop a ref that sat at the end of a sentence",
+  "edits": [ { "file": ".claude/rules/sentence-end.md", "op": "replace",
+               "anchor": "The gate is q-system/.q-system/scripts/existing-lint.py.",
+               "insert": "The gate is somewhere in the repo, look for it.", "reason": "r" } ]
+}
+JSON
+run_engine "$ENGINE" "$T/sentence.json" "$T"
+check "a ref ending a sentence is still a census member" 2 "enforcement ratchet" "$RC" "$OUT"
+rm -r "$T"
+
 # ============================ MUTATION =====================================
 # Copy the engine, break ONE guard, prove the matching case goes red. Without
 # this, a green suite only proves the tests run, not that the guards do anything.
@@ -877,6 +1010,79 @@ assert text != open(src).read(), "mutant is identical to the original"
 open(dest, "w").write(text)
 PY
 }
+echo "--- mutation: blind the body-line floor ---"
+# Stop emitting line marks and a rule with no enforcement tokens is defenceless
+# again: the whole body goes and the ratchet reports nothing missing.
+T=$(mktemp -d); mk_fixture "$T"
+MUT="$T/mutant_lines.py"
+mutate "$MUT" "            line_marks.add(\"%s|line|%d\" % (name, index))" "            pass"
+cat > "$T/gut.json" <<'JSON'
+{
+  "schema_version": 1, "slug": "gut-advisory", "reason": "swap a whole rule body",
+  "edits": [ { "file": ".claude/rules/advisory-rule.md", "op": "replace",
+               "anchor": "Never publish a number whose source is not in this repo.\n\nEvery claim traces to a file a reader can open.\n\nAmbiguity is preserved with an explicit marker, never smoothed over.",
+               "insert": "Use your judgement.", "reason": "r" } ]
+}
+JSON
+set +e
+MOUT=$(python3 "$MUT" "$T/gut.json" --root "$T" 2>&1); MRC=$?
+set -e
+if grep -q "Never publish a number" "$T/.claude/rules/advisory-rule.md"; then
+  bad "MUTATION lines: mutant did not gut the rule - the body-floor test is not load-bearing"
+else
+  ok "MUTATION lines: floor blinded -> a zero-token rule's whole body vanished (rc=$MRC), test goes RED as required"
+fi
+rm -r "$T"
+
+echo "--- mutation: drop the frontmatter pin ---"
+# Without it, the scoping key narrows, the rule stops loading, and every content
+# check reports clean because the body never moved.
+T=$(mktemp -d); mk_fixture "$T"
+MUT="$T/mutant_fm.py"
+mutate "$MUT" "        if _frontmatter(new) != _frontmatter(content):" "        if False:"
+cat > "$T/unload.json" <<'JSON'
+{
+  "schema_version": 1, "slug": "unload-rule", "reason": "narrow the scoping key",
+  "edits": [ { "file": ".claude/rules/advisory-rule.md", "op": "replace",
+               "anchor": "  - \"q-system/output/**\"",
+               "insert": "  - \"q-system/output/__never__/**\"", "reason": "r" } ]
+}
+JSON
+set +e
+MOUT=$(python3 "$MUT" "$T/unload.json" --root "$T" 2>&1); MRC=$?
+set -e
+if grep -q "__never__" "$T/.claude/rules/advisory-rule.md"; then
+  ok "MUTATION frontmatter: pin dropped -> the rule was switched off via paths: (rc=$MRC), test goes RED as required"
+else
+  bad "MUTATION frontmatter: mutant did not narrow paths: - the frontmatter test is not load-bearing"
+fi
+rm -r "$T"
+
+echo "--- mutation: restore the unbounded exec-ref pattern ---"
+# The prefix match is the whole defect: `existing-lint.py.retired` contains
+# `existing-lint.py`, so the census sees a mark that no longer points anywhere.
+T=$(mktemp -d); mk_fixture "$T"
+MUT="$T/mutant_ref.py"
+mutate "$MUT" '(?:py|sh)(?![A-Za-z0-9_-])(?!\.[A-Za-z0-9_])' '(?:py|sh)'
+cat > "$T/retire.json" <<'JSON'
+{
+  "schema_version": 1, "slug": "retire-enforcer", "reason": "point at a dead name",
+  "edits": [ { "file": ".claude/rules/enforced-rule.md", "op": "replace",
+               "anchor": "The deterministic half is `existing-lint.py`, wired PostToolUse on Edit|Write.",
+               "insert": "The deterministic half was `existing-lint.py.retired`, now unwired.",
+               "reason": "r" } ]
+}
+JSON
+set +e
+MOUT=$(python3 "$MUT" "$T/retire.json" --root "$T" 2>&1); MRC=$?
+set -e
+if grep -q "existing-lint.py.retired" "$T/.claude/rules/enforced-rule.md"; then
+  ok "MUTATION execref: boundary removed -> the rule now points at a name that does not run (rc=$MRC), test goes RED as required"
+else
+  bad "MUTATION execref: mutant did not write the dead pointer - the boundary test is not load-bearing"
+fi
+rm -r "$T"
+
 T=$(mktemp -d); mk_fixture "$T"
 MUT="$T/mutant_norm.py"
 mutate2 "$MUT" \

--- a/q-system/.q-system/scripts/test/test-apply-claude-changes.sh
+++ b/q-system/.q-system/scripts/test/test-apply-claude-changes.sh
@@ -905,6 +905,166 @@ run_engine "$ENGINE" "$T/sentence.json" "$T"
 check "a ref ending a sentence is still a census member" 2 "enforcement ratchet" "$RC" "$OUT"
 rm -r "$T"
 
+# 15l. switching a rule off with an ADDITIVE op (PR #70 round 4, major).
+# The frontmatter pin used to live inside the `replace` branch, so insert_before
+# could wedge a never-matching paths: block above the H1 of any rule that has no
+# frontmatter yet. Nothing is deleted, the body is untouched, every content
+# check reports clean -- and the rule stops loading.
+T=$(mktemp -d); mk_fixture "$T"
+cat > "$T/addfm.json" <<'JSON'
+{
+  "schema_version": 1, "slug": "add-frontmatter",
+  "reason": "switch an ENFORCED rule off by giving it a scope it can never match",
+  "edits": [ { "file": ".claude/rules/enforced-rule.md", "op": "insert_before",
+               "anchor": "# Sample Rule (ENFORCED)",
+               "insert": "---\npaths:\n  - \"__never__/**\"\n---\n\n", "reason": "r" } ]
+}
+JSON
+SUM=$(shasum -a 256 "$T/.claude/rules/enforced-rule.md" | awk '{print $1}')
+run_engine "$ENGINE" "$T/addfm.json" "$T"
+check "insert_before cannot ADD frontmatter to a rule" 2 "frontmatter" "$RC" "$OUT"
+check_one_line "insert_before adding frontmatter" "$OUT"
+if [ "$SUM" = "$(shasum -a 256 "$T/.claude/rules/enforced-rule.md" | awk '{print $1}')" ]; then
+  ok "adding frontmatter wrote nothing"
+else bad "adding frontmatter SWITCHED THE RULE OFF"; fi
+
+# insert_after INSIDE an existing frontmatter block is the same move on a rule
+# that already has one.
+cat > "$T/widenfm.json" <<'JSON'
+{
+  "schema_version": 1, "slug": "narrow-frontmatter-additively",
+  "reason": "append a second, narrower scope key inside the frontmatter",
+  "edits": [ { "file": ".claude/rules/advisory-rule.md", "op": "insert_after",
+               "anchor": "  - \"q-system/output/**\"",
+               "insert": "\nglobs:\n  - \"__never__/**\"", "reason": "r" } ]
+}
+JSON
+run_engine "$ENGINE" "$T/widenfm.json" "$T"
+check "insert_after inside frontmatter refused" 2 "frontmatter" "$RC" "$OUT"
+
+# Additive edits to the BODY of a rule stay free; the pin is about the block,
+# not about the file. A guard that refused this would refuse the whole tool.
+cat > "$T/bodyadd.json" <<'JSON'
+{
+  "schema_version": 1, "slug": "extend-body",
+  "reason": "add a sentence to the body of a frontmattered rule",
+  "edits": [ { "file": ".claude/rules/advisory-rule.md", "op": "insert_after",
+               "anchor": "Every claim traces to a file a reader can open.",
+               "insert": "\n\nA claim with no file is marked unverified.", "reason": "r" } ]
+}
+JSON
+run_engine "$ENGINE" "$T/bodyadd.json" "$T"
+check "additive body edit still succeeds" 0 "OK applied extend-body" "$RC" "$OUT"
+rm -r "$T"
+
+# 15m. a rule in a SUBDIRECTORY of rules/ (PR #70 round 4, minor).
+# rule_text_only permits any depth; the content census used to read one
+# directory level, so a rule one level down was inside replace's reach and
+# outside every content check at the same time.
+T=$(mktemp -d); mk_fixture "$T"
+mkdir -p "$T/.claude/rules/sub"
+cat > "$T/.claude/rules/sub/deep-rule.md" <<'MD'
+# Deep Rule (ENFORCED)
+
+The deterministic half is `existing-lint.py`, wired PostToolUse on Edit|Write.
+
+Every generated file is checked before it is written.
+
+No output leaves this repo without passing that check.
+MD
+cat > "$T/gutdeep.json" <<'JSON'
+{
+  "schema_version": 1, "slug": "gut-deep-rule",
+  "reason": "gut a rule that lives one directory below rules/",
+  "edits": [ { "file": ".claude/rules/sub/deep-rule.md", "op": "replace",
+               "anchor": "# Deep Rule (ENFORCED)\n\nThe deterministic half is `existing-lint.py`, wired PostToolUse on Edit|Write.\n\nEvery generated file is checked before it is written.\n\nNo output leaves this repo without passing that check.",
+               "insert": "# Deep Rule\n\nUse your judgement.", "reason": "r" } ]
+}
+JSON
+SUM=$(shasum -a 256 "$T/.claude/rules/sub/deep-rule.md" | awk '{print $1}')
+run_engine "$ENGINE" "$T/gutdeep.json" "$T"
+check "gutting a rule in a rules/ subdir refused" 2 "enforcement ratchet" "$RC" "$OUT"
+check_one_line "gutting a rule in a subdir" "$OUT"
+if [ "$SUM" = "$(shasum -a 256 "$T/.claude/rules/sub/deep-rule.md" | awk '{print $1}')" ]; then
+  ok "gutting a subdir rule wrote nothing"
+else bad "gutting a subdir rule REMOVED an ENFORCED body"; fi
+
+# The subdir is censused, not fenced off: correcting a sentence there still works.
+cat > "$T/deepfix.json" <<'JSON'
+{
+  "schema_version": 1, "slug": "fix-deep-rule",
+  "reason": "correct one sentence in a subdir rule",
+  "edits": [ { "file": ".claude/rules/sub/deep-rule.md", "op": "replace",
+               "anchor": "No output leaves this repo without passing that check.",
+               "insert": "No generated output leaves this repo without passing that check.",
+               "reason": "r" } ]
+}
+JSON
+run_engine "$ENGINE" "$T/deepfix.json" "$T"
+check "a subdir rule is still correctable" 0 "OK applied fix-deep-rule" "$RC" "$OUT"
+rm -r "$T"
+
+# 15n. repointing an enforcer at a directory that does not exist (PR #70 round 4,
+# minor). The exec-ref mark was the BASENAME only, so moving the route while
+# keeping the filename left the census member intact and the reader's route dead.
+T=$(mktemp -d); mk_fixture "$T"
+printf -- '# Routed Rule (ENFORCED)\n\nThe gate is q-system/.q-system/scripts/existing-lint.py, run PostToolUse.\n\nIt refuses on a bad write.\n' \
+  > "$T/.claude/rules/routed-rule.md"
+cat > "$T/reroute.json" <<'JSON'
+{
+  "schema_version": 1, "slug": "reroute-enforcer",
+  "reason": "keep the filename, move the route to a directory that does not exist",
+  "edits": [ { "file": ".claude/rules/routed-rule.md", "op": "replace",
+               "anchor": "The gate is q-system/.q-system/scripts/existing-lint.py, run PostToolUse.",
+               "insert": "The gate is q-system/retired/hooks/existing-lint.py, run PostToolUse.",
+               "reason": "r" } ]
+}
+JSON
+SUM=$(shasum -a 256 "$T/.claude/rules/routed-rule.md" | awk '{print $1}')
+run_engine "$ENGINE" "$T/reroute.json" "$T"
+check "repointing an enforcer to a dead directory refused" 2 "enforcement ratchet" "$RC" "$OUT"
+if [ "$SUM" = "$(shasum -a 256 "$T/.claude/rules/routed-rule.md" | awk '{print $1}')" ]; then
+  ok "repointing the enforcer wrote nothing"
+else bad "repointing the enforcer left a dead route in the rule"; fi
+rm -r "$T"
+
+# 15o. moving (ENFORCED out of the heading and parking it in prose that says the
+# opposite (PR #70 round 4, minor). A whole-file presence boolean sees the token
+# either way, the line count GROWS, and the rule reads as advisory.
+T=$(mktemp -d); mk_fixture "$T"
+cat > "$T/park.json" <<'JSON'
+{
+  "schema_version": 1, "slug": "park-the-marker",
+  "reason": "take the marker off the heading while keeping the token in the file",
+  "edits": [ { "file": ".claude/rules/enforced-rule.md", "op": "replace",
+               "anchor": "# Sample Rule (ENFORCED)",
+               "insert": "# Sample Rule\n\nThis rule is no longer (ENFORCED); treat it as advisory guidance.",
+               "reason": "r" } ]
+}
+JSON
+SUM=$(shasum -a 256 "$T/.claude/rules/enforced-rule.md" | awk '{print $1}')
+run_engine "$ENGINE" "$T/park.json" "$T"
+check "moving (ENFORCED out of the heading refused" 2 "enforcement ratchet" "$RC" "$OUT"
+check_one_line "moving (ENFORCED out of the heading" "$OUT"
+if [ "$SUM" = "$(shasum -a 256 "$T/.claude/rules/enforced-rule.md" | awk '{print $1}')" ]; then
+  ok "parking the marker wrote nothing"
+else bad "parking the marker DEMOTED the rule to advisory"; fi
+
+# Rewording the heading around the marker stays free: the census counts how many
+# headings carry it, not what they say, so a title fix is not a demotion.
+cat > "$T/retitle.json" <<'JSON'
+{
+  "schema_version": 1, "slug": "retitle-rule",
+  "reason": "reword the heading, keep the marker on it",
+  "edits": [ { "file": ".claude/rules/enforced-rule.md", "op": "replace",
+               "anchor": "# Sample Rule (ENFORCED)",
+               "insert": "# Sample Rule: writes only (ENFORCED)", "reason": "r" } ]
+}
+JSON
+run_engine "$ENGINE" "$T/retitle.json" "$T"
+check "rewording an (ENFORCED heading still succeeds" 0 "OK applied retitle-rule" "$RC" "$OUT"
+rm -r "$T"
+
 # ============================ MUTATION =====================================
 # Copy the engine, break ONE guard, prove the matching case goes red. Without
 # this, a green suite only proves the tests run, not that the guards do anything.
@@ -1039,7 +1199,7 @@ echo "--- mutation: drop the frontmatter pin ---"
 # check reports clean because the body never moved.
 T=$(mktemp -d); mk_fixture "$T"
 MUT="$T/mutant_fm.py"
-mutate "$MUT" "        if _frontmatter(new) != _frontmatter(content):" "        if False:"
+mutate "$MUT" "    if _frontmatter(after) != _frontmatter(before):" "    if False:"
 cat > "$T/unload.json" <<'JSON'
 {
   "schema_version": 1, "slug": "unload-rule", "reason": "narrow the scoping key",
@@ -1083,6 +1243,119 @@ else
 fi
 rm -r "$T"
 
+echo "--- mutation: put the frontmatter pin back inside the replace branch ---"
+# Where it lived in round 3. The additive ops then reach the block again and an
+# insert_before switches an ENFORCED rule off without deleting one character.
+T=$(mktemp -d); mk_fixture "$T"
+MUT="$T/mutant_fmops.py"
+mutate "$MUT" '    _guard_frontmatter(rel, content, new)' \
+              '    _guard_frontmatter(rel, content, new) if op == "replace" else None'
+cat > "$T/addfm.json" <<'JSON'
+{
+  "schema_version": 1, "slug": "add-frontmatter", "reason": "scope a rule out of existence",
+  "edits": [ { "file": ".claude/rules/enforced-rule.md", "op": "insert_before",
+               "anchor": "# Sample Rule (ENFORCED)",
+               "insert": "---\npaths:\n  - \"__never__/**\"\n---\n\n", "reason": "r" } ]
+}
+JSON
+set +e
+MOUT=$(python3 "$MUT" "$T/addfm.json" --root "$T" 2>&1); MRC=$?
+set -e
+if grep -q "__never__" "$T/.claude/rules/enforced-rule.md"; then
+  ok "MUTATION fm-ops: pin re-scoped to replace -> insert_before switched an ENFORCED rule off (rc=$MRC), test goes RED as required"
+else
+  bad "MUTATION fm-ops: mutant did not add frontmatter - case 15l is not load-bearing"
+fi
+rm -r "$T"
+
+echo "--- mutation: put the rule census back to one directory level ---"
+# The one-level listing is what left a subdirectory rule inside replace's reach
+# and outside the content census at the same time.
+T=$(mktemp -d); mk_fixture "$T"
+mkdir -p "$T/.claude/rules/sub"
+cat > "$T/.claude/rules/sub/deep-rule.md" <<'MD'
+# Deep Rule (ENFORCED)
+
+The deterministic half is `existing-lint.py`, wired PostToolUse on Edit|Write.
+
+Every generated file is checked before it is written.
+
+No output leaves this repo without passing that check.
+MD
+MUT="$T/mutant_depth.py"
+mutate "$MUT" '    for dirpath, dirnames, filenames in os.walk(rules_dir):' \
+              '    for dirpath, dirnames, filenames in [(rules_dir, [], sorted(os.listdir(rules_dir)))]:'
+cat > "$T/gutdeep.json" <<'JSON'
+{
+  "schema_version": 1, "slug": "gut-deep-rule", "reason": "gut a rule below rules/",
+  "edits": [ { "file": ".claude/rules/sub/deep-rule.md", "op": "replace",
+               "anchor": "# Deep Rule (ENFORCED)\n\nThe deterministic half is `existing-lint.py`, wired PostToolUse on Edit|Write.\n\nEvery generated file is checked before it is written.\n\nNo output leaves this repo without passing that check.",
+               "insert": "# Deep Rule\n\nUse your judgement.", "reason": "r" } ]
+}
+JSON
+set +e
+MOUT=$(python3 "$MUT" "$T/gutdeep.json" --root "$T" 2>&1); MRC=$?
+set -e
+if grep -q "Use your judgement." "$T/.claude/rules/sub/deep-rule.md"; then
+  ok "MUTATION depth: census back to one level -> a subdir ENFORCED rule was gutted (rc=$MRC), test goes RED as required"
+else
+  bad "MUTATION depth: mutant did not gut the subdir rule - case 15m is not load-bearing"
+fi
+rm -r "$T"
+
+echo "--- mutation: drop the directory prefix from the exec-ref pattern ---"
+# Basename-only marks: the filename survives the move, so the census cannot tell
+# a live route from one pointed at a directory that does not exist.
+T=$(mktemp -d); mk_fixture "$T"
+printf -- '# Routed Rule (ENFORCED)\n\nThe gate is q-system/.q-system/scripts/existing-lint.py, run PostToolUse.\n\nIt refuses on a bad write.\n' \
+  > "$T/.claude/rules/routed-rule.md"
+MUT="$T/mutant_route.py"
+mutate "$MUT" '(?<![A-Za-z0-9_./-])(?:[A-Za-z0-9_.-]+/)*[A-Za-z0-9_]' '[A-Za-z0-9_]'
+cat > "$T/reroute.json" <<'JSON'
+{
+  "schema_version": 1, "slug": "reroute-enforcer", "reason": "move the route, keep the name",
+  "edits": [ { "file": ".claude/rules/routed-rule.md", "op": "replace",
+               "anchor": "The gate is q-system/.q-system/scripts/existing-lint.py, run PostToolUse.",
+               "insert": "The gate is q-system/retired/hooks/existing-lint.py, run PostToolUse.",
+               "reason": "r" } ]
+}
+JSON
+set +e
+MOUT=$(python3 "$MUT" "$T/reroute.json" --root "$T" 2>&1); MRC=$?
+set -e
+if grep -q "q-system/retired/hooks" "$T/.claude/rules/routed-rule.md"; then
+  ok "MUTATION route: prefix dropped -> the rule now routes readers to a directory that does not exist (rc=$MRC), test goes RED as required"
+else
+  bad "MUTATION route: mutant did not write the dead route - case 15n is not load-bearing"
+fi
+rm -r "$T"
+
+echo "--- mutation: stop counting which headings carry (ENFORCED ---"
+# Leaves the whole-file occurrence count, which is exactly the boolean that let
+# the marker be lifted off the heading and parked in prose saying the opposite.
+T=$(mktemp -d); mk_fixture "$T"
+MUT="$T/mutant_head.py"
+mutate "$MUT" '                token_marks.add("%s|enforced-heading|%d" % (name, index))' \
+              '                pass'
+cat > "$T/park.json" <<'JSON'
+{
+  "schema_version": 1, "slug": "park-the-marker", "reason": "demote while keeping the token",
+  "edits": [ { "file": ".claude/rules/enforced-rule.md", "op": "replace",
+               "anchor": "# Sample Rule (ENFORCED)",
+               "insert": "# Sample Rule\n\nThis rule is no longer (ENFORCED); treat it as advisory guidance.",
+               "reason": "r" } ]
+}
+JSON
+set +e
+MOUT=$(python3 "$MUT" "$T/park.json" --root "$T" 2>&1); MRC=$?
+set -e
+if grep -q "treat it as advisory guidance" "$T/.claude/rules/enforced-rule.md"; then
+  ok "MUTATION heading: placement uncounted -> (ENFORCED left the heading for a sentence saying the opposite (rc=$MRC), test goes RED as required"
+else
+  bad "MUTATION heading: mutant did not demote the rule - case 15o is not load-bearing"
+fi
+rm -r "$T"
+
 T=$(mktemp -d); mk_fixture "$T"
 MUT="$T/mutant_norm.py"
 mutate2 "$MUT" \
@@ -1116,7 +1389,11 @@ echo "--- mutation: blind the rule-content census ---"
 # quiet demotion through, or case 15b is decoration.
 T=$(mktemp -d); mk_fixture "$T"
 MUT="$T/mutant_marks.py"
-mutate "$MUT" '        if "(ENFORCED" in text:' '        if False:'
+# Both (ENFORCED counters, because either one alone still refuses the demotion:
+# the occurrence count and the heading count each see this edit.
+mutate2 "$MUT" \
+  '                token_marks.add("%s|enforced|%d" % (name, index))' '                pass' \
+  '                token_marks.add("%s|enforced-heading|%d" % (name, index))' '                pass'
 cat > "$T/demote.json" <<'JSON'
 {
   "schema_version": 1, "slug": "demote-rule", "reason": "quietly downgrade a rule",

--- a/q-system/.q-system/scripts/test/test-apply-claude-changes.sh
+++ b/q-system/.q-system/scripts/test/test-apply-claude-changes.sh
@@ -50,6 +50,16 @@ mk_fixture() {  # mk_fixture <root>
   mkdir -p "$r/q-system/.q-system/scripts" "$r/q-system/output"
   echo "# existing" > "$r/.claude/rules/coding-standards.md"
   echo "# agent" > "$r/.claude/agents/preflight.md"
+  # A rule carrying both enforcement-bearing token classes the content census
+  # counts: an (ENFORCED marker and a named executable. The last paragraph is
+  # the false claim a `replace` has to be able to correct.
+  cat > "$r/.claude/rules/enforced-rule.md" <<'MD'
+# Sample Rule (ENFORCED)
+
+The deterministic half is `existing-lint.py`, wired PostToolUse on Edit|Write.
+
+This rule is enforced end to end and covers every path in the repo.
+MD
   echo "print('lint')" > "$r/q-system/.q-system/scripts/existing-lint.py"
   cat > "$r/.claude/settings.json" <<'JSON'
 {
@@ -224,7 +234,7 @@ rm -r "$T"
 
 # ------------------------- 5. removal / disable is not expressible (no bypass)
 T=$(mktemp -d); mk_fixture "$T"
-for OP in replace delete remove overwrite; do
+for OP in delete remove overwrite; do
   cat > "$T/op.json" <<JSON
 {
   "schema_version": 1, "slug": "op-$OP", "reason": "try to remove a hook",
@@ -233,7 +243,7 @@ for OP in replace delete remove overwrite; do
 }
 JSON
   run_engine "$ENGINE" "$T/op.json" "$T"
-  check "op '$OP' refused as non-additive" 2 "is not additive" "$RC" "$OUT"
+  check "op '$OP' refused as unknown" 2 "is not a permitted op" "$RC" "$OUT"
 done
 
 # The flag the old design would have used. It must not be a bypass; it must not
@@ -556,6 +566,212 @@ case "$OUT" in
 esac
 rm -r "$T"
 
+# ---------------------------------------- 15. replace, pinned to rule text
+# ASK-289. Additive-only meant a wrong sentence in a rule could only be BURIED,
+# never corrected -- design-auto-invoke.md still carries a narrowing paragraph
+# wedged ABOVE its own H1 because insert_before was the only expressible op.
+# `replace` fixes that, and is safe only because the census now reads rule
+# CONTENT (see the two ratchet cases below), not just the directory listing.
+T=$(mktemp -d); mk_fixture "$T"
+cat > "$T/fixclaim.json" <<'JSON'
+{
+  "schema_version": 1, "slug": "fix-false-claim",
+  "reason": "correct an overbroad enforcement sentence",
+  "edits": [ { "file": ".claude/rules/enforced-rule.md", "op": "replace",
+               "anchor": "This rule is enforced end to end and covers every path in the repo.",
+               "insert": "This rule is enforced on Edit|Write only; other paths are advisory.",
+               "reason": "the old sentence claimed coverage the hook does not have" } ]
+}
+JSON
+run_engine "$ENGINE" "$T/fixclaim.json" "$T"
+check "replace on rule text succeeds" 0 "OK applied fix-false-claim" "$RC" "$OUT"
+check_one_line "replace on rule text" "$OUT"
+if grep -q "other paths are advisory" "$T/.claude/rules/enforced-rule.md"; then
+  ok "replace wrote the corrected sentence"
+else bad "replace did not write the corrected sentence"; fi
+if grep -q "covers every path in the repo" "$T/.claude/rules/enforced-rule.md"; then
+  bad "replace left the false claim in place (it was buried, not corrected)"
+else ok "replace REMOVED the false claim, which no additive op could do"; fi
+if grep -q "(ENFORCED)" "$T/.claude/rules/enforced-rule.md"; then
+  ok "replace left the (ENFORCED) marker and the exec ref untouched"
+else bad "replace collaterally dropped the (ENFORCED) marker"; fi
+
+# Idempotent: the anchor is gone but the insert is present exactly once.
+BEFORE_RERUN=$(shasum -a 256 "$T/.claude/rules/enforced-rule.md" | awk '{print $1}')
+run_engine "$ENGINE" "$T/fixclaim.json" "$T"
+check "replace re-run is a no-op" 0 "OK already-applied" "$RC" "$OUT"
+if [ "$BEFORE_RERUN" = "$(shasum -a 256 "$T/.claude/rules/enforced-rule.md" | awk '{print $1}')" ]; then
+  ok "replace re-run changed nothing"
+else bad "replace re-run mutated the file"; fi
+rm -r "$T"
+
+# 15b. the ratchet reads rule CONTENT: stripping (ENFORCED) is refused.
+T=$(mktemp -d); mk_fixture "$T"
+cat > "$T/demote.json" <<'JSON'
+{
+  "schema_version": 1, "slug": "demote-rule",
+  "reason": "quietly downgrade a rule to advisory",
+  "edits": [ { "file": ".claude/rules/enforced-rule.md", "op": "replace",
+               "anchor": "# Sample Rule (ENFORCED)",
+               "insert": "# Sample Rule", "reason": "drop the marker" } ]
+}
+JSON
+SUM=$(shasum -a 256 "$T/.claude/rules/enforced-rule.md" | awk '{print $1}')
+run_engine "$ENGINE" "$T/demote.json" "$T"
+check "stripping (ENFORCED) refused by the ratchet" 2 "enforcement ratchet" "$RC" "$OUT"
+check_one_line "stripping (ENFORCED)" "$OUT"
+if [ "$SUM" = "$(shasum -a 256 "$T/.claude/rules/enforced-rule.md" | awk '{print $1}')" ]; then
+  ok "stripping (ENFORCED) wrote nothing"
+else bad "stripping (ENFORCED) mutated the rule"; fi
+
+# 15c. dropping the executable a rule routes readers to is the same class.
+cat > "$T/unwire.json" <<'JSON'
+{
+  "schema_version": 1, "slug": "unwire-rule",
+  "reason": "remove the pointer to the enforcer",
+  "edits": [ { "file": ".claude/rules/enforced-rule.md", "op": "replace",
+               "anchor": "The deterministic half is `existing-lint.py`, wired PostToolUse on Edit|Write.",
+               "insert": "The deterministic half is a hook.", "reason": "drop the ref" } ]
+}
+JSON
+run_engine "$ENGINE" "$T/unwire.json" "$T"
+check "dropping an exec reference refused by the ratchet" 2 "enforcement ratchet" "$RC" "$OUT"
+rm -r "$T"
+
+# 15d. replace cannot reach the config surface. .claude/settings.json is named
+# outright; the pair requirement is satisfied so the SCOPE check is what refuses.
+mk_replace_settings() {  # mk_replace_settings <root>
+  # Deliberately picks a swap NO other layer objects to: the census keys on the
+  # command string (unchanged), the JSON stays valid, permissions do not move.
+  # Only the rule-text scope check stands between this and a broken hook.
+  cat > "$1/rep-settings.json" <<'JSON'
+{
+  "schema_version": 1, "slug": "replace-settings",
+  "reason": "reach the config surface through the one non-additive op",
+  "requires": { "template_pairs": ["existing-lint.py"] },
+  "edits": [ { "file": ".claude/settings.json", "op": "replace",
+               "anchor": "\"type\": \"command\"", "insert": "\"type\": \"cmd\"",
+               "reason": "silently break the hook type" } ]
+}
+JSON
+}
+T=$(mktemp -d); mk_fixture "$T"; mk_replace_settings "$T"
+SUM=$(shasum -a 256 "$T/.claude/settings.json" | awk '{print $1}')
+run_engine "$ENGINE" "$T/rep-settings.json" "$T"
+check "replace on settings.json refused" 2 "replace may not target" "$RC" "$OUT"
+if [ "$SUM" = "$(shasum -a 256 "$T/.claude/settings.json" | awk '{print $1}')" ]; then
+  ok "replace on settings.json wrote nothing"
+else bad "replace MUTATED settings.json"; fi
+
+cat > "$T/rep-agent.json" <<'JSON'
+{
+  "schema_version": 1, "slug": "replace-agent", "reason": "reach an agent file",
+  "edits": [ { "file": ".claude/agents/preflight.md", "op": "replace",
+               "anchor": "# agent", "insert": "# other", "reason": "r" } ]
+}
+JSON
+run_engine "$ENGINE" "$T/rep-agent.json" "$T"
+check "replace outside .claude/rules/ refused" 2 "only permitted on" "$RC" "$OUT"
+rm -r "$T"
+
+# 15e. a symlink parked in .claude/rules/ is a second name for a file the string
+# scope check would wave through. Same class as settings.local.json (round 1)
+# and the ./ spelling (round 2), arriving through the new op.
+T=$(mktemp -d); mk_fixture "$T"
+ln -s "../settings.json" "$T/.claude/rules/sneak.md"
+cat > "$T/sneak.json" <<'JSON'
+{
+  "schema_version": 1, "slug": "sneak-settings",
+  "reason": "reach settings.json through a symlink inside rules/",
+  "requires": { "template_pairs": ["existing-lint.py"] },
+  "edits": [ { "file": ".claude/rules/sneak.md", "op": "replace",
+               "anchor": "\"type\": \"command\"", "insert": "\"type\": \"cmd\"",
+               "reason": "r" } ]
+}
+JSON
+SUM=$(shasum -a 256 "$T/.claude/settings.json" | awk '{print $1}')
+run_engine "$ENGINE" "$T/sneak.json" "$T"
+check "symlink-to-settings refused" 2 "replace may not target" "$RC" "$OUT"
+if [ "$SUM" = "$(shasum -a 256 "$T/.claude/settings.json" | awk '{print $1}')" ]; then
+  ok "symlink-to-settings wrote nothing"
+else bad "symlink-to-settings MUTATED settings.json"; fi
+
+# A symlink out of rules/ that is NOT the settings pair: the realpath check is
+# the only layer left, so this case is what makes that check load-bearing.
+ln -s "../agents/preflight.md" "$T/.claude/rules/sneak2.md"
+cat > "$T/sneak2.json" <<'JSON'
+{
+  "schema_version": 1, "slug": "sneak-agent",
+  "reason": "reach an agent file through a symlink inside rules/",
+  "edits": [ { "file": ".claude/rules/sneak2.md", "op": "replace",
+               "anchor": "# agent", "insert": "# other", "reason": "r" } ]
+}
+JSON
+run_engine "$ENGINE" "$T/sneak2.json" "$T"
+check "symlink out of rules/ refused" 2 "resolves outside" "$RC" "$OUT"
+rm -r "$T"
+
+# 15f. replace is not a delete: an empty insert is refused, so "remove this
+# paragraph" stays inexpressible (the Not-doing line of ASK-289).
+T=$(mktemp -d); mk_fixture "$T"
+cat > "$T/erase.json" <<'JSON'
+{
+  "schema_version": 1, "slug": "erase-para", "reason": "delete by replacing with nothing",
+  "edits": [ { "file": ".claude/rules/enforced-rule.md", "op": "replace",
+               "anchor": "This rule is enforced end to end and covers every path in the repo.",
+               "insert": "", "reason": "r" } ]
+}
+JSON
+run_engine "$ENGINE" "$T/erase.json" "$T"
+check "empty insert refused (no delete op)" 2 "must be a non-empty string" "$RC" "$OUT"
+
+# Whitespace-only is the same delete wearing a hat.
+cat > "$T/erase2.json" <<'JSON'
+{
+  "schema_version": 1, "slug": "erase-para-ws", "reason": "delete via whitespace",
+  "edits": [ { "file": ".claude/rules/enforced-rule.md", "op": "replace",
+               "anchor": "This rule is enforced end to end and covers every path in the repo.",
+               "insert": "   ", "reason": "r" } ]
+}
+JSON
+run_engine "$ENGINE" "$T/erase2.json" "$T"
+check "whitespace-only insert refused" 2 "must be a non-empty string" "$RC" "$OUT"
+
+# 15g. anchor contained in the insert never converges: every run would find the
+# anchor again and grow the file. Refused, with the additive op named instead.
+cat > "$T/grow.json" <<'JSON'
+{
+  "schema_version": 1, "slug": "grow-forever", "reason": "anchor survives its own replacement",
+  "edits": [ { "file": ".claude/rules/enforced-rule.md", "op": "replace",
+               "anchor": "# Sample Rule (ENFORCED)",
+               "insert": "# Sample Rule (ENFORCED) and then some", "reason": "r" } ]
+}
+JSON
+run_engine "$ENGINE" "$T/grow.json" "$T"
+check "non-converging replace refused" 2 "never converges" "$RC" "$OUT"
+
+# 15h. anchor arithmetic is the same as for the insert ops.
+printf 'dup\ndup\n' > "$T/.claude/rules/dup.md"
+cat > "$T/repdup.json" <<'JSON'
+{
+  "schema_version": 1, "slug": "rep-dup", "reason": "anchor matches twice",
+  "edits": [ { "file": ".claude/rules/dup.md", "op": "replace",
+               "anchor": "dup", "insert": "X", "reason": "r" } ]
+}
+JSON
+run_engine "$ENGINE" "$T/repdup.json" "$T"
+check "ambiguous replace anchor refused" 2 "must be exactly 1" "$RC" "$OUT"
+cat > "$T/repabs.json" <<'JSON'
+{
+  "schema_version": 1, "slug": "rep-absent", "reason": "anchor is not there",
+  "edits": [ { "file": ".claude/rules/enforced-rule.md", "op": "replace",
+               "anchor": "NO SUCH TEXT ANYWHERE", "insert": "X", "reason": "r" } ]
+}
+JSON
+run_engine "$ENGINE" "$T/repabs.json" "$T"
+check "absent replace anchor refused" 2 "anchor not found" "$RC" "$OUT"
+rm -r "$T"
+
 # ============================ MUTATION =====================================
 # Copy the engine, break ONE guard, prove the matching case goes red. Without
 # this, a green suite only proves the tests run, not that the guards do anything.
@@ -684,6 +900,47 @@ if grep -q 'Bash(:\*)' "$T/.claude/settings.json"; then
   ok "MUTATION normalize: both readers restored -> ./ spelling widened permissions.allow (rc=$MRC), test goes RED as required"
 else
   bad "MUTATION normalize: mutant did not widen permissions - the ./ test is not load-bearing"
+fi
+rm -r "$T"
+
+echo
+echo "--- mutation: blind the rule-content census ---"
+# Before ASK-289 the rule census was a directory listing, so it could not see
+# anything a replace did INSIDE a file. Putting that blindness back must let the
+# quiet demotion through, or case 15b is decoration.
+T=$(mktemp -d); mk_fixture "$T"
+MUT="$T/mutant_marks.py"
+mutate "$MUT" '        if "(ENFORCED" in text:' '        if False:'
+cat > "$T/demote.json" <<'JSON'
+{
+  "schema_version": 1, "slug": "demote-rule", "reason": "quietly downgrade a rule",
+  "edits": [ { "file": ".claude/rules/enforced-rule.md", "op": "replace",
+               "anchor": "# Sample Rule (ENFORCED)",
+               "insert": "# Sample Rule", "reason": "drop the marker" } ]
+}
+JSON
+set +e
+python3 "$MUT" "$T/demote.json" --root "$T" >/dev/null 2>&1; MRC=$?
+set -e
+if grep -q "(ENFORCED)" "$T/.claude/rules/enforced-rule.md"; then
+  bad "MUTATION marks: census blinded but the demotion was still refused - case 15b is not load-bearing"
+else
+  ok "MUTATION marks: census blinded -> (ENFORCED) silently stripped (rc=$MRC), test goes RED as required"
+fi
+rm -r "$T"
+
+echo
+echo "--- mutation: remove the rule-text scope pin on replace ---"
+T=$(mktemp -d); mk_fixture "$T"; mk_replace_settings "$T"
+MUT="$T/mutant_scope.py"
+mutate "$MUT" '            rule_text_only(root, rel, settings_key, template_key)' '            pass'
+set +e
+python3 "$MUT" "$T/rep-settings.json" --root "$T" >/dev/null 2>&1; MRC=$?
+set -e
+if grep -q '"type": "cmd"' "$T/.claude/settings.json"; then
+  ok "MUTATION scope: pin removed -> replace reached settings.json and broke a hook (rc=$MRC), test goes RED as required"
+else
+  bad "MUTATION scope: pin removed but settings.json is untouched - case 15d is not load-bearing"
 fi
 rm -r "$T"
 


### PR DESCRIPTION
Closes ASK-289 (do not merge from here; closeout runs through /issue-verify and /issue-closeout).

## The problem

`apply_claude_changes.py` was additive-only, so a wrong sentence in a `.claude/` rule could be **buried but never corrected**. The scar is visible in the repo right now: `.claude/rules/design-auto-invoke.md` carries its narrowing paragraph wedged **above its own H1**, because `insert_before` was the only expressible op (ASK-134). A false enforcement claim had no fix.

## What changed

`replace` is now an op. It is safe only because of the second half of this change.

**Pinned to rule TEXT** (`rule_text_only`) — three checks, each covering a hole the other two leave:
- *identity*: refuses `.claude/settings.json` / `settings-template.json` under any spelling (resolved by inode upstream, so a case variant or `./` spelling arrives as the same key)
- *shape*: refuses anything that is not `.claude/rules/*.md`, so `agents/` and `output-styles/` keep the additive-only guarantee they had before
- *realpath*: refuses a symlink parked at `.claude/rules/x.md` pointing elsewhere. `scoped_path` permits that today (it only asks the target stay under `.claude/`), so a string-shape check alone waves it through — the `settings.local.json` (round 1) and `./` (round 2) classes arriving through the new op

**The census now reads rule CONTENT** (`_rule_content_marks`), not just the `rules/` directory listing. A listing is blind to everything a replace does inside a file. Two countable enforcement tokens per rule:
- an `(ENFORCED` marker — demoting a rule to advisory is enforcement-weakening
- each named `.py`/`.sh` the rule routes a reader to — a rule whose pointer to its enforcer vanishes is a rule nobody can act on

Prose meaning is deliberately **not** counted. A ratchet that judged tone or length would refuse the honest corrections this op exists to enable.

**Still no delete** (the issue's Not-doing line): `insert` must be a non-empty, non-blank string, so "replace this paragraph with nothing" is refused at load. An anchor contained in its own replacement is refused too — it never converges, and would grow the file on every run while already-applied stayed undetectable.

**One ambiguity check, not two**: anchor arithmetic extracted to `_unique_anchor_hits` so `replace` and the insert ops share it rather than keeping two copies free to drift.

## Verification

`bash q-system/.q-system/scripts/test/test-apply-claude-changes.sh`

RED first — every new case refused with `op 'replace' is not additive`. Then:

```
passed: 81   failed: 0
```

Two new mutation cases prove the new guards are load-bearing:

```
PASS: MUTATION marks: census blinded -> (ENFORCED) silently stripped (rc=0), test goes RED as required
PASS: MUTATION scope: pin removed -> replace reached settings.json and broke a hook (rc=0), test goes RED as required
```

All five pre-existing mutation cases still pass.

## Blast radius

`apply_claude_changes.py` is the only write route into `.claude/`. The additive ops, the L2 ratchet, L3 verify+revert, the lock, and the permission surfaces are unchanged. The config surface is unreachable by `replace`.

## Honest boundary

The content census counts markers and executable references, not meaning. A replace that rewrites a rule into something vaguer while keeping its `(ENFORCED` marker and every script name passes the ratchet. That is the deliberate trade: the alternative refuses the corrections this exists to enable.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
