### PR TITLE
Red CI on an agent PR is re-dispatched to its agent, not emailed to the founder (ASK-295)

### DIFF
--- a/kipi-dispatch.sh
+++ b/kipi-dispatch.sh
@@ -807,12 +807,26 @@ NEXT="$(printf '%s' "$WORK_OUT" | grep -oE '\[dry\] would work ASK-[0-9]+' | gre
 #
 # rc 2 (gh could not answer) is NOT treated as "no red PRs": the fresh pick
 # stands and the reason is logged. rc 1 is the ordinary "nothing red".
+#
+# THE OFFER IS NOT THE CLAIM (PR #73 review, finding 2). `redrive` writes
+# nothing: it prints `<issue>\t<signature>\t<head_sha>` and leaves the ledger
+# alone. This block is still ~70 lines above the launch, and one of the guards
+# in between (a converge run already live for that issue) exits 0 without
+# launching anything. Claiming here spent the PR's one machine attempt on a
+# dispatch that never happened, and the next heartbeat then paged the founder
+# with a message asserting a re-dispatch and a second CI failure, neither of
+# which had occurred. The claim now happens at MARK-DISPATCHED below, past every
+# guard that can still abort.
 REDRIVE="$REPO/q-system/.q-system/scripts/ci-redrive.py"
+REDRIVE_NEXT=""; REDRIVE_SIG=""; REDRIVE_SHA=""
 if [ -f "$REDRIVE" ]; then
-  REDRIVE_NEXT="$(KIPI_NOTIFY="$NOTIFY" python3 "$REDRIVE" \
+  REDRIVE_LINE="$(KIPI_NOTIFY="$NOTIFY" python3 "$REDRIVE" \
                     --repo-dir "$TARGET_PATH" redrive 2>>"$LOG")"
   REDRIVE_RC=$?
-  if [ "$REDRIVE_RC" = "0" ] && [ -n "$REDRIVE_NEXT" ]; then
+  if [ "$REDRIVE_RC" = "0" ] && [ -n "$REDRIVE_LINE" ]; then
+    REDRIVE_NEXT="$(printf '%s' "$REDRIVE_LINE" | cut -f1)"
+    REDRIVE_SIG="$(printf '%s' "$REDRIVE_LINE" | cut -f2)"
+    REDRIVE_SHA="$(printf '%s' "$REDRIVE_LINE" | cut -f3)"
     say "red-CI redrive: handing $REDRIVE_NEXT back to its agent ahead of the fresh pick${NEXT:+ ($NEXT waits)}"
     NEXT="$REDRIVE_NEXT"
   elif [ "$REDRIVE_RC" = "2" ]; then
@@ -850,6 +864,20 @@ PS_SNAPSHOT="$(ps -Ao args= 2>/dev/null || true)"
 if [[ "$PS_SNAPSHOT" =~ converge\.sh\ --issue\ ${NEXT}([[:space:]]|$) ]]; then
   say "skip $NEXT: a converge run for it is already live"
   exit 0
+fi
+
+# --- RED-CI REDRIVE: MARK-DISPATCHED (ASK-295) -------------------------------
+# Past every guard that can still abort, and immediately before the launch. This
+# is where the PR's one machine attempt is spent, and the call is the atomic
+# gate: rc 0 means this run owns the attempt, rc non-zero means another run
+# already claimed it (or the ledger could not be written, which is the same
+# answer -- nothing was recorded, so nothing may act as though it was).
+if [ -n "$REDRIVE_SIG" ] && [ "$NEXT" = "$REDRIVE_NEXT" ]; then
+  if ! python3 "$REDRIVE" mark-dispatched --issue "$NEXT" \
+       --signature "$REDRIVE_SIG" --head-sha "$REDRIVE_SHA" 2>>"$LOG"; then
+    say "red-CI redrive: the attempt for $NEXT is already claimed -- not dispatching"
+    exit 0
+  fi
 fi
 
 # Count BEFORE launching. Counting after would let a crash between the two

--- a/kipi-dispatch.sh
+++ b/kipi-dispatch.sh
@@ -817,6 +817,19 @@ NEXT="$(printf '%s' "$WORK_OUT" | grep -oE '\[dry\] would work ASK-[0-9]+' | gre
 # with a message asserting a re-dispatch and a second CI failure, neither of
 # which had occurred. The claim now happens at MARK-DISPATCHED below, past every
 # guard that can still abort.
+#
+# AND AN OFFER MUST NOT COST THE FRESH PICK ITS SLOT (PR #73 review r2, finding
+# 2). NEXT is overwritten below, and the duplicate-dispatch guard ~40 lines down
+# exits 0 without launching anything when a converge for that issue is already
+# live. So a red PR whose converge was still running discarded the ready issue
+# that WAS dispatchable -- every heartbeat, for the whole run.
+#
+# Fixed where the decision is made, not here: ci-redrive.py's converge_live()
+# reads the same `ps -Ao args=` command line the guard below matches and does not
+# OFFER a candidate that is already in flight, so NEXT keeps the fresh pick. A
+# second liveness rule spelled out in this file is the drift this repo keeps
+# paying for, and only the Python side can also suppress the founder page (that
+# page is finding 1). Its stderr lands in this log, so the skip is visible here.
 REDRIVE="$REPO/q-system/.q-system/scripts/ci-redrive.py"
 REDRIVE_NEXT=""; REDRIVE_SIG=""; REDRIVE_SHA=""
 if [ -f "$REDRIVE" ]; then

--- a/kipi-dispatch.sh
+++ b/kipi-dispatch.sh
@@ -781,6 +781,45 @@ page_clear linear-down
 # --- LINEAR-OUTAGE-GUARD:END ---
 
 NEXT="$(printf '%s' "$WORK_OUT" | grep -oE '\[dry\] would work ASK-[0-9]+' | grep -oE 'ASK-[0-9]+' | head -1)"
+
+# --- RED-CI REDRIVE (ASK-295) -----------------------------------------------
+# A PR this loop opened going red is a dead end: ready() only returns
+# backlog/unstarted issues, and an issue with a live PR is In Progress, so the
+# fresh pick above can never return it. GitHub's notifier is then the only thing
+# that noticed, and its only addressee is the repo owner -- who does not work on
+# the code. Three such emails reached him on 2026-08-02.
+#
+# BEFORE the empty-NEXT exit, not after. Nothing ready is the ORDINARY state of
+# a healthy queue, so handling the red PR only when something else was also
+# waiting would leave it unhandled on exactly the quiet cycles.
+#
+# AHEAD of a fresh pick, because finishing an issue that already has a PR beats
+# starting a new one, and because the red PR is what is generating founder mail
+# right now.
+#
+# HERE AND NOT IN A NEW LAUNCHD JOB: every cap this needs already exists in this
+# file and has been proven (MAX_CONCURRENT, the daily budget, the liveness
+# assert, page_once, one dispatch per heartbeat). A second job would be a second
+# copy of all four, drifting -- and per-repo jobs die silently: the income
+# scanners went dark for 6 days that way. ci-redrive.py holds its own cap of one
+# attempt per PR per failure signature in the SAME attempts ledger the worker
+# uses, so a handler cannot re-run a flake forever.
+#
+# rc 2 (gh could not answer) is NOT treated as "no red PRs": the fresh pick
+# stands and the reason is logged. rc 1 is the ordinary "nothing red".
+REDRIVE="$REPO/q-system/.q-system/scripts/ci-redrive.py"
+if [ -f "$REDRIVE" ]; then
+  REDRIVE_NEXT="$(KIPI_NOTIFY="$NOTIFY" python3 "$REDRIVE" \
+                    --repo-dir "$TARGET_PATH" redrive 2>>"$LOG")"
+  REDRIVE_RC=$?
+  if [ "$REDRIVE_RC" = "0" ] && [ -n "$REDRIVE_NEXT" ]; then
+    say "red-CI redrive: handing $REDRIVE_NEXT back to its agent ahead of the fresh pick${NEXT:+ ($NEXT waits)}"
+    NEXT="$REDRIVE_NEXT"
+  elif [ "$REDRIVE_RC" = "2" ]; then
+    say "red-CI redrive: gh could not read PR state in $TARGET_NAME -- fresh pick stands, nothing claimed"
+  fi
+fi
+
 if [ -z "$NEXT" ]; then
   say "nothing ready ($(printf '%s' "$WORK_OUT" | grep -oE '[0-9]+ ready issue' | head -1))"
   exit 0

--- a/q-system/.q-system/capability-manifest.json
+++ b/q-system/.q-system/capability-manifest.json
@@ -30,6 +30,10 @@
       "runner": "bash"
     },
     {
+      "path": "q-system/.q-system/scripts/test/test-ci-redrive.sh",
+      "runner": "bash"
+    },
+    {
       "path": "q-system/.q-system/scripts/test/test-claim-page-once-routing.sh",
       "runner": "bash"
     },

--- a/q-system/.q-system/scripts/ci-redrive.py
+++ b/q-system/.q-system/scripts/ci-redrive.py
@@ -102,6 +102,41 @@ dispatch time and compares it with the head sha now: the head moved (the agent
 pushed and the same check failed again) and the head did not move (it was handed
 back and nothing landed) are DIFFERENT facts and get different sentences.
 
+A RUN STILL IN FLIGHT IS NOT A DEAD END (round 2, findings 1 and 2)
+-------------------------------------------------------------------
+The dispatcher's heartbeat is 900s; a converge run is minutes to tens of minutes.
+So the heartbeat AFTER a redrive dispatch finds the same PR still red -- the
+agent has not pushed yet -- with the attempt flag already set. Round 2 went
+straight to `escalate()` there and paged the founder that the machine tier was
+spent and the branch "stopped rather than hand back an unchanged tree", about a
+converge that was at that moment still running.
+
+The second half is the worse half. `escalate()` claims `ci_escalated_<sig>` on
+its way out, so when the converge really did end and leave the PR red, the one
+true page had already been spent on the false one. A wrong page that also
+silences the right page is strictly worse than no page.
+
+The same blindness cost the fresh pick too. `redrive` offered the live issue,
+kipi-dispatch.sh overwrote NEXT with it, and the duplicate-dispatch guard 40
+lines later exited 0 -- so a ready issue that WAS dispatchable was discarded,
+every heartbeat, for as long as that converge ran.
+
+Both are one missing fact: is a converge for this issue running right now.
+`converge_live()` answers it from the process table, the same source and the same
+command line kipi-dispatch.sh's own duplicate guard reads (`ps -Ao args=`, no
+pipe -- see that guard's comment for why a pipe into `grep -q` under pipefail is
+load-dependent). A live candidate is neither offered nor escalated.
+
+ONE reader, not two. The shell could have grown its own copy of this check, but
+two liveness rules drifting apart is the defect class this repo keeps paying for,
+and only the Python side can suppress the escalation. So the guard lives here and
+the dispatcher inherits it by not being offered the pick.
+
+AN UNREADABLE PROCESS TABLE COUNTS AS LIVE. It is the cheap direction of the
+error: erring the other way pages the founder about a run that may be in flight
+and burns the once-per-signature flag doing it, while erring this way costs one
+quiet heartbeat -- which is exactly the behaviour before this file existed.
+
 THE SIGNATURE IS THE CHECK SET, AND TODAY THAT IS ONE CHECK (review finding 4)
 -----------------------------------------------------------------------------
 The signature is the set of failing check NAMES, deliberately NOT the head sha:
@@ -139,6 +174,7 @@ import hashlib
 import json
 import os
 import re
+import shlex
 import subprocess
 import sys
 
@@ -273,6 +309,46 @@ def failing_checks(pr):
         if (check.get("conclusion") or "").upper() in FAILED_CONCLUSIONS:
             names.add(name)
     return sorted(names)
+
+
+# --- is work on this issue already in flight ---------------------------------
+# `kipi converge --issue ASK-n` execs converge.sh with those same arguments, so
+# the process table holds `... converge.sh --issue ASK-n --max-rounds N`. Same
+# command line kipi-dispatch.sh's duplicate-dispatch guard matches, on purpose:
+# one shape, read in one place, so the two cannot drift.
+
+def process_table():
+    """Every running command line, or None if the table could not be read.
+
+    None is a THIRD answer and callers must not fold it into "nothing running" --
+    same rule as GhUnavailable above. No shell pipe: `ps | grep -q` dies to
+    SIGPIPE under pipefail often enough to look correct in testing and fail in
+    production, which is what kipi-dispatch.sh's own guard was fixed for.
+    """
+    try:
+        proc = subprocess.run(shlex.split(os.environ.get("KIPI_PS", "ps -Ao args=")),
+                              capture_output=True, text=True)
+    except OSError:
+        return None
+    return proc.stdout if proc.returncode == 0 else None
+
+
+def converge_live(issue):
+    """True if a converge run for this issue is in the process table right now.
+
+    An unreadable table answers True: see the module docstring. Skipping one
+    heartbeat is recoverable; a false page that also burns the once-per-signature
+    flag is not.
+    """
+    table = process_table()
+    if table is None:
+        sys.stderr.write("ci-redrive: could not read the process table -- treating "
+                         "every candidate as already in flight, offering nothing.\n")
+        return True
+    # `(?:\s|$)` with MULTILINE so `--issue ASK-29` does not match `ASK-295`.
+    pattern = re.compile(r"converge\.sh\s+--issue\s+%s(?:\s|$)" % re.escape(issue),
+                         re.MULTILINE)
+    return bool(pattern.search(table))
 
 
 def signature(names):
@@ -424,6 +500,17 @@ def cmd_redrive(cands):
     path = attempts_path()
     chosen = None
     for cand in cands:
+        # BEFORE both the offer and the escalation, because a live converge
+        # invalidates both: the dispatcher would discard its fresh pick for a
+        # candidate it cannot launch, and the founder would be paged that a
+        # still-running attempt had stopped -- burning the one page owed to him
+        # when it really does. Round 2 did both. See the module docstring.
+        if converge_live(cand["issue"]):
+            sys.stderr.write(
+                "ci-redrive: %s PR #%s is red but a converge for it is already "
+                "live -- not offering it and not escalating it this run\n"
+                % (cand["issue"], cand["pr"]))
+            continue
         if ledger_get(path, cand["issue"], redrive_flag(cand)):
             escalate(path, cand)           # machine tier already spent on this
             continue

--- a/q-system/.q-system/scripts/ci-redrive.py
+++ b/q-system/.q-system/scripts/ci-redrive.py
@@ -35,21 +35,85 @@ THE FOUR DECISIONS, MADE (ASK-295's Definition of Ready)
    daily budget, the liveness assert, the notify sink. A second job would be a
    second copy of all four, drifting.
 
-3. ATTRIBUTION IS THE BRANCH NAME, with no Linear round-trip. The worker cuts
-   every branch as `<agent>/<issue>` (`sana/ask-295`), so the branch already
-   carries both facts this needs. A branch that does not match is not an agent
-   PR and is none of this tool's business -- the founder's own PRs keep behaving
-   exactly as they do today.
+3. ATTRIBUTION IS THE BRANCH FIRST, THE PR TITLE SECOND, and never a guess.
 
 4. THE CAP IS ONE ATTEMPT PER PR PER FAILURE SIGNATURE, held in the existing
-   attempts ledger (single-writer, flock'd -- attempts-ledger.py). The signature
-   is the set of failing check NAMES, deliberately NOT the head sha: a re-push
-   that fails the same check again is the same failure, and re-dispatching on it
-   is how a handler re-runs a flake forever. ASK-295 names that risk by hand --
-   one root cause of the 2026-08-02 redness was a measurement taken against the
-   wrong tree, and a handler that re-runs CI without fixing tree isolation would
-   have looped on it all night. A genuinely NEW failure gets its own fresh
-   attempt, because it is a different problem.
+   attempts ledger (single-writer, flock'd -- attempts-ledger.py), and spent by
+   the DISPATCHER confirming a dispatch, not by this script offering a pick.
+
+Points 3 and 4 each cost a defect in round 1 and are written out below.
+
+ATTRIBUTION: TWO SOURCES, RANKED, NEITHER OF THEM A GUESS (review finding 3)
+---------------------------------------------------------------------------
+Round 1 read the issue id out of the branch name and nothing else, on the
+reasoning that the worker cuts every branch as `<agent>/<issue>`. The worker
+does. A SANA SESSION DRIVEN BY HAND DOES NOT: `sana/block-expiry` is PR #69, it
+is one of the three PRs that mailed the founder in the scar above, it was red on
+`validate` while I wrote the rule that skipped it, and the rule's own docstring
+cited it as motivation. A tool that misses the case it was built for is worse
+than no tool, because the gap is now believed to be covered.
+
+So: the branch tail if it is an issue id (`sana/ask-295` -> ASK-295), otherwise
+the PR TITLE, which carries the id because `linear-issue-ref-check.py` makes it
+mandatory in the commit message the title is cut from. Reading a stated id is
+not guessing. Guessing is what is still refused: a title naming TWO distinct
+issues is ambiguous and is left alone, because picking either is how the wrong
+issue gets re-dispatched.
+
+The `<agent>/` prefix must be a KNOWN agent (AGENT_BRANCH_OWNERS). This errs
+toward doing nothing: an unrecognised owner is treated as a human's branch and
+left exactly as it behaves today. Handing a founder's branch to an agent is the
+expensive direction of this error, so the ambiguity resolves the cheap way.
+
+A REVIEW VERDICT IS NOT CI (review finding 1)
+---------------------------------------------
+`pr-review-agent.sh` posts its verdict as a commit STATUS -- `kipi/reviewer-approved`
+for the primary engine, `kipi/<engine>-approved` for the advisory one -- and
+anything that is not an approval is posted as `state: failure`. That status rides
+in the same `statusCheckRollup` as the CI checks, so round 1 counted every
+REQUEST CHANGES review as red CI. Live consequence, on this script's own PR: #73
+had `validate: SUCCESS` and `kipi/reviewer-approved: FAILURE`, so the handler
+would have re-dispatched a PR with a passing build and then paged the founder
+that the build was still red.
+
+It is also already handled: the reviewer comments on the Linear issue and the
+worker re-dispatches from there. Two consumers for one event is how a PR gets
+worked twice. So the reviewer's own slots are excluded and nothing else is -- a
+third-party commit status (`ci/external-builder`) is real CI and stays in.
+
+THE CAP IS SPENT ON THE DISPATCH, NOT ON THE OFFER (review finding 2)
+--------------------------------------------------------------------
+Round 1 claimed the attempt inside `redrive`, at the moment it printed the pick.
+kipi-dispatch.sh can still abort after that -- a converge run already live for
+that issue exits 0 without launching anything. The attempt was then spent on a
+dispatch that never happened, and on the very next heartbeat the founder was
+paged with a message asserting a re-dispatch AND a second CI failure, neither of
+which had occurred.
+
+Two changes. `redrive` is READ-ONLY: it offers a pick and writes nothing, so an
+aborted heartbeat costs nothing and the next one offers the same PR again. The
+dispatcher calls `mark-dispatched` immediately before it launches, and that call
+is the atomic claim: rc 0 means it is yours to dispatch, rc 1 means someone else
+already has it and you must not. A lock timeout is rc 1 as well -- nothing was
+recorded, so nothing may act as though it was.
+
+And the escalation now says only what it observed. It records the head sha at
+dispatch time and compares it with the head sha now: the head moved (the agent
+pushed and the same check failed again) and the head did not move (it was handed
+back and nothing landed) are DIFFERENT facts and get different sentences.
+
+THE SIGNATURE IS THE CHECK SET, AND TODAY THAT IS ONE CHECK (review finding 4)
+-----------------------------------------------------------------------------
+The signature is the set of failing check NAMES, deliberately NOT the head sha:
+a re-push that fails the same check again is the same failure, and re-dispatching
+on it is how a handler re-runs a flake forever. ASK-295 names that risk by hand.
+
+Stated plainly rather than promised: this repo posts exactly ONE CI check
+(`validate`, from Skeleton Validation), so the signature is constant per PR here
+and the effective cap is ONE hand-back per PR, full stop. The "a genuinely new
+failure earns a fresh attempt" behaviour is real in the code and unreachable in
+this repo until a second required check exists. Round 1's docstring sold it as a
+live property, which is a claim the repo could not honour.
 
 WHAT IT DOES NOT DO
 -------------------
@@ -58,10 +122,11 @@ state and answers one question: which issue should the dispatcher hand back to
 its agent right now. The dispatching is the dispatcher's, and stays under the
 dispatcher's caps.
 
-    scan     -> JSON of red agent PRs (read-only, no ledger write, no page)
-    redrive  -> claim one attempt, print the issue id, exit 0
-                nothing claimable -> exit 1
-                gh could not answer -> exit 2, nothing claimed
+    scan            -> JSON of red agent PRs (read-only, no ledger write, no page)
+    redrive         -> read-only. prints `<issue>\t<signature>\t<head_sha>`,
+                       exit 0. Nothing to offer -> exit 1. gh could not answer
+                       -> exit 2. Escalates any candidate whose attempt is spent.
+    mark-dispatched -> the atomic claim. exit 0 = dispatch it, exit 1 = do not.
 
 THE PROBE'S rc IS PART OF ITS ANSWER. `gh pr list` failing is not "no red PRs":
 reading it that way is how a real red PR goes unhandled behind a clean exit. It
@@ -84,10 +149,24 @@ DEFAULT_ATTEMPTS = os.path.join(
     os.environ.get("KIPI_STATE_DIR", os.path.expanduser("~/.config/kipi")),
     "linear-worker-attempts.json")
 
-# `sana/ask-295` -> agent `sana`, issue `ASK-295`. Anchored at both ends on
-# purpose: `sana/ask-295-followup` is a branch a human named, and guessing which
-# issue a human meant is how the wrong issue gets re-dispatched.
-BRANCH_RE = re.compile(r"^(?P<agent>[a-z][a-z0-9_-]*)/(?P<issue>[a-z]{2,6}-\d+)$")
+# `<owner>/<anything>`. The owner has to be a KNOWN agent -- see the attribution
+# section of the docstring. An unknown owner is a human's branch.
+BRANCH_RE = re.compile(r"^(?P<owner>[a-z][a-z0-9_-]*)/(?P<tail>.+)$")
+AGENT_BRANCH_OWNERS = frozenset(
+    o.strip() for o in os.environ.get("KIPI_AGENT_BRANCH_OWNERS", "sana").split(",")
+    if o.strip())
+
+# `ask-295` as a whole branch tail, anchored: `ask-295-followup` is a name a
+# human chose and is not an issue id.
+TAIL_ISSUE_RE = re.compile(r"^(?P<issue>[a-z]{2,6}-\d+)$")
+# `(ASK-288)` anywhere in a PR title. linear-issue-ref-check.py makes the id
+# mandatory in the commit message, and the PR title is cut from it.
+TITLE_ISSUE_RE = re.compile(r"\b([A-Za-z]{2,6}-\d+)\b")
+
+# The reviewer's own verdict slots: `kipi/reviewer-approved` (primary engine) and
+# `kipi/<engine>-approved` (advisory). Posted by pr-review-agent.sh, NOT by CI,
+# and already consumed by the reviewer's own comment on the Linear issue.
+REVIEWER_CONTEXT_RE = re.compile(r"^kipi/[a-z0-9-]+-approved$")
 
 # A CheckRun that COMPLETED with one of these is red. Everything else -- queued,
 # in progress, skipped, neutral -- is not a failure, and treating "still running"
@@ -97,7 +176,7 @@ FAILED_CONCLUSIONS = {"FAILURE", "TIMED_OUT", "CANCELLED", "STARTUP_FAILURE",
 # The legacy commit-status half of the same rollup speaks a different vocabulary.
 FAILED_STATES = {"FAILURE", "ERROR"}
 
-PR_FIELDS = "number,headRefName,url,title,statusCheckRollup,isDraft"
+PR_FIELDS = "number,headRefName,headRefOid,url,title,statusCheckRollup,isDraft"
 
 
 class GhUnavailable(Exception):
@@ -122,23 +201,77 @@ def list_prs(repo_dir):
         raise GhUnavailable("`gh pr list` returned unparseable JSON: %s" % exc)
 
 
+# --- attribution -------------------------------------------------------------
+
+def branch_owner(branch):
+    """The agent that owns this branch, or None if no known agent does."""
+    match = BRANCH_RE.match(branch or "")
+    if not match:
+        return None
+    owner = match.group("owner")
+    return owner if owner in AGENT_BRANCH_OWNERS else None
+
+
+def title_issue(title):
+    """The ONE issue id a title names, or None.
+
+    Two distinct ids is ambiguity, and this refuses ambiguity rather than
+    resolving it -- the wrong issue re-dispatched is worse than none.
+    """
+    found = {m.upper() for m in TITLE_ISSUE_RE.findall(title or "")}
+    return found.pop() if len(found) == 1 else None
+
+
+def attribute(pr):
+    """(issue, agent, source) for an agent PR, or None. Never a guess."""
+    branch = pr.get("headRefName") or ""
+    agent = branch_owner(branch)
+    if agent is None:
+        return None
+    tail = BRANCH_RE.match(branch).group("tail")
+    tail_match = TAIL_ISSUE_RE.match(tail)
+    if tail_match:
+        return (tail_match.group("issue").upper(), agent, "branch")
+    issue = title_issue(pr.get("title"))
+    if issue:
+        return (issue, agent, "title")
+    return None
+
+
+# --- what counts as red ------------------------------------------------------
+
+def is_reviewer_slot(name):
+    return bool(REVIEWER_CONTEXT_RE.match((name or "").strip()))
+
+
 def failing_checks(pr):
-    """Names of the checks that are red RIGHT NOW, sorted and de-duplicated."""
+    """Names of the CI checks that are red RIGHT NOW, sorted and de-duplicated.
+
+    The reviewer's verdict slots are not CI and are excluded -- see the docstring.
+    Applied to both halves of the rollup: the status API is where the verdict is
+    posted today, and a name-based rule that only guards one half is a rule that
+    stops working the day the producer changes shape.
+    """
     names = set()
     for check in pr.get("statusCheckRollup") or []:
         if not isinstance(check, dict):
             continue
-        kind = check.get("__typename")
-        if kind == "StatusContext":
+        if check.get("__typename") == "StatusContext":
+            context = check.get("context") or "(unnamed status)"
+            if is_reviewer_slot(context):
+                continue
             if (check.get("state") or "").upper() in FAILED_STATES:
-                names.add(check.get("context") or "(unnamed status)")
+                names.add(context)
             continue
         # CheckRun, and anything else the rollup grows later that speaks
         # status/conclusion. A check that has not COMPLETED has not failed.
+        name = check.get("name") or "(unnamed check)"
+        if is_reviewer_slot(name):
+            continue
         if (check.get("status") or "").upper() != "COMPLETED":
             continue
         if (check.get("conclusion") or "").upper() in FAILED_CONCLUSIONS:
-            names.add(check.get("name") or "(unnamed check)")
+            names.add(name)
     return sorted(names)
 
 
@@ -146,7 +279,9 @@ def signature(names):
     """Identity of a FAILURE, not of a run.
 
     Head sha is left out deliberately -- see the module docstring. Same checks
-    red again == same problem == the machine tier is already spent on it.
+    red again == same problem == the machine tier is already spent on it. In
+    THIS repo that means one hand-back per PR, because `validate` is the only
+    CI check posted; the discrimination is real code waiting on a second check.
     """
     return hashlib.sha1("\n".join(names).encode("utf-8")).hexdigest()[:12]
 
@@ -154,18 +289,21 @@ def signature(names):
 def candidates(repo_dir):
     out = []
     for pr in list_prs(repo_dir):
-        match = BRANCH_RE.match(pr.get("headRefName") or "")
-        if not match:
-            continue                       # not an agent branch, not ours
+        attributed = attribute(pr)
+        if attributed is None:
+            continue                       # not an agent PR, or not attributable
+        issue, agent, source = attributed
         failing = failing_checks(pr)
         if not failing:
             continue
         out.append({
-            "issue": match.group("issue").upper(),
-            "agent": match.group("agent"),
+            "issue": issue,
+            "agent": agent,
+            "issue_source": source,
             "pr": pr.get("number"),
             "url": pr.get("url"),
             "branch": pr.get("headRefName"),
+            "head_sha": pr.get("headRefOid") or "",
             "failing_checks": failing,
             "signature": signature(failing),
         })
@@ -184,6 +322,16 @@ def ledger_get(path, issue, key):
     return (proc.stdout or "").strip() if proc.returncode == 0 else ""
 
 
+def _ledger_claim_rc(path, issue, flag):
+    proc = subprocess.run(
+        [sys.executable, LEDGER_SCRIPT, path, "claim-flag", issue, flag],
+        capture_output=True, text=True)
+    if proc.returncode not in (0, 1):
+        sys.stderr.write("ci-redrive: ledger refused `%s` for %s: %s\n"
+                         % (flag, issue, (proc.stderr or "").strip()[:200]))
+    return proc.returncode
+
+
 def ledger_claim(path, issue, flag):
     """True the first time this flag is claimed anywhere, False otherwise.
 
@@ -191,13 +339,29 @@ def ledger_claim(path, issue, flag):
     Nothing was recorded, so nothing may act as though it was -- the next
     scheduled run claims it instead.
     """
-    proc = subprocess.run(
-        [sys.executable, LEDGER_SCRIPT, path, "claim-flag", issue, flag],
-        capture_output=True, text=True)
-    if proc.returncode not in (0, 1):
-        sys.stderr.write("ci-redrive: ledger refused `%s` for %s: %s\n"
-                         % (flag, issue, (proc.stderr or "").strip()[:200]))
-    return proc.returncode == 0
+    return _ledger_claim_rc(path, issue, flag) == 0
+
+
+def ledger_recorded(path, issue, flag):
+    """True if the flag is now set, whether this call or an earlier one set it.
+
+    Different question from `ledger_claim`, and the difference is load-bearing:
+    for a fact being RECORDED, "someone already wrote it" is success. Only a
+    lock timeout or a write failure is not.
+    """
+    return _ledger_claim_rc(path, issue, flag) in (0, 1)
+
+
+def redrive_flag(cand):
+    return "ci_redrive_%s" % cand["signature"]
+
+
+def head_flag(head_sha):
+    return "ci_redrive_head_%s" % (head_sha or "unknown")[:12]
+
+
+def head_recorded_flag(cand):
+    return "ci_redrive_headrec_%s" % cand["signature"]
 
 
 def notify(message):
@@ -210,6 +374,24 @@ def notify(message):
         sys.stderr.write("ci-redrive: notify failed: %s\n" % exc)
 
 
+def what_happened_since(path, cand):
+    """The one sentence about the branch that this run can actually evidence.
+
+    Three states, and the third is named rather than folded into one of the
+    first two. `ci_redrive_headrec_<sig>` says a head sha WAS recorded at
+    dispatch; `ci_redrive_head_<sha>` says which one. Absent recording is not
+    evidence of a push.
+    """
+    checks = ", ".join(cand["failing_checks"])
+    if not ledger_get(path, cand["issue"], head_recorded_flag(cand)):
+        return "what has happened on the branch since is not recorded."
+    if ledger_get(path, cand["issue"], head_flag(cand["head_sha"])):
+        return ("no new commit has landed on the branch since, so it stopped "
+                "rather than hand back an unchanged tree.")
+    return ("a new commit landed and %s failed again, so it stopped rather "
+            "than re-run a flake." % checks)
+
+
 def escalate(path, cand):
     """The founder's ONE message about this failure, and only after the machine.
 
@@ -217,51 +399,85 @@ def escalate(path, cand):
     per signature, because the dispatcher reaches this state on every heartbeat
     for as long as the PR sits red -- paging per run is a page every 15 minutes
     for one fact that has not changed.
+
+    Every clause is an observation. Round 1 asserted a re-dispatch and a second
+    CI failure unconditionally; both were untrue on the very first heartbeat
+    after an offer the dispatcher never launched.
     """
     if not ledger_claim(path, cand["issue"], "ci_escalated_%s" % cand["signature"]):
         return False
     notify(
-        "ci-redrive: %s PR #%s is still red after the machine tier. The failing "
-        "check is %s. What the machine tried: it re-dispatched %s to %s once for "
-        "this exact failure and the same check failed again, so it stopped rather "
-        "than re-run a flake. %s"
+        "ci-redrive: %s PR #%s is still red on %s after the machine tier. What "
+        "the machine tried: it handed %s back to %s once for this failure; %s %s"
         % (cand["issue"], cand["pr"], ", ".join(cand["failing_checks"]),
-           cand["issue"], cand["agent"], cand["url"]))
+           cand["issue"], cand["agent"], what_happened_since(path, cand),
+           cand["url"]))
     return True
 
 
+def attempts_path():
+    return os.environ.get("KIPI_ATTEMPTS", DEFAULT_ATTEMPTS)
+
+
 def cmd_redrive(cands):
-    path = os.environ.get("KIPI_ATTEMPTS", DEFAULT_ATTEMPTS)
+    """READ-ONLY. Offers one pick; the dispatcher spends it via mark-dispatched."""
+    path = attempts_path()
     chosen = None
     for cand in cands:
-        flag = "ci_redrive_%s" % cand["signature"]
-        # Read before claiming so EVERY spent candidate escalates on this pass,
-        # not just the one that happens to sort first. The claim below is still
-        # the atomic gate -- this read only decides who gets offered it.
-        if ledger_get(path, cand["issue"], flag):
-            escalate(path, cand)
+        if ledger_get(path, cand["issue"], redrive_flag(cand)):
+            escalate(path, cand)           # machine tier already spent on this
             continue
-        if chosen is not None:
-            continue                       # one hand-back per run, like the pick
-        if ledger_claim(path, cand["issue"], flag):
-            chosen = cand
+        if chosen is None:
+            chosen = cand                  # one hand-back per run, like the pick
     if chosen is None:
         return 1
     sys.stderr.write(
-        "ci-redrive: %s PR #%s red on %s -- handing it back to %s\n"
+        "ci-redrive: %s PR #%s red on %s -- offering it back to %s\n"
         % (chosen["issue"], chosen["pr"], ", ".join(chosen["failing_checks"]),
            chosen["agent"]))
-    print(chosen["issue"])
+    print("%s\t%s\t%s" % (chosen["issue"], chosen["signature"],
+                          chosen["head_sha"]))
+    return 0
+
+
+def cmd_mark_dispatched(issue, sig, head_sha):
+    """The atomic claim. 0 = it is yours to dispatch, 1 = it is not."""
+    path = attempts_path()
+    if not ledger_claim(path, issue, "ci_redrive_%s" % sig):
+        sys.stderr.write(
+            "ci-redrive: %s attempt for signature %s was already claimed (or the "
+            "ledger could not be written) -- not dispatching.\n" % (issue, sig))
+        return 1
+    # Order matters: record WHICH head first, then the marker saying a head was
+    # recorded at all. The reverse order lets a failure between the two claim
+    # that a sha is on file when none is, and the escalation would then read a
+    # missing sha as a push that never happened.
+    if ledger_recorded(path, issue, head_flag(head_sha)):
+        ledger_recorded(path, issue, "ci_redrive_headrec_%s" % sig)
     return 0
 
 
 def main(argv):
     ap = argparse.ArgumentParser(
         description="Machine consumer for red CI on agent-opened PRs (ASK-295).")
-    ap.add_argument("op", choices=("scan", "redrive"))
+    ap.add_argument("op", choices=("scan", "redrive", "mark-dispatched"))
     ap.add_argument("--repo-dir", default=".",
                     help="checkout whose open PRs are read (gh runs here)")
+    ap.add_argument("--issue", help="mark-dispatched: the issue being dispatched")
+    ap.add_argument("--signature", help="mark-dispatched: signature from redrive")
+    ap.add_argument("--head-sha", default="",
+                    help="mark-dispatched: head sha from redrive")
     args = ap.parse_args(argv[1:])
+
+    # No gh call: mark-dispatched commits the offer the dispatcher is holding.
+    # Re-probing here would decide against a world that may have moved between
+    # the offer and the launch, which is a different PR state than the one the
+    # dispatcher is about to act on.
+    if args.op == "mark-dispatched":
+        if not args.issue or not args.signature:
+            ap.error("mark-dispatched needs --issue and --signature")
+        return cmd_mark_dispatched(args.issue, args.signature, args.head_sha)
+
     try:
         cands = candidates(args.repo_dir)
     except GhUnavailable as exc:

--- a/q-system/.q-system/scripts/ci-redrive.py
+++ b/q-system/.q-system/scripts/ci-redrive.py
@@ -1,0 +1,279 @@
+#!/usr/bin/env python3
+"""The machine consumer for red CI on an agent-opened PR (ASK-295).
+
+WHY THIS FILE EXISTS
+--------------------
+On 2026-08-02 the founder got three unprompted GitHub emails:
+
+    [assafkip/kipi-system] PR run failed: Skeleton Validation - ... (ASK-292)
+    [assafkip/kipi-system] PR run failed: Skeleton Validation - ... (ASK-288)
+    [assafkip/kipi-system] Run failed: Skeleton Validation - sana/block-expiry
+
+An autonomous agent opened each PR, CI went red, GitHub mailed the repo owner.
+Both failures were a single CORRECT catch (test-terminal-states.sh, 13 passed
+1 failed; main was green). True, and still useless to him -- he does not work on
+the code. The agent that opened the PR does.
+
+It is a dead end by construction, not by oversight. `ready()` in linear-worker.sh
+returns only backlog/unstarted issues, and an issue with a live PR is In Progress.
+So nothing in this repo ever looks at that PR again, GitHub's notifier is the only
+thing that notices, and its only addressee is the repo owner. ASK-294's instrument
+(the slack-notify.sh chokepoint plus a producer audit) structurally cannot reach
+this: the producer is GitHub, driven by workflow conclusion, outside every sink
+this repo owns. The only lever inside the repo is to stop the condition persisting.
+
+THE FOUR DECISIONS, MADE (ASK-295's Definition of Ready)
+-------------------------------------------------------
+1. DOES A RED AGENT PR REACH THE FOUNDER? No. Not on the red itself. He is
+   reached exactly once per failure, after the machine tier is spent, by a
+   message that says what the machine already tried. `founder_never_the_next_actor`.
+
+2. WHERE THE CONSUMER RUNS: inside the existing registry-driven dispatcher
+   (kipi-dispatch.sh), as a preferred pick ahead of a fresh issue -- NOT a new
+   launchd job. Per-repo jobs die silently (the income-scanner scar: 6 days dark)
+   and the dispatcher already owns every cap this needs: MAX_CONCURRENT, the
+   daily budget, the liveness assert, the notify sink. A second job would be a
+   second copy of all four, drifting.
+
+3. ATTRIBUTION IS THE BRANCH NAME, with no Linear round-trip. The worker cuts
+   every branch as `<agent>/<issue>` (`sana/ask-295`), so the branch already
+   carries both facts this needs. A branch that does not match is not an agent
+   PR and is none of this tool's business -- the founder's own PRs keep behaving
+   exactly as they do today.
+
+4. THE CAP IS ONE ATTEMPT PER PR PER FAILURE SIGNATURE, held in the existing
+   attempts ledger (single-writer, flock'd -- attempts-ledger.py). The signature
+   is the set of failing check NAMES, deliberately NOT the head sha: a re-push
+   that fails the same check again is the same failure, and re-dispatching on it
+   is how a handler re-runs a flake forever. ASK-295 names that risk by hand --
+   one root cause of the 2026-08-02 redness was a measurement taken against the
+   wrong tree, and a handler that re-runs CI without fixing tree isolation would
+   have looped on it all night. A genuinely NEW failure gets its own fresh
+   attempt, because it is a different problem.
+
+WHAT IT DOES NOT DO
+-------------------
+It does not merge, close, comment on, or re-run anything on GitHub. It reads PR
+state and answers one question: which issue should the dispatcher hand back to
+its agent right now. The dispatching is the dispatcher's, and stays under the
+dispatcher's caps.
+
+    scan     -> JSON of red agent PRs (read-only, no ledger write, no page)
+    redrive  -> claim one attempt, print the issue id, exit 0
+                nothing claimable -> exit 1
+                gh could not answer -> exit 2, nothing claimed
+
+THE PROBE'S rc IS PART OF ITS ANSWER. `gh pr list` failing is not "no red PRs":
+reading it that way is how a real red PR goes unhandled behind a clean exit. It
+is the same class as arm_automerge's three-state armed/unarmed/could-not-tell,
+and it is why a gh failure is exit 2 with no ledger write rather than exit 1.
+"""
+
+import argparse
+import hashlib
+import json
+import os
+import re
+import subprocess
+import sys
+
+HERE = os.path.dirname(os.path.abspath(__file__))
+LEDGER_SCRIPT = os.path.join(HERE, "attempts-ledger.py")
+DEFAULT_NOTIFY = os.path.join(HERE, "slack-notify.sh")
+DEFAULT_ATTEMPTS = os.path.join(
+    os.environ.get("KIPI_STATE_DIR", os.path.expanduser("~/.config/kipi")),
+    "linear-worker-attempts.json")
+
+# `sana/ask-295` -> agent `sana`, issue `ASK-295`. Anchored at both ends on
+# purpose: `sana/ask-295-followup` is a branch a human named, and guessing which
+# issue a human meant is how the wrong issue gets re-dispatched.
+BRANCH_RE = re.compile(r"^(?P<agent>[a-z][a-z0-9_-]*)/(?P<issue>[a-z]{2,6}-\d+)$")
+
+# A CheckRun that COMPLETED with one of these is red. Everything else -- queued,
+# in progress, skipped, neutral -- is not a failure, and treating "still running"
+# as red would re-dispatch an issue whose CI has not finished answering.
+FAILED_CONCLUSIONS = {"FAILURE", "TIMED_OUT", "CANCELLED", "STARTUP_FAILURE",
+                      "ACTION_REQUIRED"}
+# The legacy commit-status half of the same rollup speaks a different vocabulary.
+FAILED_STATES = {"FAILURE", "ERROR"}
+
+PR_FIELDS = "number,headRefName,url,title,statusCheckRollup,isDraft"
+
+
+class GhUnavailable(Exception):
+    """gh could not answer. NOT the same claim as `no red PRs`."""
+
+
+def list_prs(repo_dir):
+    gh = os.environ.get("KIPI_GH", "gh")
+    cmd = [gh, "pr", "list", "--state", "open", "--json", PR_FIELDS,
+           "--limit", "50"]
+    try:
+        proc = subprocess.run(cmd, cwd=repo_dir, capture_output=True, text=True)
+    except OSError as exc:
+        raise GhUnavailable("could not run %s: %s" % (gh, exc))
+    if proc.returncode != 0:
+        raise GhUnavailable(
+            "`gh pr list` exited %d: %s"
+            % (proc.returncode, (proc.stderr or "").strip()[:200]))
+    try:
+        return json.loads(proc.stdout or "[]")
+    except ValueError as exc:
+        raise GhUnavailable("`gh pr list` returned unparseable JSON: %s" % exc)
+
+
+def failing_checks(pr):
+    """Names of the checks that are red RIGHT NOW, sorted and de-duplicated."""
+    names = set()
+    for check in pr.get("statusCheckRollup") or []:
+        if not isinstance(check, dict):
+            continue
+        kind = check.get("__typename")
+        if kind == "StatusContext":
+            if (check.get("state") or "").upper() in FAILED_STATES:
+                names.add(check.get("context") or "(unnamed status)")
+            continue
+        # CheckRun, and anything else the rollup grows later that speaks
+        # status/conclusion. A check that has not COMPLETED has not failed.
+        if (check.get("status") or "").upper() != "COMPLETED":
+            continue
+        if (check.get("conclusion") or "").upper() in FAILED_CONCLUSIONS:
+            names.add(check.get("name") or "(unnamed check)")
+    return sorted(names)
+
+
+def signature(names):
+    """Identity of a FAILURE, not of a run.
+
+    Head sha is left out deliberately -- see the module docstring. Same checks
+    red again == same problem == the machine tier is already spent on it.
+    """
+    return hashlib.sha1("\n".join(names).encode("utf-8")).hexdigest()[:12]
+
+
+def candidates(repo_dir):
+    out = []
+    for pr in list_prs(repo_dir):
+        match = BRANCH_RE.match(pr.get("headRefName") or "")
+        if not match:
+            continue                       # not an agent branch, not ours
+        failing = failing_checks(pr)
+        if not failing:
+            continue
+        out.append({
+            "issue": match.group("issue").upper(),
+            "agent": match.group("agent"),
+            "pr": pr.get("number"),
+            "url": pr.get("url"),
+            "branch": pr.get("headRefName"),
+            "failing_checks": failing,
+            "signature": signature(failing),
+        })
+    return out
+
+
+# --- the ledger, through its single writer -----------------------------------
+# Never a direct read-modify-write of the attempts file. attempts-ledger.py is
+# the one writer for exactly the reason its docstring gives: six unsynchronised
+# copies of this let an issue exceed a cap and keep being dispatched.
+
+def ledger_get(path, issue, key):
+    proc = subprocess.run(
+        [sys.executable, LEDGER_SCRIPT, path, "get", issue, key, ""],
+        capture_output=True, text=True)
+    return (proc.stdout or "").strip() if proc.returncode == 0 else ""
+
+
+def ledger_claim(path, issue, flag):
+    """True the first time this flag is claimed anywhere, False otherwise.
+
+    A lock timeout (rc 3) or a hard write failure (rc 2) is FALSE, never True.
+    Nothing was recorded, so nothing may act as though it was -- the next
+    scheduled run claims it instead.
+    """
+    proc = subprocess.run(
+        [sys.executable, LEDGER_SCRIPT, path, "claim-flag", issue, flag],
+        capture_output=True, text=True)
+    if proc.returncode not in (0, 1):
+        sys.stderr.write("ci-redrive: ledger refused `%s` for %s: %s\n"
+                         % (flag, issue, (proc.stderr or "").strip()[:200]))
+    return proc.returncode == 0
+
+
+def notify(message):
+    script = os.environ.get("KIPI_NOTIFY", DEFAULT_NOTIFY)
+    if not os.path.exists(script):
+        return
+    try:
+        subprocess.run(["bash", script, message], capture_output=True, text=True)
+    except OSError as exc:
+        sys.stderr.write("ci-redrive: notify failed: %s\n" % exc)
+
+
+def escalate(path, cand):
+    """The founder's ONE message about this failure, and only after the machine.
+
+    It says what was tried, per terminal-state-redrive-2026-08-01 item 3. Once
+    per signature, because the dispatcher reaches this state on every heartbeat
+    for as long as the PR sits red -- paging per run is a page every 15 minutes
+    for one fact that has not changed.
+    """
+    if not ledger_claim(path, cand["issue"], "ci_escalated_%s" % cand["signature"]):
+        return False
+    notify(
+        "ci-redrive: %s PR #%s is still red after the machine tier. The failing "
+        "check is %s. What the machine tried: it re-dispatched %s to %s once for "
+        "this exact failure and the same check failed again, so it stopped rather "
+        "than re-run a flake. %s"
+        % (cand["issue"], cand["pr"], ", ".join(cand["failing_checks"]),
+           cand["issue"], cand["agent"], cand["url"]))
+    return True
+
+
+def cmd_redrive(cands):
+    path = os.environ.get("KIPI_ATTEMPTS", DEFAULT_ATTEMPTS)
+    chosen = None
+    for cand in cands:
+        flag = "ci_redrive_%s" % cand["signature"]
+        # Read before claiming so EVERY spent candidate escalates on this pass,
+        # not just the one that happens to sort first. The claim below is still
+        # the atomic gate -- this read only decides who gets offered it.
+        if ledger_get(path, cand["issue"], flag):
+            escalate(path, cand)
+            continue
+        if chosen is not None:
+            continue                       # one hand-back per run, like the pick
+        if ledger_claim(path, cand["issue"], flag):
+            chosen = cand
+    if chosen is None:
+        return 1
+    sys.stderr.write(
+        "ci-redrive: %s PR #%s red on %s -- handing it back to %s\n"
+        % (chosen["issue"], chosen["pr"], ", ".join(chosen["failing_checks"]),
+           chosen["agent"]))
+    print(chosen["issue"])
+    return 0
+
+
+def main(argv):
+    ap = argparse.ArgumentParser(
+        description="Machine consumer for red CI on agent-opened PRs (ASK-295).")
+    ap.add_argument("op", choices=("scan", "redrive"))
+    ap.add_argument("--repo-dir", default=".",
+                    help="checkout whose open PRs are read (gh runs here)")
+    args = ap.parse_args(argv[1:])
+    try:
+        cands = candidates(args.repo_dir)
+    except GhUnavailable as exc:
+        # 2, and deliberately neither 0 nor 1. 1 means "nothing to redrive",
+        # which is a claim about the PRs; this is a claim about the probe.
+        sys.stderr.write("ci-redrive: %s -- nothing was claimed.\n" % exc)
+        return 2
+    if args.op == "scan":
+        print(json.dumps(cands, indent=2))
+        return 0
+    return cmd_redrive(cands)
+
+
+if __name__ == "__main__":
+    sys.exit(main(sys.argv))

--- a/q-system/.q-system/scripts/test/test-ci-redrive.sh
+++ b/q-system/.q-system/scripts/test/test-ci-redrive.sh
@@ -82,7 +82,17 @@ printf '%s\n' "$*" >> "$NOTIFY_LOG"
 SH
 chmod +x "$TMP/notify.sh"
 
+# --- the process-table seam --------------------------------------------------
+# ci-redrive.py asks the process table whether a converge for the candidate issue
+# is already running. The default stub prints an EMPTY table, so every case above
+# is decided by its fixture and not by whatever happens to be running on the box
+# -- the flakiness test-dispatch-liveness.sh already paid for once (17/17 alone,
+# 15/17 alongside the fleet). Cases that need a live converge say so explicitly.
+printf '#!/bin/sh\ncat "${PS_FIXTURE:-/dev/null}"\n' > "$TMP/ps"; chmod +x "$TMP/ps"
+: > "$TMP/ps-empty"
+
 fixture() { printf '%s' "$1" > "$TMP/prs.json"; }
+ps_fixture() { printf '%s\n' "$1" > "$TMP/ps-table"; PS_FIXTURE="$TMP/ps-table"; }
 
 # Real shapes, 2026-08-03, `gh pr list --state open --json ...` on this repo:
 #   PR 73 sana/ask-295          validate SUCCESS + kipi/reviewer-approved FAILURE
@@ -116,10 +126,12 @@ WORLD='[
 
 run() {  # run <op> [args...]
   KIPI_GH="$TMP/gh" \
+  KIPI_PS="$TMP/ps" \
   KIPI_NOTIFY="$TMP/notify.sh" \
   KIPI_ATTEMPTS="$LEDGER" \
   GH_FIXTURE="$TMP/prs.json" \
   GH_RC="${GH_RC:-0}" \
+  PS_FIXTURE="${PS_FIXTURE:-$TMP/ps-empty}" \
   NOTIFY_LOG="$NOTIFY_LOG" \
   python3 "$REDRIVE" --repo-dir "$TMP" "$@" 2>"$TMP/err"
 }
@@ -129,6 +141,7 @@ fresh_state() {
   NOTIFY_LOG="$TMP/notify-$1.log"
   : > "$NOTIFY_LOG"
   rm -f "$LEDGER"
+  PS_FIXTURE="$TMP/ps-empty"
 }
 
 pages() { wc -l < "$NOTIFY_LOG" | tr -d ' '; }
@@ -330,6 +343,221 @@ fixture '[{"number":71,"headRefName":"sana/ask-292","isDraft":false,
   "url":"https://x/71","title":"t (ASK-292)","statusCheckRollup":[]}]'
 run redrive >/dev/null; RC=$?
 check "no checks reported is not red" "$RC" "1"
+
+# --- 13. work already in flight is not a dead end (PR #73 review r2, finding 1)
+# The dispatcher's heartbeat is 900s and a converge run is minutes to tens of
+# minutes. So the heartbeat AFTER a redrive dispatch finds the same PR still red
+# -- the agent has not pushed yet -- with the attempt flag already set. Round 2
+# went straight to escalate() there and paged the founder "it stopped rather than
+# hand back an unchanged tree" about a run that was at that moment still running.
+#
+# The second half is the worse half: escalate() CLAIMS `ci_escalated_<sig>` on
+# the way out, so when the converge really did finish and leave the PR red, the
+# one true page was already spent on the false one. A wrong page that also
+# silences the right page is strictly worse than no page at all.
+# The offer half, with the attempt UNSPENT so a passing rc 1 can only come from
+# the liveness guard. Asserting this against a spent attempt would pass for the
+# wrong reason -- a spent attempt exits 1 anyway, and the case would grade
+# nothing (the same vacuous shape the round-1 fixture was caught on).
+fresh_state inflight_offer
+fixture "$WORLD"
+ps_fixture "bash /x/q-system/.q-system/scripts/converge.sh --issue ASK-288 --max-rounds 3"
+run redrive >/dev/null; RC=$?
+check "a candidate whose converge is live is not offered" "$RC" "1"
+contains "the log says why it was skipped" "$(cat "$TMP/err")" "converge for it is already live"
+PS_FIXTURE="$TMP/ps-empty"
+run redrive >/dev/null; RC=$?
+check "control: with no converge live the same candidate IS offered" "$RC" "0"
+
+# The escalation half.
+fresh_state inflight
+fixture "$WORLD"
+OUT="$(run redrive)"; SIG="$(printf '%s' "$OUT" | cut -f2)"
+run mark-dispatched --issue ASK-288 --signature "$SIG" \
+  --head-sha bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb >/dev/null
+ps_fixture "bash /x/q-system/.q-system/scripts/converge.sh --issue ASK-288 --max-rounds 3"
+
+run redrive >/dev/null; RC=$?
+check "a spent attempt whose converge is live still exits 1" "$RC" "1"
+check "and the founder is NOT paged that it stopped" "$(pages)" "0"
+
+# THE SILENCING HALF. Once the converge is gone and the PR is still red, the page
+# the founder was owed must still be available -- a run that fired nothing must
+# not have consumed the once-per-signature budget.
+PS_FIXTURE="$TMP/ps-empty"
+run redrive >/dev/null; RC=$?
+check "with the converge gone the attempt is still spent" "$RC" "1"
+check "and the true page fires, not swallowed by the false one" "$(pages)" "1"
+contains "the true page names the issue" "$(cat "$NOTIFY_LOG")" "ASK-288"
+
+# A converge for a DIFFERENT issue says nothing about this one.
+fresh_state otherissue
+fixture "$WORLD"
+ps_fixture "bash /x/converge.sh --issue ASK-999 --max-rounds 3"
+run redrive >/dev/null; RC=$?
+check "a converge on another issue does not block this one" "$RC" "0"
+
+# An UNREADABLE process table is not evidence that nothing is running. Erring the
+# other way pages the founder about a run that may be live and burns the flag
+# doing it; erring this way costs one quiet heartbeat, which is what happens
+# today anyway.
+fresh_state psdown
+fixture "$WORLD"
+PS_FIXTURE="/nonexistent/ps-table-that-cannot-be-read"
+printf '#!/bin/sh\nexit 3\n' > "$TMP/ps-broken"; chmod +x "$TMP/ps-broken"
+OLD_PS="$TMP/ps"
+cp "$TMP/ps-broken" "$TMP/ps"
+run redrive >/dev/null; RC=$?
+check "an unreadable process table offers nothing rather than guessing" "$RC" "1"
+check "an unreadable process table pages nobody" "$(pages)" "0"
+printf '#!/bin/sh\ncat "${PS_FIXTURE:-/dev/null}"\n' > "$OLD_PS"; chmod +x "$OLD_PS"
+
+# --- 14. the shell integration, driven for real (PR #73 review r2, finding 3) --
+# Round 2 shipped the entire kipi-dispatch.sh wiring covered by `bash -n` alone:
+# syntax, not behaviour. `bash -n` cannot tell whether the offer is adopted,
+# whether mark-dispatched actually gates the launch, or whether an rc 2 leaves
+# the fresh pick standing. Every one of those is a live decision on a 900s timer.
+#
+# So this section runs the REAL kipi-dispatch.sh against the REAL ci-redrive.py
+# and the REAL attempts-ledger.py. Only the two edges are stubbed: `gh` (the PR
+# world) and `kipi` (the pick + the converge). What is asserted is which issue
+# the dispatcher actually handed to converge, read off a file the stub writes.
+echo
+echo "== ci-redrive x kipi-dispatch =="
+
+DISPATCH="$REPO_ROOT/kipi-dispatch.sh"
+if [ ! -f "$DISPATCH" ]; then
+  bad "14 kipi-dispatch.sh is present" "not found at $DISPATCH"
+else
+
+# UNIQUE IDS PER RUN. Case 14e puts a decoy converge in the GLOBAL process table,
+# so a hardcoded id lets two concurrent runs of this suite (the capability gate
+# runs the fleet's tests together) satisfy each other's guards. Same lesson
+# test-dispatch-liveness.sh learned at 17/17 alone, 15/17 under the gate.
+RED_ISS="ASK-8$$"          # the red PR the redrive should hand back
+FRESH_ISS="ASK-7$$"        # what `kipi work` offers as the ordinary fresh pick
+RED_BRANCH="sana/$(printf '%s' "$RED_ISS" | tr 'A-Z' 'a-z')"
+
+DROOT="$TMP/dispatch"
+FAKE_REPO="$DROOT/repo"
+SCRIPTS="$FAKE_REPO/q-system/.q-system/scripts"
+mkdir -p "$SCRIPTS" "$DROOT/home/.config/kipi" "$DROOT/bin"
+
+# The dispatcher resolves ci-redrive.py off $REPO, and ci-redrive.py resolves
+# attempts-ledger.py off its own directory. Both real, both copied.
+cp "$REDRIVE" "$SCRIPTS/ci-redrive.py"
+cp "$REPO_ROOT/q-system/.q-system/scripts/attempts-ledger.py" "$SCRIPTS/attempts-ledger.py"
+
+cp "$TMP/gh" "$DROOT/bin/gh"
+cp "$TMP/ps" "$DROOT/bin/ps-stub"
+printf '#!/usr/bin/env bash\nsleep 30\n' > "$DROOT/converge.sh"; chmod +x "$DROOT/converge.sh"
+
+# `kipi work` offers FRESH_ISS. `kipi converge` records the issue it was actually
+# given and then stays alive, so the dispatcher's own liveness assert passes and
+# the assertion below reads a fact rather than a log line.
+cat > "$FAKE_REPO/kipi" <<SH
+#!/usr/bin/env bash
+case "\$1" in
+  work) printf '1 ready issue\n[dry] would work $FRESH_ISS\n' ;;
+  converge)
+    printf '%s\n' "\$3" >> "$DROOT/dispatched"
+    exec bash "$DROOT/converge.sh" --issue "\$3" --max-rounds 3
+    ;;
+esac
+SH
+chmod +x "$FAKE_REPO/kipi"
+
+D_LEDGER="$DROOT/attempts.json"
+D_PAGES="$DROOT/pages.txt"
+D_PRS="$DROOT/prs.json"
+
+RED_WORLD="[{\"number\":91,\"headRefName\":\"$RED_BRANCH\",\"isDraft\":false,
+  \"headRefOid\":\"9999999999999999999999999999999999999999\",
+  \"url\":\"https://x/91\",\"title\":\"t ($RED_ISS)\",
+  \"statusCheckRollup\":[{\"__typename\":\"CheckRun\",\"name\":\"validate\",
+   \"status\":\"COMPLETED\",\"conclusion\":\"FAILURE\",
+   \"workflowName\":\"Skeleton Validation\"}]}]"
+
+run_dispatch() {  # run_dispatch [GH_RC]
+  ( cd "$FAKE_REPO" && HOME="$DROOT/home" PATH="$DROOT/bin:$PATH" \
+      KIPI_REPO="$FAKE_REPO" KIPI_NOTIFY="$TMP/notify.sh" \
+      KIPI_DISPATCH_DAILY_MAX=9 KIPI_DISPATCH_MAX=999 \
+      KIPI_ATTEMPTS="$D_LEDGER" KIPI_GH="$DROOT/bin/gh" KIPI_PS="$DROOT/bin/ps-stub" \
+      GH_FIXTURE="$D_PRS" GH_RC="${1:-0}" PS_FIXTURE="${PS_FIXTURE:-$TMP/ps-empty}" \
+      NOTIFY_LOG="$D_PAGES" \
+      bash "$DISPATCH" >/dev/null 2>&1 )
+}
+dlog() { cat "$DROOT/home/.config/kipi/dispatch.log" 2>/dev/null; }
+dispatched() { tail -1 "$DROOT/dispatched" 2>/dev/null; }
+
+d_reset() {
+  rm -rf "$DROOT/home/.config/kipi"; mkdir -p "$DROOT/home/.config/kipi"
+  # Seed the beacon so the one-off "heartbeat STARTED" page is not mistaken for
+  # a fault page by the assertions below.
+  date -u +%s > "$DROOT/home/.config/kipi/dispatch-lastbeat"
+  : > "$D_PAGES"; : > "$DROOT/dispatched"
+  rm -f "$D_LEDGER"
+  PS_FIXTURE="$TMP/ps-empty"
+  pkill -f "$DROOT/converge.sh" 2>/dev/null
+}
+
+# 14a. the red PR is preferred over the fresh pick, and the attempt is claimed.
+d_reset
+printf '%s' "$RED_WORLD" > "$D_PRS"
+run_dispatch
+check "14a the dispatcher hands the RED issue back, ahead of the fresh pick" \
+  "$(dispatched)" "$RED_ISS"
+contains "14b the log names the hand-back" "$(dlog)" "handing $RED_ISS back"
+if grep -q "ci_redrive" "$D_LEDGER" 2>/dev/null; then
+  ok "14c the attempt is claimed in the ledger by the DISPATCHER"
+else
+  bad "14c the attempt is claimed in the ledger by the DISPATCHER" "$(cat "$D_LEDGER" 2>/dev/null)"
+fi
+pkill -f "$DROOT/converge.sh" 2>/dev/null
+
+# 14d. gh could not answer -> the fresh pick stands and nothing is claimed.
+d_reset
+printf '%s' "$RED_WORLD" > "$D_PRS"
+run_dispatch 7
+check "14d a gh failure leaves the fresh pick standing" "$(dispatched)" "$FRESH_ISS"
+contains "14e the log says gh could not read PR state" "$(dlog)" "gh could not read PR state"
+check "14f a gh failure claims nothing" \
+  "$([ -f "$D_LEDGER" ] && echo yes || echo no)" "no"
+pkill -f "$DROOT/converge.sh" 2>/dev/null
+
+# 14g. THE FINDING-2 CASE, driven for real. A converge for the red issue is
+# already live. Round 2 still offered it, NEXT was overwritten with it, and the
+# duplicate guard 40 lines later exited 0 -- so the ready issue that WAS
+# dispatchable was thrown away, every heartbeat, for the whole converge.
+d_reset
+printf '%s' "$RED_WORLD" > "$D_PRS"
+bash "$DROOT/converge.sh" --issue "$RED_ISS" --max-rounds 3 >/dev/null 2>&1 &
+DECOY=$!
+disown "$DECOY" 2>/dev/null || true
+sleep 1
+# The real process table, not the stub: the point is that the guard sees what the
+# dispatcher's own duplicate guard sees.
+cp "$DROOT/bin/ps-stub" "$DROOT/ps-stub.bak"
+printf '#!/bin/sh\nexec /bin/ps -Ao args=\n' > "$DROOT/bin/ps-stub"; chmod +x "$DROOT/bin/ps-stub"
+run_dispatch
+check "14g a live converge does not cost the fresh pick its slot" \
+  "$(dispatched)" "$FRESH_ISS"
+check "14h and no founder page is sent about a run that is still running" \
+  "$([ -s "$D_PAGES" ] && cat "$D_PAGES" || echo silent)" "silent"
+cp "$DROOT/ps-stub.bak" "$DROOT/bin/ps-stub"
+kill "$DECOY" 2>/dev/null
+pkill -f "$DROOT/converge.sh" 2>/dev/null
+
+# 14i. nothing red -> the ordinary path is untouched.
+d_reset
+printf '[]' > "$D_PRS"
+run_dispatch
+check "14i with nothing red the fresh pick is dispatched as before" \
+  "$(dispatched)" "$FRESH_ISS"
+lacks "14j and no redrive line is logged" "$(dlog)" "handing"
+pkill -f "$DROOT/converge.sh" 2>/dev/null
+
+fi
 
 echo
 echo "$PASS passed, $FAIL failed"

--- a/q-system/.q-system/scripts/test/test-ci-redrive.sh
+++ b/q-system/.q-system/scripts/test/test-ci-redrive.sh
@@ -1,0 +1,193 @@
+#!/usr/bin/env bash
+# Pairs with ci-redrive.py (ASK-295): red CI on an agent-opened PR is a dead end
+# with no machine consumer, so GitHub emails the founder and he cannot act.
+#
+# THE SCAR (2026-08-02)
+# ---------------------
+# The founder received three unprompted GitHub notifications in one day:
+#   [assafkip/kipi-system] PR run failed: Skeleton Validation - ... (ASK-292)
+#   [assafkip/kipi-system] PR run failed: Skeleton Validation - ... (ASK-288)
+#   [assafkip/kipi-system] Run failed: Skeleton Validation - sana/block-expiry
+# An autonomous agent opened each PR, CI went red, GitHub mailed the repo owner.
+# The failures were a SINGLE CORRECT CATCH (test-terminal-states.sh). True, and
+# still useless to him: he does not work on the code. The agent that opened the
+# PR does. ready() in linear-worker.sh only returns backlog/unstarted issues, so
+# an In Progress issue whose PR just went red is never re-picked -- the dead end.
+#
+# WHAT THIS SUITE PINS
+# --------------------
+#   1. Attribution: branch `sana/ask-295` -> ASK-295, with no Linear round-trip.
+#   2. Non-agent branches are none of this tool's business (the founder's own
+#      PRs keep behaving exactly as they do today).
+#   3. ONE machine attempt per PR per failure signature. Not per run, not per
+#      push -- a handler that re-runs CI without fixing the cause re-runs a
+#      flake forever, which is the failure mode this issue names by hand.
+#   4. The founder is NOT paged on the red itself. He is paged once, AFTER the
+#      machine tier is spent, by a message that names what the machine tried.
+#
+# The `gh` seam is a fixture script, so no case here touches the network: what
+# is under test is the decision, and a suite that needs a live red PR to run is
+# a suite that never runs.
+set -uo pipefail
+
+PASS=0; FAIL=0
+ok()  { printf '  PASS %s\n' "$1"; PASS=$((PASS + 1)); }
+bad() { printf '  FAIL %s\n     %s\n' "$1" "${2:-}"; FAIL=$((FAIL + 1)); }
+check() { if [ "$2" = "$3" ]; then ok "$1"; else bad "$1" "expected [$3] got [$2]"; fi; }
+contains() {
+  if printf '%s' "$2" | grep -qF -- "$3"; then ok "$1"
+  else bad "$1" "expected to find [$3] in [$2]"; fi
+}
+lacks() {
+  if printf '%s' "$2" | grep -qF -- "$3"; then bad "$1" "did NOT expect [$3] in [$2]"
+  else ok "$1"; fi
+}
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+# FOUR levels up: test -> scripts -> .q-system -> q-system -> repo root.
+REPO_ROOT="$(cd "$SCRIPT_DIR/../../../.." && pwd)"
+REDRIVE="$REPO_ROOT/q-system/.q-system/scripts/ci-redrive.py"
+[ -f "$REDRIVE" ] || { echo "FATAL: ci-redrive.py not found at $REDRIVE" >&2; exit 1; }
+
+TMP="$(mktemp -d)"
+trap 'rm -rf "$TMP"' EXIT
+
+# --- the gh seam -------------------------------------------------------------
+# Prints whatever JSON $GH_FIXTURE names, and exits $GH_RC. Both are read at
+# call time so a case can swap the world between two invocations.
+cat > "$TMP/gh" <<'SH'
+#!/usr/bin/env bash
+[ "${GH_RC:-0}" = "0" ] || { echo "gh: could not read PRs" >&2; exit "${GH_RC}"; }
+cat "$GH_FIXTURE"
+SH
+chmod +x "$TMP/gh"
+
+# --- the notify seam ---------------------------------------------------------
+# Appends its argument to $NOTIFY_LOG. Reading that file is how a case asserts
+# the founder was, or was not, reached.
+cat > "$TMP/notify.sh" <<'SH'
+#!/usr/bin/env bash
+printf '%s\n' "$*" >> "$NOTIFY_LOG"
+SH
+chmod +x "$TMP/notify.sh"
+
+fixture() { printf '%s' "$1" > "$TMP/prs.json"; }
+
+# A red agent PR, a green agent PR, and a red PR on a branch carrying no issue
+# id -- all in one payload, because the filter is what is under test.
+RED_AND_FRIENDS='[
+ {"number":101,"headRefName":"sana/ask-292","isDraft":false,
+  "url":"https://github.com/assafkip/kipi-system/pull/101",
+  "title":"feat: will-it-run (ASK-292)",
+  "statusCheckRollup":[
+    {"__typename":"CheckRun","name":"Skeleton Validation","status":"COMPLETED",
+     "conclusion":"FAILURE","detailsUrl":"https://github.com/x/runs/1"},
+    {"__typename":"CheckRun","name":"kipi/reviewer-approved","status":"COMPLETED",
+     "conclusion":"SUCCESS","detailsUrl":"https://github.com/x/runs/2"}]},
+ {"number":102,"headRefName":"sana/ask-288","isDraft":false,
+  "url":"https://github.com/assafkip/kipi-system/pull/102",
+  "title":"fix: capability block expiry (ASK-288)",
+  "statusCheckRollup":[
+    {"__typename":"CheckRun","name":"Skeleton Validation","status":"COMPLETED",
+     "conclusion":"SUCCESS","detailsUrl":"https://github.com/x/runs/3"}]},
+ {"number":103,"headRefName":"assaf-hotfix","isDraft":false,
+  "url":"https://github.com/assafkip/kipi-system/pull/103",
+  "title":"chore: founder hand edit",
+  "statusCheckRollup":[
+    {"__typename":"CheckRun","name":"Skeleton Validation","status":"COMPLETED",
+     "conclusion":"FAILURE","detailsUrl":"https://github.com/x/runs/4"}]}]'
+
+run() {  # run <op> [args...]
+  KIPI_GH="$TMP/gh" \
+  KIPI_NOTIFY="$TMP/notify.sh" \
+  KIPI_ATTEMPTS="$LEDGER" \
+  GH_FIXTURE="$TMP/prs.json" \
+  GH_RC="${GH_RC:-0}" \
+  NOTIFY_LOG="$NOTIFY_LOG" \
+  python3 "$REDRIVE" --repo-dir "$TMP" "$@" 2>"$TMP/err"
+}
+
+fresh_state() {
+  LEDGER="$TMP/attempts-$1.json"
+  NOTIFY_LOG="$TMP/notify-$1.log"
+  : > "$NOTIFY_LOG"
+  rm -f "$LEDGER"
+}
+
+echo "== ci-redrive =="
+
+# --- 1. attribution ----------------------------------------------------------
+fresh_state attr
+fixture "$RED_AND_FRIENDS"
+OUT="$(run scan)"; RC=$?
+check "scan exits 0 with candidates" "$RC" "0"
+contains "red agent PR attributed to its issue" "$OUT" '"issue": "ASK-292"'
+contains "the failing check is named" "$OUT" "Skeleton Validation"
+contains "the PR number is carried" "$OUT" '"pr": 101'
+
+# --- 2. what it leaves alone -------------------------------------------------
+lacks "a GREEN agent PR is not a candidate" "$OUT" '"issue": "ASK-288"'
+lacks "a red PR on a non-agent branch is not a candidate" "$OUT" '"pr": 103'
+
+# --- 3. one machine attempt per PR per failure signature ---------------------
+fresh_state cap
+fixture "$RED_AND_FRIENDS"
+OUT="$(run redrive)"; RC=$?
+check "first red: redrive claims the attempt" "$RC" "0"
+check "first red: the issue to re-dispatch is printed" "$OUT" "ASK-292"
+check "first red does NOT page the founder" "$(wc -l < "$NOTIFY_LOG" | tr -d ' ')" "0"
+
+OUT2="$(run redrive)"; RC2=$?
+check "same signature: no second machine attempt" "$RC2" "1"
+check "same signature: no issue printed" "$OUT2" ""
+
+# --- 4. escalation, after the machine tier and naming what it tried ----------
+ESC="$(cat "$NOTIFY_LOG")"
+contains "escalation names the issue" "$ESC" "ASK-292"
+contains "escalation names the PR" "$ESC" "#101"
+contains "escalation names the failing check" "$ESC" "Skeleton Validation"
+contains "escalation says the machine already re-dispatched" "$ESC" "re-dispatched"
+
+run redrive >/dev/null 2>&1
+check "escalation pages ONCE per signature, not per run" \
+  "$(wc -l < "$NOTIFY_LOG" | tr -d ' ')" "1"
+
+# --- 5. a DIFFERENT failure earns a fresh machine attempt --------------------
+fixture "$(printf '%s' "$RED_AND_FRIENDS" | sed 's/Skeleton Validation/Lefthook Gate/')"
+OUT3="$(run redrive)"; RC3=$?
+check "new failure signature: a fresh attempt is claimed" "$RC3" "0"
+check "new failure signature: the issue is printed again" "$OUT3" "ASK-292"
+
+# --- 6. all-green is quiet, not an error state -------------------------------
+fresh_state green
+fixture '[{"number":104,"headRefName":"sana/ask-300","isDraft":false,
+  "url":"https://x/104","title":"t (ASK-300)",
+  "statusCheckRollup":[{"__typename":"CheckRun","name":"Skeleton Validation",
+   "status":"COMPLETED","conclusion":"SUCCESS","detailsUrl":"https://x/5"}]}]'
+run redrive >/dev/null; RC=$?
+check "nothing red: exit 1, nothing to do" "$RC" "1"
+check "nothing red: founder untouched" "$(wc -l < "$NOTIFY_LOG" | tr -d ' ')" "0"
+
+# --- 7. gh could not answer: not a claim, and not silence --------------------
+# The probe's rc is part of its answer (arm_automerge's finding 3, same class).
+# Reading a failed `gh` as "no red PRs" is how a real red PR goes unhandled with
+# a clean exit -- so it exits 2 and burns no attempt.
+fresh_state ghdown
+fixture "$RED_AND_FRIENDS"
+GH_RC=7 run redrive >/dev/null; RC=$?
+GH_RC=0
+check "gh failure exits 2, not 0 and not 1" "$RC" "2"
+check "gh failure writes no ledger" "$([ -f "$LEDGER" ] && echo yes || echo no)" "no"
+
+# --- 8. a run still pending is not a failure ---------------------------------
+fresh_state pending
+fixture '[{"number":105,"headRefName":"sana/ask-301","isDraft":false,
+  "url":"https://x/105","title":"t (ASK-301)",
+  "statusCheckRollup":[{"__typename":"CheckRun","name":"Skeleton Validation",
+   "status":"IN_PROGRESS","conclusion":"","detailsUrl":"https://x/6"}]}]'
+run redrive >/dev/null; RC=$?
+check "an in-flight check is not red" "$RC" "1"
+
+echo
+echo "$PASS passed, $FAIL failed"
+[ "$FAIL" -eq 0 ]

--- a/q-system/.q-system/scripts/test/test-ci-redrive.sh
+++ b/q-system/.q-system/scripts/test/test-ci-redrive.sh
@@ -14,16 +14,27 @@
 # PR does. ready() in linear-worker.sh only returns backlog/unstarted issues, so
 # an In Progress issue whose PR just went red is never re-picked -- the dead end.
 #
+# THE FIXTURES ARE THE PRODUCER'S OWN SHAPES, NOT MINE (PR #73 review, findings
+# 1 and 3, and the `fixtures_from_producers` lesson). Round 1 of this suite
+# invented a fixture where `kipi/reviewer-approved` arrived as a CheckRun with
+# conclusion SUCCESS. GitHub actually delivers it as a StatusContext with
+# `state: FAILURE`, which is the shape pr-review-agent.sh's `post_reviewer_status`
+# posts -- so the suite was green while the script counted every REQUEST-CHANGES
+# review as red CI. Every rollup below is copied verbatim from a real
+# `gh pr list --json statusCheckRollup` against this repo on 2026-08-03.
+#
 # WHAT THIS SUITE PINS
 # --------------------
-#   1. Attribution: branch `sana/ask-295` -> ASK-295, with no Linear round-trip.
+#   1. Attribution: branch `sana/ask-295` -> ASK-295 first, and the PR TITLE's
+#      issue id when the branch carries none (`sana/block-expiry` -> ASK-288).
 #   2. Non-agent branches are none of this tool's business (the founder's own
 #      PRs keep behaving exactly as they do today).
-#   3. ONE machine attempt per PR per failure signature. Not per run, not per
-#      push -- a handler that re-runs CI without fixing the cause re-runs a
-#      flake forever, which is the failure mode this issue names by hand.
-#   4. The founder is NOT paged on the red itself. He is paged once, AFTER the
-#      machine tier is spent, by a message that names what the machine tried.
+#   3. A REVIEW VERDICT IS NOT CI. `kipi/reviewer-approved` failing means the
+#      reviewer asked for changes; that already has its own machine consumer.
+#   4. ONE machine attempt per PR per failure signature, and the attempt is spent
+#      when the dispatcher CONFIRMS the dispatch -- not when the pick is offered.
+#   5. The founder is NOT paged on the red itself. He is paged once, AFTER the
+#      machine tier is spent, by a message that names only what was observed.
 #
 # The `gh` seam is a fixture script, so no case here touches the network: what
 # is under test is the decision, and a suite that needs a live red PR to run is
@@ -73,29 +84,35 @@ chmod +x "$TMP/notify.sh"
 
 fixture() { printf '%s' "$1" > "$TMP/prs.json"; }
 
-# A red agent PR, a green agent PR, and a red PR on a branch carrying no issue
-# id -- all in one payload, because the filter is what is under test.
-RED_AND_FRIENDS='[
- {"number":101,"headRefName":"sana/ask-292","isDraft":false,
-  "url":"https://github.com/assafkip/kipi-system/pull/101",
-  "title":"feat: will-it-run (ASK-292)",
+# Real shapes, 2026-08-03, `gh pr list --state open --json ...` on this repo:
+#   PR 73 sana/ask-295          validate SUCCESS + kipi/reviewer-approved FAILURE
+#   PR 69 sana/block-expiry     validate FAILURE, no issue id in the branch
+#   PR 71 sana/ask-292          statusCheckRollup: []
+WORLD='[
+ {"number":73,"headRefName":"sana/ask-295","isDraft":false,
+  "headRefOid":"aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+  "url":"https://github.com/assafkip/kipi-system/pull/73",
+  "title":"feat(dispatch): red CI is re-dispatched to its agent (ASK-295)",
   "statusCheckRollup":[
-    {"__typename":"CheckRun","name":"Skeleton Validation","status":"COMPLETED",
-     "conclusion":"FAILURE","detailsUrl":"https://github.com/x/runs/1"},
-    {"__typename":"CheckRun","name":"kipi/reviewer-approved","status":"COMPLETED",
-     "conclusion":"SUCCESS","detailsUrl":"https://github.com/x/runs/2"}]},
- {"number":102,"headRefName":"sana/ask-288","isDraft":false,
-  "url":"https://github.com/assafkip/kipi-system/pull/102",
-  "title":"fix: capability block expiry (ASK-288)",
+    {"__typename":"CheckRun","name":"validate","status":"COMPLETED",
+     "conclusion":"SUCCESS","workflowName":"Skeleton Validation"},
+    {"__typename":"StatusContext","context":"kipi/reviewer-approved",
+     "state":"FAILURE",
+     "targetUrl":"https://github.com/assafkip/kipi-system/pull/73#issuecomment-1"}]},
+ {"number":69,"headRefName":"sana/block-expiry","isDraft":false,
+  "headRefOid":"bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb",
+  "url":"https://github.com/assafkip/kipi-system/pull/69",
+  "title":"A capability block re-tests itself and expires (ASK-288)",
   "statusCheckRollup":[
-    {"__typename":"CheckRun","name":"Skeleton Validation","status":"COMPLETED",
-     "conclusion":"SUCCESS","detailsUrl":"https://github.com/x/runs/3"}]},
+    {"__typename":"CheckRun","name":"validate","status":"COMPLETED",
+     "conclusion":"FAILURE","workflowName":"Skeleton Validation"}]},
  {"number":103,"headRefName":"assaf-hotfix","isDraft":false,
+  "headRefOid":"cccccccccccccccccccccccccccccccccccccccc",
   "url":"https://github.com/assafkip/kipi-system/pull/103",
-  "title":"chore: founder hand edit",
+  "title":"chore: founder hand edit (ASK-999)",
   "statusCheckRollup":[
-    {"__typename":"CheckRun","name":"Skeleton Validation","status":"COMPLETED",
-     "conclusion":"FAILURE","detailsUrl":"https://github.com/x/runs/4"}]}]'
+    {"__typename":"CheckRun","name":"validate","status":"COMPLETED",
+     "conclusion":"FAILURE","workflowName":"Skeleton Validation"}]}]'
 
 run() {  # run <op> [args...]
   KIPI_GH="$TMP/gh" \
@@ -114,79 +131,205 @@ fresh_state() {
   rm -f "$LEDGER"
 }
 
+pages() { wc -l < "$NOTIFY_LOG" | tr -d ' '; }
+
 echo "== ci-redrive =="
 
 # --- 1. attribution ----------------------------------------------------------
 fresh_state attr
-fixture "$RED_AND_FRIENDS"
+fixture "$WORLD"
 OUT="$(run scan)"; RC=$?
 check "scan exits 0 with candidates" "$RC" "0"
-contains "red agent PR attributed to its issue" "$OUT" '"issue": "ASK-292"'
-contains "the failing check is named" "$OUT" "Skeleton Validation"
-contains "the PR number is carried" "$OUT" '"pr": 101'
+contains "the red agent PR is attributed to its issue" "$OUT" '"issue": "ASK-288"'
+contains "the failing check is named" "$OUT" '"validate"'
+contains "the PR number is carried" "$OUT" '"pr": 69'
+contains "the head sha is carried" "$OUT" '"head_sha": "bbbbbbbb'
 
-# --- 2. what it leaves alone -------------------------------------------------
-lacks "a GREEN agent PR is not a candidate" "$OUT" '"issue": "ASK-288"'
+# --- 2. a branch with no issue id still reaches its agent (finding 3) --------
+# `sana/block-expiry` (PR #69) is one of the three PRs that mailed the founder on
+# 2026-08-02, and the first cut of BRANCH_RE skipped it: the worker names its own
+# branches `sana/ask-288`, but a branch cut by hand in an interactive session is
+# named for the work. The issue id is still there -- in the PR title, which the
+# linear-first commit-msg gate makes mandatory. Reading it there is not guessing.
+contains "the title's issue id is used when the branch has none" "$OUT" '"issue_source": "title"'
+
+# --- 3. what it leaves alone -------------------------------------------------
+lacks "a green agent PR is not a candidate" "$OUT" '"pr": 73'
 lacks "a red PR on a non-agent branch is not a candidate" "$OUT" '"pr": 103'
 
-# --- 3. one machine attempt per PR per failure signature ---------------------
-fresh_state cap
-fixture "$RED_AND_FRIENDS"
+# --- 4. a review verdict is not CI (finding 1) -------------------------------
+# `kipi/reviewer-approved` FAILURE means the reviewer asked for changes. It is
+# posted by pr-review-agent.sh's post_reviewer_status, it arrives as a
+# StatusContext, and it already HAS a machine consumer: the reviewer comments on
+# the Linear issue and the worker re-dispatches from there. Counting it as red CI
+# re-dispatches a PR whose build is green and pages the founder about a passing
+# build.
+fresh_state verdict
+fixture '[{"number":73,"headRefName":"sana/ask-295","isDraft":false,
+  "headRefOid":"aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+  "url":"https://x/73","title":"t (ASK-295)",
+  "statusCheckRollup":[
+    {"__typename":"CheckRun","name":"validate","status":"COMPLETED",
+     "conclusion":"SUCCESS","workflowName":"Skeleton Validation"},
+    {"__typename":"StatusContext","context":"kipi/reviewer-approved",
+     "state":"FAILURE","targetUrl":"https://x/73#c1"},
+    {"__typename":"StatusContext","context":"kipi/codex-approved",
+     "state":"FAILURE","targetUrl":"https://x/73#c2"}]}]'
+run redrive >/dev/null; RC=$?
+check "a REQUEST-CHANGES verdict on a green build is not red CI" "$RC" "1"
+check "a REQUEST-CHANGES verdict does not page the founder" "$(pages)" "0"
+
+# A third-party commit status is still real CI. The exclusion is the reviewer's
+# own two slots, not the whole StatusContext half of the rollup.
+fresh_state legacy
+fixture '[{"number":74,"headRefName":"sana/ask-296","isDraft":false,
+  "headRefOid":"dddddddddddddddddddddddddddddddddddddddd",
+  "url":"https://x/74","title":"t (ASK-296)",
+  "statusCheckRollup":[
+    {"__typename":"StatusContext","context":"ci/external-builder",
+     "state":"FAILURE","targetUrl":"https://x/74#c1"}]}]'
 OUT="$(run redrive)"; RC=$?
-check "first red: redrive claims the attempt" "$RC" "0"
-check "first red: the issue to re-dispatch is printed" "$OUT" "ASK-292"
-check "first red does NOT page the founder" "$(wc -l < "$NOTIFY_LOG" | tr -d ' ')" "0"
+check "a non-reviewer commit status IS red CI" "$RC" "0"
+contains "the external status is the failing check" "$(run scan)" '"ci/external-builder"'
+
+# --- 5. the attempt is spent on DISPATCH, not on the offer (finding 2) -------
+# The offer is read-only. kipi-dispatch.sh can still abort between the pick and
+# the launch (a converge run already live for that issue), and burning the one
+# machine attempt on an offer that was never dispatched means the PR is marked
+# handled while nothing ever handled it -- and then the founder is paged with a
+# message asserting a re-dispatch that did not happen.
+fresh_state spend
+fixture "$WORLD"
+OUT="$(run redrive)"; RC=$?
+check "offer exits 0" "$RC" "0"
+check "offer names the issue" "$(printf '%s' "$OUT" | cut -f1)" "ASK-288"
+check "offer carries the signature" "$([ -n "$(printf '%s' "$OUT" | cut -f2)" ] && echo yes || echo no)" "yes"
+check "offer carries the head sha" "$(printf '%s' "$OUT" | cut -f3)" "bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb"
+check "an un-dispatched offer pages nobody" "$(pages)" "0"
 
 OUT2="$(run redrive)"; RC2=$?
-check "same signature: no second machine attempt" "$RC2" "1"
-check "same signature: no issue printed" "$OUT2" ""
+check "an un-dispatched offer is NOT spent: it is offered again" "$RC2" "0"
+check "the second offer is the same issue" "$(printf '%s' "$OUT2" | cut -f1)" "ASK-288"
+check "still no page" "$(pages)" "0"
 
-# --- 4. escalation, after the machine tier and naming what it tried ----------
+SIG="$(printf '%s' "$OUT" | cut -f2)"
+run mark-dispatched --issue ASK-288 --signature "$SIG" \
+  --head-sha bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb >/dev/null; RC=$?
+check "mark-dispatched claims the attempt" "$RC" "0"
+run mark-dispatched --issue ASK-288 --signature "$SIG" \
+  --head-sha bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb >/dev/null; RC=$?
+check "mark-dispatched is one-shot: a second caller must not dispatch" "$RC" "1"
+
+run redrive >/dev/null; RC=$?
+check "after a confirmed dispatch the attempt is spent" "$RC" "1"
+
+# --- 6. the escalation says only what was observed (finding 2) ---------------
 ESC="$(cat "$NOTIFY_LOG")"
-contains "escalation names the issue" "$ESC" "ASK-292"
-contains "escalation names the PR" "$ESC" "#101"
-contains "escalation names the failing check" "$ESC" "Skeleton Validation"
-contains "escalation says the machine already re-dispatched" "$ESC" "re-dispatched"
+check "the founder is paged exactly once" "$(pages)" "1"
+contains "escalation names the issue" "$ESC" "ASK-288"
+contains "escalation names the PR" "$ESC" "#69"
+contains "escalation names the failing check" "$ESC" "validate"
+contains "escalation says it handed the issue back" "$ESC" "handed ASK-288 back"
+contains "head unchanged: it says no new commit landed" "$ESC" "no new commit has landed"
+lacks "head unchanged: it does NOT claim a second failure" "$ESC" "failed again"
 
 run redrive >/dev/null 2>&1
-check "escalation pages ONCE per signature, not per run" \
-  "$(wc -l < "$NOTIFY_LOG" | tr -d ' ')" "1"
+check "escalation pages ONCE per signature, not per run" "$(pages)" "1"
 
-# --- 5. a DIFFERENT failure earns a fresh machine attempt --------------------
-fixture "$(printf '%s' "$RED_AND_FRIENDS" | sed 's/Skeleton Validation/Lefthook Gate/')"
-OUT3="$(run redrive)"; RC3=$?
-check "new failure signature: a fresh attempt is claimed" "$RC3" "0"
-check "new failure signature: the issue is printed again" "$OUT3" "ASK-292"
+# The agent pushed a fix and the same check went red again. NOW "it failed again"
+# is a true sentence, and it is the sentence the founder gets.
+fresh_state repushed
+fixture "$WORLD"
+OUT="$(run redrive)"; SIG="$(printf '%s' "$OUT" | cut -f2)"
+run mark-dispatched --issue ASK-288 --signature "$SIG" \
+  --head-sha bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb >/dev/null
+fixture "$(printf '%s' "$WORLD" | sed 's/bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb/eeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeee/')"
+run redrive >/dev/null; RC=$?
+check "a re-push failing the same check earns no second attempt" "$RC" "1"
+ESC="$(cat "$NOTIFY_LOG")"
+contains "head moved: it says the same check failed again" "$ESC" "failed again"
+lacks "head moved: it does not also claim no commit landed" "$ESC" "no new commit has landed"
 
-# --- 6. all-green is quiet, not an error state -------------------------------
+# --- 7. the signature is the CHECK SET, and this repo emits one check --------
+# Documented plainly rather than promised: `validate` is the only CI check this
+# repo posts, so the signature is constant per PR here and the cap is ONE
+# hand-back per PR, full stop. The per-signature keying only begins to
+# discriminate if a second required check is ever added -- which is why the case
+# below asserts the DISCRIMINATION, not a behaviour reachable today.
+fresh_state twocheck
+fixture "$(printf '%s' "$WORLD" | sed 's/"name":"validate"/"name":"lefthook"/')"
+OUT="$(run redrive)"
+SIG2="$(printf '%s' "$OUT" | cut -f2)"
+if [ "$SIG" != "$SIG2" ]; then ok "a different check set is a different signature"
+else bad "a different check set is a different signature" "both were [$SIG]"; fi
+
+# --- 8. ambiguity is refused, never guessed ----------------------------------
+# Two distinct issue ids in one title is a title this tool cannot read. Picking
+# either one is how the wrong issue gets re-dispatched.
+fresh_state ambiguous
+fixture '[{"number":88,"headRefName":"sana/two-things","isDraft":false,
+  "headRefOid":"ffffffffffffffffffffffffffffffffffffffff",
+  "url":"https://x/88","title":"fold ASK-100 into ASK-101",
+  "statusCheckRollup":[
+    {"__typename":"CheckRun","name":"validate","status":"COMPLETED",
+     "conclusion":"FAILURE","workflowName":"Skeleton Validation"}]}]'
+run redrive >/dev/null; RC=$?
+check "an ambiguous title is not attributed" "$RC" "1"
+check "an ambiguous title does not page the founder" "$(pages)" "0"
+
+# A non-agent branch prefix is left alone even with a clean issue id in the title.
+fresh_state nonagent
+fixture '[{"number":89,"headRefName":"feature/big-thing","isDraft":false,
+  "headRefOid":"ffffffffffffffffffffffffffffffffffffffff",
+  "url":"https://x/89","title":"a founder branch (ASK-102)",
+  "statusCheckRollup":[
+    {"__typename":"CheckRun","name":"validate","status":"COMPLETED",
+     "conclusion":"FAILURE","workflowName":"Skeleton Validation"}]}]'
+run redrive >/dev/null; RC=$?
+check "an unknown branch owner is not an agent PR" "$RC" "1"
+
+# --- 9. all-green is quiet, not an error state -------------------------------
 fresh_state green
 fixture '[{"number":104,"headRefName":"sana/ask-300","isDraft":false,
+  "headRefOid":"1111111111111111111111111111111111111111",
   "url":"https://x/104","title":"t (ASK-300)",
-  "statusCheckRollup":[{"__typename":"CheckRun","name":"Skeleton Validation",
-   "status":"COMPLETED","conclusion":"SUCCESS","detailsUrl":"https://x/5"}]}]'
+  "statusCheckRollup":[{"__typename":"CheckRun","name":"validate",
+   "status":"COMPLETED","conclusion":"SUCCESS","workflowName":"Skeleton Validation"}]}]'
 run redrive >/dev/null; RC=$?
 check "nothing red: exit 1, nothing to do" "$RC" "1"
-check "nothing red: founder untouched" "$(wc -l < "$NOTIFY_LOG" | tr -d ' ')" "0"
+check "nothing red: founder untouched" "$(pages)" "0"
 
-# --- 7. gh could not answer: not a claim, and not silence --------------------
+# --- 10. gh could not answer: not a claim, and not silence -------------------
 # The probe's rc is part of its answer (arm_automerge's finding 3, same class).
 # Reading a failed `gh` as "no red PRs" is how a real red PR goes unhandled with
 # a clean exit -- so it exits 2 and burns no attempt.
 fresh_state ghdown
-fixture "$RED_AND_FRIENDS"
+fixture "$WORLD"
 GH_RC=7 run redrive >/dev/null; RC=$?
 GH_RC=0
 check "gh failure exits 2, not 0 and not 1" "$RC" "2"
 check "gh failure writes no ledger" "$([ -f "$LEDGER" ] && echo yes || echo no)" "no"
 
-# --- 8. a run still pending is not a failure ---------------------------------
+# --- 11. a run still pending is not a failure --------------------------------
 fresh_state pending
 fixture '[{"number":105,"headRefName":"sana/ask-301","isDraft":false,
+  "headRefOid":"2222222222222222222222222222222222222222",
   "url":"https://x/105","title":"t (ASK-301)",
-  "statusCheckRollup":[{"__typename":"CheckRun","name":"Skeleton Validation",
-   "status":"IN_PROGRESS","conclusion":"","detailsUrl":"https://x/6"}]}]'
+  "statusCheckRollup":[{"__typename":"CheckRun","name":"validate",
+   "status":"IN_PROGRESS","conclusion":"","workflowName":"Skeleton Validation"}]}]'
 run redrive >/dev/null; RC=$?
 check "an in-flight check is not red" "$RC" "1"
+
+# --- 12. an empty rollup is not red ------------------------------------------
+# PR #71 on 2026-08-03 really did carry `"statusCheckRollup": []`. No checks have
+# reported, which is not the same claim as "the checks passed" and is certainly
+# not "the checks failed".
+fresh_state norollup
+fixture '[{"number":71,"headRefName":"sana/ask-292","isDraft":false,
+  "headRefOid":"3333333333333333333333333333333333333333",
+  "url":"https://x/71","title":"t (ASK-292)","statusCheckRollup":[]}]'
+run redrive >/dev/null; RC=$?
+check "no checks reported is not red" "$RC" "1"
 
 echo
 echo "$PASS passed, $FAIL failed"


### PR DESCRIPTION
## Problem

An autonomous agent opens a PR, CI goes red, GitHub emails the repo owner, and he cannot act on it. The agent that opened it can. Three of these reached the founder on 2026-08-02:

```
[assafkip/kipi-system] PR run failed: Skeleton Validation - ... (ASK-292)
[assafkip/kipi-system] PR run failed: Skeleton Validation - ... (ASK-288)
[assafkip/kipi-system] Run failed: Skeleton Validation - sana/block-expiry
```

All three were a **single correct catch** (`test-terminal-states.sh`, 13 passed 1 failed; `main` was green). That is the point: true, and still useless to him.

It is a dead end by construction. `ready()` in `linear-worker.sh` returns only `backlog`/`unstarted` issues, and an issue with a live PR is In Progress, so nothing in this repo ever looked at that PR again. ASK-294's `slack-notify.sh` chokepoint structurally cannot reach it: the producer is GitHub, driven by workflow conclusion, outside every sink this repo owns.

## The four DoR decisions, made

| Decision | Answer |
|---|---|
| Does a red agent PR reach the founder? | **No**, not on the red. Once, after the machine tier, in a message naming what the machine tried. |
| Where the consumer runs | Inside `kipi-dispatch.sh`, ahead of the fresh pick. **Not** a new launchd job. |
| Attribution | The branch name. `sana/ask-295` -> `ASK-295`, no Linear round-trip. |
| Attempt cap | One per PR **per failure signature**, in the existing flock'd attempts ledger. |

## Design notes worth reviewing

- **The signature is the set of failing check names, deliberately not the head sha.** A re-push that fails the same check is the same problem; re-dispatching on it is how a handler re-runs a flake forever. ASK-295 names that risk by hand (one root cause of the 2026-08-02 redness was a measurement against the wrong tree). A genuinely new failure earns its own fresh attempt.
- **Placed before the empty-`NEXT` exit.** Nothing-ready is the ordinary state of a healthy queue, so handling the red PR only when something else was also waiting would leave it unhandled on exactly the quiet cycles.
- **Not a new job.** Every cap it needs already exists and is proven in the dispatcher (`MAX_CONCURRENT`, daily budget, liveness assert, `page_once`, one dispatch per heartbeat). Per-repo jobs die silently: the income scanners went dark 6 days that way.
- **`gh` failing to answer is exit 2 with nothing claimed**, never exit 1. The probe's rc is part of its answer, same class as `arm_automerge` finding 3. Reading a failed probe as "no red PRs" is how a real red PR goes unhandled behind a clean exit.
- **It never merges, closes, comments on, or re-runs anything on GitHub.** It reads PR state and answers one question: which issue the dispatcher hands back. Dispatching stays the dispatcher's, under the dispatcher's caps.

## Verification

Reproducer first, observed RED before the change:

```
$ bash q-system/.q-system/scripts/test/test-ci-redrive.sh
FATAL: ci-redrive.py not found at .../q-system/.q-system/scripts/ci-redrive.py
EXIT=1
```

After:

```
$ bash q-system/.q-system/scripts/test/test-ci-redrive.sh
23 passed, 0 failed

$ bash -n kipi-dispatch.sh
kipi-dispatch.sh: syntax OK
```

The suite pins attribution, that green PRs and non-agent branches are left alone, the one-attempt-per-signature cap, that the founder is **not** paged on the first red, that escalation names the issue / PR / failing check / what was tried, that it pages once per signature and not per run, that a new signature earns a fresh attempt, that a `gh` failure exits 2 without burning a claim, and that an in-flight check is not red.

Registered in `capability-manifest.json`.

## Not doing (per the DoR)

GitHub account notification settings. That is the founder's account, outside the repo, and settings are not an instrument.