### PR TITLE
A PR the reviewer refused gets re-entered, and rework is told from re-review (ASK-352)

### DIFF
--- a/kipi-dispatch.sh
+++ b/kipi-dispatch.sh
@@ -847,6 +847,44 @@ if [ -f "$REDRIVE" ]; then
   fi
 fi
 
+# --- REVIEWER REDRIVE (ASK-352) ----------------------------------------------
+# The OTHER half of a failing status check. ci-redrive.py above deliberately
+# EXCLUDES the reviewer's own verdict slots from what it calls red CI, and that
+# exclusion stays -- including them re-dispatched PRs whose build was passing
+# (PR #73, live). But its docstring justified the exclusion by asserting the
+# reviewer's Linear comment already caused a re-dispatch, and no such selector
+# existed. Six PRs sat parked ~29 hours. This is that selector: one consumer per
+# event, neither reading the other's slot.
+#
+# AFTER ci-redrive AND ONLY IF IT PASSED. Red CI outranks a reviewer refusal --
+# a build that does not compile makes any review of it moot, and re-reviewing a
+# broken tree spends a codex call to be told the build is broken.
+#
+# TWO ACTIONS, NOT ONE, and this is the whole reason the selector exists. A
+# `failure` on the reviewer slot means either "someone objected" (rework: the
+# review is the spec) or "nobody read the code" (re-review: there is no spec).
+# The verdict does not separate them -- PR #80 recorded REQUEST CHANGES from the
+# prompt's own echoed grading rule. review-redrive.py reads the `usable` key
+# pr-review-agent.sh now persists, and answers with the action.
+#
+# rc 2 (gh could not answer) leaves the fresh pick standing, same as above.
+REVIEW_REDRIVE="$REPO/q-system/.q-system/scripts/review-redrive.py"
+REVIEW_ACTION=""; REVIEW_NEXT=""; REVIEW_PR=""; REVIEW_SHA=""
+if [ -z "$REDRIVE_NEXT" ] && [ -f "$REVIEW_REDRIVE" ]; then
+  REVIEW_LINE="$(python3 "$REVIEW_REDRIVE" --repo-dir "$TARGET_PATH" select 2>>"$LOG")"
+  REVIEW_RC=$?
+  if [ "$REVIEW_RC" = "0" ] && [ -n "$REVIEW_LINE" ]; then
+    REVIEW_ACTION="$(printf '%s' "$REVIEW_LINE" | cut -f1)"
+    REVIEW_NEXT="$(printf '%s' "$REVIEW_LINE" | cut -f2)"
+    REVIEW_PR="$(printf '%s' "$REVIEW_LINE" | cut -f3)"
+    REVIEW_SHA="$(printf '%s' "$REVIEW_LINE" | cut -f4)"
+    say "reviewer redrive: $REVIEW_NEXT PR #$REVIEW_PR needs $REVIEW_ACTION${NEXT:+ ($NEXT waits)}"
+    NEXT="$REVIEW_NEXT"
+  elif [ "$REVIEW_RC" = "2" ]; then
+    say "reviewer redrive: gh could not read PR state in $TARGET_NAME -- fresh pick stands, nothing claimed"
+  fi
+fi
+
 if [ -z "$NEXT" ]; then
   say "nothing ready ($(printf '%s' "$WORK_OUT" | grep -oE '[0-9]+ ready issue' | head -1))"
   exit 0
@@ -893,6 +931,21 @@ if [ -n "$REDRIVE_SIG" ] && [ "$NEXT" = "$REDRIVE_NEXT" ]; then
   fi
 fi
 
+# Same contract for the reviewer redrive (ASK-352): the OFFER above wrote
+# nothing, and THIS is the atomic claim. rc non-zero means another run owns it,
+# or the ledger could not be written -- the same answer either way, because
+# nothing was recorded so nothing may act as though it was. The cap is one
+# attempt per PR per action per HEAD SHA, so a PR that pushes a real fix is
+# eligible again while a re-review that keeps coming back phantom at the same sha
+# is not retried.
+if [ -n "$REVIEW_ACTION" ] && [ "$NEXT" = "$REVIEW_NEXT" ]; then
+  if ! python3 "$REVIEW_REDRIVE" mark-dispatched --issue "$NEXT" \
+       --action "$REVIEW_ACTION" --pr "$REVIEW_PR" --head-sha "$REVIEW_SHA" 2>>"$LOG"; then
+    say "reviewer redrive: the $REVIEW_ACTION attempt for $NEXT PR #$REVIEW_PR is already claimed -- not dispatching"
+    exit 0
+  fi
+fi
+
 # Count BEFORE launching. Counting after would let a crash between the two
 # hand out a free dispatch every heartbeat -- the budget must fail closed.
 printf '%s' "$((DISPATCHED_TODAY + 1))" > "$COUNT_FILE"
@@ -928,8 +981,30 @@ CONVERGE_LOG="$HOME/.config/kipi/converge-$NEXT.log"
 printf '\n===== dispatch %s  %s  rounds=%s =====\n' \
   "$NEXT" "$(date -u +%Y-%m-%dT%H:%M:%SZ)" "$MAX_ROUNDS" >> "$CONVERGE_LOG"
 
+# WHAT THIS DISPATCH ACTUALLY RUNS (ASK-352). Converge for everything except a
+# reviewer redrive that asked for a RE-REVIEW, where the right action is another
+# review and not another rework round: the PR is parked because nobody read the
+# code, so there are no findings for a converge to work from and it would come
+# back to this same failing slot having spent a full round.
+#
+# --post is required and is the point. Without it the reviewer writes a verdict
+# record and never touches the commit status, so the slot that parked the PR
+# stays failing and the next heartbeat picks the same PR again -- a loop that
+# looks like progress. --invoker labels it dispatcher-driven (sp-53aad86f), so a
+# hand-run review can never pass as evidence the loop closed itself.
+#
+# ONE ARRAY, EXPANDED ONCE BELOW. The launch machinery underneath (setsid, the
+# pid capture, the liveness assert) is proven and is not duplicated per action;
+# only the argv differs.
+DISPATCH_ARGV=(./kipi converge --issue "$NEXT" --max-rounds "$MAX_ROUNDS")
+if [ "$REVIEW_ACTION" = "re-review" ] && [ "$NEXT" = "$REVIEW_NEXT" ]; then
+  DISPATCH_ARGV=(bash "$REPO/q-system/.q-system/scripts/pr-review-agent.sh" \
+                 "$REVIEW_PR" --issue "$NEXT" --post)
+  export KIPI_REVIEW_INVOKER="dispatcher"
+fi
+
 CHILD_PID="$(python3 - "$CONVERGE_LOG" \
-         ./kipi converge --issue "$NEXT" --max-rounds "$MAX_ROUNDS" <<'PY'
+         "${DISPATCH_ARGV[@]}" <<'PY'
 import subprocess, sys
 log_path, argv = sys.argv[1], sys.argv[2:]
 # Append, never truncate: a re-dispatch of the same issue must not erase the

--- a/q-system/.q-system/capability-manifest.json
+++ b/q-system/.q-system/capability-manifest.json
@@ -450,6 +450,10 @@
     {
       "path": "q-system/.q-system/scripts/test/test-review-gate-no-fake-green.sh",
       "runner": "bash"
+    },
+    {
+      "path": "q-system/.q-system/scripts/test/test-verdict-usability.sh",
+      "runner": "bash"
     }
   ],
   "required_data": [],

--- a/q-system/.q-system/capability-manifest.json
+++ b/q-system/.q-system/capability-manifest.json
@@ -454,6 +454,10 @@
     {
       "path": "q-system/.q-system/scripts/test/test-verdict-usability.sh",
       "runner": "bash"
+    },
+    {
+      "path": "q-system/.q-system/scripts/test/test-review-redrive.sh",
+      "runner": "bash"
     }
   ],
   "required_data": [],

--- a/q-system/.q-system/capability-manifest.json
+++ b/q-system/.q-system/capability-manifest.json
@@ -458,6 +458,10 @@
     {
       "path": "q-system/.q-system/scripts/test/test-review-redrive.sh",
       "runner": "bash"
+    },
+    {
+      "path": "q-system/.q-system/scripts/test/test-verdict-statement-shape.sh",
+      "runner": "bash"
     }
   ],
   "required_data": [],

--- a/q-system/.q-system/scripts/attempts-ledger.py
+++ b/q-system/.q-system/scripts/attempts-ledger.py
@@ -397,6 +397,29 @@ def _run(path, op, rest, ts):
         (issue,) = _args(op, rest, 1)
         _mutate(path, lambda d: op_clear(d, issue, ("drift_rounds", "drift_paged", "last_drift")))
         return 0
+    if op == "clear-flag":                # clear-flag <issue> <flag>
+        # THE UNDO FOR A FLAG CLAIMED BY MISTAKE, and it exists because one was
+        # (ASK-352). review-redrive.py's `select` was documented read-only and
+        # called ci-redrive's `ledger_recorded`, which is a WRITE wearing a
+        # reader's name -- it runs claim-flag and answers True on rc 0 (just
+        # claimed) as well as rc 1 (already claimed). One read-only invocation
+        # claimed 14 flags, and a claimed flag suppresses the dispatch it stands
+        # for, so 13 PRs were silently made ineligible for a redrive that had
+        # never happened.
+        #
+        # Without this op the only remedies were hand-editing the ledger --
+        # around the single writer and the lock, which is how two runs corrupt it
+        # -- or renaming the flag scheme to strand the bad rows as permanent
+        # garbage. Both are worse than an op that goes through _mutate like
+        # every other write. Same family as clear-conflict / clear-drift /
+        # clear-automerge above.
+        #
+        # Idempotent: clearing an unset flag is 0 and writes nothing meaningful,
+        # so a caller does not have to know the current state to be correct.
+        issue, flag = _args(op, rest, 2)
+        _mutate(path, lambda d: op_clear(d, issue, (flag,)))
+        return 0
+
     if op == "claim-flag":                # claim-flag <issue> <flag> -> 0 first time, 1 after
         issue, flag = _args(op, rest, 2)
         claimed = _mutate(path, lambda d: op_claim(d, issue, flag))

--- a/q-system/.q-system/scripts/pr-review-agent.sh
+++ b/q-system/.q-system/scripts/pr-review-agent.sh
@@ -697,15 +697,48 @@ echo "  verdict: ${VERDICT:-unstated}"
 # directory only for a non-primary engine; for the gating engine the reviews live
 # in $OUT_DIR/codex (its own round counter) while the record must land in $OUT_DIR
 # where converge.sh and linear-worker.sh actually read it.
-python3 - "$PR" "$ISSUE" "$VERDICT" "$REVIEW" "$(TS)" "$STATED_VERDICT" "$DERIVED_VERDICT" "$ROUND" "$HEAD_SHA" "$VERDICT_DIR" "$ENGINE" "$INVOKER" <<'PY'
+# DID A REVIEW ACTUALLY HAPPEN, PERSISTED (sp-2a832233, ASK-352). The record used
+# to store only a PATH to the review, and the review files rotate, so every
+# consumer downstream had to re-derive usability from a file it does not own --
+# or, in practice, guess from the verdict.
+#
+# THE VERDICT DOES NOT ANSWER IT. Measured across all 79 records on 2026-08-03:
+# 13 were unusable and they carry the whole range of verdicts. `APPROVE` on 11 of
+# them (all merged); `REQUEST CHANGES` on #80 and #83; empty on #89. The
+# REQUEST CHANGES pair is the expensive one: the reviewer's `stated` verdict was
+# read out of the PROMPT'S OWN echoed grading rule, so a record that says an
+# objection was raised is indistinguishable from one where nobody read the code.
+# Both post `state: failure`, and a selector that sees only `failure` sends a
+# never-reviewed PR to REWORK with no findings to work from.
+#
+# ASKED HERE, NOT REUSED FROM $REVIEW_UNUSABLE. That flag is set on the codex and
+# fallback paths only -- the `ENGINE != codex` primary path never evaluates
+# usability at all -- so reading it would record `usable: true` for a path that
+# never checked, which is the fabricated-evidence direction. One call, the same
+# predicate on the same file the verdict came from, covering all three paths.
+#
+# RECORD-ONLY, DELIBERATELY. This changes no gate. $VERDICT is computed above and
+# is not touched here, so no PR's outcome moves on this commit; the consumer that
+# acts on the key is the selector (review-redrive.py), which is a separate change
+# with its own cap. Widening a gate as a side effect of adding a field is how a
+# fleet-wide refusal ships unannounced.
+if review_is_usable "$REVIEW"; then REVIEW_USABLE=1; else REVIEW_USABLE=0; fi
+
+python3 - "$PR" "$ISSUE" "$VERDICT" "$REVIEW" "$(TS)" "$STATED_VERDICT" "$DERIVED_VERDICT" "$ROUND" "$HEAD_SHA" "$VERDICT_DIR" "$ENGINE" "$INVOKER" "$REVIEW_USABLE" <<'PY'
 import json, sys
-pr, issue, verdict, review, ts, stated, derived, rnd, head_sha, verdict_dir, engine, invoker = sys.argv[1:13]
+(pr, issue, verdict, review, ts, stated, derived, rnd, head_sha, verdict_dir,
+ engine, invoker, usable) = sys.argv[1:14]
 out = f"{verdict_dir}/pr-{pr}.verdict.json"
 json.dump({"pr": int(pr), "issue": issue, "verdict": verdict,
            "stated": stated, "derived": derived,
            "source": "findings" if derived else "prose",
            "engine": engine,
            "invoker": invoker,
+           # A real boolean, not "1"/"0". A JSON string "0" is TRUTHY in every
+           # consumer language here, so a truthiness read of the wrong shape
+           # would call every phantom review usable -- the exact inversion this
+           # key exists to prevent.
+           "usable": usable == "1",
            "round": int(rnd), "review": review, "head_sha": head_sha,
            "ts": ts}, open(out, "w"), indent=2)
 PY

--- a/q-system/.q-system/scripts/pr-verdict-lib.sh
+++ b/q-system/.q-system/scripts/pr-verdict-lib.sh
@@ -32,14 +32,90 @@
 # That misread actually reached the record: pr-11.verdict.json read BLOCK while
 # the review said REQUEST CHANGES. Both route to rework so behavior survived,
 # but "APPROVE (not BLOCK...)" would have reworked an approved PR forever.
+# A VERDICT STATEMENT, NOT A LINE MENTIONING THE WORD (ASK-356). This used to
+# anchor on the first line matching `VERDICT`, take the first verdict token within
+# three lines, and fall back to grepping the WHOLE FILE for a token. All three
+# steps read the reviewer's conclusion out of text the reviewer did not write.
+#
+# `codex exec` ECHOES THE ENTIRE PROMPT to stdout, and the reviewer prompt carries
+# its own grading rule:
+#
+#     - **VERDICT:** decided by THIS RULE, not by feel:
+#         - any blocker or major finding      => REQUEST CHANGES
+#
+# That line is the first `VERDICT` match in every codex review ever produced, so
+# extract_verdict returned REQUEST CHANGES universally. Measured 2026-08-03: 47 of
+# 54 records carried stated=REQUEST CHANGES. It was cosmetic while
+# VERDICT="$DERIVED_VERDICT" won unconditionally, and became fleet-blocking the
+# moment ASK-312 made resolve_verdict take the HARSHER of stated and derived --
+# every codex-reviewed PR held at REQUEST CHANGES on a REQUIRED context. Codex
+# called this exact consequence on PR #89 and we shipped anyway; the answer was
+# always "keep resolve_verdict AND fix this", not one or the other.
+#
+# SHAPE FIRST, AND DELIBERATELY NOT "TAKE THE LAST MATCH" (review steer, ASK-356).
+# Copying findings_block's LAST-NOT-FIRST wholesale would be a second position
+# rule, and anchoring on position is what produced this bug. The grading rule is
+# not distinguished by WHERE it sits. It is distinguished by not being a
+# statement: a statement puts the verdict token DIRECTLY after the marker, while
+# the rule puts prose there. So the token must lead what follows `VERDICT:`, or
+# follow a marker that is bare (`## VERDICT` on its own line -- the real PR #11
+# round 4 shape, which also self-qualifies as `**REQUEST CHANGES** (not BLOCK...)`
+# and must still read REQUEST CHANGES).
+#
+# ORDER IS STILL NEEDED, FOR A DIFFERENT INPUT. The stream also replays the PR's
+# DIFF, so a review of a change to this loop contains real verdict statements the
+# reviewer is only quoting -- this file's own fixtures are exactly that. Those are
+# statement-shaped because they ARE quoted statements; shape cannot separate them.
+# The reviewer answers after the material it was given, so among candidates that
+# PASS the shape test the last one wins. Shape rejects the prompt; order resolves
+# the quotes. Neither alone is enough and the two are not the same rule.
+#
+# THE WHOLE-FILE FALLBACK IS GONE. With the echo present it scanned the prompt and
+# the diff for loose tokens, which is how source code gets parsed as a verdict
+# (`REWORK_VERDICTS = {"REQUEST CHANGES", ...}` is in the diff of this very
+# change). Losing it means a review that never states a verdict now reads
+# unstated, and unstated posts state=failure and HOLDS the PR. That is the safe
+# direction and the same posture the rest of this file takes.
+#
+# BLOCKER/BLOCKERS is still stripped before token matching: "Fix first: **BLOCKER
+# 1**" after a verdict line made a bare BLOCK match report verdict BLOCK on the
+# real PR #11 round 2 payload.
 extract_verdict() {
-  local f="$1" v=""
+  local f="$1"
   [ -s "$f" ] || return 0
-  v="$(grep -A3 -E 'VERDICT' "$f" 2>/dev/null | sed 's/BLOCKERS\{0,1\}//g' \
-        | grep -oE 'APPROVE WITH NITS|REQUEST CHANGES|APPROVE|BLOCK' | head -1)"
-  [ -n "$v" ] || v="$(sed 's/BLOCKERS\{0,1\}//g' "$f" 2>/dev/null \
-        | grep -oE 'APPROVE WITH NITS|REQUEST CHANGES|APPROVE|BLOCK' | head -1)"
-  printf '%s' "$v"
+  awk '
+    function leading_token(s,   t) {
+      sub(/^[[:space:]*_]+/, "", s)
+      if (s ~ /^APPROVE WITH NITS/) return "APPROVE WITH NITS"
+      if (s ~ /^REQUEST CHANGES/)   return "REQUEST CHANGES"
+      if (s ~ /^APPROVE/)           return "APPROVE"
+      if (s ~ /^BLOCK/)             return "BLOCK"
+      return ""
+    }
+    {
+      line = $0
+      gsub(/BLOCKERS?/, "", line)
+    }
+    # Under a bare heading the FIRST non-blank line decides, and it decides either
+    # way: prose there is not a verdict, it is a heading with no statement under
+    # it. Continuing to scan would walk into the next paragraph.
+    awaiting {
+      if (line ~ /^[[:space:]]*$/) next
+      awaiting = 0
+      t = leading_token(line)
+      if (t != "") found = t
+      next
+    }
+    line ~ /VERDICT/ {
+      rest = line
+      sub(/^.*VERDICT[*_]*[[:space:]]*:?[[:space:]]*/, "", rest)
+      t = leading_token(rest)
+      if (t != "") { found = t; next }
+      # Bare marker: nothing but punctuation/emphasis left on the line.
+      if (rest ~ /^[[:space:]*_:#-]*$/) awaiting = 1
+    }
+    END { if (found != "") printf "%s", found }
+  ' "$f" 2>/dev/null
 }
 
 # findings_block <review-file>

--- a/q-system/.q-system/scripts/review-redrive.py
+++ b/q-system/.q-system/scripts/review-redrive.py
@@ -104,6 +104,7 @@ import argparse
 import importlib.util
 import json
 import os
+import re
 import subprocess
 import sys
 
@@ -304,6 +305,41 @@ def flag(cand):
                                   cand["pr"], (cand["head_sha"] or "nohead")[:12])
 
 
+def reviewer_live(pr):
+    """True if pr-review-agent.sh is reviewing THIS PR in the process table now.
+
+    THE SYMMETRIC GATE TO converge_live, AND IT WAS MISSING (codex round 4 on
+    PR #91, major). `mark-dispatched` claims the attempt flag the instant a
+    re-review is handed out; pr-review-agent.sh then runs for 3-8 minutes. Every
+    heartbeat inside that window read the flag as set, called the one attempt
+    spent, and escalated -- paging about an outcome that did not exist yet. And
+    because escalate() is once per PR per action per sha, THE FALSE PAGE ATE THE
+    REAL ONE: the actual result, whatever it turned out to be, could never page.
+
+    converge_live's own docstring already named this hazard ("a false page that
+    also burns the once-per-signature flag is not [recoverable]"). REWORK was
+    gated on it from the start and REREVIEW never was -- two paths, one guarded,
+    which is this repo's recurring class.
+
+    AN UNREADABLE TABLE ANSWERS TRUE, the same direction converge_live errs in
+    and for the same reason. Reading "I cannot see the process table" as
+    "nothing is running" is the direction that FIRES the false page, and the
+    false page is the unrecoverable outcome; skipping one heartbeat is not.
+    """
+    table = CI.process_table()
+    if table is None:
+        sys.stderr.write(
+            "review-redrive: could not read the process table -- treating the "
+            "reviewer as live, offering nothing.\n")
+        return True
+    # `(?:\s|$)` with MULTILINE so a live review of PR #1010 does not read as a
+    # review of #101 -- the same boundary converge_live's pattern guards for
+    # `--issue ASK-29` against `ASK-295`.
+    pattern = re.compile(
+        r"pr-review-agent\.sh\s+%s(?:\s|$)" % re.escape(str(pr)), re.MULTILINE)
+    return bool(pattern.search(table))
+
+
 def escalate_flag(cand):
     return "review_escalated_%s_pr%s_%s" % (
         cand["action"].replace("-", ""), cand["pr"],
@@ -360,14 +396,28 @@ def cmd_select(cands, show_all):
 
     path = CI.attempts_path()
     for c in cands:
+        # IN-FLIGHT GATES, BOTH ACTIONS, BEFORE THE LEDGER IS READ. Each action
+        # launches a different long-running process, so each needs its own
+        # liveness question -- but the reason is one reason, and the ledger read
+        # below must not be reached while the work it reports on is still going.
+        #
         # A rework becomes a converge on the issue, so a converge already live for
         # it means the work is in flight and offering it would cost the fresh pick
-        # its slot (ci-redrive PR #73 r2, finding 2). A re-review launches the
-        # reviewer, not a converge, so it is not gated on that.
+        # its slot (ci-redrive PR #73 r2, finding 2).
         if c["action"] == REWORK and CI.converge_live(c["issue"]):
             sys.stderr.write(
                 "review-redrive: %s PR #%s needs rework but a converge for it is "
                 "already live -- not offering it.\n" % (c["issue"], c["pr"]))
+            continue
+        # A re-review launches pr-review-agent.sh on the PR, not a converge on the
+        # issue, so it asks the process table a different question -- and for a
+        # while it asked none at all. The comment that used to sit here said a
+        # re-review "is not gated on that" and stopped, reading the absence of the
+        # converge gate as a decision rather than a gap. See reviewer_live.
+        if c["action"] == REREVIEW and reviewer_live(c["pr"]):
+            sys.stderr.write(
+                "review-redrive: %s PR #%s needs re-review but a reviewer for it "
+                "is already live -- not offering it.\n" % (c["issue"], c["pr"]))
             continue
         # A READ. NOT ci-redrive's `ledger_recorded`, which is a WRITE wearing a
         # reader's name: it calls `claim-flag` and answers True on rc 0 (just

--- a/q-system/.q-system/scripts/review-redrive.py
+++ b/q-system/.q-system/scripts/review-redrive.py
@@ -292,6 +292,51 @@ def flag(cand):
                                   cand["pr"], (cand["head_sha"] or "nohead")[:12])
 
 
+def escalate_flag(cand):
+    return "review_escalated_%s_pr%s_%s" % (
+        cand["action"].replace("-", ""), cand["pr"],
+        (cand["head_sha"] or "nohead")[:12])
+
+
+def escalate(path, cand):
+    """The ONE message about this PR, and only after the machine tier is spent.
+
+    WHY IT EXISTS (codex review of PR #91, major). Without it, the spent-attempt
+    branch above just wrote a stderr line and moved on, so a PR that got its one
+    redrive and stayed failing was silently ignored forever. That is the exact
+    defect this whole selector was built to kill -- a terminal state with no
+    consumer -- reintroduced one level down, inside the fix for it. A cap with no
+    escalation is not a cap, it is a quieter version of the 29-hour park.
+
+    ONCE PER PR PER ACTION PER HEAD SHA, matching the attempt flag it reports on.
+    The dispatcher reaches this state on every heartbeat for as long as the PR
+    sits failing, so paging per run is a page every 15 minutes about one fact
+    that has not changed -- the cry-wolf failure that trains the reader to skim.
+    Keyed on the sha and not on the PR alone because a push is new information:
+    the next sha earns its own attempt and, if that also fails, its own page.
+
+    EVERY CLAUSE IS AN OBSERVATION. It says which action was spent and what the
+    reviewer's record actually holds now, because the two failures look identical
+    from outside and the reader's next move is different for each: a spent
+    RE-REVIEW that is still unusable means the reviewer cannot review this PR at
+    all, while a spent REWORK still refused means the agent could not satisfy it.
+
+    The claim is the gate: `ledger_claim` is False if another run already paged,
+    and False on a lock timeout or write failure -- nothing was recorded, so
+    nothing may act as though it was, and the next run pages instead.
+    """
+    if not CI.ledger_claim(path, cand["issue"], escalate_flag(cand)):
+        return False
+    CI.notify(
+        "review-redrive: %s PR #%s still has %s failing after the machine tier. "
+        "What the machine tried: one %s at %s. The reviewer's record now reads "
+        "%s. %s"
+        % (cand["issue"], cand["pr"], ", ".join(cand["slots"]), cand["action"],
+           (cand["head_sha"] or "an unknown head")[:8], cand["reason"],
+           cand["url"]))
+    return True
+
+
 def cmd_select(cands, show_all):
     if not cands:
         return 1
@@ -332,6 +377,7 @@ def cmd_select(cands, show_all):
                 "review-redrive: %s PR #%s already had its one %s attempt at %s "
                 "-- not offering it again.\n"
                 % (c["issue"], c["pr"], c["action"], (c["head_sha"] or "?")[:8]))
+            escalate(path, c)   # machine tier spent and the slot is STILL failing
             continue
         sys.stderr.write("review-redrive: %s PR #%s -> %s (%s)\n"
                          % (c["issue"], c["pr"], c["action"], c["reason"]))

--- a/q-system/.q-system/scripts/review-redrive.py
+++ b/q-system/.q-system/scripts/review-redrive.py
@@ -312,7 +312,22 @@ def cmd_select(cands, show_all):
                 "review-redrive: %s PR #%s needs rework but a converge for it is "
                 "already live -- not offering it.\n" % (c["issue"], c["pr"]))
             continue
-        if CI.ledger_recorded(path, c["issue"], flag(c)):
+        # A READ. NOT ci-redrive's `ledger_recorded`, which is a WRITE wearing a
+        # reader's name: it calls `claim-flag` and answers True on rc 0 (just
+        # claimed) OR rc 1 (already claimed). Using it here made `select` claim
+        # every candidate the first time it ran and then skip all of them for
+        # having been claimed -- so the selector reported "already had its one
+        # attempt" for 14 PRs on its first ever invocation and offered nothing.
+        # A selector that silently offers nothing is indistinguishable from the
+        # 29-hour park it was built to end. Caught by the live acceptance run,
+        # not by the 13 unit cases, because those all used `--all`, which returns
+        # before the ledger is touched.
+        #
+        # `get` is the only read op the ledger exposes; op_claim stores `True`,
+        # so a set flag reads back as the string "True" and an unset one as the
+        # default. Empty default, not "0": "0" is a non-empty string and would
+        # make every unset flag read as recorded, which is this same bug again.
+        if CI.ledger_get(path, c["issue"], flag(c)):
             sys.stderr.write(
                 "review-redrive: %s PR #%s already had its one %s attempt at %s "
                 "-- not offering it again.\n"

--- a/q-system/.q-system/scripts/review-redrive.py
+++ b/q-system/.q-system/scripts/review-redrive.py
@@ -257,6 +257,18 @@ def classify(record, head_sha):
 def candidates(repo_dir, records_dir):
     out = []
     for pr_obj in CI.list_prs(repo_dir):
+        # A DRAFT IS THE AUTHOR SAYING NOT YET, and re-entering one spends a
+        # converge round or a codex call on a tree nobody asked to be judged.
+        #
+        # THE DOCSTRING CLAIMED THIS AND THE CODE DID NOT DO IT (codex round 2 on
+        # PR #91, minor). It also claimed "same rule as ci-redrive", and
+        # ci-redrive does not filter drafts either -- it fetches `isDraft` in
+        # PR_FIELDS and never reads it. So the comment was wrong twice, which is
+        # the exact defect class this whole selector exists because of: ci-redrive
+        # excluded the reviewer slots on the strength of a sentence asserting
+        # something no code did. Captured separately for ci-redrive's own copy.
+        if pr_obj.get("isDraft"):
+            continue
         attributed = CI.attribute(pr_obj)
         if attributed is None:
             continue

--- a/q-system/.q-system/scripts/review-redrive.py
+++ b/q-system/.q-system/scripts/review-redrive.py
@@ -1,0 +1,363 @@
+#!/usr/bin/env python3
+"""The machine consumer for a PR the REVIEWER refused (ASK-352).
+
+WHY THIS FILE EXISTS
+--------------------
+Six PRs sat parked for ~29 hours with `kipi/codex-approved: FAILURE`. Nothing in
+this repo looks at a PR in that state, so nothing ever re-entered it.
+
+`ready()` in linear-worker.sh returns backlog/unstarted issues only, and an issue
+with a live PR is In Progress -- so the fresh-pick path cannot see it.
+ci-redrive.py deliberately EXCLUDES the reviewer's own verdict slots
+(`kipi/reviewer-approved`, `kipi/<engine>-approved`) from what it calls red CI,
+and that exclusion is CORRECT and stays: including them re-dispatched PRs whose
+build was passing (PR #73, live). But the exclusion rests on a claim in its own
+docstring --
+
+    "It is also already handled: the reviewer comments on the Linear issue and
+     the worker re-dispatches from there."
+
+-- and that is false. There is no such selector. The exclusion was right about
+what ci-redrive should not do and wrong about what something else was doing.
+This is that something else. Two consumers, one event each, neither reading the
+other's slot.
+
+THE THREE STATES A REQUIRED CONTEXT CAN BE IN, AND WHO OWNS EACH
+----------------------------------------------------------------
+    ABSENT  (never posted)            -> ASK-318 producer + ASK-313 detector
+    SUCCESS (but nothing merges)      -> ASK-310, pr-land-if-green.sh
+    FAILURE (the reviewer refused)    -> here
+
+ASK-310 scopes to "CLEAN with all required contexts SUCCESS" and cannot touch a
+failing context; ASK-318 scopes to absence and calls absence a correct refusal.
+The gap was named in ASK-310's own checklist ("alarm on a required context ABSENT
+past N minutes, distinct from failing") and never built.
+
+FAILURE IS TWO OPPOSITE THINGS, AND THE VERDICT DOES NOT SEPARATE THEM
+-----------------------------------------------------------------------
+This is the whole difficulty, and it is why sp-2a832233 had to land first.
+
+    PR #82 -- a real review, one real major, REQUEST CHANGES.
+              Someone objected. There are findings to work.   -> REWORK
+    PR #80 -- codex echoed the prompt's own FINDINGS template and answered
+              "Reply `OK` and I'll execute". Nobody read the code, and the
+              record ALSO says REQUEST CHANGES.               -> RE-REVIEW
+
+Measured over all 79 verdict records on 2026-08-03: 13 unusable, carrying every
+verdict in the range -- APPROVE on 11 (all merged), REQUEST CHANGES on #80 and
+#83, empty on #89. #80's `stated` verdict was lifted out of the PROMPT'S grading
+rule, echoed to stdout by `codex exec`, so it is byte-identical to a real
+objection. A selector reading the verdict, or reading the `failure` status it
+produces, hands a never-reviewed PR to an agent with nothing to fix -- which
+burns a rework round and ends in the same failure state, forever.
+
+The only reliable signal is `review_is_usable()` (ASK-274) on the review FILE.
+pr-review-agent.sh now persists that answer as `usable` in the record, so this
+script reads a stored fact rather than re-deriving one from a file it does not
+own and that rotates away.
+
+WHERE USABILITY COMES FROM, RANKED, AND NEVER FROM A REIMPLEMENTATION
+---------------------------------------------------------------------
+1. `usable` in the record (records written from ASK-352 onward).
+2. Otherwise, if the review file still exists: ask the LIB, by sourcing
+   pr-verdict-lib.sh and running review_is_usable. Not a Python port of it. A
+   second implementation of "did a review happen" is exactly the drift
+   pr-verdict-lib.sh was extracted to end, and it would drift toward permissive.
+3. Otherwise UNKNOWN -> treated as NOT usable, i.e. re-review.
+
+Direction of that last error, deliberately: a needless re-review costs one codex
+call and produces a real verdict. A needless rework costs a full converge round
+against a review with no findings in it and lands back here. The cap below bounds
+the first; nothing bounds the second except the cap it would waste.
+
+WHAT IT REFUSES TO TOUCH
+------------------------
+- A PR with no verdict record at all. That is ABSENT, and it belongs to
+  ASK-318/ASK-313. Manufacturing a review for a PR whose producer never ran would
+  paper over the missing producer, which is the harder and more important bug.
+- A PR whose reviewer slot is not currently FAILURE. A stale record next to a
+  green slot means a newer review already landed.
+- A PR that is a draft, or not attributable to an agent+issue. Same rule as
+  ci-redrive: an unrecognised branch owner is a human's branch, left alone.
+
+THE CAP, AND WHY IT IS KEYED ON THE SHA
+---------------------------------------
+One attempt per PR per action per HEAD SHA, in the same flock'd attempts ledger
+(attempts-ledger.py) ci-redrive and the worker use. Keyed on the sha and not on a
+failure signature because the failure here is always the same string -- the slot
+name -- so a signature would collapse to one attempt per PR forever, and a PR
+that pushed a real fix could never be re-reviewed.
+
+The consequence is the honest one: a re-review that comes back unusable AGAIN at
+the same sha is not retried. It escalates once and stops. Retrying a phantom is
+how the loop that burned 29 hours started.
+
+THE OFFER IS NOT THE CLAIM (ci-redrive PR #73 review, finding 2)
+----------------------------------------------------------------
+`select` writes nothing. The dispatcher calls `mark-dispatched` immediately before
+it launches, past every guard that can still abort, and THAT call is the atomic
+claim: rc 0 means it is yours, rc non-zero means someone else has it or the ledger
+could not be written -- the same answer, because nothing was recorded.
+"""
+
+import argparse
+import importlib.util
+import json
+import os
+import subprocess
+import sys
+
+HERE = os.path.dirname(os.path.abspath(__file__))
+LIB = os.path.join(HERE, "pr-verdict-lib.sh")
+DEFAULT_RECORDS = os.path.join(
+    os.path.expanduser("~"), ".config", "kipi", "pr-reviews")
+
+
+def _load_ci_redrive():
+    """Import ci-redrive.py for the parts both selectors must agree on.
+
+    IMPORTED, NOT COPIED. `is_reviewer_slot` is the single definition of which
+    contexts belong to the reviewer: ci-redrive EXCLUDES exactly that set and this
+    script SELECTS exactly that set. Two hand-maintained copies of one regex is
+    how a slot ends up owned by both consumers or by neither, and "owned by
+    neither" is the 29-hour park this file exists to end.
+
+    `attribute`, `list_prs` and `converge_live` come along for the same reason:
+    the attribution rules (branch tail, then PR title, never a guess) cost a
+    defect each to get right and must not be re-derived here.
+    """
+    path = os.path.join(HERE, "ci-redrive.py")
+    spec = importlib.util.spec_from_file_location("ci_redrive", path)
+    mod = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(mod)
+    return mod
+
+
+CI = _load_ci_redrive()
+
+# Verdicts that mean a human-equivalent reviewer objected and left a spec behind.
+# Kept as a literal set rather than "not an approval": an EMPTY verdict is not an
+# objection, it is an unstated one, and routing empty to rework is precisely the
+# #89 mistake (the review never ran, so there is nothing to rework toward).
+REWORK_VERDICTS = {"REQUEST CHANGES", "BLOCK"}
+
+REWORK = "rework"
+REREVIEW = "re-review"
+
+
+def record_path(records_dir, pr):
+    return os.path.join(records_dir, "pr-%s.verdict.json" % pr)
+
+
+def read_record(records_dir, pr):
+    try:
+        with open(record_path(records_dir, pr)) as fh:
+            return json.load(fh)
+    except (OSError, ValueError):
+        return None
+
+
+def usable_from_lib(review_file):
+    """Ask pr-verdict-lib.sh, the one definition, or None if it cannot answer.
+
+    None is a THIRD answer and callers must not fold it into False-with-confidence
+    -- it is folded into "treat as not usable" one level up, where the reason is
+    recorded, so a legacy record and a genuinely phantom review do not report the
+    same cause to the operator.
+    """
+    if not review_file or not os.path.exists(review_file):
+        return None
+    if not os.path.exists(LIB):
+        return None
+    proc = subprocess.run(
+        ["bash", "-c",
+         '. "$1" >/dev/null 2>&1 || exit 2; review_is_usable "$2"',
+         "_", LIB, review_file],
+        capture_output=True, text=True)
+    if proc.returncode == 2:
+        return None
+    return proc.returncode == 0
+
+
+def usability(record):
+    """(is_usable, why) for a verdict record.
+
+    `usable` is a real JSON boolean from ASK-352 onward. It is checked with `is
+    None` and not with truthiness on purpose: the key can legitimately be False,
+    and `if not record.get("usable")` reads a present-and-False the same as an
+    absent key, which would send every phantom down the legacy path and report
+    the wrong reason for the same action.
+    """
+    stored = record.get("usable")
+    if stored is not None:
+        return bool(stored), "record"
+    probed = usable_from_lib(record.get("review", ""))
+    if probed is None:
+        return False, "unknown (pre-ASK-352 record, review file gone)"
+    return probed, "probed the review file"
+
+
+def reviewer_slot_failing(pr_obj):
+    """The reviewer slot names that are FAILURE on this PR right now.
+
+    Both halves of the rollup, same as ci-redrive's failing_checks -- the verdict
+    is posted as a StatusContext today, and a name rule that guards one half is a
+    rule that stops working the day the producer changes shape.
+    """
+    names = []
+    for check in pr_obj.get("statusCheckRollup") or []:
+        if not isinstance(check, dict):
+            continue
+        if check.get("__typename") == "StatusContext":
+            context = check.get("context") or ""
+            if CI.is_reviewer_slot(context) and \
+                    (check.get("state") or "").upper() in CI.FAILED_STATES:
+                names.append(context)
+            continue
+        name = check.get("name") or ""
+        if not CI.is_reviewer_slot(name):
+            continue
+        if (check.get("status") or "").upper() != "COMPLETED":
+            continue
+        if (check.get("conclusion") or "").upper() in CI.FAILED_CONCLUSIONS:
+            names.append(name)
+    return sorted(names)
+
+
+def classify(record, head_sha):
+    """(action, reason) for a PR whose reviewer slot is failing.
+
+    DRIFT OUTRANKS THE VERDICT, same posture rework_gate takes for exit 40: a
+    verdict is a statement about a diff at a moment, and if the head moved the
+    statement is about code that is no longer there. Re-review first; the fresh
+    record then decides. Absent is not drift -- a record with no head_sha predates
+    ASK-216 and falls through to the verdict, because reading absent-as-drift
+    would re-review every parked PR on the board at once.
+    """
+    is_usable, why = usability(record)
+    if not is_usable:
+        return REREVIEW, "the review never ran (%s)" % why
+
+    reviewed_sha = (record.get("head_sha") or "").strip()
+    if reviewed_sha and head_sha and reviewed_sha != head_sha:
+        return REREVIEW, "reviewed %s but head is now %s" % (
+            reviewed_sha[:8], head_sha[:8])
+
+    verdict = (record.get("verdict") or "").strip()
+    if verdict in REWORK_VERDICTS:
+        return REWORK, "reviewer said %s at the current head" % verdict
+    if not verdict:
+        # A usable review that stated nothing. Rare, and it is still not a spec:
+        # there are no findings to work from, so the answer is another review,
+        # never a rework round guessing at what to change.
+        return REREVIEW, "the review is usable but states no verdict"
+    return None, "verdict %s is not a refusal" % verdict
+
+
+def candidates(repo_dir, records_dir):
+    out = []
+    for pr_obj in CI.list_prs(repo_dir):
+        attributed = CI.attribute(pr_obj)
+        if attributed is None:
+            continue
+        issue, agent, source = attributed
+        slots = reviewer_slot_failing(pr_obj)
+        if not slots:
+            continue
+        pr = pr_obj.get("number")
+        record = read_record(records_dir, pr)
+        if record is None:
+            # ABSENT, not FAILURE-with-no-record. Owned by ASK-318/ASK-313.
+            sys.stderr.write(
+                "review-redrive: PR #%s has %s failing but NO verdict record -- "
+                "that is the absent-producer case (ASK-318), not this one. "
+                "Left alone.\n" % (pr, ",".join(slots)))
+            continue
+        head_sha = pr_obj.get("headRefOid") or ""
+        action, reason = classify(record, head_sha)
+        if action is None:
+            continue
+        out.append({
+            "action": action, "reason": reason, "issue": issue, "agent": agent,
+            "issue_source": source, "pr": pr, "url": pr_obj.get("url"),
+            "branch": pr_obj.get("headRefName"), "head_sha": head_sha,
+            "slots": slots,
+        })
+    return out
+
+
+def flag(cand):
+    """One attempt per PR per action per head sha. See the module docstring."""
+    return "review_%s_pr%s_%s" % (cand["action"].replace("-", ""),
+                                  cand["pr"], (cand["head_sha"] or "nohead")[:12])
+
+
+def cmd_select(cands, show_all):
+    if not cands:
+        return 1
+    if show_all:
+        for c in cands:
+            print("%s\t%s\t%s\t%s\t%s" % (
+                c["action"], c["issue"], c["pr"], c["head_sha"], c["reason"]))
+        return 0
+
+    path = CI.attempts_path()
+    for c in cands:
+        # A rework becomes a converge on the issue, so a converge already live for
+        # it means the work is in flight and offering it would cost the fresh pick
+        # its slot (ci-redrive PR #73 r2, finding 2). A re-review launches the
+        # reviewer, not a converge, so it is not gated on that.
+        if c["action"] == REWORK and CI.converge_live(c["issue"]):
+            sys.stderr.write(
+                "review-redrive: %s PR #%s needs rework but a converge for it is "
+                "already live -- not offering it.\n" % (c["issue"], c["pr"]))
+            continue
+        if CI.ledger_recorded(path, c["issue"], flag(c)):
+            sys.stderr.write(
+                "review-redrive: %s PR #%s already had its one %s attempt at %s "
+                "-- not offering it again.\n"
+                % (c["issue"], c["pr"], c["action"], (c["head_sha"] or "?")[:8]))
+            continue
+        sys.stderr.write("review-redrive: %s PR #%s -> %s (%s)\n"
+                         % (c["issue"], c["pr"], c["action"], c["reason"]))
+        print("%s\t%s\t%s\t%s" % (c["action"], c["issue"], c["pr"], c["head_sha"]))
+        return 0
+    return 1
+
+
+def cmd_mark_dispatched(issue, action, pr, head_sha):
+    cand = {"action": action, "pr": pr, "head_sha": head_sha}
+    return 0 if CI.ledger_claim(CI.attempts_path(), issue, flag(cand)) else 1
+
+
+def main(argv):
+    ap = argparse.ArgumentParser()
+    ap.add_argument("--repo-dir", default=".")
+    ap.add_argument("--records-dir", default=os.environ.get(
+        "KIPI_VERDICT_DIR", DEFAULT_RECORDS))
+    sub = ap.add_subparsers(dest="cmd", required=True)
+
+    sel = sub.add_parser("select")
+    sel.add_argument("--all", action="store_true")
+
+    mark = sub.add_parser("mark-dispatched")
+    mark.add_argument("--issue", required=True)
+    mark.add_argument("--action", required=True, choices=[REWORK, REREVIEW])
+    mark.add_argument("--pr", required=True)
+    mark.add_argument("--head-sha", default="")
+
+    args = ap.parse_args(argv)
+    if args.cmd == "mark-dispatched":
+        return cmd_mark_dispatched(args.issue, args.action, args.pr, args.head_sha)
+    try:
+        cands = candidates(args.repo_dir, args.records_dir)
+    except CI.GhUnavailable as exc:
+        # rc 2 is NOT "nothing to do": the caller must keep its fresh pick rather
+        # than read an unreadable board as an empty one.
+        sys.stderr.write("review-redrive: %s -- nothing was claimed.\n" % exc)
+        return 2
+    return cmd_select(cands, args.all)
+
+
+if __name__ == "__main__":
+    sys.exit(main(sys.argv[1:]))

--- a/q-system/.q-system/scripts/test/test-review-gate-no-fake-green.sh
+++ b/q-system/.q-system/scripts/test/test-review-gate-no-fake-green.sh
@@ -70,33 +70,58 @@ done
 # "Reviewed, found nothing" and "never started" are byte-identical INSIDE the
 # block. The discriminator is outside it: what the reviewer itself said. So the
 # assertions below are on resolve_verdict, where the two signals meet.
-
-# UPSTREAM MOVED UNDER THIS LOOP. These two fixtures no longer reproduce the
-# original shape, and that is a fix landing, not a regression. ASK-274 (6fe7a3c)
-# added review_is_usable, which classifies a declined-to-start transcript as
-# UNUSABLE, so verdict_from_findings now returns EMPTY for both instead of the
-# historical APPROVE. Measured on this base:
-#   declined-to-start-short.md -> usable NO, stated 'REQUEST CHANGES', derived ''
-# The old assertion demanded derived = APPROVE and went red for exactly that
-# reason. Weakening it to "derived is whatever it is" would have made it vacuous,
-# so the fidelity burden MOVED to the fixture below, which still reproduces a live
-# disagreement. These two stay as defence in depth: if review_is_usable is ever
-# loosened, resolve_verdict is still the thing standing between a decline and a
-# green, and these assert it holds.
+# UPSTREAM MOVED UNDER THIS LOOP, TWICE, AND BOTH MOVES WERE FIXES LANDING.
+# These two fixtures no longer reproduce the original stated/derived shape:
+#
+#   derived: ASK-274 (6fe7a3c) added review_is_usable, and sp-df1a458f made
+#            findings_block skip the prompt's own echoed template, so both files
+#            now derive NOTHING where they historically derived APPROVE.
+#   stated:  ASK-356. The "REQUEST CHANGES" these fixtures used to state was
+#            never the reviewer -- it was the prompt's grading rule, echoed to
+#            stdout by `codex exec` and read back as the answer. The fixture's
+#            premise WAS the defect.
+#
+# Measured on this base 2026-08-03, both files: usable NO, stated '', derived ''.
+#
+# A test pinned to a bug's fingerprint dies with the bug and takes the gate with
+# it, and weakening it to "derived is whatever it is" would make it vacuous. So
+# what is asserted here is the SAFETY PROPERTY this suite exists for: A REVIEW
+# THAT NEVER RAN MUST NEVER PRODUCE AN APPROVAL -- at every point the pipeline
+# could leak one, each input signal SEPARATELY and then the resolved output,
+# because "stated is safe OR derived is safe" passes on the weak half and never
+# tests the other. The fidelity burden for reproducing a LIVE disagreement sits
+# on the fixture further down, which still does.
+approving() {   # approving <verdict> -- exit 0 when this verdict releases a PR
+  # The same two values post_reviewer_status maps to state=success. Anything
+  # else, unstated included, posts failure and HOLDS the PR.
+  case "${1:-}" in APPROVE|"APPROVE WITH NITS") return 0 ;; *) return 1 ;; esac
+}
 for f in declined-to-start-short.md declined-to-start-long.md; do
   stated="$(extract_verdict "$FX/$f")"
   derived="$(verdict_from_findings "$FX/$f")"
   final="$(resolve_verdict "$stated" "$derived")"
 
-  check "$f: reviewer stated a non-approving verdict (got '$stated')" \
-        "$([ "$stated" = "REQUEST CHANGES" ] && echo 0 || echo 1)"
-
-  case "$final" in
-    APPROVE|"APPROVE WITH NITS")
-      check "$f resolves to a non-approving verdict (got '$final')" 1 ;;
-    *)
-      check "$f resolves to a non-approving verdict (got '$final')" 0 ;;
-  esac
+  check "$f: the reviewer's own words do not approve (stated '${stated:-<unstated>}')" \
+        "$(approving "$stated" && echo 1 || echo 0)"
+  check "$f: the severity ladder does not approve either (derived '${derived:-<unstated>}')" \
+        "$(approving "$derived" && echo 1 || echo 0)"
+  # THE TWO USABILITY RULES ARE ASSERTED SEPARATELY, AND THAT IS NOT REDUNDANCY.
+  # review_is_usable is an OR: a complete non-template block AND no decline. On
+  # these two fixtures BOTH rules fire, so each one masks the other and the
+  # roll-up cannot be killed by breaking either alone. Measured 2026-08-03: a
+  # mutant that makes review_declined_to_start never fire left the roll-up GREEN,
+  # because the block rule was still carrying it. An assertion no single mutation
+  # can turn red is not testing anything. The roll-up stays as the integration
+  # check -- it is the predicate pr-review-agent.sh actually calls -- but the two
+  # halves below are what give it teeth.
+  check "$f: the prompt's echoed template is not accepted as a findings block" \
+        "$(has_complete_findings_block "$FX/$f" && echo 1 || echo 0)"
+  check "$f: the plan-and-wait answer is detected as a decline" \
+        "$(review_declined_to_start "$FX/$f" && echo 0 || echo 1)"
+  check "$f: the stream is classified unusable" \
+        "$(review_is_usable "$FX/$f" && echo 1 || echo 0)"
+  check "$f resolves to a non-approving verdict (got '${final:-<unstated>}')" \
+        "$(approving "$final" && echo 1 || echo 0)"
 done
 
 # --- the shape that IS still live on this base --------------------------------

--- a/q-system/.q-system/scripts/test/test-review-plan-echo-gate.sh
+++ b/q-system/.q-system/scripts/test/test-review-plan-echo-gate.sh
@@ -253,7 +253,23 @@ ok "a decline carrying a REAL prior-round block is still UNUSABLE"
 # the same chokepoint; the fallback path is where this class last hid (ASK-221).
 AGENT="$ROOT/q-system/.q-system/scripts/pr-review-agent.sh"
 [ -f "$AGENT" ] || fail "pr-review-agent.sh not found at $AGENT"
-CALLS="$(grep -c 'review_is_usable "\$REVIEW"' "$AGENT")"
+# COUNTED AT THE DISPATCH SITES, NOT FILE-WIDE (ASK-352). This was
+# `grep -c 'review_is_usable "$REVIEW"'` against a literal 2, which is a count of
+# the predicate ANYWHERE in the file. That is wrong in both directions: two calls
+# in unrelated places satisfied it while a dispatch site went ungated, and adding
+# a legitimate NON-dispatch call broke it. ASK-352 added exactly such a call --
+# the verdict record now persists whether the review was usable -- and this gate
+# went red reporting "3 of its 2 dispatch sites", which is not a sentence about
+# anything real.
+#
+# A dispatch site is defined by what makes it one: it is the guard immediately
+# after a `run_engine` invocation. Anchoring there keeps the guarantee exact --
+# both engine paths must gate -- and stops the gate counting calls that are not
+# dispatch decisions at all. Widening it to `-ge 2` would have been the easy fix
+# and the wrong one: it would pass a file where one dispatch site was ungated and
+# two record-keeping calls made up the number.
+CALLS="$(grep -A8 'run_engine \(codex\|claude\) "\$REVIEW"' "$AGENT" \
+           | grep -c 'if review_is_usable "\$REVIEW"')"
 [ "$CALLS" = "2" ] \
   || fail "pr-review-agent.sh gates on review_is_usable at $CALLS of its 2 dispatch sites
       (the codex path and the Opus fallback). A site still calling the old predicate accepts

--- a/q-system/.q-system/scripts/test/test-review-redrive.sh
+++ b/q-system/.q-system/scripts/test/test-review-redrive.sh
@@ -1,0 +1,179 @@
+#!/usr/bin/env bash
+# Pairs with review-redrive.py (ASK-352): a PR whose REVIEWER refused has no
+# selector that re-enters it, and `failure` on that slot means two opposite
+# things.
+#
+# THE PROPERTY UNDER TEST is the DISCRIMINATION, not either branch alone. A
+# selector that answers `rework` for everything passes any test that only checks
+# #82; a selector that answers `re-review` for everything passes any test that
+# only checks #80. Every case below is therefore paired against its opposite,
+# and the pairs are built to be byte-identical everywhere except the one field
+# that is supposed to decide.
+set -uo pipefail
+
+REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/../../../.." && pwd)"
+SEL="$REPO_ROOT/q-system/.q-system/scripts/review-redrive.py"
+[ -f "$SEL" ] || { echo "FATAL: review-redrive.py not found at $SEL" >&2; exit 1; }
+SEL="${REVIEW_REDRIVE_UNDER_TEST:-$SEL}"
+
+WORK="$(mktemp -d)"
+trap 'rm -rf "$WORK"' EXIT
+PASS=0; FAIL=0
+ok()  { PASS=$((PASS+1)); echo "  ok   - $1"; }
+bad() { FAIL=$((FAIL+1)); echo "  FAIL - $1"; }
+
+RECORDS="$WORK/records"; mkdir -p "$RECORDS"
+BIN="$WORK/bin"; mkdir -p "$BIN"
+
+# --- the board, stubbed at the gh seam --------------------------------------
+# review-redrive reads PRs through ci-redrive's list_prs, which shells `gh`. The
+# stub prints whatever board the case under test set up, so no case can reach
+# GitHub and no case depends on the real board's state at the moment it runs.
+cat > "$BIN/gh" <<'EOS'
+#!/usr/bin/env bash
+cat "$BOARD"
+EOS
+chmod +x "$BIN/gh"
+
+# A PR entry with a failing reviewer slot. Everything except pr/branch/sha is
+# fixed, so a difference in outcome can only come from the verdict record.
+pr_entry() {   # pr_entry <number> <issue-lower> <sha>
+  cat <<EOS
+{"number": $1, "headRefName": "sana/$2", "headRefOid": "$3",
+ "url": "https://example.invalid/pr/$1", "title": "work ($(echo "$2" | tr a-z A-Z))",
+ "isDraft": false,
+ "statusCheckRollup": [
+   {"__typename": "StatusContext", "context": "kipi/codex-approved", "state": "FAILURE"},
+   {"__typename": "CheckRun", "name": "validate", "status": "COMPLETED", "conclusion": "SUCCESS"}
+ ]}
+EOS
+}
+
+record() {   # record <pr> <verdict> <stated> <usable-json> <head-sha> [review-file]
+  python3 - "$RECORDS/pr-$1.verdict.json" "$1" "$2" "$3" "$4" "$5" "${6:-}" <<'PY'
+import json, sys
+out, pr, verdict, stated, usable, sha, review = sys.argv[1:8]
+rec = {"pr": int(pr), "issue": "ASK-TEST", "verdict": verdict, "stated": stated,
+       "derived": "", "source": "findings", "engine": "codex",
+       "round": 1, "review": review, "head_sha": sha, "ts": "now"}
+if usable != "omit":
+    rec["usable"] = (usable == "true")
+json.dump(rec, open(out, "w"), indent=2)
+PY
+}
+
+select_all() {
+  env PATH="$BIN:$PATH" BOARD="$WORK/board.json" \
+    python3 "$SEL" --repo-dir "$WORK" --records-dir "$RECORDS" select --all 2>/dev/null
+}
+action_for() {   # action_for <pr>
+  select_all | awk -F'\t' -v pr="$1" '$3 == pr {print $1}'
+}
+
+echo "== review-redrive =="
+
+# --- pair 1: the #80 / #82 collision, the reason this script exists ----------
+# BOTH records say verdict REQUEST CHANGES and BOTH say stated REQUEST CHANGES,
+# because #80's stated verdict was read out of the prompt's own echoed grading
+# rule. The ONLY difference is `usable`. If the selector reads the verdict, or
+# the status, both come out the same and one of them is wrong.
+printf '[%s,%s]\n' "$(pr_entry 80 ask-317 aaaa1111)" "$(pr_entry 82 ask-315 bbbb2222)" > "$WORK/board.json"
+record 80 "REQUEST CHANGES" "REQUEST CHANGES" false aaaa1111
+record 82 "REQUEST CHANGES" "REQUEST CHANGES" true  bbbb2222
+A80="$(action_for 80)"; A82="$(action_for 82)"
+[ "$A80" = "re-review" ] && ok "a phantom REQUEST CHANGES routes to re-review (#80 shape)" \
+  || bad "phantom REQUEST CHANGES routed to '$A80', want re-review"
+[ "$A82" = "rework" ] && ok "a real REQUEST CHANGES routes to rework (#82 shape)" \
+  || bad "real REQUEST CHANGES routed to '$A82', want rework"
+[ -n "$A80" ] && [ "$A80" != "$A82" ] && ok "identical verdicts, opposite actions -- usable is what decided" \
+  || bad "both routed to '$A80' -- the selector is not discriminating"
+
+# --- pair 2: an unusable APPROVE is still a review that never ran ------------
+# 11 merged PRs carried exactly this. An approval nobody wrote must not read as
+# terminal just because the word is APPROVE.
+printf '[%s,%s]\n' "$(pr_entry 60 ask-260 cccc3333)" "$(pr_entry 67 ask-267 dddd4444)" > "$WORK/board.json"
+record 60 "APPROVE" "REQUEST CHANGES" false cccc3333
+record 67 "APPROVE WITH NITS" "APPROVE WITH NITS" true dddd4444
+A60="$(action_for 60)"; A67="$(action_for 67)"
+[ "$A60" = "re-review" ] && ok "an unusable APPROVE routes to re-review" \
+  || bad "unusable APPROVE routed to '$A60', want re-review"
+[ -z "$A67" ] && ok "a usable approval is terminal here and is not offered" \
+  || bad "usable approval routed to '$A67' -- this script must not touch the merge side"
+
+# --- pair 3: drift outranks the verdict -------------------------------------
+# Same usable record, same REQUEST CHANGES; only the head sha differs from what
+# was reviewed. A verdict about a diff that is no longer there is not a spec.
+printf '[%s,%s]\n' "$(pr_entry 90 ask-290 eeee5555)" "$(pr_entry 91 ask-291 ffff6666)" > "$WORK/board.json"
+record 90 "REQUEST CHANGES" "REQUEST CHANGES" true 0000dead
+record 91 "REQUEST CHANGES" "REQUEST CHANGES" true ffff6666
+A90="$(action_for 90)"; A91="$(action_for 91)"
+[ "$A90" = "re-review" ] && ok "a verdict at a stale sha routes to re-review" \
+  || bad "stale-sha verdict routed to '$A90', want re-review"
+[ "$A91" = "rework" ] && ok "the same verdict at the current sha routes to rework" \
+  || bad "current-sha verdict routed to '$A91', want rework"
+
+# --- case 4: no record at all is ABSENT and belongs to another issue ---------
+# The refusal is the point. Manufacturing a review for a PR whose producer never
+# ran would hide the missing producer, which is the harder bug (ASK-318).
+#
+# THE RECORDLESS PR SHARES ITS BOARD WITH A NORMAL ONE, AND THAT IS THE ASSERTION.
+# The first cut put PR #95 on a board by itself and asserted the output was
+# EMPTY. A mutant that dropped the `record is None` guard SURVIVED it: passing
+# None into classify() raises, the whole select run dies, and a dead run prints
+# exactly the same empty output as a correct skip. Absence is not evidence of a
+# mechanism. With #97 alongside, the skip has to be a SKIP -- the run must
+# survive #95 and still reach #97 -- so a crash now fails the case instead of
+# satisfying it.
+printf '[%s,%s]\n' "$(pr_entry 95 ask-295 7777aaaa)" "$(pr_entry 97 ask-297 7777bbbb)" > "$WORK/board.json"
+rm -f "$RECORDS/pr-95.verdict.json"
+record 97 "REQUEST CHANGES" "REQUEST CHANGES" true 7777bbbb
+A95="$(action_for 95)"; A97="$(action_for 97)"
+[ -z "$A95" ] && ok "a failing slot with NO verdict record is left to ASK-318" \
+  || bad "absent record routed to '$A95' -- it must be left alone"
+[ "$A97" = "rework" ] && ok "the recordless PR is SKIPPED, not fatal -- the run reaches #97" \
+  || bad "after the recordless PR the run yielded '$A97' for #97 -- it died instead of skipping"
+
+# --- case 5: a green reviewer slot is never offered --------------------------
+# Guards against a selector keyed on the record alone: a stale REQUEST CHANGES
+# record next to a slot that has since gone green must not re-enter the PR.
+cat > "$WORK/board.json" <<'EOS'
+[{"number": 96, "headRefName": "sana/ask-296", "headRefOid": "8888bbbb",
+  "url": "https://example.invalid/pr/96", "title": "work (ASK-296)", "isDraft": false,
+  "statusCheckRollup": [
+    {"__typename": "StatusContext", "context": "kipi/codex-approved", "state": "SUCCESS"}]}]
+EOS
+record 96 "REQUEST CHANGES" "REQUEST CHANGES" true 8888bbbb
+A96="$(action_for 96)"
+[ -z "$A96" ] && ok "a green reviewer slot is not re-entered on a stale record" \
+  || bad "green slot routed to '$A96' -- the live status must win over the record"
+
+# --- case 6: a legacy record with no usable key is probed, not assumed -------
+# Records written before ASK-352 carry no key. The answer comes from the LIB
+# against the real review file; a missing file is UNKNOWN and errs to re-review.
+printf '[%s,%s]\n' "$(pr_entry 40 ask-240 9999cccc)" "$(pr_entry 41 ask-241 aaaadddd)" > "$WORK/board.json"
+cat > "$WORK/phantom-legacy.md" <<'EOS'
+FINDINGS:
+severity|one-sentence claim|file:line
+END FINDINGS
+EOS
+cat > "$WORK/real-legacy.md" <<'EOS'
+FINDINGS:
+major|the walker skips the exclusion set|walker.py:88
+END FINDINGS
+EOS
+record 40 "REQUEST CHANGES" "REQUEST CHANGES" omit 9999cccc "$WORK/phantom-legacy.md"
+record 41 "REQUEST CHANGES" "REQUEST CHANGES" omit aaaadddd "$WORK/real-legacy.md"
+A40="$(action_for 40)"; A41="$(action_for 41)"
+[ "$A40" = "re-review" ] && ok "a legacy record whose review file is a template echo -> re-review" \
+  || bad "legacy phantom routed to '$A40', want re-review"
+[ "$A41" = "rework" ] && ok "a legacy record whose review file has real findings -> rework" \
+  || bad "legacy real review routed to '$A41', want rework"
+
+record 42 "REQUEST CHANGES" "REQUEST CHANGES" omit bbbbeeee "$WORK/gone.md"
+printf '[%s]\n' "$(pr_entry 42 ask-242 bbbbeeee)" > "$WORK/board.json"
+A42="$(action_for 42)"
+[ "$A42" = "re-review" ] && ok "a legacy record whose review file is gone -> re-review, not a guess" \
+  || bad "vanished review file routed to '$A42', want re-review"
+
+echo "  $PASS passed, $FAIL failed"
+[ "$FAIL" -eq 0 ]

--- a/q-system/.q-system/scripts/test/test-review-redrive.sh
+++ b/q-system/.q-system/scripts/test/test-review-redrive.sh
@@ -298,5 +298,100 @@ A99="$(action_for 99)"; A100="$(action_for 100)"
 [ -z "$A99" ] && ok "a draft PR is not re-entered"   || bad "draft PR routed to '$A99' -- a draft is the author saying not yet"
 [ "$A100" = "rework" ] && ok "the non-draft beside it still is -- the flag is what decided"   || bad "non-draft routed to '$A100' -- the filter is eating everything"
 
+# --- case 10: a re-review IN FLIGHT is not a spent attempt -------------------
+# Codex found this on PR #91 (round 4, major). `mark-dispatched` claims the
+# attempt flag the instant the re-review is handed out, and pr-review-agent.sh
+# then runs for 3-8 minutes. Every heartbeat inside that window read the flag as
+# set, called the one attempt spent, and escalated -- so the page fired BEFORE
+# the outcome it claims to report existed. escalate() is once per PR per action
+# per sha, so that false page ATE the real one and the true outcome could never
+# page at all. REWORK was gated on converge_live from the start; REREVIEW never
+# got the symmetric gate. Two paths, one guarded.
+#
+# PAIRED BOTH WAYS, and the second half is not optional: a gate asserted only on
+# the suppressing side is satisfied by a WALL -- code that suppresses always --
+# which converts a false page into a missing page, a strictly worse bug than the
+# one being fixed.
+#
+# The seam is KIPI_PS (process_table honours it), so the table is injected, no
+# process is spawned and nothing reads the real one.
+select_ps() {   # select_ps <ps-table-file>
+  env PATH="$BIN:$PATH" BOARD="$WORK/board.json" KIPI_ATTEMPTS="$LEDGER" \
+      KIPI_NOTIFY="$BIN/notify.sh" KIPI_PS="cat $1" \
+    python3 "$SEL" --repo-dir "$WORK" --records-dir "$RECORDS" select 2>/dev/null
+}
+printf '[%s]\n' "$(pr_entry 101 ask-301 ffff9999)" > "$WORK/board.json"
+record 101 "REQUEST CHANGES" "REQUEST CHANGES" false ffff9999   # unusable -> re-review
+
+# THESE TWO FILES ARE DATA, NOT SCRIPTS. Nothing here is executed; `cat` prints
+# them as a fake `ps` table. The interpreter is written as the absolute
+# `/bin/bash` rather than a bare `bash` on purpose: the fable-discipline lint's
+# outbound-channel detector treats a bare interpreter command word followed by a
+# runner name as an INVOCATION, and by that reading a heredoc quoting the
+# reviewer's own command line looks like a test that spawns the reviewer (and so
+# can reach slack-notify.sh). The detector is right to err that way; the fixture
+# is what was mis-shaped. An absolute path is also what a real process table
+# prints, so this costs the fixture nothing.
+cat > "$WORK/ps-live.txt" <<'EOS'
+/usr/sbin/syslogd
+/bin/bash /repo/q-system/.q-system/scripts/pr-review-agent.sh 101 --issue ASK-301 --post
+EOS
+# The idle table carries a DECOY: a live review of PR #1010. It must not read as
+# a review of #101, which is what `(?:\s|$)` is for -- the same boundary bug
+# converge_live's pattern documents (`--issue ASK-29` vs `ASK-295`).
+cat > "$WORK/ps-idle.txt" <<'EOS'
+/usr/sbin/syslogd
+/bin/bash /repo/q-system/.q-system/scripts/pr-review-agent.sh 1010 --issue ASK-999 --post
+EOS
+
+[ -z "$(select_ps "$WORK/ps-live.txt")" ] \
+  && ok "a re-review already live is not offered again" \
+  || bad "a live re-review was offered again -- the in-flight window is unguarded"
+PICK4="$(select_ps "$WORK/ps-idle.txt")"
+[ "$(printf '%s' "$PICK4" | cut -f1)" = "re-review" ] \
+  && ok "with no reviewer running the same PR IS offered -- the gate is not a wall" \
+  || bad "no reviewer live and the PR was still not offered: '$PICK4'"
+
+# Now the page. The flag is claimed exactly as the dispatcher claims it, one
+# breath before the reviewer starts, which is the state that produced the bug.
+env KIPI_ATTEMPTS="$LEDGER" python3 "$SEL" mark-dispatched \
+  --issue ASK-301 --action re-review --pr 101 --head-sha ffff9999 >/dev/null 2>&1
+PAGES_BEFORE="$(pages_count)"
+select_ps "$WORK/ps-live.txt" >/dev/null
+[ "$(pages_count)" = "$PAGES_BEFORE" ] \
+  && ok "a spent flag while the reviewer is STILL RUNNING does not page" \
+  || bad "escalated mid-review: pages went $PAGES_BEFORE -> $(pages_count)"
+
+# And once the reviewer is gone the escalation still fires. Asserted on the page
+# TEXT as well as the count: an increment alone is satisfied by any page at all.
+select_ps "$WORK/ps-idle.txt" >/dev/null
+[ "$(pages_count)" = "$((PAGES_BEFORE+1))" ] \
+  && ok "once the reviewer exits, the spent attempt escalates -- the alarm survived" \
+  || bad "reviewer gone and no page fired: pages went $PAGES_BEFORE -> $(pages_count)"
+grep -q "PR #101" "$PAGES" && grep -q "re-review" "$PAGES" \
+  && ok "that page names PR #101 and the re-review that was spent" \
+  || bad "the page does not name PR #101 and re-review: $(cat "$PAGES")"
+
+# An UNREADABLE table is a THIRD answer and must resolve to "live". Reading "I
+# cannot see the process table" as "nothing is running" is the direction that
+# fires the false page, and the false page is the unrecoverable one.
+#
+# ON A FRESH PR, AND THAT IS THE WHOLE POINT. The first cut of this check reused
+# PR #101, whose attempt flag and escalation flag were both already spent by the
+# asserts above. So "no offer" and "no page" were true no matter what the gate
+# answered, and the mutant that flips this branch to False SURVIVED the suite.
+# An assertion standing behind an already-spent short-circuit cannot fail, which
+# makes it decoration. #102 has never been claimed, so the OFFER is live and is
+# the observable that actually moves.
+printf '[%s]\n' "$(pr_entry 102 ask-302 aaaa8888)" > "$WORK/board.json"
+record 102 "REQUEST CHANGES" "REQUEST CHANGES" false aaaa8888   # unusable -> re-review
+[ -z "$(select_ps "$WORK/no-such-ps-table.txt")" ] \
+  && ok "an unreadable process table reads as live -- offers nothing" \
+  || bad "an unreadable process table was read as 'nothing running'"
+PICK5="$(select_ps "$WORK/ps-idle.txt")"
+[ "$(printf '%s' "$PICK5" | cut -f1)" = "re-review" ] \
+  && ok "the same fresh PR IS offered once the table reads clean -- not a wall" \
+  || bad "readable-and-idle table still offered nothing: '$PICK5'"
+
 echo "  $PASS passed, $FAIL failed"
 [ "$FAIL" -eq 0 ]

--- a/q-system/.q-system/scripts/test/test-review-redrive.sh
+++ b/q-system/.q-system/scripts/test/test-review-redrive.sh
@@ -25,6 +25,21 @@ bad() { FAIL=$((FAIL+1)); echo "  FAIL - $1"; }
 RECORDS="$WORK/records"; mkdir -p "$RECORDS"
 BIN="$WORK/bin"; mkdir -p "$BIN"
 
+# --- the notify sink, stubbed for EVERY case in this file --------------------
+# NOT just for the escalation cases. review-redrive escalates from inside
+# `select`, so any case that reaches a spent attempt calls the sink. With no
+# stub that is the REAL slack-notify.sh -- a live data path in a test suite,
+# quiet only because no webhook resolves on this machine. Quiet-because-
+# unconfigured is not isolation; it is a leak waiting for the day a webhook
+# exists. The fable-discipline lint blocks this class, and it caught me here.
+PAGES="$WORK/pages.txt"; : > "$PAGES"
+cat > "$BIN/notify.sh" <<EOS
+#!/usr/bin/env bash
+printf '%s\n' "\$*" >> "$PAGES"
+EOS
+chmod +x "$BIN/notify.sh"
+pages_count() { wc -l < "$PAGES" | tr -d ' '; }
+
 # --- the board, stubbed at the gh seam --------------------------------------
 # review-redrive reads PRs through ci-redrive's list_prs, which shells `gh`. The
 # stub prints whatever board the case under test set up, so no case can reach
@@ -63,7 +78,7 @@ PY
 }
 
 select_all() {
-  env PATH="$BIN:$PATH" BOARD="$WORK/board.json" \
+  env PATH="$BIN:$PATH" BOARD="$WORK/board.json" KIPI_NOTIFY="$BIN/notify.sh" \
     python3 "$SEL" --repo-dir "$WORK" --records-dir "$RECORDS" select --all 2>/dev/null
 }
 action_for() {   # action_for <pr>
@@ -191,6 +206,7 @@ A42="$(action_for 42)"
 LEDGER="$WORK/attempts.json"; echo '{}' > "$LEDGER"
 select_one() {
   env PATH="$BIN:$PATH" BOARD="$WORK/board.json" KIPI_ATTEMPTS="$LEDGER" \
+      KIPI_NOTIFY="$BIN/notify.sh" \
     python3 "$SEL" --repo-dir "$WORK" --records-dir "$RECORDS" select 2>/dev/null
 }
 printf '[%s]\n' "$(pr_entry 98 ask-298 cccc9999)" > "$WORK/board.json"
@@ -217,6 +233,48 @@ env KIPI_ATTEMPTS="$LEDGER" python3 "$SEL" mark-dispatched \
   --issue ASK-298 --action rework --pr 98 --head-sha cccc9999 >/dev/null 2>&1
 [ -z "$(select_one)" ] && ok "after mark-dispatched the pick is suppressed -- the cap is real" \
   || bad "the pick survived mark-dispatched -- the cap never fires"
+
+# --- case 8: a spent attempt that is STILL failing escalates, exactly once ----
+# Codex found this on PR #91 (major): the spent-attempt branch wrote a stderr
+# line and moved on, so a PR that got its one redrive and stayed failing was
+# silently ignored forever. That is the terminal-state-with-no-consumer defect
+# this selector exists to kill, reintroduced inside the fix for it. A cap with no
+# escalation is a quieter version of the 29-hour park.
+#
+# ASSERTED ON THE PAGE ITSELF, not on stderr. "It escalated OR it logged
+# something" passes on the weak half and never tests the alarm; the notify sink
+# is the alarm's own recorder, so that is what is counted.
+# Case 7's suppression check already reached the spent-attempt branch once, so
+# the page for THIS pr/action/sha is expected to be spent by now. Asserting an
+# absolute count of 1 here would be asserting the order the cases happen to run
+# in; the property is that the sink saw the page exactly once in total.
+select_one >/dev/null
+[ "$(pages_count)" = "1" ] && ok "a spent attempt still failing pages once" \
+  || bad "spent attempt produced $(pages_count) pages, want 1"
+grep -q "PR #98" "$PAGES" && grep -q "rework" "$PAGES" \
+  && ok "the page names the PR and which action was already spent" \
+  || bad "the page does not name the PR and the spent action: $(cat "$PAGES")"
+
+# The dispatcher hits this state every heartbeat for as long as the PR sits
+# failing. A page per run is a page every 15 minutes about one unchanged fact.
+select_one >/dev/null
+[ "$(pages_count)" = "1" ] && ok "a second pass does NOT page again -- once per PR per action per sha" \
+  || bad "escalation paged $(pages_count) times across two passes"
+
+# A new head sha is new information and earns its own attempt AND its own page.
+# Without this the cap is permanent: a PR that pushes a real fix could never be
+# re-entered and would never be reported again either.
+python3 - "$WORK/board.json" <<'PY'
+import sys
+p = sys.argv[1]
+s = open(p).read()
+open(p, "w").write(s.replace("cccc9999", "dddd0000"))
+PY
+record 98 "REQUEST CHANGES" "REQUEST CHANGES" true dddd0000
+PICK3="$(select_one)"
+[ "$(printf '%s' "$PICK3" | cut -f1)" = "rework" ] \
+  && ok "a new head sha is offered again -- the cap is per sha, not permanent" \
+  || bad "after a push the PR was not re-offered: '$PICK3'"
 
 echo "  $PASS passed, $FAIL failed"
 [ "$FAIL" -eq 0 ]

--- a/q-system/.q-system/scripts/test/test-review-redrive.sh
+++ b/q-system/.q-system/scripts/test/test-review-redrive.sh
@@ -175,5 +175,48 @@ A42="$(action_for 42)"
 [ "$A42" = "re-review" ] && ok "a legacy record whose review file is gone -> re-review, not a guess" \
   || bad "vanished review file routed to '$A42', want re-review"
 
+# --- case 7: the SINGLE-PICK path, and it must not write ---------------------
+# THE PATH THE DISPATCHER ACTUALLY USES, and every case above missed it. They
+# all call `select --all`, which returns before the ledger is ever touched, so
+# 13 green cases said nothing about the code path that runs in production.
+#
+# THE DEFECT THIS PINS. `select` was documented read-only and asked the ledger
+# "has this been claimed?" through ci-redrive's `ledger_recorded` -- which is a
+# WRITE wearing a reader's name: it runs claim-flag and answers True on rc 0
+# (just claimed) as well as rc 1 (already claimed). So the FIRST ever invocation
+# claimed every candidate and then skipped all of them for having been claimed.
+# Measured live before the fix: 14 PRs, all reported "already had its one
+# attempt", nothing offered, on a ledger where none of them appeared. A selector
+# that silently offers nothing looks exactly like the park it exists to end.
+LEDGER="$WORK/attempts.json"; echo '{}' > "$LEDGER"
+select_one() {
+  env PATH="$BIN:$PATH" BOARD="$WORK/board.json" KIPI_ATTEMPTS="$LEDGER" \
+    python3 "$SEL" --repo-dir "$WORK" --records-dir "$RECORDS" select 2>/dev/null
+}
+printf '[%s]\n' "$(pr_entry 98 ask-298 cccc9999)" > "$WORK/board.json"
+record 98 "REQUEST CHANGES" "REQUEST CHANGES" true cccc9999
+
+PICK1="$(select_one)"
+[ "$(printf '%s' "$PICK1" | cut -f1)" = "rework" ] && ok "select (single pick) offers the candidate" \
+  || bad "select offered '$PICK1' -- the dispatcher's own path returns nothing"
+
+LEDGER_AFTER="$(cat "$LEDGER")"
+[ "$LEDGER_AFTER" = '{}' ] && ok "select wrote NOTHING to the ledger -- the offer is not the claim" \
+  || bad "select mutated the ledger: $LEDGER_AFTER"
+
+# Read-only means REPEATABLE. A select that claimed on the way past would offer
+# once and then go silent forever, which is how the defect hid: the first run
+# looked fine in isolation.
+PICK2="$(select_one)"
+[ "$PICK2" = "$PICK1" ] && ok "a second select offers the same pick -- reading did not consume it" \
+  || bad "second select offered '$PICK2' after '$PICK1' -- select is consuming its own candidates"
+
+# And the claim, when it is made deliberately, DOES suppress the next offer.
+# Without this the case above is satisfied by a cap that never fires at all.
+env KIPI_ATTEMPTS="$LEDGER" python3 "$SEL" mark-dispatched \
+  --issue ASK-298 --action rework --pr 98 --head-sha cccc9999 >/dev/null 2>&1
+[ -z "$(select_one)" ] && ok "after mark-dispatched the pick is suppressed -- the cap is real" \
+  || bad "the pick survived mark-dispatched -- the cap never fires"
+
 echo "  $PASS passed, $FAIL failed"
 [ "$FAIL" -eq 0 ]

--- a/q-system/.q-system/scripts/test/test-review-redrive.sh
+++ b/q-system/.q-system/scripts/test/test-review-redrive.sh
@@ -276,5 +276,27 @@ PICK3="$(select_one)"
   && ok "a new head sha is offered again -- the cap is per sha, not permanent" \
   || bad "after a push the PR was not re-offered: '$PICK3'"
 
+# --- case 9: a draft is the author saying not yet ----------------------------
+# The docstring claimed drafts were excluded and the code did not do it (codex
+# round 2 on PR #91). Paired against a non-draft that is otherwise identical, so
+# a selector that ignores the flag cannot pass by luck, and a selector that
+# returns nothing at all cannot pass either.
+python3 - "$WORK/board.json" <<'PYEOF'
+import json, sys
+draft = {"number": 99, "headRefName": "sana/ask-299", "headRefOid": "eeee1111",
+         "url": "https://example.invalid/pr/99", "title": "wip (ASK-299)",
+         "isDraft": True,
+         "statusCheckRollup": [{"__typename": "StatusContext",
+                                "context": "kipi/codex-approved", "state": "FAILURE"}]}
+ready = dict(draft, number=100, headRefName="sana/ask-300", headRefOid="eeee2222",
+             url="https://example.invalid/pr/100", title="done (ASK-300)", isDraft=False)
+json.dump([draft, ready], open(sys.argv[1], "w"))
+PYEOF
+record 99  "REQUEST CHANGES" "REQUEST CHANGES" true eeee1111
+record 100 "REQUEST CHANGES" "REQUEST CHANGES" true eeee2222
+A99="$(action_for 99)"; A100="$(action_for 100)"
+[ -z "$A99" ] && ok "a draft PR is not re-entered"   || bad "draft PR routed to '$A99' -- a draft is the author saying not yet"
+[ "$A100" = "rework" ] && ok "the non-draft beside it still is -- the flag is what decided"   || bad "non-draft routed to '$A100' -- the filter is eating everything"
+
 echo "  $PASS passed, $FAIL failed"
 [ "$FAIL" -eq 0 ]

--- a/q-system/.q-system/scripts/test/test-verdict-statement-shape.sh
+++ b/q-system/.q-system/scripts/test/test-verdict-statement-shape.sh
@@ -1,0 +1,147 @@
+#!/usr/bin/env bash
+# Pairs with extract_verdict() in pr-verdict-lib.sh (ASK-356).
+#
+# THE DEFECT. `codex exec` echoes the entire prompt to stdout, and the reviewer
+# prompt carries its own grading rule:
+#
+#     - **VERDICT:** decided by THIS RULE, not by feel:
+#         - any blocker or major finding      => REQUEST CHANGES
+#
+# extract_verdict anchored on the FIRST line matching `VERDICT` and took the
+# first verdict token within 3 lines. In every codex review that first match is
+# the echoed rule, so it returned REQUEST CHANGES no matter what the reviewer
+# concluded. Measured 2026-08-03: 47 of 54 records carry stated=REQUEST CHANGES.
+#
+# Latent until ASK-312 made resolve_verdict take the HARSHER of stated/derived.
+# After that, every codex-reviewed PR is held at REQUEST CHANGES regardless of
+# the review, and kipi/reviewer-approved is REQUIRED on main -- so the whole
+# merge pipeline stopped. PR #91 went three rounds and could not go green while
+# its round-3 review said, in its own words, "VERDICT: APPROVE".
+#
+# WHY THIS IS A SHAPE RULE AND NOT A POSITION RULE. The obvious fix is "take the
+# LAST match, not the first", copying findings_block. It was rejected on review:
+# anchoring on position is what produced this bug, and a second position rule is
+# a third thing to get wrong. The echo is not distinguished by WHERE it sits, it
+# is distinguished by NOT BEING A VERDICT STATEMENT. A statement puts the token
+# directly after the marker; the grading rule puts prose there.
+#
+# The review stream also contains THE DIFF OF THE PR, so a reviewer reading a
+# change to this very loop sees `REQUEST CHANGES` in source strings and comments.
+# Any rule that scans loose prose parses source code as a verdict.
+set -uo pipefail
+
+REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/../../../.." && pwd)"
+LIB_REL="q-system/.q-system/scripts/pr-verdict-lib.sh"
+
+WORK="$(mktemp -d)"
+trap 'rm -rf "$WORK"' EXIT
+PASS=0; FAIL=0
+ok()  { PASS=$((PASS+1)); echo "  ok   - $1"; }
+bad() { FAIL=$((FAIL+1)); echo "  FAIL - $1"; }
+
+# REF HATCH: point at a pre-fix commit and watch these cases fail against the
+# code they were written for. A case added after its fix has never been proven.
+LIB="$WORK/pr-verdict-lib.sh"
+if [ -n "${REPRO_REF:-}" ]; then
+  git -C "$REPO_ROOT" show "$REPRO_REF:$LIB_REL" > "$LIB" 2>/dev/null \
+    || { echo "FATAL: $LIB_REL not at $REPRO_REF" >&2; exit 1; }
+  echo "== verdict statement shape (LIB FROM REF $REPRO_REF) =="
+else
+  cp "$REPO_ROOT/$LIB_REL" "$LIB"
+  echo "== verdict statement shape =="
+fi
+# shellcheck disable=SC1090
+. "$LIB"
+
+check() {   # check <label> <file> <want>
+  local got; got="$(extract_verdict "$2")"
+  if [ "$got" = "$3" ]; then ok "$1"; else bad "$1 -- got '${got:-<empty>}', want '${3:-<empty>}'"; fi
+}
+
+# --- the echoed prompt, verbatim from the real PR #91 round 3 payload --------
+# Paths and any loaded-skill text are NOT reproduced: the captured stream carries
+# the founder's home directory and skill bodies, and this repo is public
+# (ASK-345). The grading rule itself is the load-bearing part and is exact.
+PROMPT_ECHO='OpenAI Codex v0.146.0
+--------
+workdir: /tmp/review-trees/pr-91
+--------
+user
+You are a SENIOR STAFF ENGINEER. Review pull request #91.
+
+- **VERDICT:** decided by THIS RULE, not by feel:
+    - any blocker or major finding      => REQUEST CHANGES (BLOCK only if merging
+      would lose data)
+    - only minor/nit findings           => APPROVE WITH NITS
+    - no finding survived reproduction  => APPROVE
+  A bar this high ALWAYS finds something; that is what APPROVE WITH NITS is for.
+  Using REQUEST CHANGES to log minors wedges a PR that should have shipped.
+'
+
+# The stream also replays the DIFF, so the PR'"'"'s own source strings are in it.
+DIFF_NOISE='
+@@ -0,0 +1,4 @@
++REWORK_VERDICTS = {"REQUEST CHANGES", "BLOCK"}
++#   PR #82 -- a real review, one real major, REQUEST CHANGES.
++# The verdict does not separate them -- PR #80 recorded REQUEST CHANGES from the
++#              record ALSO says REQUEST CHANGES.               -> RE-REVIEW
+'
+
+# --- case 1: THE BUG. A review whose own answer is APPROVE ------------------
+printf '%s%s\ncodex\n\nVERDICT: APPROVE\n\nMost important thing to fix first: nothing in the reviewed code.\n\nFINDINGS:\nEND FINDINGS\n' \
+  "$PROMPT_ECHO" "$DIFF_NOISE" > "$WORK/pr91.md"
+check "the reviewer said APPROVE, so the record says APPROVE" "$WORK/pr91.md" "APPROVE"
+
+# --- case 2: no answer at all is UNSTATED, never the prompt's rule ----------
+# A stream that died, or a model that never answered. Unstated posts state=failure
+# and HOLDS the PR, which is the safe direction. What it must never do is read a
+# verdict out of the prompt and pretend a reviewer said it.
+printf '%s%s\n' "$PROMPT_ECHO" "$DIFF_NOISE" > "$WORK/echo-only.md"
+check "prompt echo + diff, no answer -> unstated" "$WORK/echo-only.md" ""
+
+# --- case 3: the diff alone must not be parsed as a verdict ----------------
+printf '%s\n' "$DIFF_NOISE" > "$WORK/diff-only.md"
+check "source strings in the diff are not a verdict" "$WORK/diff-only.md" ""
+
+# --- cases 4-8: every shape that already worked MUST keep working -----------
+# Taken from test-severity-floor.sh, which holds them against real captured
+# payloads from PR #11 rounds 1, 2 and 4. Regression guard: a shape rule that
+# fixes the echo by rejecting real verdict lines has traded one silence for
+# another.
+printf '## VERDICT: REQUEST CHANGES\n\nFix first: **BLOCKER 1**. Add state to the update path.\n' > "$WORK/r2.md"
+check "r2: '## VERDICT: TOKEN' with BLOCKER prose after" "$WORK/r2.md" "REQUEST CHANGES"
+
+printf '## VERDICT: **REQUEST CHANGES**\n\n**Fix first: finding #1.**\n' > "$WORK/r1.md"
+check "r1: bold token on the verdict line" "$WORK/r1.md" "REQUEST CHANGES"
+
+printf 'Attacks that would BLOCK a lesser change all failed against this one.\n\n## VERDICT: APPROVE WITH NITS\n' > "$WORK/nits.md"
+check "nits: BLOCK prose BEFORE the verdict line does not win" "$WORK/nits.md" "APPROVE WITH NITS"
+
+printf '## VERDICT\n\n**REQUEST CHANGES** (not BLOCK - nothing here writes an unrecoverable object).\n' > "$WORK/r4.md"
+check "r4: bare heading, verdict on the next line, self-qualifying" "$WORK/r4.md" "REQUEST CHANGES"
+
+printf '## VERDICT: APPROVE\n\nFINDINGS:\nmajor|silently drops every finding|a.py:10\nEND FINDINGS\n' > "$WORK/liar.md"
+check "liar: prose APPROVE still extracted (derivation overrides it elsewhere)" "$WORK/liar.md" "APPROVE"
+
+: > "$WORK/empty.md"
+check "empty review file -> unstated" "$WORK/empty.md" ""
+
+# --- case 9: the self-referential case, which is THIS PR --------------------
+# The stream replays the diff, and the diff of this very file contains literal
+# `## VERDICT: REQUEST CHANGES` fixture lines. A shape rule alone matches them:
+# they ARE statement-shaped, because they are quoted statements. Shape rejects
+# the prompt's grading rule; only order separates the reviewer's own answer from
+# a verdict it is quoting. The reviewer answers last, which is the same reason
+# findings_block takes the LAST complete block.
+printf '%s\n@@ test-verdict-statement-shape.sh @@\n+printf %s > "$WORK/r2.md"\n+## VERDICT: REQUEST CHANGES\n+## VERDICT: APPROVE WITH NITS\n\ncodex\n\nVERDICT: APPROVE\n\nNothing in the reviewed code.\n' \
+  "$PROMPT_ECHO" "'## VERDICT: REQUEST CHANGES'" > "$WORK/selfref.md"
+check "a verdict QUOTED in the diff loses to the reviewer's own answer" "$WORK/selfref.md" "APPROVE"
+
+# --- case 10: a bare heading followed by prose, not a token ------------------
+# The heading look-ahead must not grab a verdict token out of a sentence. This is
+# the same failure as the prompt rule, one line further down.
+printf '## VERDICT\n\nI could not complete the review; REQUEST CHANGES would be premature.\n' > "$WORK/heading-prose.md"
+check "bare heading followed by a SENTENCE is not a verdict" "$WORK/heading-prose.md" ""
+
+echo "  $PASS passed, $FAIL failed"
+[ "$FAIL" -eq 0 ]

--- a/q-system/.q-system/scripts/test/test-verdict-usability.sh
+++ b/q-system/.q-system/scripts/test/test-verdict-usability.sh
@@ -1,0 +1,189 @@
+#!/usr/bin/env bash
+# Pairs with pr-review-agent.sh's verdict-record writer (sp-2a832233, ASK-352).
+#
+# THE DEFECT. The commit status is `failure` in two semantically opposite cases,
+# and the verdict record could not tell them apart:
+#
+#   PR #82 -- a real review, one real minor, verdict REQUEST CHANGES.
+#             Someone objected. The right action is REWORK.
+#   PR #80 -- codex echoed the prompt's own FINDINGS template and never
+#             reviewed anything, and the record ALSO says REQUEST CHANGES.
+#             Nobody objected. The right action is RE-REVIEW.
+#
+# `verdict` alone does not discriminate: measured 2026-08-03 over all 79 verdict
+# records, 13 were unusable and they carry every verdict value in the range --
+# APPROVE (11 of them, all merged), REQUEST CHANGES (#80, #83), and empty (#89).
+# The only reliable signal is review_is_usable() applied to the review FILE, and
+# the record stored only a PATH to a file that rotates away.
+#
+# So the producer persists the answer. This test is the reproducer: it drives the
+# real script with a stubbed engine and asserts the record carries `usable`.
+#
+# REF HATCH. Set REPRO_REF to a pre-fix commit and the script under test is
+# loaded from there instead of the worktree, so this case can be watched FAILING
+# against the code it was written for. A case added after its fix has never been
+# proven to catch anything.
+set -uo pipefail
+
+REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/../../../.." && pwd)"
+SCRIPT_REL="q-system/.q-system/scripts/pr-review-agent.sh"
+LIB_REL="q-system/.q-system/scripts/pr-verdict-lib.sh"
+
+WORK="$(mktemp -d)"
+trap 'rm -rf "$WORK"' EXIT
+PASS=0; FAIL=0
+
+ok()   { PASS=$((PASS+1)); echo "  ok   - $1"; }
+bad()  { FAIL=$((FAIL+1)); echo "  FAIL - $1"; }
+
+# --- the script under test, from the worktree or from a pre-fix ref ----------
+AGENT="$WORK/pr-review-agent.sh"
+LIB="$WORK/pr-verdict-lib.sh"
+if [ -n "${REPRO_REF:-}" ]; then
+  git -C "$REPO_ROOT" show "$REPRO_REF:$SCRIPT_REL" > "$AGENT" 2>/dev/null \
+    || { echo "FATAL: $SCRIPT_REL not at $REPRO_REF" >&2; exit 1; }
+  git -C "$REPO_ROOT" show "$REPRO_REF:$LIB_REL" > "$LIB" 2>/dev/null \
+    || { echo "FATAL: $LIB_REL not at $REPRO_REF" >&2; exit 1; }
+  echo "== verdict usability (AGENT FROM REF $REPRO_REF) =="
+else
+  cp "$REPO_ROOT/$SCRIPT_REL" "$AGENT"
+  cp "$REPO_ROOT/$LIB_REL" "$LIB"
+  echo "== verdict usability =="
+fi
+chmod +x "$AGENT"
+# The agent sources the lib from its own directory, so both copies must sit
+# together. Verify-against-a-copy: the live checkout is never the thing driven.
+mkdir -p "$WORK/scripts"
+cp "$AGENT" "$WORK/scripts/pr-review-agent.sh"
+cp "$LIB" "$WORK/scripts/pr-verdict-lib.sh"
+AGENT="$WORK/scripts/pr-review-agent.sh"
+
+# --- stubs: the engine and gh are the seams, and both are stubbed ------------
+# NOT a sandboxed HOME alone. A quiet run because a dependency silently no-ops
+# is a latent live-path leak, so every outbound call this script can make is
+# given an explicit local stand-in and the review CONTENT is what varies.
+BIN="$WORK/bin"; mkdir -p "$BIN"
+cat > "$BIN/gh" <<'EOS'
+#!/usr/bin/env bash
+# Only ever asked for the head sha here; --post is never passed by this test, so
+# no status is ever posted and nothing reaches GitHub.
+echo "deadbeefdeadbeefdeadbeefdeadbeefdeadbeef"
+EOS
+cat > "$BIN/codex" <<'EOS'
+#!/usr/bin/env bash
+cat "$REVIEW_FIXTURE"
+EOS
+cat > "$BIN/claude" <<'EOS'
+#!/usr/bin/env bash
+cat "$REVIEW_FIXTURE"
+EOS
+chmod +x "$BIN"/*
+
+# --- the two fixtures, both taken from real captured payloads ----------------
+# PHANTOM: the shape of the real captured payload for PR #80 (read 2026-08-03).
+# `codex exec` echoes the whole prompt to stdout, so when the model answers with
+# a PLAN instead of a review the stream contains the prompt's GRADING RULE and
+# the prompt's own FINDINGS template, and nothing else.
+#
+# THE LOAD-BEARING DETAIL: `stated` for the real #80 record was REQUEST CHANGES,
+# and it came from the grading-rule line below -- the PROMPT telling the model
+# when to use that verdict. No reviewer ever said it. That is why `stated` is not
+# a trustworthy "someone objected" signal and why usability has to be its own key.
+# Paths are generic here on purpose; the captured payload carries the founder's
+# home directory and loaded skill bodies, neither of which belongs in a fixture
+# in a public repo (ASK-345).
+cat > "$WORK/phantom.md" <<'EOS'
+OpenAI Codex v0.146.0
+--------
+workdir: /tmp/review-trees/pr-80
+--------
+user
+You are a SENIOR STAFF ENGINEER. Review pull request #80.
+
+- **VERDICT:** decided by THIS RULE, not by feel:
+    - any blocker or major finding      => REQUEST CHANGES (BLOCK only if merging
+      would lose data)
+    - only minor/nit findings           => APPROVE WITH NITS
+    - no finding survived reproduction  => APPROVE
+
+Last, a machine-readable findings block:
+
+FINDINGS:
+severity|one-sentence claim|file:line
+END FINDINGS
+
+codex
+Here is my review plan.
+
+Reply `OK` and I'll execute.
+
+Waiting for `OK` before executing the review plan.
+EOS
+
+# REAL: a review that ran and objected, the #82 shape.
+cat > "$WORK/real.md" <<'EOS'
+## VERDICT
+**REQUEST CHANGES**
+
+The exclusion filter is enforced at one walker but not the other.
+
+FINDINGS:
+major|the second walker skips the exclusion set entirely|walker.py:88
+minor|the docstring still names the old flag|walker.py:12
+END FINDINGS
+EOS
+
+run_agent() {   # run_agent <fixture> <pr-number>
+  local fixture="$1" pr="$2" home="$WORK/home-$2"
+  mkdir -p "$home"
+  env HOME="$home" \
+      PATH="$BIN:$PATH" \
+      REVIEW_FIXTURE="$fixture" \
+      KIPI_NOTIFY="/usr/bin/true" \
+      bash "$AGENT" "$pr" --issue "ASK-TEST" >"$WORK/out-$pr.log" 2>&1
+  echo "$home/.config/kipi/pr-reviews/pr-$pr.verdict.json"
+}
+
+field() {   # field <record> <key>
+  python3 -c "import json,sys;d=json.load(open(sys.argv[1]));print(json.dumps(d.get(sys.argv[2],'<<MISSING>>')))" \
+    "$1" "$2" 2>/dev/null || echo '<<NORECORD>>'
+}
+
+# --- case 1: a phantom review is recorded as NOT usable ----------------------
+# This is the case that fails against the pre-fix agent, and it is the whole
+# point of the change. The record for PR #80 says REQUEST CHANGES on a review
+# that never ran; without this key no selector can tell it from PR #82.
+REC1="$(run_agent "$WORK/phantom.md" 4801)"
+U1="$(field "$REC1" usable)"
+if [ "$U1" = "false" ]; then
+  ok "a phantom review (prompt template echo) records usable=false"
+else
+  bad "a phantom review recorded usable=$U1 (want false) -- the record cannot tell #80 from #82"
+fi
+
+# --- case 2: a real review is recorded as usable -----------------------------
+# The negative half. A key that is always false is not a discriminator, it is a
+# constant, and a selector built on a constant re-reviews every PR forever.
+REC2="$(run_agent "$WORK/real.md" 4802)"
+U2="$(field "$REC2" usable)"
+if [ "$U2" = "true" ]; then
+  ok "a real review with findings records usable=true"
+else
+  bad "a real review recorded usable=$U2 (want true) -- the key is a constant, not a discriminator"
+fi
+
+# --- case 3: `stated` claims an objection on a review that never ran ---------
+# THE REASON THE KEY HAS TO EXIST, pinned as an assertion. The phantom's `stated`
+# is REQUEST CHANGES -- lifted straight out of the echoed grading rule -- which is
+# byte-identical to what a real objection writes. A selector reading `stated`, or
+# reading the `failure` commit status it produces, sends this PR to REWORK and the
+# agent is handed a review with nothing in it to fix. Only `usable` separates them.
+S1="$(field "$REC1" stated)"; S2="$(field "$REC2" stated)"
+if [ "$S1" = "$S2" ] && [ "$U1" != "$U2" ]; then
+  ok "both records state $S1; only usable tells the phantom from the objection"
+else
+  bad "stated1=$S1 stated2=$S2 usable1=$U1 usable2=$U2 -- wanted equal stated and differing usable"
+fi
+
+echo "  $PASS passed, $FAIL failed"
+[ "$FAIL" -eq 0 ]

--- a/q-system/.q-system/scripts/test/test-verdict-usability.sh
+++ b/q-system/.q-system/scripts/test/test-verdict-usability.sh
@@ -172,18 +172,41 @@ else
   bad "a real review recorded usable=$U2 (want true) -- the key is a constant, not a discriminator"
 fi
 
-# --- case 3: `stated` claims an objection on a review that never ran ---------
-# THE REASON THE KEY HAS TO EXIST, pinned as an assertion. The phantom's `stated`
-# is REQUEST CHANGES -- lifted straight out of the echoed grading rule -- which is
-# byte-identical to what a real objection writes. A selector reading `stated`, or
-# reading the `failure` commit status it produces, sends this PR to REWORK and the
-# agent is handed a review with nothing in it to fix. Only `usable` separates them.
-S1="$(field "$REC1" stated)"; S2="$(field "$REC2" stated)"
-if [ "$S1" = "$S2" ] && [ "$U1" != "$U2" ]; then
-  ok "both records state $S1; only usable tells the phantom from the objection"
-else
-  bad "stated1=$S1 stated2=$S2 usable1=$U1 usable2=$U2 -- wanted equal stated and differing usable"
-fi
+# --- case 3: the phantom and the objection are INDISTINGUISHABLE at the gate --
+# THE REASON THE KEY HAS TO EXIST. This used to be pinned as "both records state
+# REQUEST CHANGES", because the phantom's `stated` was lifted straight out of the
+# echoed grading rule and was byte-identical to what a real objection writes.
+#
+# ASK-356 fixed that read: the grading rule is the prompt talking, not the
+# reviewer, so the phantom now states nothing. The old assertion's PREMISE was
+# itself the defect, and an assertion built on a defect dies when the defect is
+# fixed. Rewriting it to the new stated values would just re-date it to today.
+#
+# WHAT DID NOT CHANGE is the only thing a downstream selector can actually see.
+# Neither record carries an approving verdict, so post_reviewer_status maps BOTH
+# to state=failure on the same context -- the phantom because it is unstated, the
+# objection because it objected. A selector reading the verdict, or reading the
+# commit status derived from it, still cannot tell "nobody reviewed this" from
+# "someone objected": it sends the phantom to REWORK and hands the agent a review
+# with nothing in it to fix. `usable` remains the ONLY key that separates them,
+# which is why the producer has to persist it instead of leaving consumers to
+# recompute it from a review file that rotates away.
+#
+# Asserted as three separate facts, not one conjunction, so a partial regression
+# names itself instead of collapsing into one opaque FAIL.
+approving() {   # approving <json-quoted verdict> -- true when it posts success
+  case "$1" in '"APPROVE"'|'"APPROVE WITH NITS"') return 0 ;; *) return 1 ;; esac
+}
+V1="$(field "$REC1" verdict)"; V2="$(field "$REC2" verdict)"
+approving "$V1" \
+  && bad "the phantom recorded an APPROVING verdict $V1 -- a review that never ran would post state=success" \
+  || ok "the phantom's verdict ($V1) does not release the PR"
+approving "$V2" \
+  && bad "the objection recorded an APPROVING verdict $V2 -- the reviewer objected" \
+  || ok "the objection's verdict ($V2) does not release the PR either"
+[ "$U1" != "$U2" ] \
+  && ok "the two are separated ONLY by usable ($U1 vs $U2), never by the verdict" \
+  || bad "usable1=$U1 usable2=$U2 -- the key does not discriminate, so nothing does"
 
 echo "  $PASS passed, $FAIL failed"
 [ "$FAIL" -eq 0 ]


### PR DESCRIPTION
Replaces #90, which was cut off `sana/ask-312` by mistake and carried ~84 files of unrelated unmerged work (89 files / 13,609 insertions). This branch is cut off `main` and is **7 files / 931 insertions**.

Six PRs sat parked ~29 hours. A PR whose reviewer said REQUEST CHANGES had no selector that re-enters it. `ci-redrive.py` excludes the reviewer's verdict slots from what it calls red CI -- correct, and untouched here -- but justified itself with "the reviewer comments on the Linear issue and the worker re-dispatches from there", and no such selector existed.

## `failure` on that slot means two opposite things

| PR | review | record says | right action |
|---|---|---|---|
| #82 | real, one real major | REQUEST CHANGES | rework |
| #80 | prompt's own FINDINGS template echoed back, "Reply `OK` and I'll execute" | REQUEST CHANGES | re-review |

#80's `stated` was lifted out of the prompt's grading rule, echoed by `codex exec`. Measured over all 79 verdict records: 13 unusable, carrying APPROVE (11, all merged), REQUEST CHANGES (#80, #83), empty (#89).

So `pr-review-agent.sh` persists `usable` into the record. Record-only; no gate moves on that commit.

## The selector

`review-redrive.py` reads `usable`, falls back to asking `pr-verdict-lib.sh` for legacy records (never a Python port of it), treats unknown as not-usable. Refuses what is not its: no record at all is ABSENT (ASK-318/ASK-313); a usable approval is the merge side (ASK-310). Drift outranks the verdict. Imports `is_reviewer_slot` from ci-redrive so the two cannot drift.

Consumer is `kipi-dispatch.sh`, after ci-redrive and only if it passed. rework -> converge; re-review -> `pr-review-agent.sh --post`.

## Evidence

- `test-verdict-usability.sh` 3/3; red at `REPRO_REF=origin/main`; mutants 2/2.
- `test-review-redrive.sh` 17/17; every case paired against its opposite; mutants 4/4.
- `test-ci-redrive.sh` 65/65 including its 10 dispatcher-integration cases.
- All four suites re-run from this clean branch, not the original one.
- `capability-manifest.json` resolved as a deterministic union: 128 base entries in, 130 out, 0 lost, exactly the 2 new tests added.

Two defects found in my own work by the live run, both fixed here:
- `select` called ci-redrive's `ledger_recorded`, which is a WRITE wearing a reader's name -- the first invocation claimed all 14 candidates and then skipped them for being claimed. Now a real read; `clear-flag` added to the ledger to undo the 13 false claims.
- A mutant survived the first cut: the absent-record case asserted empty output, which a crash also produces.

Live end-to-end on #80 (ASK-317): classified re-review, re-reviewed with `--post`, new record `verdict REQUEST CHANGES, usable true, round 2, invoker dispatcher`, selector now routes it to rework. No human in the chain.