### PR TITLE
A required check nobody posts is detected and handed to its real producer (ASK-313)

### DIFF
--- a/kipi-dispatch.sh
+++ b/kipi-dispatch.sh
@@ -847,6 +847,71 @@ if [ -f "$REDRIVE" ]; then
   fi
 fi
 
+# --- WEDGED PR: A REQUIRED CHECK NOBODY POSTED (ASK-313) ---------------------
+# ABOVE the `nothing ready` exit, deliberately. A wedged PR is most likely
+# EXACTLY when no issue is ready: the issue is done, the PR is open, and the
+# board is quiet. Putting this after the early exit would make the detector go
+# silent in the one state it exists for -- the same shape as the ASK-222 scar,
+# where the arm lived past a `continue` that skipped the finished PRs.
+#
+# THE SCAR (2026-08-02). PR #75 sat BLOCKED with `validate` green,
+# `kipi/reviewer-approved` ABSENT, auto-merge armed and correctly refusing, and
+# nothing anywhere said so. `kipi/reviewer-approved` has one producer,
+# pr-review-agent.sh, whose only automated caller is linear-worker.sh step 5 --
+# reachable only for a DoR-ready issue the dispatcher picked. A PR opened by
+# hand therefore carries a required check with no producer, forever.
+#
+# THIS RUNS THE REAL PRODUCER; IT DOES NOT FAKE THE STATUS. The context stays
+# required and stays honest. See ci-redrive.py's `wedged` docstring for why the
+# textbook "always post it green" fix is the wrong one here (twice over).
+#
+# THE SPEND IS BOUNDED BY TWO INDEPENDENT CAPS: `wedged` offers at most one PR
+# per heartbeat, and the attempts ledger allows one review per PR per
+# missing-context set. So the ceiling is the number of open PRs, once each, not
+# one review every 15 minutes.
+if [ -f "$REDRIVE" ]; then
+  WEDGED_LINE="$(KIPI_NOTIFY="$NOTIFY" python3 "$REDRIVE" \
+                   --repo-dir "$TARGET_PATH" wedged 2>>"$LOG")"
+  WEDGED_RC=$?
+  if [ "$WEDGED_RC" = "2" ]; then
+    say "wedged-PR sweep: gh could not read PR or protection state in $TARGET_NAME -- nothing claimed"
+  elif [ "$WEDGED_RC" = "0" ] && [ -n "$WEDGED_LINE" ]; then
+    WEDGED_PR="$(printf '%s' "$WEDGED_LINE" | cut -f1)"
+    WEDGED_SIG="$(printf '%s' "$WEDGED_LINE" | cut -f2)"
+    # Same snapshot-and-=~ form as the converge guard above, and for the same
+    # reason: `ps | grep -q` under pipefail dies to SIGPIPE load-dependently.
+    # A reviewer already live on this PR would otherwise get a second one.
+    # Its OWN snapshot: the converge guard's PS_SNAPSHOT is taken ~50 lines
+    # below this, past the `nothing ready` exit, so reading it here would be an
+    # unbound variable under `set -u` on every quiet heartbeat. A second `ps` is
+    # cheaper than reordering code that is load-bearing and proven.
+    WEDGED_PS="$(ps -Ao args= 2>/dev/null || true)"
+    if [[ "$WEDGED_PS" =~ pr-review-agent\.sh\ ${WEDGED_PR}([[:space:]]|$) ]]; then
+      say "wedged-PR sweep: a reviewer is already live on PR #$WEDGED_PR -- leaving it"
+    elif ! python3 "$REDRIVE" mark-reviewed --pr "$WEDGED_PR" \
+           --signature "$WEDGED_SIG" 2>>"$LOG"; then
+      say "wedged-PR sweep: the attempt for PR #$WEDGED_PR is already claimed -- not reviewing"
+    else
+      # Detached, for the reason the converge child below is detached: launchd
+      # reaps this job's whole process group on exit, and a codex review takes
+      # minutes. `nohup ... &` is NOT enough here -- that was proven, see the
+      # comment on the converge launch.
+      WEDGED_LOG="$HOME/.config/kipi/wedged-review-pr$WEDGED_PR.log"
+      printf '\n===== wedged review PR #%s  %s =====\n' \
+        "$WEDGED_PR" "$(date -u +%Y-%m-%dT%H:%M:%SZ)" >> "$WEDGED_LOG"
+      python3 - "$WEDGED_LOG" \
+        bash "$REPO/q-system/.q-system/scripts/pr-review-agent.sh" \
+        "$WEDGED_PR" --post --engine codex <<'PY'
+import subprocess, sys
+log_path, argv = sys.argv[1], sys.argv[2:]
+log = open(log_path, "ab", buffering=0)
+subprocess.Popen(argv, stdout=log, stderr=log, start_new_session=True)
+PY
+      say "wedged-PR sweep: PR #$WEDGED_PR is blocked on a required check nothing posted -- ran the reviewer (log: $WEDGED_LOG)"
+    fi
+  fi
+fi
+
 if [ -z "$NEXT" ]; then
   say "nothing ready ($(printf '%s' "$WORK_OUT" | grep -oE '[0-9]+ ready issue' | head -1))"
   exit 0

--- a/q-system/.q-system/capability-manifest.json
+++ b/q-system/.q-system/capability-manifest.json
@@ -434,6 +434,10 @@
     {
       "path": "q-system/.q-system/scripts/test/test-capability-map-wiring.py",
       "runner": "python3"
+    },
+    {
+      "path": "q-system/.q-system/scripts/test/test-wedged-pr.sh",
+      "runner": "bash"
     }
   ],
   "required_data": [],
@@ -519,7 +523,7 @@
     },
     {
       "path": "q-system/.q-system/scripts/stat-verify.py",
-      "reason": "802-line stat verification engine; zero hook wiring and its stat-registry.json data file exists in exactly one instance — wiring it is a founder product decision",
+      "reason": "802-line stat verification engine; zero hook wiring and its stat-registry.json data file exists in exactly one instance \u2014 wiring it is a founder product decision",
       "spillover_id": "sp-72b60bff"
     },
     {
@@ -539,8 +543,8 @@
     }
   ],
   "uncovered_known": [
-    "plugins/*/tests — prd-os plugin suite, run by the plugin's own harness; outside v1 scan roots (finding-9 deferred)",
+    "plugins/*/tests \u2014 prd-os plugin suite, run by the plugin's own harness; outside v1 scan roots (finding-9 deferred)",
     "repo-root *.sh utilities are wiring surfaces, not test artifacts",
-    "stat-registry.json: NOT expressible as required_data in v1 — the one instance holding it keeps canonical under its own instance_q_dir (not q-system/) and its registry name differs from its dir basename, so a scoped entry could never fire (grounded 2026-07-23). Declared gap; owning decision + instance detail in spillover sp-72b60bff"
+    "stat-registry.json: NOT expressible as required_data in v1 \u2014 the one instance holding it keeps canonical under its own instance_q_dir (not q-system/) and its registry name differs from its dir basename, so a scoped entry could never fire (grounded 2026-07-23). Declared gap; owning decision + instance detail in spillover sp-72b60bff"
   ]
 }

--- a/q-system/.q-system/scripts/ci-redrive.py
+++ b/q-system/.q-system/scripts/ci-redrive.py
@@ -212,7 +212,8 @@ FAILED_CONCLUSIONS = {"FAILURE", "TIMED_OUT", "CANCELLED", "STARTUP_FAILURE",
 # The legacy commit-status half of the same rollup speaks a different vocabulary.
 FAILED_STATES = {"FAILURE", "ERROR"}
 
-PR_FIELDS = "number,headRefName,headRefOid,url,title,statusCheckRollup,isDraft"
+PR_FIELDS = ("number,headRefName,headRefOid,url,title,statusCheckRollup,isDraft,"
+             "baseRefName")
 
 
 class GhUnavailable(Exception):
@@ -309,6 +310,151 @@ def failing_checks(pr):
         if (check.get("conclusion") or "").upper() in FAILED_CONCLUSIONS:
             names.add(name)
     return sorted(names)
+
+
+# --- a REQUIRED context nobody posted (ASK-313) ------------------------------
+# failing_checks() above can only see contexts that were POSTED. An ABSENT
+# required context contributes zero rollup entries, so every reader built on the
+# rollup reads a wedged PR as healthy. On 2026-08-02 PR #75 sat BLOCKED with
+# `validate` green, `kipi/reviewer-approved` absent, auto-merge armed, and zero
+# alerts; `gh pr checks` said the checks had passed (cli/cli#6448 -- the CLI does
+# not surface expected-but-unreported contexts, still open). The only way to see
+# absence is to DIFF what protection DECLARES against what the head has actual.
+#
+# WHY NOT THE STANDARD GITHUB FIX. The documented remedy for a never-reported
+# required check is a job that always posts it green (GHES 3.2 troubleshooting,
+# "Handling skipped but required checks"; re-actors/alls-green; Mergify ci-gate).
+# It is wrong here twice over:
+#   1. Absence of `kipi/reviewer-approved` is a CORRECT refusal, not a
+#      misconfiguration. linear-worker.sh:687 -- "Remove kipi/reviewer-approved
+#      from that set and this becomes an unreviewed-merge machine."
+#   2. GitHub requires BOTH when a check run and a commit status share a name
+#      ("If a check and a commit status have the same name, both must pass when
+#      that name is required"). An Actions job named `kipi/reviewer-approved`
+#      would ADD a second thing to satisfy, deepening the deadlock it meant to
+#      fix.
+# So this does not fake the status. It finds the wedge and hands the PR to the
+# REAL producer, pr-review-agent.sh, which is the only thing allowed to post it.
+
+def required_contexts(repo_dir, branch, _cache={}):
+    """Contexts branch protection REQUIRES on `branch`. Raises GhUnavailable.
+
+    Both halves are read. GitHub populates `contexts` (legacy) and `checks` (the
+    app-pinned form) and a reader that trusts one of them stops working the day
+    the other is the only one written.
+
+    404 AND EVERY OTHER FAILURE ARE DIFFERENT ANSWERS, and conflating them was
+    a real bug in this function's first version. Round 1 raised on any non-zero
+    rc, reasoning that repo-preflight.sh already refuses to dispatch against an
+    unprotected repo so 404 could never legitimately arrive. That is a claim
+    about the DEFAULT branch, and this is asked about a PR's BASE branch. The
+    very first live run hit it:
+
+        $ ci-redrive.py --repo-dir . wedged
+        could not read branch protection for sana/block-expiry
+          (rc 1): gh: Branch not protected (HTTP 404)   -- rc 2, whole sweep dead
+
+    A stacked PR based on another agent's branch is ordinary here, and one
+    unprotected base blinded the sweep for every other PR -- the exact silence
+    this detector exists to end, reintroduced by the detector.
+
+    So: 404 is DEFINITE ("no protection, therefore nothing required, therefore
+    this PR cannot wedge") and yields the empty set. Anything else -- notably
+    the 403 a token without admin gets -- stays INDEFINITE and raises, because
+    reading "I am not allowed to look" as "nothing is required" would report
+    every wedged PR healthy at the moment the tool lost the ability to tell.
+    """
+    if branch in _cache:
+        return _cache[branch]
+    gh = os.environ.get("KIPI_GH", "gh")
+    cmd = [gh, "api", "repos/{owner}/{repo}/branches/%s/protection" % branch]
+    try:
+        proc = subprocess.run(cmd, cwd=repo_dir, capture_output=True, text=True)
+    except OSError as exc:
+        raise GhUnavailable("could not run %s: %s" % (gh, exc))
+    if proc.returncode != 0:
+        stderr = (proc.stderr or "").strip()
+        # gh's own format is `gh: <message> (HTTP <code>)`, and 404 here is the
+        # documented body for "Branch not protected". Matched on the code, not
+        # on the message text, so a wording change does not silently turn a
+        # definite answer into an indefinite one.
+        if "(HTTP 404)" in stderr:
+            _cache[branch] = set()
+            return _cache[branch]
+        raise GhUnavailable(
+            "could not read branch protection for %s (rc %d): %s"
+            % (branch, proc.returncode, stderr[:200]))
+    try:
+        data = json.loads(proc.stdout or "{}")
+    except ValueError as exc:
+        raise GhUnavailable("branch protection for %s is unparseable: %s"
+                            % (branch, exc))
+    rsc = data.get("required_status_checks") or {}
+    names = set(rsc.get("contexts") or [])
+    for entry in rsc.get("checks") or []:
+        if isinstance(entry, dict) and entry.get("context"):
+            names.add(entry["context"])
+    _cache[branch] = names
+    return names
+
+
+def posted_contexts(pr):
+    """Every context name the head commit carries, WHATEVER its state.
+
+    State is deliberately ignored. A required context posted and FAILING is a
+    PR that was reviewed and rejected -- a visible state with its own consumer
+    (the reviewer comments on the Linear issue and the worker re-dispatches).
+    Folding red into absent would re-review every rejected PR forever.
+    """
+    names = set()
+    for check in pr.get("statusCheckRollup") or []:
+        if not isinstance(check, dict):
+            continue
+        if check.get("__typename") == "StatusContext":
+            if check.get("context"):
+                names.add(check["context"])
+            continue
+        if check.get("name"):
+            names.add(check["name"])
+    return names
+
+
+def wedged_candidates(repo_dir):
+    """Open PRs carrying a required context that nothing has posted.
+
+    NOT filtered by attribute(): redrive hands a red PR back to the agent that
+    owns the branch, so it only speaks for agent branches. Branch protection
+    does not care who pushed. The founder's own hand-opened PR wedges
+    identically, and it is the one class with no agent to hand it back to -- so
+    excluding it would leave exactly the population that cannot self-heal.
+    """
+    out = []
+    for pr in list_prs(repo_dir):
+        if pr.get("isDraft"):
+            continue          # not asking to merge; a review would be spend nobody asked for
+        # RED CI OUTRANKS A WEDGE, and this is a spend rule learned from real
+        # data. PR #76 on 2026-08-02 was BOTH: `validate` FAILURE and
+        # `kipi/reviewer-approved` absent. Reviewing a PR whose build is broken
+        # buys a codex review of a tree that is about to change, and the redrive
+        # tier already owns that PR. It becomes this tier's business the moment
+        # CI is green -- nothing is dropped, only ordered.
+        if failing_checks(pr):
+            continue
+        base = pr.get("baseRefName") or "main"
+        missing = sorted(required_contexts(repo_dir, base) - posted_contexts(pr))
+        if not missing:
+            continue
+        attributed = attribute(pr)
+        out.append({
+            "pr": pr.get("number"),
+            "url": pr.get("url"),
+            "branch": pr.get("headRefName"),
+            "head_sha": pr.get("headRefOid") or "",
+            "issue": attributed[0] if attributed else None,
+            "missing": missing,
+            "signature": signature(missing),
+        })
+    return out
 
 
 # --- is work on this issue already in flight ---------------------------------
@@ -544,17 +690,94 @@ def cmd_mark_dispatched(issue, sig, head_sha):
     return 0
 
 
+# --- the wedged tier (ASK-313) -----------------------------------------------
+# Keyed by PR, not by issue. A wedge is a property of the PULL REQUEST -- the
+# founder's hand-opened PR has no issue at all, and two PRs for one issue can
+# wedge independently. `PR-<n>` is a plain dict key to attempts-ledger.py, the
+# same single writer the redrive tier goes through, so the two tiers cannot
+# race each other into exceeding a cap.
+
+def wedged_key(cand):
+    return "PR-%s" % cand["pr"]
+
+
+def wedged_flag(cand):
+    return "wedged_review_%s" % cand["signature"]
+
+
+def escalate_wedged(path, cand):
+    """One page, AFTER the machine tier is spent. Every clause an observation."""
+    if not ledger_claim(path, wedged_key(cand),
+                        "wedged_escalated_%s" % cand["signature"]):
+        return False
+    notify(
+        "ci-redrive: PR #%s is BLOCKED on a required check nothing posted (%s) "
+        "and the machine tier is spent -- the reviewer was run once for this "
+        "and the context is still absent. %s"
+        % (cand["pr"], ", ".join(cand["missing"]), cand["url"]))
+    return True
+
+
+def cmd_wedged(cands):
+    """READ-ONLY. Offers one PR; the dispatcher spends it via mark-reviewed."""
+    path = attempts_path()
+    chosen = None
+    for cand in cands:
+        # A live converge for this issue reaches the reviewer at its own step 5,
+        # so offering it here would buy a second codex review of the same head.
+        # Only askable when the PR HAS an issue; a founder PR never does.
+        if cand["issue"] and converge_live(cand["issue"]):
+            sys.stderr.write(
+                "ci-redrive: PR #%s is wedged but a converge for %s is live -- "
+                "its own review will post the context\n"
+                % (cand["pr"], cand["issue"]))
+            continue
+        if ledger_get(path, wedged_key(cand), wedged_flag(cand)):
+            escalate_wedged(path, cand)    # machine tier already spent
+            continue
+        if chosen is None:
+            chosen = cand
+    if chosen is None:
+        return 1
+    sys.stderr.write(
+        "ci-redrive: PR #%s is BLOCKED on required context(s) nothing posted: "
+        "%s -- offering it to the reviewer\n"
+        % (chosen["pr"], ", ".join(chosen["missing"])))
+    print("%s\t%s\t%s" % (chosen["pr"], chosen["signature"], chosen["head_sha"]))
+    return 0
+
+
+def cmd_mark_reviewed(pr, sig):
+    """The atomic claim. 0 = it is yours to review, 1 = it is not."""
+    path = attempts_path()
+    if not ledger_claim(path, "PR-%s" % pr, "wedged_review_%s" % sig):
+        sys.stderr.write(
+            "ci-redrive: the wedged-review attempt for PR #%s signature %s was "
+            "already claimed (or the ledger could not be written) -- not "
+            "running the reviewer.\n" % (pr, sig))
+        return 1
+    return 0
+
+
 def main(argv):
     ap = argparse.ArgumentParser(
-        description="Machine consumer for red CI on agent-opened PRs (ASK-295).")
-    ap.add_argument("op", choices=("scan", "redrive", "mark-dispatched"))
+        description="Machine consumer for red CI on agent-opened PRs (ASK-295) "
+                    "and for PRs wedged on an unposted required check (ASK-313).")
+    ap.add_argument("op", choices=("scan", "redrive", "mark-dispatched",
+                                   "wedged", "mark-reviewed"))
     ap.add_argument("--repo-dir", default=".",
                     help="checkout whose open PRs are read (gh runs here)")
     ap.add_argument("--issue", help="mark-dispatched: the issue being dispatched")
     ap.add_argument("--signature", help="mark-dispatched: signature from redrive")
     ap.add_argument("--head-sha", default="",
                     help="mark-dispatched: head sha from redrive")
+    ap.add_argument("--pr", help="mark-reviewed: the PR being handed to the reviewer")
     args = ap.parse_args(argv[1:])
+
+    if args.op == "mark-reviewed":
+        if not args.pr or not args.signature:
+            ap.error("mark-reviewed needs --pr and --signature")
+        return cmd_mark_reviewed(args.pr, args.signature)
 
     # No gh call: mark-dispatched commits the offer the dispatcher is holding.
     # Re-probing here would decide against a world that may have moved between
@@ -564,6 +787,16 @@ def main(argv):
         if not args.issue or not args.signature:
             ap.error("mark-dispatched needs --issue and --signature")
         return cmd_mark_dispatched(args.issue, args.signature, args.head_sha)
+
+    if args.op == "wedged":
+        try:
+            return cmd_wedged(wedged_candidates(args.repo_dir))
+        except GhUnavailable as exc:
+            # 2, same contract as below: a claim about the PROBE, never about
+            # the PRs. Folding an unreadable protection response into "nothing
+            # is wedged" is the original defect wearing the detector's coat.
+            sys.stderr.write("ci-redrive: %s -- nothing was claimed.\n" % exc)
+            return 2
 
     try:
         cands = candidates(args.repo_dir)

--- a/q-system/.q-system/scripts/ci-redrive.py
+++ b/q-system/.q-system/scripts/ci-redrive.py
@@ -497,6 +497,35 @@ def converge_live(issue):
     return bool(pattern.search(table))
 
 
+def reviewer_live(pr):
+    """True if a reviewer for this PR is in the process table right now.
+
+    A CLAIMED ATTEMPT IS NOT A COMPLETED ATTEMPT (codex on PR #78, major).
+    The reviewer is launched DETACHED and takes minutes; the heartbeat is 900s.
+    So the next run sees the ledger flag, reads it as "the machine tier is
+    spent", and pages that the reviewer ran and the context is still absent --
+    while it is mid-flight. That page also claims `wedged_escalated_<sig>`, so
+    the one page owed to the founder is burnt on a false alarm and the REAL
+    failure is then silent. Exactly the scar cmd_redrive already guards with
+    converge_live; it was not carried into this tier.
+
+    The dispatcher's own `WEDGED_PS` check does not cover this: that only stops
+    a second reviewer being LAUNCHED. The escalation decision lives here.
+
+    An unreadable table answers True, same direction as converge_live: skipping
+    one heartbeat is recoverable, a false page that also burns the flag is not.
+    """
+    table = process_table()
+    if table is None:
+        sys.stderr.write("ci-redrive: could not read the process table -- treating "
+                         "every wedged PR as already under review.\n")
+        return True
+    # `(?:\s|$)` MULTILINE so PR 7 does not match `pr-review-agent.sh 75`.
+    pattern = re.compile(r"pr-review-agent\.sh\s+%s(?:\s|$)" % re.escape(str(pr)),
+                         re.MULTILINE)
+    return bool(pattern.search(table))
+
+
 def signature(names):
     """Identity of a FAILURE, not of a run.
 
@@ -732,8 +761,18 @@ def cmd_wedged(cands):
                 "its own review will post the context\n"
                 % (cand["pr"], cand["issue"]))
             continue
+        # BEFORE both the offer and the escalation, for the two different
+        # reasons cmd_redrive gives: offering would buy a second review of the
+        # same head, and escalating would page that a still-running attempt had
+        # stopped -- burning the one page owed to the founder. Found by codex
+        # reviewing this change (PR #78, major).
+        if reviewer_live(cand["pr"]):
+            sys.stderr.write(
+                "ci-redrive: PR #%s is wedged and its reviewer is still running "
+                "-- not offering it and not escalating it this run\n" % cand["pr"])
+            continue
         if ledger_get(path, wedged_key(cand), wedged_flag(cand)):
-            escalate_wedged(path, cand)    # machine tier already spent
+            escalate_wedged(path, cand)    # machine tier spent AND finished
             continue
         if chosen is None:
             chosen = cand

--- a/q-system/.q-system/scripts/test/test-wedged-pr.sh
+++ b/q-system/.q-system/scripts/test/test-wedged-pr.sh
@@ -369,6 +369,43 @@ OUT="$(run wedged)"; RC=$?
 check "14a rc 0: green CI + absent required context is a wedge" "$RC" "0"
 contains "14b names the PR" "$OUT" "76"
 
+# --- 15. A CLAIMED ATTEMPT IS NOT A COMPLETED ATTEMPT ------------------------
+# Found by codex reviewing THIS change (PR #78): "the second heartbeat falsely
+# escalates a wedged PR while its detached reviewer is still running, then
+# suppresses the later real alert."
+#
+# The reviewer is launched DETACHED and takes minutes; the heartbeat is 900s.
+# So the very next run sees the ledger flag set, reads it as "the machine tier
+# is spent", and pages the founder that the reviewer ran and the context is
+# still absent -- while the reviewer is mid-flight. Worse, that page CLAIMS
+# `wedged_escalated_<sig>`, so when the reviewer really does fail, the one page
+# owed to the founder has already been burnt on a false alarm.
+#
+# cmd_redrive already guards exactly this and says why: "the founder would be
+# paged that a still-running attempt had stopped -- burning the one page owed
+# to him when it really does." That guard was not carried into this tier.
+# The dispatcher's own WEDGED_PS check does NOT cover it: that only stops a
+# SECOND reviewer being launched, and the escalation lives in here.
+ps_fixture() { printf '%s\n' "$1" > "$TMP/ps-table"; PS_FIXTURE="$TMP/ps-table"; }
+
+fresh_state 15; fixture "$WEDGED"
+OUT="$(run wedged)"; SIG="$(printf '%s' "$OUT" | cut -f2)"
+run mark-reviewed --pr 75 --signature "$SIG" >/dev/null
+# the detached reviewer this run just launched is still going
+ps_fixture "bash /Users/x/q-system/.q-system/scripts/pr-review-agent.sh 75 --post --engine codex"
+run wedged >/dev/null; RC=$?
+check "15a rc 1: nothing offered while its own reviewer is live" "$RC" "1"
+check "15b NOT paged about a reviewer that is still running" "$(pages)" "0"
+lacks "15c no escalation text" "$(cat "$NOTIFY_LOG")" "machine tier is spent"
+
+# --- 16. ...AND THE REAL PAGE STILL FIRES ONCE THE REVIEWER IS GONE ----------
+# The discrimination for 15. If 15 were implemented by simply never escalating,
+# the founder would never hear about a wedge the machine could not fix.
+ps_fixture ""                      # reviewer exited, context still absent
+run wedged >/dev/null
+check "16a paged once the reviewer is actually gone" "$(pages)" "1"
+contains "16b and it names the missing context" "$(cat "$NOTIFY_LOG")" "kipi/reviewer-approved"
+
 echo
 printf 'wedged-pr: %d passed, %d failed\n' "$PASS" "$FAIL"
 [ "$FAIL" -eq 0 ]

--- a/q-system/.q-system/scripts/test/test-wedged-pr.sh
+++ b/q-system/.q-system/scripts/test/test-wedged-pr.sh
@@ -1,0 +1,374 @@
+#!/usr/bin/env bash
+# Pairs with ci-redrive.py's `wedged` op (ASK-313): a REQUIRED status context
+# that nothing ever posts blocks a PR forever, silently.
+#
+# THE SCAR (2026-08-02)
+# ---------------------
+# PR #75 (ASK-311) sat at mergeStateStatus=BLOCKED with auto-merge armed,
+# `validate` SUCCESS, and `kipi/reviewer-approved` ABSENT. Measured that day:
+#
+#   $ gh api repos/assafkip/kipi-system/branches/main/protection
+#     required_status_checks.contexts = ["validate","kipi/reviewer-approved"]
+#   $ gh pr view 75 --json mergeStateStatus   -> BLOCKED
+#   $ gh pr checks 75                          -> validate only
+#
+# `kipi/reviewer-approved` has exactly one producer, pr-review-agent.sh, whose
+# only automated caller is linear-worker.sh:1802 -- reachable only from the
+# dispatcher loop, for DoR-ready issues. A PR opened by hand gets a required
+# check with no producer. Auto-merge was armed and correctly refusing; nothing
+# said so, so the founder was told it would land on its own.
+#
+# WHY THE STANDARD GITHUB FIX IS THE WRONG FIX HERE
+# -------------------------------------------------
+# The documented remedy for a never-reported required check is a no-op job that
+# always posts the context green. That would be catastrophic on this repo.
+# linear-worker.sh:687 states the blast radius: "Remove `kipi/reviewer-approved`
+# from that set and this becomes an unreviewed-merge machine." ABSENCE HERE IS A
+# CORRECT REFUSAL. So nothing in this suite asserts that a wedged PR becomes
+# mergeable -- it asserts that the wedge is SEEN and handed to the real
+# producer. A fix that made these PRs green would pass a suite built the other
+# way, which is why the discrimination is written down here.
+#
+# WHY THE EXISTING SWEEP CANNOT SEE THIS
+# --------------------------------------
+# failing_checks() iterates statusCheckRollup, so it can only observe contexts
+# that were POSTED. An absent required context contributes zero rollup entries.
+# The sweep reads a wedged PR as perfectly healthy. Case 1 pins exactly that.
+#
+# WHAT THIS SUITE PINS
+# --------------------
+#   1. Required-but-absent is detected (the wedge).
+#   2. NEGATIVE SELF-TEST: a PR with every required context posted is NOT
+#      wedged. Without this, a detector that returned "wedged" unconditionally
+#      would pass case 1.
+#   3. A required context POSTED and FAILING is not a wedge. That PR was
+#      reviewed and rejected -- a visible state with its own consumer. Folding
+#      it in here would re-review every rejected PR forever.
+#   4. Protection unreadable is a THIRD answer (rc 2), never "nothing required".
+#      Reading a 404/403 as "no requirements" would report every wedged PR
+#      healthy at the exact moment the tool lost the ability to tell.
+#   5. One reviewer run per PR per missing-context set, claimed through the
+#      SAME attempts ledger the redrive path uses.
+#   6. Drafts are excluded: a draft is not asking to merge, and spending a codex
+#      review on one is spending the founder's money on a question nobody asked.
+#
+# The gh seam is a fixture script that dispatches on ARGV -- this detector makes
+# two different gh calls (`pr list` and `api .../protection`), so the existing
+# print-one-file stub in test-ci-redrive.sh cannot express these cases.
+set -uo pipefail
+
+PASS=0; FAIL=0
+ok()  { printf '  PASS %s\n' "$1"; PASS=$((PASS + 1)); }
+bad() { printf '  FAIL %s\n     %s\n' "$1" "${2:-}"; FAIL=$((FAIL + 1)); }
+check() { if [ "$2" = "$3" ]; then ok "$1"; else bad "$1" "expected [$3] got [$2]"; fi; }
+contains() {
+  if printf '%s' "$2" | grep -qF -- "$3"; then ok "$1"
+  else bad "$1" "expected to find [$3] in [$2]"; fi
+}
+lacks() {
+  if printf '%s' "$2" | grep -qF -- "$3"; then bad "$1" "did NOT expect [$3] in [$2]"
+  else ok "$1"; fi
+}
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+# FOUR levels up: test -> scripts -> .q-system -> q-system -> repo root.
+REPO_ROOT="$(cd "$SCRIPT_DIR/../../../.." && pwd)"
+REDRIVE="$REPO_ROOT/q-system/.q-system/scripts/ci-redrive.py"
+[ -f "$REDRIVE" ] || { echo "FATAL: ci-redrive.py not found at $REDRIVE" >&2; exit 1; }
+
+TMP="$(mktemp -d)"
+trap 'rm -rf "$TMP"' EXIT
+
+# --- the gh seam, dispatching on ARGV ----------------------------------------
+# `pr list ...`            -> $GH_FIXTURE          (the open PRs)
+# `api .../protection`     -> $PROT_FIXTURE        (branch protection)
+# $PROT_RC != 0 makes ONLY the protection call fail, which is the real-world
+# shape: a token that can list PRs but cannot read protection (that endpoint
+# needs admin). A stub that failed both would test a different outage.
+# The two failure MESSAGES are gh's own, copied from real runs on 2026-08-02:
+#   unprotected base : `gh: Branch not protected (HTTP 404)`      rc 1
+#   no admin scope   : `gh: Resource not accessible ... (HTTP 403)` rc 1
+# Both exit 1. Only the HTTP code separates a definite answer from an
+# indefinite one, which is exactly why the reader matches on the code.
+cat > "$TMP/gh" <<'SH'
+#!/usr/bin/env bash
+for a in "$@"; do
+  case "$a" in
+    */protection)
+      if [ -n "${PROT_404_BRANCH:-}" ] && [[ "$a" == *"/branches/${PROT_404_BRANCH}/protection" ]]; then
+        echo "gh: Branch not protected (HTTP 404)" >&2; exit 1
+      fi
+      [ "${PROT_RC:-0}" = "0" ] || {
+        echo "gh: Resource not accessible by integration (HTTP 403)" >&2
+        exit "${PROT_RC}"; }
+      cat "$PROT_FIXTURE"; exit 0 ;;
+  esac
+done
+[ "${GH_RC:-0}" = "0" ] || { echo "gh: could not read PRs" >&2; exit "${GH_RC}"; }
+cat "$GH_FIXTURE"
+SH
+chmod +x "$TMP/gh"
+
+cat > "$TMP/notify.sh" <<'SH'
+#!/usr/bin/env bash
+printf '%s\n' "$*" >> "$NOTIFY_LOG"
+SH
+chmod +x "$TMP/notify.sh"
+
+printf '#!/bin/sh\ncat "${PS_FIXTURE:-/dev/null}"\n' > "$TMP/ps"; chmod +x "$TMP/ps"
+: > "$TMP/ps-empty"
+
+# Real shape, `gh api repos/assafkip/kipi-system/branches/main/protection`,
+# 2026-08-02. Both halves are populated by GitHub; the reader must not depend
+# on only one of them.
+PROT_BOTH='{"required_status_checks":{"strict":false,
+  "contexts":["validate","kipi/reviewer-approved"],
+  "checks":[{"context":"validate","app_id":null},
+            {"context":"kipi/reviewer-approved","app_id":null}]}}'
+
+# PR 75 verbatim from `gh pr list --json ...` on 2026-08-02: validate green,
+# NO reviewer-approved entry at all. This is the wedge.
+WEDGED='[
+ {"number":75,"headRefName":"sana/ask-311","isDraft":false,"baseRefName":"main",
+  "headRefOid":"1111111111111111111111111111111111111111",
+  "url":"https://github.com/assafkip/kipi-system/pull/75",
+  "title":"feat(guard): when Opus is stuck, Fable triages (ASK-311)",
+  "statusCheckRollup":[
+    {"__typename":"CheckRun","name":"validate","status":"COMPLETED",
+     "conclusion":"SUCCESS","workflowName":"Skeleton Validation"}]}]'
+
+# Same PR with the reviewer's verdict posted and FAILING. Reviewed, rejected,
+# visible. Not a wedge.
+REVIEWED_RED='[
+ {"number":75,"headRefName":"sana/ask-311","isDraft":false,"baseRefName":"main",
+  "headRefOid":"1111111111111111111111111111111111111111",
+  "url":"https://github.com/assafkip/kipi-system/pull/75",
+  "title":"feat(guard): when Opus is stuck, Fable triages (ASK-311)",
+  "statusCheckRollup":[
+    {"__typename":"CheckRun","name":"validate","status":"COMPLETED",
+     "conclusion":"SUCCESS","workflowName":"Skeleton Validation"},
+    {"__typename":"StatusContext","context":"kipi/reviewer-approved",
+     "state":"FAILURE","targetUrl":"https://github.com/x/y/pull/75#c1"}]}]'
+
+# Every required context posted and green.
+HEALTHY='[
+ {"number":76,"headRefName":"sana/ask-300","isDraft":false,"baseRefName":"main",
+  "headRefOid":"2222222222222222222222222222222222222222",
+  "url":"https://github.com/assafkip/kipi-system/pull/76",
+  "title":"fix: something (ASK-300)",
+  "statusCheckRollup":[
+    {"__typename":"CheckRun","name":"validate","status":"COMPLETED",
+     "conclusion":"SUCCESS","workflowName":"Skeleton Validation"},
+    {"__typename":"StatusContext","context":"kipi/reviewer-approved",
+     "state":"SUCCESS","targetUrl":"https://github.com/x/y/pull/76#c1"}]}]'
+
+# A draft, wedged in exactly the same way. Not asking to merge.
+DRAFT='[
+ {"number":80,"headRefName":"sana/ask-301","isDraft":true,"baseRefName":"main",
+  "headRefOid":"3333333333333333333333333333333333333333",
+  "url":"https://github.com/assafkip/kipi-system/pull/80",
+  "title":"wip (ASK-301)",
+  "statusCheckRollup":[
+    {"__typename":"CheckRun","name":"validate","status":"COMPLETED",
+     "conclusion":"SUCCESS","workflowName":"Skeleton Validation"}]}]'
+
+# The founder's own hand-opened PR: no agent prefix on the branch. It wedges
+# identically -- branch protection does not care who pushed -- so the detector
+# must not inherit redrive's agent-only attribution.
+FOUNDER='[
+ {"number":103,"headRefName":"assaf-hotfix","isDraft":false,"baseRefName":"main",
+  "headRefOid":"4444444444444444444444444444444444444444",
+  "url":"https://github.com/assafkip/kipi-system/pull/103",
+  "title":"chore: founder hand edit",
+  "statusCheckRollup":[
+    {"__typename":"CheckRun","name":"validate","status":"COMPLETED",
+     "conclusion":"SUCCESS","workflowName":"Skeleton Validation"}]}]'
+
+fixture()      { printf '%s' "$1" > "$TMP/prs.json"; }
+prot_fixture() { printf '%s' "$1" > "$TMP/prot.json"; }
+
+run() {  # run <op> [args...]
+  KIPI_GH="$TMP/gh" \
+  KIPI_PS="$TMP/ps" \
+  KIPI_NOTIFY="$TMP/notify.sh" \
+  KIPI_ATTEMPTS="$LEDGER" \
+  GH_FIXTURE="$TMP/prs.json" \
+  PROT_FIXTURE="$TMP/prot.json" \
+  GH_RC="${GH_RC:-0}" \
+  PROT_RC="${PROT_RC:-0}" \
+  PROT_404_BRANCH="${PROT_404_BRANCH:-}" \
+  PS_FIXTURE="${PS_FIXTURE:-$TMP/ps-empty}" \
+  NOTIFY_LOG="$NOTIFY_LOG" \
+  python3 "$REDRIVE" --repo-dir "$TMP" "$@" 2>"$TMP/err"
+}
+
+fresh_state() {
+  LEDGER="$TMP/attempts-$1.json"
+  NOTIFY_LOG="$TMP/notify-$1.log"
+  : > "$NOTIFY_LOG"
+  rm -f "$LEDGER"
+  PS_FIXTURE="$TMP/ps-empty"
+  GH_RC=0; PROT_RC=0; PROT_404_BRANCH=""
+  prot_fixture "$PROT_BOTH"
+}
+
+pages() { wc -l < "$NOTIFY_LOG" | tr -d ' '; }
+
+echo "== wedged-PR detection (ASK-313) =="
+
+# --- 1. the scar itself ------------------------------------------------------
+fresh_state 1; fixture "$WEDGED"
+OUT="$(run wedged)"; RC=$?
+check "1a rc 0: a required context nobody posted is a wedge" "$RC" "0"
+contains "1b names the PR" "$OUT" "75"
+contains "1c names the missing context in stderr" "$(cat "$TMP/err")" "kipi/reviewer-approved"
+
+# --- 2. NEGATIVE SELF-TEST ---------------------------------------------------
+# Without this, "return wedged for everything" passes case 1.
+fresh_state 2; fixture "$HEALTHY"
+OUT="$(run wedged)"; RC=$?
+check "2a rc 1: every required context posted is NOT a wedge" "$RC" "1"
+check "2b prints nothing" "$OUT" ""
+
+# --- 3. posted-and-failing is not absent -------------------------------------
+fresh_state 3; fixture "$REVIEWED_RED"
+OUT="$(run wedged)"; RC=$?
+check "3a rc 1: reviewed-and-rejected is a visible state, not a wedge" "$RC" "1"
+check "3b prints nothing" "$OUT" ""
+
+# --- 4. protection unreadable is a third answer ------------------------------
+fresh_state 4; fixture "$WEDGED"; PROT_RC=1
+OUT="$(run wedged)"; RC=$?
+check "4a rc 2: unreadable protection is not 'nothing required'" "$RC" "2"
+check "4b claims nothing" "$OUT" ""
+lacks "4c does not page on a probe failure" "$(cat "$NOTIFY_LOG")" "wedged"
+
+# --- 5. one attempt per PR per missing set -----------------------------------
+fresh_state 5; fixture "$WEDGED"
+OUT="$(run wedged)"; RC=$?
+check "5a offered once" "$RC" "0"
+SIG="$(printf '%s' "$OUT" | cut -f2)"
+run mark-reviewed --pr 75 --signature "$SIG" >/dev/null; MRC=$?
+check "5b the claim succeeds the first time" "$MRC" "0"
+OUT2="$(run wedged)"; RC2=$?
+check "5c not offered twice for the same missing set" "$RC2" "1"
+run mark-reviewed --pr 75 --signature "$SIG" >/dev/null; MRC2=$?
+check "5d the claim is refused the second time" "$MRC2" "1"
+
+# --- 6. drafts are not asking to merge ---------------------------------------
+fresh_state 6; fixture "$DRAFT"
+OUT="$(run wedged)"; RC=$?
+check "6a rc 1: a draft is excluded" "$RC" "1"
+check "6b prints nothing" "$OUT" ""
+
+# --- 7. the founder's own PR wedges too --------------------------------------
+# redrive attributes only agent branches. Branch protection does not, so this
+# detector must not inherit that filter, or the one PR class that has NO agent
+# to hand it back to is the one class left wedged forever.
+fresh_state 7; fixture "$FOUNDER"
+OUT="$(run wedged)"; RC=$?
+check "7a rc 0: a non-agent branch wedges identically" "$RC" "0"
+contains "7b names the PR" "$OUT" "103"
+
+# --- 8. the founder hears about it, once, after the machine tier -------------
+fresh_state 8; fixture "$WEDGED"
+OUT="$(run wedged)"; SIG="$(printf '%s' "$OUT" | cut -f2)"
+run mark-reviewed --pr 75 --signature "$SIG" >/dev/null
+run wedged >/dev/null            # machine tier spent -> escalate
+check "8a paged once" "$(pages)" "1"
+contains "8b the page names the missing context" "$(cat "$NOTIFY_LOG")" "kipi/reviewer-approved"
+run wedged >/dev/null            # and not again
+check "8c not paged twice for one fact" "$(pages)" "1"
+
+# --- 9. EACH half of the protection response is load-bearing -----------------
+# Added because mutation testing killed nothing here: with both halves populated
+# (which is what GitHub sends today) a reader of EITHER one passes every case
+# above, so "both halves are read" was an unpinned claim. Deleting the
+# `contexts` loop survived the whole suite. These two cases are the only thing
+# that makes the claim real, and they are why the reader may not be "simplified"
+# back to one half later.
+PROT_LEGACY_ONLY='{"required_status_checks":{"strict":false,
+  "contexts":["validate","kipi/reviewer-approved"],"checks":[]}}'
+PROT_CHECKS_ONLY='{"required_status_checks":{"strict":false,
+  "contexts":[],
+  "checks":[{"context":"validate","app_id":null},
+            {"context":"kipi/reviewer-approved","app_id":null}]}}'
+
+fresh_state 9; fixture "$WEDGED"; prot_fixture "$PROT_LEGACY_ONLY"
+OUT="$(run wedged)"; RC=$?
+check "9a legacy contexts[] alone is honoured" "$RC" "0"
+contains "9b names the missing context" "$(cat "$TMP/err")" "kipi/reviewer-approved"
+
+fresh_state 10; fixture "$WEDGED"; prot_fixture "$PROT_CHECKS_ONLY"
+OUT="$(run wedged)"; RC=$?
+check "10a checks[] alone is honoured" "$RC" "0"
+contains "10b names the missing context" "$(cat "$TMP/err")" "kipi/reviewer-approved"
+
+# --- 11. AN UNPROTECTED BASE MUST NOT BLIND THE WHOLE SWEEP ------------------
+# The first live run of this detector died exactly here:
+#   ci-redrive: could not read branch protection for sana/block-expiry
+#     (rc 1): gh: Branch not protected (HTTP 404) -- nothing was claimed.  rc 2
+# A stacked PR based on another agent's branch is ordinary in this fleet, and
+# one unprotected base returned rc 2 for the ENTIRE sweep -- reintroducing the
+# silence the detector exists to end. 404 is a DEFINITE answer: no protection,
+# nothing required, that PR cannot wedge. The wedged PR on `main` must still be
+# found in the same pass.
+STACKED='[
+ {"number":90,"headRefName":"sana/ask-320","isDraft":false,
+  "baseRefName":"sana/block-expiry",
+  "headRefOid":"5555555555555555555555555555555555555555",
+  "url":"https://github.com/assafkip/kipi-system/pull/90",
+  "title":"stacked on an unprotected base (ASK-320)",
+  "statusCheckRollup":[]},
+ {"number":75,"headRefName":"sana/ask-311","isDraft":false,"baseRefName":"main",
+  "headRefOid":"1111111111111111111111111111111111111111",
+  "url":"https://github.com/assafkip/kipi-system/pull/75",
+  "title":"feat(guard): when Opus is stuck, Fable triages (ASK-311)",
+  "statusCheckRollup":[
+    {"__typename":"CheckRun","name":"validate","status":"COMPLETED",
+     "conclusion":"SUCCESS","workflowName":"Skeleton Validation"}]}]'
+
+fresh_state 11; fixture "$STACKED"; PROT_404_BRANCH="sana/block-expiry"
+OUT="$(run wedged)"; RC=$?
+check "11a rc 0: an unprotected base does not kill the sweep" "$RC" "0"
+contains "11b the wedged PR on main is still found" "$OUT" "75"
+lacks "11c the stacked PR is not called wedged" "$OUT" "90"
+
+# --- 12. 403 IS STILL INDEFINITE ---------------------------------------------
+# The discrimination case for 11. A token that cannot READ protection must not
+# be read as a repo that REQUIRES nothing -- that is the original defect.
+fresh_state 12; fixture "$WEDGED"; PROT_RC=1
+OUT="$(run wedged)"; RC=$?
+check "12a rc 2: 403 stays indefinite" "$RC" "2"
+contains "12b names the code it refused on" "$(cat "$TMP/err")" "403"
+
+# --- 13. RED CI OUTRANKS A WEDGE ---------------------------------------------
+# Real shape: PR #76, 2026-08-02, was BOTH red on `validate` AND missing
+# `kipi/reviewer-approved`. The redrive tier owns a red PR; reviewing it here
+# would buy a codex read of a tree that is about to change. Case 14 is the
+# discrimination: the same PR IS this tier's business once CI goes green.
+RED_AND_WEDGED='[
+ {"number":76,"headRefName":"sana/ask-312","isDraft":false,"baseRefName":"main",
+  "headRefOid":"6666666666666666666666666666666666666666",
+  "url":"https://github.com/assafkip/kipi-system/pull/76",
+  "title":"The review gate cannot go green on a review that never ran (ASK-312)",
+  "statusCheckRollup":[
+    {"__typename":"CheckRun","name":"validate","status":"COMPLETED",
+     "conclusion":"FAILURE","workflowName":"Skeleton Validation"}]}]'
+
+fresh_state 13; fixture "$RED_AND_WEDGED"
+OUT="$(run wedged)"; RC=$?
+check "13a rc 1: a red PR is the redrive tier's, not this one's" "$RC" "1"
+check "13b prints nothing" "$OUT" ""
+
+# --- 14. ...AND IS PICKED UP THE MOMENT CI GOES GREEN ------------------------
+# Without this, "skip everything with any check" would pass case 13.
+GREEN_AND_WEDGED="${RED_AND_WEDGED/\"conclusion\":\"FAILURE\"/\"conclusion\":\"SUCCESS\"}"
+fresh_state 14; fixture "$GREEN_AND_WEDGED"
+OUT="$(run wedged)"; RC=$?
+check "14a rc 0: green CI + absent required context is a wedge" "$RC" "0"
+contains "14b names the PR" "$OUT" "76"
+
+echo
+printf 'wedged-pr: %d passed, %d failed\n' "$PASS" "$FAIL"
+[ "$FAIL" -eq 0 ]

--- a/q-system/output/rca/rca-coverage-assumed-from-existence-2026-08-02.md
+++ b/q-system/output/rca/rca-coverage-assumed-from-existence-2026-08-02.md
@@ -324,6 +324,43 @@ which was not doing the isolating everyone assumed it was.
       suites). `PYTEST_CURRENT_TEST`-keyed chokepoint refusal exists for the
       ASK-311 path only; generalising it is not in this issue
 
+## The limit of this fix, found by pointing it at its own PR (`sp-9e6c8196`)
+
+This fix makes a wedge VISIBLE by handing the PR to the real producer. It does
+not make the producer correct, and those are different claims.
+
+PR #78 (this change) wedged exactly like #75, was detected by its own detector,
+and the reviewer was run. codex then **declined to start**: the run ended on
+*"Reply `OK` and I'll run the read-only adversarial review exactly as planned"*,
+having said *"Per the repo's multi-file review rule, I'm pausing for your OK
+before executing."* The repo's own `CLAUDE.md` rule ("state your approach and
+wait for OK") leaks into the reviewer's context, and codex is invoked with
+`</dev/null`, so the OK can never arrive.
+
+ASK-312's `resolve_verdict` did its job — it failed CLOSED, so no false APPROVE
+was posted. But the status posted was `kipi/reviewer-approved=failure` on a PR
+nobody read. **A false REQUEST CHANGES, not a false green.**
+
+The interaction with this change is the part worth writing down:
+
+- The wedged tier spends one attempt per PR per missing-context set. Once any
+  status is posted the PR is no longer absent, so this tier never revisits it.
+- For an agent PR with an issue id that is fine: REQUEST CHANGES has a rework
+  path and the worker re-dispatches.
+- For a PR with **no** issue id — the founder's own, the class this detector was
+  widened to cover — there is no rework path, so a declined review leaves a
+  permanent false rejection.
+
+So the honest scope of the fix is: absence becomes a visible state with a
+machine consumer. It is not: the verdict on that state is trustworthy.
+
+It is intermittent, not deterministic. PR #68's review the same hour was real:
+1.47 MB of output, three majors and a minor, each with an executed reproducer.
+That is why this is captured rather than treated as a blocker on this change.
+
+Evidence: `~/.config/kipi/pr-reviews/codex/pr-78-20260802-211816.md` (7597 bytes)
+versus `pr-68-20260802-210908.md` (1474493 bytes).
+
 ## What is deliberately left open
 
 - **The producer is still local-only.** A launchd job on one Mac is the sole

--- a/q-system/output/rca/rca-coverage-assumed-from-existence-2026-08-02.md
+++ b/q-system/output/rca/rca-coverage-assumed-from-existence-2026-08-02.md
@@ -354,10 +354,15 @@ The interaction with this change is the part worth writing down:
 So the honest scope of the fix is: absence becomes a visible state with a
 machine consumer. It is not: the verdict on that state is trustworthy.
 
-**Correction, after re-running it: this is REPRODUCIBLE, not intermittent.** The
-first write-up of this section called it a flake on the strength of PR #68
-succeeding. A second run on #78 declined identically — *"Reply `OK` and I'll
-execute."* / *"Waiting for `OK` to begin the read-only review."* Two of two.
+**This claim was corrected twice, and the second correction reverses the
+first.** Round 1 called it intermittent (on #68 succeeding). Round 2 called it
+REPRODUCIBLE after #78 declined twice. Round 3 is the truth: across four runs of
+the same prompt it is **3 declines and 1 real review** — run C2, in the isolated
+worktree, produced a full adversarial review with findings. So it is neither a
+one-off nor deterministic, and the two earlier confident labels were each drawn
+from too few runs. Recording the sequence rather than only the answer, because
+the pattern — a label asserted at n=1, re-asserted at n=2, wrong both times — is
+the same over-claiming this document is about.
 
 So it is PR-dependent, not random, and the discriminator is NOT identified.
 PR #68's review the same hour was genuinely real (1.47 MB, three majors and a
@@ -473,6 +478,54 @@ The conclusion nevertheless holds, for a reason the void_reason did not give:
 (measured above). So this is an enumeration gap whose effect is not
 load-bearing — recorded here as an instance of the class, not as a false
 resolution to reverse.
+
+## The review that did run found a real major in this change
+
+Run C2 completed a genuine adversarial review and returned one finding:
+
+> `major|The second heartbeat falsely escalates a wedged PR while its detached
+> reviewer is still running, then suppresses the later real alert|ci-redrive.py:735`
+
+It is correct, and it is **this document's class one more time.** The reviewer is
+launched DETACHED and takes minutes; the heartbeat is 900s. So the next run read
+the ledger flag as "the machine tier is spent", paged the founder that the
+reviewer had run and the context was still absent — while it was mid-flight —
+and that page claimed `wedged_escalated_<sig>`, so the REAL failure would then
+have been silent. A claimed attempt is not a completed attempt.
+
+`cmd_redrive` already guards exactly this, and its comment already names the
+scar: *"the founder would be paged that a still-running attempt had stopped --
+burning the one page owed to him when it really does."* **I did not carry the
+guard into the new tier.** A guard existing in one tier is not a guard in the
+tier next to it — the same shape as the required check that existed without a
+producer.
+
+The dispatcher's own `WEDGED_PS` check does not cover it: that only stops a
+second reviewer being LAUNCHED. The escalation decision lives in `cmd_wedged`.
+
+Fixed with `reviewer_live(pr)`, reproducer first:
+
+```
+before: wedged-pr: 37 passed, 2 failed   (15b, 15c)
+after:  wedged-pr: 39 passed, 0 failed
+```
+
+Mutation-tested 3 ways — guard removed, never-live, always-live — all killed,
+with case 16 as the discrimination so the fix cannot be "never escalate".
+`test-ci-redrive.sh` still 65/65.
+
+Worth stating plainly: **the detector caught its own PR, the review it triggered
+found a real defect in the detector, and that defect was an un-enumerated copy
+of a guard the neighbouring tier already had.** That is the strongest evidence in
+this document that the class is structural rather than anecdotal.
+
+### A process error of mine, recorded
+
+I removed the discriminator worktree with `git worktree remove --force` while
+runs C and C2 were still executing against it. C2 noticed and said so in its own
+output: *"`/tmp/ask313-disc-...` disappeared without any delete command from
+this session."* It completed anyway; run C did not. I should have checked for
+live consumers before removing the tree.
 
 ## What is deliberately left open
 

--- a/q-system/output/rca/rca-coverage-assumed-from-existence-2026-08-02.md
+++ b/q-system/output/rca/rca-coverage-assumed-from-existence-2026-08-02.md
@@ -354,12 +354,28 @@ The interaction with this change is the part worth writing down:
 So the honest scope of the fix is: absence becomes a visible state with a
 machine consumer. It is not: the verdict on that state is trustworthy.
 
-It is intermittent, not deterministic. PR #68's review the same hour was real:
-1.47 MB of output, three majors and a minor, each with an executed reproducer.
-That is why this is captured rather than treated as a blocker on this change.
+**Correction, after re-running it: this is REPRODUCIBLE, not intermittent.** The
+first write-up of this section called it a flake on the strength of PR #68
+succeeding. A second run on #78 declined identically — *"Reply `OK` and I'll
+execute."* / *"Waiting for `OK` to begin the read-only review."* Two of two.
 
-Evidence: `~/.config/kipi/pr-reviews/codex/pr-78-20260802-211816.md` (7597 bytes)
-versus `pr-68-20260802-210908.md` (1474493 bytes).
+So it is PR-dependent, not random, and the discriminator is NOT identified.
+PR #68's review the same hour was genuinely real (1.47 MB, three majors and a
+minor, each with an executed reproducer), so the producer is not simply broken.
+Naming the difference would be a guess, and guessing is the thing this whole
+document is about; it is left as an open question in `sp-9e6c8196`.
+
+| run | file | bytes | outcome |
+|---|---|---|---|
+| #68 | `pr-68-20260802-210908.md` | 1,474,493 | real review, 3 major + 1 minor |
+| #78 r1 | `pr-78-20260802-211816.md` | 7,597 | declined to start |
+| #78 r2 | `pr-78-20260802-212132.md` | 8,424 | declined to start |
+
+**Consequence for this change: ASK-313 cannot merge on a real verdict until the
+decline is fixed or a review actually runs.** Its own required check is red from
+a review that never happened — the mirror image of the defect it fixes, and the
+sharpest possible demonstration that a posted status is not evidence of a
+review. That is stated here rather than worked around.
 
 ## What is deliberately left open
 

--- a/q-system/output/rca/rca-coverage-assumed-from-existence-2026-08-02.md
+++ b/q-system/output/rca/rca-coverage-assumed-from-existence-2026-08-02.md
@@ -1,0 +1,344 @@
+# RCA: a mechanism's existence is counted as coverage, and nothing reconciles declared against observed
+
+**Date:** 2026-08-02
+**Trigger:** PR #75 (ASK-311) would not merge. Diagnosing why surfaced a cluster of seven observations from one session.
+**Issue:** ASK-313
+**Surface-fix commit:** see ASK-313 branch `sana/ask-313`
+**Structural-fix commit:** same
+
+## What happened
+
+ASK-311 shipped on `sana/ask-311` and was opened as PR #75 with auto-merge armed.
+It never merged. Measured 2026-08-02:
+
+```
+$ gh pr view 75 --json mergeStateStatus,autoMergeRequest
+  mergeStateStatus = BLOCKED, autoMergeRequest = enabled (SQUASH)
+$ gh api repos/assafkip/kipi-system/branches/main/protection
+  required_status_checks.contexts = ["validate","kipi/reviewer-approved"]
+$ gh pr checks 75
+  validate  pass
+  (kipi/reviewer-approved absent -- not listed at all)
+```
+
+`kipi/reviewer-approved` is REQUIRED on every PR to `main`. Its only producer is
+`pr-review-agent.sh`. That script's only automated caller is
+`linear-worker.sh:1802`, reachable only from the dispatcher loop
+(`com.kipi.dispatch.plist`, 900s) for a DoR-ready issue it picked. No GitHub
+Actions workflow posts it; `validate.yml` is the only workflow in the repo.
+
+So a PR opened by any path other than the dispatcher carries a required check
+with no producer. Auto-merge was armed and correctly refusing. Nothing alerted.
+
+## Surface symptom
+
+Seven observations were collected. They are not one incident, and separating
+them was the first job.
+
+| # | Observation | In the class? |
+|---|---|---|
+| 1 | `kipi/reviewer-approved` required with no producer for most PRs (`sp-59de96e9`) | **yes** |
+| 2 | "auto-merge is armed, it will land on its own" — asserted from a partial read | yes, reporting layer |
+| 3 | Memory index asserted "Codex OUT of credits", refuted by a real billed call | yes, reporting layer |
+| 4 | `capability-gate.py:422` runs a pytest module as `python3 <file>`; 0 tests collected, exit 0, counted as covered (`sp-c2b64f9b`) | **yes** |
+| 5 | ASK-311 made `test_token_guard.py` bill real Fable calls (0.7s to 60.9s); caught only by running a neighbouring suite | **yes** |
+| 6 | `rca-specification-reported-as-state-2026-08-02.md` — 9 false claims, each substituting a specification for an observation | yes, this class stated epistemically |
+| 7 | Merge conflict in `capability-manifest.json` with a concurrent ASK-122 session | **no** |
+
+### Why #7 is not in the class (decided with evidence, not assumed)
+
+`capability-manifest.json` is a structured JSON object whose `expected_tests` is
+a 109-entry list, not an append-only ledger. Two branches each appending an
+entry conflict textually. Two facts rule it out of the class:
+
+- **git refused loudly.** Every other observation here is a *silent* wrong
+  answer. A conflict marker is the inverse failure mode: maximum visibility, no
+  false confidence. Nothing was reported as covered when it was not.
+- **The fleet's own precedent does not extend.** `.gitattributes` sets
+  `merge=union` on `.prd-os/receipts.jsonl` precisely because it is append-only
+  line data. Union on a JSON array produces invalid JSON, so the existing remedy
+  is not applicable and its absence here is correct, not an oversight.
+
+#7 is ordinary concurrency cost. It is real and it recurs, but it is a different
+problem with a different fix, and bundling it would have hidden both.
+
+## This class was already named, EARLIER THE SAME DAY
+
+The most important finding here is not the class. It is that the class was
+already written down before this incident was diagnosed, and the recurrence
+happened anyway.
+
+Commit `e0353b7` (ASK-312, 2026-08-02, ~4 hours before this) shipped five RCAs
+and named the common structure directly:
+
+> each is a claim of coverage that nothing enumerates, failing in the direction
+> that looks like success
+
+with `absence-read-as-success` as one of its five classes — including the
+required review gate itself. The sibling RCA is
+`q-system/output/rca/rca-absence-read-as-success-2026-08-02.md`.
+
+So the hypothesis this investigation was asked to test was correct AND already
+recorded. What that means for the fix matters:
+
+- **Naming a class does not enumerate its instances.** The ASK-312 write-up
+  found `absence-read-as-success` in the review gate's *verdict logic* (a green
+  posted for a review that never ran) and fixed it there, in `resolve_verdict`.
+  The same class in the same file's *delivery* path — the status never posted at
+  all — was not enumerated, because nothing enumerates. Each instance was found
+  by tripping over it.
+- Its action item list names the `rc==0`-treated-as-success shape, which is
+  observation #4 (`sp-c2b64f9b`). That is already owned there and is not
+  re-litigated here.
+
+The corrective this RCA adds is therefore not another description of the class.
+It is one executable reconciliation in one domain that had none, plus the honest
+statement that the other domains still have none.
+
+## Surface root cause
+
+`kipi/reviewer-approved` has one producer on one code path. That is a wiring
+gap, and on its own it would be a one-line fix.
+
+## Structural root cause
+
+### Root cause 1 — the sweep can only see what was POSTED (latent-defect)
+
+`ci-redrive.py` already sweeps every open PR every 900s. But `failing_checks()`
+iterates `statusCheckRollup`, so it can only observe contexts that exist. **An
+absent required context contributes zero rollup entries.** Every reader built on
+the rollup therefore reads a wedged PR as perfectly healthy. The sweep was not
+misconfigured; it was structurally incapable of seeing absence.
+
+This is the same shape as #4. `capability-gate.py:422` invokes a declared test
+and counts `ran += 1` on exit 0. A pytest-only module collects zero tests and
+exits 0. The gate observed an exit code and reported coverage.
+
+Both count the EXISTENCE or the EXIT CODE of a mechanism as evidence that the
+mechanism did its job. Neither reconciles what is DECLARED to be covered against
+what was OBSERVED to run.
+
+### Root cause 2 — the fleet already solved this once, in one domain only (latent-defect)
+
+The 2026-07-23 silent-absence capability gate was built on exactly the right
+idea: *diff declared-vs-actual, both directions.* Its own comment in
+`validate.yml` says so — "it discovers every test artifact by convention, diffs
+declared-vs-actual BOTH directions."
+
+That principle was applied to test artifacts and to nothing else. Required
+status checks are a declared-coverage set with an observable actual set, and no
+one diffed them. **The coverage boundary of that gate is a boundary nobody
+wrote down**, so its silence on PR #75 read as reassurance.
+
+### Root cause 3 — the tooling actively misreports this state (environmental-trigger)
+
+`gh pr checks 75` printed `validate pass` and did not mention
+`kipi/reviewer-approved` at all. This is a known, still-open GitHub CLI defect:
+[cli/cli#6448](https://github.com/cli/cli/issues/6448) — `gh pr checks` and
+`gh pr status` report success while a required check sits in `Expected`, because
+the CLI does not surface expected-but-unreported contexts.
+
+This is load-bearing for #2 and it is why #2 is not simply carelessness. The
+cheap check was one keystroke away and returned a wrong answer; the correct
+check (`gh api .../branches/main/protection` plus a set-diff) is four times
+longer and nobody had written it. That is the same finding as the 2026-08-02
+specification-vs-state RCA, root cause 1: *the cheap check and the correct check
+are different checks, and only the cheap one is at hand.*
+
+### Root cause 4 — a new outbound call retroactively arms every older suite (latent-defect)
+
+#5 is the same class one layer down. ASK-311 added an outbound call to shared
+code, which put a pre-existing suite (`test_token_guard.py`) on a live billing
+path. The suite was declared covered, ran, and passed. Nothing measured that
+what it exercised had changed underneath it. It was caught by running a
+neighbouring suite by hand, which is not a mechanism.
+
+## Prior art: is this solved elsewhere?
+
+Researched 2026-08-02 with sources.
+
+**Yes for the general footgun, no for this shape.**
+
+- GitHub documents the deadlock:
+  [Troubleshooting required status checks](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/collaborating-on-repositories-with-code-quality-features/troubleshooting-required-status-checks)
+  — "the pull request is blocked with 'Waiting for status to be reported'",
+  "Associated checks stay in a 'Pending' state and block merging". There is no
+  timeout and no alert. Absent is not failed.
+- The classic remedy is an inverse-filter twin workflow posting the same context
+  green ([GHES 3.2 archived docs](https://docs.github.com/en/enterprise-server@3.2/repositories/configuring-branches-and-merges-in-your-repository/defining-the-mergeability-of-pull-requests/troubleshooting-required-status-checks)),
+  or an always-running aggregator
+  ([re-actors/alls-green](https://github.com/re-actors/alls-green),
+  [Mergify ci-gate](https://docs.mergify.com/monorepo-ci/github-actions/)). The
+  recipe was quietly dropped from current docs; the replacement ask
+  ([community #142210](https://github.com/orgs/community/discussions/142210))
+  has zero answers.
+
+**The standard fix does not fit this fleet, and applying it would have made
+things worse.** Two independent reasons:
+
+1. Absence of `kipi/reviewer-approved` is a *correct refusal*, not a
+   misconfiguration. `linear-worker.sh:687` states the blast radius: "Remove
+   `kipi/reviewer-approved` from that set and this becomes an unreviewed-merge
+   machine." A job that always posts it green converts a review gate into
+   decoration on a repo that fans out fleet-wide through `kipi update`.
+2. GitHub requires **both** when a check run and a commit status share a name —
+   "If a check and a commit status have the same name, both must pass when that
+   name is required." `kipi/reviewer-approved` is a legacy Commit Status, so an
+   Actions job named after it would *add* a second thing to satisfy and deepen
+   the deadlock.
+
+**On detection there is no off-the-shelf art at all.** `mergeStateStatus:
+BLOCKED` does not say what is blocking
+([cli/cli#10775](https://github.com/cli/cli/issues/10775)); a request for a
+mergeability-evaluation endpoint is unanswered
+([community #162462](https://github.com/orgs/community/discussions/162462)).
+The only workable approach found is the one built here: read required contexts
+from the protection API, set-diff against the contexts posted on the head, and
+act where the diff is non-empty and nothing is failing.
+
+## The fix
+
+`ci-redrive.py` gains a `wedged` tier. It does **not** fake the status; it finds
+the wedge and hands the PR to the real producer.
+
+- `required_contexts(repo_dir, branch)` reads branch protection, both the legacy
+  `contexts` half and the `checks` half.
+- `posted_contexts(pr)` reads every context name on the head regardless of
+  state. A required context posted and FAILING is a reviewed-and-rejected PR —
+  a visible state with its own consumer — not a wedge.
+- `wedged_candidates()` diffs them. Not filtered by `attribute()`: branch
+  protection does not care who pushed, and the founder's own PR is the one class
+  with no agent to hand it back to.
+- `kipi-dispatch.sh` runs `pr-review-agent.sh` on one wedged PR per heartbeat,
+  detached, bounded by the same attempts ledger the redrive tier uses.
+
+Placement detail that matters: the block sits **above** the `nothing ready`
+early exit. A wedge is most likely exactly when no issue is ready — the issue is
+done, the PR is open, the board is quiet.
+
+### Two defects the live run found in the fix itself
+
+1. **404 and 403 are different answers.** Version 1 raised on any non-zero rc,
+   reasoning that `repo-preflight.sh` already refuses unprotected repos. That is
+   a claim about the DEFAULT branch; this asks about each PR's BASE branch. The
+   first live run died on it:
+   `could not read branch protection for sana/block-expiry (rc 1): gh: Branch
+   not protected (HTTP 404)` — rc 2, entire sweep dead. A stacked PR is ordinary
+   here, and one unprotected base reintroduced the exact silence the detector
+   exists to end. 404 is now definite (nothing required, cannot wedge); 403
+   stays indefinite.
+2. **Red CI outranks a wedge.** Real PR #76 was both red on `validate` and
+   missing the required context. Reviewing a PR whose build is broken buys a
+   codex read of a tree about to change. The redrive tier owns it until CI is
+   green.
+
+Both were found by running against the real repo, not by reasoning. Neither
+would have been caught by the fixture suite as first written.
+
+## Verification
+
+Reproducer: `q-system/.q-system/scripts/test/test-wedged-pr.sh`, registered in
+`capability-manifest.json` so it runs in CI.
+
+```
+before the fix:  wedged-pr:  6 passed, 15 failed
+after  the fix:  wedged-pr: 34 passed,  0 failed
+```
+
+The 6 that "passed" before were false passes — argparse exits 2 on an unknown
+op, which trivially satisfied the rc-2 and prints-nothing assertions. That is
+why the suite was mutation-tested rather than trusted:
+
+| Mutant | Killed by |
+|---|---|
+| unreadable protection reads as empty | 4a |
+| a FAILING required context counts as absent | 3a |
+| drafts included | 6a |
+| agent branches only (founder PR dropped) | 7a |
+| ledger cap ignored | 5c |
+| drop the legacy `contexts` half | 9a |
+| drop the `checks` half | 10a |
+| 404 treated as indefinite | 11a |
+| all failures treated as empty | 12a |
+| red-CI precedence removed | 13a |
+
+10 of 10 killed. Cases 9 and 10 exist **because** mutation found nothing: with
+both protection halves populated (what GitHub sends today) a reader of either
+one passed every case, so "both halves are read" was an unpinned claim.
+
+Verified against the live repo, not a simulation. Ground truth from
+`gh pr checks` / the statuses API on 4 real PRs:
+
+| PR | posted statuses | detector |
+|---|---|---|
+| #75 | `kipi/reviewer-approved` (failure) | correctly NOT wedged |
+| #76 | none, `validate` FAILING | correctly deferred to redrive |
+| #68 | none, `validate` passing | correctly offered to the reviewer |
+| #77 | none, converge live for ASK-288 | correctly skipped |
+
+## Found while verifying: a test suite on a live, billed path (`sp-c5f09ad2`)
+
+Running the repo's own gate suite locally to check this change surfaced a
+separate instance of the same class, confirmed by process tree rather than by
+reading:
+
+```
+capability-gate.py                       <- the CI gate
+  test-severity-floor.sh
+    linear-worker.sh --apply --issue ...  <- the REAL worker
+      pr-review-agent.sh 808 --issue ...  <- the REAL reviewer
+        codex exec --model gpt-5.6-sol -C /Users/.../wt/ask-313
+```
+
+That last line is a real, billed codex call, pointed at the working tree, from a
+test. `pr-review-agent.sh 901 --post` was also observed in the process table the
+same evening. The suite is quiet in CI only because the runner has no codex
+credentials — an accidental shield, not isolation. The fable-discipline lint
+exists to block exactly this and did not see it, because the live call is three
+processes below the line the test actually writes.
+
+Not fixed here (it is a different file, a different owner, and a fix would be
+scope creep on a data path already known to be delicate). The billed processes
+were killed; the finding is captured as `sp-c5f09ad2`.
+
+It is listed in this RCA rather than only in the ledger because it is the
+cleanest available demonstration of the class: a gate whose silence was trusted,
+which was not doing the isolating everyone assumed it was.
+
+## Action items
+
+- [x] Reproducer written and shown failing before the fix (ASK-313)
+- [x] `wedged` tier in `ci-redrive.py`, wired from `kipi-dispatch.sh` (ASK-313)
+- [x] Test registered in `capability-manifest.json` so it runs in CI (ASK-313)
+- [x] Verified against real PRs #75/#76/#68/#77 (ASK-313)
+- [x] `sp-c5f09ad2` captured: `test-severity-floor.sh` passes `--post` through
+      `"$@"` to a live-capable reviewer; confirm the isolation is a stubbed seam
+      and not an accidental shield
+- [ ] `sp-c2b64f9b`: `capability-gate.py:422` must distinguish "ran and asserted"
+      from "exited 0". NOT re-owned here — it is already action item 1 of
+      `rca-absence-read-as-success-2026-08-02.md` ("`rc==0` treated as success
+      where the tool is known to exit 0 on failure"). Left open against that
+      item so one fix serves both; duplicating it would split one decision
+      across two tickets, which is the failure ASK-122 already paid for
+- [ ] No mechanism yet measures root cause 4 (a new outbound call arming older
+      suites). `PYTEST_CURRENT_TEST`-keyed chokepoint refusal exists for the
+      ASK-311 path only; generalising it is not in this issue
+
+## What is deliberately left open
+
+- **The producer is still local-only.** A launchd job on one Mac is the sole
+  producer of a GitHub-side required check. If that Mac is off, PRs wedge; they
+  are now *detected and paged* rather than silent, but not produced. Moving the
+  producer into Actions is a real option and a much larger blast radius (it
+  needs codex credentials in CI), so it is not bundled here.
+- **No separate spend lane** for wedged reviews. The ceiling is the number of
+  open PRs, once each per missing-context set — bounded, but it does not draw
+  from `KIPI_DISPATCH_DAILY_MAX`.
+- **#7 (the manifest conflict)** is untouched by design, per the decomposition
+  above.
+
+## Cause-type tags
+
+`latent-defect` (root causes 1, 2, 4) · `environmental-trigger` (root cause 3,
+the `gh pr checks` misreport) · not `human-error`: the cheap check returned a
+wrong answer and the correct check did not exist.

--- a/q-system/output/rca/rca-coverage-assumed-from-existence-2026-08-02.md
+++ b/q-system/output/rca/rca-coverage-assumed-from-existence-2026-08-02.md
@@ -377,6 +377,103 @@ a review that never happened — the mirror image of the defect it fixes, and th
 sharpest possible demonstration that a posted status is not evidence of a
 review. That is stated here rather than worked around.
 
+## Investigating the decline: a named suspect, refuted by measurement
+
+A hypothesis was raised that the decline is the 2026-06-30 shape — an unguarded
+`UserPromptSubmit` hook firing inside codex's session — with
+`voice-dna-loader.py` (an injector, no `CLAUDECODE` guard) as the concrete
+suspect, wired in `.claude/settings.json`. Prior art: `sp-28bf75a4`,
+`sp-a2aaaf41`, `sp-40d892d9`.
+
+**The suspect is refuted. The decline cause remains unidentified.**
+
+### What was measured
+
+**Codex does not read `.claude/settings.json` at all.** It loads three separate
+hook sources, each trust-keyed by ABSOLUTE PATH in `~/.codex/config.toml`:
+
+| source | UserPromptSubmit hooks |
+|---|---|
+| `~/.codex/hooks.json` (global) | `v2-channel-write.sh`, `v2-channel-inject.sh` |
+| `<repo>/.codex/hooks.json` (tracked) | `token-guard.py`, `voice-dna-loader.py` |
+| plugin `hooks.json` (kipi-core etc.) | none (PostToolUse only) |
+
+Two corrections fall out, and one of them is mine:
+
+- The hypothesis named the wrong file. `.claude/settings.json` is never read by
+  codex.
+- My first answer — "voice-dna-loader never runs under codex" — was also wrong.
+  It IS wired for codex, in the repo's own tracked `.codex/hooks.json`. I had
+  checked one config and generalised, which is the class this document is about.
+
+**But it does not fire on a review, for two independent reasons, each measured:**
+
+1. *It emits nothing on this prompt.* Fed the exact 123-line review prompt:
+   ```
+   voice-dna-loader.py  -> rc 0, 0 bytes   (looks_like_writing_request False)
+   token-guard.py       -> rc 0, 0 bytes
+   ```
+2. *It is not even loaded in a review.* Reviews run in
+   `~/.config/kipi/review-trees/pr-NN`, and the repo's `.codex/hooks.json` is
+   trusted against the REPO's absolute path, so it is not active there. Every
+   review output carries exactly 4 `hook: UserPromptSubmit` lines = the two
+   GLOBAL hooks, and `v2-channel-inject.sh` opens with a cwd filter for
+   `~/projects/ktlyst-hub/product*` — paths retired 2026-07-07 — so it exits 0
+   immediately.
+
+**So no kipi hook injects anything into any codex review.** The associated worry
+— that founder-voice instructions have been polluting every codex review ever
+run in this repo, including PR #75's — is cleared by measurement, not by
+argument.
+
+### Two more candidates, both refuted
+
+- **The `AGENTS.md` "wait for OK" rule.** codex NAMED this rule as its reason
+  ("Per the repo's multi-file review rule"), so it was the strongest candidate.
+  Removed it from `AGENTS.md` and `CLAUDE.md` in an isolated worktree and re-ran
+  the identical prompt: **it declined anyway.** A stated reason is not a cause.
+- **`CLAUDE_PROJECT_DIR` unset under codex.** In a bash simulation, both repo
+  hooks resolve to `/q-system/...` and exit **rc 2** — the BLOCK code — which
+  would be exactly `sp-28bf75a4`. But running codex from inside the repo for
+  real returns rc 0 and answers normally, with no hook error. **The simulation
+  was not the running system**, so this is not claimed as a live defect, and
+  `sp-28bf75a4`'s scenario does not reproduce today.
+
+### The discriminator I intended did not work, and that is reported, not hidden
+
+The plan was hooks-on versus hooks-off. Emptying `UserPromptSubmit` in the
+worktree's `.codex/hooks.json` changed nothing, because that file is untrusted
+at a `/tmp` path and was never loaded; **all four runs show the same 4 hook
+lines.** So there is no clean on/off comparison here and the one run that looked
+different proves nothing — it was also read off a file that was still being
+written. Both errors are recorded rather than the conclusion kept.
+
+**The discriminator stays open. No second guess is substituted.** `sp-9e6c8196`
+carries it.
+
+## Was `sp-a2aaaf41` falsely resolved?
+
+Checked, because a hand-cleared gate would be another instance of the class.
+**It was not hand-cleared.** Its ledger entry carries a `void_reason` recording
+an empirical test — "empirically tested all 13 PostToolUse hooks on a real
+code-file edit ... NONE block; they self-scope by file type" — which is the
+sanctioned second exit in `no-orphan-findings.md` ("if it turns out not to be a
+real item ... the reason is recorded; the item is not deleted").
+
+**Its enumeration was incomplete, though, and that part is a real instance.** It
+scoped to 13 PostToolUse hooks plus `token-guard`, and never named
+`voice-dna-loader` — the OTHER `UserPromptSubmit` hook, unguarded and an
+injector — nor the `.codex/hooks.json` load path through which codex actually
+gets these hooks. A claim of the form "token-guard was the only hook that
+blocked a foreign runtime" rests on an enumeration that did not cover the event
+it generalises over.
+
+The conclusion nevertheless holds, for a reason the void_reason did not give:
+`voice-dna-loader` is intent-gated and silent on any non-writing prompt
+(measured above). So this is an enumeration gap whose effect is not
+load-bearing — recorded here as an instance of the class, not as a false
+resolution to reverse.
+
 ## What is deliberately left open
 
 - **The producer is still local-only.** A launchd job on one Mac is the sole


### PR DESCRIPTION
## The scar

PR #75 sat `BLOCKED` with auto-merge armed, `validate` green, and `kipi/reviewer-approved` **absent**. Zero alerts. `gh pr checks` reported the checks as passing — it does not surface expected-but-unreported contexts ([cli/cli#6448](https://github.com/cli/cli/issues/6448), open).

`kipi/reviewer-approved` is required on every PR to `main`. Its only producer is `pr-review-agent.sh`, whose only automated caller is `linear-worker.sh:1802` — reachable only from the dispatcher, for a DoR-ready issue it picked. **A PR opened any other way carries a required check with no producer, forever.**

`ci-redrive.py` already sweeps every open PR, but `failing_checks()` reads `statusCheckRollup`, so it can only see contexts that were POSTED. An absent one contributes zero entries: the sweep read a wedged PR as healthy.

## What this does

A `wedged` tier that diffs **declared** (branch protection) against **actual** (contexts on the head) and hands the PR to the real producer. It does not fake the status.

The textbook fix — a job that always posts the context green — is wrong twice here:
1. Absence is a *correct refusal*. `linear-worker.sh:687`: "Remove `kipi/reviewer-approved` from that set and this becomes an unreviewed-merge machine."
2. GitHub requires **both** when a check run and a commit status share a name, so an Actions job named after it would *deepen* the deadlock.

## Two defects the live run found in the fix itself

- **404 != 403.** v1 raised on any non-zero rc, reasoning `repo-preflight.sh` already refuses unprotected repos. That is true of the DEFAULT branch; this asks about each PR's BASE. A stacked PR onto `sana/block-expiry` returned rc 2 for the *whole sweep* — reintroducing the silence the detector exists to end. 404 is now definite, 403 stays indefinite.
- **Red CI outranks a wedge.** Real PR #76 was both. Reviewing a broken build buys a read of a tree about to change.

## Verification

```
before: wedged-pr:  6 passed, 15 failed
after:  wedged-pr: 34 passed,  0 failed
```

The 6 were **false** passes (argparse exits 2 on an unknown op), so the suite was mutation-tested — **10/10 mutants killed**. Cases 9/10 exist *because* mutation found nothing: with both protection halves populated, a reader of either passed everything, so "both halves are read" was an unpinned claim.

Verified against live PRs, not fixtures:

| PR | state | detector |
|---|---|---|
| #75 | status posted (failure) | correctly NOT wedged |
| #76 | red `validate` | correctly deferred to redrive |
| #77 | converge live | correctly skipped |
| #68 | green, never reviewed | **offered, reviewed, `kipi/reviewer-approved` now posted** |

PR #68 went from silently wedged to `REQUEST CHANGES` by codex — end-to-end proof on a real PR.

`test-ci-redrive.sh` still 65/65.

## Also found

`sp-c5f09ad2` — `test-severity-floor.sh` reaches a **real billed `codex exec`** through the real `linear-worker.sh --apply` and `pr-review-agent.sh`. Confirmed by process tree. Quiet in CI only because the runner has no codex credentials: an accidental shield, not isolation. Captured, not fixed here.

## Left open

- The producer is still local-only (a launchd job on one Mac). Wedges are now *detected and paged* rather than silent, but not *produced* if that Mac is off. Moving it into Actions needs codex credentials in CI — much larger blast radius, not bundled.
- `sp-c2b64f9b` (`capability-gate.py:422` counts exit-0 as covered) is left against the existing action item in `rca-absence-read-as-success-2026-08-02.md` rather than re-owned here.

RCA: `q-system/output/rca/rca-coverage-assumed-from-existence-2026-08-02.md`

Closes `sp-59de96e9`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)