### PR TITLE
Handle the condition, send nothing: 48 founder pings/24h to 1 (ASK-294)

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -109,6 +109,10 @@
           },
           {
             "type": "command",
+            "command": "python3 \"$CLAUDE_PROJECT_DIR/q-system/.q-system/scripts/notify-receipts-surface.py\" 2>/dev/null || true"
+          },
+          {
+            "type": "command",
             "command": "python3 \"$CLAUDE_PROJECT_DIR/q-system/.q-system/scripts/memory-scores-surface.py\" 2>/dev/null || true"
           },
           {

--- a/automation/voice-refresh-nudge.sh
+++ b/automation/voice-refresh-nudge.sh
@@ -10,7 +10,7 @@ ROOT="$(cd "$(dirname "$0")/.." && pwd)"
 NOTIFY="$ROOT/q-system/.q-system/scripts/slack-notify.sh"
 MSG="Voice refresh due. Run /voice-refresh in a session to pull this month's Granola meetings and refresh your voice DNA."
 if [ -x "$NOTIFY" ]; then
-  bash "$NOTIFY" "$MSG"
+  bash "$NOTIFY" --kind decision --class publish "$MSG"
 else
   # slack-notify is a silent no-op when unconfigured; log so a dead nudge is visible.
   echo "[voice-refresh-nudge] slack-notify.sh not executable at $NOTIFY" >&2

--- a/automation/voice-refresh-nudge.sh
+++ b/automation/voice-refresh-nudge.sh
@@ -10,7 +10,7 @@ ROOT="$(cd "$(dirname "$0")/.." && pwd)"
 NOTIFY="$ROOT/q-system/.q-system/scripts/slack-notify.sh"
 MSG="Voice refresh due. Run /voice-refresh in a session to pull this month's Granola meetings and refresh your voice DNA."
 if [ -x "$NOTIFY" ]; then
-  bash "$NOTIFY" --kind decision --class publish "$MSG"
+  bash "$NOTIFY" "$MSG" --kind decision --class publish
 else
   # slack-notify is a silent no-op when unconfigured; log so a dead nudge is visible.
   echo "[voice-refresh-nudge] slack-notify.sh not executable at $NOTIFY" >&2

--- a/kipi-dispatch.sh
+++ b/kipi-dispatch.sh
@@ -46,19 +46,26 @@ LOG="$HOME/.config/kipi/dispatch.log"
 MAX_CONCURRENT="${KIPI_DISPATCH_MAX:-2}"
 MAX_ROUNDS="${KIPI_DISPATCH_ROUNDS:-3}"
 NOTIFY="${KIPI_NOTIFY:-$REPO/q-system/.q-system/scripts/slack-notify.sh}"
+# OVERRIDABLE, unlike PREFLIGHT above, and the difference is the direction each
+# one fails. Aiming the preflight at /bin/true would DISARM a client-repo safety
+# gate; aiming this at a missing path only disables self-healing, so the loop
+# pages exactly as it did before. The suite needs it because it extracts
+# stale_check into a harness file, where a $REPO-relative path resolves into the
+# fixture clone and the handler is silently inert -- which is how it first shipped.
+FF_MERGE="${KIPI_FF_MERGE:-$REPO/q-system/.q-system/scripts/ff-merge-if-safe.sh}"
 # Founder decision 2026-08-01: the converge/worker claude -p calls inherit this;
 # unpinned they rode the interactive default (Fable) and burned quota on 2026-08-01.
 export ANTHROPIC_MODEL="${KIPI_DISPATCH_MODEL:-claude-opus-5}"
 
 mkdir -p "$(dirname "$LOG")"
 say() { printf '%s %s\n' "$(date -u +%Y-%m-%dT%H:%M:%SZ)" "$*" >> "$LOG"; }
-page() { bash "$NOTIFY" "$1" >/dev/null 2>&1 || true; }
+page() { bash "$NOTIFY" --kind receipt "$1" >/dev/null 2>&1 || true; }
 # Same notifier, but REPORTS whether it went out. page() ends in `|| true` on
 # purpose -- a notifier must never take its caller down -- which makes it useless
 # to a caller that has to know. Kept as a sibling rather than changing page()'s
 # contract for the dozen sites that correctly do not care. Used by stale_check,
 # which must not write a dedupe marker for a page that never arrived.
-page_ok() { bash "$NOTIFY" "$1" >/dev/null 2>&1; }
+page_ok() { local m="$1"; shift; bash "$NOTIFY" "$@" "$m" >/dev/null 2>&1; }  # notify-kind-skip: callers classify
 
 # ONE PAGE PER STATE, NOT ONE PER HEARTBEAT (ASK-283, 2026-08-02).
 # Audited across this file: four guards -- missing repo, unusable `date`, gh off
@@ -149,6 +156,7 @@ page_clear() {
 
 page_once() {
   local key="$1" msg="$2" mark hash now prev stamp lock
+  shift 2   # remaining args = classification flags, passed through to the sink
   mark="$(dirname "$LOG")/paged-$key"
   hash="$(printf '%s' "$msg" | cksum | tr -d ' \n')"
   now="$(date -u +%s)"
@@ -194,7 +202,7 @@ page_once() {
       return 0
     fi
   fi
-  if page_ok "$msg"; then
+  if page_ok "$msg" "$@"; then
     printf '%s\n%s\n' "$hash" "$now" > "$mark" 2>/dev/null || true
   else
     say "page: $key did NOT go out; leaving the marker unset so the next heartbeat retries it"
@@ -204,7 +212,7 @@ page_once() {
 
 cd "$REPO" 2>/dev/null || {
   say "FATAL: repo not found at $REPO"
-  page_once repo-missing "kipi dispatch: repo not found at $REPO -- the Linear loop is DEAD. Do: check the path in com.kipi.dispatch.plist."
+  page_once repo-missing "kipi dispatch: repo not found at $REPO -- the Linear loop is DEAD. Do: check the path in com.kipi.dispatch.plist." --kind receipt
   exit 1
 }
 page_clear repo-missing
@@ -285,7 +293,48 @@ stale_check() {
   base="$(git rev-list --count "$local_head..$remote_head" 2>/dev/null || echo 0)"
   case "$base" in ''|*[!0-9]*) return 0 ;; esac   # unparseable count = no answer = run
   [ "$base" -gt 0 ] || { page_clear stale-checkout; return 0; }
-  say "STALE: origin/main holds $base commit(s) this checkout lacks (HEAD ${local_head:0:7}, origin/main ${remote_head:0:7}). Dispatching would run superseded control code and auto-merge the result."
+  say "STALE: origin/main holds $base commit(s) this checkout lacks (HEAD ${local_head:0:7}, origin/main ${remote_head:0:7})."
+
+  # SELF-HEAL FIRST; PAGE ONLY FOR WHAT IS ACTUALLY THE FOUNDER'S CALL (ASK-294).
+  # This block sent 15 of the 48 founder pings measured in one 24h window, every
+  # one of them naming him as the actor and handing him a shell command for
+  # something the loop can do itself. He said it twice: "why do I keep getting
+  # slack messages I can't do anything about", then "I just want the underlying
+  # issues to be dealt with so I don't get a message."
+  #
+  # The comment above still stands: a blind `git merge --ff-only` here is a
+  # data-loss path and was removed for it. ff-merge-if-safe.sh is not that. It
+  # proves the fast-forward cannot clobber anything -- over the EXACT finite set
+  # of paths the merge writes, not over the whole tree -- and declines otherwise.
+  # See its header for why that bound is what makes the difference.
+  local ff_out ff_rc cls
+  ff_out="$(bash "$FF_MERGE" "$REPO" main origin 2>&1)"; ff_rc=$?
+  say "stale-check: ff-merge-if-safe rc=$ff_rc: $ff_out"
+  if [ "$ff_rc" -eq 0 ]; then
+    # Handled. The founder hears nothing, which is the entire point.
+    page_clear stale-checkout
+    return 0
+  fi
+  if [ "$ff_rc" -eq 2 ]; then
+    # No answer is not proof of staleness. Same fail-open posture as the fetch above.
+    say "stale-check: no freshness answer, proceeding"
+    return 0
+  fi
+  # ANY OTHER CODE IS THE HANDLER ITSELF BEING BROKEN, NOT A VERDICT ABOUT THE
+  # TREE. A missing or non-executable script exits 127, and the first cut read
+  # that as "refuses to merge" and paged the founder -- turning a bug in my own
+  # code into a page about his. Only 0, 1 and 2 are answers.
+  if [ "$ff_rc" -ne 1 ]; then
+    say "stale-check: ff-merge-if-safe is not answering (rc=$ff_rc); proceeding without a freshness answer"
+    return 0
+  fi
+  # Only two things get here, and both are on the short list of what genuinely
+  # needs him: a diverged history (a real merge, irreversible) and a path the
+  # merge would overwrite that git is not tracking (outside the canonical tree).
+  case "$ff_out" in
+    collision:*) cls="out-of-tree-write" ;;
+    *)           cls="irreversible-git" ;;
+  esac
 
   # ONE PAGE PER STALE EPISODE, NOT ONE PER COMMIT.
   # The measured complaint: 19 refusing cycles overnight sent 9 Slack pages, one
@@ -298,7 +347,7 @@ stale_check() {
   # shas go to the log, which is free, not to the founder's phone, which is not.
   # page_clear on the healthy path below turns a recovery into silence and makes the
   # NEXT episode page immediately, which is what a per-sha key was reaching for.
-  page_once stale-checkout "kipi dispatch: paused -- this checkout is behind origin/main, so it will not dispatch (it would run superseded control code and auto-merge the result). Do: cd $REPO && git merge --ff-only origin/main. The loop resumes by itself once the checkout is current."
+  page_once stale-checkout "kipi dispatch: paused -- this checkout is behind origin/main and could NOT be brought current unattended: $ff_out. The loop resumes by itself once this is resolved." --kind decision --class "$cls"
   return 1
 }
 stale_check || exit 0
@@ -577,7 +626,7 @@ BUDGET_DAY="$(date -v-"${RESET_HOUR}"H +%Y-%m-%d 2>/dev/null \
               || date -d "-${RESET_HOUR} hours" +%Y-%m-%d 2>/dev/null)"
 if [ -z "$BUDGET_DAY" ]; then
   say "FATAL: could not compute the budget day (neither BSD nor GNU date worked)"
-  page_once budget-day "kipi dispatch: cannot compute its spend budget window, so it refused to dispatch rather than run uncapped. Do: check \`date -v-7H\` on this machine."
+  page_once budget-day "kipi dispatch: cannot compute its spend budget window, so it refused to dispatch rather than run uncapped. Do: check \`date -v-7H\` on this machine." --kind receipt
   exit 1
 fi
 page_clear budget-day
@@ -651,7 +700,7 @@ if command -v gh >/dev/null 2>&1; then
 fi
 if ! command -v gh >/dev/null 2>&1; then
   say "FATAL: gh not on PATH ($PATH)"
-  page_once gh-missing "kipi dispatch: gh CLI is not on PATH and I could not find it in the usual install dirs, so no PR can be opened and the Linear loop is stalled. Do: install gh, or add its directory to PATH in com.kipi.dispatch.plist."
+  page_once gh-missing "kipi dispatch: gh CLI is not on PATH and I could not find it in the usual install dirs, so no PR can be opened and the Linear loop is stalled. Do: install gh, or add its directory to PATH in com.kipi.dispatch.plist." --kind receipt
   exit 1
 fi
 
@@ -766,7 +815,7 @@ WORK_RC=$?
 # SURVIVED. A fixture must not be anchored to the text it is testing.
 if printf '%s' "$WORK_OUT" | grep -qiE 'INFRA: linear unreachable|infra_error|authentication|unauthorized'; then
   say "infra error from kipi work: $(printf '%s' "$WORK_OUT" | head -3 | tr '\n' ' ')"
-  page_once linear-down "kipi dispatch: Linear is unreachable or auth expired, so NO issues can be picked up. The loop is stopped, not slow. Do: run \`bash kipi work\` by hand and check the Linear token."
+  page_once linear-down "kipi dispatch: Linear is unreachable or auth expired, so NO issues can be picked up. The loop is stopped, not slow. Do: run \`bash kipi work\` by hand and check the Linear token." --kind decision --class credential
   exit 1
 fi
 # A RUN THAT NEVER REACHED LINEAR IS NOT EVIDENCE LINEAR RECOVERED -- the same rule

--- a/kipi-dispatch.sh
+++ b/kipi-dispatch.sh
@@ -35,6 +35,11 @@
 # class this repo keeps finding. One source of truth, asked politely.
 set -uo pipefail
 
+# Captured at ENTRY so stale_check's post-self-heal `exec` can replay the exact
+# invocation. "$@" inside a function is that function's argv, not the script's,
+# so reading it there would silently drop every flag launchd passed.
+DISPATCH_ARGV=("$@")
+
 REPO="${KIPI_REPO:-/Users/assafkipnis/projects/kipi-system}"
 # HARDCODED OFF $REPO, DELIBERATELY NOT AN ENV VAR. Every other path in this file
 # takes a KIPI_* override for testability; this one must not. A variable here would
@@ -320,7 +325,38 @@ stale_check() {
   if [ "$ff_rc" -eq 0 ]; then
     # Handled. The founder hears nothing, which is the entire point.
     page_clear stale-checkout
-    return 0
+    # RE-EXEC, DO NOT RETURN (PR #72 review, minor). Returning 0 here let the SAME
+    # bash process finish the cycle -- on the control code the fast-forward had
+    # just superseded, which is verbatim the hazard this guard's own text at the
+    # top of the block names as its reason for existing. git unlinks and recreates
+    # the file, so the open fd survives and bash keeps executing the PRE-merge
+    # bytes: nothing corrupts, and nothing new runs either. Self-healing into a
+    # cycle of stale code is the refusal it replaced, minus the page.
+    #
+    # BOUNDED AT ONE. An unbounded re-exec inside a 15-minute launchd job is a
+    # spin, and the second image takes this same code path. It cannot loop --
+    # after the merge HEAD equals origin/main, so stale_check returns early well
+    # before here -- but "cannot" is an argument and the env flag is a brake.
+    # Exported so it survives the exec; test 2c asserts exactly 2 images.
+    if [ "${KIPI_DISPATCH_REEXECED:-0}" = "1" ]; then
+      say "stale-check: already re-executed once this cycle; continuing on the current image"
+      return 0
+    fi
+    export KIPI_DISPATCH_REEXECED=1
+    say "stale-check: fast-forwarded; re-executing so the rest of this cycle runs the merged code"
+    # $DISPATCH_ARGV is captured at entry because "$@" inside a function is the
+    # FUNCTION's argv, not the script's. The ${x[@]+"${x[@]}"} guard is required:
+    # under `set -u`, bash 3.2 (what macOS ships) errors on "${arr[@]}" for an
+    # EMPTY array, and it also keeps this line safe in the test harness, which
+    # extracts this function without the capture above it.
+    # THE INTERPRETER IS EXPLICIT, NOT INHERITED FROM THE EXEC BIT. `exec "$0"`
+    # requires $0 to be executable and to carry a usable shebang, which is true
+    # of this file and NOT true of a caller that invokes it as `bash <path>` --
+    # the paired test harness does exactly that and got "Permission denied,
+    # cannot execute". Re-execing through the same bash that is already running
+    # depends on neither, and keeps the second image on the same interpreter as
+    # the first instead of whatever `bash` resolves to on PATH.
+    exec "${BASH:-bash}" "$0" ${DISPATCH_ARGV[@]+"${DISPATCH_ARGV[@]}"}
   fi
   if [ "$ff_rc" -eq 2 ]; then
     # No answer is not proof of staleness. Same fail-open posture as the fetch above.

--- a/kipi-dispatch.sh
+++ b/kipi-dispatch.sh
@@ -59,13 +59,20 @@ export ANTHROPIC_MODEL="${KIPI_DISPATCH_MODEL:-claude-opus-5}"
 
 mkdir -p "$(dirname "$LOG")"
 say() { printf '%s %s\n' "$(date -u +%Y-%m-%dT%H:%M:%SZ)" "$*" >> "$LOG"; }
-page() { bash "$NOTIFY" --kind receipt "$1" >/dev/null 2>&1 || true; }
+# $1 = message, $2.. = classification flags. Defaults to receipt because most
+# callers here are all-clears ("Nothing to do", the daily cap), but NOT all of
+# them are -- see the two liveness sites below, which stay decisions.
+page() {
+  local m="$1"; shift
+  [ $# -gt 0 ] || set -- --kind receipt
+  bash "$NOTIFY" "$m" "$@" >/dev/null 2>&1 || true  # notify-kind-skip: default set above, callers may override
+}
 # Same notifier, but REPORTS whether it went out. page() ends in `|| true` on
 # purpose -- a notifier must never take its caller down -- which makes it useless
 # to a caller that has to know. Kept as a sibling rather than changing page()'s
 # contract for the dozen sites that correctly do not care. Used by stale_check,
 # which must not write a dedupe marker for a page that never arrived.
-page_ok() { local m="$1"; shift; bash "$NOTIFY" "$@" "$m" >/dev/null 2>&1; }  # notify-kind-skip: callers classify
+page_ok() { local m="$1"; shift; bash "$NOTIFY" "$m" "$@" >/dev/null 2>&1; }  # notify-kind-skip: callers classify
 
 # ONE PAGE PER STATE, NOT ONE PER HEARTBEAT (ASK-283, 2026-08-02).
 # Audited across this file: four guards -- missing repo, unusable `date`, gh off
@@ -916,7 +923,7 @@ if [ "$RC" -ne 0 ]; then
   # A launch that failed must NOT report success -- that is the same shape as
   # the bug above. The budget slot is already spent, so say so plainly.
   say "FAILED to launch converge for $NEXT (rc=$RC); the budget slot is spent"
-  page "kipi dispatch: could not launch the converge run for $NEXT, so NO work is happening even though the loop looks alive. Do: run \`bash kipi-dispatch.sh\` by hand and read the error."
+  page "kipi dispatch: could not launch the converge run for $NEXT, so NO work is happening even though the loop looks alive. Do: run \`bash kipi-dispatch.sh\` by hand and read the error." --kind decision --class spend
   exit 1
 fi
 
@@ -960,7 +967,7 @@ if [ "$DISPATCH_OK" -eq 1 ]; then
   say "dispatched $NEXT (confirmed running)"
 else
   say "DISPATCH DIED: $NEXT was launched but no converge process is alive after 10s"
-  page "kipi dispatch: $NEXT was launched but died immediately -- the loop is spending budget and doing no work. Do: check ~/.config/kipi/converge-$NEXT.log and whether launchd is reaping the child."
+  page "kipi dispatch: $NEXT was launched but died immediately -- the loop is spending budget and doing no work. Do: check ~/.config/kipi/converge-$NEXT.log and whether launchd is reaping the child." --kind decision --class spend
   exit 1
 fi
 exit 0

--- a/lefthook.yml
+++ b/lefthook.yml
@@ -36,6 +36,16 @@ pre-commit:
     receipts-ledger:
       run: python3 q-system/.q-system/scripts/receipts-ledger-check.py
 
+    # ASK-294. A new producer that pages the founder without declaring a --kind
+    # is caught at the commit that writes it, not weeks later in the channel.
+    # Wired HERE and not only in kipi check because the runtime gate in
+    # slack-notify.sh deliberately FAILS OPEN for an unclassified caller: kipi
+    # update ships that script to instances carrying producers this repo has
+    # never seen, and silencing one of those is worse than the noise it stops.
+    # This is the half that closes the hole where the code actually lives.
+    notify-callsite-audit:
+      run: python3 q-system/.q-system/scripts/notify-callsite-audit.py
+
     blocked-paths:
       run: |
         # Block .env, .envrc, .env.<env>, *.pem/*.key (incl. rotations like key.pem.old), *.jsonl,

--- a/plugins/prd-os/.claude-plugin/plugin.json
+++ b/plugins/prd-os/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "prd-os",
-  "version": "0.9.2",
+  "version": "0.9.3",
   "description": "PRD operating system: capture rough ideas, draft reviewable PRDs, run standard and adversarial review (Codex or a Claude senior-staff-engineer subagent, recorded truthfully), triage findings, decompose approved PRDs into atomic issue specs, and execute those issues with scope enforcement, stop-gate receipts, and reviewer-attributed findings.",
   "author": {
     "name": "Assaf Kipnis"

--- a/plugins/prd-os/skills/fable-discipline/scripts/test_fable_discipline_lint.py
+++ b/plugins/prd-os/skills/fable-discipline/scripts/test_fable_discipline_lint.py
@@ -89,7 +89,7 @@ CASES = [
 PAGER_RUNNER = (
     '#!/usr/bin/env bash\n'
     'NOTIFY="${KIPI_NOTIFY:-$SCRIPT_DIR/slack-notify.sh}"\n'
-    'bash "$NOTIFY" "a human needs to look at this"\n'
+    'bash "$NOTIFY" "a human needs to look at this"\n'  # notify-kind-skip: fixture text, not a call
 )
 # Names the notifier only in PROSE -> not notify-capable, must not be flagged.
 QUIET_RUNNER = (

--- a/q-system/.q-system/capability-manifest.json
+++ b/q-system/.q-system/capability-manifest.json
@@ -206,6 +206,10 @@
       "runner": "bash"
     },
     {
+      "path": "q-system/.q-system/scripts/test/test-notify-receipts-surface.sh",
+      "runner": "bash"
+    },
+    {
       "path": "q-system/.q-system/scripts/test/test-open-loops-heartbeat-exit.sh",
       "runner": "bash"
     },

--- a/q-system/.q-system/capability-manifest.json
+++ b/q-system/.q-system/capability-manifest.json
@@ -2,6 +2,10 @@
   "schema_version": 1,
   "expected_tests": [
     {
+      "path": "plugins/kipi-design/hooks/test_dogfood_gate.py",
+      "runner": "python3"
+    },
+    {
       "path": "plugins/prd-os/scripts/test/test_spillover_ledger_root.py",
       "runner": "python3"
     },
@@ -54,11 +58,11 @@
       "runner": "bash"
     },
     {
-      "path": "q-system/.q-system/scripts/test/test-findings-block-reader.sh",
+      "path": "q-system/.q-system/scripts/test/test-ff-merge-if-safe.sh",
       "runner": "bash"
     },
     {
-      "path": "q-system/.q-system/scripts/test/test-repo-preflight.sh",
+      "path": "q-system/.q-system/scripts/test/test-findings-block-reader.sh",
       "runner": "bash"
     },
     {
@@ -194,15 +198,11 @@
       "runner": "bash"
     },
     {
+      "path": "q-system/.q-system/scripts/test/test-notify-decision-gate.sh",
+      "runner": "bash"
+    },
+    {
       "path": "q-system/.q-system/scripts/test/test-notify-fixture-guard.sh",
-      "runner": "bash"
-    },
-    {
-      "path": "q-system/.q-system/scripts/test/test-worker-project-scope.sh",
-      "runner": "bash"
-    },
-    {
-      "path": "q-system/.q-system/scripts/test/test-worker-refusal.sh",
       "runner": "bash"
     },
     {
@@ -222,10 +222,6 @@
       "runner": "bash"
     },
     {
-      "path": "plugins/kipi-design/hooks/test_dogfood_gate.py",
-      "runner": "python3"
-    },
-    {
       "path": "q-system/.q-system/scripts/test/test-propagation-entrypoints.py",
       "runner": "python3"
     },
@@ -243,6 +239,10 @@
     },
     {
       "path": "q-system/.q-system/scripts/test/test-receipts-ledger-check.sh",
+      "runner": "bash"
+    },
+    {
+      "path": "q-system/.q-system/scripts/test/test-repo-preflight.sh",
       "runner": "bash"
     },
     {
@@ -308,6 +308,14 @@
     },
     {
       "path": "q-system/.q-system/scripts/test/test-voice-lint-warn-detectors.sh",
+      "runner": "bash"
+    },
+    {
+      "path": "q-system/.q-system/scripts/test/test-worker-project-scope.sh",
+      "runner": "bash"
+    },
+    {
+      "path": "q-system/.q-system/scripts/test/test-worker-refusal.sh",
       "runner": "bash"
     },
     {
@@ -392,6 +400,10 @@
       "runner": "python3"
     },
     {
+      "path": "q-system/.q-system/scripts/test_review_tier.py",
+      "runner": "python3"
+    },
+    {
       "path": "q-system/.q-system/scripts/test_session_recall.py",
       "runner": "python3"
     },
@@ -401,10 +413,6 @@
     },
     {
       "path": "q-system/.q-system/scripts/test_system_manifest.py",
-      "runner": "python3"
-    },
-    {
-      "path": "q-system/.q-system/scripts/test_review_tier.py",
       "runner": "python3"
     },
     {
@@ -511,7 +519,7 @@
     },
     {
       "path": "q-system/.q-system/scripts/stat-verify.py",
-      "reason": "802-line stat verification engine; zero hook wiring and its stat-registry.json data file exists in exactly one instance — wiring it is a founder product decision",
+      "reason": "802-line stat verification engine; zero hook wiring and its stat-registry.json data file exists in exactly one instance \u2014 wiring it is a founder product decision",
       "spillover_id": "sp-72b60bff"
     },
     {
@@ -531,8 +539,8 @@
     }
   ],
   "uncovered_known": [
-    "plugins/*/tests — prd-os plugin suite, run by the plugin's own harness; outside v1 scan roots (finding-9 deferred)",
+    "plugins/*/tests \u2014 prd-os plugin suite, run by the plugin's own harness; outside v1 scan roots (finding-9 deferred)",
     "repo-root *.sh utilities are wiring surfaces, not test artifacts",
-    "stat-registry.json: NOT expressible as required_data in v1 — the one instance holding it keeps canonical under its own instance_q_dir (not q-system/) and its registry name differs from its dir basename, so a scoped entry could never fire (grounded 2026-07-23). Declared gap; owning decision + instance detail in spillover sp-72b60bff"
+    "stat-registry.json: NOT expressible as required_data in v1 \u2014 the one instance holding it keeps canonical under its own instance_q_dir (not q-system/) and its registry name differs from its dir basename, so a scoped entry could never fire (grounded 2026-07-23). Declared gap; owning decision + instance detail in spillover sp-72b60bff"
   ]
 }

--- a/q-system/.q-system/scripts/claude-integrity-tripwire.py
+++ b/q-system/.q-system/scripts/claude-integrity-tripwire.py
@@ -274,7 +274,7 @@ def notify(root, message):
     notifier = os.environ.get("KIPI_NOTIFY") or os.path.join(
         root, "q-system", ".q-system", "scripts", "slack-notify.sh")
     try:
-        subprocess.run([notifier, message], capture_output=True, timeout=20)
+        subprocess.run([notifier, "--kind", "receipt", message], capture_output=True, timeout=20)
     except Exception:
         pass  # a dead notifier must never stop the revert
 

--- a/q-system/.q-system/scripts/claude-integrity-tripwire.py
+++ b/q-system/.q-system/scripts/claude-integrity-tripwire.py
@@ -274,7 +274,7 @@ def notify(root, message):
     notifier = os.environ.get("KIPI_NOTIFY") or os.path.join(
         root, "q-system", ".q-system", "scripts", "slack-notify.sh")
     try:
-        subprocess.run([notifier, "--kind", "receipt", message], capture_output=True, timeout=20)
+        subprocess.run([notifier, message, "--kind", "receipt"], capture_output=True, timeout=20)
     except Exception:
         pass  # a dead notifier must never stop the revert
 

--- a/q-system/.q-system/scripts/converge.sh
+++ b/q-system/.q-system/scripts/converge.sh
@@ -725,7 +725,7 @@ while [ "$ROUND" -lt "$MAX_ROUNDS" ]; do
   PR="$(pr_for_branch)"
   if [ -z "$PR" ]; then
     say "STOP exit-7: no PR on $BRANCH after round $ROUND (worker rc=$WRC). Sana could not open one; see $LOG"
-    bash "$NOTIFY" "converge $ISSUE: stopped, no PR after round $ROUND" 2>/dev/null || true
+    bash "$NOTIFY" --kind receipt "converge $ISSUE: stopped, no PR after round $ROUND" 2>/dev/null || true
     exit 7
   fi
 
@@ -821,12 +821,12 @@ while [ "$ROUND" -lt "$MAX_ROUNDS" ]; do
       esac
     fi
     say "DONE exit-1: PR #$PR verdict '$VERDICT' after $ROUND round(s). $MERGE_LOG"
-    bash "$NOTIFY" "converge $ISSUE: $VERDICT after $ROUND round(s), $MERGE_PAGE" 2>/dev/null || true
+    bash "$NOTIFY" --kind receipt "converge $ISSUE: $VERDICT after $ROUND round(s), $MERGE_PAGE" 2>/dev/null || true
     exit 1
   fi
   if [ "$GATE" = "20" ]; then
     say "STOP exit-7: PR #$PR has no verdict after round $ROUND -- the review died or timed out. Re-run: kipi review $PR --issue $ISSUE --post"
-    bash "$NOTIFY" "converge $ISSUE: review produced no verdict on round $ROUND" 2>/dev/null || true
+    bash "$NOTIFY" --kind receipt "converge $ISSUE: review produced no verdict on round $ROUND" 2>/dev/null || true
     exit 7
   fi
 
@@ -863,7 +863,7 @@ while [ "$ROUND" -lt "$MAX_ROUNDS" ]; do
       STALL_PAGE="converge $ISSUE: PR #$PR is '$VERDICT' at $REVIEWED_SHA but its head $SHA was never reviewed, and round $ROUND changed nothing - unreviewed code is sitting at the head, needs a human"
     fi
     say "$STALL_LOG"
-    bash "$NOTIFY" "$STALL_PAGE" 2>/dev/null || true
+    bash "$NOTIFY" --kind receipt "$STALL_PAGE" 2>/dev/null || true
     exit 5
   fi
   LAST_VERDICT="$VERDICT"; LAST_SHA="$SHA"
@@ -871,5 +871,5 @@ while [ "$ROUND" -lt "$MAX_ROUNDS" ]; do
 done
 
 say "STOP exit-2: hit the $MAX_ROUNDS-round cap still at '$LAST_VERDICT'. A cap-out means the reviewer and Sana disagree persistently; read the last review before raising the cap."
-bash "$NOTIFY" "converge $ISSUE: hit $MAX_ROUNDS-round cap, still $LAST_VERDICT" 2>/dev/null || true
+bash "$NOTIFY" --kind receipt "converge $ISSUE: hit $MAX_ROUNDS-round cap, still $LAST_VERDICT" 2>/dev/null || true
 exit 2

--- a/q-system/.q-system/scripts/converge.sh
+++ b/q-system/.q-system/scripts/converge.sh
@@ -725,7 +725,7 @@ while [ "$ROUND" -lt "$MAX_ROUNDS" ]; do
   PR="$(pr_for_branch)"
   if [ -z "$PR" ]; then
     say "STOP exit-7: no PR on $BRANCH after round $ROUND (worker rc=$WRC). Sana could not open one; see $LOG"
-    bash "$NOTIFY" "converge $ISSUE: stopped, no PR after round $ROUND" --kind receipt 2>/dev/null || true
+    KIPI_NOTIFY_KIND=receipt bash "$NOTIFY" "converge $ISSUE: stopped, no PR after round $ROUND" 2>/dev/null || true
     exit 7
   fi
 
@@ -821,12 +821,12 @@ while [ "$ROUND" -lt "$MAX_ROUNDS" ]; do
       esac
     fi
     say "DONE exit-1: PR #$PR verdict '$VERDICT' after $ROUND round(s). $MERGE_LOG"
-    bash "$NOTIFY" "converge $ISSUE: $VERDICT after $ROUND round(s), $MERGE_PAGE" --kind receipt 2>/dev/null || true
+    KIPI_NOTIFY_KIND=receipt bash "$NOTIFY" "converge $ISSUE: $VERDICT after $ROUND round(s), $MERGE_PAGE" 2>/dev/null || true
     exit 1
   fi
   if [ "$GATE" = "20" ]; then
     say "STOP exit-7: PR #$PR has no verdict after round $ROUND -- the review died or timed out. Re-run: kipi review $PR --issue $ISSUE --post"
-    bash "$NOTIFY" "converge $ISSUE: review produced no verdict on round $ROUND" --kind receipt 2>/dev/null || true
+    KIPI_NOTIFY_KIND=receipt bash "$NOTIFY" "converge $ISSUE: review produced no verdict on round $ROUND" 2>/dev/null || true
     exit 7
   fi
 
@@ -863,7 +863,7 @@ while [ "$ROUND" -lt "$MAX_ROUNDS" ]; do
       STALL_PAGE="converge $ISSUE: PR #$PR is '$VERDICT' at $REVIEWED_SHA but its head $SHA was never reviewed, and round $ROUND changed nothing - unreviewed code is sitting at the head, needs a human"
     fi
     say "$STALL_LOG"
-    bash "$NOTIFY" "$STALL_PAGE" --kind receipt 2>/dev/null || true
+    KIPI_NOTIFY_KIND=receipt bash "$NOTIFY" "$STALL_PAGE" 2>/dev/null || true
     exit 5
   fi
   LAST_VERDICT="$VERDICT"; LAST_SHA="$SHA"
@@ -871,5 +871,5 @@ while [ "$ROUND" -lt "$MAX_ROUNDS" ]; do
 done
 
 say "STOP exit-2: hit the $MAX_ROUNDS-round cap still at '$LAST_VERDICT'. A cap-out means the reviewer and Sana disagree persistently; read the last review before raising the cap."
-bash "$NOTIFY" "converge $ISSUE: hit $MAX_ROUNDS-round cap, still $LAST_VERDICT" --kind receipt 2>/dev/null || true
+KIPI_NOTIFY_KIND=receipt bash "$NOTIFY" "converge $ISSUE: hit $MAX_ROUNDS-round cap, still $LAST_VERDICT" 2>/dev/null || true
 exit 2

--- a/q-system/.q-system/scripts/converge.sh
+++ b/q-system/.q-system/scripts/converge.sh
@@ -725,7 +725,7 @@ while [ "$ROUND" -lt "$MAX_ROUNDS" ]; do
   PR="$(pr_for_branch)"
   if [ -z "$PR" ]; then
     say "STOP exit-7: no PR on $BRANCH after round $ROUND (worker rc=$WRC). Sana could not open one; see $LOG"
-    bash "$NOTIFY" --kind receipt "converge $ISSUE: stopped, no PR after round $ROUND" 2>/dev/null || true
+    bash "$NOTIFY" "converge $ISSUE: stopped, no PR after round $ROUND" --kind receipt 2>/dev/null || true
     exit 7
   fi
 
@@ -821,12 +821,12 @@ while [ "$ROUND" -lt "$MAX_ROUNDS" ]; do
       esac
     fi
     say "DONE exit-1: PR #$PR verdict '$VERDICT' after $ROUND round(s). $MERGE_LOG"
-    bash "$NOTIFY" --kind receipt "converge $ISSUE: $VERDICT after $ROUND round(s), $MERGE_PAGE" 2>/dev/null || true
+    bash "$NOTIFY" "converge $ISSUE: $VERDICT after $ROUND round(s), $MERGE_PAGE" --kind receipt 2>/dev/null || true
     exit 1
   fi
   if [ "$GATE" = "20" ]; then
     say "STOP exit-7: PR #$PR has no verdict after round $ROUND -- the review died or timed out. Re-run: kipi review $PR --issue $ISSUE --post"
-    bash "$NOTIFY" --kind receipt "converge $ISSUE: review produced no verdict on round $ROUND" 2>/dev/null || true
+    bash "$NOTIFY" "converge $ISSUE: review produced no verdict on round $ROUND" --kind receipt 2>/dev/null || true
     exit 7
   fi
 
@@ -863,7 +863,7 @@ while [ "$ROUND" -lt "$MAX_ROUNDS" ]; do
       STALL_PAGE="converge $ISSUE: PR #$PR is '$VERDICT' at $REVIEWED_SHA but its head $SHA was never reviewed, and round $ROUND changed nothing - unreviewed code is sitting at the head, needs a human"
     fi
     say "$STALL_LOG"
-    bash "$NOTIFY" --kind receipt "$STALL_PAGE" 2>/dev/null || true
+    bash "$NOTIFY" "$STALL_PAGE" --kind receipt 2>/dev/null || true
     exit 5
   fi
   LAST_VERDICT="$VERDICT"; LAST_SHA="$SHA"
@@ -871,5 +871,5 @@ while [ "$ROUND" -lt "$MAX_ROUNDS" ]; do
 done
 
 say "STOP exit-2: hit the $MAX_ROUNDS-round cap still at '$LAST_VERDICT'. A cap-out means the reviewer and Sana disagree persistently; read the last review before raising the cap."
-bash "$NOTIFY" --kind receipt "converge $ISSUE: hit $MAX_ROUNDS-round cap, still $LAST_VERDICT" 2>/dev/null || true
+bash "$NOTIFY" "converge $ISSUE: hit $MAX_ROUNDS-round cap, still $LAST_VERDICT" --kind receipt 2>/dev/null || true
 exit 2

--- a/q-system/.q-system/scripts/ff-merge-if-safe.sh
+++ b/q-system/.q-system/scripts/ff-merge-if-safe.sh
@@ -1,0 +1,110 @@
+#!/bin/bash
+# Bring a checkout up to origin/<branch> UNATTENDED, or refuse with a reason.
+# ASK-294. Called by kipi-dispatch.sh's stale_check.
+#
+# WHY THIS EXISTS. 15 of the 48 founder pings in the measured 24h window were one
+# line repeated: "kipi dispatch: refused to run -- origin/main has N commit(s)
+# this checkout lacks. Do: cd <repo> && git merge --ff-only origin/main". It named
+# the founder as the actor and handed him a shell command for something the loop
+# can do itself. That is a defect in the producer, not a wording problem.
+#
+# WHY IT IS NOT JUST `git merge --ff-only`. An automatic ff-merge was built into
+# kipi-dispatch.sh on 2026-08-02 and REMOVED the same night after three review
+# rounds, each finding a NEW way for it to lose data (ASK-284 carries the record):
+#   r1  a fast-forward SILENTLY OVERWRITES ignored files. Measured on this
+#       checkout: an untracked-not-ignored collision ABORTS the merge, but an
+#       IGNORED one fast-forwards with exit 0 and leaves no reflog to recover
+#       from -- and `ls-files --others --exclude-standard` cannot even enumerate
+#       that class (3982 such files here).
+#   r2  the backup added to fix r1 continued the merge when a copy FAILED.
+# Three rounds each finding a new instance of one class is a statement about the
+# surface, not about care taken.
+#
+# WHAT CHANGES THE ANSWER. Those rounds tried to make an UNBOUNDED write safe --
+# protect the whole working tree against anything a merge might touch. It is not
+# unbounded. `git diff --name-only HEAD origin/<branch>` is the EXACT, finite set
+# of paths the fast-forward will write. The precondition only has to hold over
+# that set, and every member of it is individually checkable. So this script
+# never copies, never backs up, never writes outside .git: it PROVES the merge
+# cannot clobber anything, or it declines and says which path stopped it.
+#
+# Exit codes (kipi-dispatch.sh depends on these):
+#   0  the checkout is current -- either already current, or fast-forwarded here.
+#      Nothing to tell the founder. This is the quiet path and the common one.
+#   1  refused. stdout carries one line naming WHY and WHICH path. The caller
+#      decides whether that is a founder decision.
+#   2  no answer (fetch failed, not a git repo, unreadable state). Fail OPEN --
+#      offline is not proof of staleness, and wedging the loop on a network blip
+#      is worse than running one cycle behind.
+set -uo pipefail
+
+REPO="${1:-$PWD}"
+BRANCH="${2:-main}"
+REMOTE="${3:-origin}"
+
+cd "$REPO" 2>/dev/null || { echo "no-answer: not a directory: $REPO"; exit 2; }
+git rev-parse --git-dir >/dev/null 2>&1 || { echo "no-answer: not a git repo: $REPO"; exit 2; }
+
+LOCAL="$(git rev-parse HEAD 2>/dev/null)" || { echo "no-answer: cannot read HEAD"; exit 2; }
+REMOTE_REF="$REMOTE/$BRANCH"
+UPSTREAM="$(git rev-parse "$REMOTE_REF" 2>/dev/null)" || { echo "no-answer: cannot read $REMOTE_REF"; exit 2; }
+
+# Already current, or ahead-only. An agent commits locally before it opens a PR,
+# so "ahead" must keep running or the loop wedges on its own work.
+[ "$LOCAL" = "$UPSTREAM" ] && { echo "current: already at $REMOTE_REF"; exit 0; }
+BEHIND="$(git rev-list --count "$LOCAL..$UPSTREAM" 2>/dev/null)" || { echo "no-answer: rev-list failed"; exit 2; }
+case "$BEHIND" in ''|*[!0-9]*) echo "no-answer: unparseable behind-count"; exit 2 ;; esac
+[ "$BEHIND" -gt 0 ] || { echo "current: nothing to pull from $REMOTE_REF"; exit 0; }
+
+# --- precondition 1: it must be a TRUE fast-forward --------------------------
+# A diverged tree needs a real merge, which can conflict and can rewrite history.
+# That is an irreversible git op and the founder owns it. This is the one branch
+# of this script that is allowed to reach his phone.
+if ! git merge-base --is-ancestor "$LOCAL" "$UPSTREAM" 2>/dev/null; then
+  AHEAD="$(git rev-list --count "$UPSTREAM..$LOCAL" 2>/dev/null || echo '?')"
+  echo "diverged: HEAD has $AHEAD commit(s) $REMOTE_REF lacks and is $BEHIND behind; a real merge is needed, not a fast-forward"
+  exit 1
+fi
+
+# --- precondition 2: nothing the merge writes may already be at risk ---------
+# THE BOUNDED SET. Not "is the tree clean" (it never is -- this repo carries
+# review-scratch dirs and 3982 ignored files) but "is any path this merge TOUCHES
+# unsafe to overwrite". Two ways a path can be unsafe, and r1's scar is the first:
+#   a) it exists on disk but git does not track it -> ignored or untracked. A
+#      fast-forward overwrites the ignored case silently, with no reflog. This is
+#      the exact class that killed the previous attempt, and it is cheap to test
+#      once you only ask about the paths being written.
+#   b) it is tracked but locally modified -> the fast-forward would either abort
+#      or bury uncommitted work.
+COLLISIONS=""
+while IFS= read -r path; do
+  [ -n "$path" ] || continue
+  if [ -e "$path" ] && ! git ls-files --error-unmatch -- "$path" >/dev/null 2>&1; then
+    COLLISIONS="$COLLISIONS $path(untracked-or-ignored)"
+    continue
+  fi
+  if ! git diff --quiet HEAD -- "$path" 2>/dev/null; then
+    COLLISIONS="$COLLISIONS $path(locally-modified)"
+  fi
+done <<EOF
+$(git diff --name-only "$LOCAL" "$UPSTREAM" 2>/dev/null)
+EOF
+
+if [ -n "$COLLISIONS" ]; then
+  # Deliberately NOT "back it up and merge anyway": r2 removed the previous
+  # attempt because its backup silently continued when a copy failed. Refusing is
+  # the only branch with no write surface at all.
+  set -- $COLLISIONS
+  echo "collision: $# path(s) the fast-forward would overwrite are untracked, ignored, or locally modified:${COLLISIONS}"
+  exit 1
+fi
+
+# --- the merge ---------------------------------------------------------------
+# --ff-only is belt-and-braces: precondition 1 already proved it, and if git
+# disagrees with us we take git's answer and refuse rather than force anything.
+if MERGE_OUT="$(git merge --ff-only "$UPSTREAM" 2>&1)"; then
+  echo "merged: fast-forwarded $BEHIND commit(s) to ${UPSTREAM:0:7} with no collisions"
+  exit 0
+fi
+echo "refused: git declined the fast-forward despite the preconditions: $(printf '%s' "$MERGE_OUT" | head -2 | tr '\n' ' ')"
+exit 1

--- a/q-system/.q-system/scripts/fleet-health-daily.py
+++ b/q-system/.q-system/scripts/fleet-health-daily.py
@@ -1624,7 +1624,7 @@ def main() -> int:
         {"ran_at": _now(), "per_detector": per_detector, "outcome": outcome}, indent=2))
 
     if not args.quiet and should_notify(outcome, per_detector, args.apply) and NOTIFY.exists():
-        subprocess.run(["bash", str(NOTIFY), notify_text(outcome, per_detector)],
+        subprocess.run(["bash", str(NOTIFY), "--kind", "receipt", notify_text(outcome, per_detector)],
                        timeout=20, check=False)
     return 0
 

--- a/q-system/.q-system/scripts/fleet-health-daily.py
+++ b/q-system/.q-system/scripts/fleet-health-daily.py
@@ -1624,7 +1624,7 @@ def main() -> int:
         {"ran_at": _now(), "per_detector": per_detector, "outcome": outcome}, indent=2))
 
     if not args.quiet and should_notify(outcome, per_detector, args.apply) and NOTIFY.exists():
-        subprocess.run(["bash", str(NOTIFY), "--kind", "receipt", notify_text(outcome, per_detector)],
+        subprocess.run(["bash", str(NOTIFY), notify_text(outcome, per_detector), "--kind", "receipt"],
                        timeout=20, check=False)
     return 0
 

--- a/q-system/.q-system/scripts/launchd-health-check.py
+++ b/q-system/.q-system/scripts/launchd-health-check.py
@@ -215,7 +215,7 @@ def send_ping(message):
     if not NOTIFY_SCRIPT.exists():
         return
     try:
-        subprocess.run(["bash", str(NOTIFY_SCRIPT), "--kind", "receipt", message], timeout=20)
+        subprocess.run(["bash", str(NOTIFY_SCRIPT), message, "--kind", "receipt"], timeout=20)
     except Exception:
         pass
 

--- a/q-system/.q-system/scripts/launchd-health-check.py
+++ b/q-system/.q-system/scripts/launchd-health-check.py
@@ -215,7 +215,7 @@ def send_ping(message):
     if not NOTIFY_SCRIPT.exists():
         return
     try:
-        subprocess.run(["bash", str(NOTIFY_SCRIPT), message], timeout=20)
+        subprocess.run(["bash", str(NOTIFY_SCRIPT), "--kind", "receipt", message], timeout=20)
     except Exception:
         pass
 

--- a/q-system/.q-system/scripts/lessons-daily.sh
+++ b/q-system/.q-system/scripts/lessons-daily.sh
@@ -19,7 +19,7 @@ mkdir -p "$(dirname "$LOG")"
 # Observed 2026-07-27: the 06:00 run logged "propagate FAILED", Slacked it, and
 # `launchctl list` still said LastExitStatus = 0. Pinned by
 # test/test-lessons-daily-exit.sh.
-fail() { echo "$(TS) FAILURE: $*" >> "$LOG"; bash "$NOTIFY" --kind receipt "lessons-daily: $*" 2>/dev/null; exit 1; }
+fail() { echo "$(TS) FAILURE: $*" >> "$LOG"; bash "$NOTIFY" "lessons-daily: $*" --kind receipt 2>/dev/null; exit 1; }
 
 # The plist pins PATH to include ~/.local/bin, so a missing binary here is a
 # broken machine, not a normal night. Skipping silently would make this job dark
@@ -61,7 +61,7 @@ MSG="Fleet learning ($(date +%Y-%m-%d)): ${PUB} new lesson(s), ${PROP}"
 [ "$PUB" -gt 0 ] && [ -n "${TITLES:-}" ] && MSG="$MSG — ${TITLES}"
 [ "$HELD" -gt 0 ] && MSG="$MSG · ${HELD} held for review (possible client data, see lesson-candidates/)"
 [ "$PROP" = "propagate FAILED" ] && MSG="$MSG · propagation FAILED, see log"
-bash "$NOTIFY" --kind receipt "$MSG"
+bash "$NOTIFY" "$MSG" --kind receipt
 echo "$(TS) slacked: $MSG" >> "$LOG"
 
 # Lessons that published but never reached the fleet are a half-done run: the

--- a/q-system/.q-system/scripts/lessons-daily.sh
+++ b/q-system/.q-system/scripts/lessons-daily.sh
@@ -19,7 +19,7 @@ mkdir -p "$(dirname "$LOG")"
 # Observed 2026-07-27: the 06:00 run logged "propagate FAILED", Slacked it, and
 # `launchctl list` still said LastExitStatus = 0. Pinned by
 # test/test-lessons-daily-exit.sh.
-fail() { echo "$(TS) FAILURE: $*" >> "$LOG"; bash "$NOTIFY" "lessons-daily: $*" 2>/dev/null; exit 1; }
+fail() { echo "$(TS) FAILURE: $*" >> "$LOG"; bash "$NOTIFY" --kind receipt "lessons-daily: $*" 2>/dev/null; exit 1; }
 
 # The plist pins PATH to include ~/.local/bin, so a missing binary here is a
 # broken machine, not a normal night. Skipping silently would make this job dark
@@ -61,7 +61,7 @@ MSG="Fleet learning ($(date +%Y-%m-%d)): ${PUB} new lesson(s), ${PROP}"
 [ "$PUB" -gt 0 ] && [ -n "${TITLES:-}" ] && MSG="$MSG — ${TITLES}"
 [ "$HELD" -gt 0 ] && MSG="$MSG · ${HELD} held for review (possible client data, see lesson-candidates/)"
 [ "$PROP" = "propagate FAILED" ] && MSG="$MSG · propagation FAILED, see log"
-bash "$NOTIFY" "$MSG"
+bash "$NOTIFY" --kind receipt "$MSG"
 echo "$(TS) slacked: $MSG" >> "$LOG"
 
 # Lessons that published but never reached the fleet are a half-done run: the

--- a/q-system/.q-system/scripts/lessons-daily.sh
+++ b/q-system/.q-system/scripts/lessons-daily.sh
@@ -19,7 +19,7 @@ mkdir -p "$(dirname "$LOG")"
 # Observed 2026-07-27: the 06:00 run logged "propagate FAILED", Slacked it, and
 # `launchctl list` still said LastExitStatus = 0. Pinned by
 # test/test-lessons-daily-exit.sh.
-fail() { echo "$(TS) FAILURE: $*" >> "$LOG"; bash "$NOTIFY" "lessons-daily: $*" --kind receipt 2>/dev/null; exit 1; }
+fail() { echo "$(TS) FAILURE: $*" >> "$LOG"; KIPI_NOTIFY_KIND=receipt bash "$NOTIFY" "lessons-daily: $*" 2>/dev/null; exit 1; }
 
 # The plist pins PATH to include ~/.local/bin, so a missing binary here is a
 # broken machine, not a normal night. Skipping silently would make this job dark
@@ -61,7 +61,7 @@ MSG="Fleet learning ($(date +%Y-%m-%d)): ${PUB} new lesson(s), ${PROP}"
 [ "$PUB" -gt 0 ] && [ -n "${TITLES:-}" ] && MSG="$MSG — ${TITLES}"
 [ "$HELD" -gt 0 ] && MSG="$MSG · ${HELD} held for review (possible client data, see lesson-candidates/)"
 [ "$PROP" = "propagate FAILED" ] && MSG="$MSG · propagation FAILED, see log"
-bash "$NOTIFY" "$MSG" --kind receipt
+KIPI_NOTIFY_KIND=receipt bash "$NOTIFY" "$MSG"
 echo "$(TS) slacked: $MSG" >> "$LOG"
 
 # Lessons that published but never reached the fleet are a half-done run: the

--- a/q-system/.q-system/scripts/linear-dor-drafter.py
+++ b/q-system/.q-system/scripts/linear-dor-drafter.py
@@ -565,7 +565,7 @@ def notify(message: str) -> bool:
     if not NOTIFY_SCRIPT.exists():
         return False
     try:
-        subprocess.run(["bash", str(NOTIFY_SCRIPT), message], timeout=20)
+        subprocess.run(["bash", str(NOTIFY_SCRIPT), "--kind", "receipt", message], timeout=20)
         return True
     except Exception:  # noqa: BLE001 - a failed ping must not fail the run
         return False

--- a/q-system/.q-system/scripts/linear-dor-drafter.py
+++ b/q-system/.q-system/scripts/linear-dor-drafter.py
@@ -565,7 +565,7 @@ def notify(message: str) -> bool:
     if not NOTIFY_SCRIPT.exists():
         return False
     try:
-        subprocess.run(["bash", str(NOTIFY_SCRIPT), "--kind", "receipt", message], timeout=20)
+        subprocess.run(["bash", str(NOTIFY_SCRIPT), message, "--kind", "receipt"], timeout=20)
         return True
     except Exception:  # noqa: BLE001 - a failed ping must not fail the run
         return False

--- a/q-system/.q-system/scripts/linear-worker.sh
+++ b/q-system/.q-system/scripts/linear-worker.sh
@@ -249,7 +249,7 @@ run_bounded() {  # run_bounded <seconds> <cmd...>
 # environment that is down from a worker that was invoked wrong.
 if ! git -C "$TARGET_REPO" fetch --quiet origin 2>>"$LOG"; then
   say "INFRA: git fetch failed in $TARGET_REPO. Stopping before any worktree is cut from a stale base."
-  bash "$NOTIFY" "worker: git fetch failed in $TARGET_REPO -- the run did NO work. Check credentials/network." --kind receipt 2>/dev/null || true
+  KIPI_NOTIFY_KIND=receipt bash "$NOTIFY" "worker: git fetch failed in $TARGET_REPO -- the run did NO work. Check credentials/network." 2>/dev/null || true
   exit 9
 fi
 
@@ -432,7 +432,7 @@ if [ "$PROJECT_KNOWN" = "False" ]; then
   say "MISCONFIG: repo identity '$REPO_PROJECT' (from $TARGET_REPO) matches NO Linear project on team ASK."
   say "MISCONFIG: every issue would be filtered out, so this run picked nothing for a config reason, not an empty board."
   say "MISCONFIG: fix by renaming the Linear project to match the checkout, or set KIPI_LINEAR_PROJECT."
-  bash "$NOTIFY" "kipi worker: repo identity '$REPO_PROJECT' matches no Linear project, so the queue reads empty and NO work can ever be picked. Do: set KIPI_LINEAR_PROJECT in the worker's environment, or rename the project to match the checkout." --kind receipt 2>/dev/null || true
+  KIPI_NOTIFY_KIND=receipt bash "$NOTIFY" "kipi worker: repo identity '$REPO_PROJECT' matches no Linear project, so the queue reads empty and NO work can ever be picked. Do: set KIPI_LINEAR_PROJECT in the worker's environment, or rename the project to match the checkout." 2>/dev/null || true
   exit 9
 fi
 
@@ -637,7 +637,7 @@ ledger_fault() {
   say "WARN: the attempts ledger did not record the $flag flag for $issue (exit $rc) -- $detail"
   [ "$LEDGER_FAULT_ALERTED" -eq 0 ] || return 0
   LEDGER_FAULT_ALERTED=1
-  bash "$NOTIFY" "kipi worker: the attempts ledger at $ATTEMPTS is not answering (exit $rc, first seen on $issue/$flag). Once-only pages cannot be de-duplicated while this holds, so the worker is staying quiet on them rather than re-posting. Do: check the ledger file is writable." --kind receipt 2>/dev/null || true
+  KIPI_NOTIFY_KIND=receipt bash "$NOTIFY" "kipi worker: the attempts ledger at $ATTEMPTS is not answering (exit $rc, first seen on $issue/$flag). Once-only pages cannot be de-duplicated while this holds, so the worker is staying quiet on them rather than re-posting. Do: check the ledger file is writable." 2>/dev/null || true
 }
 
 page_once() {
@@ -735,7 +735,7 @@ arm_automerge() {
       # unarmed, and quieting it would re-create the stall one layer down.
       say "WARN: could not arm auto-merge on PR #$pr for $ISSUE and could not read its state either -- gh answered neither. If it sits green: gh pr merge --auto --squash $pr"
       if page_once "$ISSUE" automerge_unknown_paged; then
-        bash "$NOTIFY" "worker: $ISSUE PR #$pr -- gh could neither arm auto-merge nor read its state, so whether this PR merges itself is unknown. Needs a human to check: gh pr merge --auto --squash $pr" --kind receipt 2>/dev/null || true
+        KIPI_NOTIFY_KIND=receipt bash "$NOTIFY" "worker: $ISSUE PR #$pr -- gh could neither arm auto-merge nor read its state, so whether this PR merges itself is unknown. Needs a human to check: gh pr merge --auto --squash $pr" 2>/dev/null || true
       fi
     else
       AUTOMERGE="unarmed"
@@ -749,7 +749,7 @@ arm_automerge() {
       # not kill the silent stall, it relocates it.
       say "WARN: could not arm auto-merge on PR #$pr for $ISSUE -- it will sit green and unmerged until someone runs: gh pr merge --auto --squash $pr"
       if page_once "$ISSUE" automerge_unarmed_paged; then
-        bash "$NOTIFY" "worker: $ISSUE PR #$pr is NOT armed -- it goes green and sits there forever. Needs a human: gh pr merge --auto --squash $pr" --kind receipt 2>/dev/null || true
+        KIPI_NOTIFY_KIND=receipt bash "$NOTIFY" "worker: $ISSUE PR #$pr is NOT armed -- it goes green and sits there forever. Needs a human: gh pr merge --auto --squash $pr" 2>/dev/null || true
       fi
     fi
   fi
@@ -881,7 +881,7 @@ A DoR that cannot be met from the environment the worker actually runs in is a d
       # no page() helper here -- calling one would have been a silent no-op under
       # `set -uo pipefail` (command-not-found, no -e), i.e. a terminal state that
       # pages nobody, which is the exact defect this block fixes.
-      bash "$NOTIFY" "kipi worker: $ISSUE is STUCK after $N attempts and the loop has stopped picking it up. Reason: $STUCK_WHY. Do: read the comment on $ISSUE -- it names the three options." --kind receipt 2>/dev/null || true
+      KIPI_NOTIFY_KIND=receipt bash "$NOTIFY" "kipi worker: $ISSUE is STUCK after $N attempts and the loop has stopped picking it up. Reason: $STUCK_WHY. Do: read the comment on $ISSUE -- it names the three options." 2>/dev/null || true
     fi
     continue
   fi
@@ -1012,7 +1012,7 @@ A DoR that cannot be met from the environment the worker actually runs in is a d
       if [ "$DR" -ge "$MAX_DRIFT_ROUNDS" ]; then
         say "skip $ISSUE: PR #$EXISTING_PR is '$PR_VERDICT' recorded at $REVIEWED_SHA but the head is $CURRENT_SHA, still never reviewed after $DR/$MAX_DRIFT_ROUNDS drift round(s) -- a human resolves this one."
         if page_once "$ISSUE" drift_paged; then
-          bash "$NOTIFY" "worker: $ISSUE PR #$EXISTING_PR is approved at $REVIEWED_SHA but its head $CURRENT_SHA is still unreviewed after $MAX_DRIFT_ROUNDS re-review round(s) - unreviewed code sits at the head, needs a human" --kind receipt 2>/dev/null || true
+          KIPI_NOTIFY_KIND=receipt bash "$NOTIFY" "worker: $ISSUE PR #$EXISTING_PR is approved at $REVIEWED_SHA but its head $CURRENT_SHA is still unreviewed after $MAX_DRIFT_ROUNDS re-review round(s) - unreviewed code sits at the head, needs a human" 2>/dev/null || true
         fi
         continue
       fi
@@ -1034,7 +1034,7 @@ A DoR that cannot be met from the environment the worker actually runs in is a d
       if [ "$CR" -ge "$MAX_CONFLICT_ROUNDS" ]; then
         say "skip $ISSUE: PR #$EXISTING_PR is '$PR_VERDICT' but $MERGE_STATE after $CR/$MAX_CONFLICT_ROUNDS conflict round(s) -- a human resolves this one."
         if page_once "$ISSUE" conflict_paged; then
-          bash "$NOTIFY" "worker: $ISSUE PR #$EXISTING_PR is approved but still $MERGE_STATE after $MAX_CONFLICT_ROUNDS rebase round(s) - needs a human" --kind receipt 2>/dev/null || true
+          KIPI_NOTIFY_KIND=receipt bash "$NOTIFY" "worker: $ISSUE PR #$EXISTING_PR is approved but still $MERGE_STATE after $MAX_CONFLICT_ROUNDS rebase round(s) - needs a human" 2>/dev/null || true
         fi
         continue
       fi
@@ -1167,7 +1167,7 @@ A DoR that cannot be met from the environment the worker actually runs in is a d
     if ! position_tree_on_pr_head "$TREE" "$BRANCH"; then
       say "skip $ISSUE: $TREE is missing PR #$EXISTING_PR's commits and cannot be moved onto them -- $POSITION_REFUSAL. Refusing a round that would force-push over the PR. A human resolves this one: $TREE"
       if page_once "$ISSUE" tree_paged; then
-        bash "$NOTIFY" "worker: $ISSUE worktree does not hold PR #$EXISTING_PR's commits and has local work - $TREE needs a human" --kind receipt 2>/dev/null || true
+        KIPI_NOTIFY_KIND=receipt bash "$NOTIFY" "worker: $ISSUE worktree does not hold PR #$EXISTING_PR's commits and has local work - $TREE needs a human" 2>/dev/null || true
       fi
       # Release before skipping: a claim held by a run that did nothing wedges
       # this issue for every later run, which is the failure this refusal exists
@@ -1410,7 +1410,7 @@ Anything real you find and are not fixing: capture it, never just mention it:
       "Worker run FAILED (attempt $N2 of $MAX_ATTEMPTS, rc=$rc). Log: ~/.config/kipi/linear-worker.log" \
       --agent "$AGENT" >/dev/null 2>&1 || true
     if [ "$N2" -ge "$MAX_ATTEMPTS" ]; then
-      bash "$NOTIFY" "worker: $ISSUE stuck after $MAX_ATTEMPTS attempts - needs a human" --kind receipt 2>/dev/null || true
+      KIPI_NOTIFY_KIND=receipt bash "$NOTIFY" "worker: $ISSUE stuck after $MAX_ATTEMPTS attempts - needs a human" 2>/dev/null || true
     fi
   fi
 

--- a/q-system/.q-system/scripts/linear-worker.sh
+++ b/q-system/.q-system/scripts/linear-worker.sh
@@ -249,7 +249,7 @@ run_bounded() {  # run_bounded <seconds> <cmd...>
 # environment that is down from a worker that was invoked wrong.
 if ! git -C "$TARGET_REPO" fetch --quiet origin 2>>"$LOG"; then
   say "INFRA: git fetch failed in $TARGET_REPO. Stopping before any worktree is cut from a stale base."
-  bash "$NOTIFY" "worker: git fetch failed in $TARGET_REPO -- the run did NO work. Check credentials/network." 2>/dev/null || true
+  bash "$NOTIFY" --kind receipt "worker: git fetch failed in $TARGET_REPO -- the run did NO work. Check credentials/network." 2>/dev/null || true
   exit 9
 fi
 
@@ -432,7 +432,7 @@ if [ "$PROJECT_KNOWN" = "False" ]; then
   say "MISCONFIG: repo identity '$REPO_PROJECT' (from $TARGET_REPO) matches NO Linear project on team ASK."
   say "MISCONFIG: every issue would be filtered out, so this run picked nothing for a config reason, not an empty board."
   say "MISCONFIG: fix by renaming the Linear project to match the checkout, or set KIPI_LINEAR_PROJECT."
-  bash "$NOTIFY" "kipi worker: repo identity '$REPO_PROJECT' matches no Linear project, so the queue reads empty and NO work can ever be picked. Do: set KIPI_LINEAR_PROJECT in the worker's environment, or rename the project to match the checkout." 2>/dev/null || true
+  bash "$NOTIFY" --kind receipt "kipi worker: repo identity '$REPO_PROJECT' matches no Linear project, so the queue reads empty and NO work can ever be picked. Do: set KIPI_LINEAR_PROJECT in the worker's environment, or rename the project to match the checkout." 2>/dev/null || true
   exit 9
 fi
 
@@ -637,7 +637,7 @@ ledger_fault() {
   say "WARN: the attempts ledger did not record the $flag flag for $issue (exit $rc) -- $detail"
   [ "$LEDGER_FAULT_ALERTED" -eq 0 ] || return 0
   LEDGER_FAULT_ALERTED=1
-  bash "$NOTIFY" "kipi worker: the attempts ledger at $ATTEMPTS is not answering (exit $rc, first seen on $issue/$flag). Once-only pages cannot be de-duplicated while this holds, so the worker is staying quiet on them rather than re-posting. Do: check the ledger file is writable." 2>/dev/null || true
+  bash "$NOTIFY" --kind receipt "kipi worker: the attempts ledger at $ATTEMPTS is not answering (exit $rc, first seen on $issue/$flag). Once-only pages cannot be de-duplicated while this holds, so the worker is staying quiet on them rather than re-posting. Do: check the ledger file is writable." 2>/dev/null || true
 }
 
 page_once() {
@@ -735,7 +735,7 @@ arm_automerge() {
       # unarmed, and quieting it would re-create the stall one layer down.
       say "WARN: could not arm auto-merge on PR #$pr for $ISSUE and could not read its state either -- gh answered neither. If it sits green: gh pr merge --auto --squash $pr"
       if page_once "$ISSUE" automerge_unknown_paged; then
-        bash "$NOTIFY" "worker: $ISSUE PR #$pr -- gh could neither arm auto-merge nor read its state, so whether this PR merges itself is unknown. Needs a human to check: gh pr merge --auto --squash $pr" 2>/dev/null || true
+        bash "$NOTIFY" --kind receipt "worker: $ISSUE PR #$pr -- gh could neither arm auto-merge nor read its state, so whether this PR merges itself is unknown. Needs a human to check: gh pr merge --auto --squash $pr" 2>/dev/null || true
       fi
     else
       AUTOMERGE="unarmed"
@@ -749,7 +749,7 @@ arm_automerge() {
       # not kill the silent stall, it relocates it.
       say "WARN: could not arm auto-merge on PR #$pr for $ISSUE -- it will sit green and unmerged until someone runs: gh pr merge --auto --squash $pr"
       if page_once "$ISSUE" automerge_unarmed_paged; then
-        bash "$NOTIFY" "worker: $ISSUE PR #$pr is NOT armed -- it goes green and sits there forever. Needs a human: gh pr merge --auto --squash $pr" 2>/dev/null || true
+        bash "$NOTIFY" --kind receipt "worker: $ISSUE PR #$pr is NOT armed -- it goes green and sits there forever. Needs a human: gh pr merge --auto --squash $pr" 2>/dev/null || true
       fi
     fi
   fi
@@ -881,7 +881,7 @@ A DoR that cannot be met from the environment the worker actually runs in is a d
       # no page() helper here -- calling one would have been a silent no-op under
       # `set -uo pipefail` (command-not-found, no -e), i.e. a terminal state that
       # pages nobody, which is the exact defect this block fixes.
-      bash "$NOTIFY" "kipi worker: $ISSUE is STUCK after $N attempts and the loop has stopped picking it up. Reason: $STUCK_WHY. Do: read the comment on $ISSUE -- it names the three options." 2>/dev/null || true
+      bash "$NOTIFY" --kind receipt "kipi worker: $ISSUE is STUCK after $N attempts and the loop has stopped picking it up. Reason: $STUCK_WHY. Do: read the comment on $ISSUE -- it names the three options." 2>/dev/null || true
     fi
     continue
   fi
@@ -1012,7 +1012,7 @@ A DoR that cannot be met from the environment the worker actually runs in is a d
       if [ "$DR" -ge "$MAX_DRIFT_ROUNDS" ]; then
         say "skip $ISSUE: PR #$EXISTING_PR is '$PR_VERDICT' recorded at $REVIEWED_SHA but the head is $CURRENT_SHA, still never reviewed after $DR/$MAX_DRIFT_ROUNDS drift round(s) -- a human resolves this one."
         if page_once "$ISSUE" drift_paged; then
-          bash "$NOTIFY" "worker: $ISSUE PR #$EXISTING_PR is approved at $REVIEWED_SHA but its head $CURRENT_SHA is still unreviewed after $MAX_DRIFT_ROUNDS re-review round(s) - unreviewed code sits at the head, needs a human" 2>/dev/null || true
+          bash "$NOTIFY" --kind receipt "worker: $ISSUE PR #$EXISTING_PR is approved at $REVIEWED_SHA but its head $CURRENT_SHA is still unreviewed after $MAX_DRIFT_ROUNDS re-review round(s) - unreviewed code sits at the head, needs a human" 2>/dev/null || true
         fi
         continue
       fi
@@ -1034,7 +1034,7 @@ A DoR that cannot be met from the environment the worker actually runs in is a d
       if [ "$CR" -ge "$MAX_CONFLICT_ROUNDS" ]; then
         say "skip $ISSUE: PR #$EXISTING_PR is '$PR_VERDICT' but $MERGE_STATE after $CR/$MAX_CONFLICT_ROUNDS conflict round(s) -- a human resolves this one."
         if page_once "$ISSUE" conflict_paged; then
-          bash "$NOTIFY" "worker: $ISSUE PR #$EXISTING_PR is approved but still $MERGE_STATE after $MAX_CONFLICT_ROUNDS rebase round(s) - needs a human" 2>/dev/null || true
+          bash "$NOTIFY" --kind receipt "worker: $ISSUE PR #$EXISTING_PR is approved but still $MERGE_STATE after $MAX_CONFLICT_ROUNDS rebase round(s) - needs a human" 2>/dev/null || true
         fi
         continue
       fi
@@ -1167,7 +1167,7 @@ A DoR that cannot be met from the environment the worker actually runs in is a d
     if ! position_tree_on_pr_head "$TREE" "$BRANCH"; then
       say "skip $ISSUE: $TREE is missing PR #$EXISTING_PR's commits and cannot be moved onto them -- $POSITION_REFUSAL. Refusing a round that would force-push over the PR. A human resolves this one: $TREE"
       if page_once "$ISSUE" tree_paged; then
-        bash "$NOTIFY" "worker: $ISSUE worktree does not hold PR #$EXISTING_PR's commits and has local work - $TREE needs a human" 2>/dev/null || true
+        bash "$NOTIFY" --kind receipt "worker: $ISSUE worktree does not hold PR #$EXISTING_PR's commits and has local work - $TREE needs a human" 2>/dev/null || true
       fi
       # Release before skipping: a claim held by a run that did nothing wedges
       # this issue for every later run, which is the failure this refusal exists
@@ -1410,7 +1410,7 @@ Anything real you find and are not fixing: capture it, never just mention it:
       "Worker run FAILED (attempt $N2 of $MAX_ATTEMPTS, rc=$rc). Log: ~/.config/kipi/linear-worker.log" \
       --agent "$AGENT" >/dev/null 2>&1 || true
     if [ "$N2" -ge "$MAX_ATTEMPTS" ]; then
-      bash "$NOTIFY" "worker: $ISSUE stuck after $MAX_ATTEMPTS attempts - needs a human" 2>/dev/null || true
+      bash "$NOTIFY" --kind receipt "worker: $ISSUE stuck after $MAX_ATTEMPTS attempts - needs a human" 2>/dev/null || true
     fi
   fi
 

--- a/q-system/.q-system/scripts/linear-worker.sh
+++ b/q-system/.q-system/scripts/linear-worker.sh
@@ -249,7 +249,7 @@ run_bounded() {  # run_bounded <seconds> <cmd...>
 # environment that is down from a worker that was invoked wrong.
 if ! git -C "$TARGET_REPO" fetch --quiet origin 2>>"$LOG"; then
   say "INFRA: git fetch failed in $TARGET_REPO. Stopping before any worktree is cut from a stale base."
-  bash "$NOTIFY" --kind receipt "worker: git fetch failed in $TARGET_REPO -- the run did NO work. Check credentials/network." 2>/dev/null || true
+  bash "$NOTIFY" "worker: git fetch failed in $TARGET_REPO -- the run did NO work. Check credentials/network." --kind receipt 2>/dev/null || true
   exit 9
 fi
 
@@ -432,7 +432,7 @@ if [ "$PROJECT_KNOWN" = "False" ]; then
   say "MISCONFIG: repo identity '$REPO_PROJECT' (from $TARGET_REPO) matches NO Linear project on team ASK."
   say "MISCONFIG: every issue would be filtered out, so this run picked nothing for a config reason, not an empty board."
   say "MISCONFIG: fix by renaming the Linear project to match the checkout, or set KIPI_LINEAR_PROJECT."
-  bash "$NOTIFY" --kind receipt "kipi worker: repo identity '$REPO_PROJECT' matches no Linear project, so the queue reads empty and NO work can ever be picked. Do: set KIPI_LINEAR_PROJECT in the worker's environment, or rename the project to match the checkout." 2>/dev/null || true
+  bash "$NOTIFY" "kipi worker: repo identity '$REPO_PROJECT' matches no Linear project, so the queue reads empty and NO work can ever be picked. Do: set KIPI_LINEAR_PROJECT in the worker's environment, or rename the project to match the checkout." --kind receipt 2>/dev/null || true
   exit 9
 fi
 
@@ -637,7 +637,7 @@ ledger_fault() {
   say "WARN: the attempts ledger did not record the $flag flag for $issue (exit $rc) -- $detail"
   [ "$LEDGER_FAULT_ALERTED" -eq 0 ] || return 0
   LEDGER_FAULT_ALERTED=1
-  bash "$NOTIFY" --kind receipt "kipi worker: the attempts ledger at $ATTEMPTS is not answering (exit $rc, first seen on $issue/$flag). Once-only pages cannot be de-duplicated while this holds, so the worker is staying quiet on them rather than re-posting. Do: check the ledger file is writable." 2>/dev/null || true
+  bash "$NOTIFY" "kipi worker: the attempts ledger at $ATTEMPTS is not answering (exit $rc, first seen on $issue/$flag). Once-only pages cannot be de-duplicated while this holds, so the worker is staying quiet on them rather than re-posting. Do: check the ledger file is writable." --kind receipt 2>/dev/null || true
 }
 
 page_once() {
@@ -735,7 +735,7 @@ arm_automerge() {
       # unarmed, and quieting it would re-create the stall one layer down.
       say "WARN: could not arm auto-merge on PR #$pr for $ISSUE and could not read its state either -- gh answered neither. If it sits green: gh pr merge --auto --squash $pr"
       if page_once "$ISSUE" automerge_unknown_paged; then
-        bash "$NOTIFY" --kind receipt "worker: $ISSUE PR #$pr -- gh could neither arm auto-merge nor read its state, so whether this PR merges itself is unknown. Needs a human to check: gh pr merge --auto --squash $pr" 2>/dev/null || true
+        bash "$NOTIFY" "worker: $ISSUE PR #$pr -- gh could neither arm auto-merge nor read its state, so whether this PR merges itself is unknown. Needs a human to check: gh pr merge --auto --squash $pr" --kind receipt 2>/dev/null || true
       fi
     else
       AUTOMERGE="unarmed"
@@ -749,7 +749,7 @@ arm_automerge() {
       # not kill the silent stall, it relocates it.
       say "WARN: could not arm auto-merge on PR #$pr for $ISSUE -- it will sit green and unmerged until someone runs: gh pr merge --auto --squash $pr"
       if page_once "$ISSUE" automerge_unarmed_paged; then
-        bash "$NOTIFY" --kind receipt "worker: $ISSUE PR #$pr is NOT armed -- it goes green and sits there forever. Needs a human: gh pr merge --auto --squash $pr" 2>/dev/null || true
+        bash "$NOTIFY" "worker: $ISSUE PR #$pr is NOT armed -- it goes green and sits there forever. Needs a human: gh pr merge --auto --squash $pr" --kind receipt 2>/dev/null || true
       fi
     fi
   fi
@@ -881,7 +881,7 @@ A DoR that cannot be met from the environment the worker actually runs in is a d
       # no page() helper here -- calling one would have been a silent no-op under
       # `set -uo pipefail` (command-not-found, no -e), i.e. a terminal state that
       # pages nobody, which is the exact defect this block fixes.
-      bash "$NOTIFY" --kind receipt "kipi worker: $ISSUE is STUCK after $N attempts and the loop has stopped picking it up. Reason: $STUCK_WHY. Do: read the comment on $ISSUE -- it names the three options." 2>/dev/null || true
+      bash "$NOTIFY" "kipi worker: $ISSUE is STUCK after $N attempts and the loop has stopped picking it up. Reason: $STUCK_WHY. Do: read the comment on $ISSUE -- it names the three options." --kind receipt 2>/dev/null || true
     fi
     continue
   fi
@@ -1012,7 +1012,7 @@ A DoR that cannot be met from the environment the worker actually runs in is a d
       if [ "$DR" -ge "$MAX_DRIFT_ROUNDS" ]; then
         say "skip $ISSUE: PR #$EXISTING_PR is '$PR_VERDICT' recorded at $REVIEWED_SHA but the head is $CURRENT_SHA, still never reviewed after $DR/$MAX_DRIFT_ROUNDS drift round(s) -- a human resolves this one."
         if page_once "$ISSUE" drift_paged; then
-          bash "$NOTIFY" --kind receipt "worker: $ISSUE PR #$EXISTING_PR is approved at $REVIEWED_SHA but its head $CURRENT_SHA is still unreviewed after $MAX_DRIFT_ROUNDS re-review round(s) - unreviewed code sits at the head, needs a human" 2>/dev/null || true
+          bash "$NOTIFY" "worker: $ISSUE PR #$EXISTING_PR is approved at $REVIEWED_SHA but its head $CURRENT_SHA is still unreviewed after $MAX_DRIFT_ROUNDS re-review round(s) - unreviewed code sits at the head, needs a human" --kind receipt 2>/dev/null || true
         fi
         continue
       fi
@@ -1034,7 +1034,7 @@ A DoR that cannot be met from the environment the worker actually runs in is a d
       if [ "$CR" -ge "$MAX_CONFLICT_ROUNDS" ]; then
         say "skip $ISSUE: PR #$EXISTING_PR is '$PR_VERDICT' but $MERGE_STATE after $CR/$MAX_CONFLICT_ROUNDS conflict round(s) -- a human resolves this one."
         if page_once "$ISSUE" conflict_paged; then
-          bash "$NOTIFY" --kind receipt "worker: $ISSUE PR #$EXISTING_PR is approved but still $MERGE_STATE after $MAX_CONFLICT_ROUNDS rebase round(s) - needs a human" 2>/dev/null || true
+          bash "$NOTIFY" "worker: $ISSUE PR #$EXISTING_PR is approved but still $MERGE_STATE after $MAX_CONFLICT_ROUNDS rebase round(s) - needs a human" --kind receipt 2>/dev/null || true
         fi
         continue
       fi
@@ -1167,7 +1167,7 @@ A DoR that cannot be met from the environment the worker actually runs in is a d
     if ! position_tree_on_pr_head "$TREE" "$BRANCH"; then
       say "skip $ISSUE: $TREE is missing PR #$EXISTING_PR's commits and cannot be moved onto them -- $POSITION_REFUSAL. Refusing a round that would force-push over the PR. A human resolves this one: $TREE"
       if page_once "$ISSUE" tree_paged; then
-        bash "$NOTIFY" --kind receipt "worker: $ISSUE worktree does not hold PR #$EXISTING_PR's commits and has local work - $TREE needs a human" 2>/dev/null || true
+        bash "$NOTIFY" "worker: $ISSUE worktree does not hold PR #$EXISTING_PR's commits and has local work - $TREE needs a human" --kind receipt 2>/dev/null || true
       fi
       # Release before skipping: a claim held by a run that did nothing wedges
       # this issue for every later run, which is the failure this refusal exists
@@ -1410,7 +1410,7 @@ Anything real you find and are not fixing: capture it, never just mention it:
       "Worker run FAILED (attempt $N2 of $MAX_ATTEMPTS, rc=$rc). Log: ~/.config/kipi/linear-worker.log" \
       --agent "$AGENT" >/dev/null 2>&1 || true
     if [ "$N2" -ge "$MAX_ATTEMPTS" ]; then
-      bash "$NOTIFY" --kind receipt "worker: $ISSUE stuck after $MAX_ATTEMPTS attempts - needs a human" 2>/dev/null || true
+      bash "$NOTIFY" "worker: $ISSUE stuck after $MAX_ATTEMPTS attempts - needs a human" --kind receipt 2>/dev/null || true
     fi
   fi
 

--- a/q-system/.q-system/scripts/notify-callsite-audit.py
+++ b/q-system/.q-system/scripts/notify-callsite-audit.py
@@ -1,0 +1,144 @@
+#!/usr/bin/env python3
+"""Every founder-notification call site must declare a --kind. (ASK-294)
+
+Pairs with: slack-notify.sh (the runtime half) and
+test/test-notify-decision-gate.sh (which drives both halves).
+
+WHY A SECOND, STATIC GATE AT ALL. The runtime gate fails OPEN for a caller with
+no --kind, on purpose -- kipi update ships slack-notify.sh to instances carrying
+producers this repo has never seen, and refusing those would silence an
+instance-local alert nobody has migrated. That deliberate hole is exactly wide
+enough for a NEW producer in THIS repo to be written bare and go unnoticed,
+which is how 11 producers came to violate founder-notifications.md while it was
+sitting there being correct. So the hole is closed statically where the code
+lives, and left open at runtime where the fleet lives.
+
+WHAT COUNTS AS A CALL SITE -- and why the window is 4 lines, not 1. The four
+Python producers build the argv across several lines:
+
+    subprocess.run(["bash", str(NOTIFY_SCRIPT),
+                    "--kind", "receipt",
+                    message], timeout=20)
+
+so a per-line grep reports every one of them as bare. The check therefore reads
+a window after the invocation token. That is a real limit, not a subtlety to
+hide: see HONEST BOUNDARY below.
+
+HONEST BOUNDARY (what this does NOT catch):
+  * A call site that computes its argv dynamically (kind held in a variable
+    built elsewhere, argv assembled in a list far from the call).
+  * A producer that passes --kind decision --class <allowlisted> for something
+    that is not really a founder decision. The enum bounds the vocabulary, it
+    cannot audit intent. Only review does.
+  * Producers in other repos. Fleet instances are outside this walk by design.
+"""
+import argparse
+import os
+import re
+import subprocess
+import sys
+
+# AN INVOCATION, NOT A MENTION. The first cut matched a bare `slack-notify.sh`
+# anywhere and reported 53 sites against a measured population of 11 producers --
+# it was counting docstrings, a test's own assertion string, and three paragraphs
+# of fable-discipline-lint prose ABOUT this script. A detector that cries wolf on
+# comments gets switched off, so it must match the shape of a call: an interpreter
+# followed by the notifier. Every real site in this repo is one of three forms.
+INVOKE = re.compile(
+    r"""(?:
+          bash\s+["']?\$\{?(?:KIPI_)?NOTIFY          # bash "$NOTIFY"
+        | bash\s+["'][^"']*slack-notify\.sh["']      # bash "$SKEL/.../slack-notify.sh"
+        | subprocess\.run\(\s*\[[^\]]*(?i:notif)     # subprocess.run([notifier, msg]
+        )""",
+    re.VERBOSE,
+)
+KIND = re.compile(r"--kind")
+WINDOW = 4
+
+# CROSS-CHECKED AGAINST A MEASURED POPULATION, not eyeballed. Diffing this
+# detector's output against the 11 producers found by hand caught faults in BOTH
+# directions, which is the whole reason to do it:
+#   * false POSITIVES: an over-broad `slack-notify.sh` match counted docstrings
+#     and a lint's own prose about this script -- 53 sites against a real 30.
+#   * false NEGATIVES, two real leaks:
+#     - an `^[A-Z_]+=` exclusion meant to skip `NOTIFY=...` assignments also ate
+#       `KIPI_INSTANCE_NAME="$name" bash .../slack-notify.sh "..."`, a live page.
+#       Dropped entirely: every INVOKE form already requires an interpreter next
+#       to the notifier, so a plain assignment cannot match one anyway.
+#     - claude-integrity-tripwire.py runs `subprocess.run([notifier, message])`
+#       with NO "bash" argv[0] and a lowercase name, so a bash-anchored pattern
+#       could never see its four pages. Hence the third form.
+# `bash -n` and a read-through would have caught neither.
+NOT_A_CALL = re.compile(
+    r"""(?:
+          ^\s*(?:\#|\*|//)                    # comment
+        | env\[|setdefault|export\s           # test/env stubbing
+        )""",
+    re.VERBOSE,
+)
+
+# Review scratch trees hold frozen copies of old worker/converge revisions. They
+# are not shipped, not loaded, and rewriting them would be noise in every diff.
+SKIP_DIRS = (".pr", ".review-", "node_modules", ".prd-os/")
+SKIP_FILES = ("slack-notify.sh", "notify-callsite-audit.py")
+
+
+def tracked_files(repo):
+    """git ls-files, so the walk matches what actually ships."""
+    out = subprocess.run(
+        ["git", "-C", repo, "ls-files"],
+        capture_output=True, text=True, check=False,
+    )
+    for rel in out.stdout.splitlines():
+        if not rel.endswith((".sh", ".py")):
+            continue
+        if any(rel.startswith(d) or ("/" + d) in rel for d in SKIP_DIRS):
+            continue
+        if os.path.basename(rel) in SKIP_FILES:
+            continue
+        yield rel
+
+
+def offending_sites(repo):
+    """Return [(relpath, lineno, text)] for invocations with no --kind nearby."""
+    found = []
+    for rel in tracked_files(repo):
+        path = os.path.join(repo, rel)
+        try:
+            with open(path, encoding="utf-8", errors="replace") as fh:
+                lines = fh.read().splitlines()
+        except OSError:
+            continue
+        for i, line in enumerate(lines):
+            if not INVOKE.search(line) or NOT_A_CALL.search(line):
+                continue
+            window = "\n".join(lines[i:i + WINDOW])
+            if not KIND.search(window):
+                found.append((rel, i + 1, line.strip()[:110]))
+    return found
+
+
+def main():
+    ap = argparse.ArgumentParser(description=__doc__)
+    ap.add_argument("--repo", default=os.path.join(os.path.dirname(__file__), "..", "..", ".."))
+    args = ap.parse_args()
+    repo = os.path.abspath(args.repo)
+
+    bad = offending_sites(repo)
+    if not bad:
+        print("notify-callsite-audit: OK -- every call site declares a --kind")
+        return 0
+
+    print("notify-callsite-audit: %d call site(s) reach the founder with no --kind.\n" % len(bad))
+    for rel, lineno, text in bad:
+        print("  %s:%d\n      %s" % (rel, lineno, text))
+    print(
+        "\nFix: pass --kind receipt (the machine handled it; it is recorded, not delivered)\n"
+        "  or --kind decision --class <irreversible-git|out-of-tree-write|spend|publish>.\n"
+        "A page that names the founder as the actor is a defect in the producer."
+    )
+    return 1
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/q-system/.q-system/scripts/notify-callsite-audit.py
+++ b/q-system/.q-system/scripts/notify-callsite-audit.py
@@ -52,7 +52,14 @@ INVOKE = re.compile(
         )""",
     re.VERBOSE,
 )
-KIND = re.compile(r"--kind")
+# TWO ACCEPTED FORMS. Shell producers classify with a command-prefix env var,
+# because a flag in argv is visible to notify stubs: stubs recording "$1" break
+# when flags come first, and stubs recording "$*" pull the flags into the page
+# TEXT when they come last. Both happened on this branch. A prefix is invisible
+# to both forms, so no stub here or in any fleet instance needs to know this
+# feature exists. argv flags stay valid for dispatch's page()/page_ok()
+# pass-through, for the Python producers (whose stubs read "$1"), and by hand.
+KIND = re.compile(r"--kind|KIPI_NOTIFY_KIND=")
 WINDOW = 4
 
 # CROSS-CHECKED AGAINST A MEASURED POPULATION, not eyeballed. Diffing this

--- a/q-system/.q-system/scripts/notify-callsite-audit.py
+++ b/q-system/.q-system/scripts/notify-callsite-audit.py
@@ -31,6 +31,11 @@ HONEST BOUNDARY (what this does NOT catch):
     that is not really a founder decision. The enum bounds the vocabulary, it
     cannot audit intent. Only review does.
   * Producers in other repos. Fleet instances are outside this walk by design.
+  * A LITERAL path executed directly with no interpreter AND no argument on the
+    same line -- `"$SKEL/.../slack-notify.sh"` alone. That is indistinguishable
+    from a `chmod +x` continuation operand without parsing the shell, and there
+    is a live instance of the operand form in this repo. The `$NOTIFY` variable
+    form, which is how every real producer here writes it, IS caught bare.
 """
 import argparse
 import os
@@ -42,16 +47,52 @@ import sys
 # anywhere and reported 53 sites against a measured population of 11 producers --
 # it was counting docstrings, a test's own assertion string, and three paragraphs
 # of fable-discipline-lint prose ABOUT this script. A detector that cries wolf on
-# comments gets switched off, so it must match the shape of a call: an interpreter
-# followed by the notifier. Every real site in this repo is one of three forms.
-INVOKE = re.compile(
-    r"""(?:
-          bash\s+["']?\$\{?(?:KIPI_)?NOTIFY          # bash "$NOTIFY"
-        | bash\s+["'][^"']*slack-notify\.sh["']      # bash "$SKEL/.../slack-notify.sh"
-        | subprocess\.run\(\s*\[[^\]]*(?i:notif)     # subprocess.run([notifier, msg]
-        )""",
+# comments gets switched off, so it must match the shape of a call.
+#
+# COMMAND POSITION, NOT AN INTERPRETER TOKEN (PR #72 review, minor). The version
+# before this one required `bash ` adjacent to the notifier, and a reviewer
+# planted four realistic bare producers against it. It caught ONE. It missed
+# `"$NOTIFY" "msg"` -- and slack-notify.sh is mode 755, so a direct exec is the
+# NATURAL form, not an exotic one -- and it missed `sh "$NOTIFY" "msg"`. A gate
+# whose entire stated purpose is catching FUTURE producers cannot be blind to
+# the most obvious way to write one.
+#
+# The interpreter requirement was load-bearing for a reason, though, and dropping
+# it naively re-opens what it was protecting: an `^[A-Z_]+=` exclusion had been
+# removed on the grounds that "every INVOKE form already requires an interpreter
+# next to the notifier", which is what stops `NOTIFY="$SKEL/.../slack-notify.sh"`
+# from reading as a call. So the anchor moves from "an interpreter precedes it"
+# to "it is in COMMAND POSITION": start of line, or after ; & | ( or a shell
+# keyword, optionally preceded by env assignments (the live
+# `KIPI_INSTANCE_NAME="$n" bash .../slack-notify.sh` shape). A bare assignment
+# has the notifier on the RIGHT of an `=`, never in command position, so it
+# still cannot match -- verified by the negative cases in the paired suite.
+_CMD_POS = r"""(?:^|[;&|(]|\b(?:then|else|elif|do|if|while|until|eval|exec|command)\s)
+               \s*
+               (?:[A-Za-z_][A-Za-z_0-9]*=(?:"[^"]*"|'[^']*'|\S*)\s+)*"""
+_INTERP = r"""(?:(?:ba|da|k|z)?sh\s+(?:-\S+\s+)*)"""
+# THE TRAILING BOUNDARY IS NOT DECORATION. Without `(?![A-Za-z0-9_])`, `$NOTIFY`
+# also matches `$NOTIFY_RC` -- pr-review-agent.sh:848 prints that inside a WARN
+# string, and widening this pattern reported that echo as an unclassified pager.
+# A detector that cries wolf gets switched off, which is how the over-broad first
+# cut (53 sites against a real 30) nearly died.
+_NOTIFY_VAR = r"""["']?\$\{?(?:KIPI_)?NOTIFY\}?["']?(?![A-Za-z0-9_])"""
+_NOTIFY_PATH = r"""["'][^"']*slack-notify\.sh["']"""
+SHELL_INVOKE = re.compile(
+    _CMD_POS + r"(?:" + _INTERP + r"?" + _NOTIFY_VAR + r"|"
+    # A LITERAL PATH WITH NO INTERPRETER MUST CARRY AN ARGUMENT. `chmod +x \` +
+    # a continuation line holding only "$skel/.../slack-notify.sh" is
+    # line-initial, so command position alone reads it as a call. A real bare
+    # exec passes a message; a chmod/cp/install operand is the last token on its
+    # line. Requiring a following argument separates them without a shell parser.
+    + r"(?:" + _INTERP + _NOTIFY_PATH + r"|" + _NOTIFY_PATH + r"\s+\S)" + r")",
     re.VERBOSE,
 )
+# PYTHON PRODUCERS GET THE PYTHON FORM ONLY. Shell command-position logic applied
+# to a .py file read `"q-system/.../slack-notify.sh",` -- a plain list element in
+# test_review_tier.py's coverage table -- as an invocation. A path in a Python
+# list is data; the only way a .py file reaches the sink is by spawning it.
+PY_INVOKE = re.compile(r"subprocess\.run\(\s*\[[^\]]*(?i:notif)")
 # TWO ACCEPTED FORMS. Shell producers classify with a command-prefix env var,
 # because a flag in argv is visible to notify stubs: stubs recording "$1" break
 # when flags come first, and stubs recording "$*" pull the flags into the page
@@ -61,6 +102,15 @@ INVOKE = re.compile(
 # pass-through, for the Python producers (whose stubs read "$1"), and by hand.
 KIND = re.compile(r"--kind|KIPI_NOTIFY_KIND=")
 WINDOW = 4
+# A COMMENT MUST NOT SATISFY THE WINDOW (PR #72 review, minor). The window exists
+# because the Python producers build argv across several lines. It was a plain
+# 4-line slice, so a bare call followed by
+#     # TODO(ASK-999): decide whether this should be --kind receipt or a decision.
+# exempted itself -- prose next to a call could turn the gate off. Comment lines
+# are now skipped rather than counted, so the window still spans four lines of
+# actual CODE and a real multi-line call with a comment in the middle is not
+# truncated either. NOT_A_CALL already handles a comment on the invocation line.
+COMMENT_ONLY = re.compile(r"^\s*(?:#|//|\*)")
 
 # CROSS-CHECKED AGAINST A MEASURED POPULATION, not eyeballed. Diffing this
 # detector's output against the 11 producers found by hand caught faults in BOTH
@@ -123,13 +173,43 @@ def offending_sites(repo):
                 lines = fh.read().splitlines()
         except OSError:
             continue
+        invoke = PY_INVOKE if rel.endswith(".py") else SHELL_INVOKE
         for i, line in enumerate(lines):
-            if not INVOKE.search(line) or NOT_A_CALL.search(line):
+            if not invoke.search(line) or NOT_A_CALL.search(line):
                 continue
-            window = "\n".join(lines[i:i + WINDOW])
-            if not KIND.search(window):
+            if not KIND.search(kind_window(lines, i)):
                 found.append((rel, i + 1, line.strip()[:110]))
     return found
+
+
+def kind_window(lines, i, size=WINDOW):
+    """The call line plus the next `size - 1` lines that are not comments."""
+    window = [lines[i]]
+    j = i + 1
+    while len(window) < size and j < len(lines):
+        if not COMMENT_ONLY.match(lines[j]):
+            window.append(lines[j])
+        j += 1
+    return "\n".join(window)
+
+
+def allowed_classes(repo):
+    """The class enum, read from its ONE source: slack-notify.sh.
+
+    PR #72 review, minor: this gate's fix text hardcoded four classes while
+    ALLOWED_CLASSES permitted five, and kipi-dispatch.sh already used the fifth
+    (`credential`). An author following the gate's own instruction could not
+    discover a class the codebase relies on. A second copy of a list is a second
+    thing to drift, so there is no copy -- and no hardcoded fallback either,
+    because a fallback that silently disagrees is the bug wearing a hat.
+    """
+    path = os.path.join(repo, "q-system", ".q-system", "scripts", "slack-notify.sh")
+    try:
+        with open(path, encoding="utf-8") as fh:
+            match = re.search(r'^ALLOWED_CLASSES="([^"]*)"', fh.read(), re.M)
+    except OSError:
+        return None
+    return match.group(1).split() if match else None
 
 
 def main():
@@ -146,10 +226,12 @@ def main():
     print("notify-callsite-audit: %d call site(s) reach the founder with no --kind.\n" % len(bad))
     for rel, lineno, text in bad:
         print("  %s:%d\n      %s" % (rel, lineno, text))
+    classes = allowed_classes(repo)
+    enum = "|".join(classes) if classes else "see ALLOWED_CLASSES in slack-notify.sh"
     print(
         "\nFix: pass --kind receipt (the machine handled it; it is recorded, not delivered)\n"
-        "  or --kind decision --class <irreversible-git|out-of-tree-write|spend|publish>.\n"
-        "A page that names the founder as the actor is a defect in the producer."
+        "  or --kind decision --class <%s>.\n"
+        "A page that names the founder as the actor is a defect in the producer." % enum
     )
     return 1
 

--- a/q-system/.q-system/scripts/notify-callsite-audit.py
+++ b/q-system/.q-system/scripts/notify-callsite-audit.py
@@ -69,10 +69,17 @@ WINDOW = 4
 #       with NO "bash" argv[0] and a lowercase name, so a bash-anchored pattern
 #       could never see its four pages. Hence the third form.
 # `bash -n` and a read-through would have caught neither.
+# ONE EXPLICIT ACK, never a widened detector. Three shapes legitimately reach the
+# sink without a literal --kind on the line: the dispatcher's page_ok() pass-through
+# (its CALLERS carry the classification), a lint fixture that only quotes a call,
+# and this gate's own suite, which must be able to make a bare call to prove the
+# fail-open path. Loosening the regex to accommodate them would blind it to the
+# real thing; a marker keeps each exemption named, greppable and countable.
 NOT_A_CALL = re.compile(
     r"""(?:
           ^\s*(?:\#|\*|//)                    # comment
         | env\[|setdefault|export\s           # test/env stubbing
+        | notify-kind-skip                    # explicit, per-line ack
         )""",
     re.VERBOSE,
 )

--- a/q-system/.q-system/scripts/notify-receipts-surface.py
+++ b/q-system/.q-system/scripts/notify-receipts-surface.py
@@ -1,0 +1,180 @@
+#!/usr/bin/env python3
+"""The READING end of the founder-notification sink. (ASK-294)
+
+Pairs with: slack-notify.sh (the only writer) and
+test/test-notify-receipts-surface.sh (which drives both halves).
+
+WHY THIS FILE EXISTS -- it is a review finding, not a nice-to-have. ASK-294
+converted most producers from "page the founder" to `--kind receipt`, which is
+recorded to notify-receipts.jsonl and never delivered. slack-notify.sh's own
+comment asserted this file read that ledger at SessionStart. It did not exist,
+and nothing else in the repo opened the ledger, so three dispatch pages that
+mean the Linear loop is DEAD (repo-missing, gh-missing, budget-day) reached no
+human AND no machine. page_once compounded it: the sink exits 0 for a receipt,
+so the dedupe marker was written and the page counted as delivered.
+
+That is the "quieter, not shorter" failure this whole issue exists to stop.
+The founder's requirement was never "fewer pings", it was "they should go to
+you or sana" -- ROUTED, not dropped. A sink with no reader is dropped with
+extra steps.
+
+WHAT IT SURFACES: every row nothing delivered to a human. That is one predicate
+covering three distinct conditions, deliberately:
+  * receipts        -- the machine handled it; the agent should still see that
+                       it happened overnight.
+  * refusals        -- a producer asked for something the enum does not allow.
+                       A swallowed alert is the precise failure founder-
+                       notifications.md exists to prevent, so it surfaces here.
+  * failed delivery -- `delivered:false` on a `decision`. slack-notify.sh exits
+                       0 even when curl fails (sp-21815b25), so a dropped page
+                       is otherwise invisible to everyone. This reader is the
+                       only place it shows up.
+Rows that DID reach the phone are skipped: the founder already has them, and
+repeating them to the agent is the noise this issue was opened about.
+
+TWO FILES, ONE WRITER EACH. slack-notify.sh appends to the ledger under flock
+and owns it exclusively. This reader never writes the ledger -- it keeps its own
+byte cursor beside it. Read-state in the ledger rows would make it a second
+writer to a file whose whole point is that concurrent dispatchers cannot corrupt
+it.
+
+THE CURSOR IS BYTES, AND SHRINKAGE RESETS IT. A rotated or truncated ledger
+leaves the offset past EOF; reading from there is silent forever, which is
+exactly the bug this file fixes wearing a different hat. `size < offset` means
+the file is not the one the cursor described, so it restarts at 0.
+
+Runs on SessionStart. Exit 0 ALWAYS -- a notification reader that can block a
+session would be a worse outage than the noise it reports.
+
+HONEST BOUNDARY (what this does NOT do):
+  * It does not act. It puts the row in front of the agent; whether the
+    condition gets handled is still the agent's call and nothing checks it.
+  * It surfaces THIS machine's ledger. Fleet instances write their own.
+  * It cannot tell a receipt that was genuinely handled from one that was
+    demoted to shut it up. Only review does.
+"""
+from __future__ import annotations
+
+import argparse
+import json
+import os
+import sys
+
+# Cap the block so an overnight storm cannot bury the rest of the session
+# context. The remainder is COUNTED, never silently dropped -- a truncation that
+# reads as "that was all of it" is the same lie as having no reader.
+MAX_ROWS = 20
+MESSAGE_CLIP = 200
+
+
+def default_ledger() -> str:
+    return os.environ.get(
+        "KIPI_NOTIFY_RECEIPTS",
+        os.path.join(os.path.expanduser("~"), ".config", "kipi", "notify-receipts.jsonl"),
+    )
+
+
+def read_cursor(cursor_path: str, size: int) -> int:
+    """Byte offset to resume from. Anything unparseable or past EOF means 0."""
+    try:
+        with open(cursor_path, encoding="utf-8") as fh:
+            offset = int(fh.read().strip())
+    except (OSError, ValueError):
+        return 0
+    if offset < 0 or offset > size:
+        return 0  # rotated, truncated, or a cursor from another file
+    return offset
+
+
+def write_cursor(cursor_path: str, offset: int) -> None:
+    try:
+        os.makedirs(os.path.dirname(cursor_path) or ".", exist_ok=True)
+        with open(cursor_path, "w", encoding="utf-8") as fh:
+            fh.write("%d\n" % offset)
+    except OSError:
+        pass  # an unwritable cursor re-surfaces rows; it must never break a session
+
+
+def unread_rows(ledger: str, cursor_path: str):
+    """Return (rows_nobody_delivered, new_offset). Empty on any read problem."""
+    try:
+        size = os.path.getsize(ledger)
+    except OSError:
+        return [], None
+    offset = read_cursor(cursor_path, size)
+    if offset >= size:
+        return [], size
+    rows = []
+    try:
+        with open(ledger, encoding="utf-8", errors="replace") as fh:
+            fh.seek(offset)
+            for line in fh:
+                line = line.strip()
+                if not line:
+                    continue
+                try:
+                    row = json.loads(line)
+                except ValueError:
+                    continue  # one corrupt line must not blind the reader
+                if isinstance(row, dict) and not row.get("delivered"):
+                    rows.append(row)
+            new_offset = fh.tell()
+    except OSError:
+        return [], None
+    return rows, new_offset
+
+
+def describe(row: dict) -> str:
+    kind = row.get("kind") or "?"
+    if row.get("refused"):
+        tag = "REFUSED"
+    elif kind == "decision":
+        tag = "UNDELIVERED DECISION"   # curl failed; nobody's phone got this
+    else:
+        tag = kind.upper()
+    klass = row.get("class")
+    if klass:
+        tag = "%s/%s" % (tag, klass)
+    message = str(row.get("message", "")).replace("\n", " ")
+    if len(message) > MESSAGE_CLIP:
+        message = message[: MESSAGE_CLIP - 1] + "…"
+    return "  [%s] %s  %s" % (tag, row.get("ts", "?"), message)
+
+
+def main() -> int:
+    ap = argparse.ArgumentParser(description="Surface undelivered founder-notification rows.")
+    ap.add_argument("--ledger", default=None, help="path to notify-receipts.jsonl")
+    args = ap.parse_args()
+
+    ledger = args.ledger or default_ledger()
+    cursor_path = ledger + ".cursor"
+
+    rows, new_offset = unread_rows(ledger, cursor_path)
+    if new_offset is not None:
+        write_cursor(cursor_path, new_offset)
+    if not rows:
+        return 0
+
+    shown, hidden = rows[-MAX_ROWS:], max(0, len(rows) - MAX_ROWS)
+    print("MACHINE NOTIFICATIONS SINCE YOUR LAST SESSION (%d)" % len(rows))
+    print("=" * 62)
+    print("Nothing below reached the founder. It was recorded for you instead.")
+    print("A REFUSED row is a producer bug. An UNDELIVERED DECISION means the")
+    print("webhook dropped a page that was meant for his phone.")
+    print()
+    if hidden:
+        print("  ... %d older row(s) not shown; full ledger: %s" % (hidden, ledger))
+    for row in shown:
+        print(describe(row))
+    print()
+    print("Ledger: %s" % ledger)
+    print("=" * 62)
+    return 0
+
+
+if __name__ == "__main__":
+    try:
+        sys.exit(main())
+    except Exception as exc:  # noqa: BLE001 -- a SessionStart hook never blocks
+        print("notify-receipts-surface: skipped (%s)" % exc, file=sys.stderr)
+        sys.exit(0)

--- a/q-system/.q-system/scripts/open-loops-heartbeat.sh
+++ b/q-system/.q-system/scripts/open-loops-heartbeat.sh
@@ -95,7 +95,7 @@ work_instance() {
     echo "$(TS) heartbeat[$name]: agent run failed/timeout" >> "$LOG"
     log_step "$name" failed "agent run failed/timeout"
     SWEEP_FAILURES=$((SWEEP_FAILURES + 1))
-    KIPI_INSTANCE_NAME="$name" bash "$SKEL/q-system/.q-system/scripts/slack-notify.sh" "heartbeat: autonomous run failed/timeout -- check open-loops-heartbeat.log" 2>/dev/null || true
+    KIPI_INSTANCE_NAME="$name" bash "$SKEL/q-system/.q-system/scripts/slack-notify.sh" --kind receipt "heartbeat: autonomous run failed/timeout -- check open-loops-heartbeat.log" 2>/dev/null || true
   fi
 }
 
@@ -135,7 +135,7 @@ json.dump(expected, open('$RUNLOG_TMP.expected', 'w'))
 if ! AUDIT_OUT="$(python3 "$SKEL/q-system/.q-system/scripts/run-step-audit.py" \
     --manifest "$RUNLOG_TMP.expected" --log "$RUNLOG" --job open-loops-heartbeat 2>&1)"; then
   echo "$(TS) heartbeat AUDIT: $AUDIT_OUT" >> "$LOG"
-  bash "$SKEL/q-system/.q-system/scripts/slack-notify.sh" "heartbeat step-audit: $(printf '%s' "$AUDIT_OUT" | head -3 | tr '\n' ' ')" 2>/dev/null || true
+  bash "$SKEL/q-system/.q-system/scripts/slack-notify.sh" --kind receipt "heartbeat step-audit: $(printf '%s' "$AUDIT_OUT" | head -3 | tr '\n' ' ')" 2>/dev/null || true
   SWEEP_FAILURES=$((SWEEP_FAILURES + 1))
 else
   echo "$(TS) heartbeat AUDIT: $AUDIT_OUT" >> "$LOG"

--- a/q-system/.q-system/scripts/open-loops-heartbeat.sh
+++ b/q-system/.q-system/scripts/open-loops-heartbeat.sh
@@ -95,7 +95,7 @@ work_instance() {
     echo "$(TS) heartbeat[$name]: agent run failed/timeout" >> "$LOG"
     log_step "$name" failed "agent run failed/timeout"
     SWEEP_FAILURES=$((SWEEP_FAILURES + 1))
-    KIPI_INSTANCE_NAME="$name" bash "$SKEL/q-system/.q-system/scripts/slack-notify.sh" "heartbeat: autonomous run failed/timeout -- check open-loops-heartbeat.log" --kind receipt 2>/dev/null || true
+    KIPI_INSTANCE_NAME="$name" KIPI_NOTIFY_KIND=receipt bash "$SKEL/q-system/.q-system/scripts/slack-notify.sh" "heartbeat: autonomous run failed/timeout -- check open-loops-heartbeat.log" 2>/dev/null || true
   fi
 }
 
@@ -135,7 +135,7 @@ json.dump(expected, open('$RUNLOG_TMP.expected', 'w'))
 if ! AUDIT_OUT="$(python3 "$SKEL/q-system/.q-system/scripts/run-step-audit.py" \
     --manifest "$RUNLOG_TMP.expected" --log "$RUNLOG" --job open-loops-heartbeat 2>&1)"; then
   echo "$(TS) heartbeat AUDIT: $AUDIT_OUT" >> "$LOG"
-  bash "$SKEL/q-system/.q-system/scripts/slack-notify.sh" "heartbeat step-audit: $(printf '%s' "$AUDIT_OUT" --kind receipt | head -3 | tr '\n' ' ')" 2>/dev/null || true
+  KIPI_NOTIFY_KIND=receipt bash "$SKEL/q-system/.q-system/scripts/slack-notify.sh" "heartbeat step-audit: $(printf '%s' "$AUDIT_OUT" | head -3 | tr '\n' ' ')" 2>/dev/null || true
   SWEEP_FAILURES=$((SWEEP_FAILURES + 1))
 else
   echo "$(TS) heartbeat AUDIT: $AUDIT_OUT" >> "$LOG"

--- a/q-system/.q-system/scripts/open-loops-heartbeat.sh
+++ b/q-system/.q-system/scripts/open-loops-heartbeat.sh
@@ -95,7 +95,7 @@ work_instance() {
     echo "$(TS) heartbeat[$name]: agent run failed/timeout" >> "$LOG"
     log_step "$name" failed "agent run failed/timeout"
     SWEEP_FAILURES=$((SWEEP_FAILURES + 1))
-    KIPI_INSTANCE_NAME="$name" bash "$SKEL/q-system/.q-system/scripts/slack-notify.sh" --kind receipt "heartbeat: autonomous run failed/timeout -- check open-loops-heartbeat.log" 2>/dev/null || true
+    KIPI_INSTANCE_NAME="$name" bash "$SKEL/q-system/.q-system/scripts/slack-notify.sh" "heartbeat: autonomous run failed/timeout -- check open-loops-heartbeat.log" --kind receipt 2>/dev/null || true
   fi
 }
 
@@ -135,7 +135,7 @@ json.dump(expected, open('$RUNLOG_TMP.expected', 'w'))
 if ! AUDIT_OUT="$(python3 "$SKEL/q-system/.q-system/scripts/run-step-audit.py" \
     --manifest "$RUNLOG_TMP.expected" --log "$RUNLOG" --job open-loops-heartbeat 2>&1)"; then
   echo "$(TS) heartbeat AUDIT: $AUDIT_OUT" >> "$LOG"
-  bash "$SKEL/q-system/.q-system/scripts/slack-notify.sh" --kind receipt "heartbeat step-audit: $(printf '%s' "$AUDIT_OUT" | head -3 | tr '\n' ' ')" 2>/dev/null || true
+  bash "$SKEL/q-system/.q-system/scripts/slack-notify.sh" "heartbeat step-audit: $(printf '%s' "$AUDIT_OUT" --kind receipt | head -3 | tr '\n' ' ')" 2>/dev/null || true
   SWEEP_FAILURES=$((SWEEP_FAILURES + 1))
 else
   echo "$(TS) heartbeat AUDIT: $AUDIT_OUT" >> "$LOG"

--- a/q-system/.q-system/scripts/pr-review-agent.sh
+++ b/q-system/.q-system/scripts/pr-review-agent.sh
@@ -544,7 +544,7 @@ note_degraded_transition() {   # note_degraded_transition <0|1> [reason]
   else
     msg="reviewer: codex is BACK (PR #$PR) -- $STATUS_CONTEXT is an independent second opinion again."
   fi
-  bash "$NOTIFY" "$msg" --kind receipt 2>/dev/null || true
+  KIPI_NOTIFY_KIND=receipt bash "$NOTIFY" "$msg" 2>/dev/null || true
 }
 
 echo "$(TS) running the $ENGINE reviewer (bounded at ${TIMEOUT_SECONDS}s)..."
@@ -842,7 +842,7 @@ Sana: reply to this comment on THIS issue. For each finding, either the file:lin
       # the same overclaim this commit is removing one layer down. So: attempt it,
       # record what came back, and leave the stderr WARN above as the one record
       # that is always written.
-      NOTIFY_OUT="$(bash "$NOTIFY" "reviewer: PR #$PR review did NOT reach $ISSUE ($ENGINE engine, verdict ${VERDICT:-unstated}). The gate moved but the findings are not on the issue, so the rework conversation cannot start." --kind receipt 2>&1)"
+      KIPI_NOTIFY_KIND=receipt NOTIFY_OUT="$(bash "$NOTIFY" "reviewer: PR #$PR review did NOT reach $ISSUE ($ENGINE engine, verdict ${VERDICT:-unstated}). The gate moved but the findings are not on the issue, so the rework conversation cannot start." 2>&1)"
       NOTIFY_RC=$?
       if [ "$NOTIFY_RC" -ne 0 ]; then
         echo "  WARN: the page about that loss ALSO failed (rc=$NOTIFY_RC${NOTIFY_OUT:+: $NOTIFY_OUT}). This loss is recorded ONLY in this log." >&2

--- a/q-system/.q-system/scripts/pr-review-agent.sh
+++ b/q-system/.q-system/scripts/pr-review-agent.sh
@@ -544,7 +544,7 @@ note_degraded_transition() {   # note_degraded_transition <0|1> [reason]
   else
     msg="reviewer: codex is BACK (PR #$PR) -- $STATUS_CONTEXT is an independent second opinion again."
   fi
-  bash "$NOTIFY" "$msg" 2>/dev/null || true
+  bash "$NOTIFY" --kind receipt "$msg" 2>/dev/null || true
 }
 
 echo "$(TS) running the $ENGINE reviewer (bounded at ${TIMEOUT_SECONDS}s)..."
@@ -842,7 +842,7 @@ Sana: reply to this comment on THIS issue. For each finding, either the file:lin
       # the same overclaim this commit is removing one layer down. So: attempt it,
       # record what came back, and leave the stderr WARN above as the one record
       # that is always written.
-      NOTIFY_OUT="$(bash "$NOTIFY" "reviewer: PR #$PR review did NOT reach $ISSUE ($ENGINE engine, verdict ${VERDICT:-unstated}). The gate moved but the findings are not on the issue, so the rework conversation cannot start." 2>&1)"
+      NOTIFY_OUT="$(bash "$NOTIFY" --kind receipt "reviewer: PR #$PR review did NOT reach $ISSUE ($ENGINE engine, verdict ${VERDICT:-unstated}). The gate moved but the findings are not on the issue, so the rework conversation cannot start." 2>&1)"
       NOTIFY_RC=$?
       if [ "$NOTIFY_RC" -ne 0 ]; then
         echo "  WARN: the page about that loss ALSO failed (rc=$NOTIFY_RC${NOTIFY_OUT:+: $NOTIFY_OUT}). This loss is recorded ONLY in this log." >&2

--- a/q-system/.q-system/scripts/pr-review-agent.sh
+++ b/q-system/.q-system/scripts/pr-review-agent.sh
@@ -544,7 +544,7 @@ note_degraded_transition() {   # note_degraded_transition <0|1> [reason]
   else
     msg="reviewer: codex is BACK (PR #$PR) -- $STATUS_CONTEXT is an independent second opinion again."
   fi
-  bash "$NOTIFY" --kind receipt "$msg" 2>/dev/null || true
+  bash "$NOTIFY" "$msg" --kind receipt 2>/dev/null || true
 }
 
 echo "$(TS) running the $ENGINE reviewer (bounded at ${TIMEOUT_SECONDS}s)..."
@@ -842,7 +842,7 @@ Sana: reply to this comment on THIS issue. For each finding, either the file:lin
       # the same overclaim this commit is removing one layer down. So: attempt it,
       # record what came back, and leave the stderr WARN above as the one record
       # that is always written.
-      NOTIFY_OUT="$(bash "$NOTIFY" --kind receipt "reviewer: PR #$PR review did NOT reach $ISSUE ($ENGINE engine, verdict ${VERDICT:-unstated}). The gate moved but the findings are not on the issue, so the rework conversation cannot start." 2>&1)"
+      NOTIFY_OUT="$(bash "$NOTIFY" "reviewer: PR #$PR review did NOT reach $ISSUE ($ENGINE engine, verdict ${VERDICT:-unstated}). The gate moved but the findings are not on the issue, so the rework conversation cannot start." --kind receipt 2>&1)"
       NOTIFY_RC=$?
       if [ "$NOTIFY_RC" -ne 0 ]; then
         echo "  WARN: the page about that loss ALSO failed (rc=$NOTIFY_RC${NOTIFY_OUT:+: $NOTIFY_OUT}). This loss is recorded ONLY in this log." >&2

--- a/q-system/.q-system/scripts/slack-notify.sh
+++ b/q-system/.q-system/scripts/slack-notify.sh
@@ -42,7 +42,14 @@ set -uo pipefail
 # read literally: founder sign-off exists for irreversible acts and for writes
 # outside the canonical tree, plus the two authorizations only he holds. Four
 # cases, and every one of them is something a machine must NOT decide alone.
-ALLOWED_CLASSES="irreversible-git out-of-tree-write spend publish"
+#
+# `credential` is the fifth and it was NOT in the first cut. Dispatch pages once
+# when the Linear token is dead: no issue can be picked, the loop is stopped not
+# slow, and no agent can rotate a secret it cannot read. Refusing that page would
+# have left the whole loop silently dark -- a gate that swallows a real alert is a
+# worse outage than the noise it was built to stop, which outranks this issue.
+# Adding a class is deliberately a diff someone reviews; that is the brake.
+ALLOWED_CLASSES="irreversible-git out-of-tree-write spend publish credential"
 
 KIND=""; CLASS=""; MSG=""
 while [ $# -gt 0 ]; do

--- a/q-system/.q-system/scripts/slack-notify.sh
+++ b/q-system/.q-system/scripts/slack-notify.sh
@@ -51,7 +51,26 @@ set -uo pipefail
 # Adding a class is deliberately a diff someone reviews; that is the brake.
 ALLOWED_CLASSES="irreversible-git out-of-tree-write spend publish credential"
 
-KIND=""; CLASS=""; MSG=""
+# CLASSIFICATION COMES FROM THE ENVIRONMENT FIRST, argv SECOND. That order is a
+# scar, not a preference. argv flags were tried first and broke suites that had
+# nothing to do with this change, in BOTH possible arrangements:
+#   flags BEFORE the message -> the message leaves $1, and notify stubs across
+#     these suites record "$1". Three untouched suites went red at once.
+#   flags AFTER the message  -> "$*" gains " --kind receipt", and a stub that
+#     records "$*" feeds that into assertions about the page PROSE.
+#     test-severity-floor: "the healthy page now carries receipt prose on a run
+#     where the receipt LANDED" -- every converged PR would have paged about a
+#     problem that was not there.
+# Rewriting the four stubs was the wrong instinct: they are tests this change
+# never touched, and editing them regressed three.
+#
+# A command-prefix env var is invisible to BOTH forms -- "$1" is still the
+# message, "$*" is still exactly the message -- so no stub here or in any fleet
+# instance has to know this feature exists. Written as a prefix and never
+# exported, so it stays per-invocation. argv still wins when both are given:
+# dispatch's page_ok() passes flags straight through, and the sink has to remain
+# usable by hand.
+KIND="${KIPI_NOTIFY_KIND:-}"; CLASS="${KIPI_NOTIFY_CLASS:-}"; MSG=""
 while [ $# -gt 0 ]; do
   case "$1" in
     --kind)  KIND="${2:-}"; shift 2 || break ;;

--- a/q-system/.q-system/scripts/slack-notify.sh
+++ b/q-system/.q-system/scripts/slack-notify.sh
@@ -8,11 +8,84 @@
 #   2. ~/.config/kipi/slack-webhook  (gitignored file, one line)
 # No webhook configured -> silent no-op (exit 0), so callers never break.
 #
-# Usage: slack-notify.sh "message text"
+# Usage:
+#   slack-notify.sh --kind receipt "message"                        (never delivered)
+#   slack-notify.sh --kind decision --class <allowlisted> "message" (delivered)
+#   slack-notify.sh "message"                                       (legacy, fail-open)
 set -uo pipefail
 
-MSG="${1:-}"
+# === THE DECISION GATE (ASK-294) =============================================
+# The founder, twice in one session: "why do I keep getting slack messages I
+# can't do anything about that you should be seeing and dealing with", then
+# "I don't want to get slack messages that are useless to me. they should go to
+# you or sana."
+#
+# MEASURED: 48 messages reached #general in 24h from 11 producers, and NOTHING in
+# the fleet reads the channel back -- no job, no hook, no agent. A write-only
+# webhook means every message terminates at the founder by construction. Most of
+# them said "nothing to do" in their own text, which is the cry-wolf failure
+# loop-exits.md already documents: a channel of non-actionable lines trains him
+# to skim, and the skim is how the one page that matters gets missed.
+#
+# AN ALERT IS A RECEIPT, NEVER A MECHANISM. The machine handles the condition;
+# the message records that it did. A message asking the founder to perform a
+# step is a defect in the PRODUCER, not a wording problem.
+#
+# WHY A CLOSED ENUM AND NOT A WORDING LINT. The obvious cheap gate is "refuse a
+# message that reads non-actionable", and it fails immediately: a producer that
+# wants through just rewords. The enum is the opposite shape -- a producer
+# cannot argue its way past it, it has to add a case to ALLOWED_CLASSES in a
+# reviewed diff, which is exactly the visibility that was missing while 11
+# producers violated founder-notifications.md for weeks.
+#
+# THE ALLOWLIST IS NOT A STYLE CHOICE. It is feedback_founder_never_the_next_actor
+# read literally: founder sign-off exists for irreversible acts and for writes
+# outside the canonical tree, plus the two authorizations only he holds. Four
+# cases, and every one of them is something a machine must NOT decide alone.
+ALLOWED_CLASSES="irreversible-git out-of-tree-write spend publish"
+
+KIND=""; CLASS=""; MSG=""
+while [ $# -gt 0 ]; do
+  case "$1" in
+    --kind)  KIND="${2:-}"; shift 2 || break ;;
+    --class) CLASS="${2:-}"; shift 2 || break ;;
+    --)      shift; MSG="${1:-}"; break ;;
+    *)       MSG="$1"; shift ;;
+  esac
+done
 [ -n "$MSG" ] || exit 0
+
+# REFUSE means "do not deliver", never "discard". Every outcome below is written
+# to the ledger, including the refusals, because a silently swallowed alert is
+# the precise failure founder-notifications.md exists to prevent. The refusal is
+# a routing decision, not a censorship decision.
+REFUSED=0; DELIVER=0; REASON=""
+case "$KIND" in
+  receipt)
+    DELIVER=0; REASON="receipt: handled by the machine, recorded not delivered" ;;
+  decision)
+    if [ -z "$CLASS" ]; then
+      REFUSED=1; REASON="--kind decision requires --class from: $ALLOWED_CLASSES"
+    else
+      case " $ALLOWED_CLASSES " in
+        *" $CLASS "*) DELIVER=1; REASON="founder decision ($CLASS)" ;;
+        *) REFUSED=1; REASON="unknown --class '$CLASS'; allowed: $ALLOWED_CLASSES" ;;
+      esac
+    fi ;;
+  "")
+    # FAIL OPEN, LOUDLY. kipi update ships this script fleet-wide, and instances
+    # carry producers this repo has never seen (a cole-gtm voice-lint nudge posts
+    # here today). Refusing an unmigrated caller would silence an instance-local
+    # alert nobody has looked at yet -- the "gate that silences a real alert is a
+    # worse outage than the noise" line, which outranks this whole issue. So it
+    # goes through wearing a marker, and the ledger row is the migration list.
+    KIND="unclassified"; DELIVER=1
+    REASON="legacy one-arg caller: no --kind declared"
+    MSG="[unclassified] $MSG" ;;
+  *)
+    REFUSED=1; REASON="unknown --kind '$KIND'; expected receipt or decision" ;;
+esac
+[ "$REFUSED" -eq 0 ] || DELIVER=0
 
 # Project label so the founder always knows which instance pinged. Resolved in order:
 #   KIPI_INSTANCE_NAME (set by the fleet heartbeat = exact registry name)
@@ -94,13 +167,64 @@ if [ -n "${KIPI_LINEAR_API_URL:-}" ]; then
   fi
 fi
 
-HOOK="${KIPI_SLACK_WEBHOOK:-}"
-if [ -z "$HOOK" ] && [ -f "$HOME/.config/kipi/slack-webhook" ]; then
-  HOOK="$(tr -d '\n\r' < "$HOME/.config/kipi/slack-webhook")"
+DELIVERED=0
+if [ "$DELIVER" -eq 1 ]; then
+  HOOK="${KIPI_SLACK_WEBHOOK:-}"
+  if [ -z "$HOOK" ] && [ -f "$HOME/.config/kipi/slack-webhook" ]; then
+    HOOK="$(tr -d '\n\r' < "$HOME/.config/kipi/slack-webhook")"
+  fi
+  if [ -n "$HOOK" ]; then   # unconfigured -> silent, so callers never break
+    PAYLOAD="$(python3 -c "import json,sys; print(json.dumps({'text': sys.argv[1]}))" "$MSG" 2>/dev/null)"
+    if [ -n "$PAYLOAD" ] \
+       && curl -fsS -X POST -H 'Content-type: application/json' --data "$PAYLOAD" "$HOOK" >/dev/null 2>&1; then
+      DELIVERED=1
+    fi
+  fi
 fi
-[ -n "$HOOK" ] || exit 0   # not configured yet -> silent
 
-PAYLOAD="$(python3 -c "import json,sys; print(json.dumps({'text': sys.argv[1]}))" "$MSG" 2>/dev/null)"
-[ -n "$PAYLOAD" ] || exit 0
-curl -fsS -X POST -H 'Content-type: application/json' --data "$PAYLOAD" "$HOOK" >/dev/null 2>&1 || true
+# --- THE MACHINE SINK --------------------------------------------------------
+# The founder's actual requirement is not "fewer pings", it is "they should go to
+# you or sana". So a receipt is not dropped, it is ROUTED: every outcome lands
+# here as one JSON row, and notify-receipts-surface.py reads it at SessionStart
+# so the agent sees overnight machine activity instead of the founder seeing it.
+#
+# AT THE SOURCE, NOT BY POLLING SLACK. ASK-294 forbids a Slack reader and it is
+# right: the producer already knows the condition, so round-tripping it through a
+# chat channel would add a failure mode and buy nothing. The producer writes the
+# ledger directly; Slack stays a delivery endpoint with no read path.
+#
+# SINGLE WRITER VIA flock, not `>>`. Up to two dispatchers, a converge run and a
+# heartbeat can call this in the same second, and an append is only atomic below
+# the pipe buffer -- the voice-lint nudge already posts a ~700-byte multi-line
+# body, and an interleaved write would corrupt two rows, not one.
+RECEIPTS="${KIPI_NOTIFY_RECEIPTS:-$HOME/.config/kipi/notify-receipts.jsonl}"
+python3 - "$RECEIPTS" "$KIND" "$CLASS" "$DELIVERED" "$REFUSED" "$REASON" "$LABEL" "$MSG" <<'PY' 2>/dev/null || true
+import fcntl, json, os, sys, time
+path, kind, klass, delivered, refused, reason, label, msg = sys.argv[1:9]
+os.makedirs(os.path.dirname(path) or ".", exist_ok=True)
+row = {
+    "ts": time.strftime("%Y-%m-%dT%H:%M:%SZ", time.gmtime()),
+    "label": label,
+    "kind": kind,
+    "class": klass or None,
+    "delivered": delivered == "1",
+    "refused": refused == "1",
+    "reason": reason,
+    "message": msg,
+    "read": False,
+}
+with open(path, "a", encoding="utf-8") as fh:
+    fcntl.flock(fh.fileno(), fcntl.LOCK_EX)
+    fh.write(json.dumps(row, ensure_ascii=False) + "\n")
+    fh.flush()
+    fcntl.flock(fh.fileno(), fcntl.LOCK_UN)
+PY
+
+if [ "$REFUSED" -eq 1 ]; then
+  # Loud, and on stderr rather than dropped: the producer is misconfigured and
+  # somebody reading a run-log has to be able to see which call was turned away.
+  printf 'slack-notify: REFUSED -- %s. Message recorded to %s, NOT delivered: %s\n' \
+         "$REASON" "$RECEIPTS" "$MSG" >&2
+  exit 2
+fi
 exit 0

--- a/q-system/.q-system/scripts/slack-notify.sh
+++ b/q-system/.q-system/scripts/slack-notify.sh
@@ -214,6 +214,21 @@ fi
 # here as one JSON row, and notify-receipts-surface.py reads it at SessionStart
 # so the agent sees overnight machine activity instead of the founder seeing it.
 #
+# THAT SENTENCE WAS A CLAIM BEFORE IT WAS A FACT, and PR #72 review caught it as
+# a major. The surfacer did not exist; nothing in the repo opened this file. So
+# "recorded, not delivered" meant three dispatch pages that say the Linear loop
+# is DEAD reached no human AND no machine, while page_once wrote its dedupe
+# marker because this script exits 0 for a receipt. A sink with no reader is a
+# drop with extra steps. The reader ships alongside this file now, is wired into
+# SessionStart in BOTH .claude/settings.json and settings-template.json, and
+# test-notify-receipts-surface.sh fails loudly if it goes missing again.
+#
+# READ-STATE LIVES IN A CURSOR THE READER OWNS, NOT IN THE ROW. A `read` field
+# here would have made the surfacer a second writer to a file whose entire
+# design is that two dispatchers, a converge run and a heartbeat cannot corrupt
+# it. One writer per file: this script owns the ledger, the surfacer owns
+# <ledger>.cursor.
+#
 # AT THE SOURCE, NOT BY POLLING SLACK. ASK-294 forbids a Slack reader and it is
 # right: the producer already knows the condition, so round-tripping it through a
 # chat channel would add a failure mode and buy nothing. The producer writes the
@@ -237,7 +252,6 @@ row = {
     "refused": refused == "1",
     "reason": reason,
     "message": msg,
-    "read": False,
 }
 with open(path, "a", encoding="utf-8") as fh:
     fcntl.flock(fh.fileno(), fcntl.LOCK_EX)

--- a/q-system/.q-system/scripts/test/test-dispatch-stale-checkout.sh
+++ b/q-system/.q-system/scripts/test/test-dispatch-stale-checkout.sh
@@ -59,6 +59,11 @@ done
 HARNESS="$WORK/stale_check.sh"
 {
   echo 'set -uo pipefail'
+  # ONE LINE PER PROCESS IMAGE. Case 2c asserts that a successful self-heal
+  # REPLACES the running image rather than finishing the cycle on the control
+  # code the merge just superseded, and the only way to observe that from
+  # outside is to count how many times the script started.
+  echo 'printf "HARNESS-START\n" >&2'
   echo 'REPO="$PWD"'
   # say() goes to STDERR, matching production where it appends to $LOG. On stdout it
   # would be swallowed by any command substitution around the code under test.
@@ -165,6 +170,33 @@ echo "$OUT" | grep -q 'VERDICT=RUN' \
 echo "$OUT" | grep -q '^PAGE ' \
   && bad "THE DEFECT: paged the founder about something it handled itself" \
   || ok "no page: the condition was handled, so there is nothing to tell him"
+
+echo
+echo "== 2c. after a self-heal the cycle must RESTART, not finish on old code =="
+# PR #72 review, minor. On ff_rc == 0 the function returned 0 and the SAME bash
+# process carried on. The refusal this handler replaced existed precisely because
+# dispatching "would run superseded control code" -- and after the fast-forward
+# that is exactly what the rest of the cycle did. git unlinks and recreates, so
+# the open fd survives and bash keeps executing the PRE-merge bytes: no
+# corruption, and no new code either. The guard's own text named the hazard and
+# then walked into it.
+#
+# Counting process starts is the check because it is the only thing observable
+# from outside that distinguishes "returned" from "re-executed".
+C2C="$(fresh_clone c-reexec)"
+advance_origin two-c
+S2C="$WORK/s2c"; mkdir -p "$S2C"
+OUT2C="$(run_check "$C2C" "$S2C" 2>&1)"
+STARTS="$(printf '%s\n' "$OUT2C" | grep -c 'HARNESS-START')"
+[ "$STARTS" -eq 2 ] \
+  && ok "the merged control code runs the rest of the cycle (2 process images)" \
+  || bad "THE DEFECT: $STARTS image(s); the cycle finished on pre-merge control code"
+# BOUNDED, AND THAT BOUND IS THE POINT. A re-exec inside a 15-minute launchd job
+# is a spin risk, so the second image must not re-exec again even though it will
+# take the same code path. Exactly 2 above is that assertion; this one names why.
+printf '%s\n' "$OUT2C" | grep -q 'VERDICT=RUN' \
+  && ok "the second image reaches a verdict and stops (no exec loop)" \
+  || bad "the re-exec did not terminate in a verdict: $(printf '%s' "$OUT2C" | tr '\n' ' ')"
 
 echo
 echo "== 2b. behind + a path the merge would clobber -> REFUSE and page =="

--- a/q-system/.q-system/scripts/test/test-dispatch-stale-checkout.sh
+++ b/q-system/.q-system/scripts/test/test-dispatch-stale-checkout.sh
@@ -67,6 +67,11 @@ HARNESS="$WORK/stale_check.sh"
   # can be reproduced at all.
   echo 'page_ok() { printf "PAGE %s\n" "$1"; [ "${KIPI_TEST_PAGE_FAILS:-0}" = "1" ] && return 1; return 0; }'
   echo 'PAGE_REPING_SECONDS="${KIPI_PAGE_REPING_SECONDS:-86400}"'
+  # The self-heal handler (ASK-294). $REPO is the fixture clone in here, so the
+  # production $REPO-relative path resolves to a file that does not exist and the
+  # handler is silently INERT -- which is how it first shipped, with every case
+  # below still green because a missing script reads as "declined to merge".
+  echo "FF_MERGE=\"$(cd "$(dirname "$DISPATCH")" && pwd)/q-system/.q-system/scripts/ff-merge-if-safe.sh\""
   awk '/^page_lock\(\) \{/,/^\}/'   "$DISPATCH"
   awk '/^page_clear\(\) \{/,/^\}/'  "$DISPATCH"
   awk '/^page_once\(\) \{/,/^\}/'   "$DISPATCH"
@@ -94,6 +99,27 @@ fresh_clone() {
   ( cd "$d"; git config user.email t@e.com; git config user.name t )
   echo "$d"
 }
+# A clone that is behind AND CANNOT be brought current unattended, so it still
+# pages. Cases 6, 7 and 9 test page_once mechanics -- dedupe, clear-on-recovery,
+# failed-delivery -- which say nothing about WHY the loop refused. Before ASK-294
+# a plain behind-clone was enough to make it page; now that shape self-heals and
+# is silent, so those cases would have been asserting against zero pages and
+# passing for the wrong reason once someone "fixed" them. The collision is on a
+# path origin ADDS, so recovery is just moving the local file aside.
+advance_origin_add() {
+  ( cd "$WORK/seed"; echo blocked > "$1"; git add "$1"; git commit -qm "add $1"; git push -q origin main ) >/dev/null 2>&1
+}
+# THE BLOCKER PATH IS UNIQUE PER FIXTURE. With one shared name the second caller
+# cloned an origin that ALREADY tracked blocker.txt, so the local file was tracked
+# (no collision at all), the re-add was an empty commit (origin never moved), and
+# cases 7 and 9 measured zero pages against a checkout that was not even stale --
+# green for a reason that had nothing to do with what they assert.
+pageable_clone() {
+  local d; d="$(fresh_clone "$1")"
+  printf 'local untracked work\n' > "$d/blocker-$1.txt"
+  advance_origin_add "blocker-$1.txt"
+  echo "$d"
+}
 # LOG is set even though say() is stubbed: page_once derives its marker dir from
 # $(dirname "$LOG"), so an unset LOG trips `set -u` inside the code under test.
 CHECKSTATE="$WORK/checkstate"; mkdir -p "$CHECKSTATE"
@@ -107,26 +133,59 @@ echo "$OUT" | grep -q 'VERDICT=RUN' \
   || bad "an up-to-date checkout was refused: $(echo "$OUT" | tr '\n' ' ')"
 
 echo
-echo "== 2. behind -> REFUSE, and the page carries the remedy =="
+# CONTRACT CHANGED DELIBERATELY, 2026-08-02, ASK-294. This case used to assert
+# that a behind-but-clean checkout REFUSES, leaves the tree untouched, and pages
+# the founder a `git merge --ff-only` command to type. That page fired 15 times in
+# one measured 24h window; he asked twice why he keeps getting messages he cannot
+# act on, then: "I just want the underlying issues to be dealt with so I don't get
+# a message."
+#
+# The guard that stood here ("the guard must not grow hands") encoded ASK-284's
+# finding that an automatic ff-merge loses data. That finding STANDS and is not
+# being waved away -- it is answered. ASK-284's three rounds each tried to make an
+# UNBOUNDED write safe. ff-merge-if-safe.sh does not attempt that: it merges only
+# after proving the fast-forward cannot clobber anything over the EXACT finite set
+# of paths it writes, and declines otherwise. The scar's protection now lives in
+# test-ff-merge-if-safe.sh, case 4, which holds the specific thing that killed the
+# last attempt -- a fast-forward silently overwriting a GITIGNORED file, exit 0,
+# no reflog. Removing a guard is only honest if you can name what replaced it.
+echo "== 2. behind + clean -> the loop merges it ITSELF and stays silent =="
 C2="$(fresh_clone c-behind)"
 B2="$(git -C "$C2" rev-parse HEAD)"
 advance_origin two
 S2="$WORK/s2"; mkdir -p "$S2"
 OUT="$(run_check "$C2" "$S2")"
-echo "$OUT" | grep -q 'VERDICT=REFUSE' \
-  && ok "a checkout behind origin/main refuses to dispatch" \
-  || bad "THE DEFECT: a stale checkout dispatched, running superseded control code"
-# THE GUARD MUST NOT GROW HANDS. The auto-merge was removed for losing data; if a
-# future edit puts one back, this catches it.
-[ "$(git -C "$C2" rev-parse HEAD)" = "$B2" ] \
-  && ok "the working tree was NOT touched (no auto-merge; ASK-284 owns that)" \
-  || bad "THE DEFECT: something rewrote the founder's working tree"
+echo "$OUT" | grep -q 'VERDICT=RUN' \
+  && ok "a behind-but-clean checkout is brought current and dispatches" \
+  || bad "THE DEFECT: still refusing work the loop could unblock itself: $(echo "$OUT" | tr '\n' ' ')"
+[ "$(git -C "$C2" rev-parse HEAD)" != "$B2" ] \
+  && [ "$(git -C "$C2" rev-parse HEAD)" = "$(git -C "$C2" rev-parse origin/main)" ] \
+  && ok "the checkout ACTUALLY advanced to origin/main" \
+  || bad "THE DEFECT: reported RUN without merging (HEAD still $B2)"
 echo "$OUT" | grep -q '^PAGE ' \
-  && ok "the refusal pages the founder" \
+  && bad "THE DEFECT: paged the founder about something it handled itself" \
+  || ok "no page: the condition was handled, so there is nothing to tell him"
+
+echo
+echo "== 2b. behind + a path the merge would clobber -> REFUSE and page =="
+# The half that must STILL reach him. A file git is not tracking, sitting where
+# the merge wants to write, is data only he can adjudicate. A gate that silences
+# this is a worse outage than the noise it was built to stop.
+C2B="$(fresh_clone c-collide)"
+advance_origin threeee
+( cd "$C2B" && git rm -q --cached f.txt && git commit -qm untrack ) >/dev/null 2>&1
+printf 'LOCAL WORK GIT CANNOT SEE\n' > "$C2B/f.txt"
+S2B="$WORK/s2b"; mkdir -p "$S2B"
+OUT2B="$(run_check "$C2B" "$S2B")"
+echo "$OUT2B" | grep -q 'VERDICT=REFUSE' \
+  && ok "a checkout with a clobberable path refuses to dispatch" \
+  || bad "THE DEFECT: merged over a path git is not tracking: $(echo "$OUT2B" | tr '\n' ' ')"
+echo "$OUT2B" | grep -q '^PAGE ' \
+  && ok "that refusal DOES page: it is a real founder decision" \
   || bad "refused silently: an unattended refusal nobody is told about is a dead loop"
-echo "$OUT" | grep -q 'git merge --ff-only' \
-  && ok "the page carries the fix command" \
-  || bad "the page does not say what to do"
+grep -q 'LOCAL WORK GIT CANNOT SEE' "$C2B/f.txt" \
+  && ok "the at-risk file is untouched" \
+  || bad "THE DEFECT: the at-risk file was overwritten"
 
 echo
 echo "== 3. ahead: local commits not yet pushed -> RUN (must not wedge) =="
@@ -175,7 +234,7 @@ echo "== 6. THE ASK-283 REGRESSION: one page per EPISODE, not one per commit =="
 # The measured complaint. A per-sha key sent 9 pages for one unchanged problem
 # because main kept moving. Four heartbeats across four different remote shas must
 # produce exactly ONE page.
-C6="$(fresh_clone c-episode)"
+C6="$(pageable_clone c-episode)"
 S6="$WORK/s6"; mkdir -p "$S6"
 advance_origin ep-1
 P_TOTAL=0
@@ -203,14 +262,18 @@ echo "$MUTED_OUT" | grep -q 'SAY STALE' \
 
 echo
 echo "== 7. recovery clears the page state, so the NEXT episode is heard at once =="
-C7="$(fresh_clone c-recover)"
+C7="$(pageable_clone c-recover)"
 S7="$WORK/s7"; mkdir -p "$S7"
 advance_origin rec-1
 R1="$(run_check "$C7" "$S7" | grep -c '^PAGE ' || true)"
 R2="$(run_check "$C7" "$S7" | grep -c '^PAGE ' || true)"          # unchanged -> muted
-( cd "$C7"; git merge -q --ff-only origin/main ) >/dev/null 2>&1  # a human fixes it
+( cd "$C7"; mv blocker-c-recover.txt blocker.kept; git merge -q --ff-only origin/main ) >/dev/null 2>&1  # a human fixes it
 RCLR="$(run_check "$C7" "$S7" 2>&1)"                              # healthy -> clears
-advance_origin rec-2                                              # a NEW episode
+# The NEW episode has to be a PAGEABLE one. A plain `advance_origin` now leaves the
+# clone behind-but-clean, which self-heals silently -- so this case would read 1/0/0
+# and blame page_clear for a mute that never happened.
+printf 'more local untracked work\n' > "$C7/blocker2-c-recover.txt"
+advance_origin_add blocker2-c-recover.txt                         # a NEW episode
 R3="$(run_check "$C7" "$S7" | grep -c '^PAGE ' || true)"
 if [ "${R1:-0}" -eq 1 ] && [ "${R2:-0}" -eq 0 ] && [ "${R3:-0}" -eq 1 ]; then
   ok "pages, mutes the repeat, and pages again on a new episode ($R1/$R2/$R3)"
@@ -241,7 +304,7 @@ echo
 echo "== 9. a FAILED page must not create the dedupe marker (codex round 4, major 2) =="
 # Writing the marker for a page that never went out permanently silences the founder
 # about a refusing loop. A storm is annoying; silence is invisible, and worse.
-C9="$(fresh_clone c-pagefail)"
+C9="$(pageable_clone c-pagefail)"
 S9="$WORK/s9"; mkdir -p "$S9"
 advance_origin pf-1
 F1="$( cd "$C9" && KIPI_TEST_PAGE_FAILS=1 LOG="$S9/dispatch.log" bash "$HARNESS" 2>/dev/null | grep -c '^PAGE ' || true )"

--- a/q-system/.q-system/scripts/test/test-ff-merge-if-safe.sh
+++ b/q-system/.q-system/scripts/test/test-ff-merge-if-safe.sh
@@ -1,0 +1,143 @@
+#!/bin/bash
+# Pairs with: ff-merge-if-safe.sh (ASK-294 stale-checkout handler).
+#
+# EVERY CASE RUNS AGAINST A THROWAWAY REPO BUILT IN mktemp -d. Nothing here ever
+# points at the founder's checkout: the script under test performs a real
+# `git merge` on whatever it is handed, so a suite that aimed it at the live tree
+# would BE the data-loss bug it exists to prevent.
+#
+# The two cases that carry the design are 4 and 7, and they pull in opposite
+# directions:
+#   4  an IGNORED file in the merge set must STOP the merge (the ASK-284 r1 scar:
+#      a fast-forward overwrites it silently, exit 0, no reflog).
+#   7  an ignored file OUTSIDE the merge set must NOT stop it. This checkout
+#      carries 3982 ignored files, so a guard keyed on "is the tree clean" would
+#      refuse every time and the handler would be decoration -- quiet, green, and
+#      never once doing its job.
+set -uo pipefail
+
+HERE="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+SUT="$(cd "$HERE/.." && pwd)/ff-merge-if-safe.sh"
+
+PASS=0; FAIL=0
+ok()  { PASS=$((PASS+1)); printf '  ok   %s\n' "$1"; }
+bad() { FAIL=$((FAIL+1)); printf '  FAIL %s\n     %s\n' "$1" "${2:-}"; }
+
+WORK="$(mktemp -d)"; trap 'rm -rf "$WORK"' EXIT
+G() { git -C "$1" -c user.email=t@t -c user.name=t -c commit.gpgsign=false "${@:2}"; }
+
+# origin = a bare repo; clone = the "checkout" the loop runs. Real remotes, so
+# rev-parse origin/main resolves exactly as it does in production.
+new_pair() {
+  local n="$1" up="$WORK/$1.git" wt="$WORK/$1" ignore="${2:-}"
+  git init -q --bare "$up"
+  # A bare repo's HEAD defaults to refs/heads/master, so `git clone` of it checks
+  # out nothing and every author-side commit+push fails with "src refspec main
+  # does not match any". symbolic-ref rather than --initial-branch: works on the
+  # older git macOS ships too.
+  git -C "$up" symbolic-ref HEAD refs/heads/main
+  git init -q "$wt"; G "$wt" remote add origin "$up"
+  printf 'base\n' > "$wt/base.txt"
+  # The ignore rule must live in the BASE commit for case 4. An ignore rule that
+  # exists only upstream is not in effect locally, so that case would silently
+  # degrade into the plain-untracked case 3 and prove nothing new.
+  [ -z "$ignore" ] || printf '%s\n' "$ignore" > "$wt/.gitignore"
+  G "$wt" add -A; G "$wt" commit -qm base
+  G "$wt" branch -M main; G "$wt" push -q origin main
+  # A second clone is where "origin moves ahead" is authored.
+  rm -rf "$WORK/$n-author"; git clone -q "$up" "$WORK/$n-author"
+  G "$WORK/$n-author" config user.email t@t; G "$WORK/$n-author" config user.name t
+}
+advance_origin() {  # advance_origin <name> <file> <content>
+  local n="$1" wt="$WORK/$1-author"
+  printf '%s\n' "$3" > "$wt/$2"
+  # add -f, not add -A: case 4's incoming file is covered by the base commit's
+  # .gitignore, so `add -A` skipped it, the author's commit was EMPTY, origin
+  # never moved, and the case passed as "already current" while testing nothing.
+  # A tracked file that also matches .gitignore is exactly the shape that scar is
+  # about, so the fixture has to be able to create it.
+  G "$wt" add -f "$2"; G "$wt" commit -qm "add $2"; G "$wt" push -q origin main
+  G "$WORK/$1" fetch -q origin main
+  # The fixture must have actually moved origin, or every assertion after it is
+  # measuring an unchanged repo.
+  [ "$(git -C "$WORK/$1" rev-parse HEAD)" != "$(git -C "$WORK/$1" rev-parse origin/main)" ] \
+    || bad "harness: advance_origin($1,$2) did NOT move origin/main" "the case below tests nothing"
+}
+run() { bash "$SUT" "$WORK/$1" main origin > "$WORK/$1.out" 2>&1; echo $? > "$WORK/$1.rc"; }
+rc()  { cat "$WORK/$1.rc"; }
+out() { cat "$WORK/$1.out"; }
+
+echo "== ASK-294 unattended fast-forward handler =="
+
+# 1. already current -> quiet
+new_pair c1; run c1
+[ "$(rc c1)" = 0 ] && out c1 | grep -q '^current' && ok "already current: exit 0, no page" \
+  || bad "already current" "rc=$(rc c1) out=$(out c1)"
+
+# 2. behind + clean -> merges itself, and HEAD REALLY MOVES
+new_pair c2; advance_origin c2 new.txt hello; BEFORE="$(git -C "$WORK/c2" rev-parse HEAD)"; run c2
+AFTER="$(git -C "$WORK/c2" rev-parse HEAD)"
+[ "$(rc c2)" = 0 ] && out c2 | grep -q '^merged' && ok "behind + clean: exit 0, reports merged" \
+  || bad "behind + clean merges" "rc=$(rc c2) out=$(out c2)"
+[ "$BEFORE" != "$AFTER" ] && [ "$AFTER" = "$(git -C "$WORK/c2" rev-parse origin/main)" ] \
+  && ok "the working tree ACTUALLY advanced to origin/main" \
+  || bad "tree advanced" "before=$BEFORE after=$AFTER"
+[ -f "$WORK/c2/new.txt" ] && ok "the incoming file is present on disk afterwards" \
+  || bad "incoming file present" "new.txt missing"
+
+# 3. incoming path already exists UNTRACKED -> refuse
+new_pair c3; advance_origin c3 new.txt fromorigin
+printf 'local work\n' > "$WORK/c3/new.txt"; run c3
+[ "$(rc c3)" = 1 ] && out c3 | grep -q 'collision' && ok "untracked collision: refuses" \
+  || bad "untracked collision refuses" "rc=$(rc c3) out=$(out c3)"
+grep -q 'local work' "$WORK/c3/new.txt" && ok "the untracked file is UNTOUCHED after the refusal" \
+  || bad "untracked file preserved" "content=$(cat "$WORK/c3/new.txt")"
+
+# 4. THE r1 SCAR: incoming path exists and is GITIGNORED -> must still refuse.
+#    Bare `git merge --ff-only` overwrites this case silently with exit 0.
+new_pair c4 'secret.env'; advance_origin c4 secret.env "FROM_ORIGIN"
+printf 'MY_REAL_LOCAL_SECRET\n' > "$WORK/c4/secret.env"
+# Prove the fixture is what it claims BEFORE asserting on it. If secret.env were
+# merely untracked rather than ignored this case would duplicate case 3 and the
+# r1 scar would go untested while the suite stayed green.
+git -C "$WORK/c4" status --porcelain | grep -q 'secret\.env' \
+  && bad "harness: secret.env is NOT actually ignored" "status shows it as untracked"
+run c4
+[ "$(rc c4)" = 1 ] && out c4 | grep -q 'collision' && ok "IGNORED collision: refuses (the r1 scar)" \
+  || bad "ignored collision refuses" "rc=$(rc c4) out=$(out c4)"
+grep -q 'MY_REAL_LOCAL_SECRET' "$WORK/c4/secret.env" 2>/dev/null \
+  && ok "the ignored file is UNTOUCHED (bare --ff-only would have eaten it)" \
+  || bad "ignored file preserved" "content=$(cat "$WORK/c4/secret.env" 2>/dev/null)"
+
+# 5. incoming path is TRACKED but locally modified -> refuse
+new_pair c5; advance_origin c5 base.txt changed-upstream
+printf 'changed-locally\n' > "$WORK/c5/base.txt"; run c5
+[ "$(rc c5)" = 1 ] && out c5 | grep -q 'collision' && ok "locally-modified tracked path: refuses" \
+  || bad "locally-modified refuses" "rc=$(rc c5) out=$(out c5)"
+
+# 6. diverged -> refuse, and say diverged (this is the founder-decision branch)
+new_pair c6; advance_origin c6 up.txt upstream
+printf 'mine\n' > "$WORK/c6/mine.txt"; G "$WORK/c6" add -A; G "$WORK/c6" commit -qm local; run c6
+[ "$(rc c6)" = 1 ] && out c6 | grep -q '^diverged' && ok "diverged: refuses and names it diverged" \
+  || bad "diverged refuses" "rc=$(rc c6) out=$(out c6)"
+
+# 7. THE OVER-REFUSAL GUARD: ignored junk OUTSIDE the merge set must not block.
+#    Without this case a "tree is clean" check would pass every other test here
+#    and still never merge once in production.
+new_pair c7; advance_origin c7 new.txt hello
+mkdir -p "$WORK/c7/.prXXrev"; printf 'scratch\n' > "$WORK/c7/.prXXrev/junk"
+printf 'untracked-elsewhere\n' > "$WORK/c7/unrelated.txt"; run c7
+[ "$(rc c7)" = 0 ] && out c7 | grep -q '^merged' \
+  && ok "untracked files OUTSIDE the merge set do NOT block the merge" \
+  || bad "does not over-refuse" "rc=$(rc c7) out=$(out c7)"
+[ -f "$WORK/c7/unrelated.txt" ] && ok "those untracked files survive the merge" \
+  || bad "unrelated untracked survives" "gone"
+
+# 8. not a repo -> fail OPEN (2), never refuse on ignorance
+mkdir -p "$WORK/c8"; run c8
+[ "$(rc c8)" = 2 ] && ok "not a git repo: exit 2 (no answer, fail open)" \
+  || bad "no-answer exit 2" "rc=$(rc c8) out=$(out c8)"
+
+echo
+printf 'passed %d, failed %d\n' "$PASS" "$FAIL"
+[ "$FAIL" -eq 0 ]

--- a/q-system/.q-system/scripts/test/test-notify-decision-gate.sh
+++ b/q-system/.q-system/scripts/test/test-notify-decision-gate.sh
@@ -98,6 +98,31 @@ else bad "receipt IS recorded to the machine ledger" "receipts.jsonl empty/missi
 [ "$(cat "$D/rc")" = "0" ] && ok "receipt exits 0 (a receipt is not a failure)" \
   || bad "receipt exits 0" "rc=$(cat "$D/rc")"
 
+# --- 1b. THE MESSAGE MUST STAY IN $1 -----------------------------------------
+# Not a style preference; it is a fleet compatibility contract. Notify stubs
+# across this repo record "$1" (test-dispatch-liveness, test-severity-floor,
+# test-linear-dor-failure-reporting all do), and so do stubs in repos not
+# checked out here. The first cut of this gate took `--kind receipt "$msg"`,
+# which moved the message out of $1 and turned three untouched suites red at
+# once. The parser accepts flags in ANY position so that call sites can keep the
+# message first; this case is what stops someone "tidying" that back into a
+# flags-only-first parser and breaking every such stub silently.
+D="$WORK/c1b"; run_notify "$D" "message first, flags after" --kind receipt
+if delivered "$D"; then bad "message-first receipt is NOT delivered" "curl was called"
+else ok "message-first receipt parses (not delivered)"; fi
+[ "$(field "$D" message)" = "[testinst] message first, flags after" ] \
+  && ok "message-first: the MESSAGE is recorded, not the flag" \
+  || bad "message-first records the message" "got '$(field "$D" message)'"
+
+D="$WORK/c1c"; run_notify "$D" --kind receipt "flags first, message after"
+[ "$(field "$D" message)" = "[testinst] flags first, message after" ] \
+  && ok "flags-first still parses identically (both orders supported)" \
+  || bad "flags-first records the message" "got '$(field "$D" message)'"
+
+D="$WORK/c1d"; run_notify "$D" "a decision, message first" --kind decision --class spend
+delivered "$D" && ok "message-first decision+class IS delivered" \
+  || bad "message-first decision delivered" "curl never called; err=$(cat "$D/err")"
+
 # --- 2. an allowlisted founder decision DOES get through ---------------------
 # This is the half that matters most. A gate that silences a real alert is a
 # worse outage than the noise it was built to stop, so this case is asserted

--- a/q-system/.q-system/scripts/test/test-notify-decision-gate.sh
+++ b/q-system/.q-system/scripts/test/test-notify-decision-gate.sh
@@ -123,6 +123,59 @@ D="$WORK/c1d"; run_notify "$D" "a decision, message first" --kind decision --cla
 delivered "$D" && ok "message-first decision+class IS delivered" \
   || bad "message-first decision delivered" "curl never called; err=$(cat "$D/err")"
 
+# --- 1e. THE ENV PREFIX: classification invisible to argv --------------------
+# This is how every shell producer classifies, and the reason is compatibility,
+# not taste. Notify stubs across these suites record either "$1" or "$*", and a
+# flag in argv breaks one or the other whichever end it sits on: flags first take
+# the message out of $1 (three suites went red at once), flags last append
+# " --kind receipt" to "$*" so an assertion on the page PROSE reads it
+# (test-severity-floor caught exactly that). A command-prefix env var is invisible
+# to both. These cases exist so nobody "simplifies" it back into argv.
+run_env() {
+  local dir="$1" kind="$2" klass="$3" msg="$4"
+  rm -rf "$dir"; mkdir -p "$dir"
+  env -u KIPI_LINEAR_API_URL PATH="$WORK/bin:$PATH" \
+      KIPI_TEST_CURL_LOG="$dir/curl.log" \
+      KIPI_SLACK_WEBHOOK="https://hooks.example.invalid/T/B/X" \
+      KIPI_NOTIFY_RECEIPTS="$dir/receipts.jsonl" \
+      KIPI_INSTANCE_NAME="testinst" \
+      KIPI_NOTIFY_KIND="$kind" KIPI_NOTIFY_CLASS="$klass" \
+      bash "$NOTIFY" "$msg" >"$dir/out" 2>"$dir/err"   # notify-kind-skip: env carries it
+  echo $? > "$dir/rc"
+  assert_ran "$dir"
+}
+D="$WORK/e1"; run_env "$D" receipt "" "converge ASK-1: stopped, no PR after round 4"
+delivered "$D" && bad "env receipt is NOT delivered" "curl was called" \
+  || ok "env-classified receipt is NOT delivered"
+[ "$(field "$D" kind)" = "receipt" ] && ok "env receipt is recorded as a receipt" \
+  || bad "env receipt recorded" "got '$(field "$D" kind)'"
+[ "$(field "$D" message)" = "[testinst] converge ASK-1: stopped, no PR after round 4" ] \
+  && ok "the recorded message carries NO flag text (the whole point)" \
+  || bad "message free of flags" "got '$(field "$D" message)'"
+
+D="$WORK/e2"; run_env "$D" decision credential "Linear auth expired, no issue can be picked"
+delivered "$D" && ok "env decision + allowlisted class IS delivered" \
+  || bad "env decision delivered" "curl never called; err=$(cat "$D/err")"
+grep -q -- '--kind' "$D/curl.log" 2>/dev/null \
+  && bad "the delivered payload leaks flag text" "payload=$(cat "$D/curl.log")" \
+  || ok "the delivered payload is the message alone, no flag text"
+
+D="$WORK/e3"; run_env "$D" decision made-up-class "should not reach a human"
+delivered "$D" && bad "env unknown class is REFUSED" "curl was called" \
+  || ok "env unknown class is REFUSED (the enum still binds)"
+
+# argv wins over the env, so dispatch's page_ok() pass-through keeps working
+# even if something upstream exported a kind.
+D="$WORK/e4"; rm -rf "$D"; mkdir -p "$D"
+env -u KIPI_LINEAR_API_URL PATH="$WORK/bin:$PATH" \
+    KIPI_TEST_CURL_LOG="$D/curl.log" KIPI_SLACK_WEBHOOK="https://hooks.example.invalid/T/B/X" \
+    KIPI_NOTIFY_RECEIPTS="$D/receipts.jsonl" KIPI_INSTANCE_NAME="testinst" \
+    KIPI_NOTIFY_KIND=receipt \
+    bash "$NOTIFY" "a real founder decision" --kind decision --class spend \
+    >"$D/out" 2>"$D/err"; echo $? > "$D/rc"
+delivered "$D" && ok "argv classification OVERRIDES the env" \
+  || bad "argv overrides env" "curl never called; err=$(cat "$D/err")"
+
 # --- 2. an allowlisted founder decision DOES get through ---------------------
 # This is the half that matters most. A gate that silences a real alert is a
 # worse outage than the noise it was built to stop, so this case is asserted

--- a/q-system/.q-system/scripts/test/test-notify-decision-gate.sh
+++ b/q-system/.q-system/scripts/test/test-notify-decision-gate.sh
@@ -240,7 +240,7 @@ delivered "$D" && bad "fixture guard outranks the decision gate" "curl was calle
 if [ ! -f "$AUDIT" ]; then
   bad "notify-callsite-audit.py exists" "missing at $AUDIT"
 else
-  if python3 "$AUDIT" --repo "$REPO" >"$WORK/audit.out" 2>&1; then
+  if python3 "$AUDIT" --repo "$REPO" >"$WORK/audit.out" 2>&1; then  # fable-discipline-lint-skip: the audit only READS files; it never execs the notifier
     ok "every notifier call site in this repo declares a --kind"
   else
     bad "every notifier call site declares a --kind" "$(head -20 "$WORK/audit.out")"
@@ -265,12 +265,72 @@ else
   grep -q 'notify-kind-skip' "$PLANT/q-system/.q-system/scripts/rogue-producer.sh" \
     && bad "harness: the planted rogue is pre-exempted" "it carries a skip marker"
   ( cd "$PLANT" && git init -q . && git add -A && git -c user.email=t@t -c user.name=t commit -qm t ) >/dev/null 2>&1
-  if python3 "$AUDIT" --repo "$PLANT" >"$WORK/plant.out" 2>&1; then
+  if python3 "$AUDIT" --repo "$PLANT" >"$WORK/plant.out" 2>&1; then  # fable-discipline-lint-skip: the audit only READS files; it never execs the notifier
     bad "audit CATCHES a bare call site (negative self-test)" "planted rogue producer passed"
   else
     grep -q 'rogue-producer.sh' "$WORK/plant.out" \
       && ok "audit CATCHES a bare call site and names the file" \
       || bad "audit names the offending file" "$(head -10 "$WORK/plant.out")"
+  fi
+
+  # --- 6b. THE SHAPES IT MISSED (PR #72 review, minor) ------------------------
+  # One planted rogue proved the gate can fire; it did not prove the gate covers
+  # the forms a real producer takes. The reviewer planted four and the gate
+  # caught ONE. Every miss below would page the founder:
+  #   * `"$NOTIFY" "msg"` -- slack-notify.sh is mode 755, so a direct exec is
+  #     the NATURAL form, not an exotic one.
+  #   * `sh "$NOTIFY" "msg"` -- any interpreter, not just bash.
+  #   * a bare call whose 4-line window contains --kind in a COMMENT. The window
+  #     exists for the Python producers that build argv across lines; a comment
+  #     satisfying it means a rogue call can be exempted by prose next to it.
+  # This is a hole for FUTURE producers, which is the gate's entire stated
+  # purpose, so it is asserted shape by shape rather than in aggregate.
+  SHAPES="$WORK/shapes"; rm -rf "$SHAPES"; mkdir -p "$SHAPES/q-system/.q-system/scripts"
+  cp "$AUDIT" "$SHAPES/q-system/.q-system/scripts/" 2>/dev/null || true
+  # The REAL sink goes into the plant too. Case 6c asserts the fix text against
+  # ALLOWED_CLASSES, and the audit reads that list out of slack-notify.sh -- a
+  # plant without it exercises the "cannot read the enum" fallback instead of the
+  # thing under test, and 6c would fail for a reason 6c is not about.
+  cp "$NOTIFY" "$SHAPES/q-system/.q-system/scripts/" 2>/dev/null || true
+  # Assembled from a placeholder for the same reason as the plant above: a
+  # heredoc would put these literal call shapes in THIS file and the repo-wide
+  # audit at the top of section 6 would flag them.
+  {
+    echo '#!/bin/bash'
+    echo 'NOTIFY="$SCRIPT_DIR/slack-notify.sh"'
+    printf 'bash "$%s" "shape 1: bash-prefixed, bare"\n' NOTIFY
+    printf '"$%s" "shape 2: direct exec, the script is mode 755"\n' NOTIFY
+    printf 'sh "$%s" "shape 3: a different interpreter"\n' NOTIFY
+    printf 'bash "$%s" "shape 4: bare, but a comment below mentions the flag"\n' NOTIFY
+    echo '# TODO(ASK-999): decide whether this should be --kind receipt or a decision.'
+  } > "$SHAPES/q-system/.q-system/scripts/shapes-producer.sh"
+  ( cd "$SHAPES" && git init -q . && git add -A && git -c user.email=t@t -c user.name=t commit -qm t ) >/dev/null 2>&1
+  python3 "$AUDIT" --repo "$SHAPES" >"$WORK/shapes.out" 2>&1  # fable-discipline-lint-skip: the audit only READS files; it never execs the notifier
+  CAUGHT="$(grep -c 'shapes-producer.sh:' "$WORK/shapes.out" 2>/dev/null || echo 0)"
+  for n in 1 2 3 4; do
+    if grep -q "shape $n:" "$WORK/shapes.out"; then
+      ok "audit catches shape $n"
+    else
+      bad "audit catches shape $n" "$CAUGHT of 4 caught; output: $(head -20 "$WORK/shapes.out")"
+    fi
+  done
+
+  # --- 6c. the gate's fix text cannot drift from the runtime allowlist --------
+  # PR #72 review, minor: the fix text listed four classes while ALLOWED_CLASSES
+  # permits five, and kipi-dispatch.sh already uses the fifth (`credential`). An
+  # author following the gate's own instruction could not discover a class the
+  # codebase relies on. Asserted against slack-notify.sh rather than against a
+  # copy of the list, so the two cannot drift apart again silently.
+  RUNTIME_CLASSES="$(sed -n 's/^ALLOWED_CLASSES="\(.*\)"$/\1/p' "$NOTIFY")"
+  [ -n "$RUNTIME_CLASSES" ] || bad "harness: could not read ALLOWED_CLASSES from slack-notify.sh"
+  MISSING=""
+  for c in $RUNTIME_CLASSES; do
+    grep -q -- "$c" "$WORK/shapes.out" || MISSING="$MISSING $c"
+  done
+  if [ -z "$MISSING" ]; then
+    ok "the audit's fix text names every class the runtime actually allows"
+  else
+    bad "the audit's fix text names every allowed class" "absent from the fix text:$MISSING"
   fi
 fi
 

--- a/q-system/.q-system/scripts/test/test-notify-decision-gate.sh
+++ b/q-system/.q-system/scripts/test/test-notify-decision-gate.sh
@@ -1,0 +1,191 @@
+#!/bin/bash
+# Pairs with: slack-notify.sh (the founder-notification chokepoint) and
+# notify-callsite-audit.py (the static half).
+#
+# ASK-294. The founder, twice in one session: "why do I keep getting slack
+# messages I can't do anything about", then "I don't want to get slack messages
+# that are useless to me. they should go to you or sana."
+#
+# MEASURED BEFORE THE CHANGE: 48 messages reached #general in 24h from 11
+# producers, and ZERO consumers read the channel back. Every one terminated at
+# the founder by construction.
+#
+# The contract this suite holds: a message reaches the founder's phone ONLY when
+# it names a founder DECISION from a closed allowlist. Everything else is a
+# receipt -- recorded to a machine-readable ledger an agent reads, never
+# delivered. A closed enum is the point: a producer cannot reword its way into
+# the founder's phone, it has to edit the allowlist in a reviewed diff.
+set -uo pipefail
+
+HERE="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+SCRIPTS="$(cd "$HERE/.." && pwd)"
+REPO="$(cd "$SCRIPTS/../../.." && pwd)"
+# BASH_SOURCE-derived, never $PWD: this suite must test the copy it ships beside,
+# not whatever checkout happened to be current when someone ran it.
+NOTIFY="$SCRIPTS/slack-notify.sh"
+AUDIT="$SCRIPTS/notify-callsite-audit.py"
+
+PASS=0; FAIL=0
+ok()   { PASS=$((PASS+1)); printf '  ok   %s\n' "$1"; }
+bad()  { FAIL=$((FAIL+1)); printf '  FAIL %s\n     %s\n' "$1" "${2:-}"; }
+
+WORK="$(mktemp -d)"
+trap 'rm -rf "$WORK"' EXIT
+
+# Stub curl by prepending to PATH -- the shipped script takes no "where to post"
+# knob, and adding one would be a documented way to aim a real page at /dev/null.
+# Same posture kipi-dispatch.sh takes with its preflight path.
+mkdir -p "$WORK/bin"
+cat > "$WORK/bin/curl" <<'STUB'
+#!/bin/bash
+# Record the delivery attempt and its payload; never touch the network.
+out="$KIPI_TEST_CURL_LOG"
+prev=""
+for a in "$@"; do
+  if [ "$prev" = "--data" ]; then printf '%s\n' "$a" >> "$out"; fi
+  prev="$a"
+done
+exit 0
+STUB
+chmod +x "$WORK/bin/curl"
+
+# One invocation shape for every case, so a case can never accidentally test a
+# different caller than the others.
+run_notify() {
+  local dir="$1"; shift
+  rm -rf "$dir"; mkdir -p "$dir"
+  # `-u` BEFORE the assignments: BSD env (macOS) parses options only until the
+  # first operand, so `KEY=v -u NAME` reads -u as a utility name and dies 127.
+  # That cost three FALSE PASSES on the first run of this suite -- "curl was
+  # never called" is true when the script never ran at all, so every
+  # not-delivered assertion passed for the wrong reason. Hence assert_ran below.
+  env -u KIPI_LINEAR_API_URL \
+      PATH="$WORK/bin:$PATH" \
+      KIPI_TEST_CURL_LOG="$dir/curl.log" \
+      KIPI_SLACK_WEBHOOK="https://hooks.example.invalid/T/B/X" \
+      KIPI_NOTIFY_RECEIPTS="$dir/receipts.jsonl" \
+      KIPI_INSTANCE_NAME="testinst" \
+      bash "$NOTIFY" "$@" >"$dir/out" 2>"$dir/err"
+  echo $? > "$dir/rc"
+  assert_ran "$dir"
+}
+# A not-delivered assertion is only meaningful if the sink actually executed.
+assert_ran() {
+  local rc; rc="$(cat "$1/rc")"
+  if [ "$rc" = "127" ] || grep -q '^env: \|No such file or directory' "$1/err" 2>/dev/null; then
+    bad "harness: sink actually ran" "rc=$rc err=$(head -2 "$1/err")"
+  fi
+}
+delivered() { [ -s "$1/curl.log" ]; }
+recorded()  { [ -s "$1/receipts.jsonl" ]; }
+field() { python3 -c "
+import json,sys
+rows=[json.loads(l) for l in open(sys.argv[1]) if l.strip()]
+print(rows[-1].get(sys.argv[2]))" "$1/receipts.jsonl" "$2" 2>/dev/null; }
+
+echo "== ASK-294 founder-notification decision gate =="
+
+# --- 1. a receipt never reaches the phone, but is never lost either -----------
+D="$WORK/c1"; run_notify "$D" --kind receipt "converge ASK-289: stopped, no PR after round 4"
+if delivered "$D"; then bad "receipt is NOT delivered" "curl was called: $(cat "$D/curl.log")"
+else ok "receipt is NOT delivered"; fi
+if recorded "$D"; then ok "receipt IS recorded to the machine ledger"
+else bad "receipt IS recorded to the machine ledger" "receipts.jsonl empty/missing"; fi
+[ "$(field "$D" kind)" = "receipt" ] && ok "receipt row carries kind=receipt" \
+  || bad "receipt row carries kind=receipt" "got '$(field "$D" kind)'"
+[ "$(field "$D" delivered)" = "False" ] && ok "receipt row records delivered=false" \
+  || bad "receipt row records delivered=false" "got '$(field "$D" delivered)'"
+[ "$(cat "$D/rc")" = "0" ] && ok "receipt exits 0 (a receipt is not a failure)" \
+  || bad "receipt exits 0" "rc=$(cat "$D/rc")"
+
+# --- 2. an allowlisted founder decision DOES get through ---------------------
+# This is the half that matters most. A gate that silences a real alert is a
+# worse outage than the noise it was built to stop, so this case is asserted
+# against the delivery recorder itself, not against "no error was printed".
+D="$WORK/c2"; run_notify "$D" --kind decision --class irreversible-git \
+  "kipi dispatch: paused -- this checkout is behind origin/main. Do: git merge --ff-only origin/main"
+if delivered "$D"; then ok "decision + allowlisted class IS delivered"
+else bad "decision + allowlisted class IS delivered" "curl never called; err=$(cat "$D/err")"; fi
+[ "$(field "$D" delivered)" = "True" ] && ok "decision row records delivered=true" \
+  || bad "decision row records delivered=true" "got '$(field "$D" delivered)'"
+
+D="$WORK/c2b"; run_notify "$D" --kind decision --class out-of-tree-write \
+  "wrote 3 files outside the canonical tree, needs sign-off"
+delivered "$D" && ok "second allowlisted class (out-of-tree-write) IS delivered" \
+  || bad "second allowlisted class delivered" "curl never called"
+
+# --- 3. the closed enum is what stops rewording -------------------------------
+D="$WORK/c3"; run_notify "$D" --kind decision --class needs-a-human \
+  "worker: ASK-1 is STUCK. Needs a human."
+if delivered "$D"; then bad "unknown decision class is REFUSED" "curl was called"
+else ok "unknown decision class is REFUSED"; fi
+[ "$(cat "$D/rc")" = "2" ] && ok "refusal exits 2" || bad "refusal exits 2" "rc=$(cat "$D/rc")"
+grep -qi 'refus' "$D/err" && ok "refusal is loud on stderr" \
+  || bad "refusal is loud on stderr" "err=$(cat "$D/err")"
+[ "$(field "$D" refused)" = "True" ] && ok "refused row is still recorded (nothing is lost)" \
+  || bad "refused row is still recorded" "got '$(field "$D" refused)'"
+
+D="$WORK/c4"; run_notify "$D" --kind decision "no class at all"
+delivered "$D" && bad "decision with NO class is REFUSED" "curl was called" \
+  || ok "decision with NO class is REFUSED"
+
+D="$WORK/c5"; run_notify "$D" --kind chatter "a fourth kind someone invented"
+delivered "$D" && bad "unknown kind is REFUSED" "curl was called" || ok "unknown kind is REFUSED"
+
+# --- 4. legacy one-arg callers FAIL OPEN, loudly ------------------------------
+# Fleet instances carry producers this repo does not, and kipi update ships this
+# script to them. Refusing an unclassified message would silence an instance-local
+# alert nobody has migrated yet -- the exact "gate that silences a real alert"
+# failure. So it is delivered, marked, and recorded for the migration to find.
+D="$WORK/c6"; run_notify "$D" "a producer that has not been migrated yet"
+delivered "$D" && ok "unclassified legacy call still DELIVERS (fail-open)" \
+  || bad "unclassified legacy call still delivers" "curl never called"
+grep -q 'unclassified' "$D/curl.log" && ok "unclassified delivery is MARKED in the text" \
+  || bad "unclassified delivery is marked" "payload=$(cat "$D/curl.log")"
+[ "$(field "$D" kind)" = "unclassified" ] && ok "unclassified row is recorded as such" \
+  || bad "unclassified row recorded" "got '$(field "$D" kind)'"
+
+# --- 5. the fixture guard still outranks everything ---------------------------
+# A decision-class page from a fixture run must STILL not reach a human. The
+# 2026-08-01 scar (three tests paging the founder live) outranks this issue.
+D="$WORK/c7"; rm -rf "$D"; mkdir -p "$D"
+env PATH="$WORK/bin:$PATH" KIPI_TEST_CURL_LOG="$D/curl.log" \
+    KIPI_SLACK_WEBHOOK="https://hooks.example.invalid/T/B/X" \
+    KIPI_NOTIFY_RECEIPTS="$D/receipts.jsonl" \
+    KIPI_LINEAR_API_URL="http://127.0.0.1:8123/graphql" \
+    bash "$NOTIFY" --kind decision --class irreversible-git "fixture must never page" \
+    >"$D/out" 2>"$D/err"
+delivered "$D" && bad "fixture guard outranks the decision gate" "curl was called" \
+  || ok "fixture guard outranks the decision gate"
+
+# --- 6. the static half: no producer may call the sink without a kind ---------
+if [ ! -f "$AUDIT" ]; then
+  bad "notify-callsite-audit.py exists" "missing at $AUDIT"
+else
+  if python3 "$AUDIT" --repo "$REPO" >"$WORK/audit.out" 2>&1; then
+    ok "every notifier call site in this repo declares a --kind"
+  else
+    bad "every notifier call site declares a --kind" "$(head -20 "$WORK/audit.out")"
+  fi
+  # NEGATIVE SELF-TEST. A checker that cannot fail is not a checker. Plant a
+  # producer that calls the sink bare and prove the audit catches it.
+  PLANT="$WORK/plant"; rm -rf "$PLANT"; mkdir -p "$PLANT/q-system/.q-system/scripts"
+  cp "$AUDIT" "$PLANT/q-system/.q-system/scripts/" 2>/dev/null || true
+  cat > "$PLANT/q-system/.q-system/scripts/rogue-producer.sh" <<'ROGUE'
+#!/bin/bash
+NOTIFY="$SCRIPT_DIR/slack-notify.sh"
+bash "$NOTIFY" "a bare page with no kind at all"
+ROGUE
+  ( cd "$PLANT" && git init -q . && git add -A && git -c user.email=t@t -c user.name=t commit -qm t ) >/dev/null 2>&1
+  if python3 "$AUDIT" --repo "$PLANT" >"$WORK/plant.out" 2>&1; then
+    bad "audit CATCHES a bare call site (negative self-test)" "planted rogue producer passed"
+  else
+    grep -q 'rogue-producer.sh' "$WORK/plant.out" \
+      && ok "audit CATCHES a bare call site and names the file" \
+      || bad "audit names the offending file" "$(head -10 "$WORK/plant.out")"
+  fi
+fi
+
+echo
+printf 'passed %d, failed %d\n' "$PASS" "$FAIL"
+[ "$FAIL" -eq 0 ]

--- a/q-system/.q-system/scripts/test/test-notify-decision-gate.sh
+++ b/q-system/.q-system/scripts/test/test-notify-decision-gate.sh
@@ -65,7 +65,7 @@ run_notify() {
       KIPI_SLACK_WEBHOOK="https://hooks.example.invalid/T/B/X" \
       KIPI_NOTIFY_RECEIPTS="$dir/receipts.jsonl" \
       KIPI_INSTANCE_NAME="testinst" \
-      bash "$NOTIFY" "$@" >"$dir/out" 2>"$dir/err"
+      bash "$NOTIFY" "$@" >"$dir/out" 2>"$dir/err"   # notify-kind-skip: kind comes from each case
   echo $? > "$dir/rc"
   assert_ran "$dir"
 }
@@ -171,11 +171,21 @@ else
   # producer that calls the sink bare and prove the audit catches it.
   PLANT="$WORK/plant"; rm -rf "$PLANT"; mkdir -p "$PLANT/q-system/.q-system/scripts"
   cp "$AUDIT" "$PLANT/q-system/.q-system/scripts/" 2>/dev/null || true
-  cat > "$PLANT/q-system/.q-system/scripts/rogue-producer.sh" <<'ROGUE'
-#!/bin/bash
-NOTIFY="$SCRIPT_DIR/slack-notify.sh"
-bash "$NOTIFY" "a bare page with no kind at all"
-ROGUE
+  # ASSEMBLED, NOT HEREDOC'd. A heredoc puts the literal `bash "$NOTIFY" ...` in
+  # THIS file, where the audit flags it -- and the obvious fix, adding a
+  # notify-kind-skip marker to that line, silently lands the marker INSIDE the
+  # generated fixture. That is exactly what happened: the planted rogue arrived
+  # pre-exempted, the audit correctly ignored it, and the negative self-test
+  # reported the guard as broken when the guard was fine. Building the call from a
+  # placeholder keeps this source clean and the generated file genuinely bare.
+  {
+    echo '#!/bin/bash'
+    echo 'NOTIFY="$SCRIPT_DIR/slack-notify.sh"'
+    printf 'bash "$%s" "a bare page with no kind at all"\n' NOTIFY
+  } > "$PLANT/q-system/.q-system/scripts/rogue-producer.sh"
+  # The planted fixture must actually be bare, or the assertion below proves nothing.
+  grep -q 'notify-kind-skip' "$PLANT/q-system/.q-system/scripts/rogue-producer.sh" \
+    && bad "harness: the planted rogue is pre-exempted" "it carries a skip marker"
   ( cd "$PLANT" && git init -q . && git add -A && git -c user.email=t@t -c user.name=t commit -qm t ) >/dev/null 2>&1
   if python3 "$AUDIT" --repo "$PLANT" >"$WORK/plant.out" 2>&1; then
     bad "audit CATCHES a bare call site (negative self-test)" "planted rogue producer passed"

--- a/q-system/.q-system/scripts/test/test-notify-fixture-guard.sh
+++ b/q-system/.q-system/scripts/test/test-notify-fixture-guard.sh
@@ -97,9 +97,9 @@ fi
 send() {
   : > "$CAPTURE_FILE"
   if [ -n "${1:-}" ]; then
-    env "$1" bash "$NOTIFY" "guard suite probe" 2> "$WORK/err"
+    env "$1" bash "$NOTIFY" "guard suite probe" 2> "$WORK/err"  # notify-kind-skip: fixture-guard suite
   else
-    env -u KIPI_LINEAR_API_URL bash "$NOTIFY" "guard suite probe" 2> "$WORK/err"
+    env -u KIPI_LINEAR_API_URL bash "$NOTIFY" "guard suite probe" 2> "$WORK/err"  # notify-kind-skip: fixture-guard suite
   fi
   sleep 0.3
   printf '%s|%s' "$(wc -l < "$CAPTURE_FILE" | tr -d ' ')" "$(cat "$WORK/err")"

--- a/q-system/.q-system/scripts/test/test-notify-receipts-surface.sh
+++ b/q-system/.q-system/scripts/test/test-notify-receipts-surface.sh
@@ -1,0 +1,189 @@
+#!/bin/bash
+# Pairs with: notify-receipts-surface.py (the reader half of the notify sink).
+#
+# THE DEFECT THIS SUITE EXISTS FOR (PR #72 review, major). slack-notify.sh wrote
+# every outcome to notify-receipts.jsonl and its own comment claimed
+# "notify-receipts-surface.py reads it at SessionStart". That file did not exist
+# and nothing in the repo opened the ledger. Three dispatch pages that mean the
+# Linear loop is DEAD -- repo-missing, gh-missing, budget-day -- had been
+# converted to `--kind receipt`, so they reached no human AND no machine, and
+# page_once still wrote its dedupe marker because the sink exits 0.
+#
+# "Recorded, not delivered" is only defensible if something reads the record.
+# This suite holds the reading end: the surfacer must PRINT an undelivered row,
+# must not re-print it on the next session, and must never block a session.
+set -uo pipefail
+
+HERE="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+SCRIPTS="$(cd "$HERE/.." && pwd)"
+# BASH_SOURCE-derived, never $PWD: this suite tests the copy it ships beside.
+SURFACE="$SCRIPTS/notify-receipts-surface.py"
+NOTIFY="$SCRIPTS/slack-notify.sh"
+
+PASS=0; FAIL=0
+ok()  { PASS=$((PASS+1)); printf '  ok   %s\n' "$1"; }
+bad() { FAIL=$((FAIL+1)); printf '  FAIL %s\n     %s\n' "$1" "${2:-}"; }
+
+WORK="$(mktemp -d)"
+trap 'rm -rf "$WORK"' EXIT
+
+# THE DEFECT, ASSERTED AS CASE ZERO. Before this PR the surfacer did not exist and
+# every case below "passed" by never running -- the same class of false pass that
+# cost this branch three cases already (rc=127 read as success). A missing engine
+# is the finding, so it fails loudly here instead of silently skipping.
+if [ ! -f "$SURFACE" ]; then
+  echo "  FAIL THE DEFECT: the ledger has no reader -- $SURFACE does not exist"
+  echo "-------- 0 passed, 1 failed --------"
+  exit 1
+fi
+
+LEDGER="$WORK/notify-receipts.jsonl"
+CURSOR="$LEDGER.cursor"
+surface() { python3 "$SURFACE" --ledger "$LEDGER" 2>&1; }
+
+# WHY THIS SUITE RUNS THE REAL NOTIFIER, AND WHY THAT IS STILL SAFE.
+# fable-discipline-lint flags an unstubbed slack-notify.sh in a test, and it is
+# right to: an unstubbed pager in a test is how the founder got paged live on
+# 2026-08-01. Its suggested fix (KIPI_NOTIFY=/usr/bin/true) cannot apply here --
+# the thing under test IS the row slack-notify.sh writes. A row I hand-author
+# tests my assumption about the schema, not the schema (feedback_fixtures_from_
+# producers: two green-but-wrong tests in one day came from exactly that).
+#
+# So the leak is closed structurally instead, three ways at once, and every one
+# of them alone is sufficient:
+#   1. curl is stubbed on PATH for the WHOLE suite, first line below. The
+#      network is unreachable from here no matter what any case does.
+#   2. KIPI_SLACK_WEBHOOK is unset per invocation.
+#   3. HOME is redirected into $WORK, so ~/.config/kipi/slack-webhook resolves
+#      to a file that does not exist.
+# KIPI_LINEAR_API_URL is deliberately NOT set to loopback: the fixture guard
+# exits before the ledger write, which would leave every case asserting against
+# an empty file and passing for the wrong reason.
+mkdir -p "$WORK/bin" "$WORK/home/.config/kipi"
+cat > "$WORK/bin/curl" <<'STUB'
+#!/bin/bash
+# Never touch the network. Exit code is driven by the case via KIPI_TEST_CURL_RC.
+exit "${KIPI_TEST_CURL_RC:-0}"
+STUB
+chmod +x "$WORK/bin/curl"
+export PATH="$WORK/bin:$PATH"
+
+write_row() {
+  env -u KIPI_SLACK_WEBHOOK -u KIPI_LINEAR_API_URL \
+      KIPI_NOTIFY_RECEIPTS="$LEDGER" HOME="$WORK/home" \
+      bash "$NOTIFY" "$1" "${@:2}" >/dev/null 2>&1  # notify-kind-skip: every caller passes its own --kind  # fable-discipline-lint-skip: curl stubbed on PATH above
+}
+
+echo "== 1. an undelivered receipt is SURFACED =="
+write_row "kipi dispatch: repo not found at /x -- the Linear loop is DEAD." --kind receipt
+OUT="$(surface)"
+case "$OUT" in
+  *"the Linear loop is DEAD"*) ok "the receipt reaches the agent" ;;
+  *) bad "the receipt reaches the agent" "got: $OUT" ;;
+esac
+
+echo "== 2. the same row is NOT surfaced twice =="
+OUT2="$(surface)"
+case "$OUT2" in
+  *"Linear loop is DEAD"*) bad "already-surfaced rows stay quiet" "re-printed: $OUT2" ;;
+  *) ok "already-surfaced rows stay quiet" ;;
+esac
+
+echo "== 3. a NEW row after the cursor is surfaced =="
+write_row "kipi dispatch: gh CLI is not on PATH -- the loop is stalled." --kind receipt
+OUT3="$(surface)"
+case "$OUT3" in
+  *"gh CLI is not on PATH"*) ok "the next receipt is picked up" ;;
+  *) bad "the next receipt is picked up" "got: $OUT3" ;;
+esac
+
+echo "== 4. a REFUSED row is surfaced (a swallowed alert is the worst outcome) =="
+write_row "producer used a class nobody allowlisted" --kind decision --class not-a-class
+OUT4="$(surface)"
+case "$OUT4" in
+  *"nobody allowlisted"*) ok "refusals reach the agent" ;;
+  *) bad "refusals reach the agent" "got: $OUT4" ;;
+esac
+
+echo "== 5. a DELIVERED row is not repeated to the agent =="
+# Delivery needs a webhook AND a curl that succeeds. The webhook is a .invalid
+# host and curl is the PATH stub from the top of the file, so "delivered" here
+# means "slack-notify.sh believed it delivered", which is the state under test.
+env -u KIPI_LINEAR_API_URL KIPI_TEST_CURL_RC=0 \
+    KIPI_SLACK_WEBHOOK="https://hooks.example.invalid/not-real" \
+    KIPI_NOTIFY_RECEIPTS="$LEDGER" HOME="$WORK/home" \
+    bash "$NOTIFY" "a real founder decision that landed on his phone" \
+    --kind decision --class spend >/dev/null 2>&1  # fable-discipline-lint-skip: curl stubbed on PATH above
+OUT5="$(surface)"
+case "$OUT5" in
+  *"landed on his phone"*) bad "delivered rows are not re-surfaced" "got: $OUT5" ;;
+  *) ok "delivered rows are not re-surfaced" ;;
+esac
+
+echo "== 6. a delivery that FAILED is surfaced (sp-21815b25: exit 0 hides it) =="
+env -u KIPI_LINEAR_API_URL KIPI_TEST_CURL_RC=7 \
+    KIPI_SLACK_WEBHOOK="https://hooks.example.invalid/not-real" \
+    KIPI_NOTIFY_RECEIPTS="$LEDGER" HOME="$WORK/home" \
+    bash "$NOTIFY" "this page never made it out of the machine" \
+    --kind decision --class spend >/dev/null 2>&1  # fable-discipline-lint-skip: curl stubbed on PATH above
+OUT6="$(surface)"
+case "$OUT6" in
+  *"never made it out of the machine"*) ok "a dropped page is not silently lost" ;;
+  *) bad "a dropped page is not silently lost" "got: $OUT6" ;;
+esac
+
+echo "== 7. no ledger at all -> silent, exit 0 (a session must never be blocked) =="
+OUT7="$(python3 "$SURFACE" --ledger "$WORK/does-not-exist.jsonl" 2>&1)"; RC=$?
+if [ "$RC" -eq 0 ] && [ -z "$OUT7" ]; then
+  ok "missing ledger is a silent no-op"
+else
+  bad "missing ledger is a silent no-op" "rc=$RC out=$OUT7"
+fi
+
+echo "== 8. a corrupt line does not take the session down =="
+printf 'this is not json\n' >> "$LEDGER"
+write_row "a good row written after the corrupt one" --kind receipt
+OUT8="$(surface)"; RC=$?
+if [ "$RC" -eq 0 ] && [ "${OUT8#*after the corrupt one}" != "$OUT8" ]; then
+  ok "a malformed row is skipped, the good ones still arrive"
+else
+  bad "a malformed row is skipped, the good ones still arrive" "rc=$RC out=$OUT8"
+fi
+
+echo "== 9. a TRUNCATED ledger resets the cursor instead of going blind =="
+# Rotation/truncation makes a byte cursor point past the end. Reading from a
+# stale offset would silently skip every row written afterwards -- a reader that
+# is quiet for the wrong reason is the same failure as having no reader.
+: > "$LEDGER"
+write_row "the first row after a rotation" --kind receipt
+OUT9="$(surface)"
+case "$OUT9" in
+  *"first row after a rotation"*) ok "cursor resets when the file shrinks" ;;
+  *) bad "cursor resets when the file shrinks" "got: $OUT9" ;;
+esac
+
+echo "== 10. NEGATIVE SELF-TEST: the suite can actually fail =="
+# A cursor parked at the end of the file must produce silence. If this prints,
+# every quiet assertion above is meaningless because the surfacer prints nothing
+# under any condition.
+write_row "a row that the cursor has already passed" --kind receipt
+surface >/dev/null 2>&1          # advance the cursor past it
+OUT10="$(surface)"
+if [ -z "$OUT10" ]; then
+  ok "silence is reachable, so the loud assertions above mean something"
+else
+  bad "silence is reachable" "surfacer printed with nothing new: $OUT10"
+fi
+
+echo "== 11. the cursor is the surfacer's OWN file; the ledger is untouched =="
+BEFORE="$(wc -c < "$LEDGER")"
+surface >/dev/null 2>&1
+AFTER="$(wc -c < "$LEDGER")"
+if [ "$BEFORE" = "$AFTER" ] && [ -f "$CURSOR" ]; then
+  ok "single writer holds: slack-notify.sh owns the ledger, the surfacer owns the cursor"
+else
+  bad "single writer holds" "ledger $BEFORE -> $AFTER, cursor present: $([ -f "$CURSOR" ] && echo yes || echo no)"
+fi
+
+echo "-------- $PASS passed, $FAIL failed --------"
+[ "$FAIL" -eq 0 ]

--- a/settings-template.json
+++ b/settings-template.json
@@ -126,6 +126,10 @@
           },
           {
             "type": "command",
+            "command": "test -f \"$CLAUDE_PROJECT_DIR/q-system/.q-system/scripts/notify-receipts-surface.py\" && python3 \"$CLAUDE_PROJECT_DIR/q-system/.q-system/scripts/notify-receipts-surface.py\" 2>/dev/null || true"
+          },
+          {
+            "type": "command",
             "command": "test -f \"$CLAUDE_PROJECT_DIR/q-system/.q-system/scripts/memory-scores-surface.py\" && python3 \"$CLAUDE_PROJECT_DIR/q-system/.q-system/scripts/memory-scores-surface.py\" 2>/dev/null || true"
           },
           {


### PR DESCRIPTION
Closes ASK-294.

## Measured, both ends

**Before (real 24h window, #general, 2026-08-01 12:46 to 2026-08-02 12:13 PDT): 48 messages.**

| Producer | Pings | After |
|---|---|---|
| dispatch stale-checkout | 15 | **0** (self-heals; pages only if diverged or a path collides) |
| `.claude/` integrity tripwire "armed, 41 files baselined" | 11 | 0 |
| converge stopped / cap / stalled / approved | 5 | 0 |
| reviewer "codex is not producing an independent review" | 4 | 0 |
| worker "repo identity matches no Linear project" | 4 | 0 |
| heartbeat "RESUMED... Nothing to do" | 3 | 0 |
| reviewer "codex is BACK" | 3 | 0 |
| fleet health "nothing to do now" | 1 | 0 |
| dispatch daily cap "Do: nothing" | 1 | 0 |
| cole-gtm voice-lint nudge (outside this repo) | 1 | 1 (fail-open, unclassified) |
| **Total** | **48** | **1** |

The one survivor is a producer in another repo. It is delivered on purpose: see fail-open below.

Dispatch's own log corroborates the stale-checkout half independently: 13 pings under the old per-sha dedupe key, 2 after ASK-283's constant key, in the same window. This PR takes the remaining 2 to 0 by handling the condition.

## The frame, and where I disagreed with the issue

The issue proposed the loop just run `git merge --ff-only`. **An auto-merge was built there on 2026-08-02 and removed the same night**, after three review rounds each finding a new way for it to lose data (ASK-284). Rebuilding it as specified would have re-shipped a known data-loss path.

What changed the answer: those rounds tried to make an **unbounded** write safe. It is not unbounded. `git diff --name-only HEAD origin/main` is the exact finite set of paths the fast-forward writes, and every member is individually checkable. `ff-merge-if-safe.sh` proves the merge cannot clobber anything over that set, then merges; otherwise it declines and names the path. No copies, no backups, no writes outside `.git`.

The scar's protection did not disappear, it moved: `test-ff-merge-if-safe.sh` case 4 holds the exact thing that killed the last attempt (a fast-forward silently overwriting a **gitignored** file, exit 0, no reflog). Case 7 holds the opposite failure: ignored files *outside* the merge set must not block, or the handler is decoration on a checkout carrying 3982 of them.

## Two layers

**Handlers (the fix).** The condition is resolved and nothing is emitted.

**A sink gate (the floor).** `slack-notify.sh` now requires `--kind`. `receipt` is recorded, never delivered. `decision` requires `--class` from a closed 5-value allowlist (`irreversible-git`, `out-of-tree-write`, `spend`, `publish`, `credential`). A closed enum is the point: a producer cannot reword its way onto his phone, it has to edit the allowlist in a reviewed diff.

**Message stays in `$1`, flags follow it.** The first cut put flags first, which moved the message out of `$1` and broke three suites this change never touched, because their notify stubs record `"$1"` — as would every such stub in the fleet, including repos not checked out here. The parser accepts flags in any position, so the message went back to `$1`. No test I did not write was edited to accommodate this.

**Fail-open, deliberately.** A legacy one-arg caller is still delivered, marked `[unclassified]` and recorded. `kipi update` ships this script fleet-wide and instances carry producers this repo has never seen. Silencing one of those is a worse outage than the noise. `notify-callsite-audit.py` closes that hole statically, wired into **lefthook pre-commit** so a new bare call site is caught at the commit that writes it.

**A liveness fault is not a receipt.** "could not launch the converge run" and "launched but died immediately — the loop is spending budget and doing no work" were initially swept into `page()`'s receipt default. Neither is handled by any machine, so demoting them would be the "quieter, not shorter" failure this issue exists to stop — and no test could see it, because those suites stub the notifier so the gate never runs there. Both are now `--kind decision --class spend`.

## Verification

| Check | Result |
|---|---|
| `test-notify-decision-gate.sh` | 20 passed, 0 failed (incl. negative self-test) |
| `test-ff-merge-if-safe.sh` | 13 passed, 0 failed |
| `test-dispatch-stale-checkout.sh` | 35 passed, 0 failed |
| `test-dispatch-liveness.sh` | 18 passed, 0 failed |
| `test-severity-floor.sh` | 84 ok, 0 failed |
| `test-linear-dor-failure-reporting.py` | all checks passed |
| `test-notify-fixture-guard.sh` | 25 passed, 0 failed (the 2026-08-01 scar still holds) |
| `notify-callsite-audit` | OK, all 33 sites across 11 producers declare a kind |
| Mutation | 5 planted, **5 killed, 0 survived** |

Reproducer went red first: 14 failures before implementation, including three *false* passes (rc=127, the sink never ran) that the harness now asserts against.

All of the above were re-run **in an isolated worktree**. The first mutation run was measured against the shared checkout, which had already been caught lying once (two of my edits were uncommitted there and had not come across); it was re-run and both mutated files confirmed byte-identical to HEAD afterwards.

## Note for the reviewer: prd-os 0.9.2 to 0.9.3

This notifications PR contains a **plugin version bump**. It is not scope creep. Adding a `notify-kind-skip` marker to one fable-discipline lint *fixture* counts as changing the plugin, and the `plugin-version-bump` pre-commit gate blocks a changed plugin that does not bump its version (the version-keyed cache would otherwise serve the stale copy). The gate is correct; the bump is the cost of touching that fixture.

## What this gate cannot catch

- A producer passing `--kind decision --class irreversible-git` for something that is not one. The enum bounds the vocabulary, not the intent. Only review does.
- A call site that assembles its argv dynamically.
- Producers in other repos (by design; that is the fail-open case).
- Whether a *receipt* condition is genuinely handled. The gate proves nothing was sent, not that the machine acted.

## Split out / captured

- **ASK-295** — red CI on agent-opened PRs emails the founder. Different producer; a `slack-notify.sh` chokepoint structurally cannot reach GitHub Actions.
- `sp-8c643acb` — converge escalation tier still unbuilt.
- `sp-21815b25` — `slack-notify.sh` always exits 0 on a failed curl, so a dropped page still writes the 24h dedupe marker.
- `sp-95893c63` — the fixture guard's loopback signal has a hole; 4 of the 48 pings came from test worktrees.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01QsZcVy4GyFFqVtacBfWKEs