### PR TITLE
A blocked/unavailable claim in a report must carry the command that settles it (ASK-317)

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -289,6 +289,11 @@
           },
           {
             "type": "command",
+            "command": "if test -f \"$CLAUDE_PROJECT_DIR/q-system/.q-system/scripts/blocked-claim-evidence-lint.py\"; then python3 \"$CLAUDE_PROJECT_DIR/q-system/.q-system/scripts/blocked-claim-evidence-lint.py\"; fi",
+            "timeout": 15
+          },
+          {
+            "type": "command",
             "command": "python3 \"$CLAUDE_PROJECT_DIR/q-system/.q-system/scripts/voice-stop-gate.py\"",
             "timeout": 30
           },

--- a/q-system/.q-system/capability-manifest.json
+++ b/q-system/.q-system/capability-manifest.json
@@ -434,6 +434,10 @@
     {
       "path": "q-system/.q-system/scripts/test/test-capability-map-wiring.py",
       "runner": "python3"
+    },
+    {
+      "path": "q-system/.q-system/scripts/test_blocked_claim_evidence_lint.py",
+      "runner": "python3"
     }
   ],
   "required_data": [],
@@ -519,7 +523,7 @@
     },
     {
       "path": "q-system/.q-system/scripts/stat-verify.py",
-      "reason": "802-line stat verification engine; zero hook wiring and its stat-registry.json data file exists in exactly one instance — wiring it is a founder product decision",
+      "reason": "802-line stat verification engine; zero hook wiring and its stat-registry.json data file exists in exactly one instance \u2014 wiring it is a founder product decision",
       "spillover_id": "sp-72b60bff"
     },
     {
@@ -539,8 +543,8 @@
     }
   ],
   "uncovered_known": [
-    "plugins/*/tests — prd-os plugin suite, run by the plugin's own harness; outside v1 scan roots (finding-9 deferred)",
+    "plugins/*/tests \u2014 prd-os plugin suite, run by the plugin's own harness; outside v1 scan roots (finding-9 deferred)",
     "repo-root *.sh utilities are wiring surfaces, not test artifacts",
-    "stat-registry.json: NOT expressible as required_data in v1 — the one instance holding it keeps canonical under its own instance_q_dir (not q-system/) and its registry name differs from its dir basename, so a scoped entry could never fire (grounded 2026-07-23). Declared gap; owning decision + instance detail in spillover sp-72b60bff"
+    "stat-registry.json: NOT expressible as required_data in v1 \u2014 the one instance holding it keeps canonical under its own instance_q_dir (not q-system/) and its registry name differs from its dir basename, so a scoped entry could never fire (grounded 2026-07-23). Declared gap; owning decision + instance detail in spillover sp-72b60bff"
   ]
 }

--- a/q-system/.q-system/scripts/blocked-claim-evidence-lint.py
+++ b/q-system/.q-system/scripts/blocked-claim-evidence-lint.py
@@ -102,6 +102,19 @@ class Pattern(NamedTuple):
     settles: str
 
 
+class Claim(NamedTuple):
+    """One state claim: a SENTENCE, located by its line and its place within it."""
+    line: int
+    ordinal: int  # sentence index within the line; two claims on a line are two claims
+    pattern: Pattern
+    text: str
+
+    @property
+    def key(self) -> tuple[int, int]:
+        """Identity AND reading order: max() over keys is the nearest claim above."""
+        return (self.line, self.ordinal)
+
+
 class Finding(NamedTuple):
     pattern: str
     line: int
@@ -237,25 +250,32 @@ def _settling_fences(lines: list[str], spans: list[tuple[int, int]]) -> set[int]
     return out
 
 
-def _claim_lines(lines: list[str], interior: set[int]) -> list[tuple[int, Pattern]]:
-    """(line index, matched pattern) for every unlabelled state claim, in order."""
+def _claims(lines: list[str], interior: set[int]) -> list[Claim]:
+    """Every unlabelled state claim, in reading order.
+
+    A claim is a SENTENCE, not a line. Scar (PR #79 review round 2, codex): round 1
+    bound each fence to the nearest claim LINE, and this loop kept only the first
+    claim per line, so a line carrying two claims collapsed to one entry and a single
+    fence cleared both. The laundering just moved from between lines to within one.
+    Sentences are the unit the trigger regexes already match on, so they are the unit
+    a fence has to answer.
+    """
     claims = []
     for i, line in enumerate(lines):
         if i in interior or not line.strip() or _has_provenance(line):
             continue
-        for sentence in _SENTENCE_SPLIT_RE.split(line):
+        for ordinal, sentence in enumerate(_SENTENCE_SPLIT_RE.split(line)):
             sentence = sentence.strip()
             if not sentence or sentence.endswith("?"):
                 continue  # a question is an open loop, not a claim
             hit = _first_match(sentence)
             if hit is not None:
-                claims.append((i, hit))
-                break  # one finding per line keeps the report readable
+                claims.append(Claim(i, ordinal, hit, sentence))
     return claims
 
 
-def _settled_claims(claims: list[tuple[int, Pattern]], settling: set[int]) -> set[int]:
-    """Line indices a fence settles. ONE fence settles exactly ONE claim.
+def _settled_claims(claims: list[Claim], settling: set[int]) -> set[tuple[int, int]]:
+    """The (line, ordinal) keys a fence settles. ONE fence settles exactly ONE claim.
 
     Evidence must FOLLOW the claim: a fence above it belongs to an earlier claim.
     Scar (PR #79 review, codex): the first cut cleared EVERY claim within LOOKAHEAD
@@ -263,11 +283,14 @@ def _settled_claims(claims: list[tuple[int, Pattern]], settling: set[int]) -> se
     unrelated false claim sitting next to it -- the exact laundering this gate exists
     to stop. A fence is evidence for the nearest claim it follows, and it is spent
     once, so two adjacent claims need two fences.
+
+    "Nearest" is by (line, ordinal), so on a two-claim line the fence below answers
+    the LAST sentence, and the earlier one still needs its own command.
     """
-    settled: set[int] = set()
+    settled: set[tuple[int, int]] = set()
     for fence in sorted(settling):
-        owners = [i for i, _ in claims
-                  if i < fence <= i + LOOKAHEAD and i not in settled]
+        owners = [c.key for c in claims
+                  if c.line < fence <= c.line + LOOKAHEAD and c.key not in settled]
         if owners:
             settled.add(max(owners))  # the nearest claim above this fence
     return settled
@@ -280,10 +303,13 @@ def evaluate(final_text: str) -> list[Finding]:
     lines = final_text.splitlines()
     spans = _fence_spans(lines)
     interior = {i for start, end in spans for i in range(start, end + 1)}
-    claims = _claim_lines(lines, interior)
+    claims = _claims(lines, interior)
     settled = _settled_claims(claims, _settling_fences(lines, spans))
-    return [Finding(hit.pattern_id, i + 1, lines[i].strip(), hit.why, hit.settles)
-            for i, hit in claims if i not in settled]
+    # Report the SENTENCE, not the whole line: on a two-claim line the operator has
+    # to see which half is still unsettled, not re-read the line and guess.
+    return [Finding(c.pattern.pattern_id, c.line + 1, c.text,
+                    c.pattern.why, c.pattern.settles)
+            for c in claims if c.key not in settled]
 
 
 def _first_match(sentence: str):

--- a/q-system/.q-system/scripts/blocked-claim-evidence-lint.py
+++ b/q-system/.q-system/scripts/blocked-claim-evidence-lint.py
@@ -1,0 +1,366 @@
+#!/usr/bin/env python3
+"""blocked-claim-evidence-lint: a report saying "this is blocked" must carry the
+command that settles it, or say out loud that it is an inference.
+
+WHY (ASK-317, RCA rca-inherited-claim-treated-as-verified-2026-08-02): six false
+"this is blocked" reports in one session. Each was fluent, specific, wrong, and wrong
+in the direction that transferred work to the founder or stopped work entirely. Cost:
+a correct, fully reviewed PR sat unmerged, and two non-existent decisions were put on
+the founder's plate. Every one of them was settled later by a ten-second command.
+
+THE HOLE THIS FILLS: `evidence-ledger.md` already requires a stored command and result
+for a claim, and its four gates fire on client output, handoffs, and first writes.
+NONE fire on an agent-to-agent or agent-to-founder status report -- the exact channel
+all six travelled. The rule existed; its enforcement had a hole this shape.
+
+THE THREE SUB-SHAPES, each with its own remediation (generic stderr teaches nothing):
+
+  1. rollup-as-config          a computed roll-up read as a policy statement.
+                               `mergeStateStatus: BLOCKED` is derived from several
+                               inputs; it was read as "a human must approve".
+  2. my-denial-as-object-property   a refusal aimed at MY tool layer reported as a
+                               property of the object. "I can't" became "it can't".
+                               The command had never been run.
+  3. lookup-as-runtime-fact    one lookup's result reported as a runtime fact. One
+                               `ls` returned nothing, so "the file does not exist".
+                               Mirror image: references existed, so "the scripts are
+                               LIVE" -- neither had ever been executed.
+
+MODE (this ships ADVISORY on purpose). `KIPI_BLOCKED_CLAIM_LINT_MODE`:
+  advisory (default)  exit 0, findings appended to output/blocked-claim-lint.jsonl
+  blocking            exit 2, per-sub-shape remediation on stderr
+A Stop hook that fires noisily trains the operator to skim, which costs the real alert
+later. So the false-positive rate gets measured on real session output from the
+advisory log FIRST, and `blocking` is turned on against that evidence, not against a
+hunch. The promotion is a one-word env change, not a rewrite.
+
+HONEST BOUNDARY (stated so this is not theater):
+  - It checks that a claim DECLARES its evidence, not that the evidence is true. A
+    fenced block holding two commands and no real output passes.
+  - Evidence must FOLLOW the claim within LOOKAHEAD lines, or be inline provenance.
+    Showing the command first and concluding after is not recognised; use
+    `[verified: <cmd>]` on the claim line for that shape.
+  - A blocking claim phrased with none of the trigger words passes untouched. This is
+    a keyword gate over a prose channel, and prose has infinite synonyms.
+  - Only fenced blocks count as command evidence. A command in backticks inside prose
+    does not, deliberately: claim #5 ("`gh pr merge` is denied") quoted the command it
+    had never run.
+
+Contract: reads {transcript_path, stop_hook_active} JSON on stdin (Claude Code Stop
+hook). exit 0 = pass, exit 2 = block. Per-answer bypass: put `blocked-claim-skip` in
+the answer. stdlib only.
+Self-test: `python3 test_blocked_claim_evidence_lint.py`.
+"""
+from __future__ import annotations
+
+import json
+import os
+import re
+import sys
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import NamedTuple
+
+SKIP_MARKER = "blocked-claim-skip"
+MODE = os.environ.get("KIPI_BLOCKED_CLAIM_LINT_MODE", "advisory").strip().lower()
+CALIBRATION_LOG = "q-system/output/blocked-claim-lint.jsonl"
+
+# How far AFTER a claim its settling fence may start. Two lines is the natural shape
+# (claim, blank, fence); four leaves slack for a lead-in line without letting an
+# unrelated block three claims down launder this one.
+LOOKAHEAD = 4
+
+# A fenced block is command evidence only if its first line is a command AND at least
+# one more non-empty line follows it -- the output. A command with no output settles
+# nothing; that is the "I ran it, trust me" shape.
+COMMAND_VERBS = (
+    "gh", "git", "ls", "cat", "find", "grep", "rg", "sed", "awk", "head", "tail",
+    "wc", "stat", "test", "bash", "sh", "zsh", "python3", "python", "node", "npm",
+    "make", "curl", "jq", "launchctl", "docker", "psql", "sqlite3", "open", "echo",
+    "printf", "diff", "tree", "ps", "which", "env",
+)
+_CMD_RE = re.compile(
+    r"^(?:[$%>]\s+)?(?:" + "|".join(re.escape(v) for v in COMMAND_VERBS) + r")(?:\s|$)")
+_FENCE_RE = re.compile(r"^\s*(?:```|~~~)")
+_SENTENCE_SPLIT_RE = re.compile(r"(?<=[.?!])\s+")
+_VERIFIED_RE = re.compile(r"\[verified:")
+
+sys.path.insert(0, str(Path(__file__).resolve().parent))
+try:  # the ONE provenance table, shared with handoff-provenance-lint
+    import provenance_vocabulary as PV
+except Exception:  # pragma: no cover - an instance mid-kipi-update must not break
+    PV = None
+    _FALLBACK_PROV_RE = re.compile(
+        r"\{\{UNVERIFIED\}\}|\{\{UNVALIDATED\}\}|\{\{NEEDS_PROOF\}\}"
+        r"|\bev-[0-9a-f]{10}\b")
+
+
+class Pattern(NamedTuple):
+    pattern_id: str
+    why: str
+    triggers: tuple
+    settles: str
+
+
+class Finding(NamedTuple):
+    pattern: str
+    line: int
+    text: str
+    why: str
+    settles: str
+
+
+PATTERNS = (
+    Pattern(
+        pattern_id="rollup-as-config",
+        why=("a computed roll-up read as a policy statement. `mergeStateStatus: "
+             "BLOCKED` is derived from several inputs; it is not a record of who "
+             "must approve."),
+        triggers=(
+            re.compile(r"\bblocked\b", re.I),
+            re.compile(r"\bblocks\s+(?:the|this|our|merge|it)\b", re.I),
+            re.compile(r"\bpending\s+\w*\s*approval\b", re.I),
+            re.compile(r"\brequires?\s+(?:\w+\s+){0,2}approval\b", re.I),
+            re.compile(r"\bwaiting\s+on\s+(?:review|approval|a\s+reviewer)\b", re.I),
+            re.compile(r"\bmergeStateStatus\b", re.I),
+            re.compile(r"\bout\s+of\s+credits\b", re.I),
+        ),
+        settles=(
+            "    branch protection is CONFIG; mergeStateStatus is a ROLL-UP. Read the\n"
+            "    config, not the roll-up:\n"
+            "gh api repos/<owner>/<repo>/branches/<base>/protection "
+            "--jq .required_pull_request_reviews\n"
+            "gh pr view <n> --json mergeStateStatus,mergeable,statusCheckRollup,reviewDecision\n"
+            "    Scar: `required_pull_request_reviews` was null. No human approval was\n"
+            "    ever configured, and a reviewed PR sat unmerged on that claim."
+        ),
+    ),
+    Pattern(
+        pattern_id="my-denial-as-object-property",
+        why=("a refusal aimed at MY tool layer reported as a property of the object. "
+             "\"I can't\" is a fact about this session; \"it can't\" is a claim about "
+             "the world."),
+        triggers=(
+            re.compile(r"\bdenied\b", re.I),
+            re.compile(r"\bnot\s+permitted\b", re.I),
+            re.compile(r"\bno\s+permission\b", re.I),
+            re.compile(r"\bpermission\s+(?:was\s+)?refused\b", re.I),
+            re.compile(r"\b(?:cannot|can'?t)\s+be\s+(?:run|invoked|called|used|"
+                       r"executed)\b", re.I),
+            re.compile(r"\bis\s+(?:un)?available\s+to\s+the\s+tool\s+layer\b", re.I),
+            re.compile(r"\bthe\s+tool\s+layer\s+(?:refuses|forbids|blocks)\b", re.I),
+        ),
+        settles=(
+            "    run it ONCE. The command's own error text names the fix, and a\n"
+            "    refusal you never triggered is not a refusal:\n"
+            "gh pr merge <n> --squash --admin      # or whatever you believe is denied\n"
+            "    Then report what the tool said, verbatim.\n"
+            "    Scar: `gh pr merge` was reported denied to the tool layer. It had\n"
+            "    never been run, and its error text names `--admin`."
+        ),
+    ),
+    Pattern(
+        pattern_id="lookup-as-runtime-fact",
+        why=("one lookup's result reported as a runtime fact. Absence at one path is "
+             "not absence, and the existence of references is not a run."),
+        triggers=(
+            re.compile(r"\bdoes\s+not\s+exist\b", re.I),
+            re.compile(r"\bdoesn'?t\s+exist\b", re.I),
+            re.compile(r"\bno\s+such\s+file\b", re.I),
+            re.compile(r"\bwas\s+never\s+written\b", re.I),
+            # `[^;\n]` and not `[^.;\n]`: the subject of this claim is usually a
+            # FILENAME, and a filename carries a dot. Excluding `.` here is what
+            # made the first cut miss reproducer claims 3 and 4 verbatim
+            # ("no `degraded.state` was written"). Sentence splitting already
+            # bounds the span, so the dot costs nothing.
+            re.compile(r"\bno\s+\S[^;\n]{0,40}?\s+was\s+written\b", re.I),
+            re.compile(r"\bnever\s+(?:ran|executed|fired)\b", re.I),
+            re.compile(r"\b(?:is|are)\s+missing\b", re.I),
+            re.compile(r"\b(?:is|are)\s+(?:live|running|active)\b", re.I),
+            re.compile(r"\bnothing\s+was\s+(?:written|produced|emitted)\b", re.I),
+        ),
+        settles=(
+            "    one path is not every path, and a reference is not a run. Settle both\n"
+            "    directions before reporting:\n"
+            "find <root> -name '<file>' -print -exec cat {} +\n"
+            "grep -rn '<name>' <root>          # references exist...\n"
+            "    ...now show the run: the invocation itself, or the run-log line that\n"
+            "    proves it executed.\n"
+            "    Scar: `degraded.state` was reported unwritten. It existed at the\n"
+            "    per-engine path, held `1`, and was timestamped. Separately, ten\n"
+            "    scripts were reported LIVE on the strength of references alone;\n"
+            "    none had ever been executed."
+        ),
+    ),
+)
+
+
+def _has_provenance(line: str) -> bool:
+    """A line that labels itself is doing the right thing, not a lesser thing."""
+    if _VERIFIED_RE.search(line):
+        return True
+    if PV is not None:
+        return PV.has_provenance(line)
+    return bool(_FALLBACK_PROV_RE.search(line))
+
+
+def _fence_spans(lines: list[str]) -> list[tuple[int, int]]:
+    """(start_index, end_index) for every fenced block, end inclusive."""
+    spans, open_at = [], None
+    for i, line in enumerate(lines):
+        if not _FENCE_RE.match(line):
+            continue
+        if open_at is None:
+            open_at = i
+        else:
+            spans.append((open_at, i))
+            open_at = None
+    if open_at is not None:  # unterminated fence: treat the rest as its interior
+        spans.append((open_at, len(lines) - 1))
+    return spans
+
+
+def _settling_fences(lines: list[str], spans: list[tuple[int, int]]) -> set[int]:
+    """Start indices of fences that hold a command AND at least one output line."""
+    out = set()
+    for start, end in spans:
+        inner = [ln for ln in lines[start + 1:end] if ln.strip()]
+        if len(inner) >= 2 and _CMD_RE.match(inner[0].strip()):
+            out.add(start)
+    return out
+
+
+def evaluate(final_text: str) -> list[Finding]:
+    """Every unsettled blocked/denied/unavailable/non-existent claim in the answer."""
+    if not final_text or SKIP_MARKER in final_text:
+        return []
+    lines = final_text.splitlines()
+    spans = _fence_spans(lines)
+    interior = {i for start, end in spans for i in range(start, end + 1)}
+    settling = _settling_fences(lines, spans)
+
+    findings: list[Finding] = []
+    for i, line in enumerate(lines):
+        if i in interior or not line.strip() or _has_provenance(line):
+            continue
+        # Evidence must FOLLOW the claim. A fence that precedes it belongs to an
+        # earlier claim -- one settled claim must not launder the next one.
+        if any(i < f <= i + LOOKAHEAD for f in settling):
+            continue
+        for sentence in _SENTENCE_SPLIT_RE.split(line):
+            sentence = sentence.strip()
+            if not sentence or sentence.endswith("?"):
+                continue  # a question is an open loop, not a claim
+            hit = _first_match(sentence)
+            if hit is not None:
+                findings.append(Finding(hit.pattern_id, i + 1, line.strip(),
+                                        hit.why, hit.settles))
+                break  # one finding per line keeps the report readable
+    return findings
+
+
+def _first_match(sentence: str):
+    for pattern in PATTERNS:
+        if any(trigger.search(sentence) for trigger in pattern.triggers):
+            return pattern
+    return None
+
+
+# --- Stop-hook plumbing ------------------------------------------------------
+def _final_assistant_text(records: list[dict]) -> str:
+    text = ""
+    for rec in records:
+        msg = rec.get("message", {})
+        if not isinstance(msg, dict) or msg.get("role") != "assistant":
+            continue
+        parts = [i.get("text", "") for i in msg.get("content", [])
+                 if isinstance(i, dict) and i.get("type") == "text"]
+        if parts:
+            text = "\n".join(parts)  # keep the LAST assistant text block
+    return text
+
+
+def _load_records(transcript_path: str) -> list[dict]:
+    path = Path(transcript_path) if transcript_path else None
+    if not path or not path.exists():
+        return []
+    out = []
+    for line in path.read_text(encoding="utf-8", errors="ignore").splitlines():
+        try:
+            out.append(json.loads(line))
+        except Exception:
+            continue
+    return out
+
+
+def _log_calibration(findings: list[Finding]) -> None:
+    """Advisory-mode output. This log IS the calibration evidence the promotion to
+    blocking has to be argued from, so a failure to write it must be visible, not
+    silently swallowed -- but it must never take down the turn either."""
+    root = Path(os.environ.get("CLAUDE_PROJECT_DIR", os.getcwd()))
+    target = root / CALIBRATION_LOG
+    row = {
+        "ts": datetime.now(timezone.utc).isoformat(timespec="seconds"),
+        "mode": MODE,
+        "findings": [{"pattern": f.pattern, "line": f.line, "text": f.text[:300]}
+                     for f in findings],
+    }
+    try:
+        target.parent.mkdir(parents=True, exist_ok=True)
+        with target.open("a", encoding="utf-8") as handle:
+            handle.write(json.dumps(row) + "\n")
+    except Exception as exc:
+        sys.stderr.write(f"blocked-claim-evidence-lint: calibration log unwritable "
+                         f"({type(exc).__name__}: {exc})\n")
+
+
+def _report(findings: list[Finding]) -> str:
+    blocks = []
+    for pattern_id in dict.fromkeys(f.pattern for f in findings):
+        group = [f for f in findings if f.pattern == pattern_id]
+        listed = "\n".join(f"    line {f.line}: {f.text[:120]}" for f in group[:8])
+        blocks.append(f"  [{pattern_id}] {group[0].why}\n{listed}\n\n"
+                      f"{group[0].settles}")
+    return "\n\n".join(blocks)
+
+
+def main() -> int:
+    try:
+        payload = json.load(sys.stdin)
+    except Exception:
+        return 0
+    if payload.get("stop_hook_active"):  # loop guard: block at most once per cycle
+        return 0
+    records = _load_records(payload.get("transcript_path", ""))
+    if not records:
+        return 0
+    findings = evaluate(_final_assistant_text(records))
+    if not findings:
+        return 0
+
+    if MODE != "blocking":
+        _log_calibration(findings)
+        counts = ", ".join(
+            f"{p} x{sum(1 for f in findings if f.pattern == p)}"
+            for p in dict.fromkeys(f.pattern for f in findings))
+        print(f"blocked-claim-evidence-lint (advisory): {len(findings)} unsettled "
+              f"state claim(s) [{counts}] -> {CALIBRATION_LOG}")
+        return 0
+
+    sys.stderr.write(
+        "BLOCKED-CLAIM EVIDENCE (blocked): your answer asserts a blocked, denied, "
+        "unavailable, or non-existent state with no command output next to it.\n\n"
+        + _report(findings) + "\n\n"
+        "  Attach the command AND its output in a fenced block under the claim, or "
+        "label the line as an inference ({{UNVERIFIED}} / provenance: inferred). "
+        "Labelling is the correct move, not a lesser one -- the defect is prose that "
+        "hides which kind of statement it is making.\n"
+        "  Scar 2026-08-02: six claims of this exact shape in one session. Every one "
+        "was settled later by a ten-second command. A reviewed PR sat unmerged and "
+        "two non-existent decisions reached the founder.\n"
+        f"  Deliberate exception: put `{SKIP_MARKER}` in the answer.\n")
+    return 2
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/q-system/.q-system/scripts/blocked-claim-evidence-lint.py
+++ b/q-system/.q-system/scripts/blocked-claim-evidence-lint.py
@@ -148,6 +148,13 @@ PATTERNS = (
             re.compile(r"\b(?:cannot|can'?t)\s+be\s+(?:run|invoked|called|used|"
                        r"executed)\b", re.I),
             re.compile(r"\bis\s+(?:un)?available\s+to\s+the\s+tool\s+layer\b", re.I),
+            # The repo's OWN status wording, and it was invisible to the first cut
+            # (PR #79 review, codex). The autonomous-board prompt tells agents to
+            # report when "Linear is unreachable" -- a stop claim about an external
+            # service, which is this sub-shape exactly: one failed call at my layer
+            # reported as a property of the service.
+            re.compile(r"\b(?:is|are|was|were)\s+(?:unreachable|unavailable|down|"
+                       r"offline|inaccessible)\b", re.I),
             re.compile(r"\bthe\s+tool\s+layer\s+(?:refuses|forbids|blocks)\b", re.I),
         ),
         settles=(
@@ -230,22 +237,11 @@ def _settling_fences(lines: list[str], spans: list[tuple[int, int]]) -> set[int]
     return out
 
 
-def evaluate(final_text: str) -> list[Finding]:
-    """Every unsettled blocked/denied/unavailable/non-existent claim in the answer."""
-    if not final_text or SKIP_MARKER in final_text:
-        return []
-    lines = final_text.splitlines()
-    spans = _fence_spans(lines)
-    interior = {i for start, end in spans for i in range(start, end + 1)}
-    settling = _settling_fences(lines, spans)
-
-    findings: list[Finding] = []
+def _claim_lines(lines: list[str], interior: set[int]) -> list[tuple[int, Pattern]]:
+    """(line index, matched pattern) for every unlabelled state claim, in order."""
+    claims = []
     for i, line in enumerate(lines):
         if i in interior or not line.strip() or _has_provenance(line):
-            continue
-        # Evidence must FOLLOW the claim. A fence that precedes it belongs to an
-        # earlier claim -- one settled claim must not launder the next one.
-        if any(i < f <= i + LOOKAHEAD for f in settling):
             continue
         for sentence in _SENTENCE_SPLIT_RE.split(line):
             sentence = sentence.strip()
@@ -253,10 +249,41 @@ def evaluate(final_text: str) -> list[Finding]:
                 continue  # a question is an open loop, not a claim
             hit = _first_match(sentence)
             if hit is not None:
-                findings.append(Finding(hit.pattern_id, i + 1, line.strip(),
-                                        hit.why, hit.settles))
+                claims.append((i, hit))
                 break  # one finding per line keeps the report readable
-    return findings
+    return claims
+
+
+def _settled_claims(claims: list[tuple[int, Pattern]], settling: set[int]) -> set[int]:
+    """Line indices a fence settles. ONE fence settles exactly ONE claim.
+
+    Evidence must FOLLOW the claim: a fence above it belongs to an earlier claim.
+    Scar (PR #79 review, codex): the first cut cleared EVERY claim within LOOKAHEAD
+    lines of any settling fence, so output answering one claim silently laundered an
+    unrelated false claim sitting next to it -- the exact laundering this gate exists
+    to stop. A fence is evidence for the nearest claim it follows, and it is spent
+    once, so two adjacent claims need two fences.
+    """
+    settled: set[int] = set()
+    for fence in sorted(settling):
+        owners = [i for i, _ in claims
+                  if i < fence <= i + LOOKAHEAD and i not in settled]
+        if owners:
+            settled.add(max(owners))  # the nearest claim above this fence
+    return settled
+
+
+def evaluate(final_text: str) -> list[Finding]:
+    """Every unsettled blocked/denied/unavailable/non-existent claim in the answer."""
+    if not final_text or SKIP_MARKER in final_text:
+        return []
+    lines = final_text.splitlines()
+    spans = _fence_spans(lines)
+    interior = {i for start, end in spans for i in range(start, end + 1)}
+    claims = _claim_lines(lines, interior)
+    settled = _settled_claims(claims, _settling_fences(lines, spans))
+    return [Finding(hit.pattern_id, i + 1, lines[i].strip(), hit.why, hit.settles)
+            for i, hit in claims if i not in settled]
 
 
 def _first_match(sentence: str):

--- a/q-system/.q-system/scripts/test_blocked_claim_evidence_lint.py
+++ b/q-system/.q-system/scripts/test_blocked_claim_evidence_lint.py
@@ -189,6 +189,28 @@ def main() -> int:
     cases.append(("two claims each carrying their own fence both pass",
                   mod.evaluate(paired) == []))
 
+    # === PR #79 review round 2: the SAME-LINE residue of the minor-1 fix ===
+    # Binding a fence to the nearest claim LINE still let one line hold two claims.
+    # Codex's reproducer, verbatim: both claims on one line, one fence answering only
+    # the Alice half. The merge claim rode out on the Alice claim's evidence.
+    same_line = ("- Merge is blocked pending founder approval. "
+                 "The 10 Alice scripts are LIVE.\n\n```\n"
+                 "bash alice/run.sh --list\n"
+                 "alice/collect.sh: never invoked, no run-log entry\n```\n")
+    found = mod.evaluate(same_line)
+    cases.append(("one fence settles one claim on a two-claim LINE",
+                  len(found) == 1 and found[0].pattern == "rollup-as-config"))
+    # The report must point at the sentence that is unsettled, not the whole line:
+    # the operator has to see WHICH half still needs a command.
+    cases.append(("the finding quotes the unsettled sentence, not the whole line",
+                  bool(found) and "LIVE" not in found[0].text
+                  and "blocked" in found[0].text))
+    # Collection half: two claims on one line with NO evidence are two findings.
+    both = mod.evaluate("- Merge is blocked pending approval. The scripts are LIVE.")
+    cases.append(("two claims on one line are two findings, not one",
+                  [f.pattern for f in both]
+                  == ["rollup-as-config", "lookup-as-runtime-fact"]))
+
     # === PR #79 review, minor 2: the repo's own "unreachable" status wording ===
     # Not a fabricated phrase: the autonomous-board prompt tells agents to report
     # when "Linear is unreachable". That is a stop claim, and it was invisible.

--- a/q-system/.q-system/scripts/test_blocked_claim_evidence_lint.py
+++ b/q-system/.q-system/scripts/test_blocked_claim_evidence_lint.py
@@ -173,6 +173,37 @@ def main() -> int:
     cases.append(("a settled claim does not launder an unsettled one",
                   len(found) == 1 and found[0].pattern == "my-denial-as-object-property"))
 
+    # === PR #79 review, minor 1: a fence binds to ONE claim, not to the window ===
+    # Codex reproduced this: two claims inside one lookahead window, one fence that
+    # answers only the SECOND. The window rule cleared both, so evidence for the
+    # Alice claim silently laundered the false merge claim next to it.
+    launder = (CLAIMS[0][1] + "\n" + CLAIMS[5][1] + "\n\n```\n"
+               "bash alice/run.sh --list\n"
+               "alice/collect.sh: never invoked, no run-log entry\n```\n")
+    found = mod.evaluate(launder)
+    cases.append(("one fence settles its own claim, not the claim above it",
+                  len(found) == 1 and found[0].pattern == "rollup-as-config"))
+
+    # Two claims, two fences: each still gets settled by its own evidence.
+    paired = SETTLED[0] + "\n" + SETTLED[5]
+    cases.append(("two claims each carrying their own fence both pass",
+                  mod.evaluate(paired) == []))
+
+    # === PR #79 review, minor 2: the repo's own "unreachable" status wording ===
+    # Not a fabricated phrase: the autonomous-board prompt tells agents to report
+    # when "Linear is unreachable". That is a stop claim, and it was invisible.
+    cases.append((
+        "a repo-produced 'X is unreachable' claim is flagged",
+        [f.pattern for f in mod.evaluate(
+            "- Linear is unreachable, so the board could not be refreshed.")]
+        == ["my-denial-as-object-property"]))
+    cases.append((
+        "'X is unreachable' settled by the probe that establishes it passes",
+        mod.evaluate(
+            "- Linear is unreachable, so the board could not be refreshed.\n\n```\n"
+            "python3 q-system/.q-system/scripts/linear-sync.py progress ASK-317\n"
+            "urllib.error.HTTPError: HTTP Error 401: Unauthorized\n```\n") == []))
+
     # === remediation text is per-pattern, not generic ===
     texts = {p.pattern_id: p.settles for p in mod.PATTERNS}
     cases.append(("three distinct sub-shapes are named",

--- a/q-system/.q-system/scripts/test_blocked_claim_evidence_lint.py
+++ b/q-system/.q-system/scripts/test_blocked_claim_evidence_lint.py
@@ -1,0 +1,225 @@
+#!/usr/bin/env python3
+"""Reproducer + negative self-test for blocked-claim-evidence-lint.py (ASK-317).
+
+THE REPRODUCER is `CLAIMS` below: the six real false "this is blocked" reports from
+one session (RCA rca-inherited-claim-treated-as-verified-2026-08-02, restated in
+ASK-317). Each was fluent, specific, wrong, and wrong in the direction that
+transferred work to the founder or stopped work entirely. All six must be flagged.
+
+THE NEGATIVE SELF-TEST is the same six claims WITH the command and output that
+settles each one attached. All six must pass. A lint that fails this half is a wall,
+not a gate -- it would just teach the operator to route around it.
+
+Run: python3 test_blocked_claim_evidence_lint.py
+"""
+from __future__ import annotations
+
+import importlib.util
+import json
+import subprocess
+import sys
+import tempfile
+from pathlib import Path
+
+HERE = Path(__file__).resolve().parent
+LINT = HERE / "blocked-claim-evidence-lint.py"
+
+
+def _load():
+    spec = importlib.util.spec_from_file_location("blocked_claim_lint", LINT)
+    mod = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(mod)
+    return mod
+
+
+# --- the six claims, and the pattern each one is an instance of --------------
+# (label, claim text as it was actually written, expected pattern id)
+CLAIMS = [
+    ("merge blocked pending approval",
+     "- merge is blocked pending founder approval.",
+     "rollup-as-config"),
+    ("codex credits block the PR",
+     "- codex is out of credits, that blocks the PR.",
+     "rollup-as-config"),
+    ("degraded.state absent",
+     "- no `degraded.state` was written for the codex engine.",
+     "lookup-as-runtime-fact"),
+    ("relay of the absence claim",
+     "- Sharpest finding this round: no degraded.state file was written anywhere.",
+     "lookup-as-runtime-fact"),
+    ("gh pr merge denied",
+     "- `gh pr merge` is denied to the tool layer, so I cannot merge.",
+     "my-denial-as-object-property"),
+    ("Alice scripts live",
+     "- the 10 Alice scripts are LIVE.",
+     "lookup-as-runtime-fact"),
+]
+
+# --- the settling command + its output, per claim ----------------------------
+# Attached as a fenced block directly under the claim, which is exactly the shape
+# the remediation text asks for.
+SETTLED = [
+    CLAIMS[0][1] + "\n\n```\n"
+    "gh api repos/assafkip/kipi-system/branches/main/protection --jq .required_pull_request_reviews\n"
+    "null\n```\n",
+    CLAIMS[1][1] + "\n\n```\n"
+    "sed -n '45,55p' plugins/prd-os/scripts/pr-review-agent.sh\n"
+    "# codex down -> claude fills PRIMARY and the run posts DEGRADED\n```\n",
+    CLAIMS[2][1] + "\n\n```\n"
+    "cat .prd-os/engines/codex/degraded.state\n"
+    "1\n```\n",
+    CLAIMS[3][1] + "\n\n```\n"
+    "find .prd-os -name 'degraded.state' -print -exec cat {} +\n"
+    ".prd-os/engines/codex/degraded.state\n1\n```\n",
+    CLAIMS[4][1] + "\n\n```\n"
+    "gh pr merge 74 --squash\n"
+    "GraphQL: Pull request is not mergeable (try --admin)\n```\n",
+    CLAIMS[5][1] + "\n\n```\n"
+    "bash alice/run.sh --list\n"
+    "alice/collect.sh: never invoked, no run-log entry\n```\n",
+]
+
+
+# --- subprocess harness (the real hook path) ---------------------------------
+def run_hook(answer: str, mode: str = "advisory") -> tuple[int, str]:
+    """Feed `answer` as the final assistant text through the Stop hook. -> (rc, stderr)"""
+    tmp = Path(tempfile.mkdtemp())
+    transcript = tmp / "transcript.jsonl"
+    rows = [
+        {"message": {"role": "user", "content": [{"type": "text", "text": "status?"}]}},
+        {"message": {"role": "assistant",
+                     "content": [{"type": "text", "text": answer}]}},
+    ]
+    transcript.write_text(
+        "\n".join(json.dumps(r) for r in rows) + "\n", encoding="utf-8")
+    payload = json.dumps(
+        {"transcript_path": str(transcript), "stop_hook_active": False})
+    proc = subprocess.run(
+        [sys.executable, str(LINT)], input=payload, capture_output=True, text=True,
+        env={"CLAUDE_PROJECT_DIR": str(tmp), "PATH": "/usr/bin:/bin",
+             "KIPI_BLOCKED_CLAIM_LINT_MODE": mode},
+        check=False)
+    return proc.returncode, proc.stderr
+
+
+def main() -> int:
+    if not LINT.exists():
+        print(f"FAIL: {LINT.name} does not exist yet (this is the RED state)")
+        return 1
+    mod = _load()
+    cases: list[tuple[str, bool]] = []
+
+    # === THE REPRODUCER: all six must be flagged, each as the right sub-shape ===
+    for label, text, want_pattern in CLAIMS:
+        found = mod.evaluate(text)
+        ok = len(found) == 1 and found[0].pattern == want_pattern
+        got = f"{[(f.pattern) for f in found]}"
+        cases.append((f"reproducer: {label} -> {want_pattern} (got {got})", ok))
+
+    # === THE NEGATIVE SELF-TEST: the same six, settled, must all pass ===
+    for (label, _, _), settled in zip(CLAIMS, SETTLED):
+        found = mod.evaluate(settled)
+        cases.append((f"settled: {label} passes (got {len(found)} finding(s))",
+                      found == []))
+
+    # === escape hatches ===
+    cases.append((
+        "labelled inference passes ({{UNVERIFIED}})",
+        mod.evaluate("- merge is blocked pending founder approval {{UNVERIFIED}}") == []))
+    cases.append((
+        "labelled inference passes (provenance: inferred)",
+        mod.evaluate("- the 10 Alice scripts are LIVE. provenance: inferred") == []))
+    cases.append((
+        "an ev- claim id passes",
+        mod.evaluate("- `degraded.state` does not exist (ev-a1b2c3d4e5)") == []))
+    cases.append((
+        "skip marker bypasses the whole answer",
+        mod.evaluate(
+            "- merge is blocked pending founder approval.\n"
+            f"- the scripts are LIVE.\n{mod.SKIP_MARKER}") == []))
+
+    # === it must not fire on ordinary prose ===
+    cases.append((
+        "prose with no state claim passes",
+        mod.evaluate("- Picked the branch-protection read as the next step.") == []))
+    cases.append((
+        "a question is not a claim",
+        mod.evaluate("- Is the merge blocked, or is that a roll-up? Checking now.") == []))
+
+    # === fence interiors are output, not claims ===
+    cases.append((
+        "command output inside a fence is not itself flagged",
+        mod.evaluate(
+            "- codex degraded state, checked:\n\n```\n"
+            "ls .prd-os/engines/codex/degraded.state\n"
+            "ls: no such file or directory\n```\n") == []))
+
+    # === a fence with a command but no output does not settle ===
+    cases.append((
+        "a command with no output does not settle the claim",
+        len(mod.evaluate(
+            "- merge is blocked pending founder approval.\n\n```\n"
+            "gh api repos/o/r/branches/main/protection\n```\n")) == 1))
+
+    # === a distant fence does not settle a claim it is not adjacent to ===
+    far = ("- merge is blocked pending founder approval.\n" + ("\nfiller\n" * 12) +
+           "```\ngh api repos/o/r/branches/main/protection\nnull\n```\n")
+    cases.append(("a fence far from the claim does not settle it",
+                  len(mod.evaluate(far)) == 1))
+
+    # === one settled claim does not launder an unsettled one ===
+    mixed = SETTLED[0] + "\n" + CLAIMS[4][1] + "\n"
+    found = mod.evaluate(mixed)
+    cases.append(("a settled claim does not launder an unsettled one",
+                  len(found) == 1 and found[0].pattern == "my-denial-as-object-property"))
+
+    # === remediation text is per-pattern, not generic ===
+    texts = {p.pattern_id: p.settles for p in mod.PATTERNS}
+    cases.append(("three distinct sub-shapes are named",
+                  len(mod.PATTERNS) == 3 and len(set(texts.values())) == 3))
+    cases.append(("each remediation prints a runnable command",
+                  all(any(line.strip().startswith(v) for line in t.splitlines()
+                          for v in mod.COMMAND_VERBS)
+                      for t in texts.values())))
+
+    # === exit-code contract: advisory ships first, blocking is opt-in ===
+    rc_adv, err_adv = run_hook(CLAIMS[0][1], mode="advisory")
+    cases.append(("advisory mode exits 0 on a finding", rc_adv == 0))
+    rc_blk, err_blk = run_hook(CLAIMS[0][1], mode="blocking")
+    cases.append(("blocking mode exits 2 on a finding", rc_blk == 2))
+    cases.append(("blocking stderr names the sub-shape",
+                  "rollup-as-config" in err_blk))
+    cases.append(("blocking stderr prints the settling command",
+                  "gh api" in err_blk))
+    rc_clean, _ = run_hook("- Picked the branch-protection read.", mode="blocking")
+    cases.append(("clean answer exits 0 in blocking mode", rc_clean == 0))
+    rc_loop, _ = run_hook_loop_guard()
+    cases.append(("stop_hook_active short-circuits (no block loop)", rc_loop == 0))
+
+    failures = 0
+    for name, ok in cases:
+        print(f"{'PASS' if ok else 'FAIL'}: {name}")
+        failures += 0 if ok else 1
+    print(f"\n{len(cases) - failures}/{len(cases)} passed")
+    return 1 if failures else 0
+
+
+def run_hook_loop_guard() -> tuple[int, str]:
+    tmp = Path(tempfile.mkdtemp())
+    transcript = tmp / "transcript.jsonl"
+    transcript.write_text(json.dumps(
+        {"message": {"role": "assistant",
+                     "content": [{"type": "text", "text": CLAIMS[0][1]}]}}) + "\n",
+        encoding="utf-8")
+    payload = json.dumps(
+        {"transcript_path": str(transcript), "stop_hook_active": True})
+    proc = subprocess.run(
+        [sys.executable, str(LINT)], input=payload, capture_output=True, text=True,
+        env={"CLAUDE_PROJECT_DIR": str(tmp), "PATH": "/usr/bin:/bin",
+             "KIPI_BLOCKED_CLAIM_LINT_MODE": "blocking"},
+        check=False)
+    return proc.returncode, proc.stderr
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/settings-template.json
+++ b/settings-template.json
@@ -287,6 +287,11 @@
           },
           {
             "type": "command",
+            "command": "if test -f \"$CLAUDE_PROJECT_DIR/q-system/.q-system/scripts/blocked-claim-evidence-lint.py\"; then python3 \"$CLAUDE_PROJECT_DIR/q-system/.q-system/scripts/blocked-claim-evidence-lint.py\"; fi",
+            "timeout": 15
+          },
+          {
+            "type": "command",
             "command": "if test -f \"$CLAUDE_PROJECT_DIR/q-system/.q-system/scripts/voice-stop-gate.py\"; then python3 \"$CLAUDE_PROJECT_DIR/q-system/.q-system/scripts/voice-stop-gate.py\"; fi",
             "timeout": 30
           },


### PR DESCRIPTION
Closes ASK-317 (do not merge until /issue-verify + /issue-closeout run).

## The hole

`evidence-ledger.md`'s four gates fire on client output, handoffs, and first writes.
**None fire on an agent-to-agent or agent-to-founder status report** — the exact
channel that carried six false "this is blocked" reports in one session on
2026-08-02. A correct, fully reviewed PR sat unmerged and two non-existent decisions
were put on the founder's plate. Every claim was settled later by a ten-second
command. The rule existed; its enforcement had a hole this shape.

## What shipped

`q-system/.q-system/scripts/blocked-claim-evidence-lint.py` — a Stop hook, the fifth
gate in the family. It flags a blocked / denied / unavailable / non-existent state
claim in the final answer with no command output next to it.

Three sub-shapes, each with its own remediation printing the command that settles it
(generic stderr teaches nothing):

| Sub-shape | The mistake | What settles it |
|---|---|---|
| `rollup-as-config` | a computed roll-up read as policy. `mergeStateStatus: BLOCKED` is derived from several inputs; it is not a record of who must approve | `gh api .../branches/<base>/protection --jq .required_pull_request_reviews` |
| `my-denial-as-object-property` | a refusal aimed at MY tool layer reported as a property of the object. "I can't" became "it can't" | run the command once; its own error text names the fix |
| `lookup-as-runtime-fact` | one lookup's result read as a runtime fact. Absence at one path is not absence; a reference is not a run | `find`/`grep` every declared path, then show the invocation or the run-log line |

Escape hatches are the family's usual ones: a fenced command+output block under the
claim, a provenance label (`{{UNVERIFIED}}` / `provenance: inferred`, via the shared
`provenance_vocabulary` table), or `blocked-claim-skip` on the answer.

## Reproducer first, observed RED

The six real claims, verbatim, are the reproducer.

```
python3 q-system/.q-system/scripts/test_blocked_claim_evidence_lint.py
FAIL: blocked-claim-evidence-lint.py does not exist yet (this is the RED state)
```

First implementation missed two of the six:

```
FAIL: reproducer: degraded.state absent -> lookup-as-runtime-fact (got [])
FAIL: reproducer: relay of the absence claim -> lookup-as-runtime-fact (got [])
28/30 passed
```

Cause: `[^.;]` in the `no <x> was written` trigger. The subject of that claim is
usually a FILENAME, and a filename carries a dot, so `degraded.state` fell outside
the class. Fixed to `[^;\n]` (sentence splitting already bounds the span). Green:

```
python3 q-system/.q-system/scripts/test_blocked_claim_evidence_lint.py
30/30 passed
```

## Negative self-test (this is a gate, not a wall)

The same six claims **with** their settling commands attached must all pass, and they
do (6/6). Also covered: a command with no output does not settle; a fence far from
the claim does not settle it; a settled claim does not launder the next one; a
question is not a claim; command output inside a fence is not itself flagged.

## Calibration — ships ADVISORY on purpose

`KIPI_BLOCKED_CLAIM_LINT_MODE` defaults to `advisory`: exit 0, findings appended to
`q-system/output/blocked-claim-lint.jsonl`. `blocking` (exit 2) is a one-word
promotion. A Stop hook that fires noisily trains the operator to skim, which costs
the real alert later.

The DoR asks for a week of real session output before blocking. **Real transcripts
live outside this worktree's read scope**, so that measurement runs off the advisory
log after ship. The adversarial stand-in available today, over the 48 densest
rules/skills files in the repo:

```
proxy corpus: 48 files, 13 findings, 8 files with >=1
        3  plugins/kipi-core/skills/rca/SKILL.md
        2  plugins/prd-os/skills/prd-os/SKILL.md
        2  plugins/kipi-core/skills/learn-from-correction/SKILL.md
        2  .claude/rules/rca-mode.md
```

Non-zero on prose that *discusses* blocking. That is exactly why it does not block yet.

## Wiring

- `.claude/settings.json` **and** `settings-template.json` Stop[1], right after
  `code_claim_grounding_guard.py`, behind the `test -f` no-op guard. Both, so
  `kipi update` ships the switch and not only the script.
- `q-system/.q-system/capability-manifest.json` — test registered (109 expected_tests).
- `settings-template-sync-check.py` exit 0; full lefthook pre-commit suite green.

## Not done, captured not mentioned

`evidence-ledger.md` still says "The four gates". The doc edit was **refused by the
sensitive-file permission gate** and was NOT routed around — a gate that is
inconvenient is a gate doing its job. Captured as `sp-46982eb9`; it needs a
founder-approved edit to bump four→five and add the sub-shape table.

## Open founder decision, surfaced not decided

The DoR names an unwritten arbitration rule between token-discipline's narrow
targeted reads and completeness, and proposes: *for blocking claims specifically, the
manifest is the tiebreaker — read all of the declared path*. This PR does not encode
that; it is a rule-level call.

## Honest boundaries (in the script's docstring)

- Checks that a claim DECLARES its evidence, not that the evidence is true.
- Evidence must FOLLOW the claim within 4 lines, or be inline provenance.
- A blocking claim phrased with none of the trigger words passes untouched. This is a
  keyword gate over a prose channel.
- Only fenced blocks count as command evidence — deliberately: claim #5
  (``gh pr merge`` is denied) quoted the command it had never run.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
