### PR TITLE
Tell the headless PR reviewer it has no interlocutor (ASK-363)

### DIFF
--- a/q-system/.q-system/scripts/pr-review-agent.sh
+++ b/q-system/.q-system/scripts/pr-review-agent.sh
@@ -396,6 +396,26 @@ PROMPT="You are a SENIOR STAFF ENGINEER at Meta. You have NEVER seen this codeba
 You were asked to review pull request #$PR in $REVIEW_ROOT, and you are ADVERSARIAL by default:
 your job is to find what is wrong, not to be agreeable.$ROUND_RULE
 
+## YOU ARE ALONE. THERE IS NOBODY TO ASK.
+
+This run is HEADLESS: no human is reading your output while it happens, and
+nothing you write can be answered. Do not state a plan and wait for approval,
+do not ask to begin, do not ask which files to look at. Begin immediately and
+finish in one pass, ending with the verdict and the machine-readable findings
+block.
+
+This is not a style preference. Measured 2026-08-04 on PR #97 round 4: this
+reviewer replied \"Ready for your OK to begin the read-only review\", spent 15k
+tokens, produced no findings block, and the run scored the PR unstated. The
+repo-wide skills you inherit (founder-voice, AUDHD executive-function) carry an
+INTERACTIVE rule -- state your approach and wait for OK before multi-file work
+-- which is correct when a founder is present and wrong here. In this run that
+rule does not apply: you have no interlocutor, so waiting is the same as
+producing nothing.
+
+An empty or truncated review never derives APPROVE, so stopping to ask does not
+fail safe for the author -- it just burns a round.
+
 ## Read the change
 
   gh pr view $PR


### PR DESCRIPTION
## The defect

PR #97 round 4: the reviewer replied "Ready for your OK to begin the read-only review", spent 15k tokens, and returned no findings block. The run scored the PR `unstated` and posted `kipi/reviewer-approved=failure` — correct fail-closed behaviour, but a wasted round.

**Cause:** the repo-wide skills the reviewer inherits (founder-voice, AUDHD executive-function) carry an *interactive* rule — state your approach and wait for OK before multi-file work. That is right when a founder is present and wrong in a headless run where nothing can answer. Rounds 1–3 and 5–6 were fine on the same harness, so it is nondeterministic.

## The change

One block added to the reviewer prompt: this run is headless, you have no interlocutor, begin immediately and finish in one pass. It cites the measured incident so the next reader knows why the block exists.

## Layer, stated honestly

This is a **prompt-level** fix, because whether a model stops to ask permission is a model behaviour no deterministic checker can prevent. The deterministic half already exists and is untouched: a review with no complete FINDINGS block scores `unstated`, and unstated never derives APPROVE. The failure already fails closed — this saves a round, it does not add enforcement.

## Conflict of interest, declared

I author the PRs this reviewer gates. I kept the change strictly to "do not wait for a human who is not there": it does not touch the severity anchors, the reproducer requirement, or anything that could make approval easier. Worth a human eye on that specifically.

Spillover: `sp-0c09d3d3`. Linear: ASK-363.

🤖 Generated with [Claude Code](https://claude.com/claude-code)