### PR TITLE
Stop the fleet updater blocking on its own exhaust, and name the instances it skips (ASK-363)

### DIFF
--- a/kipi-update.sh
+++ b/kipi-update.sh
@@ -171,6 +171,13 @@ SYSTEM_OWNED_PATHS=(
   "q-system/memory/.sycophancy-monthly-stamp"
   "q-system/.q-system/claude-integrity-baseline.json"
   ".claude/state/stop-gate-firings.json"
+  # plugins/ is a kipi-update DESTINATION -- the updater rsyncs it from the
+  # skeleton and overwrites it, so a dirty plugins/ tree is by definition this
+  # system's output, not founder work. Named explicitly because the case that
+  # motivated this change (travel-agent carrying a STAGED plugins/memory-lifecycle
+  # tree from an earlier run) was otherwise still blocked by the very fix that
+  # cited it (Codex review, PR #98).
+  "plugins"
 )
 FAILED_NAMES=""
 
@@ -1176,12 +1183,23 @@ PY
     if [ "${#sys_owned_dirty[@]}" -gt 0 ] && [ "$DRY_RUN" != "1" ]; then
       echo "  Committing ${#sys_owned_dirty[@]} system-written file(s) so they do not block the sync:"
       printf '    %s\n' "${sys_owned_dirty[@]}"
-      git add -- "${sys_owned_dirty[@]}" 2>/dev/null || true
-      git commit -q --no-verify -m "chore: commit system-written state before skeleton sync
+      # PATHSPEC-limited commit, and NO `git add`. Both matter: `git commit`
+      # with no pathspec commits everything ALREADY STAGED, so a founder with
+      # staged work would have had it swept into this infra commit -- the exact
+      # thing the guard below exists to prevent, reintroduced by the fix for it
+      # (Codex review, PR #98). With a pathspec, only these paths are committed
+      # no matter what else sits in the index.
+      #
+      # `[no-issue: ...]` rather than --no-verify: the instance's commit-msg
+      # gate wants a Linear id, and this is the sanctioned hatch that gets
+      # LOGGED to linear-bypass.jsonl. Bypassing an instance's hooks wholesale
+      # to land a commit in their repo is not ours to do.
+      git commit -q -m "chore: commit system-written state before skeleton sync [no-issue: fleet updater system-state commit]
 
 These files are written by the fleet itself (sycophancy stamp, integrity
-baseline, hook state). Committing them here keeps the updater from being
-blocked by its own exhaust; founder work is never included." 2>/dev/null || true
+baseline, hook state, skeleton-shipped plugins). Committing them here keeps the
+updater from being blocked by its own exhaust; founder work is never included
+because this commit is pathspec-limited." -- "${sys_owned_dirty[@]}" 2>/dev/null || true
     fi
 
     # Refuse tracked work in progress. The updater owns only its scoped sync

--- a/kipi-update.sh
+++ b/kipi-update.sh
@@ -171,14 +171,26 @@ SYSTEM_OWNED_PATHS=(
   "q-system/memory/.sycophancy-monthly-stamp"
   "q-system/.q-system/claude-integrity-baseline.json"
   ".claude/state/stop-gate-firings.json"
-  # plugins/ is a kipi-update DESTINATION -- the updater rsyncs it from the
-  # skeleton and overwrites it, so a dirty plugins/ tree is by definition this
-  # system's output, not founder work. Named explicitly because the case that
-  # motivated this change (travel-agent carrying a STAGED plugins/memory-lifecycle
-  # tree from an earlier run) was otherwise still blocked by the very fix that
-  # cited it (Codex review, PR #98).
-  "plugins"
 )
+# Skeleton-managed plugin dirs are appended at run time from the SAME
+# enumeration the sync itself uses (managed_plugin_names), never as a blanket
+# "plugins" entry. The blanket version classified the WHOLE tree as system-owned
+# and would have committed founder edits inside an instance-LOCAL plugin, which
+# the sync does not manage (Codex review, PR #98 round 2). One enumeration, one
+# meaning of "managed".
+#
+# Consequence, accepted deliberately: an ORPHANED plugin dir -- one an older
+# skeleton shipped and a newer one dropped, e.g. plugins/memory-lifecycle -- is
+# no longer covered, so it still blocks that instance. That is the right answer.
+# An orphan is genuinely ambiguous (is it founder-adopted or dead weight?) and
+# now gets NAMED in the run summary instead of silently skipped.
+system_owned_paths_for_run() {
+  local plugin_name
+  printf '%s\n' "${SYSTEM_OWNED_PATHS[@]}"
+  while IFS= read -r -d '' plugin_name; do
+    printf 'plugins/%s\n' "$plugin_name"
+  done < <(managed_plugin_names)
+}
 FAILED_NAMES=""
 
 MODEL_SKIPPED_ROOT=""
@@ -1174,12 +1186,13 @@ PY
     # work only. Each path is committed individually and only if it is actually
     # dirty; nothing outside SYSTEM_OWNED_PATHS is ever touched here.
     sys_owned_dirty=()
-    for sys_path in "${SYSTEM_OWNED_PATHS[@]}"; do
+    while IFS= read -r sys_path; do
+      [ -n "$sys_path" ] || continue
       if ! git diff --quiet -- "$sys_path" 2>/dev/null ||
           ! git diff --cached --quiet -- "$sys_path" 2>/dev/null; then
         sys_owned_dirty+=("$sys_path")
       fi
-    done
+    done < <(system_owned_paths_for_run)
     if [ "${#sys_owned_dirty[@]}" -gt 0 ] && [ "$DRY_RUN" != "1" ]; then
       echo "  Committing ${#sys_owned_dirty[@]} system-written file(s) so they do not block the sync:"
       printf '    %s\n' "${sys_owned_dirty[@]}"

--- a/kipi-update.sh
+++ b/kipi-update.sh
@@ -159,6 +159,21 @@ is_managed_plugin_path() {
 # down to 605MB free before it was killed.
 #
 # Cached per instance root so two callers cannot observe two different trees.
+# PATHS THE SYSTEM ITSELF WRITES INTO AN INSTANCE.
+# The dirty-tree guard below refuses ANY tracked modification, which is correct
+# for founder work and wrong for the updater's own exhaust: measured 2026-08-04,
+# 6 of 23 instances sat 2-6 prd-os versions behind and 4 were blocked SOLELY by
+# files this system wrote (the monthly sycophancy stamp, hook state, and a
+# plugins/ tree an EARLIER update staged and never committed). The fleet updater
+# was blocked by itself, silently. This list is deliberately narrow and explicit:
+# anything not named here is treated as founder work and still refuses.
+SYSTEM_OWNED_PATHS=(
+  "q-system/memory/.sycophancy-monthly-stamp"
+  "q-system/.q-system/claude-integrity-baseline.json"
+  ".claude/state/stop-gate-firings.json"
+)
+FAILED_NAMES=""
+
 MODEL_SKIPPED_ROOT=""
 MODEL_SKIPPED_PATHS=()
 
@@ -499,6 +514,12 @@ PY
 # increment itself in exactly one place.
 count_instance_failure() {
   FAIL=$((FAIL + 1))
+  # NAME the instance, do not just count it. The summary reported "Failed: 6"
+  # with no names, so nobody could see WHICH instances were drifting -- they sat
+  # 2-6 prd-os versions behind for weeks and each run skipped a different subset
+  # (measured 2026-08-04). A count is not a report.
+  FAILED_NAMES="$FAILED_NAMES
+    - ${name:-<unnamed>} (${path:-unknown path})"
 }
 
 abandon_instance() {
@@ -1142,6 +1163,27 @@ PY
       git merge --abort 2>/dev/null || true
     fi
 
+    # Clear the system's OWN artifacts first, so the guard below judges founder
+    # work only. Each path is committed individually and only if it is actually
+    # dirty; nothing outside SYSTEM_OWNED_PATHS is ever touched here.
+    sys_owned_dirty=()
+    for sys_path in "${SYSTEM_OWNED_PATHS[@]}"; do
+      if ! git diff --quiet -- "$sys_path" 2>/dev/null ||
+          ! git diff --cached --quiet -- "$sys_path" 2>/dev/null; then
+        sys_owned_dirty+=("$sys_path")
+      fi
+    done
+    if [ "${#sys_owned_dirty[@]}" -gt 0 ] && [ "$DRY_RUN" != "1" ]; then
+      echo "  Committing ${#sys_owned_dirty[@]} system-written file(s) so they do not block the sync:"
+      printf '    %s\n' "${sys_owned_dirty[@]}"
+      git add -- "${sys_owned_dirty[@]}" 2>/dev/null || true
+      git commit -q --no-verify -m "chore: commit system-written state before skeleton sync
+
+These files are written by the fleet itself (sycophancy stamp, integrity
+baseline, hook state). Committing them here keeps the updater from being
+blocked by its own exhaust; founder work is never included." 2>/dev/null || true
+    fi
+
     # Refuse tracked work in progress. The updater owns only its scoped sync
     # commits and must never package unrelated founder edits into an infra commit.
     if ! git diff --cached --quiet 2>/dev/null ||
@@ -1524,6 +1566,9 @@ fi
 echo "=== Summary ==="
 echo "  Updated: $PASS"
 echo "  Failed:  $FAIL"
+if [ -n "$FAILED_NAMES" ]; then
+  echo "  NOT UPDATED (still on their previous skeleton version):$FAILED_NAMES"
+fi
 echo "  Skipped: $SKIP"
 if [ -n "${GATE_FAIL:-}" ]; then
   echo "  CAPABILITY GATE RED in:$GATE_FAIL"


### PR DESCRIPTION
## The defect

`kipi update` silently stopped updating part of the fleet. Measured 2026-08-04: **6 of 23 instances sat 2–6 prd-os versions behind**, and each run reached a *different* subset — their `plugin.json` mtimes clustered at 07-30 and 08-01.

Root cause is at `kipi-update.sh` — the dirty-tree guard refuses an instance on **any** tracked modification. That is correct for founder work and it is the reason the guard exists ("must never package unrelated founder edits into an infra commit"). But it cannot distinguish founder work from the system's **own exhaust**. Four of the six were blocked *solely* by files this fleet writes:

- `q-system/memory/.sycophancy-monthly-stamp` — written by the monthly sycophancy hook (5 instances)
- `.claude/state/stop-gate-firings.json` — hook state
- `plugins/memory-lifecycle/` — shipped into travel-agent by an **earlier `kipi update`** and left staged, which then blocked every update after it

The updater was blocked by its own output, and the summary printed `Failed: 6` with no names, so nobody could see which instances were drifting.

## Two changes

1. **`SYSTEM_OWNED_PATHS`** — a narrow, explicit allowlist committed immediately before the guard runs. Each path is committed only if actually dirty. Anything not on the list is still treated as founder work and still refuses. The founder-protection intent is unchanged.
2. **The summary names every instance it did not update.** A count is not a report.

## Verification

- `bash -n kipi-update.sh` clean.
- The named-failure report immediately surfaced a real problem I could not see before: `accountant` fails its dry-run copy with `No space left on device` (disk 93%, and that instance carries an 8.7G `src-tauri/target/debug` tree the dry model has no reason to copy). Captured separately as `sp-b2f16971` — **not** fixed here, and not by deleting anyone's build cache.
- Fleet is now **22/22 governed instances at prd-os 0.12.0** (`reddit-build-radar` is `skeleton_managed: false` by design, ASK-117).

## Honest limits

- This unblocks the recurrence for the three named paths only. A *new* system-written file will re-block the fleet the same way, and the allowlist is hand-maintained.
- The four instances unblocked today were fixed by hand-committing their churn; this change prevents the next occurrence, it did not cause today's recovery.
- I did not touch the dry-run rsync scope, so `--dry` can still report false failures under disk pressure.

Linear: ASK-363. Spillover: `sp-92f7e140` (this defect), `sp-b2f16971` (dry-model disk).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
