### PR TITLE
Judgment Compiler: freeze decision-time workflow context per triage decision (ASK-363)

### DIFF
--- a/kipi
+++ b/kipi
@@ -32,6 +32,12 @@ usage() {
   echo "  kipi linear release <ASK-n> --agent <name> --session <id> Drop the claim (when the PR opens)"
   echo "  kipi linear claims            Who holds this working tree"
   echo "  kipi linear progress <ASK-n> \"<note>\" [--evidence \"...\"]  Post progress onto an issue"
+  echo "  kipi judgment assemble --prd <id> --finding <id> [--output <f>]  Freeze decision-time context"
+  echo "  kipi judgment capture ...     Validate + append one triage episode receipt"
+  echo "  kipi judgment verify          Re-walk the receipt chain (add --packet/--receipt-id to bind a run)"
+  echo "  kipi judgment evaluate        Score prospective judge-vs-founder cases + release gates"
+  echo "  kipi judgment sample-check --basis <sha256>  Reproduce the 5% sampling verdict"
+  echo "  kipi judgment policy-candidates [--min-cases N]  Detect repeated override patterns (proposals only)"
   echo "  kipi review <PR#> [--post]  Adversarial PR review (Netflix staff, fresh eyes, repro-or-drop)"
   echo "  kipi jobs [--apply]  File/refresh one migration issue per scheduled job"
   echo "  kipi work [--apply]  Autonomous worker: take a ready issue, branch, PR (never merges/closes)"
@@ -114,6 +120,28 @@ case "${1:-help}" in
     # Scheduled by q-system/.q-system/scripts/com.kipi.fleet-health.plist at 08:15.
     shift || true
     python3 "$KIPI_HOME/q-system/.q-system/scripts/fleet-health-daily.py" "$@"
+    ;;
+  judgment)
+    # Judgment Compiler (PRD prd-judgment-compiler-2026-08-04, ASK-363).
+    # Runs against the CALLER's repo: judgment_compiler.py discovers the repo
+    # root by walking up from cwd, so each instance reads its own .prd-os
+    # ledgers, not the skeleton's.
+    shift || true
+    JUDGMENT="$KIPI_HOME/plugins/prd-os/scripts/judgment_compiler.py"
+    sub="${1:-}"
+    shift || true
+    case "$sub" in
+      assemble|capture|verify|evaluate|sample-check|policy-candidates)
+        python3 "$JUDGMENT" "$sub" "$@"
+        ;;
+      selftest)
+        python3 "$JUDGMENT" --selftest
+        ;;
+      *)
+        echo "usage: kipi judgment <assemble|capture|verify|evaluate|sample-check|policy-candidates|selftest>" >&2
+        exit 1
+        ;;
+    esac
     ;;
   linear)
     # Issue-first fast path. The commit-msg gate (linear-issue-ref-check.py)

--- a/kipi
+++ b/kipi
@@ -36,6 +36,7 @@ usage() {
   echo "  kipi judgment capture ...     Validate + append one triage episode receipt"
   echo "  kipi judgment verify          Re-walk the receipt chain (add --packet/--receipt-id to bind a run)"
   echo "  kipi judgment evaluate        Score prospective judge-vs-founder cases + release gates"
+  echo "  kipi judgment reanchor        Re-cover a legitimate unanchored tail after an interrupted write"
   echo "  kipi judgment sample-check --basis <sha256>  Reproduce the 5% sampling verdict"
   echo "  kipi judgment policy-candidates [--min-cases N]  Detect repeated override patterns (proposals only)"
   echo "  kipi review <PR#> [--post]  Adversarial PR review (Netflix staff, fresh eyes, repro-or-drop)"
@@ -131,14 +132,14 @@ case "${1:-help}" in
     sub="${1:-}"
     shift || true
     case "$sub" in
-      assemble|capture|verify|evaluate|sample-check|policy-candidates)
+      assemble|capture|verify|evaluate|reanchor|sample-check|policy-candidates)
         python3 "$JUDGMENT" "$sub" "$@"
         ;;
       selftest)
         python3 "$JUDGMENT" --selftest
         ;;
       *)
-        echo "usage: kipi judgment <assemble|capture|verify|evaluate|sample-check|policy-candidates|selftest>" >&2
+        echo "usage: kipi judgment <assemble|capture|verify|evaluate|reanchor|sample-check|policy-candidates|selftest>" >&2
         exit 1
         ;;
     esac

--- a/plugins/prd-os/.claude-plugin/plugin.json
+++ b/plugins/prd-os/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "prd-os",
-  "version": "0.11.1",
+  "version": "0.11.2",
   "description": "PRD operating system: capture rough ideas, draft reviewable PRDs, run standard and adversarial review (Codex or a Claude senior-staff-engineer subagent, recorded truthfully), triage findings, decompose approved PRDs into atomic issue specs, and execute those issues with scope enforcement, stop-gate receipts, and reviewer-attributed findings.",
   "author": {
     "name": "Assaf Kipnis"

--- a/plugins/prd-os/.claude-plugin/plugin.json
+++ b/plugins/prd-os/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "prd-os",
-  "version": "0.10.2",
+  "version": "0.11.0",
   "description": "PRD operating system: capture rough ideas, draft reviewable PRDs, run standard and adversarial review (Codex or a Claude senior-staff-engineer subagent, recorded truthfully), triage findings, decompose approved PRDs into atomic issue specs, and execute those issues with scope enforcement, stop-gate receipts, and reviewer-attributed findings.",
   "author": {
     "name": "Assaf Kipnis"

--- a/plugins/prd-os/.claude-plugin/plugin.json
+++ b/plugins/prd-os/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "prd-os",
-  "version": "0.11.3",
+  "version": "0.11.4",
   "description": "PRD operating system: capture rough ideas, draft reviewable PRDs, run standard and adversarial review (Codex or a Claude senior-staff-engineer subagent, recorded truthfully), triage findings, decompose approved PRDs into atomic issue specs, and execute those issues with scope enforcement, stop-gate receipts, and reviewer-attributed findings.",
   "author": {
     "name": "Assaf Kipnis"

--- a/plugins/prd-os/.claude-plugin/plugin.json
+++ b/plugins/prd-os/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "prd-os",
-  "version": "0.11.4",
+  "version": "0.11.5",
   "description": "PRD operating system: capture rough ideas, draft reviewable PRDs, run standard and adversarial review (Codex or a Claude senior-staff-engineer subagent, recorded truthfully), triage findings, decompose approved PRDs into atomic issue specs, and execute those issues with scope enforcement, stop-gate receipts, and reviewer-attributed findings.",
   "author": {
     "name": "Assaf Kipnis"

--- a/plugins/prd-os/.claude-plugin/plugin.json
+++ b/plugins/prd-os/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "prd-os",
-  "version": "0.11.0",
+  "version": "0.11.1",
   "description": "PRD operating system: capture rough ideas, draft reviewable PRDs, run standard and adversarial review (Codex or a Claude senior-staff-engineer subagent, recorded truthfully), triage findings, decompose approved PRDs into atomic issue specs, and execute those issues with scope enforcement, stop-gate receipts, and reviewer-attributed findings.",
   "author": {
     "name": "Assaf Kipnis"

--- a/plugins/prd-os/.claude-plugin/plugin.json
+++ b/plugins/prd-os/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "prd-os",
-  "version": "0.11.2",
+  "version": "0.11.3",
   "description": "PRD operating system: capture rough ideas, draft reviewable PRDs, run standard and adversarial review (Codex or a Claude senior-staff-engineer subagent, recorded truthfully), triage findings, decompose approved PRDs into atomic issue specs, and execute those issues with scope enforcement, stop-gate receipts, and reviewer-attributed findings.",
   "author": {
     "name": "Assaf Kipnis"

--- a/plugins/prd-os/.claude-plugin/plugin.json
+++ b/plugins/prd-os/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "prd-os",
-  "version": "0.10.1",
+  "version": "0.10.2",
   "description": "PRD operating system: capture rough ideas, draft reviewable PRDs, run standard and adversarial review (Codex or a Claude senior-staff-engineer subagent, recorded truthfully), triage findings, decompose approved PRDs into atomic issue specs, and execute those issues with scope enforcement, stop-gate receipts, and reviewer-attributed findings.",
   "author": {
     "name": "Assaf Kipnis"

--- a/plugins/prd-os/.claude-plugin/plugin.json
+++ b/plugins/prd-os/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "prd-os",
-  "version": "0.9.2",
+  "version": "0.10.0",
   "description": "PRD operating system: capture rough ideas, draft reviewable PRDs, run standard and adversarial review (Codex or a Claude senior-staff-engineer subagent, recorded truthfully), triage findings, decompose approved PRDs into atomic issue specs, and execute those issues with scope enforcement, stop-gate receipts, and reviewer-attributed findings.",
   "author": {
     "name": "Assaf Kipnis"

--- a/plugins/prd-os/.claude-plugin/plugin.json
+++ b/plugins/prd-os/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "prd-os",
-  "version": "0.10.0",
+  "version": "0.10.1",
   "description": "PRD operating system: capture rough ideas, draft reviewable PRDs, run standard and adversarial review (Codex or a Claude senior-staff-engineer subagent, recorded truthfully), triage findings, decompose approved PRDs into atomic issue specs, and execute those issues with scope enforcement, stop-gate receipts, and reviewer-attributed findings.",
   "author": {
     "name": "Assaf Kipnis"

--- a/plugins/prd-os/.claude-plugin/plugin.json
+++ b/plugins/prd-os/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "prd-os",
-  "version": "0.11.6",
+  "version": "0.12.0",
   "description": "PRD operating system: capture rough ideas, draft reviewable PRDs, run standard and adversarial review (Codex or a Claude senior-staff-engineer subagent, recorded truthfully), triage findings, decompose approved PRDs into atomic issue specs, and execute those issues with scope enforcement, stop-gate receipts, and reviewer-attributed findings.",
   "author": {
     "name": "Assaf Kipnis"

--- a/plugins/prd-os/.claude-plugin/plugin.json
+++ b/plugins/prd-os/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "prd-os",
-  "version": "0.11.5",
+  "version": "0.11.6",
   "description": "PRD operating system: capture rough ideas, draft reviewable PRDs, run standard and adversarial review (Codex or a Claude senior-staff-engineer subagent, recorded truthfully), triage findings, decompose approved PRDs into atomic issue specs, and execute those issues with scope enforcement, stop-gate receipts, and reviewer-attributed findings.",
   "author": {
     "name": "Assaf Kipnis"

--- a/plugins/prd-os/CHANGELOG.md
+++ b/plugins/prd-os/CHANGELOG.md
@@ -2,6 +2,26 @@
 
 All notable changes to the `prd-os` plugin are recorded here. Format follows [Keep a Changelog](https://keepachangelog.com/en/1.1.0/). Versions follow semantic versioning; see `README.md` for the bump policy and the distinction between plugin version and config schema version.
 
+## [0.10.0] - 2026-08-04
+
+### Added
+- **Judgment Compiler** (`scripts/judgment_compiler.py`, PRD
+  prd-judgment-compiler-2026-08-04, ASK-363): append-only, hash-chained triage
+  episode receipts in `.prd-os/judgments.jsonl` (shared worktree ledger root),
+  a deterministic decision-context assembler (unknown stays unknown, every
+  fact carries a source), a split judge contract (technical_validity separate
+  from workflow_disposition, canonical 12-code reason enum), a disposition
+  evidence gate (duplicate / already-remediated / scope-removed /
+  out-of-scope / owned-by-other-prd / superseded require stable references:
+  judge output degrades to needs-human, human decisions hard-fail), a
+  prospective v2 evaluator with release gates (≥88% agreement, kappa ≥0.80,
+  ≥80% per-class recall, ≥50 cases), deterministic 5% sampling, and a
+  policy-candidate detector that cannot self-install.
+  `findings_writer.py set-disposition` now captures a receipt per
+  adjudication (new optional flags `--reason-code`, `--evidence`, `--actor`,
+  `--judge-run`; kill switch `KIPI_JUDGMENT_CAPTURE=0`). Paired tests:
+  `tests/test_judgment_compiler.py` (48 cases, written red-first).
+
 ## [Unreleased]
 
 ### Added

--- a/plugins/prd-os/CHANGELOG.md
+++ b/plugins/prd-os/CHANGELOG.md
@@ -2,6 +2,21 @@
 
 All notable changes to the `prd-os` plugin are recorded here. Format follows [Keep a Changelog](https://keepachangelog.com/en/1.1.0/). Versions follow semantic versioning; see `README.md` for the bump policy and the distinction between plugin version and config schema version.
 
+## [0.11.6] - 2026-08-04
+
+### Fixed (Codex review round 3, PR #97)
+- **`reanchor` could bless a truncated ledger when the anchor was missing.**
+  The round-1 implementation filtered every "tip anchor" error out of its chain
+  check — including the MISSING-anchor error — so deleting the anchor AND
+  truncating, then reanchoring, wrote a fresh anchor over the surviving prefix
+  and made the deletion permanent. This falsified that function's own comment
+  claiming it "can never launder tampering"; the comment is now corrected
+  rather than quietly dropped. Reanchor repairs exactly one state (an anchor
+  that exists and under-counts) and refuses a missing anchor over a non-empty
+  ledger, pointing at `verify --cross-check` — the independent source — to
+  establish what should be there. An empty ledger with no anchor stays a clean
+  no-op, so a fresh repo is not made to cry wolf.
+
 ## [0.11.5] - 2026-08-04
 
 ### Fixed (Codex review round 2, PR #97)

--- a/plugins/prd-os/CHANGELOG.md
+++ b/plugins/prd-os/CHANGELOG.md
@@ -2,6 +2,22 @@
 
 All notable changes to the `prd-os` plugin are recorded here. Format follows [Keep a Changelog](https://keepachangelog.com/en/1.1.0/). Versions follow semantic versioning; see `README.md` for the bump policy and the distinction between plugin version and config schema version.
 
+## [0.11.4] - 2026-08-04
+
+### Fixed (Codex review, PR #97 — both findings had executed reproducers)
+- **Receipts beyond the tip anchor were trusted.** An under-counting anchor was
+  treated as fine so a crashed anchor-write would not false-alarm; the cost was
+  that receipts past the anchor sat OUTSIDE deletion detection while `verify`
+  still reported "chain intact". Verify now refuses when
+  `len(records) != tip.count` in either direction, and a new `reanchor`
+  subcommand re-covers a legitimate tail. Reanchor refuses a truncated ledger
+  and refuses a broken chain, so it cannot launder tampering: it only ever
+  extends coverage over receipts that already verify.
+- **A refused receipt rolled the findings file back but left the spillover
+  append standing.** Because that ledger is append-only, the standing gate saw
+  permanent open work for a disposition the command had just reported as rolled
+  back. Spillover now fans out only after the receipt lands.
+
 ## [0.11.3] - 2026-08-04
 
 ### Testing

--- a/plugins/prd-os/CHANGELOG.md
+++ b/plugins/prd-os/CHANGELOG.md
@@ -2,6 +2,19 @@
 
 All notable changes to the `prd-os` plugin are recorded here. Format follows [Keep a Changelog](https://keepachangelog.com/en/1.1.0/). Versions follow semantic versioning; see `README.md` for the bump policy and the distinction between plugin version and config schema version.
 
+## [0.11.2] - 2026-08-04
+
+### Testing
+- Mutation-tested the suite: 17 single-invariant corruptions applied to a copy,
+  16 killed. The run exposed that 7 checks were shadowed by other checks in
+  every test (`sequence`, the prev-hash link, and 5 read-path validators the
+  suite never reached because it only exercised the write path). Added a
+  `reseal_ledger` helper that rebuilds a fully self-consistent chain so each
+  test can break exactly one invariant, plus a real 6-process concurrency test.
+  The single surviving mutation is a defensive build-time duplicate-id assert
+  that no normal path can reach; its enforced half is the read-side check, and
+  the code now says so rather than implying coverage it does not have.
+
 ## [0.11.1] - 2026-08-04
 
 ### Fixed (adversarial review, 17 findings)

--- a/plugins/prd-os/CHANGELOG.md
+++ b/plugins/prd-os/CHANGELOG.md
@@ -2,6 +2,27 @@
 
 All notable changes to the `prd-os` plugin are recorded here. Format follows [Keep a Changelog](https://keepachangelog.com/en/1.1.0/). Versions follow semantic versioning; see `README.md` for the bump policy and the distinction between plugin version and config schema version.
 
+## [0.12.0] - 2026-08-04
+
+### Fixed (Codex review round 5, PR #97)
+- **`release_gates.passed` could return True over a ledger containing decisions
+  that bypassed the evidence gate.** The PRD listed "no schema or evidence-gate
+  bypasses" as a release condition and no code read it: `_release_gates` was
+  called before the bypass rates were even computed. Executed repro: 60 perfect
+  cases plus one reason-code-less rejection returned `passed=True` with
+  `ungated_decision_rate=0.016`. Since `passed` is the field that authorizes
+  auto-decide, a caller could have enabled automation on known-invalid
+  calibration data. Two gates added (`zero_gate_bypasses`,
+  `zero_unsupported_judge_dispositions`) and the rates are now computed before
+  the gates that read them. Minor version bump: the evaluate output gains
+  fields and previously-passing gate sets can now legitimately fail.
+
+### Note on the review process
+- Codex round 5 observed that this defect lived in code unchanged since the
+  first feature commit, and concluded rounds 1-4 were miscalibrated. Recorded
+  rather than argued with: four review passes and a mutation run all cleared a
+  gate that never read its own documented condition.
+
 ## [0.11.6] - 2026-08-04
 
 ### Fixed (Codex review round 3, PR #97)

--- a/plugins/prd-os/CHANGELOG.md
+++ b/plugins/prd-os/CHANGELOG.md
@@ -2,6 +2,37 @@
 
 All notable changes to the `prd-os` plugin are recorded here. Format follows [Keep a Changelog](https://keepachangelog.com/en/1.1.0/). Versions follow semantic versioning; see `README.md` for the bump policy and the distinction between plugin version and config schema version.
 
+## [0.11.1] - 2026-08-04
+
+### Fixed (adversarial review, 17 findings)
+- **Blocker — concurrent capture forked the ledger and every writer exited 0.**
+  `capture_episode` was an unlocked read-modify-append while the ledger sits at
+  the SHARED worktree root by design. Now `fcntl.flock`-guarded across
+  read+build+append+anchor. Repro: 6 concurrent captures -> 6 receipts, chain
+  intact.
+- Deleting the tip anchor restored the entire truncation hole for one `rm`; a
+  missing anchor over a non-empty ledger is now an error (an empty ledger with
+  no anchor is still a clean fresh repo).
+- Evidence refs are RESOLVED, not just prefix-matched: `finding:`, `prd:`,
+  `issue:`, `judgment:`, `receipt:`, `spillover:`, `commit:`, `test:`/`scope:`
+  are each opened, and a ref pointing at nothing is refused.
+- `set-disposition` rolls the findings file back when receipt capture fails, so
+  the two ledgers cannot diverge on partial failure.
+- `verify` resolves policy-candidate receipt citations and checks case_count.
+- Scope regex anchored (`## Out of Scope` used to hash as `## Scope`); bare
+  `except Exception` narrowed and partial duplicate lists discarded;
+  `needs-human` abstentions no longer counted as human overrides; degenerate
+  Cohen's kappa returns 0.0 not 1.0; judge stores raw + stored output hashes and
+  validates the stored one; unvalidated packets no longer exit 1 with a
+  traceback; receipts deepcopy their packet; `human_review_rate` uses a set union.
+
+### Known bypass (deliberately not closed here)
+- Omitting `--reason-code` skips the evidence gate. Closing it changes the
+  contract of a command every fleet instance inherits, so it is its own issue
+  (spillover `sp-1caf70c9`). Interim: the receipt records a null code plus a
+  `human.reason_code` missing-context entry, and `evaluate` reports
+  `ungated_decision_rate` so the bypass is counted rather than assumed.
+
 ## [0.10.2] - 2026-08-04
 
 ### Fixed

--- a/plugins/prd-os/CHANGELOG.md
+++ b/plugins/prd-os/CHANGELOG.md
@@ -2,6 +2,23 @@
 
 All notable changes to the `prd-os` plugin are recorded here. Format follows [Keep a Changelog](https://keepachangelog.com/en/1.1.0/). Versions follow semantic versioning; see `README.md` for the bump policy and the distinction between plugin version and config schema version.
 
+## [0.10.2] - 2026-08-04
+
+### Fixed
+- **Judgment ledger truncation was undetectable.** Found by self-attack before
+  the feature shipped: a prev-hash chain proves each retained line follows the
+  previous one, but any PREFIX of a valid chain is itself a valid chain, so
+  `head -1 judgments.jsonl` still returned `VERIFY PASS`. Deletion was the one
+  tamper class the chain structurally could not see. Closed with three
+  independent checks: a monotonic `sequence` field (catches middle deletion and
+  reordering), a tip anchor `.prd-os/judgments-tip.json` recording count + last
+  hash (catches tail truncation and whole-file deletion; tamper-EVIDENT not
+  tamper-proof, since the same writer owns both files), and
+  `verify --cross-check` which requires a receipt for every dispositioned
+  finding by reading the findings ledgers — an independent source the judgment
+  writer does not control. A missing tip anchor does not hard-fail, so ledgers
+  predating the anchor still verify.
+
 ## [0.10.0] - 2026-08-04
 
 ### Added

--- a/plugins/prd-os/CHANGELOG.md
+++ b/plugins/prd-os/CHANGELOG.md
@@ -2,6 +2,18 @@
 
 All notable changes to the `prd-os` plugin are recorded here. Format follows [Keep a Changelog](https://keepachangelog.com/en/1.1.0/). Versions follow semantic versioning; see `README.md` for the bump policy and the distinction between plugin version and config schema version.
 
+## [0.11.3] - 2026-08-04
+
+### Testing
+- Pinned the shared-ledger-root behavior with a test. During this PRD's own
+  dogfood run, a sandbox that had copied a `.git` directory wrote its receipts
+  into the MAIN checkout's ledger — `_ledger_root` follows
+  `git rev-parse --git-common-dir`, which is the intended shared-across-worktrees
+  behavior, but it surprises exactly where it hurts. The behavior was right and
+  the harness was wrong; a test now states which, and `capture` reports the
+  resolved ledger path in its output so the operator can see where a receipt
+  actually landed.
+
 ## [0.11.2] - 2026-08-04
 
 ### Testing

--- a/plugins/prd-os/CHANGELOG.md
+++ b/plugins/prd-os/CHANGELOG.md
@@ -2,6 +2,17 @@
 
 All notable changes to the `prd-os` plugin are recorded here. Format follows [Keep a Changelog](https://keepachangelog.com/en/1.1.0/). Versions follow semantic versioning; see `README.md` for the bump policy and the distinction between plugin version and config schema version.
 
+## [0.11.5] - 2026-08-04
+
+### Fixed (Codex review round 2, PR #97)
+- **`reanchor` shipped in Python and in the docs but the `kipi judgment`
+  dispatcher rejected it**, so the documented recovery for an interrupted
+  anchor write did not exist at the CLI. The Python subparsers and the bash
+  allowlist are two hand-edited lists of the same thing; a `TestCliParity`
+  class now diffs them both ways and checks the usage text, so a subcommand
+  cannot ship reachable-in-one-place again. Verified by re-introducing the bug:
+  the parity tests go red.
+
 ## [0.11.4] - 2026-08-04
 
 ### Fixed (Codex review, PR #97 — both findings had executed reproducers)

--- a/plugins/prd-os/commands/prd-triage.md
+++ b/plugins/prd-os/commands/prd-triage.md
@@ -48,12 +48,25 @@ python3 "${CLAUDE_PLUGIN_ROOT}/scripts/findings_writer.py" list "$PRD_ID" --only
 
 Show them to the author. For each, ask what disposition they want. Do NOT guess the author's intent; pending findings are theirs to resolve.
 
-4. Apply each disposition:
+4. Apply each disposition. Pass the structured reason code and its evidence so
+   the judgment receipt captures a machine-checkable decision, not prose:
 
 ```bash
 python3 "${CLAUDE_PLUGIN_ROOT}/scripts/findings_writer.py" \
   set-disposition "$PRD_ID" <finding-id> <accepted|rejected|deferred> \
-  [--rationale "<text>"]
+  [--rationale "<text>"] \
+  [--reason-code <valid-fix-now|already-remediated|duplicate|owned-by-other-prd|scope-removed|out-of-scope|superseded|defer-dependency|defer-ordering|invalid-finding|insufficient-context|needs-human>] \
+  [--evidence <finding:prd/id | issue:id | prd:id | receipt:id | commit:sha | test:path | scope:path#section | judgment:receipt-id | spillover:id>]...
 ```
 
+   Every adjudication appends an immutable receipt to `.prd-os/judgments.jsonl`
+   (the Judgment Compiler ledger — `judgment_compiler.py`, enforced in code,
+   not here). Evidence-requiring codes (`duplicate`, `already-remediated`,
+   `owned-by-other-prd`, `scope-removed`, `out-of-scope`, `superseded`) are
+   REFUSED by the writer without a stable `--evidence` reference; the findings
+   file stays untouched on refusal. Omitting `--reason-code` still works and
+   records an honest `null` — prefer passing it: receipts with codes are what
+   the calibration evaluator and policy-candidate detector can learn from.
+
 5. When all findings are dispositioned, remind the author to run `/prd-approve`.
+   `kipi judgment verify` re-proves the receipt chain any time.

--- a/plugins/prd-os/scripts/findings_writer.py
+++ b/plugins/prd-os/scripts/findings_writer.py
@@ -53,6 +53,7 @@ from __future__ import annotations
 
 import argparse
 import json
+import os
 import re
 import sys
 from datetime import datetime, timezone
@@ -489,6 +490,20 @@ def cmd_set_disposition(cfg: Config, args: argparse.Namespace) -> int:  # noqa: 
             f"disposition={args.disposition!r} requires --rationale\n"
         )
         return 2
+    # Judgment Compiler fail-fast half (PRD prd-judgment-compiler-2026-08-04):
+    # an evidence-requiring reason code without its stable reference is refused
+    # BEFORE the findings file mutates, so a gate failure never leaves the
+    # ledger and the findings file disagreeing about what happened.
+    judgment_enabled = os.environ.get("KIPI_JUDGMENT_CAPTURE") != "0"
+    if judgment_enabled:
+        import judgment_compiler
+
+        gate_errors = judgment_compiler.validate_triage_decision(
+            getattr(args, "reason_code", None), getattr(args, "evidence", []))
+        if gate_errors:
+            for gate_error in gate_errors:
+                sys.stderr.write(f"{gate_error}\n")
+            return 2
     path = _findings_path(cfg, args.prd_id)
     try:
         recs = _load_findings(path)
@@ -522,6 +537,27 @@ def cmd_set_disposition(cfg: Config, args: argparse.Namespace) -> int:  # noqa: 
         return 2
     _write_all(path, recs)
     _sync_spillover_for_finding(cfg, args.prd_id, target)
+    if judgment_enabled:
+        # Append the immutable triage episode receipt. A failure here is loud:
+        # the disposition already landed, so a silent skip would strand the
+        # decision outside the judgment ledger with nothing to flag it.
+        import judgment_compiler
+
+        try:
+            judgment_compiler.capture_from_triage(
+                cfg, args.prd_id, target,
+                actor=getattr(args, "actor", "founder"),
+                reason_code=getattr(args, "reason_code", None),
+                evidence_refs=list(getattr(args, "evidence", [])),
+                rationale=(args.rationale or "").strip() or None,
+                judge_run_path=getattr(args, "judge_run", None),
+            )
+        except judgment_compiler.ValidationError as exc:
+            sys.stderr.write(
+                "disposition was written but the judgment receipt was NOT: "
+                f"{exc}\n"
+            )
+            return 2
     print(
         json.dumps(
             {
@@ -593,6 +629,14 @@ def main(argv: list[str] | None = None) -> int:
     p_set.add_argument("--rationale", default="")
     p_set.add_argument("--covered-by", default="", dest="covered_by",
                        help="umbrella coverage: the phase PRD id that owns this finding")
+    p_set.add_argument("--reason-code", default=None, dest="reason_code",
+                       help="canonical judgment reason code (judgment_compiler)")
+    p_set.add_argument("--evidence", action="append", default=[],
+                       help="stable evidence ref (repeatable), e.g. finding:<prd>/<id>")
+    p_set.add_argument("--actor", default="founder",
+                       help="who made this decision (judgment receipt)")
+    p_set.add_argument("--judge-run", default=None, dest="judge_run",
+                       help="path to a judge-run JSON bound to the context packet")
     p_set.set_defaults(func=cmd_set_disposition)
 
     p_rec = sub.add_parser("record-review")

--- a/plugins/prd-os/scripts/findings_writer.py
+++ b/plugins/prd-os/scripts/findings_writer.py
@@ -557,7 +557,12 @@ def cmd_set_disposition(cfg: Config, args: argparse.Namespace) -> int:  # noqa: 
     # our own primary write path (review 2026-08-04).
     pre_findings_bytes = path.read_bytes() if path.is_file() else None
     _write_all(path, recs)
-    _sync_spillover_for_finding(cfg, args.prd_id, target)
+    # Spillover fans out AFTER the receipt lands, not before. Ordered the other
+    # way, a refused receipt rolled the findings file back while the spillover
+    # append stood — and that ledger is append-only, so the standing gate saw
+    # permanent open work for a disposition the command had just reported as
+    # rolled back (Codex review, PR #97, executed reproducer). The receipt is
+    # the failure-prone step, so it goes first among the two irreversible ones.
     if judgment_enabled:
         import judgment_compiler
 
@@ -581,6 +586,7 @@ def cmd_set_disposition(cfg: Config, args: argparse.Namespace) -> int:  # noqa: 
                    "`kipi judgment verify --cross-check` before trusting it.\n")
             )
             return 2
+    _sync_spillover_for_finding(cfg, args.prd_id, target)
     print(
         json.dumps(
             {

--- a/plugins/prd-os/scripts/findings_writer.py
+++ b/plugins/prd-os/scripts/findings_writer.py
@@ -479,6 +479,18 @@ def _sync_spillover_for_finding(cfg: Config, prd_id: str, finding: dict) -> None
         _spillover_append(cfg, new)
 
 
+def _rollback_findings(path: Path, pre_bytes: bytes | None) -> bool:
+    """Restore the findings file to its pre-write bytes. Returns success."""
+    try:
+        if pre_bytes is None:
+            path.unlink(missing_ok=True)
+        else:
+            path.write_bytes(pre_bytes)
+        return True
+    except OSError:
+        return False
+
+
 def cmd_set_disposition(cfg: Config, args: argparse.Namespace) -> int:  # noqa: C901
     if args.disposition not in DISPOSITIONS:
         sys.stderr.write(
@@ -499,7 +511,8 @@ def cmd_set_disposition(cfg: Config, args: argparse.Namespace) -> int:  # noqa: 
         import judgment_compiler
 
         gate_errors = judgment_compiler.validate_triage_decision(
-            getattr(args, "reason_code", None), getattr(args, "evidence", []))
+            getattr(args, "reason_code", None), getattr(args, "evidence", []),
+            args.disposition, cfg)
         if gate_errors:
             for gate_error in gate_errors:
                 sys.stderr.write(f"{gate_error}\n")
@@ -535,12 +548,17 @@ def cmd_set_disposition(cfg: Config, args: argparse.Namespace) -> int:  # noqa: 
     except ValueError as exc:
         sys.stderr.write(f"{exc}\n")
         return 2
+    # Snapshot BEFORE the write so a failed capture can restore it. Mirrors the
+    # rollback cmd_add already does for its stamp step. Without this, any
+    # capture failure that the fail-fast pre-check cannot see (a stale packet, a
+    # bad --judge-run, an unresolvable evidence ref, an OSError on the shared
+    # ledger) left the findings file saying "rejected" with no receipt — the
+    # exact divergence `verify --cross-check` exists to detect, manufactured by
+    # our own primary write path (review 2026-08-04).
+    pre_findings_bytes = path.read_bytes() if path.is_file() else None
     _write_all(path, recs)
     _sync_spillover_for_finding(cfg, args.prd_id, target)
     if judgment_enabled:
-        # Append the immutable triage episode receipt. A failure here is loud:
-        # the disposition already landed, so a silent skip would strand the
-        # decision outside the judgment ledger with nothing to flag it.
         import judgment_compiler
 
         try:
@@ -552,10 +570,15 @@ def cmd_set_disposition(cfg: Config, args: argparse.Namespace) -> int:  # noqa: 
                 rationale=(args.rationale or "").strip() or None,
                 judge_run_path=getattr(args, "judge_run", None),
             )
-        except judgment_compiler.ValidationError as exc:
+        except (judgment_compiler.ValidationError, OSError) as exc:
+            rolled_back = _rollback_findings(path, pre_findings_bytes)
             sys.stderr.write(
-                "disposition was written but the judgment receipt was NOT: "
-                f"{exc}\n"
+                f"judgment receipt refused: {exc}\n"
+                + ("disposition rolled back; findings file unchanged.\n"
+                   if rolled_back else
+                   "WARNING: rollback ALSO failed. The findings file may now "
+                   "disagree with the judgment ledger; run "
+                   "`kipi judgment verify --cross-check` before trusting it.\n")
             )
             return 2
     print(

--- a/plugins/prd-os/scripts/judgment_compiler.py
+++ b/plugins/prd-os/scripts/judgment_compiler.py
@@ -1,0 +1,1416 @@
+#!/usr/bin/env python3
+"""Judgment Compiler: append-only decision receipts for PRD finding triage.
+
+PRD: q-system/output/prd-judgment-compiler-2026-08-04.md (ASK-363).
+Paired tests: plugins/prd-os/tests/test_judgment_compiler.py.
+
+Why this exists (verified v1 benchmark, founder-judge-calibration-v1): finding
+text + severity alone predict the founder's triage disposition at 40% exact
+agreement, kappa 0.032, worse than the 76.6% accept-all baseline. A disposition
+is not a property of an objection; it is a property of an objection inside
+workflow state. The findings ledger mutates records in place, so decision-time
+state is destroyed the moment state moves on. This module freezes it.
+
+Design constraints (each anchored to a scar):
+  - Ledger lives under the shared worktree root via prd_runner._ledger_root,
+    never cfg.repo_root (sp-bc42f1d3: 26 private worktree ledgers hid 71 open
+    findings from the gate that existed to see them).
+  - Receipts are append-only and hash-chained. Corrections append a superseding
+    receipt; nothing rewrites history (v1 scar: case 049's mutable body carried
+    its own adjudication into a "blind" benchmark).
+  - Missing evidence stays "unknown", never false (v1 scar: absent workflow
+    context silently became a property of the finding text).
+  - The self-test is fully in-memory (rca-founder-judge-calibration RCA: the
+    first benchmark's selftest died in Codex's read-only sandbox on a
+    tempfile call).
+  - This module contains NO code path that installs policy: promotion of a
+    policy candidate goes through the human-reviewed prd-os flow. A grep test
+    in the paired test file holds that line.
+
+Subcommands:
+  assemble           build a deterministic decision-context packet
+  capture            validate + append one triage episode receipt
+  verify             re-walk the chain; also --packet/--receipt-id binding
+  evaluate           score prospective judge-vs-human cases (read-only)
+  sample-check       deterministic 5% sampling verdict for a basis hash
+  policy-candidates  detect repeated override patterns, append proposals
+  --selftest         in-memory contract proof (read-only safe)
+
+Exit codes: 0 success, 2 validation error (matches findings_writer contract).
+"""
+
+from __future__ import annotations
+
+import argparse
+import hashlib
+import json
+import math
+import os
+import re
+import subprocess
+import sys
+from datetime import datetime, timezone
+from pathlib import Path
+
+SCRIPT_DIR = Path(__file__).resolve().parent
+if str(SCRIPT_DIR) not in sys.path:
+    sys.path.insert(0, str(SCRIPT_DIR))
+
+from config import Config, ConfigError, load as load_config  # noqa: E402
+
+RECEIPT_SCHEMA_VERSION = 1
+PACKET_SCHEMA_VERSION = 1
+LEDGER_NAME = "judgments.jsonl"
+CANDIDATES_NAME = "judgment-policy-candidates.jsonl"
+
+SAMPLE_SALT = "kipi-judgment-sample-v1"
+SAMPLE_MODULUS = 10000
+SAMPLE_THRESHOLD = 500  # 5%
+SAMPLE_RULE = f"int(sha256('{SAMPLE_SALT}:' + basis_sha256), 16) % {SAMPLE_MODULUS} < {SAMPLE_THRESHOLD}"
+
+LEGACY_DISPOSITIONS = ("pending", "accepted", "rejected", "deferred")
+TECHNICAL_VALIDITY = ("valid", "invalid", "uncertain")
+WORKFLOW_DISPOSITIONS = (
+    "fix-now", "already-remediated", "duplicate", "scope-removed",
+    "out-of-scope", "defer", "invalid", "needs-human",
+)
+REASON_CODES = (
+    "valid-fix-now", "already-remediated", "duplicate", "owned-by-other-prd",
+    "scope-removed", "out-of-scope", "superseded", "defer-dependency",
+    "defer-ordering", "invalid-finding", "insufficient-context", "needs-human",
+)
+JUDGE_OUTPUT_FIELDS = (
+    "technical_validity", "technical_reason", "workflow_disposition",
+    "workflow_reason_code", "evidence_refs", "missing_context", "confidence",
+)
+# Reason codes / workflow dispositions that must not pass without a stable
+# reference (PRD Change 4). Value = tuple of required ref prefixes; every
+# listed prefix must be present at least once.
+EVIDENCE_REQUIREMENTS = {
+    "duplicate": (("finding:", "issue:", "spillover:"),),
+    "already-remediated": (("receipt:", "commit:", "test:"),),
+    "owned-by-other-prd": (("prd:",), ("issue:",)),
+    "scope-removed": (("scope:",),),
+    "out-of-scope": (("scope:",),),
+    "superseded": (("judgment:",),),
+}
+EVIDENCE_REF_RE = re.compile(
+    r"^(finding|issue|prd|receipt|judgment|commit|test|scope|spillover):\S+$"
+)
+JUDGE_TO_LEGACY = {
+    "fix-now": "accepted",
+    "already-remediated": "rejected",
+    "duplicate": "rejected",
+    "scope-removed": "rejected",
+    "out-of-scope": "rejected",
+    "invalid": "rejected",
+    "defer": "deferred",
+    "needs-human": None,  # excluded from automation metrics
+}
+
+RECEIPT_FIELDS = frozenset((
+    "schema_version", "receipt_id", "captured_at", "finding", "review",
+    "repo_state", "prd_state", "issue_state", "scope", "duplicates",
+    "remediation", "related_prds", "prior_receipts", "missing_context",
+    "judge", "human", "sampling", "supersedes", "prev_receipt_sha256",
+))
+PACKET_FIELDS = frozenset((
+    "packet_schema_version", "assembled_at", "packet_sha256", "finding",
+    "review", "repo_state", "prd_state", "issue_state", "scope", "duplicates",
+    "remediation", "related_prds", "prior_receipts", "missing_context",
+))
+CANDIDATE_FIELDS = frozenset((
+    "candidate_id", "status", "created_at", "pattern",
+    "supporting_receipt_ids", "case_count", "counterexamples",
+    "counterexample_search", "proposed_rule", "proposed_tests",
+    "false_positive_risk", "integration_point",
+))
+
+
+class ValidationError(ValueError):
+    """A contract violation. Caller converts to exit 2."""
+
+
+# ---------------------------------------------------------------------------
+# Canonical hashing (pinned by the paired tests from the other side)
+# ---------------------------------------------------------------------------
+
+
+def canonical_hash(record: dict) -> str:
+    payload = json.dumps(record, sort_keys=True, separators=(",", ":"),
+                         ensure_ascii=False)
+    return hashlib.sha256(payload.encode("utf-8")).hexdigest()
+
+
+def packet_hash(packet: dict) -> str:
+    body = {k: v for k, v in packet.items()
+            if k not in ("packet_sha256", "assembled_at")}
+    return canonical_hash(body)
+
+
+def receipt_content_id(record: dict) -> str:
+    body = {k: v for k, v in record.items() if k != "receipt_id"}
+    return "jr-" + canonical_hash(body)[:16]
+
+
+def sample_decision(basis_sha256: str) -> bool:
+    digest = hashlib.sha256(f"{SAMPLE_SALT}:{basis_sha256}".encode()).hexdigest()
+    return int(digest, 16) % SAMPLE_MODULUS < SAMPLE_THRESHOLD
+
+
+def _now_iso() -> str:
+    return datetime.now(timezone.utc).strftime("%Y-%m-%dT%H:%M:%SZ")
+
+
+def _sha256_text(text: str) -> str:
+    return hashlib.sha256(text.encode("utf-8")).hexdigest()
+
+
+# ---------------------------------------------------------------------------
+# Ledger paths (shared across worktrees; see module docstring)
+# ---------------------------------------------------------------------------
+
+
+def _ledger_dir(cfg: Config) -> Path:
+    from prd_runner import _ledger_root  # sibling; one definition of the root
+
+    return _ledger_root(cfg.repo_root) / ".prd-os"
+
+
+def ledger_path(cfg: Config) -> Path:
+    return _ledger_dir(cfg) / LEDGER_NAME
+
+
+def candidates_path(cfg: Config) -> Path:
+    return _ledger_dir(cfg) / CANDIDATES_NAME
+
+
+def read_ledger(path: Path) -> list[dict]:
+    if not path.is_file():
+        return []
+    records = []
+    for line_number, raw in enumerate(path.read_text(encoding="utf-8").splitlines(), 1):
+        if not raw.strip():
+            continue
+        try:
+            record = json.loads(raw)
+        except json.JSONDecodeError as exc:
+            raise ValidationError(f"{path}:{line_number}: invalid JSON: {exc}") from exc
+        if not isinstance(record, dict):
+            raise ValidationError(f"{path}:{line_number}: expected an object")
+        records.append(record)
+    return records
+
+
+# ---------------------------------------------------------------------------
+# Field validators (small and boring on purpose)
+# ---------------------------------------------------------------------------
+
+
+def _require_keys(obj: dict, allowed: frozenset, where: str) -> None:
+    extra = sorted(set(obj) - allowed)
+    missing = sorted(allowed - set(obj))
+    if extra:
+        raise ValidationError(f"{where}: unknown fields {extra}")
+    if missing:
+        raise ValidationError(f"{where}: missing fields {missing}")
+
+
+def _require_str_or_unknown(value, where: str) -> None:
+    if not isinstance(value, str) or not value:
+        raise ValidationError(
+            f"{where}: must be a non-empty string (use 'unknown' for missing "
+            f"evidence, never false/null); got {value!r}")
+
+
+def _validate_confidence(value, where: str) -> None:
+    if isinstance(value, bool) or not isinstance(value, (int, float)):
+        raise ValidationError(f"{where}: confidence must be a number, got {value!r}")
+    if not math.isfinite(value) or not 0 <= value <= 1:
+        raise ValidationError(
+            f"{where}: confidence must be finite and within [0, 1], got {value!r}")
+
+
+def _validate_evidence_refs(refs, where: str) -> None:
+    if not isinstance(refs, list) or not all(isinstance(r, str) for r in refs):
+        raise ValidationError(f"{where}: evidence_refs must be a list of strings")
+    for ref in refs:
+        if not EVIDENCE_REF_RE.match(ref):
+            raise ValidationError(
+                f"{where}: evidence ref {ref!r} does not match the stable "
+                "reference grammar prefix:value")
+
+
+def evidence_gate_errors(reason_code: str | None, disposition: str | None,
+                         refs: list[str]) -> list[str]:
+    """Which required reference prefixes are missing for this decision."""
+    requirements: list[tuple[str, ...]] = []
+    for key in (reason_code, disposition):
+        for group in EVIDENCE_REQUIREMENTS.get(key or "", ()):  # type: ignore[arg-type]
+            if group not in requirements:
+                requirements.append(group)
+    errors = []
+    for group in requirements:
+        if not any(ref.startswith(prefix) for prefix in group for ref in refs):
+            errors.append(
+                f"disposition/reason {reason_code or disposition!r} requires an "
+                f"evidence ref with prefix in {sorted(group)}")
+    return errors
+
+
+def validate_judge_output(output: dict, where: str) -> None:
+    if not isinstance(output, dict):
+        raise ValidationError(f"{where}: judge output must be an object")
+    extra = sorted(set(output) - set(JUDGE_OUTPUT_FIELDS))
+    if extra:
+        raise ValidationError(f"{where}: unexpected judge output fields {extra}")
+    missing = sorted(set(JUDGE_OUTPUT_FIELDS) - set(output))
+    if missing:
+        raise ValidationError(f"{where}: missing judge output fields {missing}")
+    if output["technical_validity"] not in TECHNICAL_VALIDITY:
+        raise ValidationError(
+            f"{where}: technical_validity must be one of {TECHNICAL_VALIDITY}")
+    if output["workflow_disposition"] not in WORKFLOW_DISPOSITIONS:
+        raise ValidationError(
+            f"{where}: workflow_disposition must be one of {WORKFLOW_DISPOSITIONS}")
+    if output["workflow_reason_code"] not in REASON_CODES:
+        raise ValidationError(
+            f"{where}: workflow_reason_code must be one of the canonical "
+            f"reason codes; got {output['workflow_reason_code']!r}")
+    if not isinstance(output["technical_reason"], str):
+        raise ValidationError(f"{where}: technical_reason must be a string")
+    _validate_evidence_refs(output["evidence_refs"], where)
+    if not isinstance(output["missing_context"], list) or not all(
+            isinstance(m, str) for m in output["missing_context"]):
+        raise ValidationError(f"{where}: missing_context must be a list of strings")
+    _validate_confidence(output["confidence"], where)
+
+
+def validate_packet(packet: dict, where: str = "packet") -> None:
+    if not isinstance(packet, dict):
+        raise ValidationError(f"{where}: must be an object")
+    _require_keys(packet, PACKET_FIELDS, where)
+    if packet["packet_schema_version"] != PACKET_SCHEMA_VERSION:
+        raise ValidationError(f"{where}: unsupported packet_schema_version")
+    if packet_hash(packet) != packet["packet_sha256"]:
+        raise ValidationError(f"{where}: packet_sha256 does not match content")
+    _validate_state_groups(packet, where)
+
+
+def _validate_state_groups(container: dict, where: str) -> None:
+    """Shared shape checks for the context groups in packets and receipts."""
+    finding = container["finding"]
+    _require_keys(finding, frozenset(
+        ("prd_id", "finding_id", "severity", "body", "body_sha256")),
+        f"{where}.finding")
+    if _sha256_text(finding["body"]) != finding["body_sha256"]:
+        raise ValidationError(f"{where}.finding: body_sha256 mismatch")
+    repo_state = container["repo_state"]
+    _require_keys(repo_state, frozenset(("branch", "commit_sha", "dirty")),
+                  f"{where}.repo_state")
+    for key in ("branch", "commit_sha"):
+        _require_str_or_unknown(repo_state[key], f"{where}.repo_state.{key}")
+    if repo_state["dirty"] not in ("true", "false", "unknown"):
+        raise ValidationError(
+            f"{where}.repo_state.dirty: must be 'true'/'false'/'unknown' "
+            f"(strings — missing evidence stays unknown, never a fabricated "
+            f"boolean); got {repo_state['dirty']!r}")
+    _require_keys(container["prd_state"], frozenset(
+        ("path", "sha256", "status", "revision")), f"{where}.prd_state")
+    _require_keys(container["issue_state"], frozenset(
+        ("issue_id", "manifest_sha256", "issue_order")), f"{where}.issue_state")
+    if not isinstance(container["issue_state"]["issue_order"], list):
+        raise ValidationError(f"{where}.issue_state.issue_order: must be a list")
+    _require_keys(container["scope"], frozenset(("source", "sha256")),
+                  f"{where}.scope")
+    for name in ("duplicates", "remediation", "related_prds", "prior_receipts",
+                 "missing_context"):
+        if not isinstance(container[name], list):
+            raise ValidationError(f"{where}.{name}: must be a list")
+
+
+def validate_receipt(record: dict, where: str) -> None:
+    _require_keys(record, RECEIPT_FIELDS, where)
+    if record["schema_version"] != RECEIPT_SCHEMA_VERSION:
+        raise ValidationError(f"{where}: unsupported schema_version")
+    if receipt_content_id(record) != record["receipt_id"]:
+        raise ValidationError(
+            f"{where}: receipt_id does not match record content (mutated "
+            "receipt or forged id)")
+    _validate_state_groups(record, where)
+    _validate_review(record["review"], where)
+    _validate_sampling(record["sampling"], where)
+    _validate_judge_block(record["judge"], where)
+    _validate_human_block(record["human"], where)
+    supersedes = record["supersedes"]
+    if supersedes is not None and not isinstance(supersedes, str):
+        raise ValidationError(f"{where}: supersedes must be a receipt id or null")
+    prev = record["prev_receipt_sha256"]
+    if prev is not None and (not isinstance(prev, str) or len(prev) != 64):
+        raise ValidationError(f"{where}: prev_receipt_sha256 must be sha256 or null")
+
+
+def _validate_review(review: dict, where: str) -> None:
+    _require_keys(review, frozenset(("source", "review_run_id")), f"{where}.review")
+
+
+def _validate_sampling(sampling: dict, where: str) -> None:
+    _require_keys(sampling, frozenset(
+        ("basis_sha256", "rule", "salt", "sampled")), f"{where}.sampling")
+    if not isinstance(sampling["sampled"], bool):
+        raise ValidationError(f"{where}.sampling.sampled: must be a boolean")
+    if sampling["rule"] != SAMPLE_RULE or sampling["salt"] != SAMPLE_SALT:
+        raise ValidationError(f"{where}.sampling: rule/salt drifted from contract")
+    if sample_decision(sampling["basis_sha256"]) != sampling["sampled"]:
+        raise ValidationError(
+            f"{where}.sampling: recorded verdict does not reproduce from the rule")
+
+
+def _validate_judge_block(judge, where: str) -> None:
+    if judge is None:
+        return
+    _require_keys(judge, frozenset(
+        ("model", "prompt_sha256", "review_run_id", "input_sha256",
+         "output_sha256", "output", "converted_to_needs_human",
+         "converted_from")), f"{where}.judge")
+    validate_judge_output(judge["output"], f"{where}.judge.output")
+    if not isinstance(judge["converted_to_needs_human"], bool):
+        raise ValidationError(f"{where}.judge.converted_to_needs_human: bool required")
+
+
+def _validate_human_block(human, where: str) -> None:
+    if human is None:
+        return
+    _require_keys(human, frozenset(
+        ("actor", "decided_at", "disposition", "reason_code", "evidence_refs",
+         "rationale")), f"{where}.human")
+    if human["disposition"] not in LEGACY_DISPOSITIONS:
+        raise ValidationError(f"{where}.human.disposition: unknown disposition")
+    code = human["reason_code"]
+    if code is not None and code not in REASON_CODES:
+        raise ValidationError(
+            f"{where}.human.reason_code: must be one of the canonical reason "
+            f"codes or null; got {code!r}")
+    _validate_evidence_refs(human["evidence_refs"], f"{where}.human")
+    gate = evidence_gate_errors(code, None, human["evidence_refs"])
+    if gate:
+        raise ValidationError(f"{where}.human: " + "; ".join(gate))
+
+
+def validate_candidate(record: dict, where: str) -> None:
+    _require_keys(record, CANDIDATE_FIELDS, where)
+    if record["status"] != "proposed":
+        raise ValidationError(
+            f"{where}: candidate status must stay 'proposed' in this ledger; "
+            "promotion happens in the human-reviewed prd-os flow")
+    if not isinstance(record["counterexample_search"], str) or \
+            not record["counterexample_search"].strip():
+        raise ValidationError(
+            f"{where}: counterexample_search is required — a candidate without "
+            "a recorded counterexample search is an unsupported pattern claim")
+    if not isinstance(record["counterexamples"], list):
+        raise ValidationError(f"{where}: counterexamples must be a list")
+    if not isinstance(record["supporting_receipt_ids"], list) or \
+            not record["supporting_receipt_ids"]:
+        raise ValidationError(f"{where}: supporting_receipt_ids required")
+
+
+# ---------------------------------------------------------------------------
+# Context assembly (deterministic; unknown stays unknown)
+# ---------------------------------------------------------------------------
+
+
+def _git(repo_root: Path, *args: str) -> str | None:
+    try:
+        proc = subprocess.run(["git", *args], cwd=str(repo_root),
+                              capture_output=True, text=True, timeout=30)
+    except (OSError, subprocess.SubprocessError):
+        return None
+    if proc.returncode != 0:
+        return None
+    return proc.stdout.strip()
+
+
+def _assemble_repo_state(repo_root: Path, missing: list[str]) -> dict:
+    branch = _git(repo_root, "rev-parse", "--abbrev-ref", "HEAD")
+    commit = _git(repo_root, "rev-parse", "HEAD")
+    porcelain = _git(repo_root, "status", "--porcelain")
+    state = {
+        "branch": branch or "unknown",
+        "commit_sha": commit or "unknown",
+        "dirty": "unknown" if porcelain is None else
+                 ("true" if porcelain else "false"),
+    }
+    for key in ("branch", "commit_sha", "dirty"):
+        if state[key] == "unknown":
+            missing.append(f"repo_state.{key}")
+    return state
+
+
+def _prd_spec_path(cfg: Config, prd_id: str) -> Path:
+    return cfg.prds_dir / f"{prd_id}.md"
+
+
+def _assemble_prd_state(cfg: Config, prd_id: str, missing: list[str]) -> dict:
+    path = _prd_spec_path(cfg, prd_id)
+    rel = os.path.relpath(path, cfg.repo_root)
+    if not path.is_file():
+        missing.extend(["prd_state.sha256", "prd_state.status",
+                        "prd_state.revision"])
+        return {"path": rel, "sha256": "unknown", "status": "unknown",
+                "revision": "unknown"}
+    text = path.read_text(encoding="utf-8")
+    status_match = re.search(r"(?m)^status:\s*(\S+)", text)
+    revision = _git(cfg.repo_root, "log", "-1", "--format=%H", "--", rel)
+    if not revision:
+        missing.append("prd_state.revision")
+    if not status_match:
+        missing.append("prd_state.status")
+    return {
+        "path": rel,
+        "sha256": _sha256_text(text),
+        "status": status_match.group(1) if status_match else "unknown",
+        "revision": revision or "unknown",
+    }
+
+
+def _assemble_issue_state(cfg: Config, prd_id: str, missing: list[str]) -> dict:
+    path = _prd_spec_path(cfg, prd_id)
+    issue_id = None
+    state_path = cfg.active_issue_state_path
+    if state_path.is_file():
+        try:
+            issue_id = json.loads(state_path.read_text()).get("issue_id")
+        except (json.JSONDecodeError, OSError):
+            issue_id = None
+    if not path.is_file():
+        missing.append("issue_state.manifest")
+        return {"issue_id": issue_id, "manifest_sha256": "unknown",
+                "issue_order": []}
+    try:
+        import prd_split  # sibling: the one parser of the Issues manifest
+
+        text = path.read_text(encoding="utf-8")
+        body_start = text.find("---", 3)
+        raw = prd_split._extract_issues_block(text[body_start:])
+        entries = json.loads(raw)
+        order = [entry.get("id") for entry in entries
+                 if isinstance(entry, dict) and entry.get("id")]
+        return {"issue_id": issue_id, "manifest_sha256": _sha256_text(raw),
+                "issue_order": order}
+    except (ValueError, OSError, ImportError):
+        missing.append("issue_state.manifest")
+        return {"issue_id": issue_id, "manifest_sha256": "unknown",
+                "issue_order": []}
+
+
+def _assemble_scope(cfg: Config, prd_id: str, missing: list[str]) -> dict:
+    path = _prd_spec_path(cfg, prd_id)
+    rel = os.path.relpath(path, cfg.repo_root)
+    if path.is_file():
+        text = path.read_text(encoding="utf-8")
+        match = re.search(r"(?ms)^##\s+.*?Scope.*?$(.*?)(?=^##\s|\Z)", text)
+        if match:
+            return {"source": f"{rel}#Scope",
+                    "sha256": _sha256_text(match.group(1).strip())}
+    missing.append("scope")
+    return {"source": "unknown", "sha256": "unknown"}
+
+
+def _assemble_duplicates(cfg: Config, prd_id: str, finding_id: str,
+                         finding_body: str, missing: list[str]) -> list[dict]:
+    duplicates: list[dict] = []
+    try:
+        import findings_xref
+
+        for match in findings_xref.cross_reference(prd_id, cfg=cfg,
+                                                   repo_root=cfg.repo_root):
+            if match.get("current_finding_id") != finding_id:
+                continue
+            duplicates.append({
+                "prd_id": match["prior_prd_id"],
+                "finding_id": match["prior_finding_id"],
+                "similarity": match["similarity"],
+                "source": str(os.path.relpath(
+                    cfg.findings_dir / f"{match['prior_prd_id']}-findings.jsonl",
+                    cfg.repo_root)),
+            })
+        threshold = getattr(findings_xref, "DEFAULT_THRESHOLD", 0.5)
+        own_path = cfg.findings_dir / f"{prd_id}-findings.jsonl"
+        for record in _read_findings(own_path):
+            if record.get("id") == finding_id:
+                continue
+            similarity = findings_xref.jaccard(finding_body,
+                                               str(record.get("body", "")))
+            if similarity >= threshold:
+                duplicates.append({
+                    "prd_id": prd_id,
+                    "finding_id": record["id"],
+                    "similarity": similarity,
+                    "source": str(os.path.relpath(own_path, cfg.repo_root)),
+                })
+    except Exception:  # advisory engine failure -> honest unknown, not []
+        missing.append("duplicates")
+    return duplicates
+
+
+def _read_findings(path: Path) -> list[dict]:
+    if not path.is_file():
+        return []
+    records = []
+    for raw in path.read_text(encoding="utf-8").splitlines():
+        if not raw.strip():
+            continue
+        try:
+            record = json.loads(raw)
+        except json.JSONDecodeError:
+            continue
+        if isinstance(record, dict):
+            records.append(record)
+    return records
+
+
+def _assemble_remediation(cfg: Config, prd_id: str, finding_id: str,
+                          missing: list[str]) -> list[dict]:
+    path = cfg.receipts_path
+    if not path.is_file():
+        return []
+    rel = os.path.relpath(path, cfg.repo_root)
+    rows = []
+    try:
+        for line_number, raw in enumerate(
+                path.read_text(encoding="utf-8").splitlines(), 1):
+            if not raw.strip():
+                continue
+            record = json.loads(raw)
+            if record.get("prd_id") == prd_id and \
+                    record.get("finding_id") == finding_id:
+                rows.append({
+                    "issue_id": record.get("issue_id"),
+                    "finding_id": record.get("finding_id"),
+                    "closed_at": record.get("closed_at"),
+                    "commit_sha": record.get("commit_sha"),
+                    "source": f"{rel}:{line_number}",
+                })
+    except (json.JSONDecodeError, OSError):
+        missing.append("remediation")
+    return rows
+
+
+def assemble_packet(cfg: Config, prd_id: str, finding_id: str) -> dict:
+    findings_file = cfg.findings_dir / f"{prd_id}-findings.jsonl"
+    finding = next((r for r in _read_findings(findings_file)
+                    if r.get("id") == finding_id), None)
+    if finding is None:
+        raise ValidationError(
+            f"finding not found: {prd_id}/{finding_id} in {findings_file}")
+    body = str(finding.get("body", ""))
+    missing: list[str] = []
+    duplicates = _assemble_duplicates(cfg, prd_id, finding_id, body, missing)
+    prior = [r["receipt_id"] for r in read_ledger(ledger_path(cfg))
+             if r.get("finding", {}).get("prd_id") == prd_id
+             and r.get("finding", {}).get("finding_id") == finding_id]
+    packet = {
+        "packet_schema_version": PACKET_SCHEMA_VERSION,
+        "finding": {
+            "prd_id": prd_id,
+            "finding_id": finding_id,
+            "severity": finding.get("severity"),
+            "body": body,
+            "body_sha256": _sha256_text(body),
+        },
+        "review": {"source": finding.get("source"), "review_run_id": None},
+        "repo_state": _assemble_repo_state(cfg.repo_root, missing),
+        "prd_state": _assemble_prd_state(cfg, prd_id, missing),
+        "issue_state": _assemble_issue_state(cfg, prd_id, missing),
+        "scope": _assemble_scope(cfg, prd_id, missing),
+        "duplicates": duplicates,
+        "remediation": _assemble_remediation(cfg, prd_id, finding_id, missing),
+        "related_prds": sorted({d["prd_id"] for d in duplicates
+                                if d["prd_id"] != prd_id}),
+        "prior_receipts": prior,
+        "missing_context": sorted(set(missing)),
+    }
+    packet["assembled_at"] = _now_iso()
+    packet["packet_sha256"] = packet_hash(packet)
+    return packet
+
+
+# ---------------------------------------------------------------------------
+# Capture
+# ---------------------------------------------------------------------------
+
+
+def _check_packet_freshness(cfg: Config, packet: dict) -> None:
+    """A receipt freezes decision-time state, so the packet must BE
+    decision-time state: if the PRD or finding moved since assembly, refuse
+    and demand a re-assemble instead of freezing a lie."""
+    prd_state = packet["prd_state"]
+    if prd_state["sha256"] != "unknown":
+        path = cfg.repo_root / prd_state["path"]
+        current = _sha256_text(path.read_text(encoding="utf-8")) \
+            if path.is_file() else "unknown"
+        if current != prd_state["sha256"]:
+            raise ValidationError(
+                "stale context packet: the PRD changed after assembly "
+                f"({prd_state['path']}). Re-run assemble.")
+    finding = packet["finding"]
+    findings_file = cfg.findings_dir / f"{finding['prd_id']}-findings.jsonl"
+    current_finding = next(
+        (r for r in _read_findings(findings_file)
+         if r.get("id") == finding["finding_id"]), None)
+    if current_finding is None or \
+            _sha256_text(str(current_finding.get("body", ""))) != finding["body_sha256"]:
+        raise ValidationError(
+            "stale context packet: the finding body changed after assembly. "
+            "Re-run assemble.")
+
+
+def _load_judge_run(path: Path, packet: dict) -> dict:
+    try:
+        raw = json.loads(path.read_text(encoding="utf-8"))
+    except (json.JSONDecodeError, OSError) as exc:
+        raise ValidationError(f"judge run {path}: unreadable: {exc}") from exc
+    allowed = frozenset(("model", "prompt_sha256", "review_run_id",
+                         "input_sha256", "output"))
+    extra = sorted(set(raw) - allowed)
+    if extra:
+        raise ValidationError(f"judge run: unknown fields {extra}")
+    for key in ("model", "prompt_sha256", "input_sha256", "output"):
+        if key not in raw:
+            raise ValidationError(f"judge run: missing field {key}")
+    if raw["input_sha256"] != packet["packet_sha256"]:
+        raise ValidationError(
+            "judge run input_sha256 does not match the context packet hash — "
+            "the judge saw different context than this capture (stale hash)")
+    validate_judge_output(raw["output"], "judge run")
+    return raw
+
+
+def _judge_block_from_run(run: dict) -> dict:
+    output = dict(run["output"])
+    output_sha256 = canonical_hash(output)
+    converted_from = None
+    gate = evidence_gate_errors(output["workflow_reason_code"],
+                                output["workflow_disposition"],
+                                output["evidence_refs"])
+    if gate:
+        # PRD Change 4: an unsupported JUDGE recommendation degrades to
+        # needs-human (advisory contract). A human decision hard-fails instead.
+        converted_from = output["workflow_disposition"]
+        output["workflow_disposition"] = "needs-human"
+        output["missing_context"] = sorted(set(output["missing_context"]) |
+                                           {"required_evidence"})
+    return {
+        "model": run["model"],
+        "prompt_sha256": run["prompt_sha256"],
+        "review_run_id": run.get("review_run_id"),
+        "input_sha256": run["input_sha256"],
+        "output_sha256": output_sha256,
+        "output": output,
+        "converted_to_needs_human": converted_from is not None,
+        "converted_from": converted_from,
+    }
+
+
+def build_receipt(cfg: Config, packet: dict, *, disposition: str,
+                  actor: str, reason_code: str | None,
+                  evidence_refs: list[str], rationale: str | None,
+                  judge_run: dict | None, supersedes: str | None,
+                  existing: list[dict]) -> dict:
+    """Validate the whole episode and produce the receipt record (pure)."""
+    validate_packet(packet)
+    if disposition not in LEGACY_DISPOSITIONS:
+        raise ValidationError(f"disposition must be one of {LEGACY_DISPOSITIONS}")
+    if reason_code is not None and reason_code not in REASON_CODES:
+        raise ValidationError(
+            f"reason-code must be one of the canonical codes; got {reason_code!r}")
+    _validate_evidence_refs(evidence_refs, "human decision")
+    gate = evidence_gate_errors(reason_code, None, evidence_refs)
+    if gate:
+        raise ValidationError("human decision: " + "; ".join(gate))
+
+    known_ids = {r["receipt_id"] for r in existing}
+    if supersedes is not None and supersedes not in known_ids:
+        raise ValidationError(f"supersedes target not found: {supersedes}")
+    if supersedes is None:
+        finding = packet["finding"]
+        already_superseded = {r["supersedes"] for r in existing
+                             if r.get("supersedes")}
+        priors = [r for r in existing
+                  if r["finding"]["prd_id"] == finding["prd_id"]
+                  and r["finding"]["finding_id"] == finding["finding_id"]
+                  and r["receipt_id"] not in already_superseded]
+        if priors:
+            supersedes = priors[-1]["receipt_id"]
+
+    missing_context = list(packet["missing_context"])
+    if reason_code is None:
+        missing_context.append("human.reason_code")
+
+    record = {
+        "schema_version": RECEIPT_SCHEMA_VERSION,
+        "captured_at": _now_iso(),
+        "finding": packet["finding"],
+        "review": packet["review"],
+        "repo_state": packet["repo_state"],
+        "prd_state": packet["prd_state"],
+        "issue_state": packet["issue_state"],
+        "scope": packet["scope"],
+        "duplicates": packet["duplicates"],
+        "remediation": packet["remediation"],
+        "related_prds": packet["related_prds"],
+        "prior_receipts": packet["prior_receipts"],
+        "missing_context": sorted(set(missing_context)),
+        "judge": _judge_block_from_run(judge_run) if judge_run else None,
+        "human": {
+            "actor": actor,
+            "decided_at": _now_iso(),
+            "disposition": disposition,
+            "reason_code": reason_code,
+            "evidence_refs": evidence_refs,
+            "rationale": rationale,
+        },
+        "sampling": {
+            "basis_sha256": packet["packet_sha256"],
+            "rule": SAMPLE_RULE,
+            "salt": SAMPLE_SALT,
+            "sampled": sample_decision(packet["packet_sha256"]),
+        },
+        "supersedes": supersedes,
+        "prev_receipt_sha256": canonical_hash(existing[-1]) if existing else None,
+    }
+    record["receipt_id"] = receipt_content_id(record)
+    if record["receipt_id"] in known_ids:
+        raise ValidationError(
+            f"duplicate receipt id {record['receipt_id']}: refusing to append")
+    validate_receipt(record, record["receipt_id"])
+    return record
+
+
+def append_receipt(path: Path, record: dict) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    line = json.dumps(record, sort_keys=True, separators=(",", ":"),
+                      ensure_ascii=False)
+    with path.open("a", encoding="utf-8") as handle:
+        handle.write(line + "\n")
+        handle.flush()
+
+
+def capture_episode(cfg: Config, packet: dict, **kwargs) -> dict:
+    """The single write path into the judgments ledger."""
+    _check_packet_freshness(cfg, packet)
+    path = ledger_path(cfg)
+    existing = read_ledger(path)
+    record = build_receipt(cfg, packet, existing=existing, **kwargs)
+    append_receipt(path, record)
+    return record
+
+
+def capture_from_triage(cfg: Config, prd_id: str, finding: dict, *,
+                        actor: str, reason_code: str | None,
+                        evidence_refs: list[str], rationale: str | None,
+                        judge_run_path: str | None) -> dict:
+    """Called by findings_writer.cmd_set_disposition after the disposition
+    write. Assembles context inline; the caller pre-validated the evidence
+    gate via validate_triage_decision (fail-fast, before any mutation)."""
+    packet = assemble_packet(cfg, prd_id, finding["id"])
+    judge_run = None
+    if judge_run_path:
+        judge_run = _load_judge_run(Path(judge_run_path), packet)
+    return capture_episode(
+        cfg, packet, disposition=finding["disposition"], actor=actor,
+        reason_code=reason_code, evidence_refs=evidence_refs,
+        rationale=rationale, judge_run=judge_run, supersedes=None)
+
+
+def validate_triage_decision(reason_code: str | None,
+                             evidence_refs: list[str]) -> list[str]:
+    """Fail-fast half for findings_writer: returns error strings, no I/O."""
+    errors = []
+    if reason_code is not None and reason_code not in REASON_CODES:
+        errors.append(
+            f"reason-code must be one of {REASON_CODES}; got {reason_code!r}")
+        return errors
+    try:
+        _validate_evidence_refs(evidence_refs, "human decision")
+    except ValidationError as exc:
+        errors.append(str(exc))
+        return errors
+    errors.extend(evidence_gate_errors(reason_code, None, evidence_refs))
+    return errors
+
+
+# ---------------------------------------------------------------------------
+# Verify
+# ---------------------------------------------------------------------------
+
+
+def verify_ledger(records: list[dict]) -> list[str]:
+    errors = []
+    seen_ids: set[str] = set()
+    prev_hash: str | None = None
+    for index, record in enumerate(records, 1):
+        where = f"receipt line {index}"
+        # Duplicate detection runs on the STORED id, before content validation:
+        # a forged copy of an earlier receipt fails self-hash too, but the
+        # duplicate must be named as such (N-7) — one error per defect class.
+        rid = record.get("receipt_id")
+        if isinstance(rid, str):
+            if rid in seen_ids:
+                errors.append(f"{where}: duplicate receipt id {rid}")
+            seen_ids.add(rid)
+        try:
+            validate_receipt(record, where)
+        except ValidationError as exc:
+            errors.append(str(exc))
+            prev_hash = canonical_hash(record)
+            continue
+        if record["prev_receipt_sha256"] != prev_hash:
+            errors.append(
+                f"{where}: broken chain — prev_receipt_sha256 does not match "
+                "the previous receipt")
+        if record["supersedes"] is not None and \
+                record["supersedes"] not in seen_ids - {rid}:
+            errors.append(
+                f"{where}: supersedes {record['supersedes']} which does not "
+                "appear earlier in the ledger")
+        prev_hash = canonical_hash(record)
+    return errors
+
+
+def verify_candidates(records: list[dict]) -> list[str]:
+    errors = []
+    for index, record in enumerate(records, 1):
+        try:
+            validate_candidate(record, f"candidate line {index}")
+        except ValidationError as exc:
+            errors.append(str(exc))
+    return errors
+
+
+def verify_packet_binding(packet: dict, receipt: dict) -> list[str]:
+    errors = []
+    recomputed = packet_hash(packet)
+    if recomputed != receipt["sampling"]["basis_sha256"]:
+        errors.append(
+            "packet does not re-hash to the receipt's sampling basis "
+            f"({recomputed} != {receipt['sampling']['basis_sha256']})")
+    judge = receipt.get("judge")
+    if judge and judge["input_sha256"] != recomputed:
+        errors.append("packet does not re-hash to the judge input_sha256")
+    return errors
+
+
+# ---------------------------------------------------------------------------
+# Evaluate
+# ---------------------------------------------------------------------------
+
+
+def _active_receipts(records: list[dict]) -> tuple[list[dict], int]:
+    superseded = {r["supersedes"] for r in records if r.get("supersedes")}
+    active = [r for r in records if r["receipt_id"] not in superseded]
+    return active, len(records) - len(active)
+
+
+def _score_cases(cases: list[tuple[str, str, float]]) -> dict:
+    """cases: (gold_legacy, predicted_legacy, confidence)."""
+    labels = ("accepted", "rejected", "deferred")
+    matrix = {g: {p: 0 for p in labels} for g in labels}
+    for gold, predicted, _confidence in cases:
+        matrix[gold][predicted] += 1
+    total = len(cases)
+    correct = sum(matrix[l][l] for l in labels)
+    gold_totals = {l: sum(matrix[l].values()) for l in labels}
+    pred_totals = {l: sum(matrix[g][l] for g in labels) for l in labels}
+    per_class = {}
+    for label in labels:
+        tp = matrix[label][label]
+        recall = tp / gold_totals[label] if gold_totals[label] else 0.0
+        precision = tp / pred_totals[label] if pred_totals[label] else 0.0
+        f1 = (2 * precision * recall / (precision + recall)) \
+            if precision + recall else 0.0
+        per_class[label] = {"precision": precision, "recall": recall, "f1": f1}
+    expected = sum(gold_totals[l] * pred_totals[l] for l in labels) / (total * total) \
+        if total else 0.0
+    accuracy = correct / total if total else 0.0
+    kappa = (accuracy - expected) / (1 - expected) \
+        if total and not math.isclose(expected, 1.0) else (1.0 if total else 0.0)
+    ece = _expected_calibration_error(cases)
+    return {
+        "cases": total,
+        "exact_agreement": accuracy,
+        "balanced_accuracy": sum(per_class[l]["recall"] for l in labels) / len(labels),
+        "macro_f1": sum(per_class[l]["f1"] for l in labels) / len(labels),
+        "cohen_kappa": kappa,
+        "per_class": per_class,
+        "confusion_matrix": matrix,
+        "ece_10_bin": ece,
+    }
+
+
+def _expected_calibration_error(cases: list[tuple[str, str, float]]) -> float:
+    total = len(cases)
+    if not total:
+        return 0.0
+    ece = 0.0
+    for bin_index in range(10):
+        lower, upper = bin_index / 10, (bin_index + 1) / 10
+        members = [(gold, predicted, confidence)
+                   for gold, predicted, confidence in cases
+                   if confidence >= lower and
+                   (confidence < upper or (upper == 1.0 and confidence <= upper))]
+        if not members:
+            continue
+        mean_confidence = sum(c for _, _, c in members) / len(members)
+        accuracy = sum(1 for g, p, _ in members if g == p) / len(members)
+        ece += (len(members) / total) * abs(accuracy - mean_confidence)
+    return ece
+
+
+def evaluate(records: list[dict]) -> dict:
+    active, superseded_excluded = _active_receipts(records)
+    judged = [r for r in active if r.get("judge") and r.get("human")
+              and r["human"]["disposition"] != "pending"]
+    cases = []
+    needs_human = 0
+    converted = 0
+    for record in judged:
+        output = record["judge"]["output"]
+        if record["judge"]["converted_to_needs_human"]:
+            converted += 1
+        mapped = JUDGE_TO_LEGACY[output["workflow_disposition"]]
+        if mapped is None:
+            needs_human += 1
+            continue
+        cases.append((record["human"]["disposition"], mapped,
+                      float(output["confidence"])))
+    result = _score_cases(cases)
+    sampled = sum(1 for r in judged if r["sampling"]["sampled"])
+    by_code: dict[str, dict] = {}
+    for record in judged:
+        code = record["human"]["reason_code"] or "null"
+        bucket = by_code.setdefault(code, {"cases": 0, "agreements": 0})
+        bucket["cases"] += 1
+        mapped = JUDGE_TO_LEGACY[record["judge"]["output"]["workflow_disposition"]]
+        if mapped == record["human"]["disposition"]:
+            bucket["agreements"] += 1
+    population = {}
+    for record in active:
+        if record.get("human"):
+            disposition = record["human"]["disposition"]
+            population[disposition] = population.get(disposition, 0) + 1
+    gates = _release_gates(result)
+    result.update({
+        "superseded_excluded": superseded_excluded,
+        "active_receipts": len(active),
+        "judged_receipts": len(judged),
+        "human_review_rate": ((needs_human + sampled) / len(judged))
+        if judged else 0.0,
+        "unsupported_disposition_rate": (converted / len(judged)) if judged else 0.0,
+        "missing_context_rate": (
+            sum(1 for r in active if r["missing_context"]) / len(active))
+        if active else 0.0,
+        "by_reason_code": by_code,
+        "population_counts": population,
+        "release_gates": gates,
+    })
+    return result
+
+
+def _release_gates(scored: dict) -> dict:
+    checks = {
+        "min_cases": {"required": 50, "actual": scored["cases"],
+                      "passed": scored["cases"] >= 50},
+        "exact_agreement": {"required": 0.88, "actual": scored["exact_agreement"],
+                            "passed": scored["exact_agreement"] >= 0.88},
+        "cohen_kappa": {"required": 0.80, "actual": scored["cohen_kappa"],
+                        "passed": scored["cohen_kappa"] >= 0.80},
+        "per_class_recall": {
+            "required": 0.80,
+            "actual": {l: v["recall"] for l, v in scored["per_class"].items()},
+            "passed": all(v["recall"] >= 0.80
+                          for v in scored["per_class"].values()),
+        },
+    }
+    checks["passed"] = all(c["passed"] for c in checks.values()
+                           if isinstance(c, dict))
+    return checks
+
+
+# ---------------------------------------------------------------------------
+# Policy candidates
+# ---------------------------------------------------------------------------
+
+
+def _override_pattern_key(record: dict) -> tuple | None:
+    human = record.get("human")
+    judge = record.get("judge")
+    if not human or not judge or human["reason_code"] is None:
+        return None
+    mapped = JUDGE_TO_LEGACY[judge["output"]["workflow_disposition"]]
+    if mapped == human["disposition"] and \
+            judge["output"]["workflow_reason_code"] == human["reason_code"]:
+        return None  # agreement, nothing to compile
+    evidence_kinds = tuple(sorted({ref.split(":", 1)[0]
+                                   for ref in human["evidence_refs"]}))
+    return (human["reason_code"], evidence_kinds)
+
+
+def detect_policy_candidates(records: list[dict], min_cases: int) -> list[dict]:
+    active, _ = _active_receipts(records)
+    groups: dict[tuple, list[dict]] = {}
+    for record in active:
+        key = _override_pattern_key(record)
+        if key is not None:
+            groups.setdefault(key, []).append(record)
+    candidates = []
+    for (reason_code, evidence_kinds), members in sorted(groups.items()):
+        if len(members) < min_cases:
+            continue
+        counterexamples = [
+            r["receipt_id"] for r in active
+            if (key := _override_pattern_key(r)) is not None
+            and key[1] == evidence_kinds and key[0] != reason_code]
+        candidates.append(_candidate_record(
+            reason_code, evidence_kinds, members, counterexamples, len(active)))
+    return candidates
+
+
+def _candidate_record(reason_code: str, evidence_kinds: tuple,
+                      members: list[dict], counterexamples: list[str],
+                      searched: int) -> dict:
+    pattern = {
+        "human_reason_code": reason_code,
+        "evidence_kinds": list(evidence_kinds),
+        "judge_disagreed": True,
+    }
+    record = {
+        "status": "proposed",
+        "created_at": _now_iso(),
+        "pattern": pattern,
+        "supporting_receipt_ids": [m["receipt_id"] for m in members],
+        "case_count": len(members),
+        "counterexamples": counterexamples,
+        "counterexample_search": (
+            f"scanned {searched} active receipts for judge-overridden decisions "
+            f"sharing evidence kinds {list(evidence_kinds)} with a human reason "
+            f"code other than {reason_code!r}"),
+        "proposed_rule": (
+            f"before the LLM judge runs, resolve refs of kind "
+            f"{list(evidence_kinds)} deterministically; when they establish "
+            f"{reason_code!r}, record that disposition from the reference "
+            "itself instead of asking the judge"),
+        "proposed_tests": [
+            f"a finding whose context resolves {reason_code!r} evidence is "
+            "dispositioned without a judge call",
+            "a finding whose context lacks that evidence still reaches the judge",
+        ],
+        "false_positive_risk": (
+            f"{len(counterexamples)} counterexample(s) in the scanned window; "
+            "similarity-based references can collide on boilerplate findings"),
+        "integration_point": "before-llm-judge",
+    }
+    body = {k: v for k, v in record.items() if k != "created_at"}
+    record["candidate_id"] = "jpc-" + canonical_hash(body)[:12]
+    return record
+
+
+def append_candidates(path: Path, candidates: list[dict]) -> list[dict]:
+    existing_ids = set()
+    if path.is_file():
+        for raw in path.read_text(encoding="utf-8").splitlines():
+            if raw.strip():
+                try:
+                    existing_ids.add(json.loads(raw).get("candidate_id"))
+                except json.JSONDecodeError:
+                    continue
+    fresh = [c for c in candidates if c["candidate_id"] not in existing_ids]
+    if fresh:
+        path.parent.mkdir(parents=True, exist_ok=True)
+        with path.open("a", encoding="utf-8") as handle:
+            for candidate in fresh:
+                handle.write(json.dumps(candidate, sort_keys=True,
+                                        separators=(",", ":"),
+                                        ensure_ascii=False) + "\n")
+    return fresh
+
+
+# ---------------------------------------------------------------------------
+# Selftest (fully in-memory: must pass in a read-only sandbox)
+# ---------------------------------------------------------------------------
+
+
+def _fixture_packet(index: int = 0) -> dict:
+    body = f"fixture objection {index}"
+    packet = {
+        "packet_schema_version": PACKET_SCHEMA_VERSION,
+        "finding": {"prd_id": "prd-selftest", "finding_id": f"finding-{index + 1}",
+                    "severity": "major", "body": body,
+                    "body_sha256": _sha256_text(body)},
+        "review": {"source": "codex-review", "review_run_id": None},
+        "repo_state": {"branch": "unknown", "commit_sha": "unknown",
+                       "dirty": "unknown"},
+        "prd_state": {"path": "prd.md", "sha256": "unknown",
+                      "status": "unknown", "revision": "unknown"},
+        "issue_state": {"issue_id": None, "manifest_sha256": "unknown",
+                        "issue_order": []},
+        "scope": {"source": "unknown", "sha256": "unknown"},
+        "duplicates": [], "remediation": [], "related_prds": [],
+        "prior_receipts": [],
+        "missing_context": ["repo_state.branch"],
+    }
+    packet["assembled_at"] = "2026-08-04T00:00:00Z"
+    packet["packet_sha256"] = packet_hash(packet)
+    return packet
+
+
+def _selftest_receipt(existing: list[dict], index: int, **overrides) -> dict:
+    packet = _fixture_packet(index)
+    kwargs = dict(disposition="accepted", actor="selftest", reason_code=None,
+                  evidence_refs=[], rationale=None, judge_run=None,
+                  supersedes=None)
+    kwargs.update(overrides)
+    # cfg is unused by build_receipt's pure paths; pass None deliberately
+    return build_receipt(None, packet, existing=existing, **kwargs)  # type: ignore[arg-type]
+
+
+def selftest() -> int:
+    failures: list[str] = []
+
+    def expect(condition: bool, label: str) -> None:
+        if not condition:
+            failures.append(label)
+
+    ledger: list[dict] = []
+    ledger.append(_selftest_receipt(ledger, 0))
+    ledger.append(_selftest_receipt(ledger, 1))
+    expect(verify_ledger(ledger) == [], "clean chain verifies")
+
+    mutated = [dict(ledger[0]), ledger[1]]
+    mutated[0] = json.loads(json.dumps(mutated[0]))
+    mutated[0]["human"]["disposition"] = "rejected"
+    expect(bool(verify_ledger(mutated)), "mutated receipt is detected")
+
+    try:
+        _selftest_receipt(ledger, 2, disposition="rejected",
+                          reason_code="duplicate")
+        expect(False, "evidence-free duplicate is refused")
+    except ValidationError:
+        pass
+
+    packet = _fixture_packet(3)
+    judge_run = {
+        "model": "selftest", "prompt_sha256": "0" * 64,
+        "review_run_id": None, "input_sha256": packet["packet_sha256"],
+        "output": {
+            "technical_validity": "valid", "technical_reason": "fixture",
+            "workflow_disposition": "already-remediated",
+            "workflow_reason_code": "already-remediated",
+            "evidence_refs": [], "missing_context": [], "confidence": 0.9,
+        },
+    }
+    block = _judge_block_from_run(judge_run)
+    expect(block["output"]["workflow_disposition"] == "needs-human",
+           "unsupported judge disposition converts to needs-human")
+    expect(block["converted_to_needs_human"] is True, "conversion is flagged")
+
+    try:
+        validate_judge_output({**judge_run["output"], "vibes": "good"}, "selftest")
+        expect(False, "extra judge field is refused")
+    except ValidationError:
+        pass
+
+    basis = _sha256_text("selftest-basis")
+    expect(sample_decision(basis) == sample_decision(basis),
+           "sampling is deterministic")
+
+    report = evaluate(ledger)
+    expect(report["release_gates"]["passed"] is False,
+           "release gates stay closed with no judged cases")
+
+    if failures:
+        for failure in failures:
+            print(f"SELFTEST FAIL: {failure}", file=sys.stderr)
+        return 1
+    print("SELFTEST PASS: chain, evidence gate, judge contract, sampling, "
+          "release gates all enforced in memory")
+    return 0
+
+
+# ---------------------------------------------------------------------------
+# CLI
+# ---------------------------------------------------------------------------
+
+
+def cmd_assemble(cfg: Config, args: argparse.Namespace) -> int:
+    packet = assemble_packet(cfg, args.prd, args.finding)
+    text = json.dumps(packet, indent=2, sort_keys=True) + "\n"
+    if args.output:
+        Path(args.output).write_text(text, encoding="utf-8")
+        print(json.dumps({"packet_sha256": packet["packet_sha256"],
+                          "missing_context": packet["missing_context"],
+                          "path": args.output}, indent=2))
+    else:
+        print(text, end="")
+    return 0
+
+
+def cmd_capture(cfg: Config, args: argparse.Namespace) -> int:
+    try:
+        packet = json.loads(Path(args.context).read_text(encoding="utf-8"))
+    except (json.JSONDecodeError, OSError) as exc:
+        raise ValidationError(f"context packet unreadable: {exc}") from exc
+    if packet.get("finding", {}).get("prd_id") != args.prd or \
+            packet.get("finding", {}).get("finding_id") != args.finding:
+        raise ValidationError(
+            "context packet is for a different finding than the capture args")
+    judge_run = None
+    if args.judge_run:
+        validate_packet(packet)
+        judge_run = _load_judge_run(Path(args.judge_run), packet)
+    record = capture_episode(
+        cfg, packet, disposition=args.disposition, actor=args.actor,
+        reason_code=args.reason_code, evidence_refs=args.evidence or [],
+        rationale=args.rationale, judge_run=judge_run,
+        supersedes=args.supersedes)
+    print(json.dumps({"receipt_id": record["receipt_id"],
+                      "sampled": record["sampling"]["sampled"],
+                      "supersedes": record["supersedes"],
+                      "path": str(ledger_path(cfg))}, indent=2))
+    return 0
+
+
+def cmd_verify(cfg: Config, args: argparse.Namespace) -> int:
+    records = read_ledger(ledger_path(cfg))
+    errors = verify_ledger(records)
+    candidate_records = read_ledger(candidates_path(cfg))
+    errors.extend(verify_candidates(candidate_records))
+    if args.packet or args.receipt_id:
+        if not (args.packet and args.receipt_id):
+            raise ValidationError("--packet and --receipt-id go together")
+        packet = json.loads(Path(args.packet).read_text(encoding="utf-8"))
+        receipt = next((r for r in records
+                        if r.get("receipt_id") == args.receipt_id), None)
+        if receipt is None:
+            errors.append(f"receipt not found: {args.receipt_id}")
+        else:
+            errors.extend(verify_packet_binding(packet, receipt))
+    if errors:
+        print("VERIFY FAIL:", file=sys.stderr)
+        for error in errors:
+            print(f"  - {error}", file=sys.stderr)
+        return 2
+    print(f"VERIFY PASS: {len(records)} receipt(s), "
+          f"{len(candidate_records)} candidate(s), chain intact")
+    return 0
+
+
+def cmd_evaluate(cfg: Config, args: argparse.Namespace) -> int:
+    records = read_ledger(ledger_path(cfg))
+    errors = verify_ledger(records)
+    if errors:
+        print("EVALUATE REFUSED: ledger fails verification:", file=sys.stderr)
+        for error in errors:
+            print(f"  - {error}", file=sys.stderr)
+        return 2
+    print(json.dumps(evaluate(records), indent=2, sort_keys=True))
+    return 0
+
+
+def cmd_sample_check(cfg: Config, args: argparse.Namespace) -> int:
+    basis = args.basis.strip().lower()
+    if not re.fullmatch(r"[0-9a-f]{64}", basis):
+        raise ValidationError("--basis must be a 64-char sha256 hex digest")
+    print(json.dumps({
+        "basis_sha256": basis,
+        "sampled": sample_decision(basis),
+        "rule": SAMPLE_RULE,
+        "salt": SAMPLE_SALT,
+        "threshold": SAMPLE_THRESHOLD,
+        "modulus": SAMPLE_MODULUS,
+    }, indent=2))
+    return 0
+
+
+def cmd_policy_candidates(cfg: Config, args: argparse.Namespace) -> int:
+    records = read_ledger(ledger_path(cfg))
+    errors = verify_ledger(records)
+    if errors:
+        print("POLICY-CANDIDATES REFUSED: ledger fails verification",
+              file=sys.stderr)
+        return 2
+    candidates = detect_policy_candidates(records, args.min_cases)
+    fresh = append_candidates(candidates_path(cfg), candidates) \
+        if candidates else []
+    print(json.dumps({
+        "detected": len(candidates),
+        "appended": len(fresh),
+        "path": str(candidates_path(cfg)),
+        "note": "candidates are proposals; promotion requires the "
+                "human-reviewed prd-os path and runs before the LLM judge",
+    }, indent=2))
+    return 0
+
+
+def main(argv: list[str]) -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--selftest", action="store_true")
+    parser.add_argument("--repo-root", help="override repo root discovery")
+    sub = parser.add_subparsers(dest="cmd")
+
+    p_assemble = sub.add_parser("assemble")
+    p_assemble.add_argument("--prd", required=True)
+    p_assemble.add_argument("--finding", required=True)
+    p_assemble.add_argument("--output")
+    p_assemble.set_defaults(func=cmd_assemble)
+
+    p_capture = sub.add_parser("capture")
+    p_capture.add_argument("--prd", required=True)
+    p_capture.add_argument("--finding", required=True)
+    p_capture.add_argument("--context", required=True)
+    p_capture.add_argument("--disposition", required=True)
+    p_capture.add_argument("--reason-code", dest="reason_code")
+    p_capture.add_argument("--evidence", action="append", default=[])
+    p_capture.add_argument("--rationale")
+    p_capture.add_argument("--actor", default="founder")
+    p_capture.add_argument("--judge-run", dest="judge_run")
+    p_capture.add_argument("--supersedes")
+    p_capture.set_defaults(func=cmd_capture)
+
+    p_verify = sub.add_parser("verify")
+    p_verify.add_argument("--packet")
+    p_verify.add_argument("--receipt-id", dest="receipt_id")
+    p_verify.set_defaults(func=cmd_verify)
+
+    p_evaluate = sub.add_parser("evaluate")
+    p_evaluate.set_defaults(func=cmd_evaluate)
+
+    p_sample = sub.add_parser("sample-check")
+    p_sample.add_argument("--basis", required=True)
+    p_sample.set_defaults(func=cmd_sample_check)
+
+    p_policy = sub.add_parser("policy-candidates")
+    p_policy.add_argument("--min-cases", dest="min_cases", type=int, default=3)
+    p_policy.set_defaults(func=cmd_policy_candidates)
+
+    args = parser.parse_args(argv)
+    if args.selftest:
+        return selftest()
+    if not getattr(args, "func", None):
+        parser.error("choose a subcommand or --selftest")
+    try:
+        repo_root = Path(args.repo_root).resolve() if args.repo_root else None
+        cfg = load_config(repo_root, strict=True)
+    except ConfigError as exc:
+        print(f"config error: {exc}", file=sys.stderr)
+        return 2
+    try:
+        return args.func(cfg, args)
+    except ValidationError as exc:
+        print(f"{exc}", file=sys.stderr)
+        return 2
+
+
+if __name__ == "__main__":
+    raise SystemExit(main(sys.argv[1:]))

--- a/plugins/prd-os/scripts/judgment_compiler.py
+++ b/plugins/prd-os/scripts/judgment_compiler.py
@@ -1072,10 +1072,11 @@ def _tip_errors(records: list[dict], tip: dict | None,
         # so verify/evaluate/policy-candidates all trust a tail that could be
         # silently truncated back to the anchor later and still pass. Verify
         # cannot claim the chain is intact when it has not checked all of it.
-        # Recoverable, not corrupt: `reanchor` re-covers the tail. Re-anchoring
-        # can only ever EXTEND coverage — a deletion shows up as the branch
-        # above first, and forged appends are caught by the chain walk, not the
-        # anchor — so the repair cannot launder tampering.
+        # Recoverable, not corrupt: `reanchor` re-covers the tail, and it only
+        # accepts this one state (an anchor that exists and under-counts). It
+        # refuses a truncation and refuses a missing anchor, because without a
+        # baseline it cannot tell the two apart — see cmd_reanchor, where the
+        # first version of exactly that reasoning was wrong.
         return [f"ledger has {len(records) - tip['count']} receipt(s) BEYOND "
                 f"the tip anchor ({len(records)} present, {tip['count']} "
                 "anchored): the tail is outside deletion detection. If the "
@@ -1688,14 +1689,30 @@ def cmd_verify(cfg: Config, args: argparse.Namespace) -> int:
 def cmd_reanchor(cfg: Config, args: argparse.Namespace) -> int:
     """Re-cover a legitimate unanchored tail (crash between append and anchor).
 
-    Refuses when the CHAIN itself is broken, so this can never be used to bless
-    a tampered ledger: it only ever extends anchor coverage over receipts that
-    already verify, and a deletion presents as a truncation (fewer records than
-    the anchor), which is not a state this repairs.
+    ONE repairable state: an anchor that EXISTS and under-counts. Everything
+    else is refused.
+
+    The first version of this claimed it "can never launder tampering" and was
+    wrong — Codex review round 3 falsified that citation with an executed repro.
+    It filtered every "tip anchor" error out of the chain check, including the
+    missing-anchor error, so deleting the anchor AND truncating the ledger, then
+    running reanchor, wrote a fresh anchor over the surviving prefix and made
+    the deletion permanent. Without the old anchor there is no baseline, so this
+    command cannot tell a legitimate tail from a truncation and must not guess.
+    `verify --cross-check` reads the findings ledgers — a source this writer does
+    not own — and is the way to establish what SHOULD be there.
     """
     with ledger_lock(cfg):
         records = read_ledger(ledger_path(cfg))
         tip = read_tip(tip_path(cfg))
+        if tip is None and records:
+            raise ValidationError(
+                f"refusing to reanchor {len(records)} receipt(s) with NO existing "
+                "tip anchor: without the old anchor there is no baseline, so "
+                "this cannot prove the retained chain is complete rather than "
+                "truncated. Establish the truth first with "
+                "`kipi judgment verify --cross-check`, which reads the findings "
+                "ledgers independently.")
         if tip is not None and len(records) < tip["count"]:
             raise ValidationError(
                 f"refusing to reanchor a TRUNCATED ledger: {len(records)} "

--- a/plugins/prd-os/scripts/judgment_compiler.py
+++ b/plugins/prd-os/scripts/judgment_compiler.py
@@ -42,6 +42,8 @@ Exit codes: 0 success, 2 validation error (matches findings_writer contract).
 from __future__ import annotations
 
 import argparse
+import copy
+import fcntl
 import hashlib
 import json
 import math
@@ -49,6 +51,7 @@ import os
 import re
 import subprocess
 import sys
+from contextlib import contextmanager
 from datetime import datetime, timezone
 from pathlib import Path
 
@@ -190,6 +193,34 @@ def candidates_path(cfg: Config) -> Path:
 
 def tip_path(cfg: Config) -> Path:
     return _ledger_dir(cfg) / TIP_NAME
+
+
+@contextmanager
+def ledger_lock(cfg: Config):
+    """Exclusive lock held across read + build + append + anchor.
+
+    WHY (adversarial review 2026-08-04, reproduced with 4 concurrent captures):
+    capture is a read-modify-append. Both `sequence` and `prev_receipt_sha256`
+    are derived from the ledger AS READ, and the ledger deliberately lives at
+    the SHARED worktree root so N worktrees write one file. Without a lock, two
+    interleaved triage calls both computed sequence=N, the chain forked, and
+    BOTH processes exited 0 — the corruption only surfaced later at `verify`.
+    That is unrecoverable by contract: `evaluate` and `policy-candidates` both
+    refuse on a failed verify, and repairing it means rewriting lines, which is
+    exactly what append-only forbids. One interleaved triage would brick the
+    evaluator for the whole repo.
+
+    flock is advisory and per-host: it does not protect a ledger on a network
+    filesystem shared between machines. Named, not hidden.
+    """
+    path = _ledger_dir(cfg) / ".judgments.lock"
+    path.parent.mkdir(parents=True, exist_ok=True)
+    with path.open("a+", encoding="utf-8") as handle:
+        fcntl.flock(handle.fileno(), fcntl.LOCK_EX)
+        try:
+            yield
+        finally:
+            fcntl.flock(handle.fileno(), fcntl.LOCK_UN)
 
 
 def read_tip(path: Path) -> dict | None:
@@ -425,9 +456,12 @@ def _validate_judge_block(judge, where: str) -> None:
         return
     _require_keys(judge, frozenset(
         ("model", "prompt_sha256", "review_run_id", "input_sha256",
-         "output_sha256", "output", "converted_to_needs_human",
-         "converted_from")), f"{where}.judge")
+         "raw_output_sha256", "output_sha256", "output",
+         "converted_to_needs_human", "converted_from")), f"{where}.judge")
     validate_judge_output(judge["output"], f"{where}.judge.output")
+    if canonical_hash(judge["output"]) != judge["output_sha256"]:
+        raise ValidationError(
+            f"{where}.judge.output_sha256 does not hash the stored output")
     if not isinstance(judge["converted_to_needs_human"], bool):
         raise ValidationError(f"{where}.judge.converted_to_needs_human: bool required")
 
@@ -563,7 +597,13 @@ def _assemble_scope(cfg: Config, prd_id: str, missing: list[str]) -> dict:
     rel = os.path.relpath(path, cfg.repo_root)
     if path.is_file():
         text = path.read_text(encoding="utf-8")
-        match = re.search(r"(?ms)^##\s+.*?Scope.*?$(.*?)(?=^##\s|\Z)", text)
+        # Anchored: `.*?Scope.*?` also matched "## Out of Scope" and
+        # "## Scope Notes", and re.search takes the FIRST hit — so a PRD with
+        # either heading above its real one recorded a confident hash of the
+        # wrong section, inverting the unknown-never-becomes-a-fact rule
+        # (review 2026-08-04). No match now falls through to unknown.
+        match = re.search(
+            r"(?ms)^##\s+(?:\d+\.\s*)?Scope\s*$(.*?)(?=^##\s|\Z)", text)
         if match:
             return {"source": f"{rel}#Scope",
                     "sha256": _sha256_text(match.group(1).strip())}
@@ -603,8 +643,15 @@ def _assemble_duplicates(cfg: Config, prd_id: str, finding_id: str,
                     "similarity": similarity,
                     "source": str(os.path.relpath(own_path, cfg.repo_root)),
                 })
-    except Exception:  # advisory engine failure -> honest unknown, not []
-        missing.append("duplicates")
+    except (ImportError, OSError, ValueError, KeyError, TypeError,
+            AttributeError) as exc:
+        # Narrowed from a bare `except Exception` (repo rule: never silently
+        # swallow). Two changes: the failure is NAMED in missing_context, and
+        # partial results are DISCARDED — a half-built duplicate list recorded
+        # next to "duplicates: unknown" let partial masquerade as resolved
+        # (review 2026-08-04).
+        missing.append(f"duplicates ({type(exc).__name__}: {exc})")
+        return []
     return duplicates
 
 
@@ -743,7 +790,12 @@ def _load_judge_run(path: Path, packet: dict) -> dict:
 
 def _judge_block_from_run(run: dict) -> dict:
     output = dict(run["output"])
-    output_sha256 = canonical_hash(output)
+    # Two hashes, because the stored output is not always the emitted one:
+    # raw_output_sha256 attests what the judge actually said, output_sha256
+    # attests what this receipt stores after any gate conversion. One field
+    # covering both was unfalsifiable — the natural check failed on every
+    # converted receipt (review 2026-08-04).
+    raw_output_sha256 = canonical_hash(output)
     converted_from = None
     gate = evidence_gate_errors(output["workflow_reason_code"],
                                 output["workflow_disposition"],
@@ -760,19 +812,26 @@ def _judge_block_from_run(run: dict) -> dict:
         "prompt_sha256": run["prompt_sha256"],
         "review_run_id": run.get("review_run_id"),
         "input_sha256": run["input_sha256"],
-        "output_sha256": output_sha256,
+        "raw_output_sha256": raw_output_sha256,
+        "output_sha256": canonical_hash(output),
         "output": output,
         "converted_to_needs_human": converted_from is not None,
         "converted_from": converted_from,
     }
 
 
-def build_receipt(cfg: Config, packet: dict, *, disposition: str,
+def build_receipt(packet: dict, *, disposition: str,
                   actor: str, reason_code: str | None,
                   evidence_refs: list[str], rationale: str | None,
                   judge_run: dict | None, supersedes: str | None,
                   existing: list[dict]) -> dict:
-    """Validate the whole episode and produce the receipt record (pure)."""
+    """Validate the whole episode and produce the receipt record (pure).
+
+    Takes no Config on purpose: everything here is a function of the packet and
+    the existing chain, which is what lets --selftest prove the contract with
+    no filesystem at all. Reference RESOLUTION (which does need a repo) happens
+    in the caller, before this runs.
+    """
     validate_packet(packet)
     if disposition not in LEGACY_DISPOSITIONS:
         raise ValidationError(f"disposition must be one of {LEGACY_DISPOSITIONS}")
@@ -802,20 +861,25 @@ def build_receipt(cfg: Config, packet: dict, *, disposition: str,
     if reason_code is None:
         missing_context.append("human.reason_code")
 
+    # deepcopy, not reference: the receipt_id is a hash of this content, so a
+    # later mutation of the caller's packet (or of args.evidence) would
+    # silently invalidate an already-appended receipt and every chain link
+    # after it. Immutability held by the data, not by call ordering.
+    frozen = copy.deepcopy(packet)
     record = {
         "schema_version": RECEIPT_SCHEMA_VERSION,
         "sequence": len(existing) + 1,
         "captured_at": _now_iso(),
-        "finding": packet["finding"],
-        "review": packet["review"],
-        "repo_state": packet["repo_state"],
-        "prd_state": packet["prd_state"],
-        "issue_state": packet["issue_state"],
-        "scope": packet["scope"],
-        "duplicates": packet["duplicates"],
-        "remediation": packet["remediation"],
-        "related_prds": packet["related_prds"],
-        "prior_receipts": packet["prior_receipts"],
+        "finding": frozen["finding"],
+        "review": frozen["review"],
+        "repo_state": frozen["repo_state"],
+        "prd_state": frozen["prd_state"],
+        "issue_state": frozen["issue_state"],
+        "scope": frozen["scope"],
+        "duplicates": frozen["duplicates"],
+        "remediation": frozen["remediation"],
+        "related_prds": frozen["related_prds"],
+        "prior_receipts": frozen["prior_receipts"],
         "missing_context": sorted(set(missing_context)),
         "judge": _judge_block_from_run(judge_run) if judge_run else None,
         "human": {
@@ -823,7 +887,7 @@ def build_receipt(cfg: Config, packet: dict, *, disposition: str,
             "decided_at": _now_iso(),
             "disposition": disposition,
             "reason_code": reason_code,
-            "evidence_refs": evidence_refs,
+            "evidence_refs": list(evidence_refs),
             "rationale": rationale,
         },
         "sampling": {
@@ -854,17 +918,21 @@ def append_receipt(path: Path, record: dict) -> None:
 
 def capture_episode(cfg: Config, packet: dict, **kwargs) -> dict:
     """The single write path into the judgments ledger."""
+    validate_packet(packet)
     _check_packet_freshness(cfg, packet)
     path = ledger_path(cfg)
-    existing = read_ledger(path)
-    record = build_receipt(cfg, packet, existing=existing, **kwargs)
-    append_receipt(path, record)
+    with ledger_lock(cfg):
+        # Read INSIDE the lock: a snapshot taken outside it is exactly the
+        # stale `existing` that forked the chain in the concurrency repro.
+        existing = read_ledger(path)
+        record = build_receipt(packet, existing=existing, **kwargs)
+        append_receipt(path, record)
     # Anchor AFTER the append. If the process dies between the two the anchor
     # under-counts, and an under-counting anchor is deliberately NOT an error
     # (see _tip_errors) so a crashed write never manufactures a truncation
     # alarm. Anchoring first would do the opposite: claim a receipt that was
     # never written, and fail every later verify.
-    write_tip(tip_path(cfg), existing + [record])
+        write_tip(tip_path(cfg), existing + [record])
     return record
 
 
@@ -879,6 +947,9 @@ def capture_from_triage(cfg: Config, prd_id: str, finding: dict, *,
     judge_run = None
     if judge_run_path:
         judge_run = _load_judge_run(Path(judge_run_path), packet)
+    unresolved = resolve_evidence_refs(cfg, evidence_refs)
+    if unresolved:
+        raise ValidationError("; ".join(unresolved))
     return capture_episode(
         cfg, packet, disposition=finding["disposition"], actor=actor,
         reason_code=reason_code, evidence_refs=evidence_refs,
@@ -886,12 +957,27 @@ def capture_from_triage(cfg: Config, prd_id: str, finding: dict, *,
 
 
 def validate_triage_decision(reason_code: str | None,
-                             evidence_refs: list[str]) -> list[str]:
-    """Fail-fast half for findings_writer: returns error strings, no I/O."""
+                             evidence_refs: list[str],
+                             disposition: str | None = None,
+                             cfg: Config | None = None) -> list[str]:
+    """Fail-fast half for findings_writer, run BEFORE the findings file moves."""
     errors = []
     if reason_code is not None and reason_code not in REASON_CODES:
         errors.append(
             f"reason-code must be one of {REASON_CODES}; got {reason_code!r}")
+        return errors
+    # Omitting the code used to opt a decision out of the evidence gate
+    # entirely: `rejected --rationale "dupe of something else"` recorded a
+    # duplicate-rejection with zero evidence, which is the exact decision the
+    # gate exists to refuse (adversarial review 2026-08-04). rejected/deferred
+    # already owe a --rationale; they now owe a machine-readable code too.
+    # accepted/pending stay optional — being fixed needs no justification.
+    if reason_code is None and disposition in ("rejected", "deferred"):
+        errors.append(
+            f"disposition={disposition!r} requires --reason-code (one of "
+            f"{REASON_CODES}). Omitting it would skip the evidence gate. "
+            "Use insufficient-context or needs-human if none of the specific "
+            "codes fit.")
         return errors
     try:
         _validate_evidence_refs(evidence_refs, "human decision")
@@ -899,6 +985,8 @@ def validate_triage_decision(reason_code: str | None,
         errors.append(str(exc))
         return errors
     errors.extend(evidence_gate_errors(reason_code, None, evidence_refs))
+    if cfg is not None and evidence_refs:
+        errors.extend(resolve_evidence_refs(cfg, evidence_refs))
     return errors
 
 
@@ -950,9 +1038,19 @@ def _tip_errors(records: list[dict], tip: dict | None,
     """Deletion detection. A prefix of a valid chain is a valid chain, so the
     chain walk above cannot see a truncated tail; the anchor can."""
     if tip is None:
-        # No anchor (legacy or fresh ledger). Do not hard-fail — that would
-        # break every repo whose ledger predates the anchor — but never claim
-        # completeness we cannot check.
+        # A missing anchor used to be a silent pass ("legacy ledger"). That
+        # restored the whole truncation hole for the price of one extra `rm`:
+        # deleting the anchor is CHEAPER than editing it, and a bad rsync or
+        # `git clean` does it by accident (adversarial review 2026-08-04,
+        # reproduced: rm tip && head -1 ledger -> VERIFY PASS).
+        # Every ledger this code has ever written has an anchor — the feature
+        # shipped with it — so a non-empty ledger without one is missing
+        # evidence, not legacy. An EMPTY ledger with no anchor is a genuinely
+        # fresh repo and stays clean.
+        if records:
+            return ["tip anchor .prd-os/judgments-tip.json is MISSING while "
+                    f"{len(records)} receipt(s) exist: the anchor was deleted "
+                    "or never written, so completeness cannot be checked"]
         return []
     if len(records) < tip["count"]:
         return [f"ledger is TRUNCATED: {len(records)} receipt(s) present, tip "
@@ -964,14 +1062,102 @@ def _tip_errors(records: list[dict], tip: dict | None,
     return []
 
 
-def verify_candidates(records: list[dict]) -> list[str]:
+def verify_candidates(records: list[dict],
+                      known_receipt_ids: set[str] | None = None) -> list[str]:
+    """Validate each candidate AND resolve its receipt citations.
+
+    A candidate is the input to a human-reviewed promotion that changes triage
+    behavior, so an unresolvable citation inflating a case count is exactly the
+    claim a reviewer would lean on. Previously `supporting_receipt_ids:
+    ['jr-doesnotexist']` with `case_count: 99` verified clean (review 2026-08-04).
+    """
     errors = []
     for index, record in enumerate(records, 1):
+        where = f"candidate line {index}"
         try:
-            validate_candidate(record, f"candidate line {index}")
+            validate_candidate(record, where)
         except ValidationError as exc:
             errors.append(str(exc))
+            continue
+        if known_receipt_ids is None:
+            continue
+        dangling = [rid for rid in record["supporting_receipt_ids"]
+                    if rid not in known_receipt_ids]
+        if dangling:
+            errors.append(f"{where}: cites receipt id(s) that do not exist in "
+                          f"the ledger: {sorted(dangling)}")
+        if record["case_count"] != len(record["supporting_receipt_ids"]):
+            errors.append(
+                f"{where}: case_count {record['case_count']} does not match "
+                f"{len(record['supporting_receipt_ids'])} supporting receipt(s)")
     return errors
+
+
+def resolve_evidence_refs(cfg: Config, refs: list[str]) -> list[str]:
+    """Open each reference and report the ones that point at nothing.
+
+    WHY (adversarial review 2026-08-04): the gate used to check only that a ref
+    matched `prefix:value`, so `--evidence finding:prd-does-not-exist/finding-999`
+    and `--evidence commit:zzzz` both passed and were recorded as the evidence
+    that justified a rejection. A reference nobody opens is not evidence, and
+    the PRD sells these codes as REFUSED without a stable reference.
+
+    Unresolvable-by-design kinds are named rather than silently skipped:
+    `test:` and `scope:` point at a path (and optionally a #section) which may
+    legitimately not exist yet in the working tree of the machine running the
+    check, so they are existence-checked only when the path is present.
+    """
+    errors = []
+    for ref in refs:
+        kind, _, value = ref.partition(":")
+        problem = _resolve_one_ref(cfg, kind, value)
+        if problem:
+            errors.append(f"evidence ref {ref!r}: {problem}")
+    return errors
+
+
+def _resolve_one_ref(cfg: Config, kind: str, value: str) -> str | None:
+    if kind == "finding":
+        prd_id, _, finding_id = value.partition("/")
+        if not prd_id or not finding_id:
+            return "expected finding:<prd-id>/<finding-id>"
+        path = cfg.findings_dir / f"{prd_id}-findings.jsonl"
+        if any(r.get("id") == finding_id for r in _read_findings(path)):
+            return None
+        return f"no finding {finding_id} in {os.path.relpath(path, cfg.repo_root)}"
+    if kind == "prd":
+        return None if (cfg.prds_dir / f"{value}.md").is_file() \
+            else f"no PRD spec {value}.md"
+    if kind == "issue":
+        return None if (cfg.issues_dir / f"{value}.md").is_file() \
+            else f"no issue spec {value}.md"
+    if kind == "judgment":
+        known = {r.get("receipt_id") for r in read_ledger(ledger_path(cfg))}
+        return None if value in known else "no such judgment receipt"
+    if kind == "receipt":
+        if not cfg.receipts_path.is_file():
+            return "no receipts ledger exists"
+        for raw in cfg.receipts_path.read_text(encoding="utf-8").splitlines():
+            if raw.strip() and json.loads(raw).get("issue_id") == value:
+                return None
+        return "no remediation receipt for that issue"
+    if kind == "spillover":
+        path = _ledger_dir(cfg) / "spillover.jsonl"
+        if not path.is_file():
+            return "no spillover ledger exists"
+        return None if f'"{value}"' in path.read_text(encoding="utf-8") \
+            else "no such spillover item"
+    if kind == "commit":
+        if not re.fullmatch(r"[0-9a-f]{7,40}", value):
+            return "not a commit sha"
+        return None if _git(cfg.repo_root, "cat-file", "-e", f"{value}^{{commit}}") \
+            is not None else "commit not found in this repo"
+    if kind in ("test", "scope"):
+        candidate = cfg.repo_root / value.split("#", 1)[0]
+        if candidate.exists():
+            return None
+        return f"path {value.split('#', 1)[0]} does not exist"
+    return "unknown reference kind"
 
 
 def cross_check_findings(cfg: Config, records: list[dict],
@@ -1053,8 +1239,13 @@ def _score_cases(cases: list[tuple[str, str, float]]) -> dict:
     expected = sum(gold_totals[l] * pred_totals[l] for l in labels) / (total * total) \
         if total else 0.0
     accuracy = correct / total if total else 0.0
+    # Degenerate case (one class everywhere) => kappa undefined; the convention
+    # is 0.0, because chance agreement fully explains the result. Returning 1.0
+    # published a perfect score for a constant classifier — the single failure
+    # mode this whole PRD exists to catch, since v1's judge said "accepted"
+    # 45/50 times (review 2026-08-04).
     kappa = (accuracy - expected) / (1 - expected) \
-        if total and not math.isclose(expected, 1.0) else (1.0 if total else 0.0)
+        if total and not math.isclose(expected, 1.0) else 0.0
     ece = _expected_calibration_error(cases)
     return {
         "cases": total,
@@ -1105,7 +1296,12 @@ def evaluate(records: list[dict]) -> dict:
         cases.append((record["human"]["disposition"], mapped,
                       float(output["confidence"])))
     result = _score_cases(cases)
-    sampled = sum(1 for r in judged if r["sampling"]["sampled"])
+    # Set union, not a sum: a receipt that is BOTH needs-human and in the 5%
+    # sample was counted twice, so a "rate" could print above 1.0.
+    human_reviewed = {
+        r["receipt_id"] for r in judged
+        if JUDGE_TO_LEGACY[r["judge"]["output"]["workflow_disposition"]] is None
+        or r["sampling"]["sampled"]}
     by_code: dict[str, dict] = {}
     for record in judged:
         code = record["human"]["reason_code"] or "null"
@@ -1124,8 +1320,9 @@ def evaluate(records: list[dict]) -> dict:
         "superseded_excluded": superseded_excluded,
         "active_receipts": len(active),
         "judged_receipts": len(judged),
-        "human_review_rate": ((needs_human + sampled) / len(judged))
+        "human_review_rate": (len(human_reviewed) / len(judged))
         if judged else 0.0,
+        "needs_human_count": needs_human,
         "unsupported_disposition_rate": (converted / len(judged)) if judged else 0.0,
         "missing_context_rate": (
             sum(1 for r in active if r["missing_context"]) / len(active))
@@ -1168,6 +1365,14 @@ def _override_pattern_key(record: dict) -> tuple | None:
     if not human or not judge or human["reason_code"] is None:
         return None
     mapped = JUDGE_TO_LEGACY[judge["output"]["workflow_disposition"]]
+    if mapped is None:
+        # needs-human is an ABSTENTION, not a disagreement. Counting it as an
+        # override made the detector manufacture patterns out of the very
+        # receipts the evidence gate creates: the more the gate fired, the more
+        # "repeated overrides" it proposed rules for, each built on cases where
+        # the judge never expressed an opinion (review 2026-08-04). `evaluate`
+        # already excluded these; the detector now uses the same filter.
+        return None
     if mapped == human["disposition"] and \
             judge["output"]["workflow_reason_code"] == human["reason_code"]:
         return None  # agreement, nothing to compile
@@ -1290,8 +1495,7 @@ def _selftest_receipt(existing: list[dict], index: int, **overrides) -> dict:
                   evidence_refs=[], rationale=None, judge_run=None,
                   supersedes=None)
     kwargs.update(overrides)
-    # cfg is unused by build_receipt's pure paths; pass None deliberately
-    return build_receipt(None, packet, existing=existing, **kwargs)  # type: ignore[arg-type]
+    return build_receipt(packet, existing=existing, **kwargs)
 
 
 def selftest() -> int:
@@ -1301,15 +1505,27 @@ def selftest() -> int:
         if not condition:
             failures.append(label)
 
+    def tip_for(records: list[dict]) -> dict:
+        return {"count": len(records),
+                "last_receipt_sha256": canonical_hash(records[-1])
+                if records else None,
+                "last_receipt_id": records[-1]["receipt_id"] if records else None,
+                "updated_at": "2026-08-04T00:00:00Z"}
+
     ledger: list[dict] = []
     ledger.append(_selftest_receipt(ledger, 0))
     ledger.append(_selftest_receipt(ledger, 1))
-    expect(verify_ledger(ledger) == [], "clean chain verifies")
+    expect(verify_ledger(ledger, tip_for(ledger)) == [], "clean chain verifies")
 
     mutated = [dict(ledger[0]), ledger[1]]
     mutated[0] = json.loads(json.dumps(mutated[0]))
     mutated[0]["human"]["disposition"] = "rejected"
-    expect(bool(verify_ledger(mutated)), "mutated receipt is detected")
+    expect(bool(verify_ledger(mutated, tip_for(ledger))),
+           "mutated receipt is detected")
+    expect(bool(verify_ledger(ledger[:1], tip_for(ledger))),
+           "truncated chain is detected")
+    expect(bool(verify_ledger(ledger, None)),
+           "a missing tip anchor over a non-empty ledger is detected")
 
     try:
         _selftest_receipt(ledger, 2, disposition="rejected",
@@ -1384,10 +1600,16 @@ def cmd_capture(cfg: Config, args: argparse.Namespace) -> int:
             packet.get("finding", {}).get("finding_id") != args.finding:
         raise ValidationError(
             "context packet is for a different finding than the capture args")
+    validate_packet(packet)  # unconditional: an unvalidated packet used to
+    # reach _check_packet_freshness and raise a bare KeyError, exiting 1 and
+    # breaking the documented 0/2 contract (adversarial review 2026-08-04).
     judge_run = None
     if args.judge_run:
-        validate_packet(packet)
         judge_run = _load_judge_run(Path(args.judge_run), packet)
+    gate = validate_triage_decision(args.reason_code, args.evidence or [],
+                                    args.disposition, cfg)
+    if gate:
+        raise ValidationError("; ".join(gate))
     record = capture_episode(
         cfg, packet, disposition=args.disposition, actor=args.actor,
         reason_code=args.reason_code, evidence_refs=args.evidence or [],
@@ -1404,7 +1626,8 @@ def cmd_verify(cfg: Config, args: argparse.Namespace) -> int:
     records = read_ledger(ledger_path(cfg))
     errors = verify_ledger(records, read_tip(tip_path(cfg)))
     candidate_records = read_ledger(candidates_path(cfg))
-    errors.extend(verify_candidates(candidate_records))
+    errors.extend(verify_candidates(
+        candidate_records, {r.get("receipt_id") for r in records}))
     if getattr(args, "cross_check", False):
         errors.extend(cross_check_findings(cfg, records,
                                            getattr(args, "since", None)))

--- a/plugins/prd-os/scripts/judgment_compiler.py
+++ b/plugins/prd-os/scripts/judgment_compiler.py
@@ -901,6 +901,13 @@ def build_receipt(packet: dict, *, disposition: str,
     }
     record["receipt_id"] = receipt_content_id(record)
     if record["receipt_id"] in known_ids:
+        # DEFENSIVE, and knowingly untested: no normal path reaches it, because
+        # captured_at, prev_receipt_sha256 and sequence all differ between any
+        # two real captures, so the content hash cannot collide. A mutation run
+        # confirmed deleting this line breaks no test. The ENFORCED half is the
+        # read-side duplicate check in verify_ledger (test_n7), which catches a
+        # forged ledger. Kept because it is free and would catch a future change
+        # that made receipt content less unique.
         raise ValidationError(
             f"duplicate receipt id {record['receipt_id']}: refusing to append")
     validate_receipt(record, record["receipt_id"])

--- a/plugins/prd-os/scripts/judgment_compiler.py
+++ b/plugins/prd-os/scripts/judgment_compiler.py
@@ -1342,7 +1342,16 @@ def evaluate(records: list[dict]) -> dict:
         if record.get("human"):
             disposition = record["human"]["disposition"]
             population[disposition] = population.get(disposition, 0) + 1
-    gates = _release_gates(result)
+    # Computed BEFORE the gates, because the gates read them. They used to be
+    # computed into the result dict after _release_gates had already run, which
+    # is how a documented release condition ended up unenforced.
+    ungated_rate = (
+        sum(1 for r in active
+            if r.get("human") and r["human"]["reason_code"] is None
+            and r["human"]["disposition"] in ("rejected", "deferred"))
+        / len(active)) if active else 0.0
+    unsupported_rate = (converted / len(judged)) if judged else 0.0
+    gates = _release_gates(result, ungated_rate, unsupported_rate)
     result.update({
         "superseded_excluded": superseded_excluded,
         "active_receipts": len(active),
@@ -1351,14 +1360,9 @@ def evaluate(records: list[dict]) -> dict:
         if judged else 0.0,
         "needs_human_count": needs_human,
         # Decisions carrying no reason code skipped the evidence gate entirely
-        # (the code is what the requirements key off). Reported so the size of
-        # that known bypass is a number rather than an assumption.
-        "ungated_decision_rate": (
-            sum(1 for r in active
-                if r.get("human") and r["human"]["reason_code"] is None
-                and r["human"]["disposition"] in ("rejected", "deferred"))
-            / len(active)) if active else 0.0,
-        "unsupported_disposition_rate": (converted / len(judged)) if judged else 0.0,
+        # (the code is what the requirements key off). Reported AND gated.
+        "ungated_decision_rate": ungated_rate,
+        "unsupported_disposition_rate": unsupported_rate,
         "missing_context_rate": (
             sum(1 for r in active if r["missing_context"]) / len(active))
         if active else 0.0,
@@ -1369,8 +1373,35 @@ def evaluate(records: list[dict]) -> dict:
     return result
 
 
-def _release_gates(scored: dict) -> dict:
+def _release_gates(scored: dict, ungated_rate: float = 0.0,
+                   unsupported_rate: float = 0.0) -> dict:
+    """The gates that must ALL pass before any disposition class auto-decides.
+
+    The bypass checks are here because they were missing: the PRD listed "no
+    schema or evidence-gate bypasses" as a release condition and nothing read
+    it, so `release_gates.passed` could return True over a ledger containing
+    decisions that skipped the gate entirely (Codex review round 5, executed
+    repro: 60 clean cases + 1 ungated -> passed=True, ungated_rate=0.016).
+    A caller trusting that field would enable automation on known-invalid
+    calibration data. A gate nobody reads is not a gate.
+    """
     checks = {
+        # An ungated decision is one whose reason code was omitted, which is
+        # what keys the evidence requirements — so the evidence gate never ran
+        # for it. Any nonzero rate means the calibration set contains decisions
+        # the gate did not cover, and the release condition is literally zero.
+        "zero_gate_bypasses": {
+            "required": 0.0, "actual": ungated_rate,
+            "passed": ungated_rate == 0.0,
+        },
+        # Distinct from a bypass: this counts judge recommendations the gate
+        # CAUGHT and converted to needs-human. The gate working, not failing.
+        # Reported as a gate anyway because a judge that keeps proposing
+        # unsupported dispositions is not ready to decide unattended.
+        "zero_unsupported_judge_dispositions": {
+            "required": 0.0, "actual": unsupported_rate,
+            "passed": unsupported_rate == 0.0,
+        },
         "min_cases": {"required": 50, "actual": scored["cases"],
                       "passed": scored["cases"] >= 50},
         "exact_agreement": {"required": 0.88, "actual": scored["exact_agreement"],

--- a/plugins/prd-os/scripts/judgment_compiler.py
+++ b/plugins/prd-os/scripts/judgment_compiler.py
@@ -109,11 +109,14 @@ JUDGE_TO_LEGACY = {
 }
 
 RECEIPT_FIELDS = frozenset((
-    "schema_version", "receipt_id", "captured_at", "finding", "review",
-    "repo_state", "prd_state", "issue_state", "scope", "duplicates",
+    "schema_version", "receipt_id", "sequence", "captured_at", "finding",
+    "review", "repo_state", "prd_state", "issue_state", "scope", "duplicates",
     "remediation", "related_prds", "prior_receipts", "missing_context",
     "judge", "human", "sampling", "supersedes", "prev_receipt_sha256",
 ))
+TIP_NAME = "judgments-tip.json"
+TIP_FIELDS = frozenset(("count", "last_receipt_sha256", "last_receipt_id",
+                        "updated_at"))
 PACKET_FIELDS = frozenset((
     "packet_schema_version", "assembled_at", "packet_sha256", "finding",
     "review", "repo_state", "prd_state", "issue_state", "scope", "duplicates",
@@ -183,6 +186,54 @@ def ledger_path(cfg: Config) -> Path:
 
 def candidates_path(cfg: Config) -> Path:
     return _ledger_dir(cfg) / CANDIDATES_NAME
+
+
+def tip_path(cfg: Config) -> Path:
+    return _ledger_dir(cfg) / TIP_NAME
+
+
+def read_tip(path: Path) -> dict | None:
+    """The tip anchor: how long the chain is and what its last line hashes to.
+
+    WHY THIS EXISTS (self-attack 2026-08-04, before this file ever shipped):
+    a prev-hash chain proves each retained line follows the one before it. It
+    cannot prove the chain is COMPLETE, because any prefix of a valid chain is
+    itself a valid chain. Truncating the tail (or deleting the whole ledger)
+    passed `verify` cleanly. Reproduced: 2 receipts -> VERIFY PASS; `head -1`
+    the file -> still VERIFY PASS. The anchor closes deletion, the one
+    tamper class the chain structurally cannot see.
+
+    HONEST BOUNDARY: the anchor is written by the same process that writes the
+    ledger, so an attacker who can edit one can edit the other. This is
+    tamper-EVIDENT (accidental truncation, a crashed write, a partial sync,
+    a naive edit), not tamper-PROOF. For an independent check use
+    `verify --cross-check`, which reads the findings ledgers instead.
+    """
+    if not path.is_file():
+        return None
+    try:
+        tip = json.loads(path.read_text(encoding="utf-8"))
+    except (json.JSONDecodeError, OSError) as exc:
+        raise ValidationError(f"{path}: unreadable tip anchor: {exc}") from exc
+    if not isinstance(tip, dict):
+        raise ValidationError(f"{path}: tip anchor must be an object")
+    _require_keys(tip, TIP_FIELDS, str(path))
+    if not isinstance(tip["count"], int) or isinstance(tip["count"], bool) \
+            or tip["count"] < 0:
+        raise ValidationError(f"{path}: tip count must be a non-negative int")
+    return tip
+
+
+def write_tip(path: Path, records: list[dict]) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    payload = {
+        "count": len(records),
+        "last_receipt_sha256": canonical_hash(records[-1]) if records else None,
+        "last_receipt_id": records[-1]["receipt_id"] if records else None,
+        "updated_at": _now_iso(),
+    }
+    path.write_text(json.dumps(payload, indent=2, sort_keys=True) + "\n",
+                    encoding="utf-8")
 
 
 def read_ledger(path: Path) -> list[dict]:
@@ -333,6 +384,9 @@ def validate_receipt(record: dict, where: str) -> None:
     _require_keys(record, RECEIPT_FIELDS, where)
     if record["schema_version"] != RECEIPT_SCHEMA_VERSION:
         raise ValidationError(f"{where}: unsupported schema_version")
+    sequence = record["sequence"]
+    if isinstance(sequence, bool) or not isinstance(sequence, int) or sequence < 1:
+        raise ValidationError(f"{where}: sequence must be a positive integer")
     if receipt_content_id(record) != record["receipt_id"]:
         raise ValidationError(
             f"{where}: receipt_id does not match record content (mutated "
@@ -750,6 +804,7 @@ def build_receipt(cfg: Config, packet: dict, *, disposition: str,
 
     record = {
         "schema_version": RECEIPT_SCHEMA_VERSION,
+        "sequence": len(existing) + 1,
         "captured_at": _now_iso(),
         "finding": packet["finding"],
         "review": packet["review"],
@@ -804,6 +859,12 @@ def capture_episode(cfg: Config, packet: dict, **kwargs) -> dict:
     existing = read_ledger(path)
     record = build_receipt(cfg, packet, existing=existing, **kwargs)
     append_receipt(path, record)
+    # Anchor AFTER the append. If the process dies between the two the anchor
+    # under-counts, and an under-counting anchor is deliberately NOT an error
+    # (see _tip_errors) so a crashed write never manufactures a truncation
+    # alarm. Anchoring first would do the opposite: claim a receipt that was
+    # never written, and fail every later verify.
+    write_tip(tip_path(cfg), existing + [record])
     return record
 
 
@@ -846,12 +907,16 @@ def validate_triage_decision(reason_code: str | None,
 # ---------------------------------------------------------------------------
 
 
-def verify_ledger(records: list[dict]) -> list[str]:
+def verify_ledger(records: list[dict], tip: dict | None = None) -> list[str]:
     errors = []
     seen_ids: set[str] = set()
     prev_hash: str | None = None
     for index, record in enumerate(records, 1):
         where = f"receipt line {index}"
+        if record.get("sequence") != index:
+            errors.append(
+                f"{where}: sequence {record.get('sequence')!r} does not match "
+                f"its position {index} — a receipt was deleted or reordered")
         # Duplicate detection runs on the STORED id, before content validation:
         # a forged copy of an earlier receipt fails self-hash too, but the
         # duplicate must be named as such (N-7) — one error per defect class.
@@ -876,7 +941,27 @@ def verify_ledger(records: list[dict]) -> list[str]:
                 f"{where}: supersedes {record['supersedes']} which does not "
                 "appear earlier in the ledger")
         prev_hash = canonical_hash(record)
+    errors.extend(_tip_errors(records, tip, prev_hash))
     return errors
+
+
+def _tip_errors(records: list[dict], tip: dict | None,
+                last_hash: str | None) -> list[str]:
+    """Deletion detection. A prefix of a valid chain is a valid chain, so the
+    chain walk above cannot see a truncated tail; the anchor can."""
+    if tip is None:
+        # No anchor (legacy or fresh ledger). Do not hard-fail — that would
+        # break every repo whose ledger predates the anchor — but never claim
+        # completeness we cannot check.
+        return []
+    if len(records) < tip["count"]:
+        return [f"ledger is TRUNCATED: {len(records)} receipt(s) present, tip "
+                f"anchor recorded {tip['count']}"]
+    if len(records) == tip["count"] and tip["last_receipt_sha256"] is not None \
+            and last_hash != tip["last_receipt_sha256"]:
+        return ["ledger tail does not match the tip anchor: the last receipt "
+                "was replaced"]
+    return []
 
 
 def verify_candidates(records: list[dict]) -> list[str]:
@@ -886,6 +971,40 @@ def verify_candidates(records: list[dict]) -> list[str]:
             validate_candidate(record, f"candidate line {index}")
         except ValidationError as exc:
             errors.append(str(exc))
+    return errors
+
+
+def cross_check_findings(cfg: Config, records: list[dict],
+                         since: str | None = None) -> list[str]:
+    """Completeness check against an INDEPENDENT source: every dispositioned
+    finding should have a receipt.
+
+    The tip anchor and the ledger share a writer, so both move together if that
+    writer is wrong or malicious. The findings ledgers do not: they are written
+    by findings_writer's own path. A dispositioned finding with no receipt is
+    either a truncation the anchor missed or a capture that silently failed.
+
+    `since` filters by finding resolved_at, because findings dispositioned
+    before this feature existed have no receipt by construction and would
+    otherwise report as thousands of false gaps.
+    """
+    covered = {(r["finding"]["prd_id"], r["finding"]["finding_id"])
+               for r in records}
+    errors = []
+    for path in sorted(cfg.findings_dir.rglob("*-findings.jsonl")):
+        for record in _read_findings(path):
+            disposition = record.get("disposition")
+            if disposition in (None, "pending"):
+                continue
+            resolved_at = str(record.get("resolved_at") or "")
+            if since and resolved_at < since:
+                continue
+            key = (record.get("prd_id"), record.get("id"))
+            if key not in covered:
+                errors.append(
+                    f"{key[0]}/{key[1]}: dispositioned {disposition!r} at "
+                    f"{resolved_at or 'unknown time'} but no judgment receipt "
+                    "exists")
     return errors
 
 
@@ -1283,9 +1402,12 @@ def cmd_capture(cfg: Config, args: argparse.Namespace) -> int:
 
 def cmd_verify(cfg: Config, args: argparse.Namespace) -> int:
     records = read_ledger(ledger_path(cfg))
-    errors = verify_ledger(records)
+    errors = verify_ledger(records, read_tip(tip_path(cfg)))
     candidate_records = read_ledger(candidates_path(cfg))
     errors.extend(verify_candidates(candidate_records))
+    if getattr(args, "cross_check", False):
+        errors.extend(cross_check_findings(cfg, records,
+                                           getattr(args, "since", None)))
     if args.packet or args.receipt_id:
         if not (args.packet and args.receipt_id):
             raise ValidationError("--packet and --receipt-id go together")
@@ -1308,7 +1430,7 @@ def cmd_verify(cfg: Config, args: argparse.Namespace) -> int:
 
 def cmd_evaluate(cfg: Config, args: argparse.Namespace) -> int:
     records = read_ledger(ledger_path(cfg))
-    errors = verify_ledger(records)
+    errors = verify_ledger(records, read_tip(tip_path(cfg)))
     if errors:
         print("EVALUATE REFUSED: ledger fails verification:", file=sys.stderr)
         for error in errors:
@@ -1335,7 +1457,7 @@ def cmd_sample_check(cfg: Config, args: argparse.Namespace) -> int:
 
 def cmd_policy_candidates(cfg: Config, args: argparse.Namespace) -> int:
     records = read_ledger(ledger_path(cfg))
-    errors = verify_ledger(records)
+    errors = verify_ledger(records, read_tip(tip_path(cfg)))
     if errors:
         print("POLICY-CANDIDATES REFUSED: ledger fails verification",
               file=sys.stderr)
@@ -1381,6 +1503,11 @@ def main(argv: list[str]) -> int:
     p_verify = sub.add_parser("verify")
     p_verify.add_argument("--packet")
     p_verify.add_argument("--receipt-id", dest="receipt_id")
+    p_verify.add_argument("--cross-check", action="store_true",
+                          dest="cross_check",
+                          help="also require a receipt for every dispositioned "
+                               "finding (independent completeness check)")
+    p_verify.add_argument("--since", help="ISO timestamp floor for --cross-check")
     p_verify.set_defaults(func=cmd_verify)
 
     p_evaluate = sub.add_parser("evaluate")

--- a/plugins/prd-os/scripts/judgment_compiler.py
+++ b/plugins/prd-os/scripts/judgment_compiler.py
@@ -1064,7 +1064,24 @@ def _tip_errors(records: list[dict], tip: dict | None,
     if len(records) < tip["count"]:
         return [f"ledger is TRUNCATED: {len(records)} receipt(s) present, tip "
                 f"anchor recorded {tip['count']}"]
-    if len(records) == tip["count"] and tip["last_receipt_sha256"] is not None \
+    if len(records) > tip["count"]:
+        # An UNDER-counting anchor was originally treated as fine, on the theory
+        # that a crash between append and anchor-write must not raise a
+        # truncation alarm. Codex review (PR #97) showed what that actually
+        # bought: the receipts past the anchor sit OUTSIDE deletion detection,
+        # so verify/evaluate/policy-candidates all trust a tail that could be
+        # silently truncated back to the anchor later and still pass. Verify
+        # cannot claim the chain is intact when it has not checked all of it.
+        # Recoverable, not corrupt: `reanchor` re-covers the tail. Re-anchoring
+        # can only ever EXTEND coverage — a deletion shows up as the branch
+        # above first, and forged appends are caught by the chain walk, not the
+        # anchor — so the repair cannot launder tampering.
+        return [f"ledger has {len(records) - tip['count']} receipt(s) BEYOND "
+                f"the tip anchor ({len(records)} present, {tip['count']} "
+                "anchored): the tail is outside deletion detection. If the "
+                "extra receipts are legitimate (a crash between append and "
+                "anchor write), run `kipi judgment reanchor` to cover them."]
+    if tip["last_receipt_sha256"] is not None \
             and last_hash != tip["last_receipt_sha256"]:
         return ["ledger tail does not match the tip anchor: the last receipt "
                 "was replaced"]
@@ -1668,6 +1685,36 @@ def cmd_verify(cfg: Config, args: argparse.Namespace) -> int:
     return 0
 
 
+def cmd_reanchor(cfg: Config, args: argparse.Namespace) -> int:
+    """Re-cover a legitimate unanchored tail (crash between append and anchor).
+
+    Refuses when the CHAIN itself is broken, so this can never be used to bless
+    a tampered ledger: it only ever extends anchor coverage over receipts that
+    already verify, and a deletion presents as a truncation (fewer records than
+    the anchor), which is not a state this repairs.
+    """
+    with ledger_lock(cfg):
+        records = read_ledger(ledger_path(cfg))
+        tip = read_tip(tip_path(cfg))
+        if tip is not None and len(records) < tip["count"]:
+            raise ValidationError(
+                f"refusing to reanchor a TRUNCATED ledger: {len(records)} "
+                f"present, {tip['count']} anchored. Restore the missing "
+                "receipts first; reanchor is not a truncation eraser.")
+        chain_errors = [e for e in verify_ledger(records, None)
+                        if "tip anchor" not in e]
+        if chain_errors:
+            print("refusing to reanchor: the chain itself does not verify",
+                  file=sys.stderr)
+            for error in chain_errors:
+                print(f"  - {error}", file=sys.stderr)
+            return 2
+        write_tip(tip_path(cfg), records)
+    print(json.dumps({"reanchored": len(records),
+                      "path": str(tip_path(cfg))}, indent=2))
+    return 0
+
+
 def cmd_evaluate(cfg: Config, args: argparse.Namespace) -> int:
     records = read_ledger(ledger_path(cfg))
     errors = verify_ledger(records, read_tip(tip_path(cfg)))
@@ -1752,6 +1799,9 @@ def main(argv: list[str]) -> int:
 
     p_evaluate = sub.add_parser("evaluate")
     p_evaluate.set_defaults(func=cmd_evaluate)
+
+    p_reanchor = sub.add_parser("reanchor")
+    p_reanchor.set_defaults(func=cmd_reanchor)
 
     p_sample = sub.add_parser("sample-check")
     p_sample.add_argument("--basis", required=True)

--- a/plugins/prd-os/scripts/judgment_compiler.py
+++ b/plugins/prd-os/scripts/judgment_compiler.py
@@ -966,19 +966,21 @@ def validate_triage_decision(reason_code: str | None,
         errors.append(
             f"reason-code must be one of {REASON_CODES}; got {reason_code!r}")
         return errors
-    # Omitting the code used to opt a decision out of the evidence gate
-    # entirely: `rejected --rationale "dupe of something else"` recorded a
-    # duplicate-rejection with zero evidence, which is the exact decision the
-    # gate exists to refuse (adversarial review 2026-08-04). rejected/deferred
-    # already owe a --rationale; they now owe a machine-readable code too.
-    # accepted/pending stay optional — being fixed needs no justification.
-    if reason_code is None and disposition in ("rejected", "deferred"):
-        errors.append(
-            f"disposition={disposition!r} requires --reason-code (one of "
-            f"{REASON_CODES}). Omitting it would skip the evidence gate. "
-            "Use insufficient-context or needs-human if none of the specific "
-            "codes fit.")
-        return errors
+    # KNOWN, MEASURED BYPASS (adversarial review 2026-08-04): omitting the code
+    # opts a decision out of the evidence gate, because requirements are keyed
+    # off the code. `rejected --rationale "dupe of something else"` records a
+    # duplicate-rejection with zero evidence.
+    #
+    # Requiring a code on rejected/deferred closes it and was implemented — then
+    # reverted, because it changes the contract of `set-disposition`, a shipped
+    # command every instance in the fleet inherits (it broke 5 existing tests
+    # encoding that contract). This repo's own rule: a gate whose blast radius
+    # is the whole fleet earns its own issue instead of arriving as a side
+    # effect of another PRD. Captured as sp-1caf70c9.
+    #
+    # Until then the bypass is not silent: the receipt records reason_code null
+    # plus a `human.reason_code` missing_context entry, and `evaluate` reports
+    # `ungated_decision_rate` so its size is a number, not a vibe.
     try:
         _validate_evidence_refs(evidence_refs, "human decision")
     except ValidationError as exc:
@@ -1323,6 +1325,14 @@ def evaluate(records: list[dict]) -> dict:
         "human_review_rate": (len(human_reviewed) / len(judged))
         if judged else 0.0,
         "needs_human_count": needs_human,
+        # Decisions carrying no reason code skipped the evidence gate entirely
+        # (the code is what the requirements key off). Reported so the size of
+        # that known bypass is a number rather than an assumption.
+        "ungated_decision_rate": (
+            sum(1 for r in active
+                if r.get("human") and r["human"]["reason_code"] is None
+                and r["human"]["disposition"] in ("rejected", "deferred"))
+            / len(active)) if active else 0.0,
         "unsupported_disposition_rate": (converted / len(judged)) if judged else 0.0,
         "missing_context_rate": (
             sum(1 for r in active if r["missing_context"]) / len(active))

--- a/plugins/prd-os/tests/test_judgment_compiler.py
+++ b/plugins/prd-os/tests/test_judgment_compiler.py
@@ -657,6 +657,30 @@ class TestChainIntegrity:
         assert "TRUNCATED" in proc.stderr
         assert run_judgment(judgment_repo, "verify").returncode == 2
 
+    def test_reanchor_refuses_when_the_anchor_is_missing_entirely(
+            self, judgment_repo):
+        """Codex round 3, executed repro: deleting the anchor AND truncating,
+        then reanchoring, wrote a fresh anchor over the surviving prefix and
+        made the deletion permanent. Without the old anchor there is no
+        baseline, so this state is not repairable — it is refused."""
+        two_receipts(judgment_repo)
+        path = judgment_repo / ".prd-os" / "judgments.jsonl"
+        path.write_text(path.read_text().splitlines()[0] + "\n")  # truncate
+        (judgment_repo / ".prd-os" / "judgments-tip.json").unlink()  # and hide
+        proc = run_judgment(judgment_repo, "reanchor")
+        assert proc.returncode == 2
+        assert "NO existing" in proc.stderr
+        assert "cross-check" in proc.stderr
+        # and the ledger is still reported as unverifiable, not blessed
+        assert run_judgment(judgment_repo, "verify").returncode == 2
+
+    def test_reanchor_on_a_fresh_empty_repo_is_a_no_op(self, judgment_repo):
+        """An empty ledger with no anchor is a genuinely fresh repo: nothing to
+        prove, so refusing here would be crying wolf."""
+        proc = run_judgment(judgment_repo, "reanchor")
+        assert proc.returncode == 0, proc.stderr
+        assert json.loads(proc.stdout)["reanchored"] == 0
+
     def test_reanchor_refuses_a_broken_chain(self, judgment_repo):
         two_receipts(judgment_repo)
         path = judgment_repo / ".prd-os" / "judgments.jsonl"

--- a/plugins/prd-os/tests/test_judgment_compiler.py
+++ b/plugins/prd-os/tests/test_judgment_compiler.py
@@ -907,6 +907,63 @@ class TestEvaluate:
         assert gates["passed"] is False  # 4 cases, 75% << thresholds
         assert gates["min_cases"]["required"] == 50
 
+    def test_release_gates_fail_when_any_decision_bypassed_the_evidence_gate(self):
+        """Codex review round 5, executed repro: 60 otherwise-perfect cases plus
+        ONE reason-code-less rejection returned release_gates.passed == True
+        with a nonzero ungated rate. `passed` is the field that would authorize
+        automation, and the PRD lists zero bypasses as a release condition, so
+        a caller could enable auto-decide on known-invalid calibration data.
+
+        Built with the module's own in-memory fixtures (no repo, no tmp dir) so
+        it runs anywhere the selftest does."""
+        import importlib.util
+
+        spec = importlib.util.spec_from_file_location("jc_gate", JUDGMENT)
+        jc = importlib.util.module_from_spec(spec)
+        sys.modules["jc_gate"] = jc
+        spec.loader.exec_module(jc)
+
+        shapes = [("accepted", "fix-now", "valid-fix-now"),
+                  ("rejected", "invalid", "invalid-finding"),
+                  ("deferred", "defer", "defer-ordering")]
+        records = []
+        for index in range(60):
+            human, workflow, code = shapes[index % 3]
+            packet = jc._fixture_packet(index)
+            run = {"model": "m", "prompt_sha256": "0" * 64,
+                   "review_run_id": str(index),
+                   "input_sha256": packet["packet_sha256"],
+                   "output": {"technical_validity": "valid",
+                              "technical_reason": "ok",
+                              "workflow_disposition": workflow,
+                              "workflow_reason_code": code,
+                              "evidence_refs": [], "missing_context": [],
+                              "confidence": 1.0}}
+            records.append(jc.build_receipt(
+                packet, disposition=human, actor="human", reason_code=code,
+                evidence_refs=[], rationale=None, judge_run=run,
+                supersedes=None, existing=records))
+
+        clean = jc.evaluate(records)
+        assert clean["cases"] == 60
+        assert clean["ungated_decision_rate"] == 0.0
+        assert clean["release_gates"]["passed"] is True, (
+            "a perfect 60-case set must be able to pass, or the gate is "
+            "unpassable and this test proves nothing")
+
+        # ...now one ungated decision, and nothing else changes.
+        packet = jc._fixture_packet(999)
+        records.append(jc.build_receipt(
+            packet, disposition="rejected", actor="human", reason_code=None,
+            evidence_refs=[], rationale="ungated", judge_run=None,
+            supersedes=None, existing=records))
+        dirty = jc.evaluate(records)
+        assert dirty["ungated_decision_rate"] > 0
+        assert dirty["release_gates"]["zero_gate_bypasses"]["passed"] is False
+        assert dirty["release_gates"]["passed"] is False, (
+            "release gates reported PASSED over a ledger containing a decision "
+            "that skipped the evidence gate")
+
     def test_superseded_receipts_are_excluded(self, judgment_repo):
         recs = two_receipts(judgment_repo)  # second supersedes first
         proc = run_judgment(judgment_repo, "evaluate")

--- a/plugins/prd-os/tests/test_judgment_compiler.py
+++ b/plugins/prd-os/tests/test_judgment_compiler.py
@@ -19,6 +19,7 @@ from __future__ import annotations
 import hashlib
 import json
 import os
+import re
 import subprocess
 import sys
 from pathlib import Path
@@ -1183,6 +1184,46 @@ class TestLedgerRoot:
         payload = json.loads(proc.stdout)
         assert payload["path"].endswith("judgments.jsonl")
         assert str(judgment_repo) in payload["path"]
+
+
+class TestCliParity:
+    """The Python subparsers and the `kipi judgment` bash allowlist are two
+    lists of the same thing, edited by hand, in different files. Codex review
+    round 2 caught the predictable result: `reanchor` shipped in Python and in
+    the docs while the dispatcher rejected it, so the documented recovery for
+    an interrupted anchor write did not exist. One test, both ends."""
+
+    KIPI = PLUGIN_ROOT.parents[1] / "kipi"
+
+    def _python_subcommands(self) -> set[str]:
+        source = JUDGMENT.read_text()
+        return set(re.findall(r'sub\.add_parser\("([a-z-]+)"\)', source))
+
+    def _bash_subcommands(self) -> set[str]:
+        block = self.KIPI.read_text().split("  judgment)", 1)[1]
+        allowlist = re.search(r"^\s+([a-z|-]+)\)$", block, re.M).group(1)
+        return set(allowlist.split("|")) | {"selftest"}
+
+    def test_every_python_subcommand_is_reachable_through_kipi(self):
+        missing = self._python_subcommands() - self._bash_subcommands()
+        assert not missing, (
+            f"judgment_compiler.py exposes {sorted(missing)} but `kipi "
+            "judgment` rejects them: the CLI cannot reach a shipped command")
+
+    def test_the_dispatcher_advertises_nothing_python_lacks(self):
+        # selftest is a --flag, not a subparser, so it is exempt by name.
+        phantom = self._bash_subcommands() - self._python_subcommands() - {"selftest"}
+        assert not phantom, (
+            f"`kipi judgment` advertises {sorted(phantom)} which "
+            "judgment_compiler.py does not implement")
+
+    def test_usage_text_lists_every_subcommand(self):
+        usage_lines = [l for l in self.KIPI.read_text().splitlines()
+                       if "usage: kipi judgment" in l]
+        assert usage_lines, "the judgment dispatcher prints no usage line"
+        for name in self._python_subcommands():
+            assert name in usage_lines[0], (
+                f"{name} is dispatchable but absent from the usage text")
 
 
 class TestReadOnly:

--- a/plugins/prd-os/tests/test_judgment_compiler.py
+++ b/plugins/prd-os/tests/test_judgment_compiler.py
@@ -1,0 +1,776 @@
+"""Tests for the Judgment Compiler (PRD prd-judgment-compiler-2026-08-04, ASK-363).
+
+Test-first contract: written before judgment_compiler.py existed and run RED
+against the pre-change tree to demonstrate the five capability gaps (G-1..G-5
+in the PRD), then implementation proceeds until green.
+
+Every test runs against an ephemeral tmp repo (fable-discipline test
+isolation). Fixtures are producer-derived: findings are written by the real
+findings_writer.py `add` path, PRD files mirror the exact frontmatter +
+fenced-JSON `## Issues` manifest shape that prd_runner/prd_split produce
+(fixtures-from-producers scar: an invented fixture tests my assumption).
+
+Hash contract is pinned on BOTH ends: these tests recompute canonical hashes
+independently of the implementation (cross-process handshake lesson).
+"""
+
+from __future__ import annotations
+
+import hashlib
+import json
+import os
+import subprocess
+import sys
+from pathlib import Path
+
+import pytest
+
+
+PLUGIN_ROOT = Path(__file__).resolve().parents[1]
+SCRIPTS_DIR = PLUGIN_ROOT / "scripts"
+JUDGMENT = SCRIPTS_DIR / "judgment_compiler.py"
+
+REASON_CODES = (
+    "valid-fix-now",
+    "already-remediated",
+    "duplicate",
+    "owned-by-other-prd",
+    "scope-removed",
+    "out-of-scope",
+    "superseded",
+    "defer-dependency",
+    "defer-ordering",
+    "invalid-finding",
+    "insufficient-context",
+    "needs-human",
+)
+
+
+def canonical_hash(record: dict) -> str:
+    """Independent recomputation of the ledger's canonical hash (pins the
+    contract from the test side; the implementation must match byte-for-byte)."""
+    payload = json.dumps(record, sort_keys=True, separators=(",", ":"), ensure_ascii=False)
+    return hashlib.sha256(payload.encode("utf-8")).hexdigest()
+
+
+def run_judgment(repo: Path, *args: str, stdin_text: str | None = None,
+                 env_extra: dict | None = None) -> subprocess.CompletedProcess:
+    env = os.environ.copy()
+    env["CLAUDE_PROJECT_DIR"] = str(repo)
+    if env_extra:
+        env.update(env_extra)
+    return subprocess.run(
+        [sys.executable, str(JUDGMENT), *args],
+        cwd=str(repo),
+        capture_output=True,
+        text=True,
+        env=env,
+        input=stdin_text,
+    )
+
+
+PRD_ID = "prd-fixture-2026-08-04"
+
+
+def write_prd_spec(repo: Path, prd_id: str = PRD_ID, status: str = "in-review",
+                   issues: list[dict] | None = None) -> Path:
+    """Mirror the real PRD spec shape (frontmatter + fenced `## Issues` JSON)."""
+    if issues is None:
+        issues = [
+            {"id": "fixture-issue-a", "title": "A", "allowed_files": ["a.py"]},
+            {"id": "fixture-issue-b", "title": "B", "allowed_files": ["b.py"]},
+        ]
+    body = (
+        "---\n"
+        f"id: {prd_id}\n"
+        "title: Fixture PRD\n"
+        f"status: {status}\n"
+        "created_at: 2026-08-04T00:00:00Z\n"
+        "---\n\n"
+        "# Fixture PRD\n\n"
+        "## Problem\n\nFixture.\n\n"
+        "## Scope\n\nIn scope: the fixture paths only.\n\n"
+        "## Issues\n\n"
+        "```json\n" + json.dumps(issues, indent=2) + "\n```\n"
+    )
+    path = repo / ".prd-os" / "prds" / f"{prd_id}.md"
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(body)
+    return path
+
+
+@pytest.fixture
+def judgment_repo(fake_repo: Path, write_config, run_findings_writer) -> Path:
+    """Repo with config, a PRD spec, and one real finding written by the
+    producer (findings_writer add)."""
+    write_config(fake_repo, {"config_schema_version": 1})
+    write_prd_spec(fake_repo)
+    proc = run_findings_writer(
+        fake_repo, "add", PRD_ID, "--source", "codex-review",
+        stdin_text=json.dumps(
+            [{"severity": "major", "body": "the fixture gate can be bypassed"}]
+        ),
+    )
+    assert proc.returncode == 0, proc.stderr
+    return fake_repo
+
+
+def assemble_packet(repo: Path, prd_id: str = PRD_ID,
+                    finding_id: str = "finding-1") -> tuple[Path, dict]:
+    out = repo / "packet.json"
+    proc = run_judgment(repo, "assemble", "--prd", prd_id,
+                        "--finding", finding_id, "--output", str(out))
+    assert proc.returncode == 0, proc.stderr
+    return out, json.loads(out.read_text())
+
+
+def capture(repo: Path, packet_path: Path, *extra: str,
+            disposition: str = "accepted",
+            env_extra: dict | None = None) -> subprocess.CompletedProcess:
+    return run_judgment(
+        repo, "capture", "--prd", PRD_ID, "--finding", "finding-1",
+        "--context", str(packet_path), "--disposition", disposition,
+        "--actor", "founder", *extra, env_extra=env_extra,
+    )
+
+
+def read_ledger(repo: Path) -> list[dict]:
+    path = repo / ".prd-os" / "judgments.jsonl"
+    if not path.is_file():
+        return []
+    return [json.loads(line) for line in path.read_text().splitlines() if line.strip()]
+
+
+def make_judge_run(packet: dict, *, disposition: str = "fix-now",
+                   reason_code: str = "valid-fix-now",
+                   evidence: list[str] | None = None,
+                   confidence: float = 0.7, extra_output: dict | None = None,
+                   input_sha256: str | None = None) -> dict:
+    output = {
+        "technical_validity": "valid",
+        "technical_reason": "the gate is bypassable as described",
+        "workflow_disposition": disposition,
+        "workflow_reason_code": reason_code,
+        "evidence_refs": evidence or [],
+        "missing_context": [],
+        "confidence": confidence,
+    }
+    if extra_output:
+        output.update(extra_output)
+    return {
+        "model": "test-model",
+        "prompt_sha256": "0" * 64,
+        "review_run_id": "run-1",
+        "input_sha256": input_sha256 or packet["packet_sha256"],
+        "output": output,
+    }
+
+
+# ---------------------------------------------------------------------------
+# Gap repros (PRD section 6, run RED against the pre-change tree)
+# ---------------------------------------------------------------------------
+
+
+class TestGapRepros:
+    def test_g1_decision_time_context_survives_prd_change(self, judgment_repo):
+        """G-1: adjudicating freezes decision-time PRD state; editing the PRD
+        afterwards does not invalidate or mutate the receipt."""
+        packet_path, packet = assemble_packet(judgment_repo)
+        proc = capture(judgment_repo, packet_path)
+        assert proc.returncode == 0, proc.stderr
+        before = read_ledger(judgment_repo)
+        assert len(before) == 1
+        frozen_sha = before[0]["prd_state"]["sha256"]
+        assert frozen_sha not in ("", "unknown")
+
+        write_prd_spec(judgment_repo, status="approved")  # PRD moves on
+        after = read_ledger(judgment_repo)
+        assert after == before  # receipt untouched
+        proc = run_judgment(judgment_repo, "verify")
+        assert proc.returncode == 0, proc.stderr
+
+    def test_g2_technical_validity_and_workflow_disposition_are_separate(self, judgment_repo):
+        """G-2: a technically valid finding recorded as a workflow duplicate."""
+        packet_path, packet = assemble_packet(judgment_repo)
+        judge = make_judge_run(
+            packet, disposition="duplicate", reason_code="duplicate",
+            evidence=[f"finding:{PRD_ID}/finding-1"],
+        )
+        judge_path = judgment_repo / "judge.json"
+        judge_path.write_text(json.dumps(judge))
+        proc = capture(
+            judgment_repo, packet_path, "--judge-run", str(judge_path),
+            "--reason-code", "duplicate",
+            "--evidence", f"finding:{PRD_ID}/finding-1",
+            disposition="rejected",
+        )
+        assert proc.returncode == 0, proc.stderr
+        rec = read_ledger(judgment_repo)[-1]
+        assert rec["judge"]["output"]["technical_validity"] == "valid"
+        assert rec["judge"]["output"]["workflow_disposition"] == "duplicate"
+        assert rec["human"]["disposition"] == "rejected"
+        assert rec["human"]["reason_code"] == "duplicate"
+
+    def test_g3_duplicate_without_reference_is_refused(self, judgment_repo):
+        """G-3 / N-1 (human half): evidence-requiring disposition with no
+        stable reference fails hard before anything is written."""
+        packet_path, _ = assemble_packet(judgment_repo)
+        proc = capture(judgment_repo, packet_path,
+                       "--reason-code", "duplicate", disposition="rejected")
+        assert proc.returncode == 2
+        assert "duplicate" in proc.stderr
+        assert read_ledger(judgment_repo) == []
+
+    def test_g4_judge_run_reproducible_from_hashes(self, judgment_repo):
+        """G-4: the stored packet re-hashes to the receipt's recorded basis;
+        a corrupted packet is detected."""
+        packet_path, packet = assemble_packet(judgment_repo)
+        judge_path = judgment_repo / "judge.json"
+        judge_path.write_text(json.dumps(make_judge_run(packet)))
+        proc = capture(judgment_repo, packet_path, "--judge-run", str(judge_path))
+        assert proc.returncode == 0, proc.stderr
+        receipt_id = read_ledger(judgment_repo)[-1]["receipt_id"]
+
+        proc = run_judgment(judgment_repo, "verify", "--packet", str(packet_path),
+                            "--receipt-id", receipt_id)
+        assert proc.returncode == 0, proc.stderr
+
+        corrupted = json.loads(packet_path.read_text())
+        corrupted["finding"]["body"] = "tampered"
+        packet_path.write_text(json.dumps(corrupted))
+        proc = run_judgment(judgment_repo, "verify", "--packet", str(packet_path),
+                            "--receipt-id", receipt_id)
+        assert proc.returncode == 2
+
+    def test_g5_sampling_is_reproducible_across_processes(self, judgment_repo):
+        """G-5: the same basis yields the same verdict in two separate
+        processes, from the documented rule alone."""
+        basis = hashlib.sha256(b"fixture-basis").hexdigest()
+        first = run_judgment(judgment_repo, "sample-check", "--basis", basis)
+        second = run_judgment(judgment_repo, "sample-check", "--basis", basis)
+        assert first.returncode == 0 and second.returncode == 0
+        a, b = json.loads(first.stdout), json.loads(second.stdout)
+        assert a == b
+        expected = int(hashlib.sha256(
+            f"kipi-judgment-sample-v1:{basis}".encode()).hexdigest(), 16) % 10000 < 500
+        assert a["sampled"] is expected
+        assert a["rule"]  # the rule is recorded, not implied
+
+
+# ---------------------------------------------------------------------------
+# Assembler facts stay honest
+# ---------------------------------------------------------------------------
+
+
+class TestAssembler:
+    def test_packet_hash_is_stable_across_assemblies(self, judgment_repo):
+        _, p1 = assemble_packet(judgment_repo)
+        _, p2 = assemble_packet(judgment_repo)
+        assert p1["packet_sha256"] == p2["packet_sha256"]
+
+    def test_packet_hash_matches_independent_recomputation(self, judgment_repo):
+        _, packet = assemble_packet(judgment_repo)
+        body = {k: v for k, v in packet.items()
+                if k not in ("packet_sha256", "assembled_at")}
+        assert canonical_hash(body) == packet["packet_sha256"]
+
+    def test_n4_missing_context_is_unknown_not_false(self, judgment_repo):
+        """N-4: no git in the fixture repo, so repo state must be `unknown`
+        and listed in missing_context — never False/false."""
+        _, packet = assemble_packet(judgment_repo)
+        assert packet["repo_state"]["dirty"] == "unknown"
+        assert packet["repo_state"]["commit_sha"] == "unknown"
+        assert any(m.startswith("repo_state") for m in packet["missing_context"])
+        assert False not in packet["repo_state"].values()
+
+    def test_n4_fabricated_false_fails_packet_validation(self, judgment_repo):
+        packet_path, packet = assemble_packet(judgment_repo)
+        packet["repo_state"]["dirty"] = False  # fabricated boolean
+        body = {k: v for k, v in packet.items()
+                if k not in ("packet_sha256", "assembled_at")}
+        packet["packet_sha256"] = canonical_hash(body)  # re-hash so only the
+        # fabrication is on trial, not the hash mismatch
+        packet_path.write_text(json.dumps(packet))
+        proc = capture(judgment_repo, packet_path)
+        assert proc.returncode == 2
+        assert "dirty" in proc.stderr
+
+    def test_duplicates_and_issue_order_carry_sources(self, judgment_repo):
+        _, packet = assemble_packet(judgment_repo)
+        assert packet["issue_state"]["issue_order"] == [
+            "fixture-issue-a", "fixture-issue-b"]
+        assert packet["issue_state"]["manifest_sha256"] not in ("", "unknown")
+        assert packet["prd_state"]["status"] == "in-review"
+        for dup in packet["duplicates"]:
+            assert dup["source"]
+
+    def test_git_repo_state_is_resolved_when_git_exists(self, tmp_path, monkeypatch,
+                                                        write_config, run_findings_writer):
+        repo = tmp_path / "gitrepo"
+        repo.mkdir()
+        monkeypatch.setenv("CLAUDE_PROJECT_DIR", str(repo))
+        subprocess.run(["git", "init", "-q"], cwd=repo, check=True)
+        subprocess.run(["git", "-c", "user.email=t@t", "-c", "user.name=t",
+                        "commit", "-q", "--allow-empty", "-m", "seed"],
+                       cwd=repo, check=True)
+        write_config(repo, {"config_schema_version": 1})
+        write_prd_spec(repo)
+        proc = run_findings_writer(
+            repo, "add", PRD_ID, "--source", "codex-review",
+            stdin_text=json.dumps([{"severity": "major", "body": "b"}]))
+        assert proc.returncode == 0, proc.stderr
+        _, packet = assemble_packet(repo)
+        assert len(packet["repo_state"]["commit_sha"]) == 40
+        assert packet["repo_state"]["dirty"] in ("true", "false")
+
+
+# ---------------------------------------------------------------------------
+# Receipt chain integrity
+# ---------------------------------------------------------------------------
+
+
+def two_receipts(repo: Path) -> list[dict]:
+    packet_path, _ = assemble_packet(repo)
+    assert capture(repo, packet_path).returncode == 0
+    proc = run_judgment(
+        repo, "capture", "--prd", PRD_ID, "--finding", "finding-1",
+        "--context", str(packet_path), "--disposition", "rejected",
+        "--reason-code", "invalid-finding", "--rationale", "not real",
+        "--actor", "founder",
+    )
+    assert proc.returncode == 0, proc.stderr
+    return read_ledger(repo)
+
+
+class TestChainIntegrity:
+    def test_chain_links_and_verify_green(self, judgment_repo):
+        recs = two_receipts(judgment_repo)
+        assert len(recs) == 2
+        assert recs[0]["prev_receipt_sha256"] is None
+        first_line_hash = canonical_hash(recs[0])
+        assert recs[1]["prev_receipt_sha256"] == first_line_hash
+        assert run_judgment(judgment_repo, "verify").returncode == 0
+
+    def test_second_receipt_supersedes_first_for_same_finding(self, judgment_repo):
+        recs = two_receipts(judgment_repo)
+        assert recs[1]["supersedes"] == recs[0]["receipt_id"]
+
+    def test_n6_mutated_receipt_fails_verify(self, judgment_repo):
+        two_receipts(judgment_repo)
+        path = judgment_repo / ".prd-os" / "judgments.jsonl"
+        lines = path.read_text().splitlines()
+        rec = json.loads(lines[0])
+        rec["human"]["disposition"] = "rejected"  # history rewrite
+        lines[0] = json.dumps(rec, sort_keys=True, separators=(",", ":"),
+                              ensure_ascii=False)
+        path.write_text("\n".join(lines) + "\n")
+        proc = run_judgment(judgment_repo, "verify")
+        assert proc.returncode == 2
+        assert "1" in proc.stderr  # names the line
+
+    def test_n7_duplicate_receipt_id_fails_verify(self, judgment_repo):
+        two_receipts(judgment_repo)
+        path = judgment_repo / ".prd-os" / "judgments.jsonl"
+        lines = path.read_text().splitlines()
+        last = json.loads(lines[-1])
+        forged = dict(last)
+        forged["prev_receipt_sha256"] = canonical_hash(last)
+        path.write_text("\n".join(lines + [json.dumps(
+            forged, sort_keys=True, separators=(",", ":"), ensure_ascii=False)]) + "\n")
+        proc = run_judgment(judgment_repo, "verify")
+        assert proc.returncode == 2
+        assert "duplicate" in proc.stderr.lower()
+
+    def test_n8_broken_prev_hash_fails_verify(self, judgment_repo):
+        two_receipts(judgment_repo)
+        path = judgment_repo / ".prd-os" / "judgments.jsonl"
+        lines = path.read_text().splitlines()
+        rec = json.loads(lines[1])
+        rec["prev_receipt_sha256"] = "f" * 64
+        lines[1] = json.dumps(rec, sort_keys=True, separators=(",", ":"),
+                              ensure_ascii=False)
+        path.write_text("\n".join(lines) + "\n")
+        assert run_judgment(judgment_repo, "verify").returncode == 2
+
+    def test_supersedes_must_resolve(self, judgment_repo):
+        packet_path, _ = assemble_packet(judgment_repo)
+        proc = capture(judgment_repo, packet_path,
+                       "--supersedes", "jr-doesnotexist0000")
+        assert proc.returncode == 2
+
+
+# ---------------------------------------------------------------------------
+# Evidence gate (N-1..N-3) and judge conversion
+# ---------------------------------------------------------------------------
+
+
+class TestEvidenceGate:
+    @pytest.mark.parametrize("code", ["duplicate", "already-remediated",
+                                      "scope-removed", "out-of-scope",
+                                      "owned-by-other-prd", "superseded"])
+    def test_human_decision_without_evidence_fails(self, judgment_repo, code):
+        packet_path, _ = assemble_packet(judgment_repo)
+        proc = capture(judgment_repo, packet_path, "--reason-code", code,
+                       disposition="rejected")
+        assert proc.returncode == 2
+        assert read_ledger(judgment_repo) == []
+
+    def test_human_decision_with_evidence_passes(self, judgment_repo):
+        packet_path, _ = assemble_packet(judgment_repo)
+        proc = capture(judgment_repo, packet_path,
+                       "--reason-code", "already-remediated",
+                       "--evidence", "commit:" + "a" * 40,
+                       disposition="rejected")
+        assert proc.returncode == 0, proc.stderr
+
+    def test_judge_unsupported_disposition_converts_to_needs_human(self, judgment_repo):
+        """N-1/N-2 judge half: unsupported judge recommendation degrades to
+        needs-human and is flagged; it is never recorded as fact."""
+        packet_path, packet = assemble_packet(judgment_repo)
+        judge = make_judge_run(packet, disposition="already-remediated",
+                               reason_code="already-remediated", evidence=[])
+        judge_path = judgment_repo / "judge.json"
+        judge_path.write_text(json.dumps(judge))
+        proc = capture(judgment_repo, packet_path, "--judge-run", str(judge_path))
+        assert proc.returncode == 0, proc.stderr
+        rec = read_ledger(judgment_repo)[-1]
+        assert rec["judge"]["output"]["workflow_disposition"] == "needs-human"
+        assert rec["judge"]["converted_to_needs_human"] is True
+
+
+# ---------------------------------------------------------------------------
+# Judge output schema strictness (N-9..N-11) and stale context (N-5)
+# ---------------------------------------------------------------------------
+
+
+class TestJudgeContract:
+    def write_judge(self, repo, judge) -> Path:
+        path = repo / "judge.json"
+        path.write_text(json.dumps(judge))
+        return path
+
+    def test_n9_unknown_reason_code_rejected(self, judgment_repo):
+        packet_path, packet = assemble_packet(judgment_repo)
+        judge = make_judge_run(packet, reason_code="sounds-fine")
+        proc = capture(judgment_repo, packet_path,
+                       "--judge-run", str(self.write_judge(judgment_repo, judge)))
+        assert proc.returncode == 2
+
+    @pytest.mark.parametrize("confidence", [1.5, -0.1, float("nan"), True])
+    def test_n10_confidence_out_of_contract_rejected(self, judgment_repo, confidence):
+        packet_path, packet = assemble_packet(judgment_repo)
+        judge = make_judge_run(packet)
+        judge["output"]["confidence"] = confidence
+        path = judgment_repo / "judge.json"
+        # json.dumps(allow_nan=True) emits a bare NaN literal; json.loads
+        # accepts it back, so the validator must reject non-finite itself.
+        path.write_text(json.dumps(judge))
+        proc = capture(judgment_repo, packet_path, "--judge-run", str(path))
+        assert proc.returncode == 2
+
+    def test_n11_extra_fields_rejected(self, judgment_repo):
+        packet_path, packet = assemble_packet(judgment_repo)
+        judge = make_judge_run(packet, extra_output={"vibes": "good"})
+        proc = capture(judgment_repo, packet_path,
+                       "--judge-run", str(self.write_judge(judgment_repo, judge)))
+        assert proc.returncode == 2
+        assert "vibes" in proc.stderr
+
+    def test_stale_input_hash_rejected(self, judgment_repo):
+        packet_path, packet = assemble_packet(judgment_repo)
+        judge = make_judge_run(packet, input_sha256="b" * 64)
+        proc = capture(judgment_repo, packet_path,
+                       "--judge-run", str(self.write_judge(judgment_repo, judge)))
+        assert proc.returncode == 2
+
+    def test_n5_capture_on_stale_packet_refused_but_old_receipts_stand(self, judgment_repo):
+        packet_path, _ = assemble_packet(judgment_repo)
+        assert capture(judgment_repo, packet_path).returncode == 0
+        write_prd_spec(judgment_repo, status="approved")  # PRD changed
+        proc = run_judgment(judgment_repo, "capture", "--prd", PRD_ID,
+                            "--finding", "finding-1", "--context", str(packet_path),
+                            "--disposition", "deferred", "--reason-code",
+                            "defer-ordering", "--rationale", "later",
+                            "--actor", "founder")
+        assert proc.returncode == 2
+        assert "stale" in proc.stderr.lower()
+        assert run_judgment(judgment_repo, "verify").returncode == 0
+
+
+# ---------------------------------------------------------------------------
+# Evaluator (v2) and release gates
+# ---------------------------------------------------------------------------
+
+
+def seeded_ledger(repo: Path, n_agree: int, n_total: int) -> None:
+    """Build a prospective ledger via the real capture path: n_total decisions,
+    n_agree where the judge's mapped disposition matches the human one."""
+    for index in range(n_total):
+        finding_body = f"case {index}: distinct fixture objection"
+        proc_add = subprocess.run(
+            [sys.executable, str(SCRIPTS_DIR / "findings_writer.py"), "add",
+             PRD_ID, "--source", "codex-review"],
+            cwd=str(repo), capture_output=True, text=True,
+            env={**os.environ, "CLAUDE_PROJECT_DIR": str(repo)},
+            input=json.dumps([{"severity": "major", "body": finding_body}]),
+        )
+        assert proc_add.returncode == 0, proc_add.stderr
+        finding_id = json.loads(proc_add.stdout)["added"][0]
+        out = repo / f"packet-{index}.json"
+        proc = run_judgment(repo, "assemble", "--prd", PRD_ID,
+                            "--finding", finding_id, "--output", str(out))
+        assert proc.returncode == 0, proc.stderr
+        packet = json.loads(out.read_text())
+        judge = make_judge_run(packet)  # predicts fix-now -> accepted
+        judge_path = repo / f"judge-{index}.json"
+        judge_path.write_text(json.dumps(judge))
+        human = "accepted" if index < n_agree else "rejected"
+        args = ["capture", "--prd", PRD_ID, "--finding", finding_id,
+                "--context", str(out), "--disposition", human,
+                "--actor", "founder", "--judge-run", str(judge_path)]
+        if human == "rejected":
+            args += ["--reason-code", "invalid-finding", "--rationale", "wrong"]
+        proc = run_judgment(repo, *args)
+        assert proc.returncode == 0, proc.stderr
+
+
+class TestEvaluate:
+    def test_metrics_and_gate_status(self, judgment_repo):
+        seeded_ledger(judgment_repo, n_agree=3, n_total=4)
+        proc = run_judgment(judgment_repo, "evaluate")
+        assert proc.returncode == 0, proc.stderr
+        report = json.loads(proc.stdout)
+        assert report["cases"] == 4
+        assert report["exact_agreement"] == 0.75
+        assert "cohen_kappa" in report
+        assert "per_class" in report and "accepted" in report["per_class"]
+        assert "confusion_matrix" in report
+        assert "ece_10_bin" in report
+        assert "human_review_rate" in report
+        assert "unsupported_disposition_rate" in report
+        assert "missing_context_rate" in report
+        assert "by_reason_code" in report
+        assert "population_counts" in report
+        gates = report["release_gates"]
+        assert gates["passed"] is False  # 4 cases, 75% << thresholds
+        assert gates["min_cases"]["required"] == 50
+
+    def test_superseded_receipts_are_excluded(self, judgment_repo):
+        recs = two_receipts(judgment_repo)  # second supersedes first
+        proc = run_judgment(judgment_repo, "evaluate")
+        assert proc.returncode == 0, proc.stderr
+        report = json.loads(proc.stdout)
+        # neither fixture receipt carries a judge run -> zero scorable cases,
+        # and the superseded first receipt must not resurrect as a case
+        assert report["cases"] == 0
+        assert report["superseded_excluded"] == 1
+        assert len(recs) == 2
+
+    def test_n12_row_without_context_basis_fails_ledger_validation(self, judgment_repo):
+        """N-12: a v1-style context-free row cannot be presented as a
+        context-complete prospective case."""
+        two_receipts(judgment_repo)
+        path = judgment_repo / ".prd-os" / "judgments.jsonl"
+        lines = path.read_text().splitlines()
+        prev_hash = canonical_hash(json.loads(lines[-1]))
+        forged = {"case_id": "fjc-v1-001", "severity": "major",
+                  "finding": "history text", "founder_disposition": "accepted",
+                  "prev_receipt_sha256": prev_hash}
+        path.write_text("\n".join(lines + [json.dumps(
+            forged, sort_keys=True, separators=(",", ":"), ensure_ascii=False)]) + "\n")
+        assert run_judgment(judgment_repo, "verify").returncode == 2
+        assert run_judgment(judgment_repo, "evaluate").returncode == 2
+
+
+# ---------------------------------------------------------------------------
+# Policy candidates (N-13, N-14)
+# ---------------------------------------------------------------------------
+
+
+def seed_override_pattern(repo: Path, count: int) -> None:
+    """Judge says fix-now; founder repeatedly rejects as duplicate with the
+    same evidence-kind — the repeated pattern a policy candidate must catch."""
+    for index in range(count):
+        proc_add = subprocess.run(
+            [sys.executable, str(SCRIPTS_DIR / "findings_writer.py"), "add",
+             PRD_ID, "--source", "codex-review"],
+            cwd=str(repo), capture_output=True, text=True,
+            env={**os.environ, "CLAUDE_PROJECT_DIR": str(repo)},
+            input=json.dumps([{"severity": "major",
+                               "body": f"override case {index}"}]),
+        )
+        assert proc_add.returncode == 0, proc_add.stderr
+        finding_id = json.loads(proc_add.stdout)["added"][0]
+        out = repo / f"op-{index}.json"
+        assert run_judgment(repo, "assemble", "--prd", PRD_ID, "--finding",
+                            finding_id, "--output", str(out)).returncode == 0
+        packet = json.loads(out.read_text())
+        judge_path = repo / f"oj-{index}.json"
+        judge_path.write_text(json.dumps(make_judge_run(packet)))
+        proc = run_judgment(
+            repo, "capture", "--prd", PRD_ID, "--finding", finding_id,
+            "--context", str(out), "--disposition", "rejected",
+            "--reason-code", "duplicate",
+            "--evidence", f"finding:{PRD_ID}/finding-1",
+            "--rationale", "same defect as finding-1",
+            "--actor", "founder", "--judge-run", str(judge_path),
+        )
+        assert proc.returncode == 0, proc.stderr
+
+
+class TestPolicyCandidates:
+    def test_repeated_override_produces_candidate_with_counterexample_search(self, judgment_repo):
+        seed_override_pattern(judgment_repo, 3)
+        proc = run_judgment(judgment_repo, "policy-candidates", "--min-cases", "3")
+        assert proc.returncode == 0, proc.stderr
+        path = judgment_repo / ".prd-os" / "judgment-policy-candidates.jsonl"
+        rows = [json.loads(l) for l in path.read_text().splitlines() if l.strip()]
+        assert rows, "no candidate emitted for a 3x repeated pattern"
+        cand = rows[-1]
+        assert cand["status"] == "proposed"
+        assert cand["case_count"] >= 3
+        assert len(cand["supporting_receipt_ids"]) >= 3
+        assert "counterexamples" in cand
+        assert cand["counterexample_search"]
+        assert cand["proposed_rule"]
+        assert cand["proposed_tests"]
+        assert cand["false_positive_risk"]
+        assert cand["integration_point"] == "before-llm-judge"
+
+    def test_below_min_cases_emits_nothing(self, judgment_repo):
+        seed_override_pattern(judgment_repo, 2)
+        proc = run_judgment(judgment_repo, "policy-candidates", "--min-cases", "3")
+        assert proc.returncode == 0, proc.stderr
+        path = judgment_repo / ".prd-os" / "judgment-policy-candidates.jsonl"
+        assert not path.is_file() or not path.read_text().strip()
+
+    def test_n13_candidate_without_counterexample_search_fails_verify(self, judgment_repo):
+        seed_override_pattern(judgment_repo, 3)
+        assert run_judgment(judgment_repo, "policy-candidates",
+                            "--min-cases", "3").returncode == 0
+        path = judgment_repo / ".prd-os" / "judgment-policy-candidates.jsonl"
+        rows = [json.loads(l) for l in path.read_text().splitlines() if l.strip()]
+        rows[-1].pop("counterexample_search")
+        path.write_text("\n".join(json.dumps(r) for r in rows) + "\n")
+        assert run_judgment(judgment_repo, "verify").returncode == 2
+
+    def test_n14_no_self_install_path_exists(self, judgment_repo):
+        """N-14: the module exposes no promote/install command and never
+        touches the gate ledger or hook wiring (grep-the-source proof)."""
+        proc = run_judgment(judgment_repo, "promote")
+        assert proc.returncode != 0
+        source = JUDGMENT.read_text()
+        for forbidden in ("gates.jsonl", "gate_register", "hooks.json",
+                          "settings.json", "settings-template.json"):
+            assert forbidden not in source, (
+                f"judgment_compiler.py must not reference {forbidden}: "
+                "policy promotion is the human-reviewed path")
+
+
+# ---------------------------------------------------------------------------
+# findings_writer integration (the real caller)
+# ---------------------------------------------------------------------------
+
+
+class TestTriageIntegration:
+    def test_legacy_set_disposition_captures_receipt_with_honest_nulls(
+            self, judgment_repo, run_findings_writer):
+        proc = run_findings_writer(judgment_repo, "set-disposition", PRD_ID,
+                                   "finding-1", "accepted")
+        assert proc.returncode == 0, proc.stderr
+        recs = read_ledger(judgment_repo)
+        assert len(recs) == 1
+        assert recs[0]["human"]["disposition"] == "accepted"
+        assert recs[0]["human"]["reason_code"] is None
+        assert "human.reason_code" in recs[0]["missing_context"]
+
+    def test_set_disposition_with_reason_code_and_evidence(
+            self, judgment_repo, run_findings_writer):
+        proc = run_findings_writer(
+            judgment_repo, "set-disposition", PRD_ID, "finding-1", "rejected",
+            "--rationale", "same as finding-9",
+            "--reason-code", "duplicate",
+            "--evidence", f"finding:{PRD_ID}/finding-9")
+        assert proc.returncode == 0, proc.stderr
+        rec = read_ledger(judgment_repo)[-1]
+        assert rec["human"]["reason_code"] == "duplicate"
+        assert rec["human"]["evidence_refs"] == [f"finding:{PRD_ID}/finding-9"]
+
+    def test_set_disposition_evidence_gate_fails_fast(
+            self, judgment_repo, run_findings_writer):
+        """Gate failure leaves the findings file untouched (validated BEFORE
+        the write, not after)."""
+        findings_path = (judgment_repo / ".prd-os" / "findings" /
+                         f"{PRD_ID}-findings.jsonl")
+        before = findings_path.read_text()
+        proc = run_findings_writer(
+            judgment_repo, "set-disposition", PRD_ID, "finding-1", "rejected",
+            "--rationale", "dup", "--reason-code", "duplicate")
+        assert proc.returncode == 2
+        assert findings_path.read_text() == before
+        assert read_ledger(judgment_repo) == []
+
+    def test_kill_switch_restores_legacy_behavior(
+            self, judgment_repo, run_findings_writer):
+        proc = run_findings_writer(
+            judgment_repo, "set-disposition", PRD_ID, "finding-1", "accepted",
+            env_extra={"KIPI_JUDGMENT_CAPTURE": "0"})
+        assert proc.returncode == 0, proc.stderr
+        assert read_ledger(judgment_repo) == []
+        payload = json.loads(proc.stdout)
+        assert payload["disposition"] == "accepted"
+
+    def test_deferred_still_syncs_spillover_and_captures(
+            self, judgment_repo, run_findings_writer):
+        proc = run_findings_writer(
+            judgment_repo, "set-disposition", PRD_ID, "finding-1", "deferred",
+            "--rationale", "belongs to the next phase",
+            "--reason-code", "defer-ordering")
+        assert proc.returncode == 0, proc.stderr
+        spill = judgment_repo / ".prd-os" / "spillover.jsonl"
+        assert spill.is_file() and f"defer-{PRD_ID}-finding-1" in spill.read_text()
+        rec = read_ledger(judgment_repo)[-1]
+        assert rec["human"]["disposition"] == "deferred"
+
+    def test_redisposition_appends_superseding_receipt(
+            self, judgment_repo, run_findings_writer):
+        assert run_findings_writer(judgment_repo, "set-disposition", PRD_ID,
+                                   "finding-1", "accepted").returncode == 0
+        assert run_findings_writer(
+            judgment_repo, "set-disposition", PRD_ID, "finding-1", "rejected",
+            "--rationale", "reconsidered", "--reason-code",
+            "invalid-finding").returncode == 0
+        recs = read_ledger(judgment_repo)
+        assert len(recs) == 2
+        assert recs[1]["supersedes"] == recs[0]["receipt_id"]
+        assert run_judgment(judgment_repo, "verify").returncode == 0
+
+
+# ---------------------------------------------------------------------------
+# Read-only survival (R-5) and selftest
+# ---------------------------------------------------------------------------
+
+
+class TestReadOnly:
+    def test_selftest_passes(self, judgment_repo):
+        proc = run_judgment(judgment_repo, "--selftest")
+        assert proc.returncode == 0, proc.stderr
+        assert "SELFTEST PASS" in proc.stdout
+
+    def test_verify_evaluate_selftest_survive_read_only_repo(self, judgment_repo):
+        two_receipts(judgment_repo)
+        locked: list[Path] = []
+        for root, dirs, _files in os.walk(judgment_repo):
+            for d in dirs:
+                locked.append(Path(root) / d)
+        locked.append(judgment_repo)
+        try:
+            for path in locked:
+                os.chmod(path, 0o555)
+            assert run_judgment(judgment_repo, "verify").returncode == 0
+            assert run_judgment(judgment_repo, "evaluate").returncode == 0
+            proc = run_judgment(judgment_repo, "--selftest")
+            assert proc.returncode == 0, proc.stderr
+        finally:
+            for path in locked:
+                os.chmod(path, 0o755)

--- a/plugins/prd-os/tests/test_judgment_compiler.py
+++ b/plugins/prd-os/tests/test_judgment_compiler.py
@@ -616,17 +616,32 @@ class TestEvidenceGate:
             assert proc.returncode == 2, f"{bad} was accepted: {proc.stdout}"
         assert read_ledger(judgment_repo) == []
 
-    def test_omitting_reason_code_on_rejected_is_refused(self, judgment_repo):
-        """The gate keyed off the reason code, so omitting it skipped the gate
-        entirely — a duplicate-rejection with zero evidence (review)."""
+    def test_omitting_reason_code_is_a_known_bypass_that_is_counted(
+            self, judgment_repo):
+        """Omitting the code skips the evidence gate (requirements key off it).
+        Requiring it changes the contract of a fleet-wide shipped command, so
+        that is its own issue; here the bypass must at least be VISIBLE:
+        recorded as missing context and counted by evaluate."""
         packet_path, _ = assemble_packet(judgment_repo)
         proc = run_judgment(
             judgment_repo, "capture", "--prd", PRD_ID,
             "--finding", "finding-1", "--context", str(packet_path),
             "--disposition", "rejected", "--actor", "founder",
             "--rationale", "nah, dupe of something else")
-        assert proc.returncode == 2
-        assert "reason-code" in proc.stderr
+        assert proc.returncode == 0, proc.stderr
+        rec = read_ledger(judgment_repo)[-1]
+        assert rec["human"]["reason_code"] is None
+        assert "human.reason_code" in rec["missing_context"]
+        report = json.loads(run_judgment(judgment_repo, "evaluate").stdout)
+        assert report["ungated_decision_rate"] == 1.0
+
+    def test_ungated_rate_is_zero_when_codes_are_supplied(self, judgment_repo):
+        packet_path, _ = assemble_packet(judgment_repo)
+        assert capture(judgment_repo, packet_path, "--reason-code",
+                       "invalid-finding", "--rationale", "no",
+                       disposition="rejected").returncode == 0
+        report = json.loads(run_judgment(judgment_repo, "evaluate").stdout)
+        assert report["ungated_decision_rate"] == 0.0
 
     def test_omitting_reason_code_on_accepted_still_works(self, judgment_repo):
         """accepted/pending need no justification — being fixed is the reason."""

--- a/plugins/prd-os/tests/test_judgment_compiler.py
+++ b/plugins/prd-os/tests/test_judgment_compiler.py
@@ -342,6 +342,79 @@ def two_receipts(repo: Path) -> list[dict]:
     return read_ledger(repo)
 
 
+def reseal_ledger(repo: Path, records: list[dict]) -> None:
+    """Rewrite the ledger as a FULLY self-consistent chain: recompute every
+    prev-hash and receipt_id, then refresh the tip anchor to match.
+
+    This simulates an attacker who repairs every invariant they know about. A
+    test that reseals and then breaks exactly one thing isolates that one
+    check — otherwise a redundant check masks it and the mutation survives.
+    Added after a mutation run showed `sequence` and the prev-hash link could
+    both be disabled with all 55 tests still green.
+    """
+    sealed = []
+    prev = None
+    for record in records:
+        record = json.loads(json.dumps(record))
+        record["prev_receipt_sha256"] = prev
+        record.pop("receipt_id", None)
+        record["receipt_id"] = "jr-" + canonical_hash(record)[:16]
+        sealed.append(record)
+        prev = canonical_hash(record)
+    write_sealed(repo, sealed)
+
+
+def write_sealed(repo: Path, sealed: list[dict]) -> None:
+    path = repo / ".prd-os" / "judgments.jsonl"
+    path.write_text("".join(
+        json.dumps(r, sort_keys=True, separators=(",", ":"),
+                   ensure_ascii=False) + "\n" for r in sealed))
+    tip = {
+        "count": len(sealed),
+        "last_receipt_sha256": canonical_hash(sealed[-1]) if sealed else None,
+        "last_receipt_id": sealed[-1]["receipt_id"] if sealed else None,
+        "updated_at": "2026-08-04T00:00:00Z",
+    }
+    (repo / ".prd-os" / "judgments-tip.json").write_text(
+        json.dumps(tip, indent=2, sort_keys=True) + "\n")
+
+
+class TestInvariantIsolation:
+    """One test per integrity check, with every OTHER check repaired first."""
+
+    def test_sequence_gap_is_caught_when_everything_else_is_consistent(
+            self, judgment_repo):
+        recs = two_receipts(judgment_repo)
+        recs[1]["sequence"] = 3  # contiguity broken, nothing else is
+        reseal_ledger(judgment_repo, recs)
+        proc = run_judgment(judgment_repo, "verify")
+        assert proc.returncode == 2
+        assert "sequence" in proc.stderr.lower()
+
+    def test_broken_chain_link_is_caught_when_everything_else_is_consistent(
+            self, judgment_repo):
+        """An attacker who rewrites a receipt AND refreshes the tip anchor is
+        still caught: the anchor is tamper-evident, the chain is the real check."""
+        recs = two_receipts(judgment_repo)
+        reseal_ledger(judgment_repo, recs)
+        sealed = read_ledger(judgment_repo)
+        sealed[1]["prev_receipt_sha256"] = "f" * 64  # point at nothing
+        sealed[1].pop("receipt_id")
+        sealed[1]["receipt_id"] = "jr-" + canonical_hash(sealed[1])[:16]
+        write_sealed(judgment_repo, sealed)  # anchor refreshed to match
+        proc = run_judgment(judgment_repo, "verify")
+        assert proc.returncode == 2
+        assert "chain" in proc.stderr.lower()
+
+    def test_reseal_helper_itself_produces_a_valid_ledger(self, judgment_repo):
+        """Guard the guard: if reseal produced an invalid ledger, the two tests
+        above would pass for the wrong reason."""
+        recs = two_receipts(judgment_repo)
+        reseal_ledger(judgment_repo, recs)
+        proc = run_judgment(judgment_repo, "verify")
+        assert proc.returncode == 0, proc.stderr
+
+
 class TestChainIntegrity:
     def test_chain_links_and_verify_green(self, judgment_repo):
         recs = two_receipts(judgment_repo)
@@ -448,11 +521,28 @@ class TestChainIntegrity:
         assert proc.returncode == 2
         assert "tip anchor" in proc.stderr.lower()
 
-    def test_missing_tip_anchor_does_not_hard_fail(self, judgment_repo):
-        """A ledger predating the anchor must still verify — otherwise the
-        upgrade breaks every existing repo. Absence is not a claim."""
+    def test_deleting_the_tip_anchor_is_itself_detected(self, judgment_repo):
+        """Treating a missing anchor as "legacy, pass" restored the whole
+        truncation hole for one extra `rm` — deleting a file is cheaper than
+        editing it. Every ledger this code writes has an anchor, so a
+        non-empty ledger without one is missing evidence."""
         two_receipts(judgment_repo)
         (judgment_repo / ".prd-os" / "judgments-tip.json").unlink()
+        proc = run_judgment(judgment_repo, "verify")
+        assert proc.returncode == 2
+        assert "missing" in proc.stderr.lower()
+
+    def test_rm_anchor_then_truncate_is_still_caught(self, judgment_repo):
+        """The exact two-command attack from the review."""
+        two_receipts(judgment_repo)
+        (judgment_repo / ".prd-os" / "judgments-tip.json").unlink()
+        path = judgment_repo / ".prd-os" / "judgments.jsonl"
+        path.write_text(path.read_text().splitlines()[0] + "\n")
+        assert run_judgment(judgment_repo, "verify").returncode == 2
+
+    def test_fresh_repo_with_no_ledger_and_no_anchor_verifies_clean(
+            self, judgment_repo):
+        """Absence of BOTH is a genuinely fresh repo, not tampering."""
         assert run_judgment(judgment_repo, "verify").returncode == 0
 
     def test_cross_check_flags_a_dispositioned_finding_with_no_receipt(
@@ -504,9 +594,44 @@ class TestEvidenceGate:
         packet_path, _ = assemble_packet(judgment_repo)
         proc = capture(judgment_repo, packet_path,
                        "--reason-code", "already-remediated",
-                       "--evidence", "commit:" + "a" * 40,
+                       "--evidence", "test:.prd-os/config.json",
                        disposition="rejected")
         assert proc.returncode == 0, proc.stderr
+
+    def test_evidence_ref_that_points_at_nothing_is_refused(self, judgment_repo):
+        """Grammar was not enough: a well-formed ref to a non-existent object
+        used to be recorded as the evidence justifying a rejection."""
+        packet_path, _ = assemble_packet(judgment_repo)
+        for bad in (f"finding:{PRD_ID}/finding-999",
+                    "finding:prd-does-not-exist/finding-1",
+                    "commit:zzzz",
+                    "prd:prd-not-here",
+                    "judgment:jr-nope"):
+            proc = capture(judgment_repo, packet_path,
+                           "--reason-code", "duplicate" if bad.startswith("finding")
+                           else "already-remediated" if bad.startswith("commit")
+                           else "owned-by-other-prd" if bad.startswith("prd")
+                           else "superseded",
+                           "--evidence", bad, disposition="rejected")
+            assert proc.returncode == 2, f"{bad} was accepted: {proc.stdout}"
+        assert read_ledger(judgment_repo) == []
+
+    def test_omitting_reason_code_on_rejected_is_refused(self, judgment_repo):
+        """The gate keyed off the reason code, so omitting it skipped the gate
+        entirely — a duplicate-rejection with zero evidence (review)."""
+        packet_path, _ = assemble_packet(judgment_repo)
+        proc = run_judgment(
+            judgment_repo, "capture", "--prd", PRD_ID,
+            "--finding", "finding-1", "--context", str(packet_path),
+            "--disposition", "rejected", "--actor", "founder",
+            "--rationale", "nah, dupe of something else")
+        assert proc.returncode == 2
+        assert "reason-code" in proc.stderr
+
+    def test_omitting_reason_code_on_accepted_still_works(self, judgment_repo):
+        """accepted/pending need no justification — being fixed is the reason."""
+        packet_path, _ = assemble_packet(judgment_repo)
+        assert capture(judgment_repo, packet_path).returncode == 0
 
     def test_judge_unsupported_disposition_converts_to_needs_human(self, judgment_repo):
         """N-1/N-2 judge half: unsupported judge recommendation degrades to
@@ -771,15 +896,20 @@ class TestTriageIntegration:
 
     def test_set_disposition_with_reason_code_and_evidence(
             self, judgment_repo, run_findings_writer):
+        assert run_findings_writer(
+            judgment_repo, "add", PRD_ID, "--source", "codex-review",
+            stdin_text=json.dumps([{"severity": "minor",
+                                    "body": "the owning defect"}]),
+        ).returncode == 0  # finding-2, so the evidence ref resolves
         proc = run_findings_writer(
             judgment_repo, "set-disposition", PRD_ID, "finding-1", "rejected",
             "--rationale", "same as finding-9",
             "--reason-code", "duplicate",
-            "--evidence", f"finding:{PRD_ID}/finding-9")
+            "--evidence", f"finding:{PRD_ID}/finding-2")
         assert proc.returncode == 0, proc.stderr
         rec = read_ledger(judgment_repo)[-1]
         assert rec["human"]["reason_code"] == "duplicate"
-        assert rec["human"]["evidence_refs"] == [f"finding:{PRD_ID}/finding-9"]
+        assert rec["human"]["evidence_refs"] == [f"finding:{PRD_ID}/finding-2"]
 
     def test_set_disposition_evidence_gate_fails_fast(
             self, judgment_repo, run_findings_writer):

--- a/plugins/prd-os/tests/test_judgment_compiler.py
+++ b/plugins/prd-os/tests/test_judgment_compiler.py
@@ -406,6 +406,53 @@ class TestInvariantIsolation:
         assert proc.returncode == 2
         assert "chain" in proc.stderr.lower()
 
+    def test_forged_sampling_verdict_is_caught_on_read(self, judgment_repo):
+        """READ-path check. The suite exercised the write path, where the
+        sampler computes its own verdict, so deleting the read-time
+        reproducibility check survived every test (mutation run 2026-08-04)."""
+        recs = two_receipts(judgment_repo)
+        recs[1]["sampling"]["sampled"] = not recs[1]["sampling"]["sampled"]
+        reseal_ledger(judgment_repo, recs)
+        proc = run_judgment(judgment_repo, "verify")
+        assert proc.returncode == 2
+        assert "sampling" in proc.stderr.lower()
+
+    def test_forged_evidence_free_disposition_is_caught_on_read(
+            self, judgment_repo):
+        """A hand-written ledger line claiming `duplicate` with no evidence
+        must fail verify even though no writer would produce it."""
+        recs = two_receipts(judgment_repo)
+        recs[1]["human"]["reason_code"] = "duplicate"
+        recs[1]["human"]["evidence_refs"] = []
+        reseal_ledger(judgment_repo, recs)
+        proc = run_judgment(judgment_repo, "verify")
+        assert proc.returncode == 2
+        assert "duplicate" in proc.stderr
+
+    def test_forged_judge_output_hash_is_caught_on_read(self, judgment_repo):
+        packet_path, packet = assemble_packet(judgment_repo)
+        judge_path = judgment_repo / "judge.json"
+        judge_path.write_text(json.dumps(make_judge_run(packet)))
+        assert capture(judgment_repo, packet_path,
+                       "--judge-run", str(judge_path)).returncode == 0
+        recs = read_ledger(judgment_repo)
+        recs[-1]["judge"]["output"]["confidence"] = 0.1  # hash now stale
+        reseal_ledger(judgment_repo, recs)
+        proc = run_judgment(judgment_repo, "verify")
+        assert proc.returncode == 2
+        assert "output_sha256" in proc.stderr
+
+    def test_packet_whose_hash_does_not_match_its_body_is_refused(
+            self, judgment_repo):
+        """Distinct from the fabricated-false test, which re-hashes on purpose:
+        here the body and its self-hash simply disagree."""
+        packet_path, packet = assemble_packet(judgment_repo)
+        packet["finding"]["body"] = "silently swapped"
+        packet_path.write_text(json.dumps(packet))  # packet_sha256 untouched
+        proc = capture(judgment_repo, packet_path)
+        assert proc.returncode == 2
+        assert "packet_sha256" in proc.stderr
+
     def test_reseal_helper_itself_produces_a_valid_ledger(self, judgment_repo):
         """Guard the guard: if reseal produced an invalid ledger, the two tests
         above would pass for the wrong reason."""
@@ -979,6 +1026,50 @@ class TestTriageIntegration:
 # ---------------------------------------------------------------------------
 # Read-only survival (R-5) and selftest
 # ---------------------------------------------------------------------------
+
+
+class TestConcurrency:
+    def test_concurrent_captures_do_not_fork_the_chain(
+            self, judgment_repo, run_findings_writer):
+        """The ledger sits at the SHARED worktree root by design, so N
+        worktrees write one file. Unlocked, capture was a read-modify-append:
+        concurrent calls both derived sequence/prev_hash from a stale snapshot,
+        the chain forked, and EVERY writer exited 0 — corruption surfaced only
+        later, at a verify that append-only forbids repairing."""
+        count = 6
+        assert run_findings_writer(
+            judgment_repo, "add", PRD_ID, "--source", "codex-review",
+            stdin_text=json.dumps([
+                {"severity": "major", "body": f"distinct objection {i}"}
+                for i in range(count - 1)]),
+        ).returncode == 0
+        packets = []
+        for index in range(1, count + 1):
+            out = judgment_repo / f"cp{index}.json"
+            assert run_judgment(judgment_repo, "assemble", "--prd", PRD_ID,
+                                "--finding", f"finding-{index}",
+                                "--output", str(out)).returncode == 0
+            packets.append((f"finding-{index}", out))
+
+        procs = [
+            subprocess.Popen(
+                [sys.executable, str(JUDGMENT), "capture", "--prd", PRD_ID,
+                 "--finding", finding_id, "--context", str(out),
+                 "--disposition", "accepted", "--actor", "founder"],
+                cwd=str(judgment_repo), stdout=subprocess.DEVNULL,
+                stderr=subprocess.PIPE, text=True,
+                env={**os.environ, "CLAUDE_PROJECT_DIR": str(judgment_repo)})
+            for finding_id, out in packets
+        ]
+        errors = [proc.communicate()[1] for proc in procs]
+        assert all(proc.returncode == 0 for proc in procs), errors
+
+        recs = read_ledger(judgment_repo)
+        assert len(recs) == count, f"expected {count} receipts, got {len(recs)}"
+        assert [r["sequence"] for r in recs] == list(range(1, count + 1))
+        assert len({r["receipt_id"] for r in recs}) == count
+        proc = run_judgment(judgment_repo, "verify")
+        assert proc.returncode == 0, proc.stderr
 
 
 class TestReadOnly:

--- a/plugins/prd-os/tests/test_judgment_compiler.py
+++ b/plugins/prd-os/tests/test_judgment_compiler.py
@@ -392,6 +392,91 @@ class TestChainIntegrity:
         path.write_text("\n".join(lines) + "\n")
         assert run_judgment(judgment_repo, "verify").returncode == 2
 
+    def test_truncating_the_tail_is_detected(self, judgment_repo):
+        """Self-attack 2026-08-04: a prefix of a valid chain is a valid chain,
+        so the prev-hash walk alone passed a truncated ledger. The tip anchor
+        closes deletion — the one tamper class the chain cannot see."""
+        two_receipts(judgment_repo)
+        path = judgment_repo / ".prd-os" / "judgments.jsonl"
+        lines = path.read_text().splitlines()
+        path.write_text(lines[0] + "\n")  # drop the last receipt
+        proc = run_judgment(judgment_repo, "verify")
+        assert proc.returncode == 2
+        assert "truncated" in proc.stderr.lower()
+
+    def test_deleting_the_whole_ledger_is_detected(self, judgment_repo):
+        two_receipts(judgment_repo)
+        (judgment_repo / ".prd-os" / "judgments.jsonl").write_text("")
+        proc = run_judgment(judgment_repo, "verify")
+        assert proc.returncode == 2
+        assert "truncated" in proc.stderr.lower()
+
+    def test_deleting_a_middle_receipt_is_detected(self, judgment_repo):
+        """Sequence contiguity catches a middle deletion even where a
+        recomputed chain would look continuous."""
+        packet_path, _ = assemble_packet(judgment_repo)
+        for disposition, code, rationale in (
+                ("accepted", None, None),
+                ("rejected", "invalid-finding", "no"),
+                ("deferred", "defer-ordering", "later")):
+            args = ["capture", "--prd", PRD_ID, "--finding", "finding-1",
+                    "--context", str(packet_path), "--disposition", disposition,
+                    "--actor", "founder"]
+            if code:
+                args += ["--reason-code", code, "--rationale", rationale]
+            assert run_judgment(judgment_repo, *args).returncode == 0
+        path = judgment_repo / ".prd-os" / "judgments.jsonl"
+        lines = path.read_text().splitlines()
+        path.write_text(lines[0] + "\n" + lines[2] + "\n")  # drop the middle
+        proc = run_judgment(judgment_repo, "verify")
+        assert proc.returncode == 2
+
+    def test_replacing_the_last_receipt_is_detected(self, judgment_repo):
+        two_receipts(judgment_repo)
+        path = judgment_repo / ".prd-os" / "judgments.jsonl"
+        lines = path.read_text().splitlines()
+        forged = json.loads(lines[1])
+        forged["human"]["rationale"] = "rewritten"
+        forged["receipt_id"] = "jr-" + hashlib.sha256(json.dumps(
+            {k: v for k, v in forged.items() if k != "receipt_id"},
+            sort_keys=True, separators=(",", ":"),
+            ensure_ascii=False).encode()).hexdigest()[:16]
+        path.write_text(lines[0] + "\n" + json.dumps(
+            forged, sort_keys=True, separators=(",", ":"),
+            ensure_ascii=False) + "\n")
+        proc = run_judgment(judgment_repo, "verify")
+        assert proc.returncode == 2
+        assert "tip anchor" in proc.stderr.lower()
+
+    def test_missing_tip_anchor_does_not_hard_fail(self, judgment_repo):
+        """A ledger predating the anchor must still verify — otherwise the
+        upgrade breaks every existing repo. Absence is not a claim."""
+        two_receipts(judgment_repo)
+        (judgment_repo / ".prd-os" / "judgments-tip.json").unlink()
+        assert run_judgment(judgment_repo, "verify").returncode == 0
+
+    def test_cross_check_flags_a_dispositioned_finding_with_no_receipt(
+            self, judgment_repo, run_findings_writer):
+        """Independent completeness source: findings_writer's own ledger."""
+        assert run_findings_writer(
+            judgment_repo, "set-disposition", PRD_ID, "finding-1", "accepted",
+            env_extra={"KIPI_JUDGMENT_CAPTURE": "0"}).returncode == 0
+        assert read_ledger(judgment_repo) == []
+        plain = run_judgment(judgment_repo, "verify")
+        assert plain.returncode == 0  # chain itself is fine (it is empty)
+        crossed = run_judgment(judgment_repo, "verify", "--cross-check")
+        assert crossed.returncode == 2
+        assert "no judgment receipt" in crossed.stderr
+
+    def test_cross_check_since_floor_excludes_legacy_findings(
+            self, judgment_repo, run_findings_writer):
+        assert run_findings_writer(
+            judgment_repo, "set-disposition", PRD_ID, "finding-1", "accepted",
+            env_extra={"KIPI_JUDGMENT_CAPTURE": "0"}).returncode == 0
+        proc = run_judgment(judgment_repo, "verify", "--cross-check",
+                            "--since", "2099-01-01T00:00:00Z")
+        assert proc.returncode == 0
+
     def test_supersedes_must_resolve(self, judgment_repo):
         packet_path, _ = assemble_packet(judgment_repo)
         proc = capture(judgment_repo, packet_path,

--- a/plugins/prd-os/tests/test_judgment_compiler.py
+++ b/plugins/prd-os/tests/test_judgment_compiler.py
@@ -614,6 +614,61 @@ class TestChainIntegrity:
                             "--since", "2099-01-01T00:00:00Z")
         assert proc.returncode == 0
 
+    def test_receipts_beyond_the_tip_anchor_are_reported(self, judgment_repo):
+        """Codex review PR #97: an UNDER-counting anchor was treated as fine so
+        a crashed anchor-write would not false-alarm — but that left the
+        receipts past the anchor outside deletion detection, and verify still
+        said 'chain intact'."""
+        two_receipts(judgment_repo)
+        tip_file = judgment_repo / ".prd-os" / "judgments-tip.json"
+        tip = json.loads(tip_file.read_text())
+        recs = read_ledger(judgment_repo)
+        tip["count"] = 1  # simulate the crash: ledger moved on, anchor did not
+        tip["last_receipt_sha256"] = canonical_hash(recs[0])
+        tip["last_receipt_id"] = recs[0]["receipt_id"]
+        tip_file.write_text(json.dumps(tip, indent=2, sort_keys=True))
+        proc = run_judgment(judgment_repo, "verify")
+        assert proc.returncode == 2
+        assert "BEYOND" in proc.stderr
+        assert "reanchor" in proc.stderr
+
+    def test_reanchor_recovers_a_legitimate_unanchored_tail(self, judgment_repo):
+        two_receipts(judgment_repo)
+        tip_file = judgment_repo / ".prd-os" / "judgments-tip.json"
+        recs = read_ledger(judgment_repo)
+        tip_file.write_text(json.dumps(
+            {"count": 1, "last_receipt_sha256": canonical_hash(recs[0]),
+             "last_receipt_id": recs[0]["receipt_id"],
+             "updated_at": "2026-08-04T00:00:00Z"}, indent=2, sort_keys=True))
+        assert run_judgment(judgment_repo, "verify").returncode == 2
+        proc = run_judgment(judgment_repo, "reanchor")
+        assert proc.returncode == 0, proc.stderr
+        assert json.loads(proc.stdout)["reanchored"] == 2
+        assert run_judgment(judgment_repo, "verify").returncode == 0
+
+    def test_reanchor_refuses_a_truncated_ledger(self, judgment_repo):
+        """Reanchor must never double as a truncation eraser."""
+        two_receipts(judgment_repo)
+        path = judgment_repo / ".prd-os" / "judgments.jsonl"
+        path.write_text(path.read_text().splitlines()[0] + "\n")
+        proc = run_judgment(judgment_repo, "reanchor")
+        assert proc.returncode == 2
+        assert "TRUNCATED" in proc.stderr
+        assert run_judgment(judgment_repo, "verify").returncode == 2
+
+    def test_reanchor_refuses_a_broken_chain(self, judgment_repo):
+        two_receipts(judgment_repo)
+        path = judgment_repo / ".prd-os" / "judgments.jsonl"
+        lines = path.read_text().splitlines()
+        rec = json.loads(lines[1])
+        rec["prev_receipt_sha256"] = "f" * 64
+        lines[1] = json.dumps(rec, sort_keys=True, separators=(",", ":"),
+                              ensure_ascii=False)
+        path.write_text("\n".join(lines) + "\n")
+        proc = run_judgment(judgment_repo, "reanchor")
+        assert proc.returncode == 2
+        assert "chain" in proc.stderr.lower()
+
     def test_supersedes_must_resolve(self, judgment_repo):
         packet_path, _ = assemble_packet(judgment_repo)
         proc = capture(judgment_repo, packet_path,
@@ -986,6 +1041,36 @@ class TestTriageIntegration:
         assert proc.returncode == 2
         assert findings_path.read_text() == before
         assert read_ledger(judgment_repo) == []
+
+    def test_failed_capture_leaves_no_spillover_entry(
+            self, judgment_repo, run_findings_writer):
+        """Codex review PR #97: spillover fanned out BEFORE the receipt, so a
+        refused receipt rolled the findings file back while the append-only
+        spillover entry stood — the standing gate then saw permanent open work
+        for a disposition the command reported as rolled back."""
+        spill = judgment_repo / ".prd-os" / "spillover.jsonl"
+        before = spill.read_text() if spill.is_file() else ""
+        # An unresolvable evidence ref passes the fail-fast grammar check and
+        # fails inside capture, which is exactly the late-failure window.
+        proc = run_findings_writer(
+            judgment_repo, "set-disposition", PRD_ID, "finding-1", "deferred",
+            "--rationale", "later", "--reason-code", "defer-ordering",
+            "--evidence", "judgment:jr-doesnotexist000")
+        assert proc.returncode == 2
+        after = spill.read_text() if spill.is_file() else ""
+        assert after == before, "spillover mutated despite the rollback"
+        assert read_ledger(judgment_repo) == []
+
+    def test_successful_deferral_still_creates_the_spillover_entry(
+            self, judgment_repo, run_findings_writer):
+        """The reorder must not cost the fan-out on the success path."""
+        proc = run_findings_writer(
+            judgment_repo, "set-disposition", PRD_ID, "finding-1", "deferred",
+            "--rationale", "next phase", "--reason-code", "defer-ordering")
+        assert proc.returncode == 0, proc.stderr
+        spill = judgment_repo / ".prd-os" / "spillover.jsonl"
+        assert spill.is_file()
+        assert f"defer-{PRD_ID}-finding-1" in spill.read_text()
 
     def test_kill_switch_restores_legacy_behavior(
             self, judgment_repo, run_findings_writer):

--- a/plugins/prd-os/tests/test_judgment_compiler.py
+++ b/plugins/prd-os/tests/test_judgment_compiler.py
@@ -1072,6 +1072,34 @@ class TestConcurrency:
         assert proc.returncode == 0, proc.stderr
 
 
+class TestLedgerRoot:
+    def test_ledger_follows_the_git_common_dir_not_the_config_root(
+            self, judgment_repo, run_findings_writer):
+        """The ledger is SHARED across a worktree set on purpose, so its
+        location follows `git rev-parse --git-common-dir`, NOT the config's
+        repo_root. Pinned because that is surprising in exactly the way that
+        bites: during this PRD's own dogfood run a sandbox that had copied a
+        `.git` directory wrote its receipts into the MAIN checkout's ledger.
+        The behavior was correct; the harness was wrong. A test states which."""
+        proc = run_judgment(judgment_repo, "assemble", "--prd", PRD_ID,
+                            "--finding", "finding-1", "--output",
+                            str(judgment_repo / "p.json"))
+        assert proc.returncode == 0, proc.stderr
+        assert capture(judgment_repo, judgment_repo / "p.json").returncode == 0
+        # fake_repo's .git is a plain directory with no git metadata, so
+        # rev-parse fails and _ledger_root falls back to repo_root.
+        assert (judgment_repo / ".prd-os" / "judgments.jsonl").is_file()
+
+    def test_ledger_path_is_reported_so_the_operator_can_see_it(
+            self, judgment_repo):
+        packet_path, _ = assemble_packet(judgment_repo)
+        proc = capture(judgment_repo, packet_path)
+        assert proc.returncode == 0, proc.stderr
+        payload = json.loads(proc.stdout)
+        assert payload["path"].endswith("judgments.jsonl")
+        assert str(judgment_repo) in payload["path"]
+
+
 class TestReadOnly:
     def test_selftest_passes(self, judgment_repo):
         proc = run_judgment(judgment_repo, "--selftest")

--- a/plugins/prd-os/tests/test_judgment_compiler.py
+++ b/plugins/prd-os/tests/test_judgment_compiler.py
@@ -774,3 +774,13 @@ class TestReadOnly:
         finally:
             for path in locked:
                 os.chmod(path, 0o755)
+
+
+if __name__ == "__main__":
+    # Self-executing under the capability gate's `python3` runner (the
+    # test_prd_split_from_linear.py precedent): a manifest entry that cannot
+    # run is exactly the silent absence the gate exists to catch.
+    sys.exit(subprocess.run(
+        [sys.executable, "-m", "pytest", str(Path(__file__).resolve()), "-q"],
+        cwd=str(PLUGIN_ROOT.parent.parent),
+    ).returncode)

--- a/q-system/.q-system/capability-manifest.json
+++ b/q-system/.q-system/capability-manifest.json
@@ -462,6 +462,11 @@
     {
       "path": "q-system/.q-system/scripts/test/test-verdict-statement-shape.sh",
       "runner": "bash"
+    },
+    {
+      "path": "plugins/prd-os/tests/test_judgment_compiler.py",
+      "runner": "python3",
+      "timeout_s": 240
     }
   ],
   "required_data": [],

--- a/q-system/output/judgment-compiler-operator-guide.md
+++ b/q-system/output/judgment-compiler-operator-guide.md
@@ -1,0 +1,59 @@
+# Judgment Compiler — operator guide
+
+One page. What it does: every finding triage now leaves an immutable,
+hash-chained receipt of the decision AND the workflow state it was made in.
+Those receipts are the calibration dataset the v1 benchmark proved we were
+missing. (Energy: Quick Win per command, under 1 min each.)
+
+## Where it lives
+
+- Ledger: `.prd-os/judgments.jsonl` (main checkout, shared by all worktrees)
+- Policy proposals: `.prd-os/judgment-policy-candidates.jsonl`
+- Engine: `plugins/prd-os/scripts/judgment_compiler.py`
+- PRD: `q-system/output/prd-judgment-compiler-2026-08-04.md` (ASK-363)
+
+## Daily use (inside /prd-triage — nothing new to remember)
+
+Triage works exactly as before. One upgrade: pass a reason code + evidence and
+the decision becomes machine-learnable:
+
+```bash
+python3 plugins/prd-os/scripts/findings_writer.py \
+  set-disposition <prd-id> finding-3 rejected \
+  --rationale "same defect as finding-1" \
+  --reason-code duplicate --evidence finding:<prd-id>/finding-1
+```
+
+- `duplicate`, `already-remediated`, `owned-by-other-prd`, `scope-removed`,
+  `out-of-scope`, `superseded` are REFUSED without `--evidence` (that is the
+  point: unsupported dispositions stop passing as facts).
+- No `--reason-code`? Still works, records an honest null.
+- Emergency off switch: `KIPI_JUDGMENT_CAPTURE=0` (exact legacy behavior).
+
+## Commands (from any instance repo)
+
+```bash
+kipi judgment verify              # re-prove the whole receipt chain
+kipi judgment evaluate            # calibration metrics + release-gate status
+kipi judgment assemble --prd <id> --finding <id>   # see decision-time context
+kipi judgment sample-check --basis <sha256>        # reproduce a 5% sample verdict
+kipi judgment policy-candidates   # repeated overrides -> reviewed proposals
+kipi judgment selftest            # in-memory contract proof (read-only safe)
+```
+
+## Calibration status (2026-08-04)
+
+- Prospective context-complete decisions: **0 of 50 required**. They accrue
+  automatically as you triage; no separate data-entry task exists.
+- Release gates (all must pass before the judge auto-decides anything):
+  ≥88% exact agreement, kappa ≥0.80, ≥80% per-class recall, ≥50 cases,
+  zero evidence-gate bypasses. Check any time: `kipi judgment evaluate`.
+- Until then the judge only recommends. v1 evidence for why: 40% agreement,
+  92% confidence, worse than accept-all.
+
+## Policy candidates
+
+`kipi judgment policy-candidates` writes proposals only (`status: proposed`,
+counterexample search recorded). Promotion to a real gate = normal PRD/issue
+flow + `gate_register`. The tool has no code path to install anything — a
+grep test enforces that.

--- a/q-system/output/judgment-compiler-operator-guide.md
+++ b/q-system/output/judgment-compiler-operator-guide.md
@@ -25,15 +25,22 @@ python3 plugins/prd-os/scripts/findings_writer.py \
 ```
 
 - `duplicate`, `already-remediated`, `owned-by-other-prd`, `scope-removed`,
-  `out-of-scope`, `superseded` are REFUSED without `--evidence` (that is the
-  point: unsupported dispositions stop passing as facts).
-- No `--reason-code`? Still works, records an honest null.
+  `out-of-scope`, `superseded` are REFUSED without `--evidence`, and the
+  reference is **opened** — a ref pointing at nothing is refused too. If the
+  receipt cannot be written, the findings file rolls back, so the two never
+  disagree.
+- No `--reason-code`? Still works and records an honest null — **but be aware
+  that omitting it skips the evidence requirement entirely** (the requirements
+  key off the code). That bypass is counted: `kipi judgment evaluate` reports
+  `ungated_decision_rate`. Making the code mandatory is tracked separately
+  (`sp-1caf70c9`) because it changes a contract every instance inherits.
 - Emergency off switch: `KIPI_JUDGMENT_CAPTURE=0` (exact legacy behavior).
 
 ## Commands (from any instance repo)
 
 ```bash
 kipi judgment verify              # re-prove the whole receipt chain
+kipi judgment verify --cross-check  # ...plus: every dispositioned finding has a receipt
 kipi judgment evaluate            # calibration metrics + release-gate status
 kipi judgment assemble --prd <id> --finding <id>   # see decision-time context
 kipi judgment sample-check --basis <sha256>        # reproduce a 5% sample verdict

--- a/q-system/output/judgment-compiler-red-run-2026-08-04.txt
+++ b/q-system/output/judgment-compiler-red-run-2026-08-04.txt
@@ -1,0 +1,2 @@
+FAILED plugins/prd-os/tests/test_judgment_compiler.py::TestReadOnly::test_verify_evaluate_selftest_survive_read_only_repo
+46 failed, 2 passed in 4.23s

--- a/q-system/output/judgment-compiler-wiring-report-2026-08-04.md
+++ b/q-system/output/judgment-compiler-wiring-report-2026-08-04.md
@@ -86,6 +86,17 @@ Recorded in the PRD (N-15..N-20) and the CHANGELOG.
 
 ## Honest gaps — NOT claimed as wired
 
+0. **Capability gate: my test passes; the gate is RED on two unrelated tests.**
+   Fresh full-clone run of the final branch state: `declared: 116 tests`,
+   `tests: ran=114`, and `plugins/prd-os/tests/test_judgment_compiler.py` is
+   among those that ran and is NOT in the failure list. The 2 REDs are 60s
+   TIMEOUTS in `test-review-invoker-provenance.sh` and
+   `test-updater-issue-sequence.py`. Neither is touched by this branch
+   (`git diff origin/main...HEAD` shows zero hits), both fail on the main
+   checkout too (exit 127, missing interpreter/dependency), and the last commit
+   to either is dd8318a (ASK-221). Pre-existing, not caused here — but the gate
+   is red, so `kipi check` green is still NOT claimed.
+
 1. **`kipi check` is not fully green, and was not green before this change.**
    - Stage 1 `remote-coverage-check.py` exits 2 on the *main checkout* too
      (untracked sibling worktrees with no remote). Pre-existing, unrelated.

--- a/q-system/output/judgment-compiler-wiring-report-2026-08-04.md
+++ b/q-system/output/judgment-compiler-wiring-report-2026-08-04.md
@@ -1,0 +1,85 @@
+# WIRING REPORT — Judgment Compiler (ASK-363)
+
+Date: 2026-08-04. Branch: `worktree-judgment-compiler`. Every row is "ran X, got Y".
+
+## Definition-of-done rows
+
+| Check | Status | Evidence |
+|---|---|---|
+| New script has a caller | PASS | `findings_writer.cmd_set_disposition` imports and calls `judgment_compiler.capture_from_triage` (the one chokepoint every triage flows through). Proven live: sandbox triage produced 2 chained receipts. |
+| New CLI registered | PASS | `kipi judgment <assemble\|capture\|verify\|evaluate\|sample-check\|policy-candidates\|selftest>` case block + 6 usage lines. Ran `kipi judgment selftest` → SELFTEST PASS; `kipi judgment verify` from a sandbox repo read THAT repo's ledger, not the skeleton's. |
+| Command doc updated | PASS | `plugins/prd-os/commands/prd-triage.md` step 4 documents `--reason-code` / `--evidence` and the refusal behavior. |
+| Test exists and is discoverable | PASS | `plugins/prd-os/tests/test_judgment_compiler.py`, 55 tests. Self-executing (`python3 <path>` → 55 passed) per the `test_prd_split_from_linear.py` precedent. |
+| Capability manifest entry | PASS | `expected_tests` += `{"path": "plugins/prd-os/tests/test_judgment_compiler.py", "runner": "python3", "timeout_s": 240}`. |
+| Plugin version bumped | PASS | prd-os 0.9.2 → 0.10.2; CHANGELOG entries for the feature and the truncation fix. lefthook `plugin-version-bump` green. |
+| Ledger uses the shared worktree root | PASS | `_ledger_dir` calls `prd_runner._ledger_root` (the sp-bc42f1d3 scar helper) for both `judgments.jsonl` and the candidates ledger. |
+| Exit-code contract preserved | PASS | 0 success / 2 validation error, matching findings_writer. |
+| Kill switch | PASS | `KIPI_JUDGMENT_CAPTURE=0` → legacy behavior byte-identical, zero receipts written (test `test_kill_switch_restores_legacy_behavior`). |
+
+## Regression rows
+
+| # | What | Result |
+|---|---|---|
+| R-1 | v1 calibration self-test | `SELFTEST PASS: scoring changes, schema and coverage enforced, blind export clean` |
+| R-2 | v1 dataset verification | `VERIFY PASS: 50 unique cases, 20/20/10 balance, all source hashes match` |
+| R-3 | full prd-os suite | `406 passed, 1 skipped` (was 399 + 1 before this work; +7 new) |
+| R-5 | read-only execution | `test_verify_evaluate_selftest_survive_read_only_repo` chmods the tree 0555; verify, evaluate and selftest all exit 0 |
+| R-6 | `kipi check` | **PARTIAL — see below** |
+
+## Live end-to-end proof (sandbox repo, never the live `.prd-os`)
+
+```
+add 2 findings via findings_writer            -> finding-1, finding-2
+set-disposition finding-1 accepted            -> receipt jr-77e3335a… (reason_code null,
+                                                 missing_context ["human.reason_code", …])
+set-disposition finding-2 rejected            -> REFUSED exit 2:
+  --reason-code duplicate (no evidence)          "requires an evidence ref with prefix
+                                                  ['finding:','issue:','spillover:']"
+                                                 findings file md5 UNCHANGED (fail-fast)
+same call + --evidence finding:…/finding-1    -> accepted, receipt jr-9b7382d8…, chained
+verify                                        -> VERIFY PASS: 2 receipt(s), chain intact
+```
+
+## Defect found and fixed during this work (self-attack)
+
+Truncating the ledger tail (`head -1 judgments.jsonl`) returned `VERIFY PASS`.
+A prefix of a valid hash chain is a valid chain. Fixed with `sequence` +
+tip anchor + `verify --cross-check`; the same attack now exits 2 with
+`ledger is TRUNCATED: 1 receipt(s) present, tip anchor recorded 2`.
+Recorded in the PRD (N-15..N-20) and the CHANGELOG.
+
+## Honest gaps — NOT claimed as wired
+
+1. **`kipi check` is not fully green, and was not green before this change.**
+   - Stage 1 `remote-coverage-check.py` exits 2 on the *main checkout* too
+     (untracked sibling worktrees with no remote). Pre-existing, unrelated.
+   - `capability-gate.py` refuses to run from a `.claude/worktrees` copy by
+     design (exit 3). Run it from the primary checkout after merge.
+   - A shallow-clone attempt to run it out-of-tree produced only
+     `fatal: not a tree object` FCU errors — an artifact of `--depth 1`, not a
+     real result. A full-clone run was still executing at report time.
+   - **Therefore: `kipi check` green is NOT claimed. It must be run from the
+     primary checkout post-merge.**
+2. **The live slash-command path does not have this yet.** `/prd-triage` loads
+   from `~/.claude/plugins/marketplaces/kipi/plugins/prd-os`, which is a clone
+   of `github.com/assafkip/kipi-system.git` currently serving prd-os **0.6.0**
+   — three minor versions behind main (0.9.2) before this change even lands.
+   So the capture path is inert in real Claude sessions until the branch merges
+   AND that clone pulls. Pre-existing fleet drift, captured as spillover
+   **sp-fe57de2d**, not invented by this work. The `kipi judgment` CLI and
+   direct `findings_writer.py` invocation are unaffected (they resolve through
+   `$KIPI_HOME` / the caller's cwd).
+3. **Evidence refs are grammar-checked, not resolved.** The gate proves a ref
+   of the right kind was supplied; it does not open the target to confirm it
+   exists. `verify --cross-check` is the only check that reads an independent
+   source. Stated here rather than left for a reviewer to discover.
+4. **Zero prospective calibration cases exist.** Release gates are all closed
+   and `evaluate` reports `passed: false`. No calibration claim is made.
+
+## Propagation
+
+`plugins/` and `kipi` are skeleton-owned, so `kipi update --dry` → `kipi update`
+is required to reach instances. NOT run from this worktree (it would sync a
+branch state to the whole fleet). Sequence at merge: merge to main → run
+`kipi check` from the primary checkout → `kipi update --dry` → `kipi update` →
+refresh the marketplace clone (sp-fe57de2d).

--- a/q-system/output/judgment-compiler-wiring-report-2026-08-04.md
+++ b/q-system/output/judgment-compiler-wiring-report-2026-08-04.md
@@ -22,7 +22,9 @@ Date: 2026-08-04. Branch: `worktree-judgment-compiler`. Every row is "ran X, got
 |---|---|---|
 | R-1 | v1 calibration self-test | `SELFTEST PASS: scoring changes, schema and coverage enforced, blind export clean` |
 | R-2 | v1 dataset verification | `VERIFY PASS: 50 unique cases, 20/20/10 balance, all source hashes match` |
-| R-3 | full prd-os suite | `406 passed, 1 skipped` (was 399 + 1 before this work; +7 new) |
+| R-3 | full prd-os suite | `422 passed, 1 skipped` (was 399 + 1 before this work; +23 new, zero regressions) |
+| R-8 | mutation test | 17 single-invariant corruptions applied to a copy; **16 killed**. The one survivor is a defensive build-time assert no normal path reaches, labelled as such in the code; its enforced half is the read-side check (test_n7). |
+| R-9 | concurrency | 6 concurrent `capture` processes → 6 receipts, sequences 1..6, `verify` exit 0 |
 | R-5 | read-only execution | `test_verify_evaluate_selftest_survive_read_only_repo` chmods the tree 0555; verify, evaluate and selftest all exit 0 |
 | R-6 | `kipi check` | **PARTIAL — see below** |
 
@@ -39,6 +41,40 @@ set-disposition finding-2 rejected            -> REFUSED exit 2:
 same call + --evidence finding:…/finding-1    -> accepted, receipt jr-9b7382d8…, chained
 verify                                        -> VERIFY PASS: 2 receipt(s), chain intact
 ```
+
+## Adversarial review: 17 findings, all dispositioned
+
+A senior-staff adversarial review (`claude-adversarial`, a first-class reviewer
+source in findings_writer) returned 1 blocker, 6 major, 7 minor, 3 nit. Every
+one was real and reproduced. 16 fixed in code; 1 deferred with its own tracked
+issue. Highlights:
+
+- **Blocker — concurrent capture forked the ledger while every writer exited 0.**
+  Unlocked read-modify-append on a ledger deliberately shared across worktrees.
+  Now `fcntl.flock`-guarded. Repro before: corruption; after: 6 concurrent
+  captures → chain intact.
+- **Deleting the tip anchor re-opened the entire truncation hole** for one `rm`
+  (cheaper than editing it, and a bad rsync does it by accident). A missing
+  anchor over a non-empty ledger is now an error.
+- **Evidence refs were grammar-matched, never resolved** — `commit:zzzz` and
+  `finding:prd-does-not-exist/finding-999` were both recorded as the evidence
+  justifying a rejection. Now every ref kind is opened.
+- **Findings and judgment ledgers diverged on partial failure.** The findings
+  file now rolls back when capture fails.
+- **Deferred with its own issue (sp-1caf70c9):** omitting `--reason-code` skips
+  the evidence gate. Closing it changes the contract of a command every fleet
+  instance inherits, so it does not ride along inside this PRD. Interim: the
+  bypass is counted, not assumed — `evaluate` reports `ungated_decision_rate`.
+
+## Mistake made and corrected during this work
+
+The dogfood run used a sandbox that had copied a `.git` directory, so
+`_ledger_root` correctly resolved to the **main checkout** and wrote 17 test
+receipts into the live ledger. The behavior was right; the harness was wrong.
+The files were moved out (preserved in the session scratchpad, not deleted from
+any history — the ledger had existed for three minutes and held zero real
+workflow decisions), the repo is back to its true pre-feature state with no
+`.prd-os/judgments*` files, and a test now pins the shared-root behavior.
 
 ## Defect found and fixed during this work (self-attack)
 

--- a/q-system/output/prd-judgment-compiler-2026-08-04.md
+++ b/q-system/output/prd-judgment-compiler-2026-08-04.md
@@ -144,9 +144,34 @@ bool}`. `human` when present: `{"actor", "decided_at", "disposition":
 
 Integrity: `receipt_id` is content-derived (sha256 of the canonical record
 minus `receipt_id`); `prev_receipt_sha256` chains each line to the previous
-line's canonical hash (first = null). `verify` re-walks the chain and fails on
-mutation, reorder, duplicate id, broken link, schema violation, unknown enum,
-or non-finite/out-of-range confidence.
+line's canonical hash (first = null); `sequence` is a monotonic 1-based
+position. `verify` re-walks the chain and fails on mutation, reorder, deletion,
+duplicate id, broken link, schema violation, unknown enum, or
+non-finite/out-of-range confidence.
+
+**Deletion needs a second mechanism (found by self-attack, 2026-08-04, before
+ship).** A prev-hash chain proves each retained line follows the previous one.
+It cannot prove the chain is COMPLETE, because any prefix of a valid chain is
+itself a valid chain: `head -1 judgments.jsonl` returned `VERIFY PASS` on a
+2-receipt ledger. Three independent checks close it:
+
+1. `sequence` must equal the line's position — catches middle deletion and
+   reordering.
+2. Tip anchor `.prd-os/judgments-tip.json` (`count`, `last_receipt_sha256`,
+   `last_receipt_id`, `updated_at`), rewritten on every append — catches tail
+   truncation, whole-file deletion, and last-receipt replacement. Written after
+   the ledger append, so a crash between the two under-counts, which is
+   deliberately not an error (a crashed write must not raise a truncation
+   alarm). A missing anchor does not hard-fail: ledgers predating it still
+   verify, because absence is not a claim.
+3. `verify --cross-check` requires a receipt for every dispositioned finding,
+   read from the findings ledgers — a source the judgment writer does not own,
+   so it survives a writer that is wrong about itself. `--since` floors it so
+   pre-feature findings do not report as thousands of false gaps.
+
+**Honest boundary:** the anchor shares a writer with the ledger, so this is
+tamper-EVIDENT (accidental truncation, crashed write, partial sync, naive
+edit), not tamper-proof. Only `--cross-check` is independent.
 
 **Judge output contract (exact fields, no extras):**
 
@@ -350,6 +375,12 @@ isolation; fixtures derived from the real producer schemas, not invented).
 | N-12 | historical v1 case presented as context-complete | `evaluate` refuses records lacking a context packet hash (reconstructed-context marker impossible: schema has no path to inject v1 rows) |
 | N-13 | policy candidate with no counterexample search | candidate validation fails |
 | N-14 | policy candidate self-install | no promote/install path exists; grep-tree test proves module never writes gates.jsonl/hooks/settings |
+| N-15 | tail truncation (drop last receipt) | `verify` exits 2 naming the count mismatch |
+| N-16 | whole-ledger deletion | `verify` exits 2 |
+| N-17 | middle-receipt deletion | `verify` exits 2 (sequence contiguity) |
+| N-18 | last receipt replaced with a re-hashed forgery | `verify` exits 2 naming the tip anchor |
+| N-19 | tip anchor missing (legacy ledger) | `verify` passes — absence is not a claim, no hard-fail on upgrade |
+| N-20 | dispositioned finding with no receipt | `verify --cross-check` exits 2; `--since` floor excludes pre-feature findings |
 
 Negative-fire checks (rules must NOT fire): legacy `set-disposition` without
 `--reason-code` still succeeds (receipt records honest null);

--- a/q-system/output/prd-judgment-compiler-2026-08-04.md
+++ b/q-system/output/prd-judgment-compiler-2026-08-04.md
@@ -1,0 +1,436 @@
+# PRD: Judgment Compiler
+
+**Date:** 2026-08-04
+**Author:** Claude (Fable 5), from the founder's handoff brief `q-system/output/claude-judgment-compiler-handoff-2026-08-04.md`
+**Status:** Implementing
+**Priority:** P1 (high)
+**Linear:** ASK-363
+
+---
+
+## 1. Problem
+
+Kipi has cheap deterministic checks (hooks, gates, tests) followed by an LLM judge
+(Codex review). The missing layer is the decision context that would let anyone —
+human or model — calibrate that judge against the founder's actual triage
+decisions. Without it, the judge cannot be trusted with any workflow disposition,
+and every one of the founder's ~342 historical decisions is unusable for
+calibration because the state it depended on was never frozen.
+
+- **Evidence (verified v1 benchmark, `founder-judge-calibration-v1-run.json`,
+  hashes recorded, session `019fcb14-613e-7dd0-a3d0-8da1e4fdfc9a`):**
+  50 balanced cases (20 accepted / 20 rejected / 10 deferred). Judge given only
+  finding text + severity: 40% exact agreement, 35% balanced accuracy, macro F1
+  0.239, Cohen's kappa 0.032. Judge predicted `accepted` 45/50 times; rejected
+  recall 0%, deferred recall 10%. Mean confidence 92.2%, mean confidence on
+  wrong predictions 91.1%, 10-bin ECE 0.522. Post-stratified accuracy 73.3% —
+  **below** the 76.6% historical accept-all baseline.
+- **Impact:** The LLM judge is a confidently uncalibrated triage proxy. Every
+  finding still costs a founder decision, and repeated identical decisions
+  (duplicates, already-fixed, scope-removed) are re-made by hand because
+  nothing records the pattern in a machine-checkable form.
+- **Root cause (RCA `rca-founder-judge-calibration-context-and-temp-2026-08-03.md`):**
+  the input contract was incomplete. The founder's disposition depends on
+  workflow state the blind judge never received: duplicate status, prior
+  remediation, cross-PRD ownership, scope changes, issue ordering, superseding
+  decisions, receipt state, and current revisions. **A disposition is not a
+  property of an objection. It is a property of an objection inside workflow
+  state.** Additionally, the ledger (`findings_writer.py`) mutates records in
+  place: decision-time context is destroyed the moment state moves on, so no
+  retroactive dataset can ever be honest (v1's own leakage scars: case 049
+  carried post-adjudication text; near-identical empty-manifest findings had
+  different labels because surrounding PRD state differed).
+
+## 2. Scope
+
+### In Scope
+
+- **Immutable triage episode receipts:** versioned, append-only, hash-chained
+  ledger `.prd-os/judgments.jsonl` at the shared worktree ledger root (the
+  `_ledger_root()` pattern from `prd_runner.py`, scar sp-bc42f1d3). Corrections
+  append superseding receipts; old receipts are never mutated.
+- **Deterministic decision-context assembler:** repo/PRD/issue/scope/duplicate/
+  remediation/ordering state resolved by code with a source reference per fact;
+  missing evidence stays `unknown`, never `false`.
+- **Split judge contract:** `technical_validity` separate from
+  `workflow_disposition`, one canonical reason-code enum, strict schema
+  validation in code.
+- **Deterministic disposition evidence gate:** `duplicate`,
+  `already-remediated`, `owned-by-other-prd`, `scope-removed`, `out-of-scope`,
+  `superseded` require stable references or the recommendation converts /
+  fails (behavior split documented in Change 4).
+- **Prospective v2 calibration dataset + evaluator:** context-complete receipts
+  are the dataset; evaluator reports agreement, kappa, balanced accuracy, macro
+  F1, per-class precision/recall, confusion matrix, ECE, human-review rate,
+  unsupported-disposition rate, missing-context rate, per-reason-code results,
+  population baseline. Runs read-only.
+- **Deterministic 5% live sampling** with a recorded, reproducible rule, plus
+  unconditional escalation of `needs-human` / missing-context /
+  invalid-schema / unsupported-evidence cases.
+- **Repeated-pattern detector → policy candidates** (evidence-backed, cannot
+  self-install).
+- **Integration:** `findings_writer.py set-disposition` (the real triage
+  chokepoint) captures a receipt per adjudication; `kipi judgment` CLI family;
+  `/prd-triage` command doc updated; capability-manifest test entry.
+
+### Out of Scope
+
+- Reconstructing context for the 50 historical v1 cases (would fabricate
+  "decision-time" context; v1 stays a context-free stress-test and regression
+  artifact — brief §5).
+- Replacing Codex review or changing review thresholds.
+- Auto-deciding any disposition class before its release gate passes
+  (§6 gates; nothing passes them at ship time because zero prospective cases
+  exist yet).
+- Automatic gate installation from policy candidates (promotion goes through
+  the existing human-reviewed prd-os path).
+- A live LLM judge invocation wired into triage. The contract, hashes, and
+  validation are built; running a model per finding is a follow-on decision
+  once ≥50 prospective human decisions exist.
+- General eval infrastructure beyond this closed loop.
+
+### Non-Goals
+
+- Claiming calibration. Until prospective evidence meets the release gates, the
+  judge recommends; the founder decides.
+- Treating workflow disposition as proof of technical validity (the split
+  contract exists precisely to keep these apart).
+
+## 3. Changes
+
+### Change 1: Judgment Compiler module
+
+- **What:** New single-writer module owning receipts, context assembly, judge
+  contract validation, evidence gate, evaluator, sampling, and policy
+  candidates.
+- **Where:** `plugins/prd-os/scripts/judgment_compiler.py`
+- **Why:** Root cause = no decision-time context is ever frozen (Section 1).
+- **Exact change:** Subcommands
+  `assemble | capture | verify | evaluate | sample-check | policy-candidates`
+  plus `--selftest` (fully in-memory, read-only-safe — v1 RCA lesson).
+  Ledger: `.prd-os/judgments.jsonl` under `prd_runner._ledger_root()`.
+- **Scope:** prd-os plugin (skeleton; propagates via `kipi update`).
+
+**Receipt schema v1 (frozen; strict — unknown fields fail validation):**
+
+```json
+{
+  "schema_version": 1,
+  "receipt_id": "jr-<sha256(content)[:16]>",
+  "captured_at": "ISO-8601 UTC",
+  "finding": {"prd_id": "", "finding_id": "", "severity": "", "body": "", "body_sha256": ""},
+  "review": {"source": "codex-review|...|manual", "review_run_id": "string|null"},
+  "repo_state": {"branch": "string|unknown", "commit_sha": "string|unknown", "dirty": "true|false|unknown"},
+  "prd_state": {"path": "", "sha256": "string|unknown", "status": "string|unknown", "revision": "string|unknown"},
+  "issue_state": {"issue_id": "string|null", "manifest_sha256": "string|unknown", "issue_order": ["..."]},
+  "scope": {"source": "path#section|unknown", "sha256": "string|unknown"},
+  "duplicates": [{"prd_id": "", "finding_id": "", "similarity": 0.0, "source": ""}],
+  "remediation": [{"issue_id": "", "finding_id": "", "closed_at": "", "commit_sha": "string|null", "source": ""}],
+  "related_prds": ["..."],
+  "missing_context": ["dotted.field.paths that resolved unknown"],
+  "judge": null,
+  "human": null,
+  "sampling": {"basis_sha256": "", "rule": "sha256(salt:basis) % 10000 < 500", "salt": "kipi-judgment-sample-v1", "sampled": false},
+  "supersedes": "receipt_id|null",
+  "prev_receipt_sha256": "sha256-of-previous-canonical-line|null"
+}
+```
+
+`judge` when present: `{"model", "prompt_sha256", "input_sha256",
+"output_sha256", "output": <judge contract below>, "converted_to_needs_human":
+bool}`. `human` when present: `{"actor", "decided_at", "disposition":
+"accepted|rejected|deferred|pending", "reason_code": <enum|null>,
+"evidence_refs": [], "rationale": "string|null"}`.
+
+Integrity: `receipt_id` is content-derived (sha256 of the canonical record
+minus `receipt_id`); `prev_receipt_sha256` chains each line to the previous
+line's canonical hash (first = null). `verify` re-walks the chain and fails on
+mutation, reorder, duplicate id, broken link, schema violation, unknown enum,
+or non-finite/out-of-range confidence.
+
+**Judge output contract (exact fields, no extras):**
+
+```json
+{
+  "technical_validity": "valid | invalid | uncertain",
+  "technical_reason": "...",
+  "workflow_disposition": "fix-now | already-remediated | duplicate | scope-removed | out-of-scope | defer | invalid | needs-human",
+  "workflow_reason_code": "<canonical enum below>",
+  "evidence_refs": ["..."],
+  "missing_context": ["..."],
+  "confidence": 0.0
+}
+```
+
+**Canonical reason-code enum (from the brief; changes require repository
+evidence recorded in a PRD):** `valid-fix-now`, `already-remediated`,
+`duplicate`, `owned-by-other-prd`, `scope-removed`, `out-of-scope`,
+`superseded`, `defer-dependency`, `defer-ordering`, `invalid-finding`,
+`insufficient-context`, `needs-human`.
+
+**Evidence-ref grammar (stable references):** `finding:<prd_id>/<finding_id>`,
+`issue:<issue_id>`, `prd:<prd_id>`, `receipt:<issue_id>` (remediation receipt),
+`judgment:<receipt_id>`, `commit:<sha>`, `test:<path>`, `scope:<path#section>`,
+`spillover:<id>`.
+
+### Change 2: Deterministic decision-context assembler
+
+- **What:** `assemble --prd <id> --finding <id>` emits a context packet from
+  repository state only.
+- **Where:** same module.
+- **Why:** the LLM may reason over recorded facts, never manufacture workflow
+  state (brief §2; v1 disagreements were dominated by hidden state).
+- **Exact change:** resolves — each with `source` — duplicates
+  (`findings_xref.cross_reference`, the existing advisory engine),
+  remediation receipts (`cfg.receipts_path` rows matching prd/finding),
+  PRD path+sha256+frontmatter status+git revision, issue manifest hash and
+  ordering (PRD `## Issues` manifest), scope section hash, repo
+  branch/commit/dirty (git; `unknown` when git cannot answer), related PRDs,
+  superseding receipts (from the judgments ledger). Anything unresolvable is
+  listed in `missing_context` and valued `unknown` — never `false`.
+  The packet carries its own canonical `packet_sha256`; that hash is the
+  judge's `input_sha256` and the sampling basis.
+- **Scope:** prd-os plugin.
+
+### Change 3: Split judge contract validation
+
+- **What:** Code-level validation of the judge output contract (Change 1 JSON),
+  separate from the human disposition record.
+- **Why:** v1 collapsed technical judgment and workflow disposition into one
+  label; a finding can be technically valid and still be a duplicate, already
+  fixed, out of scope, or deferred (brief §3).
+- **Exact change:** strict field set (extras fail), enum checks, finite
+  confidence in [0,1], `input_sha256` must equal the context packet hash
+  (stale hash fails), `output_sha256` must match the canonical output hash.
+- **Scope:** prd-os plugin.
+
+### Change 4: Disposition evidence gate
+
+- **What:** Deterministic validation that evidence-requiring dispositions carry
+  resolvable stable references.
+- **Why:** unsupported dispositions must not pass as facts (brief §4).
+- **Exact change:** required refs — `already-remediated` → `receipt:`/`commit:`/
+  `test:`; `duplicate` → `finding:`/`issue:`/`spillover:`; `owned-by-other-prd`
+  → `prd:` + `issue:`; `scope-removed`/`out-of-scope` → `scope:`; `superseded`
+  → `judgment:` resolving to an existing receipt. **Behavior split (the choice
+  the brief asks to document):** a **judge** recommendation missing a required
+  ref is converted to `needs-human` and flagged
+  (`converted_to_needs_human: true`) — matching the existing Kipi contract in
+  the `cmd_advisory` script (findings_writer.py): advisory model output
+  degrades to a warning, exit code stays 0. A
+  **human** decision missing a required ref **fails validation (exit 2)** —
+  matching the existing hard contract that `rejected`/`deferred` require
+  `--rationale` in `cmd_set_disposition`.
+- **Scope:** prd-os plugin.
+
+### Change 5: Triage-flow integration (the real caller)
+
+- **What:** `findings_writer.py cmd_set_disposition` captures a judgment
+  receipt for every adjudication; new optional flags `--reason-code`,
+  `--evidence` (repeatable), `--actor`, `--judge-run <json>`.
+- **Where:** `plugins/prd-os/scripts/findings_writer.py` (single call site —
+  line 481 function), `plugins/prd-os/commands/prd-triage.md` (usage doc).
+- **Why:** a standalone script with no caller is not done (brief §Integration);
+  set-disposition is the one chokepoint every triage decision already flows
+  through.
+- **Exact change:** validate reason-code + evidence gate *before* the findings
+  file is written (fail fast, nothing mutated); after the existing write +
+  spillover sync, append the receipt. Receipt append failure is loud (exit 2,
+  divergence named). Kill switch `KIPI_JUDGMENT_CAPTURE=0` (rollback path).
+  When `--reason-code` is absent (legacy callers), the receipt records
+  `reason_code: null` and `missing_context: ["human.reason_code"]` — honest
+  unknown, no fabricated default. `/prd-triage` doc instructs passing the code.
+- **Scope:** prd-os plugin.
+
+### Change 6: `kipi judgment` CLI family
+
+- **What:** `kipi judgment <capture|assemble|verify|evaluate|sample-check|policy-candidates>`
+  delegating to the module (the `kipi linear` nested-case precedent).
+- **Where:** `kipi` (repo root), usage text.
+- **Why:** brief §Integration — CLI only through the existing command
+  architecture; founder never remembers paths.
+- **Scope:** skeleton root.
+
+### Change 7: Prospective v2 evaluator + sampling
+
+- **What:** `evaluate` scores context-complete receipts where both judge and
+  human are present (superseded receipts excluded); `sample-check` exposes the
+  deterministic sampling decision.
+- **Why:** brief §5–6. v1 must stay frozen; v2 is prospective-only.
+- **Exact change:** agreement measured at two levels: (a) legacy 3-class
+  disposition (judge `workflow_disposition` mapped: `fix-now`→accepted;
+  `already-remediated`/`duplicate`/`scope-removed`/`out-of-scope`/`invalid`→
+  rejected; `defer`→deferred; `needs-human`→excluded from automation metrics,
+  counted in human-review rate) and (b) reason-code exact match where the human
+  code exists. Release gates evaluated on (a) plus kappa. Sampling:
+  `int(sha256("kipi-judgment-sample-v1:" + basis_sha256), 16) % 10000 < 500`
+  — reproducible from the receipt alone, no RNG. Escalations (needs-human,
+  missing-context, invalid schema, unsupported evidence) are unconditional and
+  independent of the 5%.
+- **Release gates (Kipi's own, not Airbnb's):** ≥88% exact agreement, kappa
+  ≥0.80, ≥80% recall per automated class, zero schema/evidence-gate bypasses,
+  valid receipt per automated disposition, ≥50 prospective human decisions.
+  `evaluate` prints gate status; until green the judge only recommends.
+- **Scope:** prd-os plugin.
+
+### Change 8: Policy-candidate detector
+
+- **What:** `policy-candidates` groups override/agreement patterns by
+  (reason_code, context signature) and appends proposals to
+  `.prd-os/judgment-policy-candidates.jsonl` (shared ledger root).
+- **Why:** repeated decisions must become deterministic checks that run before
+  the LLM judge (brief §7).
+- **Exact change:** each candidate freezes pattern definition, supporting
+  receipt ids, case count, counterexamples + the search that produced them
+  (a candidate without a counterexample search fails validation), proposed
+  deterministic rule, proposed tests, expected false-positive risk, exact
+  integration point (`before-llm-judge`, promotion via the existing prd-os
+  review path + `gate_register`). The module contains **no** code path that
+  writes `gates.jsonl`, hooks, or settings — enforced by a grep-the-tree test
+  (single-writer chokepoint pattern).
+- **Scope:** prd-os plugin.
+
+## 4. Change Interaction Matrix
+
+| Change A | Change B | Interaction | Resolution |
+|----------|----------|-------------|------------|
+| 5 (triage capture) | 1 (ledger) | every set-disposition appends | writer validates before findings mutation; append failure is loud exit 2 |
+| 4 (evidence gate) | 5 | human decision w/ evidence-requiring code but no ref | hard fail before anything is written |
+| 4 | 3 (judge contract) | judge output w/ missing required ref | converted to needs-human, flagged, never silently dropped |
+| 2 (assembler) | 3 | judge input hash must equal packet hash | stale hash fails capture |
+| 1 | 8 (candidates) | candidates cite receipt ids | `verify` checks refs resolve; candidates cannot alter receipts |
+| 5 | existing spillover sync | deferred findings still fan out to spillover | receipt append runs after `_sync_spillover_for_finding`; both fire |
+| 7 (evaluate) | v1 artifacts | none — separate script, separate dataset | v1 files untouched; regression R-1/R-2 |
+
+## 5. Files Modified
+
+| File | Change Type | Lines Added | Lines Removed |
+|------|------------|-------------|---------------|
+| `plugins/prd-os/scripts/judgment_compiler.py` | Add | ~1100 | 0 |
+| `plugins/prd-os/scripts/findings_writer.py` | Edit | ~60 | ~2 |
+| `plugins/prd-os/commands/prd-triage.md` | Edit | ~25 | ~5 |
+| `kipi` | Edit | ~20 | 0 |
+| `plugins/prd-os/tests/test_judgment_compiler.py` | Add | ~850 | 0 |
+| `q-system/.q-system/capability-manifest.json` | Edit | +1 entry | 0 |
+| `q-system/output/prd-judgment-compiler-2026-08-04.md` | Add | this file | 0 |
+| `q-system/output/judgment-compiler-operator-guide.md` | Add | ~80 | 0 |
+
+## 6. Test Cases
+
+Test-first: the five gap repros below were run RED against the pre-change tree
+(receipts absent, no split contract, no gates), then implementation proceeds
+until green. All tests use `fake_repo` tmp fixtures (fable-discipline test
+isolation; fixtures derived from the real producer schemas, not invented).
+
+### Gap repros (brief §test-first)
+
+| # | Type | Scenario | Pass Criteria |
+|---|------|----------|---------------|
+| G-1 | DET | Adjudicate a finding, then change the PRD; decision-time context must survive | receipt freezes prd sha/status at decision time; `verify` still green after PRD edit |
+| G-2 | DET | Record technically-valid-but-duplicate | receipt holds `technical_validity: valid` AND `workflow_disposition: duplicate` as separate fields |
+| G-3 | DET | `duplicate` with no owning reference | human: exit 2; judge: converted to needs-human |
+| G-4 | DET | Re-verify a judge run from stored hashes | recomputed packet hash == stored `input_sha256`; corrupted packet fails |
+| G-5 | DET | Sample the same decision twice, two processes | identical sampled verdict; rule reproducible from receipt fields alone |
+
+### Negative tests (brief-required, all DET)
+
+| # | Scenario | Expected |
+|---|----------|----------|
+| N-1 | duplicate without owning reference | human exit 2 / judge → needs-human |
+| N-2 | already-remediated without receipt/commit/test ref | same |
+| N-3 | scope-removed without scope record | same |
+| N-4 | missing context represented as `false` | assembler emits `unknown` + missing_context entry; a packet with fabricated `false` fails validation |
+| N-5 | PRD changed after receipt capture | old receipt verifies green; new capture on stale packet exits 2 |
+| N-6 | mutated historical receipt line | `verify` fails naming the line |
+| N-7 | duplicate receipt ID | capture refuses; `verify` fails |
+| N-8 | broken prev_receipt_sha256 | `verify` fails |
+| N-9 | unknown reason code | exit 2 |
+| N-10 | confidence outside [0,1] / NaN / bool | exit 2 |
+| N-11 | judge output with extra fields | exit 2 |
+| N-12 | historical v1 case presented as context-complete | `evaluate` refuses records lacking a context packet hash (reconstructed-context marker impossible: schema has no path to inject v1 rows) |
+| N-13 | policy candidate with no counterexample search | candidate validation fails |
+| N-14 | policy candidate self-install | no promote/install path exists; grep-tree test proves module never writes gates.jsonl/hooks/settings |
+
+Negative-fire checks (rules must NOT fire): legacy `set-disposition` without
+`--reason-code` still succeeds (receipt records honest null);
+`KIPI_JUDGMENT_CAPTURE=0` disables capture and triage behaves exactly as
+before; `pending` re-dispositions capture a superseding receipt, never mutate.
+
+## 7. Regression Tests
+
+| # | What to Verify | How to Verify | Pass Criteria |
+|---|----------------|---------------|---------------|
+| R-1 | v1 self-test | `python3 q-system/.q-system/scripts/founder-judge-calibration.py --selftest` (main checkout) | SELFTEST PASS |
+| R-2 | v1 dataset verification | `... verify --dataset q-system/output/founder-judge-calibration-v1.jsonl` (main checkout) | VERIFY PASS |
+| R-3 | existing findings/triage behavior | `pytest plugins/prd-os/tests/ -q` | all pre-existing tests pass |
+| R-4 | remediation receipt readers | prd_runner archive gates unchanged (no edits to those functions) + R-3 | pass |
+| R-5 | read-only execution | run `--selftest` + `verify` in a chmod-555 sandbox | no traceback, no write attempt |
+| R-6 | `kipi check` | `kipi check` | exit 0 |
+| R-7 | wiring | `/wiring-check` report | all rows evidenced |
+
+## 8. Rollback Plan
+
+| Change | Rollback Steps | Risk |
+|--------|---------------|------|
+| Triage capture (5) | `export KIPI_JUDGMENT_CAPTURE=0` (no code change), or revert the findings_writer edit | none — flag path leaves legacy behavior byte-identical |
+| Module + CLI (1,6,7,8) | delete `judgment_compiler.py`, revert `kipi` case block | ledger files remain (append-only, inert without reader) |
+| Ledger data | never deleted; append-only by design | n/a |
+
+## 9. Change Review Checklist
+
+| Check | Status | Notes |
+|-------|--------|-------|
+| Changes are additive | Pass | only additions + optional flags; legacy call shapes unchanged |
+| No conflicts with existing enforced rules | Pass | single-writer, no-orphan-findings, skill-hook-pairing respected |
+| No hardcoded secrets | Pass | repo-local state only |
+| Propagation path verified | Pending | `kipi update --dry` at wiring stage (plugins/ + kipi are skeleton-owned) |
+| Exit codes preserved | Pass | 0/2 contract matches findings_writer |
+| AUDHD-friendly | Pass | one command per action, no pressure language |
+| Test coverage for every change | Pass | G-1..G-5, N-1..N-14, R-1..R-7 |
+
+## 10. Success Metrics
+
+| Metric | Current | Target | How to Measure |
+|--------|---------|--------|----------------|
+| Prospective context-complete decisions | 0 | ≥50 before any auto-decide | `kipi judgment evaluate` (counts) |
+| Exact agreement (v2, prospective) | n/a | ≥88% before auto-decide | `kipi judgment evaluate` |
+| Cohen's kappa (v2) | n/a | ≥0.80 | same |
+| Per-class recall (automated classes) | n/a | ≥80% each | same |
+| Unsupported-disposition rate | n/a | 0 pass-throughs (all converted/blocked) | same + N-1..N-3 |
+| Receipt chain integrity | n/a | `verify` green on live ledger | `kipi judgment verify` |
+| v1 regression | PASS | stays PASS | R-1/R-2 |
+
+## 11. Implementation Order
+
+1. This PRD (done — this file).
+2. Gap repros + negative tests written; red run recorded.
+3. `judgment_compiler.py` core: canonical hashing, receipt schema, chain
+   append/verify — then evidence gate — then assembler — then judge contract —
+   then evaluator/sampling — then policy candidates. (Each lands with its
+   tests green before the next starts.)
+4. findings_writer integration + prd-triage doc + `kipi` CLI + manifest entry.
+5. Full suite + regressions + `kipi check` + read-only run.
+6. Codex review; every finding dispositioned **through the new capture path**
+   (the system adjudicates its own review). Wiring check. Operator guide.
+   Status → Done.
+
+## 12. Open Questions
+
+| Question | Owner | Deadline | Resolution |
+|----------|-------|----------|------------|
+| When ≥50 prospective decisions exist, which model runs the judge (codex exec vs claude -p) and at what cadence? | Assaf | after calibration data accrues | open — machinery is model-agnostic; hashes bind whichever runs |
+| Should `needs-human` findings page via slack-notify.sh? | Assaf | after first live week | open — default: surfaced in `/prd-triage` output only |
+
+## 13. Wiring Checklist (MANDATORY)
+
+| Check | Status | Notes |
+|-------|--------|-------|
+| PRD file saved to `q-system/output/prd-judgment-compiler-2026-08-04.md` | Pass | this file |
+| All code/config changes implemented and tested | Pending | |
+| New files listed in folder-structure rule | N/A | plugin scripts dir already canonical |
+| New conventions referenced in root CLAUDE.md | N/A | no new convention; CLI documented in `kipi` usage |
+| New rules referenced in folder-structure rules list | N/A | no new rule file |
+| Memory entry saved | Pending | at closeout |
+| `kipi update --dry` confirms propagation | Pending | skeleton files changed (plugins/, kipi) |
+| `kipi update` run | Pending | founder-authorized run at merge, not from worktree |
+| PRD Status updated to Done | Pending | after wiring report |

--- a/q-system/output/prd-judgment-compiler-2026-08-04.md
+++ b/q-system/output/prd-judgment-compiler-2026-08-04.md
@@ -2,7 +2,7 @@
 
 **Date:** 2026-08-04
 **Author:** Claude (Fable 5), from the founder's handoff brief `q-system/output/claude-judgment-compiler-handoff-2026-08-04.md`
-**Status:** Implementing
+**Status:** Done
 **Priority:** P1 (high)
 **Linear:** ASK-363
 
@@ -451,17 +451,19 @@ before; `pending` re-dispositions capture a superseding receipt, never mutate.
 |----------|-------|----------|------------|
 | When ≥50 prospective decisions exist, which model runs the judge (codex exec vs claude -p) and at what cadence? | Assaf | after calibration data accrues | open — machinery is model-agnostic; hashes bind whichever runs |
 | Should `needs-human` findings page via slack-notify.sh? | Assaf | after first live week | open — default: surfaced in `/prd-triage` output only |
+| Make `--reason-code` mandatory on rejected/deferred (closes the last gate bypass, changes a fleet-wide command contract)? | Assaf | own issue | captured as spillover `sp-1caf70c9`; interim bypass is counted via `ungated_decision_rate` |
+| Refresh the marketplace clone so live `/prd-triage` runs current prd-os (it serves 0.6.0) | Assaf | before relying on in-session capture | captured as spillover `sp-fe57de2d` |
 
 ## 13. Wiring Checklist (MANDATORY)
 
 | Check | Status | Notes |
 |-------|--------|-------|
 | PRD file saved to `q-system/output/prd-judgment-compiler-2026-08-04.md` | Pass | this file |
-| All code/config changes implemented and tested | Pending | |
+| All code/config changes implemented and tested | Pass | 422 prd-os tests; 16/17 mutations killed |
 | New files listed in folder-structure rule | N/A | plugin scripts dir already canonical |
 | New conventions referenced in root CLAUDE.md | N/A | no new convention; CLI documented in `kipi` usage |
 | New rules referenced in folder-structure rules list | N/A | no new rule file |
-| Memory entry saved | Pending | at closeout |
-| `kipi update --dry` confirms propagation | Pending | skeleton files changed (plugins/, kipi) |
-| `kipi update` run | Pending | founder-authorized run at merge, not from worktree |
-| PRD Status updated to Done | Pending | after wiring report |
+| Memory entry saved | Pass | judgment-compiler memory file |
+| `kipi update --dry` confirms propagation | NOT RUN | deliberate: syncing a branch state to the fleet is a post-merge step |
+| `kipi update` run | NOT RUN | post-merge, founder-authorized |
+| PRD Status updated to Done | Pass | wiring report: q-system/output/judgment-compiler-wiring-report-2026-08-04.md |


### PR DESCRIPTION
## What this does

Every PRD finding triage now leaves an immutable, hash-chained receipt of the decision **and the workflow state it was made in**. Those receipts are the calibration dataset the v1 benchmark proved was missing.

**Why:** the verified v1 benchmark showed a judge given only finding text + severity scores 40% exact agreement, kappa 0.032, at 92% mean confidence — *worse than always saying accepted* (76.6% baseline). The fix was never a better prompt. A disposition is a property of an objection **inside workflow state**, and the findings ledger mutates in place, so that state was destroyed before anything could learn from it. No retroactive dataset can be honest; only prospective capture.

## Contents

- **Engine** `plugins/prd-os/scripts/judgment_compiler.py`: append-only hash-chained receipts (`.prd-os/judgments.jsonl`, shared worktree ledger root), deterministic context assembler (unknown stays `unknown`, every fact carries a source), split judge contract (`technical_validity` separate from `workflow_disposition`, 12-code enum), disposition evidence gate, prospective evaluator with release gates, seeded 5% sampling, policy-candidate detector with no self-install path.
- **Real caller**: `findings_writer.py set-disposition` validates before touching the findings file and appends a receipt after. New optional flags `--reason-code`, `--evidence`, `--actor`, `--judge-run`. Kill switch `KIPI_JUDGMENT_CAPTURE=0` restores byte-identical legacy behavior.
- **CLI**: `kipi judgment {assemble,capture,verify,evaluate,sample-check,policy-candidates,selftest}`.
- Updated `/prd-triage` docs, capability-manifest entry, prd-os 0.9.2 → 0.11.3.

## Verification

| Check | Result |
|---|---|
| `pytest plugins/prd-os/tests/` | **422 passed, 1 skipped** (was 399+1; +23 new, zero regressions) |
| Test-first red run | 48 tests written first: **46 failed / 2 passed**, recorded |
| Mutation test | 17 invariant corruptions → **16 killed** |
| Concurrency | 6 simultaneous captures → 6 receipts, sequences 1-6, `verify` exit 0 |
| v1 regressions | `SELFTEST PASS` + `VERIFY PASS`, artifacts untouched |
| Read-only | verify/evaluate/selftest all pass under `chmod 555` |

## Two defects found and fixed before shipping

**Truncation was undetectable.** Any prefix of a valid hash chain is itself a valid chain, so `head -1 judgments.jsonl` returned `VERIFY PASS`. Closed with a monotonic `sequence`, a tip anchor, and an independent `verify --cross-check` that reads the findings ledgers.

**Adversarial review returned 17 findings, all real.** The blocker: concurrent capture forked the ledger while *every writer exited 0* — now `flock`-guarded. Majors: evidence refs were grammar-matched but never opened (`commit:zzzz` passed as evidence for a rejection); the two ledgers diverged on partial failure (now rolls back); a deleted tip anchor re-opened the whole truncation hole. 16 fixed, 1 deferred with its own issue.

## Honest gaps — not claimed as done

1. **`kipi check` is NOT green.** The capability gate is RED on two 60s timeouts (`test-review-invoker-provenance.sh`, `test-updater-issue-sequence.py`). Neither is touched by this branch; both fail on the main checkout too. Pre-existing, but red is red — re-run from the primary checkout after merge.
2. **Live `/prd-triage` won't have this until the marketplace clone pulls** (it serves prd-os 0.6.0). Pre-existing fleet drift, captured as `sp-fe57de2d`.
3. **One gate bypass left open on purpose:** omitting `--reason-code` skips the evidence requirement. Closing it changes a contract every fleet instance inherits (broke 5 existing tests), so it earns its own issue — `sp-1caf70c9`. Interim: `evaluate` reports `ungated_decision_rate` so it is counted, not assumed.
4. **Evidence refs resolve, but `test:`/`scope:` are existence-checked only.**

## Calibration status

**Zero prospective cases.** All release gates (≥88% agreement, kappa ≥0.80, ≥80% per-class recall, ≥50 cases) report `passed: false`. The judge recommends; the founder decides. No calibration is claimed.

## Post-merge sequence

1. `kipi check` from the primary checkout
2. `kipi update --dry` → `kipi update` (plugins/ and kipi are skeleton-owned)
3. Refresh the marketplace clone (`sp-fe57de2d`)

Linear: ASK-363. PRD: `q-system/output/prd-judgment-compiler-2026-08-04.md`. Wiring report: `q-system/output/judgment-compiler-wiring-report-2026-08-04.md`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
