### PR TITLE
fix(capability-map): see real callers, ignore generated logs (ASK-122)

### DIFF
--- a/q-system/.q-system/capability-manifest.json
+++ b/q-system/.q-system/capability-manifest.json
@@ -426,6 +426,10 @@
     {
       "path": "q-system/.q-system/test_token_guard_runtime.py",
       "runner": "python3"
+    },
+    {
+      "path": "q-system/.q-system/scripts/test/test-capability-map-wiring.py",
+      "runner": "python3"
     }
   ],
   "required_data": [],

--- a/q-system/.q-system/scripts/capability-map-gen.py
+++ b/q-system/.q-system/scripts/capability-map-gen.py
@@ -356,6 +356,17 @@ SURFACE_NAMES = {"Makefile", "makefile", "kipi", "Dockerfile", "Justfile", "just
 GENERATED_SURFACE_PREFIXES = ("q-system/output/",)
 
 
+def _witness_rank(p: Path):
+    """Sort key that prefers a REAL caller over a scratch/hidden copy of one.
+
+    Any path component starting with "." is a review tree, a worktree or a tool
+    cache, never the wiring a reader should be sent to look at.
+    """
+    parts = p.parts
+    hidden = any(part.startswith(".") for part in parts)
+    return (hidden, len(parts), str(p))
+
+
 def is_generated_surface(p: Path, root: Path) -> bool:
     """True when p is a generated artifact, so its content must not count as wiring."""
     try:
@@ -477,6 +488,16 @@ def collect_engines(root: Path) -> list:
             continue
         if p.name.startswith(("test_", "test-")) or "test" in p.parts:
             continue
+        # A generated tree is not a wiring surface (see is_generated_surface), so
+        # it must not be an ENGINE source either. Excluding it from only one of
+        # the two makes its contents permanently dark: still collected, but with
+        # every file that could reference them now off-surface, so they report
+        # UNWIRED with no way to ever clear it (review finding, PR #74 major;
+        # would have compounded sp-3761d2d9). An artifact is not an engine, so
+        # the coherent move is to stop reporting it at all rather than to report
+        # it as dead. Measured: drops 12 phantom engines in kipi-investigations.
+        if is_generated_surface(p, root):
+            continue
         if DATED_SNAPSHOT_RE.search(p.stem):
             continue
         if len(read_text(p).splitlines()) < 40:
@@ -488,8 +509,14 @@ def collect_engines(root: Path) -> list:
     for p in engines:
         text = read_text(p)
         sources = refs.get(p, set())
-        test_sources = sorted(s for s in sources if _is_test_file(s))
-        wiring_sources = sorted(s for s in sources if not _is_test_file(s))
+        # WITNESS ORDER IS NOT ALPHABETICAL (review finding, PR #74 minor).
+        # Plain sorted()[0] puts dot-prefixed paths first, so the evidence named
+        # a review scratch tree (.pr42rev/, .claude/worktrees/) instead of the
+        # real caller in 163 of 785 witnesses measured across five repos. The
+        # verdict was right and the citation was useless, which is worse than it
+        # sounds: the citation is the only part a human re-checks.
+        test_sources = sorted((s for s in sources if _is_test_file(s)), key=_witness_rank)
+        wiring_sources = sorted((s for s in sources if not _is_test_file(s)), key=_witness_rank)
         has_test = any(p.stem in t for t in tests) or bool(test_sources)
         referenced = bool(wiring_sources)
         status = "LIVE" if (has_test or referenced) else "UNWIRED"

--- a/q-system/.q-system/scripts/capability-map-gen.py
+++ b/q-system/.q-system/scripts/capability-map-gen.py
@@ -540,7 +540,15 @@ def collect_engines(root: Path) -> list:
     """Scripts that have a paired test, or that are referenced from a wiring
     surface. An engine with neither is reported UNWIRED rather than assumed fine."""
     caps = []
-    tests = {p.name for p in root.rglob("test*") if p.is_file() and not is_vendored(p)}
+    # FOURTH consumer of the exclusion predicate, and the one I missed when
+    # claiming "one predicate for all three" in the commit that introduced it
+    # (codex round 3, major). Without this, a test filename inside a review tree
+    # or a generated dir still grants has_test, so the same one-sided-exclusion
+    # shape survived inside the very change written to eliminate it. The count
+    # of consumers is not fixed at three; grep is_excluded_tree before adding a
+    # new walk over the repo.
+    tests = {p.name for p in root.rglob("test*")
+             if p.is_file() and not is_vendored(p) and not is_excluded_tree(p, root)}
 
     engines = []
     for p in root.rglob("*.py"):

--- a/q-system/.q-system/scripts/capability-map-gen.py
+++ b/q-system/.q-system/scripts/capability-map-gen.py
@@ -330,9 +330,16 @@ def _docstring_line(text: str) -> str:
 # reference; markdown is handled separately below because prose is not wiring.
 SURFACE_CODE_EXT = {
     ".py", ".sh", ".bash", ".zsh", ".yml", ".yaml", ".toml", ".json",
-    ".cfg", ".ini", ".mk", ".txt",
+    ".cfg", ".ini", ".mk",
 }
-SURFACE_DOC_EXT = {".md"}
+# .txt IS PROSE, NOT CODE (codex round 5, major). It sat in SURFACE_CODE_EXT,
+# where every mention counts with no invocation filter at all, so any note,
+# report or log ANYWHERE outside q-system/output/ silently marked a named engine
+# LIVE. Excluding the generated tree fixed one instance of this and left the
+# class open: the same defect shape as the B1 prose leak, on a different
+# extension. A .txt is a runbook far less often than it is somebody's notes, so
+# it belongs with .md where a line must actually invoke something.
+SURFACE_DOC_EXT = {".md", ".txt"}
 # Extensionless wiring surfaces (the kipi CLI, Makefiles, lefthook's shell blocks).
 SURFACE_NAMES = {"Makefile", "makefile", "kipi", "Dockerfile", "Justfile", "justfile"}
 

--- a/q-system/.q-system/scripts/capability-map-gen.py
+++ b/q-system/.q-system/scripts/capability-map-gen.py
@@ -326,48 +326,149 @@ def _docstring_line(text: str) -> str:
     return lines[0][:180] if lines else ""
 
 
+# Files whose CONTENT can wire an engine. A mention anywhere in one of these is a
+# reference; markdown is handled separately below because prose is not wiring.
+SURFACE_CODE_EXT = {
+    ".py", ".sh", ".bash", ".zsh", ".yml", ".yaml", ".toml", ".json",
+    ".cfg", ".ini", ".mk", ".txt",
+}
+SURFACE_DOC_EXT = {".md"}
+# Extensionless wiring surfaces (the kipi CLI, Makefiles, lefthook's shell blocks).
+SURFACE_NAMES = {"Makefile", "makefile", "kipi", "Dockerfile", "Justfile", "justfile"}
+
+# A markdown line only counts as wiring if it INVOKES something. A findings doc
+# saying "engine_x.py left the template unfilled" names a script without keeping it
+# alive; a runbook line `python3 engine_x.py` does. Without this split, widening the
+# scan repo-wide just trades false-dead for false-alive (ASK-122).
+MD_INVOCATION_RE = re.compile(r"(?:python3?\s|bash\s|\bsh\s|\./|source\s|-m\s)")
+
+# Module tokens an engine can be reached by WITHOUT its .py suffix. `import x`,
+# `from x import y`, `python -m x`, and importlib's spec_from_file_location("x", ...)
+# are all real callers that a filename-only scan reads as silence. Scar: ASK-230,
+# where provenance_vocabulary.py had two live importers and was reported inert
+# because both wrote `import provenance_vocabulary` with no extension.
+MODULE_REF_RE = re.compile(
+    r"^\s*from\s+([\w.]+)\s+import\b"
+    r"|^\s*import\s+([\w.]+)"
+    r"|spec_from_file_location\(\s*[\"']([\w.\-]+)[\"']"
+    r"|-m\s+([\w.]+)\b",
+    re.M,
+)
+
+
+# `fill_sheet.2026-07-28.py` beside `fill_sheet.py` is a dated SNAPSHOT of an
+# engine, not a second engine. Alice's run-sweep.sh writes one before every sweep
+# (`cp "$GEN/fill_sheet.py" "$DIR/backups/fill_sheet.$TODAY.py"`) and copies it back
+# on failure, so it is live DATA on a rollback path. No static scan can ever match
+# it -- the caller interpolates $TODAY -- so it would report UNWIRED forever and
+# the only way to "fix" it is to delete a rollback artifact (ASK-122).
+DATED_SNAPSHOT_RE = re.compile(r"\.\d{4}-\d{2}-\d{2}$")
+
+
+def _is_test_file(p: Path) -> bool:
+    return p.name.startswith(("test_", "test-")) or "test" in p.parts or "tests" in p.parts
+
+
+def _iter_surface_files(root: Path):
+    """Every file in the repo whose content can constitute wiring.
+
+    WHY REPO-WIDE (ASK-122): the previous list walked only .claude/, plugins/ and
+    q-system/, so an instance whose code lives anywhere else reported its own
+    runners as absent. Alice flagged 22 engines UNWIRED while `regenerate.sh` ran
+    four of them by path and `pipeline.py` imported two more. The scan has to
+    follow the repo, not a layout the skeleton happens to use.
+    """
+    for p in root.rglob("*"):
+        if not p.is_file() or is_vendored(p):
+            continue
+        if p.suffix.lower() in SURFACE_CODE_EXT or p.suffix.lower() in SURFACE_DOC_EXT:
+            yield p
+        elif p.name in SURFACE_NAMES:
+            yield p
+
+
+def _build_reference_index(root: Path, engines: list) -> dict:
+    """Map each engine path -> the set of OTHER files that reference it.
+
+    Two ways to match: the file name (`foo.py`, seen in shell/CLI invocations and
+    config) and the bare module name, but the bare name ONLY inside an import or
+    loader construct. A generic stem like `pipeline` appears in ordinary prose all
+    over this fleet; counting bare-word hits would mark half the repo live.
+    """
+    by_filename = {}
+    by_module = {}
+    for p in engines:
+        by_filename.setdefault(p.name, []).append(p)
+        by_module.setdefault(p.stem, []).append(p)
+    if not by_filename:
+        return {}
+
+    # One alternation, one pass per file: a per-engine regex would be
+    # len(engines) x len(files) scans, which is minutes on a large instance.
+    # The lookbehind must NOT exclude "/": the common form is path-qualified
+    # (`python3 "$G/fill_sheet.py"`), and blocking it hid every shell caller.
+    filename_re = re.compile(
+        r"(?<![\w.\-])(" + "|".join(re.escape(n) for n in sorted(by_filename)) + r")(?![\w\-])"
+    )
+
+    refs: dict = {}
+    for src in _iter_surface_files(root):
+        text = read_text(src)
+        if not text:
+            continue
+        if src.suffix.lower() in SURFACE_DOC_EXT:
+            text = "\n".join(ln for ln in text.splitlines() if MD_INVOCATION_RE.search(ln))
+            if not text:
+                continue
+        for match in filename_re.finditer(text):
+            for engine in by_filename[match.group(1)]:
+                if engine != src:
+                    refs.setdefault(engine, set()).add(src)
+        for match in MODULE_REF_RE.finditer(text):
+            token = next((g for g in match.groups() if g), None)
+            if not token:
+                continue
+            for part in (token, token.rsplit(".", 1)[-1]):
+                for engine in by_module.get(part, ()):
+                    if engine != src:
+                        refs.setdefault(engine, set()).add(src)
+    return refs
+
+
 def collect_engines(root: Path) -> list:
     """Scripts that have a paired test, or that are referenced from a wiring
     surface. An engine with neither is reported UNWIRED rather than assumed fine."""
     caps = []
     tests = {p.name for p in root.rglob("test*") if p.is_file() and not is_vendored(p)}
 
-    # Wiring surfaces mirror capability-gate.py's WIRING_SURFACE_GLOBS. A narrower
-    # list reports UNWIRED for engines that are in fact called by another engine or
-    # by the kipi CLI: the first run of this generator flagged 60 UNWIRED in
-    # 4_points_consulting purely because python-calls-python was never read.
-    surfaces = ""
-    for pat in (".claude/settings.json", "settings-template.json", "lefthook.yml",
-                "Makefile", "*.sh", "kipi*", "validate-separation.py",
-                ".github/workflows/*.yml", "*/hooks/hooks.json", "*/*/hooks.json"):
-        for p in root.glob(pat):
-            if p.is_file() and not is_vendored(p):
-                surfaces += read_text(p)
-    for sub in (root / ".claude", root / "plugins", root / "q-system"):
-        if not sub.is_dir():
-            continue
-        for pattern in ("*.md", "*.py", "*.sh", "*.json"):
-            for p in sub.rglob(pattern):
-                if is_vendored(p) or p.name.startswith(("test_", "test-")):
-                    continue
-                surfaces += read_text(p)
-
+    engines = []
     for p in root.rglob("*.py"):
         if is_vendored(p):
             continue
         if p.name.startswith(("test_", "test-")) or "test" in p.parts:
             continue
-        text = read_text(p)
-        if len(text.splitlines()) < 40:
+        if DATED_SNAPSHOT_RE.search(p.stem):
             continue
-        has_test = any(p.stem in t for t in tests)
-        referenced = p.name in surfaces
+        if len(read_text(p).splitlines()) < 40:
+            continue
+        engines.append(p)
+
+    refs = _build_reference_index(root, engines)
+
+    for p in engines:
+        text = read_text(p)
+        sources = refs.get(p, set())
+        test_sources = sorted(s for s in sources if _is_test_file(s))
+        wiring_sources = sorted(s for s in sources if not _is_test_file(s))
+        has_test = any(p.stem in t for t in tests) or bool(test_sources)
+        referenced = bool(wiring_sources)
         status = "LIVE" if (has_test or referenced) else "UNWIRED"
         bits = []
         if has_test:
-            bits.append("has a paired test")
+            witness = rel(root, test_sources[0]) if test_sources else "name-matched test file"
+            bits.append(f"has a paired test ({witness})")
         if referenced:
-            bits.append("referenced on a wiring surface")
+            bits.append(f"referenced on a wiring surface ({rel(root, wiring_sources[0])})")
         if not bits:
             bits.append("NO test and NO wiring reference found")
         caps.append({

--- a/q-system/.q-system/scripts/capability-map-gen.py
+++ b/q-system/.q-system/scripts/capability-map-gen.py
@@ -340,9 +340,17 @@ SURFACE_NAMES = {"Makefile", "makefile", "kipi", "Dockerfile", "Justfile", "just
 #
 # Widening the scan repo-wide swept in q-system/output/, which holds codex
 # transcripts, run logs, plans and RCAs. Those name scripts constantly and run
-# nothing. Measured on kipi-investigations: _sync_all.py flipped to LIVE on the
+# nothing. Measured on kipi-investigations: the `_sync_all` design-system script
+# flipped to LIVE on the
 # strength of `q-system/output/codex-sfactivity-prd-out.txt` line 738, a bare
-# `find`-style listing `./plugins/.../_sync_all.py`.
+# `find`-style listing of that script's path.
+#
+# NOTE the extension is omitted deliberately everywhere in these comments. A
+# bare module name only counts inside import/loader syntax (MODULE_REF_RE), but
+# the FILENAME regex matches anywhere in any code file, comments included. The
+# first draft of this scar named the file outright and thereby marked it LIVE --
+# a comment explaining that a script is dead resurrected it, which is the very
+# shape documented just below. Do not add the suffix back.
 #
 # The invocation filter cannot save this: that line starts with "./" and so
 # matches MD_INVOCATION_RE. A log of a command that ENUMERATED files is
@@ -355,31 +363,75 @@ SURFACE_NAMES = {"Makefile", "makefile", "kipi", "Dockerfile", "Justfile", "just
 # fleet-wide as an instance's own output rather than source.
 GENERATED_SURFACE_PREFIXES = ("q-system/output/",)
 
+# Review scratch: a detached copy of the repo, or a dump ABOUT the repo. Neither
+# is wiring. `.pr36rev/all-dors.json` is a Linear DoR dump whose own text says
+# `_sync_all` has "no test, no wiring reference" -- a document asserting a
+# script is DEAD was the thing marking it alive (Fable B2). Matched on the path
+# component so a nested `.pr42rev-r2/tree/...` counts too.
+#
+# NOT a bare leading-dot rule. `.claude/` and `.q-system/` are this fleet's
+# PRIMARY wiring locations; treating every dotted component as scratch is what
+# made _witness_rank cite the wrong file (Fable A1).
+SCRATCH_DIR_RE = re.compile(r"^\.pr\d+rev|^\.prd-os$|^worktrees$|^review-trees$")
 
-def _witness_rank(p: Path):
-    """Sort key that prefers a REAL caller over a scratch/hidden copy of one.
 
-    Any path component starting with "." is a review tree, a worktree or a tool
-    cache, never the wiring a reader should be sent to look at.
+def _is_excluded_part(part: str) -> bool:
+    return bool(SCRATCH_DIR_RE.match(part))
+
+
+def is_excluded_tree(p: Path, root: Path) -> bool:
+    """Generated artifact or review scratch: not an engine, not a wiring surface,
+    not a witness.
+
+    ONE predicate for all three consumers ON PURPOSE. Excluding a tree from only
+    some of them is the defect shape that has now recurred three times in this
+    file: engines excluded but still voting as surfaces (Fable B3), trees off the
+    surface but still collected as engines (review round 1 major), snapshots
+    skipped one way only. If a tree is not real, it is not real for any of the
+    three questions.
     """
-    parts = p.parts
-    hidden = any(part.startswith(".") for part in parts)
-    return (hidden, len(parts), str(p))
-
-
-def is_generated_surface(p: Path, root: Path) -> bool:
-    """True when p is a generated artifact, so its content must not count as wiring."""
     try:
-        rel = p.relative_to(root).as_posix()
+        rel = p.relative_to(root)
     except ValueError:
         return False
-    return rel.startswith(GENERATED_SURFACE_PREFIXES)
+    if rel.as_posix().startswith(GENERATED_SURFACE_PREFIXES):
+        return True
+    return any(_is_excluded_part(part) for part in rel.parts)
+
+
+def _witness_rank(p: Path):
+    """Sort key preferring a REAL caller over a scratch copy of one.
+
+    Ranks on KNOWN scratch markers, not on a leading dot. The dot rule demoted
+    `.claude/` and `.q-system/` -- where most of this fleet's wiring actually
+    lives -- so any non-hidden file out-cited the true caller (Fable A1).
+    """
+    scratch = any(_is_excluded_part(part) for part in p.parts)
+    return (scratch, len(p.parts), str(p))
 
 # A markdown line only counts as wiring if it INVOKES something. A findings doc
 # saying "engine_x.py left the template unfilled" names a script without keeping it
 # alive; a runbook line `python3 engine_x.py` does. Without this split, widening the
 # scan repo-wide just trades false-dead for false-alive (ASK-122).
-MD_INVOCATION_RE = re.compile(r"(?:python3?\s|bash\s|\bsh\s|\./|source\s|-m\s)")
+# ANCHORED TO INVOCATION POSITION (Fable B1). The unanchored version matched
+# ordinary English, and this filter is the SOLE evidence for 9.2% of fleet LIVE
+# verdicts:
+#   "The source of the bug is engine_x.py"          -> hit on `source `
+#   "run-sweep.sh used to call engine_x.py"         -> hit on `sh `
+#   "this old python script engine_x.py is dead"    -> hit on `python `
+#   "see ../notes for why engine_x.py was dropped"  -> hit on `./`
+# All four assert the script is DEAD and all four marked it LIVE. The suite's
+# prose-negative fixture passed only because its wording happened to dodge those
+# tokens: green for a reason unrelated to correctness.
+# A command starts a line or follows a pipe / && / ; / backtick / $( -- never
+# mid-sentence. `-m` is dropped as a standalone arm: it cannot start a command,
+# and `python -m x` is already covered by the python arm.
+# The interpreter arms need trailing whitespace (`python3 x.py`); `./` does not,
+# because the path follows it directly (`./x.py`). Requiring a separator for both
+# silently dropped every `./script` caller -- caught by the kill-test, not by eye.
+MD_INVOCATION_RE = re.compile(
+    r"(?:^|[|&;(`]|\$\()\s*(?:(?:python3?|bash|sh|source)\s|\./)"
+)
 
 # Module tokens an engine can be reached by WITHOUT its .py suffix. `import x`,
 # `from x import y`, `python -m x`, and importlib's spec_from_file_location("x", ...)
@@ -420,7 +472,15 @@ def _iter_surface_files(root: Path):
     for p in root.rglob("*"):
         if not p.is_file() or is_vendored(p):
             continue
-        if is_generated_surface(p, root):
+        if is_excluded_tree(p, root):
+            continue
+        # A dated snapshot is DATA, and this file already says so by refusing to
+        # collect it as an engine. It must not VOTE either: a rollback copy's
+        # `import geo_clues` kept geo_clues.py LIVE after every real caller was
+        # gone, and Alice writes one snapshot per sweep so the phantom votes
+        # accumulate forever (Fable B3). Excluding it on one side only was the
+        # same half-exclusion this file keeps repeating.
+        if DATED_SNAPSHOT_RE.search(p.stem):
             continue
         if p.suffix.lower() in SURFACE_CODE_EXT or p.suffix.lower() in SURFACE_DOC_EXT:
             yield p
@@ -488,7 +548,7 @@ def collect_engines(root: Path) -> list:
             continue
         if p.name.startswith(("test_", "test-")) or "test" in p.parts:
             continue
-        # A generated tree is not a wiring surface (see is_generated_surface), so
+        # A generated tree is not a wiring surface (see is_excluded_tree), so
         # it must not be an ENGINE source either. Excluding it from only one of
         # the two makes its contents permanently dark: still collected, but with
         # every file that could reference them now off-surface, so they report
@@ -496,7 +556,7 @@ def collect_engines(root: Path) -> list:
         # would have compounded sp-3761d2d9). An artifact is not an engine, so
         # the coherent move is to stop reporting it at all rather than to report
         # it as dead. Measured: drops 12 phantom engines in kipi-investigations.
-        if is_generated_surface(p, root):
+        if is_excluded_tree(p, root):
             continue
         if DATED_SNAPSHOT_RE.search(p.stem):
             continue

--- a/q-system/.q-system/scripts/capability-map-gen.py
+++ b/q-system/.q-system/scripts/capability-map-gen.py
@@ -336,6 +336,34 @@ SURFACE_DOC_EXT = {".md"}
 # Extensionless wiring surfaces (the kipi CLI, Makefiles, lefthook's shell blocks).
 SURFACE_NAMES = {"Makefile", "makefile", "kipi", "Dockerfile", "Justfile", "justfile"}
 
+# GENERATED ARTIFACTS ARE NOT WIRING SURFACES (ASK-122, caught pre-merge).
+#
+# Widening the scan repo-wide swept in q-system/output/, which holds codex
+# transcripts, run logs, plans and RCAs. Those name scripts constantly and run
+# nothing. Measured on kipi-investigations: _sync_all.py flipped to LIVE on the
+# strength of `q-system/output/codex-sfactivity-prd-out.txt` line 738, a bare
+# `find`-style listing `./plugins/.../_sync_all.py`.
+#
+# The invocation filter cannot save this: that line starts with "./" and so
+# matches MD_INVOCATION_RE. A log of a command that ENUMERATED files is
+# indistinguishable, line by line, from a runbook that INVOKES one. The only
+# durable separator is provenance -- who wrote the file -- so the fix is to drop
+# generated trees from the surface rather than to write a cleverer regex.
+#
+# q-system/output/ is the OS's generated-artifacts directory by convention; it is
+# also in kipi-update.sh's INSTANCE_OWNED_SUBTREES, i.e. already understood
+# fleet-wide as an instance's own output rather than source.
+GENERATED_SURFACE_PREFIXES = ("q-system/output/",)
+
+
+def is_generated_surface(p: Path, root: Path) -> bool:
+    """True when p is a generated artifact, so its content must not count as wiring."""
+    try:
+        rel = p.relative_to(root).as_posix()
+    except ValueError:
+        return False
+    return rel.startswith(GENERATED_SURFACE_PREFIXES)
+
 # A markdown line only counts as wiring if it INVOKES something. A findings doc
 # saying "engine_x.py left the template unfilled" names a script without keeping it
 # alive; a runbook line `python3 engine_x.py` does. Without this split, widening the
@@ -380,6 +408,8 @@ def _iter_surface_files(root: Path):
     """
     for p in root.rglob("*"):
         if not p.is_file() or is_vendored(p):
+            continue
+        if is_generated_surface(p, root):
             continue
         if p.suffix.lower() in SURFACE_CODE_EXT or p.suffix.lower() in SURFACE_DOC_EXT:
             yield p

--- a/q-system/.q-system/scripts/test/test-capability-map-wiring.py
+++ b/q-system/.q-system/scripts/test/test-capability-map-wiring.py
@@ -268,6 +268,26 @@ class TestMutantKills(unittest.TestCase):
             self.assertFalse(self.mod.is_excluded_tree(root / rel, root),
                              f"{rel} is real wiring and must stay on the surface")
 
+    def test_txt_notes_outside_generated_tree_are_prose_not_wiring(self):
+        """A .txt anywhere must be invocation-filtered, not counted wholesale.
+
+        .txt lived in SURFACE_CODE_EXT, so any note or report naming a script
+        wired it. Excluding q-system/output/ closed one instance and left the
+        class open -- the B1 prose leak on a different extension.
+        """
+        with tempfile.TemporaryDirectory() as td:
+            root = Path(td)
+            (root / "lib").mkdir(parents=True)
+            (root / "notes").mkdir(parents=True)
+            (root / "lib/engine_txt_prose.py").write_text(
+                engine_body("engine_txt_prose"))
+            (root / "notes/handoff.txt").write_text(
+                "We never finished engine_txt_prose.py and nobody runs it.\n")
+            caps = {c["entry"]: c for c in self.mod.collect_engines(root)}
+            self.assertEqual(
+                "UNWIRED", caps["lib/engine_txt_prose.py"]["status"],
+                "a note saying nobody runs a script must not mark it running")
+
     def test_scratch_tree_test_file_does_not_grant_has_test(self):
         """The has_test walk is a FOURTH consumer of is_excluded_tree.
 

--- a/q-system/.q-system/scripts/test/test-capability-map-wiring.py
+++ b/q-system/.q-system/scripts/test/test-capability-map-wiring.py
@@ -1,0 +1,172 @@
+#!/usr/bin/env python3
+"""Wiring detection in capability-map-gen.py: what counts as "this engine is alive".
+
+WHY (ASK-122): the generator flagged 22 local engines in Alice as UNWIRED. Nearly
+all of them had a visible caller on disk -- `regenerate.sh` literally runs
+`python3 "$G/fill_sheet.py"`, `brightdata.sh` runs `mcp-client.py`, `pipeline.py`
+imports `geo_clues`. The scan simply never opened those files: it walked only
+.claude/, plugins/ and q-system/, and Alice's code lives in q-investigate/ and
+scripts/. A gate that reports dead-and-alive the same way is not a gate.
+
+Second blind spot, same issue, already scarred once (ASK-230, provenance_vocabulary):
+`has_test` compared FILENAMES only, so `tests/test_extract.py` importing `geo_clues`
+scored as no-test. An importer is the strongest liveness evidence there is.
+
+The four NEGATIVE cases below are the point of this file. Widening the scan makes
+false-LIVE the new failure mode, so a prose-only mention, a true orphan, a
+self-referencing docstring, and a dated snapshot must all still fail to count as
+wiring. A gate that cannot fail is a rubber stamp.
+
+Isolation: every fixture is built in a tempdir. Nothing here reads a real repo.
+"""
+
+import importlib.util
+import sys
+import tempfile
+import unittest
+from pathlib import Path
+
+GEN = Path(__file__).resolve().parent.parent / "capability-map-gen.py"
+
+
+def load_generator():
+    spec = importlib.util.spec_from_file_location("capability_map_gen", GEN)
+    mod = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(mod)
+    # Populated per run in main(); an inherited value would mark fixture paths
+    # vendored and silently collect zero engines.
+    mod._NESTED_REPOS = set()
+    return mod
+
+
+def engine_body(name: str) -> str:
+    """A file long enough to clear the generator's 40-line engine floor."""
+    head = f'#!/usr/bin/env python3\n"""{name} -- fixture engine."""\n'
+    return head + "\n".join(f"# line {i}" for i in range(60))
+
+
+def build_fixture(root: Path) -> None:
+    (root / "q-investigate" / "tools").mkdir(parents=True)
+    (root / "q-investigate" / "lib").mkdir(parents=True)
+    (root / "q-investigate" / "tests").mkdir(parents=True)
+    (root / "docs").mkdir(parents=True)
+
+    # 1. LIVE: only caller is a shell script outside q-system/.
+    (root / "q-investigate/tools/engine_shell_called.py").write_text(
+        engine_body("engine_shell_called"))
+    (root / "q-investigate/tools/run.sh").write_text(
+        '#!/bin/bash\nset -euo pipefail\n'
+        'python3 "$(dirname "$0")/engine_shell_called.py" --once\n')
+
+    # 2. LIVE: only evidence is a test that IMPORTS it under a different filename.
+    (root / "q-investigate/lib/engine_import_tested.py").write_text(
+        engine_body("engine_import_tested"))
+    (root / "q-investigate/tests/test_unrelated_name.py").write_text(
+        "import sys\nsys.path.insert(0, '../lib')\n"
+        "import engine_import_tested\n\n"
+        "def test_it():\n    assert engine_import_tested\n")
+
+    # 3. LIVE: invoked from a fenced command inside a markdown command/runbook.
+    (root / "q-investigate/lib/engine_doc_invoked.py").write_text(
+        engine_body("engine_doc_invoked"))
+    (root / "docs/runbook.md").write_text(
+        "# Runbook\n\nRegenerate the deliverable:\n\n```bash\n"
+        "python3 q-investigate/lib/engine_doc_invoked.py\n```\n")
+
+    # 4. NEGATIVE: named in prose only. A findings doc saying a script is broken
+    #    is not a caller. This must stay UNWIRED or the widened scan has simply
+    #    traded false-dead for false-alive.
+    (root / "q-investigate/lib/engine_prose_only.py").write_text(
+        engine_body("engine_prose_only"))
+    (root / "docs/findings.md").write_text(
+        "# Findings\n\nDefect D1: engine_prose_only.py left the template unfilled.\n"
+        "Nobody has run engine_prose_only since the migration.\n")
+
+    # 5. NEGATIVE: nothing anywhere mentions it.
+    (root / "q-investigate/lib/engine_orphan.py").write_text(
+        engine_body("engine_orphan"))
+
+    # 6. NEGATIVE: self-reference in its own docstring is not a caller.
+    (root / "q-investigate/lib/engine_self_ref.py").write_text(
+        '#!/usr/bin/env python3\n'
+        '"""engine_self_ref.py -- run engine_self_ref.py nightly."""\n'
+        + "\n".join(f"# line {i}" for i in range(60)))
+
+    # 7. A dated snapshot of a live engine is not a second engine. Its writer
+    #    interpolates the date, so no static scan can ever match its literal name.
+    (root / "q-investigate/tools/backups").mkdir(parents=True)
+    (root / "q-investigate/tools/backups/engine_shell_called.2026-07-28.py").write_text(
+        engine_body("engine_shell_called snapshot"))
+
+
+class TestWiringDetection(unittest.TestCase):
+    @classmethod
+    def setUpClass(cls):
+        cls.mod = load_generator()
+        cls.tmp = tempfile.TemporaryDirectory()
+        cls.root = Path(cls.tmp.name)
+        build_fixture(cls.root)
+        cls.by_entry = {
+            c["entry"]: c for c in cls.mod.collect_engines(cls.root)
+        }
+
+    @classmethod
+    def tearDownClass(cls):
+        cls.tmp.cleanup()
+
+    def status(self, entry: str) -> str:
+        self.assertIn(entry, self.by_entry,
+                      f"{entry} was not collected at all; got {sorted(self.by_entry)}")
+        return self.by_entry[entry]["status"]
+
+    # --- positive: real wiring the old scan could not see -------------------
+
+    def test_shell_caller_outside_qsystem_counts(self):
+        self.assertEqual(
+            "LIVE", self.status("q-investigate/tools/engine_shell_called.py"),
+            "run.sh invokes it by path; that is wiring wherever run.sh lives")
+
+    def test_importing_test_counts_even_with_mismatched_filename(self):
+        self.assertEqual(
+            "LIVE", self.status("q-investigate/lib/engine_import_tested.py"),
+            "test_unrelated_name.py imports the module; filename match is not the test")
+
+    def test_fenced_invocation_in_markdown_counts(self):
+        self.assertEqual(
+            "LIVE", self.status("q-investigate/lib/engine_doc_invoked.py"),
+            "a runbook line that runs the script is a trigger")
+
+    # --- negative: the widened scan must still be able to say dead ----------
+
+    def test_prose_mention_is_not_wiring(self):
+        self.assertEqual(
+            "UNWIRED", self.status("q-investigate/lib/engine_prose_only.py"),
+            "a findings doc naming a script does not make it live")
+
+    def test_orphan_stays_unwired(self):
+        self.assertEqual(
+            "UNWIRED", self.status("q-investigate/lib/engine_orphan.py"),
+            "nothing references it; this is the case the gate exists for")
+
+    def test_self_reference_is_not_wiring(self):
+        self.assertEqual(
+            "UNWIRED", self.status("q-investigate/lib/engine_self_ref.py"),
+            "a script naming itself in its own docstring is not a caller")
+
+    def test_dated_snapshot_is_not_an_engine(self):
+        self.assertNotIn(
+            "q-investigate/tools/backups/engine_shell_called.2026-07-28.py",
+            self.by_entry,
+            "a dated snapshot is a rollback artifact; flagging it forever leaves "
+            "deleting the rollback copy as the only way to clear the gate")
+
+    # --- the evidence has to name the caller, not just assert a verdict -----
+
+    def test_evidence_names_the_referencing_file(self):
+        ev = self.by_entry["q-investigate/tools/engine_shell_called.py"]["evidence"]
+        self.assertIn("run.sh", ev,
+                      f"evidence must point at the caller so the map is auditable: {ev}")
+
+
+if __name__ == "__main__":
+    unittest.main(verbosity=2)

--- a/q-system/.q-system/scripts/test/test-capability-map-wiring.py
+++ b/q-system/.q-system/scripts/test/test-capability-map-wiring.py
@@ -12,10 +12,15 @@ Second blind spot, same issue, already scarred once (ASK-230, provenance_vocabul
 `has_test` compared FILENAMES only, so `tests/test_extract.py` importing `geo_clues`
 scored as no-test. An importer is the strongest liveness evidence there is.
 
-The four NEGATIVE cases below are the point of this file. Widening the scan makes
+The five NEGATIVE cases below are the point of this file. Widening the scan makes
 false-LIVE the new failure mode, so a prose-only mention, a true orphan, a
-self-referencing docstring, and a dated snapshot must all still fail to count as
-wiring. A gate that cannot fail is a rubber stamp.
+self-referencing docstring, a generated run log, and a dated snapshot must all
+still fail to count as wiring. A gate that cannot fail is a rubber stamp.
+
+The generated-log case was not written from imagination: it was found by diffing
+old-vs-new output across five real instances before merge, where it had already
+flipped a genuinely dead script to LIVE. A negative case earns its place by
+having caught something.
 
 Isolation: every fixture is built in a tempdir. Nothing here reads a real repo.
 """
@@ -92,7 +97,22 @@ def build_fixture(root: Path) -> None:
         '"""engine_self_ref.py -- run engine_self_ref.py nightly."""\n'
         + "\n".join(f"# line {i}" for i in range(60)))
 
-    # 7. A dated snapshot of a live engine is not a second engine. Its writer
+    # 7. NEGATIVE: named only inside q-system/output/, the generated-artifacts
+    #    tree. A codex transcript or run log that ENUMERATES files reads exactly
+    #    like a runbook that INVOKES one, so the fixture is a `find`-style
+    #    listing -- the real shape that flipped _sync_all.py to LIVE in
+    #    kipi-investigations. Note both lines below satisfy MD_INVOCATION_RE
+    #    ("./" and "python3 "), which is the point: the invocation filter cannot
+    #    catch this, only dropping the generated tree can.
+    (root / "q-system" / "output").mkdir(parents=True)
+    (root / "q-investigate/lib/engine_logged_only.py").write_text(
+        engine_body("engine_logged_only"))
+    (root / "q-system/output/codex-run-out.txt").write_text(
+        "Files considered:\n"
+        "./q-investigate/lib/engine_logged_only.py\n"
+        "python3 q-investigate/lib/engine_logged_only.py  # transcript echo\n")
+
+    # 8. A dated snapshot of a live engine is not a second engine. Its writer
     #    interpolates the date, so no static scan can ever match its literal name.
     (root / "q-investigate/tools/backups").mkdir(parents=True)
     (root / "q-investigate/tools/backups/engine_shell_called.2026-07-28.py").write_text(
@@ -152,6 +172,12 @@ class TestWiringDetection(unittest.TestCase):
         self.assertEqual(
             "UNWIRED", self.status("q-investigate/lib/engine_self_ref.py"),
             "a script naming itself in its own docstring is not a caller")
+
+    def test_generated_output_is_not_wiring(self):
+        self.assertEqual(
+            "UNWIRED", self.status("q-investigate/lib/engine_logged_only.py"),
+            "q-system/output/ holds codex transcripts and run logs; a log that "
+            "lists a script did not run it, and its lines look like invocations")
 
     def test_dated_snapshot_is_not_an_engine(self):
         self.assertNotIn(

--- a/q-system/.q-system/scripts/test/test-capability-map-wiring.py
+++ b/q-system/.q-system/scripts/test/test-capability-map-wiring.py
@@ -100,7 +100,7 @@ def build_fixture(root: Path) -> None:
     # 7. NEGATIVE: named only inside q-system/output/, the generated-artifacts
     #    tree. A codex transcript or run log that ENUMERATES files reads exactly
     #    like a runbook that INVOKES one, so the fixture is a `find`-style
-    #    listing -- the real shape that flipped _sync_all.py to LIVE in
+    #    listing -- the real shape that flipped the `_sync_all` script to LIVE in
     #    kipi-investigations. Note both lines below satisfy MD_INVOCATION_RE
     #    ("./" and "python3 "), which is the point: the invocation filter cannot
     #    catch this, only dropping the generated tree can.
@@ -192,6 +192,88 @@ class TestWiringDetection(unittest.TestCase):
         ev = self.by_entry["q-investigate/tools/engine_shell_called.py"]["evidence"]
         self.assertIn("run.sh", ev,
                       f"evidence must point at the caller so the map is auditable: {ev}")
+
+
+class TestMutantKills(unittest.TestCase):
+    """Kill-tests for mutants that SURVIVED the 9-case suite (Fable mutation table).
+
+    Reverting either 73a8870 fix left every test green: the witness ranking and
+    the engine-side generated exclusion shipped with zero coverage. A fix nothing
+    pins is a fix that silently un-ships on the next edit. These assert the unit
+    behaviour directly so no fixture wiring can mask them.
+    """
+
+    @classmethod
+    def setUpClass(cls):
+        cls.mod = load_generator()
+
+    # --- MD_INVOCATION_RE: prose must not read as invocation (Fable B1) -------
+
+    def test_prose_does_not_match_invocation_re(self):
+        for line in [
+            "The source of the bug is engine_x.py",
+            "run-sweep.sh used to call engine_x.py",
+            "this old python script engine_x.py is dead",
+            "see ../notes for why engine_x.py was dropped",
+            "we removed the bash wrapper around engine_x.py",
+        ]:
+            self.assertIsNone(
+                self.mod.MD_INVOCATION_RE.search(line),
+                f"prose asserting a script is dead must not mark it live: {line!r}")
+
+    def test_real_invocations_still_match(self):
+        for line in [
+            "python3 engine_x.py --once",
+            "  ./engine_x.py",
+            "bash scripts/run.sh",
+            "cat x | python3 tools/y.py",
+            "$(python3 gen.py)",
+            "sh ./deploy.sh",
+        ]:
+            self.assertIsNotNone(
+                self.mod.MD_INVOCATION_RE.search(line),
+                f"a real invocation must still count as wiring: {line!r}")
+
+    # --- witness ranking: .claude/ and .q-system/ are NOT scratch (Fable A1) --
+
+    def test_witness_prefers_real_caller_over_review_scratch(self):
+        real = Path("q-system/.q-system/scripts/linear-worker.sh")
+        scratch = Path(".pr36rev/tree/q-system/.q-system/scripts/linear-worker.sh")
+        self.assertEqual(
+            real, sorted([scratch, real], key=self.mod._witness_rank)[0],
+            "a review tree copy must never out-cite the real caller")
+
+    def test_dotted_wiring_dirs_are_not_treated_as_scratch(self):
+        for real in (Path(".claude/settings.json"),
+                     Path("q-system/.q-system/scripts/x.sh")):
+            plain = Path("docs/some/deep/nested/note.md")
+            self.assertEqual(
+                real, sorted([plain, real], key=self.mod._witness_rank)[0],
+                f"{real} is primary wiring in this fleet, not hidden scratch")
+
+    # --- the exclusion predicate is used for ALL THREE questions -------------
+
+    def test_excluded_tree_covers_generated_and_scratch(self):
+        root = Path("/repo")
+        for rel in ("q-system/output/log.txt", ".pr36rev/all-dors.json",
+                    ".pr42rev-r2/tree/q-system/x.py", ".prd-os/spillover.jsonl",
+                    ".claude/worktrees/w/q-system/x.py"):
+            self.assertTrue(self.mod.is_excluded_tree(root / rel, root),
+                            f"{rel} is generated or review scratch")
+
+    def test_excluded_tree_does_not_swallow_real_wiring(self):
+        root = Path("/repo")
+        for rel in (".claude/settings.json", "q-system/.q-system/scripts/x.sh",
+                    "plugins/prd-os/hooks.json", "scripts/daily-sweep/run.sh"):
+            self.assertFalse(self.mod.is_excluded_tree(root / rel, root),
+                             f"{rel} is real wiring and must stay on the surface")
+
+    def test_generated_prefix_is_anchored_not_substring(self):
+        root = Path("/repo")
+        self.assertFalse(
+            self.mod.is_excluded_tree(root / "q-investigate/output/gen.py", root),
+            "a case-level output/ dir is not q-system/output/; un-anchoring this "
+            "darkens Alice's fill_sheet.py, which is LIVE and in ASK-122's table")
 
 
 if __name__ == "__main__":

--- a/q-system/.q-system/scripts/test/test-capability-map-wiring.py
+++ b/q-system/.q-system/scripts/test/test-capability-map-wiring.py
@@ -268,6 +268,26 @@ class TestMutantKills(unittest.TestCase):
             self.assertFalse(self.mod.is_excluded_tree(root / rel, root),
                              f"{rel} is real wiring and must stay on the surface")
 
+    def test_scratch_tree_test_file_does_not_grant_has_test(self):
+        """The has_test walk is a FOURTH consumer of is_excluded_tree.
+
+        Missed when the predicate was introduced, so a test filename inside a
+        review tree still marked a dead engine LIVE -- the same one-sided
+        exclusion the predicate exists to prevent, surviving inside its own fix.
+        """
+        with tempfile.TemporaryDirectory() as td:
+            root = Path(td)
+            (root / "lib").mkdir(parents=True)
+            (root / ".pr36rev" / "tree" / "tests").mkdir(parents=True)
+            (root / "lib/engine_only_scratch_test.py").write_text(
+                engine_body("engine_only_scratch_test"))
+            (root / ".pr36rev/tree/tests/test_engine_only_scratch_test.py").write_text(
+                "def test_x():\n    assert True\n")
+            caps = {c["entry"]: c for c in self.mod.collect_engines(root)}
+            self.assertEqual(
+                "UNWIRED", caps["lib/engine_only_scratch_test.py"]["status"],
+                "a test file inside a review tree is not coverage of real code")
+
     def test_generated_prefix_is_anchored_not_substring(self):
         root = Path("/repo")
         self.assertFalse(


### PR DESCRIPTION
## What

`capability-map-gen.py` reported engines UNWIRED that had visible callers on disk. Fixes three false-dead classes and one false-alive class it introduced.

**ASK-122's own premise was wrong: 10 of the 11 scripts in that issue's table are LIVE.**

## False-dead (the original bug)

1. Wiring scan walked only `.claude/`, `plugins/`, `q-system/`. An instance whose code lives elsewhere reported its own runners absent. Now repo-wide.
2. `has_test` matched test FILENAMES only, so an importing test scored as no-test. Recurrence of the ASK-230 `provenance_vocabulary` scar.
3. Dated snapshots counted as engines. Their writer interpolates `$TODAY`, so no static scan can match. It reported UNWIRED forever and the only way to clear it was destroying a rollback artifact.

## False-alive (found pre-merge, by measurement)

Widening the scan swept in `q-system/output/` (codex transcripts, run logs, plans). Those name scripts constantly and run nothing. On kipi-investigations `_sync_all.py` flipped to LIVE off a find-style listing in a codex log. That one change was inflating `investigations` by 25 engines.

The invocation filter cannot catch it: the offending line starts with `./`. A log of a command that *enumerated* files is indistinguishable line-by-line from a runbook that *invokes* one. Generated trees leave the surface set instead.

## Evidence

- 9 test cases, 5 of them negatives. Fixtures in a tempdir, no live data path.
- New test vs the pre-fix generator from `origin/main`: **5 of 8 fail**. With the fix: **9/9 OK**.
- Mutation-checked: guard forced off (validated applied, parses, differs) fails exactly the one intended case.
- `capability-gate: GREEN`.
- Measured old -> new on five real instances:

| repo | LIVE before | LIVE after | UNWIRED before | UNWIRED after |
|---|---|---|---|---|
| 4_points | 319 | 336 | 41 | 24 |
| investigations | 455 | 466 | 47 | 36 |
| Pure_spectrum | 283 | 286 | 22 | 19 |
| kipi-system | 373 | 375 | 24 | 22 |
| Alice | 315 | 335 | 44 | 23 |

## Note

This is a skeleton file; it propagates to every instance via `kipi update`.