### PR TITLE
The review gate cannot be filled by a review that never ran, and the reviewer stops wearing our own config (ASK-274)

### DIFF
--- a/q-system/.q-system/capability-manifest.json
+++ b/q-system/.q-system/capability-manifest.json
@@ -62,6 +62,10 @@
       "runner": "bash"
     },
     {
+      "path": "q-system/.q-system/scripts/test/test-review-plan-echo-gate.sh",
+      "runner": "bash"
+    },
+    {
       "path": "q-system/.q-system/scripts/test/test-repo-preflight.sh",
       "runner": "bash"
     },

--- a/q-system/.q-system/scripts/pr-review-agent.sh
+++ b/q-system/.q-system/scripts/pr-review-agent.sh
@@ -509,9 +509,46 @@ run_engine() {   # run_engine <claude|codex> <destination-file>
     claude) run_bounded "$TIMEOUT_SECONDS" bash -c \
               "cd '$REVIEW_ROOT' && claude -p --model '$CLAUDE_MODEL' \"\$1\" </dev/null > '$2' 2>&1" _ "$PROMPT" ;;
     codex)  run_bounded "$TIMEOUT_SECONDS" bash -c \
-              "codex exec --skip-git-repo-check --model '$CODEX_MODEL' -C '$REVIEW_ROOT' \"\$1\" </dev/null > '$2' 2>&1" _ "$PROMPT" ;;
+              "codex exec --ignore-user-config --skip-git-repo-check --model '$CODEX_MODEL' -C '$REVIEW_ROOT' \"\$1\" </dev/null > '$2' 2>&1" _ "$PROMPT" ;;
   esac
 }
+
+# --ignore-user-config KEEPS OUR OWN AGENT CONFIG OUT OF THE REVIEWER (sp-cc9955db).
+# Without it, `codex exec` loads THIS FLEET'S config into the reviewer's session.
+# The 2026-08-03 artifact shows it announcing "I'm using the assaf-voice,
+# audhd-executive-function, and fable-discipline skills", firing SessionStart and
+# UserPromptSubmit hooks, and then applying the founder's own "state your planned
+# approach and wait for OK before executing" rule TO ITS OWN REVIEW. It answered
+# with a plan in 12 seconds and reviewed nothing. sp-df1a458f is what that did to
+# the gate downstream: the echoed prompt template became the findings block.
+#
+# THE REVIEWER'S WHOLE VALUE IS THAT IT IS NOT US. A reviewer wearing the author's
+# skills, voice rules and hooks is not the independent second opinion this engine
+# exists to buy -- it is the same mental model with a different model id, which is
+# the correlated-blind-spot problem the codex engine was chosen to escape.
+#
+# THE CWD ISOLATION DOES NOT COVER IT. `-C $REVIEW_ROOT` already runs the review in
+# a detached worktree and the round-1 artifact shows the same config loading anyway:
+# it resolves from the USER HOME, not from the project directory, so no amount of
+# cwd isolation reaches it.
+#
+# WHAT THIS FLAG ACTUALLY BUYS, MEASURED, NOT ASSUMED (2026-08-03, same prompt run
+# twice against codex v0.146.0 from a neutral cwd):
+#     without the flag:  12 `hook: ` lines   -- SessionStart/UserPromptSubmit/Stop
+#     with the flag:      0 `hook: ` lines
+# The hooks are the layer that injected the plan-and-await instruction, and they
+# are gone. It is NOT total isolation: the "Skill descriptions were shortened to
+# fit the 2% skills context budget" warning appears in BOTH runs, so codex can
+# still SEE the skill catalogue with the flag set. Claiming this severs skills
+# would be an overclaim; captured separately rather than asserted here.
+#
+# NOT `--disable skills`: that flag does not exist on this codex build and errors
+# with "Unknown feature flag: skills", which would send every review down the Opus
+# fallback and mark the gate DEGRADED fleet-wide.
+#
+# sp-df1a458f's guard is the backstop either way: if a future codex build finds a
+# new road to the same behaviour, review_is_usable refuses the stream instead of
+# letting it fill a required check.
 
 
 # A codex answer is usable only if it carries a COMPLETE machine-readable block

--- a/q-system/.q-system/scripts/pr-review-agent.sh
+++ b/q-system/.q-system/scripts/pr-review-agent.sh
@@ -513,19 +513,26 @@ run_engine() {   # run_engine <claude|codex> <destination-file>
   esac
 }
 
-# A codex answer is usable only if it carries a COMPLETE machine-readable block.
-# A truncated review that green-lights a PR nobody read is the worst outcome
-# available in this script.
+
+# A codex answer is usable only if it carries a COMPLETE machine-readable block
+# AND is actually a review. A truncated -- or unstarted -- stream that green-lights
+# a PR nobody read is the worst outcome available in this script.
 #
-# THE PREDICATE NOW LIVES IN THE LIB, next to the reader that defines it
+# THE PREDICATE LIVES IN THE LIB, next to the reader that defines it
 # (sp-c0a9dac3). Its own two-marker grep here was a SECOND definition of
 # "complete": both markers, anywhere, in any order. That passes a review whose
 # only complete block is a quoted prior round while the real trailing block is
 # truncated -- unusable stays off, the gate goes green, and the verdict comes from
 # findings the review itself withdrew. One definition, one reader.
-review_has_complete_findings_block() {
-  has_complete_findings_block "$1"
-}
+#
+# IT NOW ASKS review_is_usable, WHICH IS A WIDER QUESTION (sp-df1a458f). Block
+# completeness alone said YES to a stream where the model answered "Reply `OK`
+# and I'll execute exactly that plan" and the only complete block was the
+# PROMPT'S OWN echoed template. Both dispatch sites below call this, and the
+# second one -- the Opus fallback -- is where this exact class hid last time.
+# No local wrapper: both sites call review_is_usable directly. The wrapper existed
+# only to forward to the lib, and a forwarder is one more place the two dispatch
+# paths can be made to disagree about the same file.
 
 # PAGE ON THE TRANSITION ONLY. A ping every run while codex stays down is the
 # cry-wolf failure: it trains the operator to skim, which costs the real alert
@@ -557,7 +564,7 @@ if [ "$ENGINE" != "codex" ]; then
     exit "$rc"
   fi
 elif run_engine codex "$REVIEW"; then
-  if review_has_complete_findings_block "$REVIEW"; then
+  if review_is_usable "$REVIEW"; then
     note_degraded_transition 0
     echo "$(TS) review written: $REVIEW"
   else
@@ -589,7 +596,7 @@ else
     # block, which derives APPROVE and would post state=success on the REQUIRED
     # context. Filling the gate with an unread approval is worse than leaving it
     # unstated, because unstated holds the PR and green releases it.
-    if review_has_complete_findings_block "$REVIEW"; then
+    if review_is_usable "$REVIEW"; then
       echo "$(TS) DEGRADED review written by the Opus fallback: $REVIEW"
     else
       REVIEW_UNUSABLE=1

--- a/q-system/.q-system/scripts/pr-verdict-lib.sh
+++ b/q-system/.q-system/scripts/pr-verdict-lib.sh
@@ -85,15 +85,105 @@ extract_verdict() {
 # awk, not sed, because the rule is stateful in two ways a range expression cannot
 # express: opening a new block discards an unclosed one, and the end-of-input state
 # decides whether any of it counts.
+# A BLOCK OF NOTHING BUT PLACEHOLDERS IS THE PROMPT, NOT THE REVIEW (sp-df1a458f).
+# The reviewer prompt ends with a literal template -- `severity|one-sentence
+# claim|file:line` between the two markers -- and `codex exec` echoes the whole
+# prompt to stdout. When the model answers with a PLAN instead of a review, that
+# echo is the ONLY complete block in the stream. Measured 2026-08-03 on Alice PR
+# #1 round 2: the block was accepted, `severity|` matched no severity, no
+# severities derived APPROVE, and kipi/reviewer-approved -- a REQUIRED context on
+# main -- went green on code nobody had read, 12 seconds after dispatch.
+#
+# The rule is NOT "reject a block with no severity rows": an EMPTY block is
+# legitimate and load-bearing (a round 2 that refutes everything closes with one;
+# test-severity-floor.sh and test-findings-block-reader.sh case 2 both pin it).
+# The discriminator is rows-that-are-not-findings:
+#
+#   zero rows                      -> legitimate empty block, kept
+#   >=1 row, >=1 a real severity   -> a real block, kept
+#   >=1 row, NONE a real severity  -> the template echo (or prose leaked into the
+#                                     block); not a findings block, skipped
+#
+# Skipped, not fatal: an earlier COMPLETE real block still stands, because the
+# echo arrives BEFORE the model's own answer. Truncation is unchanged -- a block
+# still open at EOF voids everything, which is the stricter case and stays.
+#
+# THE SEVERITY TOKENS HERE ARE THE SAME FOUR verdict_from_findings GRADES, and
+# they have to be: a row this function calls real but the derivation cannot grade
+# contributes nothing, so the block would count as usable and derive APPROVE --
+# the defect again, one layer down. Change the two together or not at all.
 findings_block() {
   local f="$1"
   [ -s "$f" ] || return 0
   awk '
-    /^FINDINGS:/            { buf = $0 "\n"; open = 1; next }
-    open && /^END FINDINGS/ { last = buf $0 "\n"; open = 0; next }
-    open                    { buf = buf $0 "\n" }
+    /^FINDINGS:/            { buf = $0 "\n"; open = 1; rows = 0; sev = 0; next }
+    open && /^END FINDINGS/ { if (rows == 0 || sev > 0) last = buf $0 "\n"
+                              open = 0; next }
+    open                    { buf = buf $0 "\n"
+                              if ($0 ~ /^[ \t]*$/) next
+                              rows++
+                              if ($0 ~ /^(blocker|major|minor|nit)[|]/) sev++
+                              next }
     END                     { if (open) exit 0; printf "%s", last }
   ' "$f" 2>/dev/null
+}
+
+# _text_after_last_findings_block <review-file>
+# Everything the stream said AFTER its last `END FINDINGS`, or the whole file when
+# there is no block at all. The prompt orders the block LAST ("Last, a
+# machine-readable findings block"), so this is the region a finished review has
+# nothing substantive in -- which is what makes it the right place to look for an
+# answer that never started. Internal to review_declined_to_start.
+_text_after_last_findings_block() {
+  awk '/^END FINDINGS/ { tail = ""; next } { tail = tail $0 "\n" }
+       END { printf "%s", tail }' "${1:-}" 2>/dev/null
+}
+
+# review_declined_to_start <review-file>
+# True when the reviewer answered with a PLAN and waited for confirmation instead
+# of reviewing. Exit 0 = it declined (the review is not a review).
+#
+# WHY THIS IS SEPARATE FROM THE BLOCK CHECK (sp-df1a458f, half b). Rejecting the
+# placeholder block is not enough on its own. From round 2 the stream carries the
+# PREVIOUS round's findings for the model to re-prove, so a decline can arrive
+# wrapped around a structurally perfect block full of REAL severity rows. Grading
+# those derives a verdict from findings the reviewer never examined: it wedges the
+# PR on a blocker the author may already have fixed, which is the false-BLOCK half
+# of this defect and costs as much as a false green.
+#
+# ANCHORED AFTER THE LAST BLOCK, NOT ANYWHERE IN THE FILE. A genuine review of
+# THIS script quotes plan-and-await prose in its findings -- that is a real review
+# and must land. Because the prompt puts the block last, decline language after it
+# is the model's own closing answer rather than something it was reading about.
+# Over-refusal here wedges PRs exactly as hard as under-refusal releases them,
+# so the window matters as much as the phrases.
+#
+# The phrases are the two shapes actually recorded ("Reply `OK` and I'll execute
+# exactly that plan." / "Waiting for `OK` to execute the review plan.") plus the
+# nearest generalisations. A herestring, not a pipe: `printf ... | grep -q` returns
+# 141 under `set -o pipefail` when grep exits on the first match before the write
+# finishes, which reads as NO MATCH on exactly the long inputs this sees.
+review_declined_to_start() {
+  local f="${1:-}" tail
+  [ -s "$f" ] || return 1
+  tail="$(_text_after_last_findings_block "$f")"
+  [ -n "$tail" ] || return 1
+  grep -qiE "waiting[[:space:]]+for[[:space:]]+[\`'\"]?(an[[:space:]]+)?(ok|go[- ]ahead|confirmation|approval)|reply[[:space:]]+[\`'\"]?ok[\`'\"]?[[:space:]]+(and|so|then)|say[[:space:]]+[\`'\"]?(ok|go)[\`'\"]?[[:space:]]+and[[:space:]]+i|awaiting[[:space:]]+(your[[:space:]]+)?(confirmation|approval|go[- ]ahead)" <<<"$tail"
+}
+
+# review_is_usable <review-file>
+# THE ONE QUESTION pr-review-agent.sh asks before it lets a stream fill the gate:
+# did a review actually happen here? Both dispatch sites (codex, and the Opus
+# fallback -- where this class last hid, ASK-221) gate on this single predicate,
+# so the two paths cannot drift into different answers about the same file.
+#
+# Usable means BOTH: a complete findings block that is not the prompt's own
+# template, AND an answer that did not stop to ask permission. Either one alone
+# lets a review that never ran set a REQUIRED status.
+review_is_usable() {
+  local f="${1:-}"
+  has_complete_findings_block "$f" || return 1
+  ! review_declined_to_start "$f"
 }
 
 # has_complete_findings_block <review-file>

--- a/q-system/.q-system/scripts/test/test-review-plan-echo-gate.sh
+++ b/q-system/.q-system/scripts/test/test-review-plan-echo-gate.sh
@@ -1,0 +1,263 @@
+#!/usr/bin/env bash
+# Reproducer for sp-df1a458f: a review that NEVER RAN must never fill the gate.
+# Pairs with review_is_usable() / findings_block() in pr-verdict-lib.sh.
+#
+# THE DEFECT (measured 2026-08-03, Alice PR #1 round 2). `codex exec` answered
+# with a PLAN and no review -- "Reply `OK` and I'll execute exactly that plan." /
+# "Waiting for `OK` to execute the review plan." -- in 12 seconds of wall clock.
+# Its stdout carries the ECHOED PROMPT, and the prompt contains a literal
+#
+#     FINDINGS:
+#     severity|one-sentence claim|file:line
+#     END FINDINGS
+#
+# template. That echo was the only COMPLETE block in the stream, so:
+#   has_complete_findings_block -> true   (REVIEW_UNUSABLE never set)
+#   verdict_from_findings       -> APPROVE ("severity|" matches no severity, and
+#                                           no severities means nothing was wrong)
+# and pr-review-agent.sh posted kipi/reviewer-approved=success -- a REQUIRED
+# context on main -- for code no reviewer had read. The script's own docstring
+# says "Filling the gate with an unread approval is worse than leaving it
+# unstated". This is that, exactly.
+#
+# TWO INDEPENDENT HOLES, and case 5 is why one fix is not enough:
+#   (a) a block whose only rows are the prompt's PLACEHOLDER is not a review.
+#   (b) a plan-and-await answer is not a review even when a parseable block IS
+#       present -- and from round 2 the stream carries prior-round findings the
+#       model never re-proved, so (a) alone would derive a verdict from them.
+#
+# WHY NOT "REQUIRE A SEVERITY ROW". An empty block is LEGITIMATE: a round 2 that
+# refutes every round-1 finding closes with one, and rejecting it would mark a
+# real review DEGRADED for finding nothing. Cases 2 and 3 pin that contract, and
+# they run BEFORE the defect cases so a reader that returned nothing at all --
+# which would "pass" every defect case -- fails here first.
+#
+# FIXTURE PROVENANCE. Case 4 is a VERBATIM slice of the real captured payload
+# (~/.config/kipi/pr-reviews/codex/NOT-A-REVIEW-plan-only-echoed-template-*.txt),
+# trimmed to the shape that drives the parse. Two scrubs, both required because
+# this repo is PUBLIC: the founder's home path is replaced with <WORKDIR>, and
+# the loaded-skill line is kept as the one line it is (it is evidence for the
+# sibling defect) with no skill bodies. Neither scrub touches a byte the parser
+# reads.
+#
+# Point it at the pre-fix lib to watch it fail:
+#   KIPI_TEST_LIB_REF=origin/main bash test-review-plan-echo-gate.sh
+set -uo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+ROOT="$(cd "$SCRIPT_DIR/../../../.." && pwd)"
+REF="${KIPI_TEST_LIB_REF:-}"
+
+PASS=0
+ok()   { PASS=$((PASS+1)); echo "  ok: $1"; }
+fail() { echo "FAIL: $1" >&2; exit 1; }
+
+W="$(mktemp -d)"
+trap 'rm -rf "$W"' EXIT
+
+if [ -n "$REF" ]; then
+  git -C "$ROOT" show "$REF:q-system/.q-system/scripts/pr-verdict-lib.sh" > "$W/lib.sh" \
+    || fail "cannot read pr-verdict-lib.sh at ref $REF"
+  echo "lib under test: ref $REF"
+else
+  cp "$SCRIPT_DIR/../pr-verdict-lib.sh" "$W/lib.sh" || fail "cannot copy the lib"
+  echo "lib under test: working tree"
+fi
+LIB="$W/lib.sh"
+# shellcheck disable=SC1090
+. "$LIB"
+
+# A pre-fix lib has no review_is_usable at all. Shim it to the predicate the
+# script used THEN, so the ref hatch exercises the OLD decision instead of dying
+# on an unbound function -- a test that errors out is not a test that failed.
+if ! declare -F review_is_usable >/dev/null 2>&1; then
+  echo "  (no review_is_usable in this lib -- falling back to has_complete_findings_block,"
+  echo "   which is exactly the decision the pre-fix script made)"
+  review_is_usable() { has_complete_findings_block "$1"; }
+fi
+
+# --- 1. NEGATIVE SELF-TEST: the ordinary review still works -------------------
+# A predicate hard-wired to "unusable" would pass every defect case below while
+# wedging every real PR in the repo. Assert the normal path first.
+cat > "$W/normal.md" <<'EOF'
+## VERDICT: APPROVE WITH NITS
+
+FINDINGS:
+minor|help text omits --engine|q-system/x.sh:9
+minor|the retry loop drops the last error|q-system/x.sh:12
+END FINDINGS
+EOF
+[ "$(verdict_from_findings "$W/normal.md")" = "APPROVE WITH NITS" ] \
+  || fail "the ordinary two-minor review derived '$(verdict_from_findings "$W/normal.md")'.
+      Every case below would pass vacuously."
+review_is_usable "$W/normal.md" \
+  || fail "the ordinary two-minor review was called UNUSABLE. Every open PR would wedge."
+ok "an ordinary review with two minors is usable and derives APPROVE WITH NITS"
+
+# --- 2. NEGATIVE SELF-TEST: a legitimately EMPTY block still derives APPROVE --
+# THE CONTRACT THIS FIX MUST NOT BREAK, pinned by name in test-severity-floor.sh
+# and test-findings-block-reader.sh case 2. "Reviewed, found nothing" and "never
+# started" are byte-identical INSIDE the block, so the discriminator has to be
+# something other than row-counting -- which is the whole design of the fix.
+cat > "$W/empty-block.md" <<'EOF'
+I re-ran round 1's reproducer. It does not reproduce: the delete path is behind
+the destructive-op hook, which exits 2 before the command is built.
+
+## What is sound
+
+I attacked the claim path with a concurrent second writer and it held.
+
+## VERDICT: APPROVE
+
+FINDINGS:
+END FINDINGS
+EOF
+GOT="$(verdict_from_findings "$W/empty-block.md")"
+[ "$GOT" = "APPROVE" ] \
+  || fail "a real review that refuted everything and closed with an EMPTY block derived '$GOT'.
+      Rejecting the empty block routes a real review to the fallback engine and marks the
+      status DEGRADED for finding nothing -- the opposite of what finding nothing means."
+review_is_usable "$W/empty-block.md" \
+  || fail "a real review closing with a legitimately EMPTY block was called UNUSABLE.
+      This is the round-2-refutes-everything shape; it must be able to land."
+ok "a legitimately EMPTY findings block is still usable and still derives APPROVE"
+
+# --- 3. NEGATIVE SELF-TEST: a real review may TALK about plans and OK ---------
+# The decline detector keys on the reviewer's own closing answer. A genuine
+# review that QUOTES plan-and-await prose -- reviewing this very script, say --
+# must not be thrown away. Over-refusal is the false-BLOCK half of this defect
+# and it wedges PRs just as hard as a false green.
+cat > "$W/quotes-a-plan.md" <<'EOF'
+The prompt in pr-review-agent.sh tells the model to reply `OK` before starting,
+and I am waiting for OK is exactly the failure mode this PR is about. I could
+reproduce it:
+
+FINDINGS:
+major|the reviewer prompt lets a plan-only answer satisfy the gate|q-system/.q-system/scripts/pr-review-agent.sh:512
+END FINDINGS
+EOF
+review_is_usable "$W/quotes-a-plan.md" \
+  || fail "a GENUINE review that quotes plan-and-await prose inside its findings was thrown
+      away. The detector must key on the reviewer's own closing answer, not on any
+      appearance of the words anywhere in the file."
+[ "$(verdict_from_findings "$W/quotes-a-plan.md")" = "REQUEST CHANGES" ] \
+  || fail "the genuine review quoting plan prose derived '$(verdict_from_findings "$W/quotes-a-plan.md")'"
+ok "a genuine review that QUOTES plan-and-await prose is still usable"
+
+# --- 4. THE DEFECT (a): the echoed prompt template is not a review ------------
+cat > "$W/plan-only.md" <<'EOF'
+Reading additional input from stdin...
+OpenAI Codex v0.146.0
+--------
+workdir: <WORKDIR>/review-trees/pr-1
+model: gpt-5.6-sol
+provider: openai
+approval: never
+--------
+user
+You are a SENIOR STAFF ENGINEER at Meta. You have NEVER seen this codebase before.
+
+- **VERDICT:** decided by THIS RULE, not by feel:
+    - any blocker or major finding      => REQUEST CHANGES (BLOCK only if merging
+      as-is would cause permanent or unrecoverable damage)
+    - only minor/nit findings           => APPROVE WITH NITS
+    - no finding survived reproduction  => APPROVE
+- **Last, a machine-readable findings block**, EXACTLY this shape, one line per
+  finding, empty block if none. The pipeline parses it; keep prose out of it:
+
+FINDINGS:
+severity|one-sentence claim|file:line
+END FINDINGS
+hook: SessionStart
+hook: UserPromptSubmit Completed
+codex
+I'm using the `assaf-voice`, `audhd-executive-function`, and `fable-discipline` skills to keep the review crisp, evidence-first, and reproducible.
+
+Plan:
+
+- **Deep Focus - 30-45 min:** Read the PR and diff cold, inspect real producer shapes, and run adversarial repros from $TMPDIR without modifying the repo.
+
+Reply `OK` and I'll execute exactly that plan.
+codex
+Waiting for `OK` to execute the review plan.
+hook: Stop
+tokens used
+15,255
+Waiting for `OK` to execute the review plan.
+EOF
+
+# The exact three symptoms, asserted separately so a partial fix cannot hide.
+BLOCK_OUT="$(findings_block "$W/plan-only.md")"
+case "$BLOCK_OUT" in
+  *"severity|one-sentence claim|file:line"*)
+    fail "THE DEFECT (sp-df1a458f, a): findings_block returned the PROMPT'S OWN TEMPLATE as
+      the review's findings:
+$BLOCK_OUT
+      The echoed prompt is the only complete block in a plan-only answer, so the placeholder
+      row becomes the review. It matches no severity, and no severities derives APPROVE." ;;
+esac
+ok "the echoed prompt template is not returned as a findings block"
+
+GOT="$(verdict_from_findings "$W/plan-only.md")"
+[ -z "$GOT" ] \
+  || fail "THE DEFECT (sp-df1a458f, a): a review that never ran derived verdict '$GOT'.
+      Anything non-empty here reaches the gate: APPROVE posts state=success on a REQUIRED
+      context for unread code, and a verdict resolved from the ECHOED RULE TEXT
+      ('REQUEST CHANGES' appears in the prompt) wedges a PR nobody reviewed either.
+      A review that never ran has NO verdict."
+ok "a plan-only answer derives no verdict at all (not APPROVE, not REQUEST CHANGES)"
+
+if review_is_usable "$W/plan-only.md"; then
+  fail "THE DEFECT (sp-df1a458f): the plan-only answer was counted USABLE, so REVIEW_UNUSABLE
+      is never set and the gate is filled from it."
+fi
+ok "the plan-only answer is classified UNUSABLE"
+
+# --- 5. THE DEFECT (b): a decline is not a review EVEN WITH a real block ------
+# This is why the block fix alone is not enough. From round 2 the stream carries
+# prior-round findings, so a decline can arrive with a structurally perfect block
+# full of REAL severity rows the model never re-proved. Case 4 passes on the
+# block rule; this one can only pass if the decline itself is detected.
+cat > "$W/decline-with-real-block.md" <<'EOF'
+user
+## THIS IS REVIEW ROUND 2 OF THIS PR
+
+Round 1 raised these, and you must re-prove each one:
+
+FINDINGS:
+blocker|the worker deletes the claim file on a failed push|q-system/.q-system/scripts/linear-worker.sh:88
+END FINDINGS
+codex
+Plan:
+
+- **Deep Focus - 30-45 min:** Re-run round 1's reproducers before retaining anything.
+
+Reply `OK` and I'll execute exactly that plan.
+codex
+Waiting for `OK` to execute the review plan.
+tokens used
+15,255
+EOF
+if review_is_usable "$W/decline-with-real-block.md"; then
+  fail "THE DEFECT (sp-df1a458f, b): a plan-and-await answer carrying round 1's UNRE-PROVEN
+      findings was counted usable. Its verdict then comes from findings the reviewer never
+      examined -- '$(verdict_from_findings "$W/decline-with-real-block.md")' here -- which
+      wedges the PR on a finding that may already be fixed. A decline is not a review no
+      matter how parseable the stream around it is."
+fi
+ok "a decline carrying a REAL prior-round block is still UNUSABLE"
+
+# --- 6. the decision is WIRED, not merely available --------------------------
+# A green predicate proves nothing if pr-review-agent.sh still calls the old one
+# at its dispatch sites. Both the codex path and the Opus fallback path gate on
+# the same chokepoint; the fallback path is where this class last hid (ASK-221).
+AGENT="$ROOT/q-system/.q-system/scripts/pr-review-agent.sh"
+[ -f "$AGENT" ] || fail "pr-review-agent.sh not found at $AGENT"
+CALLS="$(grep -c 'review_is_usable "\$REVIEW"' "$AGENT")"
+[ "$CALLS" = "2" ] \
+  || fail "pr-review-agent.sh gates on review_is_usable at $CALLS of its 2 dispatch sites
+      (the codex path and the Opus fallback). A site still calling the old predicate accepts
+      a plan-only answer, which is the whole defect."
+ok "both dispatch sites in pr-review-agent.sh gate on review_is_usable"
+
+echo "PASS ($PASS checks)"


### PR DESCRIPTION
`q-system/.q-system/scripts/pr-review-agent.sh` owns `kipi/reviewer-approved`, a
REQUIRED context on main. It was wrong in both directions: shipping unreviewed
code AND wedging good code. Two defects, one commit each, both reproduced first.

## Defect 1 — false APPROVE (sp-df1a458f) — `787b6f5`

On Alice PR #1 round 2, codex answered with a PLAN and no review ("Reply `OK` and
I'll execute exactly that plan.") in 12 seconds. Its stdout carries the echoed
prompt, and the prompt ends with a literal `severity|one-sentence claim|file:line`
template between the two markers. That echo was the only COMPLETE block in the
stream:

    has_complete_findings_block -> true      (REVIEW_UNUSABLE never set)
    verdict_from_findings       -> APPROVE   (no severities means nothing was wrong)

...and `kipi/reviewer-approved=success` was posted on code nobody read.

Measured on `origin/main` before touching anything:

    findings_block           -> FINDINGS:\nseverity|one-sentence claim|file:line\nEND FINDINGS
    has_complete_findings... -> TRUE (usable)
    verdict_from_findings    -> [APPROVE]
    extract_verdict          -> [REQUEST CHANGES]   <- from the ECHOED RULE TEXT

That last line is the both-directions part: the "stated" verdict is the prompt's
own grading rule, not the reviewer's. A fix that merely prefers the harsher side
turns this into a false BLOCK and wedges a PR nobody reviewed. The correct answer
is UNSTATED.

Two independent holes, both closed:

- **(a)** `findings_block` skips a block whose rows exist but contain no gradeable
  severity. An EMPTY block stays legitimate and still derives APPROVE — that is
  the round-2-refutes-everything shape, pinned by `test-severity-floor.sh` and
  `test-findings-block-reader.sh` case 2. The discriminator is
  rows-that-are-not-findings, never row-counting.
- **(b)** `review_declined_to_start`: a plan-and-await answer is not a review even
  when a parseable block IS present. From round 2 the stream carries prior-round
  findings, so (a) alone would grade findings the reviewer never re-proved. It is
  anchored AFTER the last block (the prompt orders the block last), so a genuine
  review that QUOTES plan prose still lands.

`review_is_usable` is the one predicate both dispatch sites gate on — the codex
path and the Opus fallback, where this class hid last time (ASK-221).

## Defect 2 — root cause (sp-cc9955db) — `98cf566`

Why codex answered with a plan at all: `codex exec` loaded THIS FLEET'S config
into the reviewer's session — assaf-voice, audhd-executive-function,
fable-discipline, SessionStart and UserPromptSubmit hooks — and then applied the
founder's own "state your planned approach and wait for OK" rule to its own
review. The existing `-C $REVIEW_ROOT` worktree isolation does not reach it; the
config resolves from the user home.

Proven by observation, same prompt, neutral cwd, codex v0.146.0:

    without --ignore-user-config:  12 `hook: ` lines
    with    --ignore-user-config:   0 `hook: ` lines

**Stated narrowly on purpose.** This is not total isolation. The "Skill
descriptions were shortened to fit the 2% skills context budget" warning appears
in BOTH runs, so codex still sees the skill catalogue with the flag set. The hooks
were the layer carrying the plan-and-await instruction and they are gone; claiming
the flag severs skills would be an overclaim. Captured as its own item, not
bundled here.

## Verification

    test-review-plan-echo-gate.sh   before: FAIL at case 4    after: PASS (8 checks)
    KIPI_TEST_LIB_REF=origin/main   FAILS at case 4 (the test can fail)
    test-findings-block-reader.sh   PASS 9/9
    test-severity-floor.sh          PASS 198/198

The reproducer runs three NEGATIVE self-tests first (ordinary review; legitimately
empty block; genuine review quoting plan prose), so a predicate hard-wired to
"unusable" fails there instead of passing the defect cases.

No commit status was posted to any PR during this work.

## Overlap to resolve before merge

PR #76 (ASK-312) touches the same region with `resolve_verdict`. It is
complementary, not duplicate — it fixes stated-vs-derived disagreement, which does
not fire when a plan-only answer states no verdict at all. Whichever lands second
will need a small merge in `pr-review-agent.sh`'s verdict block.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
