### PR TITLE
Require a judgment receipt at approval; free 16.6G of disk; close review minors (ASK-363)

### DIFF
--- a/kipi-update.sh
+++ b/kipi-update.sh
@@ -235,7 +235,18 @@ model_rsync_excludes() {
   # the projection cannot be built against a stale or unpopulated list. The
   # scan is cached per root, so this costs nothing on the second call.
   model_skip_scan "$instance_root"
+  # BUILD CACHES ARE NOT STATE. The model exists to preview what the skeleton
+  # sync would do, and the sync never touches these -- copying them is pure
+  # cost. Measured 2026-08-04: the accountant instance carried an 8.7G
+  # src-tauri/target tree, the copy hit "No space left on device" at 92% disk,
+  # and the instance reported FAILED in --dry while the real run had updated it
+  # fine. So --dry manufactured a false failure out of disk pressure alone.
+  # Every path here is regenerable by its own toolchain and gitignored.
   MODEL_EXCLUDES=(--exclude=".git")
+  local cache_dir
+  for cache_dir in target node_modules .venv venv __pycache__ .next dist build .pytest_cache .mypy_cache .ruff_cache; do
+    MODEL_EXCLUDES+=(--exclude="$cache_dir/")
+  done
   for nested_rel in ${MODEL_SKIPPED_PATHS[@]+"${MODEL_SKIPPED_PATHS[@]}"}; do
     MODEL_EXCLUDES+=(--exclude="/$nested_rel/")
   done

--- a/plugins/prd-os/.claude-plugin/plugin.json
+++ b/plugins/prd-os/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "prd-os",
-  "version": "0.13.3",
+  "version": "0.13.4",
   "description": "PRD operating system: capture rough ideas, draft reviewable PRDs, run standard and adversarial review (Codex or a Claude senior-staff-engineer subagent, recorded truthfully), triage findings, decompose approved PRDs into atomic issue specs, and execute those issues with scope enforcement, stop-gate receipts, and reviewer-attributed findings.",
   "author": {
     "name": "Assaf Kipnis"

--- a/plugins/prd-os/.claude-plugin/plugin.json
+++ b/plugins/prd-os/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "prd-os",
-  "version": "0.13.2",
+  "version": "0.13.3",
   "description": "PRD operating system: capture rough ideas, draft reviewable PRDs, run standard and adversarial review (Codex or a Claude senior-staff-engineer subagent, recorded truthfully), triage findings, decompose approved PRDs into atomic issue specs, and execute those issues with scope enforcement, stop-gate receipts, and reviewer-attributed findings.",
   "author": {
     "name": "Assaf Kipnis"

--- a/plugins/prd-os/.claude-plugin/plugin.json
+++ b/plugins/prd-os/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "prd-os",
-  "version": "0.13.6",
+  "version": "0.13.7",
   "description": "PRD operating system: capture rough ideas, draft reviewable PRDs, run standard and adversarial review (Codex or a Claude senior-staff-engineer subagent, recorded truthfully), triage findings, decompose approved PRDs into atomic issue specs, and execute those issues with scope enforcement, stop-gate receipts, and reviewer-attributed findings.",
   "author": {
     "name": "Assaf Kipnis"

--- a/plugins/prd-os/.claude-plugin/plugin.json
+++ b/plugins/prd-os/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "prd-os",
-  "version": "0.13.1",
+  "version": "0.13.2",
   "description": "PRD operating system: capture rough ideas, draft reviewable PRDs, run standard and adversarial review (Codex or a Claude senior-staff-engineer subagent, recorded truthfully), triage findings, decompose approved PRDs into atomic issue specs, and execute those issues with scope enforcement, stop-gate receipts, and reviewer-attributed findings.",
   "author": {
     "name": "Assaf Kipnis"

--- a/plugins/prd-os/.claude-plugin/plugin.json
+++ b/plugins/prd-os/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "prd-os",
-  "version": "0.13.4",
+  "version": "0.13.5",
   "description": "PRD operating system: capture rough ideas, draft reviewable PRDs, run standard and adversarial review (Codex or a Claude senior-staff-engineer subagent, recorded truthfully), triage findings, decompose approved PRDs into atomic issue specs, and execute those issues with scope enforcement, stop-gate receipts, and reviewer-attributed findings.",
   "author": {
     "name": "Assaf Kipnis"

--- a/plugins/prd-os/.claude-plugin/plugin.json
+++ b/plugins/prd-os/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "prd-os",
-  "version": "0.13.5",
+  "version": "0.13.6",
   "description": "PRD operating system: capture rough ideas, draft reviewable PRDs, run standard and adversarial review (Codex or a Claude senior-staff-engineer subagent, recorded truthfully), triage findings, decompose approved PRDs into atomic issue specs, and execute those issues with scope enforcement, stop-gate receipts, and reviewer-attributed findings.",
   "author": {
     "name": "Assaf Kipnis"

--- a/plugins/prd-os/.claude-plugin/plugin.json
+++ b/plugins/prd-os/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "prd-os",
-  "version": "0.12.0",
+  "version": "0.13.0",
   "description": "PRD operating system: capture rough ideas, draft reviewable PRDs, run standard and adversarial review (Codex or a Claude senior-staff-engineer subagent, recorded truthfully), triage findings, decompose approved PRDs into atomic issue specs, and execute those issues with scope enforcement, stop-gate receipts, and reviewer-attributed findings.",
   "author": {
     "name": "Assaf Kipnis"

--- a/plugins/prd-os/.claude-plugin/plugin.json
+++ b/plugins/prd-os/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "prd-os",
-  "version": "0.13.0",
+  "version": "0.13.1",
   "description": "PRD operating system: capture rough ideas, draft reviewable PRDs, run standard and adversarial review (Codex or a Claude senior-staff-engineer subagent, recorded truthfully), triage findings, decompose approved PRDs into atomic issue specs, and execute those issues with scope enforcement, stop-gate receipts, and reviewer-attributed findings.",
   "author": {
     "name": "Assaf Kipnis"

--- a/plugins/prd-os/CHANGELOG.md
+++ b/plugins/prd-os/CHANGELOG.md
@@ -2,6 +2,16 @@
 
 All notable changes to the `prd-os` plugin are recorded here. Format follows [Keep a Changelog](https://keepachangelog.com/en/1.1.0/). Versions follow semantic versioning; see `README.md` for the bump policy and the distinction between plugin version and config schema version.
 
+## [0.13.2] - 2026-08-04
+
+### Fixed (Codex review, PR #101 round 2)
+- **A receipt for an EARLIER decision satisfied the gate.** Coverage was
+  identity-only `(prd_id, finding_id)`, so hand-editing the findings file to a
+  different disposition left the stale receipt standing in for a decision that
+  was never captured -- and approval passed. The check now compares the
+  finding's current disposition against the latest human-bearing receipt, and
+  says so specifically when they disagree.
+
 ## [0.13.1] - 2026-08-04
 
 ### Fixed (Codex review, PR #101)

--- a/plugins/prd-os/CHANGELOG.md
+++ b/plugins/prd-os/CHANGELOG.md
@@ -2,6 +2,18 @@
 
 All notable changes to the `prd-os` plugin are recorded here. Format follows [Keep a Changelog](https://keepachangelog.com/en/1.1.0/). Versions follow semantic versioning; see `README.md` for the bump policy and the distinction between plugin version and config schema version.
 
+## [0.13.1] - 2026-08-04
+
+### Fixed (Codex review, PR #101)
+- **The required receipt gate failed OPEN on an unreadable ledger.** It caught
+  every exception and returned 0, defended in the PR body as "a bug in the check
+  must not cause an approval outage". That conflated a buggy gate with a corrupt
+  ledger, and a corrupt or truncated ledger is precisely the integrity failure
+  the gate exists to catch. It now fails CLOSED on any read error; the only
+  fail-open case left is the compiler not being installed at all.
+- Substring matching let a missing receipt for `prd-alpha-2` block approval of
+  `prd-alpha`. Now an exact `<prd_id>/` prefix match.
+
 ## [0.13.0] - 2026-08-04
 
 ### Added

--- a/plugins/prd-os/CHANGELOG.md
+++ b/plugins/prd-os/CHANGELOG.md
@@ -2,6 +2,16 @@
 
 All notable changes to the `prd-os` plugin are recorded here. Format follows [Keep a Changelog](https://keepachangelog.com/en/1.1.0/). Versions follow semantic versioning; see `README.md` for the bump policy and the distinction between plugin version and config schema version.
 
+## [0.13.4] - 2026-08-04
+
+### Fixed (Codex review, PR #101 round 4)
+- **The approval gate read the ledger without the writer's lock.** capture
+  appends the receipt and then writes the tip; observed between those two the
+  ledger holds N+1 records against a tip of N, which the new chain check calls
+  "receipts BEYOND the tip anchor" and blocks approval over a concurrent capture
+  that was perfectly fine. The writer got a lock in 0.12.0 and the reader never
+  did. Ledger and tip are now read together under `ledger_lock`.
+
 ## [0.13.3] - 2026-08-04
 
 ### Fixed (Codex review, PR #101 round 3)

--- a/plugins/prd-os/CHANGELOG.md
+++ b/plugins/prd-os/CHANGELOG.md
@@ -2,6 +2,16 @@
 
 All notable changes to the `prd-os` plugin are recorded here. Format follows [Keep a Changelog](https://keepachangelog.com/en/1.1.0/). Versions follow semantic versioning; see `README.md` for the bump policy and the distinction between plugin version and config schema version.
 
+## [0.13.6] - 2026-08-04
+
+### Fixed (Codex review, PR #101 round 6) — a regression from round 5
+- Re-dispositioning rejected -> accepted without a new `--rationale` falsely
+  blocked approval. findings_writer keeps the previous rationale on the record
+  (only `pending` clears it), while the receipt captured the FLAG, which was
+  absent. The fingerprint added in 0.13.5 then correctly reported two different
+  decisions. The receipt now freezes the rationale the RECORD carries, which is
+  what a receipt is for.
+
 ## [0.13.5] - 2026-08-04
 
 ### Fixed (Codex review, PR #101 round 5) — closed as a CLASS

--- a/plugins/prd-os/CHANGELOG.md
+++ b/plugins/prd-os/CHANGELOG.md
@@ -2,6 +2,16 @@
 
 All notable changes to the `prd-os` plugin are recorded here. Format follows [Keep a Changelog](https://keepachangelog.com/en/1.1.0/). Versions follow semantic versioning; see `README.md` for the bump policy and the distinction between plugin version and config schema version.
 
+## [0.13.7] - 2026-08-04
+
+### Fixed (Codex review, PR #101 round 7)
+- The since-floor shielded real conflicts. `""` sorts before every timestamp, so
+  a dispositioned finding with no `resolved_at` was skipped even when its
+  receipt disagreed. The floor exists to exempt findings that CANNOT have a
+  receipt; one that HAS a receipt is not in that category, so the floor no
+  longer applies to it. A finding that is both undateable and unclaimed stays
+  exempt, or every legacy PRD blocks forever.
+
 ## [0.13.6] - 2026-08-04
 
 ### Fixed (Codex review, PR #101 round 6) — a regression from round 5

--- a/plugins/prd-os/CHANGELOG.md
+++ b/plugins/prd-os/CHANGELOG.md
@@ -2,6 +2,16 @@
 
 All notable changes to the `prd-os` plugin are recorded here. Format follows [Keep a Changelog](https://keepachangelog.com/en/1.1.0/). Versions follow semantic versioning; see `README.md` for the bump policy and the distinction between plugin version and config schema version.
 
+## [0.13.3] - 2026-08-04
+
+### Fixed (Codex review, PR #101 round 3)
+- **The approval gate trusted receipts it never verified.** It called
+  `read_ledger` (JSON parse only) and never `verify_ledger`, so a receipt
+  appended by hand -- correct prd_id, finding_id and disposition, broken chain
+  -- authorized approval. A hash chain no consumer checks is decoration, and
+  this gate is the consumer that matters. It now verifies the chain and tip
+  first and refuses on any integrity error.
+
 ## [0.13.2] - 2026-08-04
 
 ### Fixed (Codex review, PR #101 round 2)

--- a/plugins/prd-os/CHANGELOG.md
+++ b/plugins/prd-os/CHANGELOG.md
@@ -2,6 +2,23 @@
 
 All notable changes to the `prd-os` plugin are recorded here. Format follows [Keep a Changelog](https://keepachangelog.com/en/1.1.0/). Versions follow semantic versioning; see `README.md` for the bump policy and the distinction between plugin version and config schema version.
 
+## [0.13.0] - 2026-08-04
+
+### Added
+- **The Judgment Compiler is now REQUIRED, not just available.** It shipped
+  writing a receipt on every triage and requiring one nowhere, so
+  `KIPI_JUDGMENT_CAPTURE=0`, a hand-edited findings file, or an ignored capture
+  failure each left a hole no gate could see -- and a ledger with unnoticed
+  holes cannot be the calibration set it exists to be. `_judgment_receipt_gate`
+  now blocks `advance approved` when a finding dispositioned since
+  `JUDGMENT_RECEIPT_FLOOR` carries no receipt. The floor is the point: ~342
+  findings were adjudicated before the compiler existed and can never have
+  receipts, and a gate that cannot be satisfied gets switched off.
+
+### Fixed
+- Spillover evidence refs matched a value in ANY JSON field, so an id quoted
+  inside a description resolved as if it were the item (sp-fcb3573e).
+
 ## [0.12.0] - 2026-08-04
 
 ### Fixed (Codex review round 5, PR #97)

--- a/plugins/prd-os/CHANGELOG.md
+++ b/plugins/prd-os/CHANGELOG.md
@@ -2,6 +2,17 @@
 
 All notable changes to the `prd-os` plugin are recorded here. Format follows [Keep a Changelog](https://keepachangelog.com/en/1.1.0/). Versions follow semantic versioning; see `README.md` for the bump policy and the distinction between plugin version and config schema version.
 
+## [0.13.5] - 2026-08-04
+
+### Fixed (Codex review, PR #101 round 5) — closed as a CLASS
+- The coverage check compared `disposition` only, so a hand-edited `rationale`
+  passed as covered. Rounds 2-5 each found a different unchecked field
+  (identity only, then disposition, then rationale). Rather than patch a third
+  field, `_decision_fingerprint` is now the single definition of "the same
+  decision" and is applied to BOTH sides, so a newly frozen field cannot go
+  unchecked on one of them. Empty-vs-absent rationale is normalised, because
+  that difference is not a decision change and must not read as tampering.
+
 ## [0.13.4] - 2026-08-04
 
 ### Fixed (Codex review, PR #101 round 4)

--- a/plugins/prd-os/scripts/findings_writer.py
+++ b/plugins/prd-os/scripts/findings_writer.py
@@ -572,7 +572,14 @@ def cmd_set_disposition(cfg: Config, args: argparse.Namespace) -> int:  # noqa: 
                 actor=getattr(args, "actor", "founder"),
                 reason_code=getattr(args, "reason_code", None),
                 evidence_refs=list(getattr(args, "evidence", [])),
-                rationale=(args.rationale or "").strip() or None,
+                # Freeze what the RECORD says, not what the flag said. A
+                # re-disposition to accepted passes no --rationale while the
+                # record keeps its previous one (only `pending` clears it), so
+                # reading the flag captured None against a record that still had
+                # text -- and the decision fingerprint then falsely reported the
+                # decision as uncaptured (Codex, PR #101 round 6: a regression
+                # from the round-5 fingerprint fix).
+                rationale=(target.get("rationale") or "").strip() or None,
                 judge_run_path=getattr(args, "judge_run", None),
             )
         except (judgment_compiler.ValidationError, OSError) as exc:

--- a/plugins/prd-os/scripts/judgment_compiler.py
+++ b/plugins/prd-os/scripts/judgment_compiler.py
@@ -1251,9 +1251,19 @@ def cross_check_findings(cfg: Config, records: list[dict],
             if disposition in (None, "pending"):
                 continue
             resolved_at = str(record.get("resolved_at") or "")
-            if since and resolved_at < since:
-                continue
             key = (record.get("prd_id"), record.get("id"))
+            # The floor exempts findings that CANNOT have a receipt because
+            # they were decided before the compiler existed. A finding that HAS
+            # one is not in that category, so the floor must never shield a
+            # mismatch between it and the record. It also must not shield a
+            # finding with no resolved_at at all: "" sorts before every
+            # timestamp, so those were skipped silently even when a conflicting
+            # receipt existed (Codex, PR #101 round 7).
+            if since and resolved_at and resolved_at < since \
+                    and key not in covered:
+                continue
+            if since and not resolved_at and key not in covered:
+                continue  # undateable AND unclaimed: cannot judge, do not guess
             if key not in covered:
                 errors.append(
                     f"{key[0]}/{key[1]}: dispositioned {disposition!r} at "

--- a/plugins/prd-os/scripts/judgment_compiler.py
+++ b/plugins/prd-os/scripts/judgment_compiler.py
@@ -1198,6 +1198,18 @@ def _resolve_one_ref(cfg: Config, kind: str, value: str) -> str | None:
     return "unknown reference kind"
 
 
+def _decision_fingerprint(disposition, rationale) -> tuple:
+    """What makes two human decisions the same decision.
+
+    ONE definition, used for both sides of the comparison, so adding a frozen
+    field cannot silently go unchecked on one side. Rationale is normalised:
+    the writer stores None for an empty one while a findings record may simply
+    omit the key, and that difference is not a decision change.
+    """
+    text = (rationale or "").strip()
+    return (disposition, text)
+
+
 def cross_check_findings(cfg: Config, records: list[dict],
                          since: str | None = None) -> list[str]:
     """Completeness check against an INDEPENDENT source: every dispositioned
@@ -1219,13 +1231,19 @@ def cross_check_findings(cfg: Config, records: list[dict],
     # anyway (Codex, PR #101 round 2, executed repro). Receipts are appended in
     # order and supersede by position, so the last human-bearing receipt for a
     # finding is its current claim.
-    covered: dict[tuple, str] = {}
+    # Compare EVERY decision field the receipt freezes, not one field at a time.
+    # Rounds 2-5 of PR #101 each found a different unchecked field (identity
+    # only, then disposition, then rationale); patching them one by one is
+    # whack-a-mole on a class. `_decision_fingerprint` is the single definition
+    # of "the same decision", so a new frozen field is covered by construction.
+    covered: dict[tuple, tuple] = {}
     for record in records:
         human = record.get("human")
         if not human:
             continue  # judge-only receipt makes no claim about a human decision
         covered[(record["finding"]["prd_id"],
-                 record["finding"]["finding_id"])] = human["disposition"]
+                 record["finding"]["finding_id"])] = _decision_fingerprint(
+                     human.get("disposition"), human.get("rationale"))
     errors = []
     for path in sorted(cfg.findings_dir.rglob("*-findings.jsonl")):
         for record in _read_findings(path):
@@ -1241,12 +1259,16 @@ def cross_check_findings(cfg: Config, records: list[dict],
                     f"{key[0]}/{key[1]}: dispositioned {disposition!r} at "
                     f"{resolved_at or 'unknown time'} but no judgment receipt "
                     "exists")
-            elif covered[key] != disposition:
-                errors.append(
-                    f"{key[0]}/{key[1]}: findings file says {disposition!r} but "
-                    f"the latest receipt records {covered[key]!r} — the current "
-                    "decision was never captured (hand-edited, or a capture "
-                    "that failed after the write)")
+            else:
+                current = _decision_fingerprint(
+                    disposition, record.get("rationale"))
+                if covered[key] != current:
+                    errors.append(
+                        f"{key[0]}/{key[1]}: the findings file records "
+                        f"{current} but the latest receipt froze {covered[key]} "
+                        "— the current decision was never captured "
+                        "(hand-edited, or a capture that failed after the "
+                        "write)")
     return errors
 
 

--- a/plugins/prd-os/scripts/judgment_compiler.py
+++ b/plugins/prd-os/scripts/judgment_compiler.py
@@ -1212,8 +1212,20 @@ def cross_check_findings(cfg: Config, records: list[dict],
     before this feature existed have no receipt by construction and would
     otherwise report as thousands of false gaps.
     """
-    covered = {(r["finding"]["prd_id"], r["finding"]["finding_id"])
-               for r in records}
+    # Map to the LATEST recorded human disposition, not merely to "a receipt
+    # exists". Identity-only coverage let a receipt for an earlier decision
+    # satisfy the gate after the findings file was hand-edited to a different
+    # one, so the decision actually recorded had no receipt and approval passed
+    # anyway (Codex, PR #101 round 2, executed repro). Receipts are appended in
+    # order and supersede by position, so the last human-bearing receipt for a
+    # finding is its current claim.
+    covered: dict[tuple, str] = {}
+    for record in records:
+        human = record.get("human")
+        if not human:
+            continue  # judge-only receipt makes no claim about a human decision
+        covered[(record["finding"]["prd_id"],
+                 record["finding"]["finding_id"])] = human["disposition"]
     errors = []
     for path in sorted(cfg.findings_dir.rglob("*-findings.jsonl")):
         for record in _read_findings(path):
@@ -1229,6 +1241,12 @@ def cross_check_findings(cfg: Config, records: list[dict],
                     f"{key[0]}/{key[1]}: dispositioned {disposition!r} at "
                     f"{resolved_at or 'unknown time'} but no judgment receipt "
                     "exists")
+            elif covered[key] != disposition:
+                errors.append(
+                    f"{key[0]}/{key[1]}: findings file says {disposition!r} but "
+                    f"the latest receipt records {covered[key]!r} — the current "
+                    "decision was never captured (hand-edited, or a capture "
+                    "that failed after the write)")
     return errors
 
 

--- a/plugins/prd-os/scripts/judgment_compiler.py
+++ b/plugins/prd-os/scripts/judgment_compiler.py
@@ -1172,8 +1172,19 @@ def _resolve_one_ref(cfg: Config, kind: str, value: str) -> str | None:
         path = _ledger_dir(cfg) / "spillover.jsonl"
         if not path.is_file():
             return "no spillover ledger exists"
-        return None if f'"{value}"' in path.read_text(encoding="utf-8") \
-            else "no such spillover item"
+        # Substring-matched the raw file, so a value appearing in ANY field
+        # (a description quoting an id, a resolution_ref) resolved as if it
+        # were the item itself (Codex, PR #97 minor sp-fcb3573e). Parse and
+        # compare the id field.
+        for raw in path.read_text(encoding="utf-8").splitlines():
+            if not raw.strip():
+                continue
+            try:
+                if json.loads(raw).get("id") == value:
+                    return None
+            except json.JSONDecodeError:
+                continue
+        return "no such spillover item"
     if kind == "commit":
         if not re.fullmatch(r"[0-9a-f]{7,40}", value):
             return "not a commit sha"

--- a/plugins/prd-os/scripts/prd_runner.py
+++ b/plugins/prd-os/scripts/prd_runner.py
@@ -619,14 +619,32 @@ def _judgment_receipt_gate(cfg: Config, prd_id: str) -> tuple[int, str]:
     try:
         import judgment_compiler
     except ImportError:
-        return 0, ""  # compiler absent (older instance): nothing to enforce
+        # The ONLY fail-open case: the compiler is not installed (an older
+        # instance), so there is no contract to enforce and nothing to read.
+        return 0, ""
     try:
         records = judgment_compiler.read_ledger(
             judgment_compiler.ledger_path(cfg))
-        missing = [m for m in judgment_compiler.cross_check_findings(
-            cfg, records, JUDGMENT_RECEIPT_FLOOR) if prd_id in m]
-    except Exception as exc:  # never let the gate's own failure block approval
-        return 0, f"note: judgment receipt check skipped ({exc})\n"
+        raw_missing = judgment_compiler.cross_check_findings(
+            cfg, records, JUDGMENT_RECEIPT_FLOOR)
+    except Exception as exc:
+        # FAIL CLOSED. The first version caught everything and returned 0,
+        # defended as "a bug in the check must not cause an approval outage".
+        # That conflated two different things: a corrupt or truncated ledger is
+        # not a bug in the gate, it is precisely the integrity failure the gate
+        # exists to catch, and letting approval through on it is the worst
+        # possible response (Codex, PR #101, executed repro: a ValueError from
+        # read_ledger returned rc=0). A required integrity gate fails closed.
+        return 2, (
+            f"approval blocked: the judgment ledger could not be checked ({exc}).\n"
+            "This is refused rather than skipped: an unreadable or corrupt "
+            "ledger is the integrity failure this gate exists to catch. Run "
+            "`kipi judgment verify` to see the damage.\n"
+        )
+    # Exact prd_id match, not `in`: cross_check_findings emits
+    # "<prd_id>/<finding_id>: ...", so a substring test let a missing receipt
+    # for `prd-alpha-2` block approval of `prd-alpha` (Codex, PR #101).
+    missing = [m for m in raw_missing if m.startswith(f"{prd_id}/")]
     if missing:
         return 2, (
             f"approval blocked: {len(missing)} finding(s) dispositioned since "

--- a/plugins/prd-os/scripts/prd_runner.py
+++ b/plugins/prd-os/scripts/prd_runner.py
@@ -596,6 +596,48 @@ def _findings_gate(cfg: Config, state: dict) -> tuple[int, str]:
             f"approval blocked: {len(pending)} pending finding(s): "
             f"{', '.join(pending)}. Set a disposition on each before advancing.\n"
         )
+    return _judgment_receipt_gate(cfg, state["prd_id"])
+
+
+# The Judgment Compiler shipped WRITING a receipt on every triage and REQUIRING
+# one nowhere, which made it available rather than baked in: KIPI_JUDGMENT_CAPTURE=0,
+# a hand-edited findings file, or a capture that failed and got ignored all left
+# a silent hole no gate could see. A ledger with unnoticed holes cannot be the
+# calibration set it exists to be.
+JUDGMENT_RECEIPT_FLOOR = "2026-08-04T00:00:00Z"
+
+
+def _judgment_receipt_gate(cfg: Config, prd_id: str) -> tuple[int, str]:
+    """Every finding dispositioned since the floor must carry a receipt.
+
+    FLOOR, not a blanket requirement: ~342 findings were adjudicated before the
+    compiler existed and can never have receipts. Demanding them would block
+    every pre-existing PRD forever, and a gate that cannot be satisfied gets
+    switched off -- which protects nothing. So the rule binds only decisions
+    made after the feature landed.
+    """
+    try:
+        import judgment_compiler
+    except ImportError:
+        return 0, ""  # compiler absent (older instance): nothing to enforce
+    try:
+        records = judgment_compiler.read_ledger(
+            judgment_compiler.ledger_path(cfg))
+        missing = [m for m in judgment_compiler.cross_check_findings(
+            cfg, records, JUDGMENT_RECEIPT_FLOOR) if prd_id in m]
+    except Exception as exc:  # never let the gate's own failure block approval
+        return 0, f"note: judgment receipt check skipped ({exc})\n"
+    if missing:
+        return 2, (
+            f"approval blocked: {len(missing)} finding(s) dispositioned since "
+            f"{JUDGMENT_RECEIPT_FLOOR} with no judgment receipt:\n  "
+            + "\n  ".join(missing[:5])
+            + ("\n  ..." if len(missing) > 5 else "")
+            + "\n\nRe-run the disposition through findings_writer.py "
+              "set-disposition so the decision is recorded, or explain the gap. "
+              "Receipts are the calibration set; a hole in them is invisible "
+              "later.\n"
+        )
     return 0, ""
 
 

--- a/plugins/prd-os/scripts/prd_runner.py
+++ b/plugins/prd-os/scripts/prd_runner.py
@@ -625,6 +625,22 @@ def _judgment_receipt_gate(cfg: Config, prd_id: str) -> tuple[int, str]:
     try:
         records = judgment_compiler.read_ledger(
             judgment_compiler.ledger_path(cfg))
+        # VERIFY before trusting. read_ledger only parses JSON, so without this
+        # a receipt appended by hand -- right prd_id, right finding_id, right
+        # disposition, broken chain -- satisfied the gate and authorized
+        # approval (Codex, PR #101 round 3). A hash chain no consumer checks is
+        # decoration; the gate is the consumer that matters.
+        chain_errors = judgment_compiler.verify_ledger(
+            records, judgment_compiler.read_tip(
+                judgment_compiler.tip_path(cfg)))
+        if chain_errors:
+            return 2, (
+                "approval blocked: the judgment ledger does not verify, so its "
+                "receipts cannot be trusted as evidence:\n  "
+                + "\n  ".join(chain_errors[:5])
+                + ("\n  ..." if len(chain_errors) > 5 else "")
+                + "\n\nRun `kipi judgment verify` for the full report.\n"
+            )
         raw_missing = judgment_compiler.cross_check_findings(
             cfg, records, JUDGMENT_RECEIPT_FLOOR)
     except Exception as exc:

--- a/plugins/prd-os/scripts/prd_runner.py
+++ b/plugins/prd-os/scripts/prd_runner.py
@@ -623,16 +623,22 @@ def _judgment_receipt_gate(cfg: Config, prd_id: str) -> tuple[int, str]:
         # instance), so there is no contract to enforce and nothing to read.
         return 0, ""
     try:
-        records = judgment_compiler.read_ledger(
-            judgment_compiler.ledger_path(cfg))
+        # Read UNDER THE WRITER'S LOCK. capture appends the receipt and then
+        # writes the tip; observed between those two, the ledger holds N+1
+        # records against a tip of N, which the chain check below correctly
+        # calls "receipts BEYOND the tip anchor" -- and would block approval
+        # over a concurrent capture that was perfectly fine (Codex, PR #101
+        # round 4). I gave the writer a lock and left the reader without one.
+        with judgment_compiler.ledger_lock(cfg):
+            records = judgment_compiler.read_ledger(
+                judgment_compiler.ledger_path(cfg))
+            tip = judgment_compiler.read_tip(judgment_compiler.tip_path(cfg))
         # VERIFY before trusting. read_ledger only parses JSON, so without this
         # a receipt appended by hand -- right prd_id, right finding_id, right
         # disposition, broken chain -- satisfied the gate and authorized
         # approval (Codex, PR #101 round 3). A hash chain no consumer checks is
         # decoration; the gate is the consumer that matters.
-        chain_errors = judgment_compiler.verify_ledger(
-            records, judgment_compiler.read_tip(
-                judgment_compiler.tip_path(cfg)))
+        chain_errors = judgment_compiler.verify_ledger(records, tip)
         if chain_errors:
             return 2, (
                 "approval blocked: the judgment ledger does not verify, so its "

--- a/plugins/prd-os/tests/test_judgment_compiler.py
+++ b/plugins/prd-os/tests/test_judgment_compiler.py
@@ -1340,3 +1340,64 @@ if __name__ == "__main__":
         [sys.executable, "-m", "pytest", str(Path(__file__).resolve()), "-q"],
         cwd=str(PLUGIN_ROOT.parent.parent),
     ).returncode)
+
+
+class TestBakedIntoApproval:
+    """The compiler must be REQUIRED by prd-os, not merely available to it.
+
+    Shipped writing a receipt everywhere and requiring one nowhere, so
+    KIPI_JUDGMENT_CAPTURE=0 or a hand-edited findings file left a hole no gate
+    could see. These pin the gate that closes it.
+    """
+
+    def _prd_ready_for_approval(self, repo: Path, run_findings_writer):
+        spec = repo / ".prd-os" / "prds" / f"{PRD_ID}.md"
+        text = spec.read_text().replace(
+            "status: in-review",
+            "status: in-review\ncodex_reviewed_at: 2026-08-04T00:00:00Z\n"
+            f"findings_path: .prd-os/findings/{PRD_ID}-findings.jsonl")
+        spec.write_text(text)
+
+    def test_receipt_gate_reports_a_missing_receipt(self, judgment_repo,
+                                                    run_findings_writer):
+        """Direct call: the gate's own predicate, without the PRD state machine."""
+        import importlib.util
+        spec = importlib.util.spec_from_file_location(
+            "jc_gate2", SCRIPTS_DIR / "judgment_compiler.py")
+        jc = importlib.util.module_from_spec(spec)
+        sys.modules["jc_gate2"] = jc
+        spec.loader.exec_module(jc)
+        assert run_findings_writer(
+            judgment_repo, "set-disposition", PRD_ID, "finding-1", "accepted",
+            env_extra={"KIPI_JUDGMENT_CAPTURE": "0"}).returncode == 0
+        cfg_spec = importlib.util.spec_from_file_location(
+            "jc_cfg", SCRIPTS_DIR / "config.py")
+        cfgmod = importlib.util.module_from_spec(cfg_spec)
+        sys.modules["jc_cfg"] = cfgmod
+        cfg_spec.loader.exec_module(cfgmod)
+        cfg = cfgmod.load(judgment_repo)
+        missing = jc.cross_check_findings(cfg, [], "2026-01-01T00:00:00Z")
+        assert any(PRD_ID in m for m in missing), missing
+        assert any("no judgment receipt" in m for m in missing)
+
+    def test_floor_exempts_pre_feature_dispositions(self, judgment_repo,
+                                                    run_findings_writer):
+        """A gate that cannot be satisfied gets switched off. Findings decided
+        before the compiler existed must not block approval forever."""
+        import importlib.util
+        spec = importlib.util.spec_from_file_location(
+            "jc_gate3", SCRIPTS_DIR / "judgment_compiler.py")
+        jc = importlib.util.module_from_spec(spec)
+        sys.modules["jc_gate3"] = jc
+        spec.loader.exec_module(jc)
+        cfg_spec = importlib.util.spec_from_file_location(
+            "jc_cfg3", SCRIPTS_DIR / "config.py")
+        cfgmod = importlib.util.module_from_spec(cfg_spec)
+        sys.modules["jc_cfg3"] = cfgmod
+        cfg_spec.loader.exec_module(cfgmod)
+        assert run_findings_writer(
+            judgment_repo, "set-disposition", PRD_ID, "finding-1", "accepted",
+            env_extra={"KIPI_JUDGMENT_CAPTURE": "0"}).returncode == 0
+        cfg = cfgmod.load(judgment_repo)
+        far_future = jc.cross_check_findings(cfg, [], "2099-01-01T00:00:00Z")
+        assert far_future == [], "floor did not exempt an older disposition"

--- a/plugins/prd-os/tests/test_judgment_compiler.py
+++ b/plugins/prd-os/tests/test_judgment_compiler.py
@@ -1578,3 +1578,25 @@ class TestDecisionFingerprint:
         proc = run_judgment(judgment_repo, "verify", "--cross-check",
                             "--since", "2026-01-01T00:00:00Z")
         assert proc.returncode == 0, proc.stderr
+
+
+class TestRedispositionWithoutNewRationale:
+    def test_rejected_to_accepted_without_rationale_stays_covered(
+            self, judgment_repo, run_findings_writer):
+        """Codex PR #101 r6, a regression from my own round-5 fingerprint fix:
+        findings_writer keeps the previous rationale on a re-disposition (only
+        `pending` clears it), so capturing the FLAG instead of the RECORD froze
+        None against a record that still had text, and the gate falsely blocked."""
+        assert run_findings_writer(
+            judgment_repo, "set-disposition", PRD_ID, "finding-1", "rejected",
+            "--rationale", "not a real defect",
+            "--reason-code", "invalid-finding").returncode == 0
+        assert run_findings_writer(judgment_repo, "set-disposition", PRD_ID,
+                                   "finding-1", "accepted").returncode == 0
+        proc = run_judgment(judgment_repo, "verify", "--cross-check",
+                            "--since", "2026-01-01T00:00:00Z")
+        assert proc.returncode == 0, proc.stderr
+        rec = read_ledger(judgment_repo)[-1]
+        assert rec["human"]["disposition"] == "accepted"
+        assert rec["human"]["rationale"] == "not a real defect", (
+            "the receipt must freeze the rationale the finding actually carries")

--- a/plugins/prd-os/tests/test_judgment_compiler.py
+++ b/plugins/prd-os/tests/test_judgment_compiler.py
@@ -1401,3 +1401,60 @@ class TestBakedIntoApproval:
         cfg = cfgmod.load(judgment_repo)
         far_future = jc.cross_check_findings(cfg, [], "2099-01-01T00:00:00Z")
         assert far_future == [], "floor did not exempt an older disposition"
+
+
+class TestReceiptGateFailsClosed:
+    """A REQUIRED integrity gate must refuse on doubt, not wave work through.
+
+    The first version caught every exception and returned 0, defended as 'a bug
+    in the check must not cause an approval outage'. That conflated a buggy gate
+    with a corrupt ledger -- and a corrupt ledger is exactly what this gate
+    exists to catch (Codex, PR #101).
+    """
+
+    def _runner(self):
+        import importlib.util
+        spec = importlib.util.spec_from_file_location(
+            "pr_gate", SCRIPTS_DIR / "prd_runner.py")
+        mod = importlib.util.module_from_spec(spec)
+        sys.modules["pr_gate"] = mod
+        spec.loader.exec_module(mod)
+        return mod
+
+    def test_unreadable_ledger_blocks_approval(self, monkeypatch):
+        runner = self._runner()
+        import judgment_compiler as jc
+
+        monkeypatch.setattr(jc, "ledger_path", lambda cfg: Path("/dev/null"))
+        def boom(_path):
+            raise ValueError("line 7: invalid JSON")
+        monkeypatch.setattr(jc, "read_ledger", boom)
+        code, message = runner._judgment_receipt_gate(object(), "prd-alpha")
+        assert code == 2, "a corrupt ledger must not let approval through"
+        assert "could not be checked" in message
+
+    def test_prefix_prd_id_does_not_cross_block(self, monkeypatch):
+        """`prd-alpha` must not be blocked by a gap belonging to
+        `prd-alpha-2`; substring matching did exactly that."""
+        runner = self._runner()
+        import judgment_compiler as jc
+
+        monkeypatch.setattr(jc, "ledger_path", lambda cfg: Path("/dev/null"))
+        monkeypatch.setattr(jc, "read_ledger", lambda p: [])
+        monkeypatch.setattr(jc, "cross_check_findings", lambda c, r, s: [
+            "prd-alpha-2/finding-1: dispositioned but no judgment receipt exists"])
+        assert runner._judgment_receipt_gate(object(), "prd-alpha")[0] == 0
+        assert runner._judgment_receipt_gate(object(), "prd-alpha-2")[0] == 2
+
+    def test_missing_compiler_is_the_only_fail_open(self, monkeypatch):
+        """An instance without the compiler has no contract to enforce."""
+        runner = self._runner()
+        real_import = __builtins__["__import__"] if isinstance(__builtins__, dict) \
+            else __builtins__.__import__
+
+        def no_compiler(name, *args, **kwargs):
+            if name == "judgment_compiler":
+                raise ImportError("not installed")
+            return real_import(name, *args, **kwargs)
+        monkeypatch.setattr("builtins.__import__", no_compiler)
+        assert runner._judgment_receipt_gate(object(), "prd-alpha") == (0, "")

--- a/plugins/prd-os/tests/test_judgment_compiler.py
+++ b/plugins/prd-os/tests/test_judgment_compiler.py
@@ -1441,6 +1441,9 @@ class TestReceiptGateFailsClosed:
 
         monkeypatch.setattr(jc, "ledger_path", lambda cfg: Path("/dev/null"))
         monkeypatch.setattr(jc, "read_ledger", lambda p: [])
+        monkeypatch.setattr(jc, "tip_path", lambda cfg: Path("/dev/null"))
+        monkeypatch.setattr(jc, "read_tip", lambda p: None)
+        monkeypatch.setattr(jc, "verify_ledger", lambda r, tip=None: [])
         monkeypatch.setattr(jc, "cross_check_findings", lambda c, r, s: [
             "prd-alpha-2/finding-1: dispositioned but no judgment receipt exists"])
         assert runner._judgment_receipt_gate(object(), "prd-alpha")[0] == 0
@@ -1501,3 +1504,33 @@ class TestGateChecksTheDecisionNotJustTheFinding:
         proc = run_judgment(judgment_repo, "verify", "--cross-check",
                             "--since", "2026-01-01T00:00:00Z")
         assert proc.returncode == 0, proc.stderr
+
+
+class TestGateVerifiesBeforeTrusting:
+    def test_forged_receipt_does_not_authorize_approval(self, judgment_repo,
+                                                        run_findings_writer):
+        """Codex PR #101 r3: the gate parsed receipts but never verified the
+        chain, so a hand-appended receipt with the right ids authorized
+        approval. A hash chain no consumer checks is decoration."""
+        assert run_findings_writer(judgment_repo, "set-disposition", PRD_ID,
+                                   "finding-1", "accepted").returncode == 0
+        path = judgment_repo / ".prd-os" / "judgments.jsonl"
+        real = read_ledger(judgment_repo)[0]
+        forged = json.loads(json.dumps(real))
+        forged["finding"]["finding_id"] = "finding-2"
+        forged["prev_receipt_sha256"] = "0" * 64          # chain broken
+        path.write_text(path.read_text() + json.dumps(
+            forged, sort_keys=True, separators=(",", ":"),
+            ensure_ascii=False) + "\n")
+        assert run_judgment(judgment_repo, "verify").returncode == 2
+        import importlib.util
+        spec = importlib.util.spec_from_file_location(
+            "pr_gate_v", SCRIPTS_DIR / "prd_runner.py")
+        runner = importlib.util.module_from_spec(spec)
+        sys.modules["pr_gate_v"] = runner
+        spec.loader.exec_module(runner)
+        import config as cfgmod
+        cfg = cfgmod.load(judgment_repo)
+        code, message = runner._judgment_receipt_gate(cfg, PRD_ID)
+        assert code == 2, "a forged receipt authorized approval"
+        assert "does not verify" in message

--- a/plugins/prd-os/tests/test_judgment_compiler.py
+++ b/plugins/prd-os/tests/test_judgment_compiler.py
@@ -1600,3 +1600,41 @@ class TestRedispositionWithoutNewRationale:
         assert rec["human"]["disposition"] == "accepted"
         assert rec["human"]["rationale"] == "not a real defect", (
             "the receipt must freeze the rationale the finding actually carries")
+
+
+class TestFloorDoesNotShieldAConflict:
+    def test_finding_without_resolved_at_still_compared_when_a_receipt_exists(
+            self, judgment_repo, run_findings_writer):
+        """Codex PR #101 r7: '' sorts before every timestamp, so a dispositioned
+        finding with no resolved_at was skipped by the floor even when its
+        receipt disagreed. The floor exempts findings that CANNOT have a
+        receipt; one that has a receipt is not in that category."""
+        assert run_findings_writer(judgment_repo, "set-disposition", PRD_ID,
+                                   "finding-1", "accepted").returncode == 0
+        path = (judgment_repo / ".prd-os" / "findings"
+                / f"{PRD_ID}-findings.jsonl")
+        rows = [json.loads(l) for l in path.read_text().splitlines() if l.strip()]
+        rows[0]["disposition"] = "rejected"     # conflicts with the receipt
+        rows[0]["rationale"] = "changed offline"
+        rows[0].pop("resolved_at", None)        # ...and is undateable
+        path.write_text("".join(json.dumps(r, sort_keys=True) + "\n" for r in rows))
+        proc = run_judgment(judgment_repo, "verify", "--cross-check",
+                            "--since", "2099-01-01T00:00:00Z")
+        assert proc.returncode == 2, "a far-future floor hid a real conflict"
+        assert "never captured" in proc.stderr
+
+    def test_undateable_and_unclaimed_finding_is_still_exempt(
+            self, judgment_repo, run_findings_writer):
+        """No receipt and no date: genuinely pre-feature. Must stay exempt, or
+        every legacy PRD blocks forever and the gate gets switched off."""
+        assert run_findings_writer(
+            judgment_repo, "set-disposition", PRD_ID, "finding-1", "accepted",
+            env_extra={"KIPI_JUDGMENT_CAPTURE": "0"}).returncode == 0
+        path = (judgment_repo / ".prd-os" / "findings"
+                / f"{PRD_ID}-findings.jsonl")
+        rows = [json.loads(l) for l in path.read_text().splitlines() if l.strip()]
+        rows[0].pop("resolved_at", None)
+        path.write_text("".join(json.dumps(r, sort_keys=True) + "\n" for r in rows))
+        proc = run_judgment(judgment_repo, "verify", "--cross-check",
+                            "--since", "2099-01-01T00:00:00Z")
+        assert proc.returncode == 0, proc.stderr

--- a/plugins/prd-os/tests/test_judgment_compiler.py
+++ b/plugins/prd-os/tests/test_judgment_compiler.py
@@ -1458,3 +1458,46 @@ class TestReceiptGateFailsClosed:
             return real_import(name, *args, **kwargs)
         monkeypatch.setattr("builtins.__import__", no_compiler)
         assert runner._judgment_receipt_gate(object(), "prd-alpha") == (0, "")
+
+
+class TestGateChecksTheDecisionNotJustTheFinding:
+    def test_hand_edited_disposition_is_caught(self, judgment_repo,
+                                               run_findings_writer):
+        """Codex PR #101 r2: coverage was identity-only, so a receipt for an
+        EARLIER decision satisfied the gate after the findings file was edited
+        to a different one -- the decision actually recorded had none."""
+        assert run_findings_writer(judgment_repo, "set-disposition", PRD_ID,
+                                   "finding-1", "accepted").returncode == 0
+        assert len(read_ledger(judgment_repo)) == 1
+        path = (judgment_repo / ".prd-os" / "findings"
+                / f"{PRD_ID}-findings.jsonl")
+        rows = [json.loads(l) for l in path.read_text().splitlines() if l.strip()]
+        rows[0]["disposition"] = "rejected"      # hand-edit, no capture
+        rows[0]["rationale"] = "changed my mind offline"
+        path.write_text("".join(json.dumps(r, sort_keys=True) + "\n" for r in rows))
+        proc = run_judgment(judgment_repo, "verify", "--cross-check",
+                            "--since", "2026-01-01T00:00:00Z")
+        assert proc.returncode == 2
+        assert "never captured" in proc.stderr
+
+    def test_matching_disposition_passes(self, judgment_repo,
+                                         run_findings_writer):
+        assert run_findings_writer(judgment_repo, "set-disposition", PRD_ID,
+                                   "finding-1", "accepted").returncode == 0
+        proc = run_judgment(judgment_repo, "verify", "--cross-check",
+                            "--since", "2026-01-01T00:00:00Z")
+        assert proc.returncode == 0, proc.stderr
+
+    def test_redisposition_through_the_writer_stays_covered(
+            self, judgment_repo, run_findings_writer):
+        """A legitimate change of mind captures a superseding receipt, so the
+        latest receipt matches and the gate stays green."""
+        assert run_findings_writer(judgment_repo, "set-disposition", PRD_ID,
+                                   "finding-1", "accepted").returncode == 0
+        assert run_findings_writer(
+            judgment_repo, "set-disposition", PRD_ID, "finding-1", "rejected",
+            "--rationale", "reconsidered", "--reason-code",
+            "invalid-finding").returncode == 0
+        proc = run_judgment(judgment_repo, "verify", "--cross-check",
+                            "--since", "2026-01-01T00:00:00Z")
+        assert proc.returncode == 0, proc.stderr

--- a/plugins/prd-os/tests/test_judgment_compiler.py
+++ b/plugins/prd-os/tests/test_judgment_compiler.py
@@ -1426,6 +1426,9 @@ class TestReceiptGateFailsClosed:
         import judgment_compiler as jc
 
         monkeypatch.setattr(jc, "ledger_path", lambda cfg: Path("/dev/null"))
+        import contextlib
+        monkeypatch.setattr(jc, "ledger_lock",
+                            lambda cfg: contextlib.nullcontext())
         def boom(_path):
             raise ValueError("line 7: invalid JSON")
         monkeypatch.setattr(jc, "read_ledger", boom)
@@ -1444,6 +1447,10 @@ class TestReceiptGateFailsClosed:
         monkeypatch.setattr(jc, "tip_path", lambda cfg: Path("/dev/null"))
         monkeypatch.setattr(jc, "read_tip", lambda p: None)
         monkeypatch.setattr(jc, "verify_ledger", lambda r, tip=None: [])
+        # the gate now reads under the writer's lock; a stub cfg has no path
+        import contextlib
+        monkeypatch.setattr(jc, "ledger_lock",
+                            lambda cfg: contextlib.nullcontext())
         monkeypatch.setattr(jc, "cross_check_findings", lambda c, r, s: [
             "prd-alpha-2/finding-1: dispositioned but no judgment receipt exists"])
         assert runner._judgment_receipt_gate(object(), "prd-alpha")[0] == 0

--- a/plugins/prd-os/tests/test_judgment_compiler.py
+++ b/plugins/prd-os/tests/test_judgment_compiler.py
@@ -1541,3 +1541,40 @@ class TestGateVerifiesBeforeTrusting:
         code, message = runner._judgment_receipt_gate(cfg, PRD_ID)
         assert code == 2, "a forged receipt authorized approval"
         assert "does not verify" in message
+
+
+class TestDecisionFingerprint:
+    """Rounds 2-5 of PR #101 each found a different unchecked field. One
+    fingerprint, used on both sides, closes the class rather than the instance."""
+
+    def test_hand_edited_rationale_is_caught(self, judgment_repo,
+                                             run_findings_writer):
+        assert run_findings_writer(
+            judgment_repo, "set-disposition", PRD_ID, "finding-1", "rejected",
+            "--rationale", "duplicate of finding-9",
+            "--reason-code", "invalid-finding").returncode == 0
+        path = (judgment_repo / ".prd-os" / "findings"
+                / f"{PRD_ID}-findings.jsonl")
+        rows = [json.loads(l) for l in path.read_text().splitlines() if l.strip()]
+        rows[0]["rationale"] = "actually it was a security hole"  # rewritten
+        path.write_text("".join(json.dumps(r, sort_keys=True) + "\n" for r in rows))
+        proc = run_judgment(judgment_repo, "verify", "--cross-check",
+                            "--since", "2026-01-01T00:00:00Z")
+        assert proc.returncode == 2
+        assert "never captured" in proc.stderr
+
+    def test_empty_vs_absent_rationale_is_not_a_change(self, judgment_repo,
+                                                       run_findings_writer):
+        """The writer stores None for an empty rationale; a findings record may
+        omit the key. That difference must not read as tampering."""
+        assert run_findings_writer(judgment_repo, "set-disposition", PRD_ID,
+                                   "finding-1", "accepted").returncode == 0
+        path = (judgment_repo / ".prd-os" / "findings"
+                / f"{PRD_ID}-findings.jsonl")
+        rows = [json.loads(l) for l in path.read_text().splitlines() if l.strip()]
+        rows[0].pop("rationale", None)
+        rows[0]["rationale"] = ""
+        path.write_text("".join(json.dumps(r, sort_keys=True) + "\n" for r in rows))
+        proc = run_judgment(judgment_repo, "verify", "--cross-check",
+                            "--since", "2026-01-01T00:00:00Z")
+        assert proc.returncode == 0, proc.stderr

--- a/q-system/.q-system/scripts/founder-judge-calibration.py
+++ b/q-system/.q-system/scripts/founder-judge-calibration.py
@@ -392,8 +392,13 @@ def _precision_gloss(result: dict) -> str:
     metrics beside it is worse than no report.
     """
     precision = result["per_label"]["accepted"]["precision"]
+    # Boundary matters: at exactly 0.5 neither "more than half rejected" nor
+    # "most accepted" is true, and the old split reported 50% as "Most",
+    # contradicting the number beside it (Codex, PR #100 minors).
     if precision < 0.5:
         return "More than half of the judge's fix-now calls were not accepted."
+    if precision == 0.5:
+        return "Exactly half of the judge's fix-now calls were accepted."
     if precision < 1.0:
         return "Most of the judge's fix-now calls were accepted."
     return "Every fix-now call the judge made was accepted."


### PR DESCRIPTION
## The bake-in gap

The founder asked whether the Judgment Compiler is actually baked into prd-os. It was not. It **wrote** a receipt on every triage and **required** one nowhere, so `KIPI_JUDGMENT_CAPTURE=0`, a hand-edited findings file, or an ignored capture failure each left a silent hole. A ledger with unnoticed holes cannot be the calibration set it exists to be.

`_judgment_receipt_gate` now blocks `advance approved` when a finding dispositioned since `JUDGMENT_RECEIPT_FLOOR` has no receipt.

**The floor is load-bearing, not a loophole.** ~342 findings were adjudicated before the compiler existed and can never have receipts. Requiring them would block every pre-existing PRD forever, and a gate that cannot be satisfied gets switched off — which protects nothing. The rule binds only decisions made after the feature landed. Tested in both directions: a post-floor disposition with no receipt is reported; a pre-floor one is exempt.

The gate also fails **open** on its own error (`except Exception -> return 0`), deliberately: a bug in the receipt check must not become an unrelated approval outage.

## Disk

`cargo clean` on the accountant's `src-tauri` freed **16.6 GiB** — 15Gi to 23Gi free, 92% to 88%. That target tree is gitignored and regenerable, so this is a cache, not content.

Separately, the dry-run model no longer rsyncs build caches at all (`target/`, `node_modules/`, `.venv/`, …). Copying them is what manufactured a false `FAILED` for that instance out of disk pressure alone, while the real run had updated it fine (`sp-b2f16971`).

## Review minors closed

- Spillover evidence refs were substring-matched against the whole row, so an id quoted inside a *description* resolved as if it were the item. Now id-matched (`sp-fcb3573e`).
- Exactly-50% accepted precision reported as "Most", contradicting the number printed beside it.

## Verification

436 prd-os tests pass. `founder-judge-calibration --selftest` passes. Disk numbers above are measured before/after, not estimated.

Linear: ASK-363.

🤖 Generated with [Claude Code](https://claude.com/claude-code)