### PR TITLE
Judgment receipts: required at approval (integrity), reported on drift (ASK-363)

### DIFF
--- a/kipi-update.sh
+++ b/kipi-update.sh
@@ -235,7 +235,18 @@ model_rsync_excludes() {
   # the projection cannot be built against a stale or unpopulated list. The
   # scan is cached per root, so this costs nothing on the second call.
   model_skip_scan "$instance_root"
+  # BUILD CACHES ARE NOT STATE. The model exists to preview what the skeleton
+  # sync would do, and the sync never touches these -- copying them is pure
+  # cost. Measured 2026-08-04: the accountant instance carried an 8.7G
+  # src-tauri/target tree, the copy hit "No space left on device" at 92% disk,
+  # and the instance reported FAILED in --dry while the real run had updated it
+  # fine. So --dry manufactured a false failure out of disk pressure alone.
+  # Every path here is regenerable by its own toolchain and gitignored.
   MODEL_EXCLUDES=(--exclude=".git")
+  local cache_dir
+  for cache_dir in target node_modules .venv venv __pycache__ .next dist build .pytest_cache .mypy_cache .ruff_cache; do
+    MODEL_EXCLUDES+=(--exclude="$cache_dir/")
+  done
   for nested_rel in ${MODEL_SKIPPED_PATHS[@]+"${MODEL_SKIPPED_PATHS[@]}"}; do
     MODEL_EXCLUDES+=(--exclude="/$nested_rel/")
   done

--- a/plugins/prd-os/.claude-plugin/plugin.json
+++ b/plugins/prd-os/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "prd-os",
-  "version": "0.13.3",
+  "version": "0.13.4",
   "description": "PRD operating system: capture rough ideas, draft reviewable PRDs, run standard and adversarial review (Codex or a Claude senior-staff-engineer subagent, recorded truthfully), triage findings, decompose approved PRDs into atomic issue specs, and execute those issues with scope enforcement, stop-gate receipts, and reviewer-attributed findings.",
   "author": {
     "name": "Assaf Kipnis"

--- a/plugins/prd-os/.claude-plugin/plugin.json
+++ b/plugins/prd-os/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "prd-os",
-  "version": "0.13.7",
+  "version": "0.14.0",
   "description": "PRD operating system: capture rough ideas, draft reviewable PRDs, run standard and adversarial review (Codex or a Claude senior-staff-engineer subagent, recorded truthfully), triage findings, decompose approved PRDs into atomic issue specs, and execute those issues with scope enforcement, stop-gate receipts, and reviewer-attributed findings.",
   "author": {
     "name": "Assaf Kipnis"

--- a/plugins/prd-os/.claude-plugin/plugin.json
+++ b/plugins/prd-os/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "prd-os",
-  "version": "0.13.2",
+  "version": "0.13.3",
   "description": "PRD operating system: capture rough ideas, draft reviewable PRDs, run standard and adversarial review (Codex or a Claude senior-staff-engineer subagent, recorded truthfully), triage findings, decompose approved PRDs into atomic issue specs, and execute those issues with scope enforcement, stop-gate receipts, and reviewer-attributed findings.",
   "author": {
     "name": "Assaf Kipnis"

--- a/plugins/prd-os/.claude-plugin/plugin.json
+++ b/plugins/prd-os/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "prd-os",
-  "version": "0.14.1",
+  "version": "0.14.2",
   "description": "PRD operating system: capture rough ideas, draft reviewable PRDs, run standard and adversarial review (Codex or a Claude senior-staff-engineer subagent, recorded truthfully), triage findings, decompose approved PRDs into atomic issue specs, and execute those issues with scope enforcement, stop-gate receipts, and reviewer-attributed findings.",
   "author": {
     "name": "Assaf Kipnis"

--- a/plugins/prd-os/.claude-plugin/plugin.json
+++ b/plugins/prd-os/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "prd-os",
-  "version": "0.13.6",
+  "version": "0.13.7",
   "description": "PRD operating system: capture rough ideas, draft reviewable PRDs, run standard and adversarial review (Codex or a Claude senior-staff-engineer subagent, recorded truthfully), triage findings, decompose approved PRDs into atomic issue specs, and execute those issues with scope enforcement, stop-gate receipts, and reviewer-attributed findings.",
   "author": {
     "name": "Assaf Kipnis"

--- a/plugins/prd-os/.claude-plugin/plugin.json
+++ b/plugins/prd-os/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "prd-os",
-  "version": "0.13.1",
+  "version": "0.13.2",
   "description": "PRD operating system: capture rough ideas, draft reviewable PRDs, run standard and adversarial review (Codex or a Claude senior-staff-engineer subagent, recorded truthfully), triage findings, decompose approved PRDs into atomic issue specs, and execute those issues with scope enforcement, stop-gate receipts, and reviewer-attributed findings.",
   "author": {
     "name": "Assaf Kipnis"

--- a/plugins/prd-os/.claude-plugin/plugin.json
+++ b/plugins/prd-os/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "prd-os",
-  "version": "0.14.0",
+  "version": "0.14.1",
   "description": "PRD operating system: capture rough ideas, draft reviewable PRDs, run standard and adversarial review (Codex or a Claude senior-staff-engineer subagent, recorded truthfully), triage findings, decompose approved PRDs into atomic issue specs, and execute those issues with scope enforcement, stop-gate receipts, and reviewer-attributed findings.",
   "author": {
     "name": "Assaf Kipnis"

--- a/plugins/prd-os/.claude-plugin/plugin.json
+++ b/plugins/prd-os/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "prd-os",
-  "version": "0.13.4",
+  "version": "0.13.5",
   "description": "PRD operating system: capture rough ideas, draft reviewable PRDs, run standard and adversarial review (Codex or a Claude senior-staff-engineer subagent, recorded truthfully), triage findings, decompose approved PRDs into atomic issue specs, and execute those issues with scope enforcement, stop-gate receipts, and reviewer-attributed findings.",
   "author": {
     "name": "Assaf Kipnis"

--- a/plugins/prd-os/.claude-plugin/plugin.json
+++ b/plugins/prd-os/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "prd-os",
-  "version": "0.13.5",
+  "version": "0.13.6",
   "description": "PRD operating system: capture rough ideas, draft reviewable PRDs, run standard and adversarial review (Codex or a Claude senior-staff-engineer subagent, recorded truthfully), triage findings, decompose approved PRDs into atomic issue specs, and execute those issues with scope enforcement, stop-gate receipts, and reviewer-attributed findings.",
   "author": {
     "name": "Assaf Kipnis"

--- a/plugins/prd-os/.claude-plugin/plugin.json
+++ b/plugins/prd-os/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "prd-os",
-  "version": "0.12.0",
+  "version": "0.13.0",
   "description": "PRD operating system: capture rough ideas, draft reviewable PRDs, run standard and adversarial review (Codex or a Claude senior-staff-engineer subagent, recorded truthfully), triage findings, decompose approved PRDs into atomic issue specs, and execute those issues with scope enforcement, stop-gate receipts, and reviewer-attributed findings.",
   "author": {
     "name": "Assaf Kipnis"

--- a/plugins/prd-os/.claude-plugin/plugin.json
+++ b/plugins/prd-os/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "prd-os",
-  "version": "0.13.0",
+  "version": "0.13.1",
   "description": "PRD operating system: capture rough ideas, draft reviewable PRDs, run standard and adversarial review (Codex or a Claude senior-staff-engineer subagent, recorded truthfully), triage findings, decompose approved PRDs into atomic issue specs, and execute those issues with scope enforcement, stop-gate receipts, and reviewer-attributed findings.",
   "author": {
     "name": "Assaf Kipnis"

--- a/plugins/prd-os/CHANGELOG.md
+++ b/plugins/prd-os/CHANGELOG.md
@@ -2,6 +2,16 @@
 
 All notable changes to the `prd-os` plugin are recorded here. Format follows [Keep a Changelog](https://keepachangelog.com/en/1.1.0/). Versions follow semantic versioning; see `README.md` for the bump policy and the distinction between plugin version and config schema version.
 
+## [0.13.2] - 2026-08-04
+
+### Fixed (Codex review, PR #101 round 2)
+- **A receipt for an EARLIER decision satisfied the gate.** Coverage was
+  identity-only `(prd_id, finding_id)`, so hand-editing the findings file to a
+  different disposition left the stale receipt standing in for a decision that
+  was never captured -- and approval passed. The check now compares the
+  finding's current disposition against the latest human-bearing receipt, and
+  says so specifically when they disagree.
+
 ## [0.13.1] - 2026-08-04
 
 ### Fixed (Codex review, PR #101)

--- a/plugins/prd-os/CHANGELOG.md
+++ b/plugins/prd-os/CHANGELOG.md
@@ -2,6 +2,18 @@
 
 All notable changes to the `prd-os` plugin are recorded here. Format follows [Keep a Changelog](https://keepachangelog.com/en/1.1.0/). Versions follow semantic versioning; see `README.md` for the bump policy and the distinction between plugin version and config schema version.
 
+## [0.13.1] - 2026-08-04
+
+### Fixed (Codex review, PR #101)
+- **The required receipt gate failed OPEN on an unreadable ledger.** It caught
+  every exception and returned 0, defended in the PR body as "a bug in the check
+  must not cause an approval outage". That conflated a buggy gate with a corrupt
+  ledger, and a corrupt or truncated ledger is precisely the integrity failure
+  the gate exists to catch. It now fails CLOSED on any read error; the only
+  fail-open case left is the compiler not being installed at all.
+- Substring matching let a missing receipt for `prd-alpha-2` block approval of
+  `prd-alpha`. Now an exact `<prd_id>/` prefix match.
+
 ## [0.13.0] - 2026-08-04
 
 ### Added

--- a/plugins/prd-os/CHANGELOG.md
+++ b/plugins/prd-os/CHANGELOG.md
@@ -2,6 +2,16 @@
 
 All notable changes to the `prd-os` plugin are recorded here. Format follows [Keep a Changelog](https://keepachangelog.com/en/1.1.0/). Versions follow semantic versioning; see `README.md` for the bump policy and the distinction between plugin version and config schema version.
 
+## [0.13.4] - 2026-08-04
+
+### Fixed (Codex review, PR #101 round 4)
+- **The approval gate read the ledger without the writer's lock.** capture
+  appends the receipt and then writes the tip; observed between those two the
+  ledger holds N+1 records against a tip of N, which the new chain check calls
+  "receipts BEYOND the tip anchor" and blocks approval over a concurrent capture
+  that was perfectly fine. The writer got a lock in 0.12.0 and the reader never
+  did. Ledger and tip are now read together under `ledger_lock`.
+
 ## [0.13.3] - 2026-08-04
 
 ### Fixed (Codex review, PR #101 round 3)

--- a/plugins/prd-os/CHANGELOG.md
+++ b/plugins/prd-os/CHANGELOG.md
@@ -2,6 +2,29 @@
 
 All notable changes to the `prd-os` plugin are recorded here. Format follows [Keep a Changelog](https://keepachangelog.com/en/1.1.0/). Versions follow semantic versioning; see `README.md` for the bump policy and the distinction between plugin version and config schema version.
 
+## [0.14.1] - 2026-08-04
+
+### Fixed (review of PR #102) — the date class had RELOCATED, not died
+`_prd_predates_floor` matched a date-SHAPED suffix and then string-compared it,
+so `prd-evade-0000-00-00` and `prd-evade-1970-01-01` each bought a free
+exemption from the receipt requirement. That is precisely the defect 0.14.0
+claimed to kill: the floor moved off `resolved_at` because a strippable field
+handed out a free pass, and a suffix no calendar can produce handed out the same
+pass through the new mechanism. 0.14.0's own docstring made the argument against
+it ("the alternative is the same hole in a new shape") and then did not apply it.
+
+The suffix is now parsed with `strptime` AND checked against a plausibility
+floor, both failing closed. `strptime` alone is insufficient: `1970-01-01`
+parses perfectly. The bound (2026-01-01) is MEASURED, not guessed — the 36
+prd_ids under `.prd-os/findings/` span 2026-05-13 to 2026-08-04, so it sits
+months before the earliest real PRD and cannot false-block one.
+
+Regression is table-driven so the next relocation of this class is caught by an
+existing check rather than by review. Two of its rows (`2026-02-30`,
+`2026-06-31`) exist only because a mutation run showed the real-date guard could
+be deleted with every other row still green: the plausibility floor happens to
+subsume `0000-00-00`, and string ordering happens to subsume `2026-13-45`.
+
 ## [0.14.0] - 2026-08-04
 
 ### Changed — PR #101 split: the integrity half is required, the agreement half warns

--- a/plugins/prd-os/CHANGELOG.md
+++ b/plugins/prd-os/CHANGELOG.md
@@ -2,6 +2,16 @@
 
 All notable changes to the `prd-os` plugin are recorded here. Format follows [Keep a Changelog](https://keepachangelog.com/en/1.1.0/). Versions follow semantic versioning; see `README.md` for the bump policy and the distinction between plugin version and config schema version.
 
+## [0.13.6] - 2026-08-04
+
+### Fixed (Codex review, PR #101 round 6) — a regression from round 5
+- Re-dispositioning rejected -> accepted without a new `--rationale` falsely
+  blocked approval. findings_writer keeps the previous rationale on the record
+  (only `pending` clears it), while the receipt captured the FLAG, which was
+  absent. The fingerprint added in 0.13.5 then correctly reported two different
+  decisions. The receipt now freezes the rationale the RECORD carries, which is
+  what a receipt is for.
+
 ## [0.13.5] - 2026-08-04
 
 ### Fixed (Codex review, PR #101 round 5) — closed as a CLASS

--- a/plugins/prd-os/CHANGELOG.md
+++ b/plugins/prd-os/CHANGELOG.md
@@ -2,6 +2,16 @@
 
 All notable changes to the `prd-os` plugin are recorded here. Format follows [Keep a Changelog](https://keepachangelog.com/en/1.1.0/). Versions follow semantic versioning; see `README.md` for the bump policy and the distinction between plugin version and config schema version.
 
+## [0.13.7] - 2026-08-04
+
+### Fixed (Codex review, PR #101 round 7)
+- The since-floor shielded real conflicts. `""` sorts before every timestamp, so
+  a dispositioned finding with no `resolved_at` was skipped even when its
+  receipt disagreed. The floor exists to exempt findings that CANNOT have a
+  receipt; one that HAS a receipt is not in that category, so the floor no
+  longer applies to it. A finding that is both undateable and unclaimed stays
+  exempt, or every legacy PRD blocks forever.
+
 ## [0.13.6] - 2026-08-04
 
 ### Fixed (Codex review, PR #101 round 6) — a regression from round 5

--- a/plugins/prd-os/CHANGELOG.md
+++ b/plugins/prd-os/CHANGELOG.md
@@ -2,6 +2,16 @@
 
 All notable changes to the `prd-os` plugin are recorded here. Format follows [Keep a Changelog](https://keepachangelog.com/en/1.1.0/). Versions follow semantic versioning; see `README.md` for the bump policy and the distinction between plugin version and config schema version.
 
+## [0.13.3] - 2026-08-04
+
+### Fixed (Codex review, PR #101 round 3)
+- **The approval gate trusted receipts it never verified.** It called
+  `read_ledger` (JSON parse only) and never `verify_ledger`, so a receipt
+  appended by hand -- correct prd_id, finding_id and disposition, broken chain
+  -- authorized approval. A hash chain no consumer checks is decoration, and
+  this gate is the consumer that matters. It now verifies the chain and tip
+  first and refuses on any integrity error.
+
 ## [0.13.2] - 2026-08-04
 
 ### Fixed (Codex review, PR #101 round 2)

--- a/plugins/prd-os/CHANGELOG.md
+++ b/plugins/prd-os/CHANGELOG.md
@@ -2,6 +2,23 @@
 
 All notable changes to the `prd-os` plugin are recorded here. Format follows [Keep a Changelog](https://keepachangelog.com/en/1.1.0/). Versions follow semantic versioning; see `README.md` for the bump policy and the distinction between plugin version and config schema version.
 
+## [0.13.0] - 2026-08-04
+
+### Added
+- **The Judgment Compiler is now REQUIRED, not just available.** It shipped
+  writing a receipt on every triage and requiring one nowhere, so
+  `KIPI_JUDGMENT_CAPTURE=0`, a hand-edited findings file, or an ignored capture
+  failure each left a hole no gate could see -- and a ledger with unnoticed
+  holes cannot be the calibration set it exists to be. `_judgment_receipt_gate`
+  now blocks `advance approved` when a finding dispositioned since
+  `JUDGMENT_RECEIPT_FLOOR` carries no receipt. The floor is the point: ~342
+  findings were adjudicated before the compiler existed and can never have
+  receipts, and a gate that cannot be satisfied gets switched off.
+
+### Fixed
+- Spillover evidence refs matched a value in ANY JSON field, so an id quoted
+  inside a description resolved as if it were the item (sp-fcb3573e).
+
 ## [0.12.0] - 2026-08-04
 
 ### Fixed (Codex review round 5, PR #97)

--- a/plugins/prd-os/CHANGELOG.md
+++ b/plugins/prd-os/CHANGELOG.md
@@ -2,6 +2,17 @@
 
 All notable changes to the `prd-os` plugin are recorded here. Format follows [Keep a Changelog](https://keepachangelog.com/en/1.1.0/). Versions follow semantic versioning; see `README.md` for the bump policy and the distinction between plugin version and config schema version.
 
+## [0.13.5] - 2026-08-04
+
+### Fixed (Codex review, PR #101 round 5) — closed as a CLASS
+- The coverage check compared `disposition` only, so a hand-edited `rationale`
+  passed as covered. Rounds 2-5 each found a different unchecked field
+  (identity only, then disposition, then rationale). Rather than patch a third
+  field, `_decision_fingerprint` is now the single definition of "the same
+  decision" and is applied to BOTH sides, so a newly frozen field cannot go
+  unchecked on one of them. Empty-vs-absent rationale is normalised, because
+  that difference is not a decision change and must not read as tampering.
+
 ## [0.13.4] - 2026-08-04
 
 ### Fixed (Codex review, PR #101 round 4)

--- a/plugins/prd-os/CHANGELOG.md
+++ b/plugins/prd-os/CHANGELOG.md
@@ -2,6 +2,38 @@
 
 All notable changes to the `prd-os` plugin are recorded here. Format follows [Keep a Changelog](https://keepachangelog.com/en/1.1.0/). Versions follow semantic versioning; see `README.md` for the bump policy and the distinction between plugin version and config schema version.
 
+## [0.14.2] - 2026-08-04
+
+### Fixed (Codex review, PR #102 round 2) — BLOCKER: the floor exempted the future
+A PRD-creation-date floor exempts every FUTURE decision on a pre-floor PRD, not
+just the legacy ones. 35 of the 36 real PRDs predate the floor, so the gate was a
+near-permanent no-op — the exact opposite of "receipts are required from here on".
+
+The signal was wrong, so the mechanism is deleted rather than hardened a third
+time. `_prd_predates_floor`, `_PRD_ID_DATE` and `_PRD_DATE_EARLIEST` are gone and
+the gate reads no date at all: this gate fires when a PRD is APPROVED, and a PRD
+being approved now is being decided now, whatever date its id carries. A test
+asserts none of those three names comes back, so the class is provably gone
+rather than merely unused.
+
+Measured before removing the exemption, because "a gate that cannot be satisfied
+gets switched off" is a real risk that deserved a number: of the 36 real PRDs, 21
+are archived and 13 approved and can never reach this gate again. Exactly ONE is
+still in-review, with 13 dispositioned findings, and its remedy is one
+`set-disposition` re-run per finding, which mints the receipt as a side effect.
+
+This retires the whole date-inference lineage: PR #101 rounds 2/7/8
+(`resolved_at`), 0.14.0 (prd-id date), 0.14.1 (date-shape hardening).
+
+### Fixed (Codex review, PR #102 round 2) — MAJOR: the lock did not span the check
+The gate read the ledger under `ledger_lock`, RELEASED it, and only then
+cross-checked the findings files. A concurrent, perfectly valid triage landing in
+that gap writes a disposition the stale ledger snapshot cannot see, so approval
+false-blocks on a missing receipt that does exist. The round-4 fix locked the
+read; the comparison needed the same span. Both now run inside one critical
+section. The paired test asserts `ledger_lock` depth > 0 at the moment
+`cross_check_findings` is called — re-entrancy makes that probe safe.
+
 ## [0.14.1] - 2026-08-04
 
 ### Fixed (review of PR #102) — the date class had RELOCATED, not died

--- a/plugins/prd-os/CHANGELOG.md
+++ b/plugins/prd-os/CHANGELOG.md
@@ -2,6 +2,58 @@
 
 All notable changes to the `prd-os` plugin are recorded here. Format follows [Keep a Changelog](https://keepachangelog.com/en/1.1.0/). Versions follow semantic versioning; see `README.md` for the bump policy and the distinction between plugin version and config schema version.
 
+## [0.14.0] - 2026-08-04
+
+### Changed — PR #101 split: the integrity half is required, the agreement half warns
+PR #101 took 7 Codex review rounds and rounds 7 and 8 were regressions caused by
+the round-6 fix. The 8 rounds partition cleanly, so the PR was split rather than
+patched a ninth time.
+
+- **Kept as blocking (rounds 1-5, integrity).** Fail closed on an unreadable
+  ledger, exact `prd_id` prefix match, verify the chain before trusting a
+  receipt, and read under the writer's lock. Four defects, zero self-inflicted
+  regressions. These protect the calibration set: `cmd_evaluate` reads ONLY the
+  ledger, so a missing receipt is a permanent invisible hole in it.
+- **Demoted to a warning (rounds 6-8, field agreement).** `_decision_fingerprint`
+  compared the MUTABLE findings file against the IMMUTABLE receipt. It caused two
+  of its own regressions, and three of its four tests existed to stop it blocking
+  legitimate work rather than to catch a real threat. When the two disagree the
+  receipt is still the honest record, so `advance approved` now prints a warning
+  and does not block. A gate that false-blocks gets switched off, and an off gate
+  protects nothing.
+- **`evaluate` reports `decision_disagreement_count`** and gates on it
+  (`zero_decision_disagreements`). The demotion is not a silent drop: blocking a
+  human's approval over drift is a false block, blocking AUTOMATION over it is
+  the right severity. Same shape as 41c0876, which made the release gates read
+  the evidence-gate bypass rate.
+
+### Fixed — the date-inference defect class, killed by construction
+Rounds 2, 7 and 8 were ONE defect: inferring "was this decided after the floor"
+from `resolved_at`, a mutable strippable field on a hand-editable file. The
+round-8 code admitted the inference was undecidable ("undateable AND unclaimed:
+cannot judge, do not guess") and left a documented hole — switch capture off,
+strip the date, and the missing receipt is invisible.
+
+The gate runs at `advance approved` for ONE named PRD, and PRD ids carry their
+creation date. So the floor is now read from the PRD id and no `resolved_at` is
+parsed at all: a PRD dated at or after the floor requires a receipt for every
+dispositioned finding, unconditionally; a PRD predating the floor is exempt
+(pre-compiler decisions can never have receipts). Nothing enforces a prd_id
+format, so an id whose date cannot be parsed FAILS CLOSED. `verify --cross-check`
+is unchanged and still reports both classes as errors — it is a diagnostic and
+stays maximally informative.
+
+### Fixed — the persist path is one critical section (sp-0c725cde)
+A defect in merged code, not only in #101. `_write_all` published the disposition
+and only afterwards did `capture_from_triage` take `ledger_lock` internally. The
+approval gate reads the ledger under that lock, so a gate landing in the gap saw
+a dispositioned finding with no receipt and false-blocked. Reproduced with an
+out-of-process observer that acquired the lock mid-persist and reported
+`dispositioned=1 receipts=0`. `ledger_lock` is now re-entrant per thread (flock
+keys on the open file description, so a nested acquire on a second fd deadlocks
+the caller against itself — measured) and findings_writer holds it across the
+findings write and the capture. Spillover still fans out after the receipt lands.
+
 ## [0.13.7] - 2026-08-04
 
 ### Fixed (Codex review, PR #101 round 7)

--- a/plugins/prd-os/scripts/findings_writer.py
+++ b/plugins/prd-os/scripts/findings_writer.py
@@ -572,7 +572,14 @@ def cmd_set_disposition(cfg: Config, args: argparse.Namespace) -> int:  # noqa: 
                 actor=getattr(args, "actor", "founder"),
                 reason_code=getattr(args, "reason_code", None),
                 evidence_refs=list(getattr(args, "evidence", [])),
-                rationale=(args.rationale or "").strip() or None,
+                # Freeze what the RECORD says, not what the flag said. A
+                # re-disposition to accepted passes no --rationale while the
+                # record keeps its previous one (only `pending` clears it), so
+                # reading the flag captured None against a record that still had
+                # text -- and the decision fingerprint then falsely reported the
+                # decision as uncaptured (Codex, PR #101 round 6: a regression
+                # from the round-5 fingerprint fix).
+                rationale=(target.get("rationale") or "").strip() or None,
                 judge_run_path=getattr(args, "judge_run", None),
             )
         except (judgment_compiler.ValidationError, OSError) as exc:

--- a/plugins/prd-os/scripts/findings_writer.py
+++ b/plugins/prd-os/scripts/findings_writer.py
@@ -556,43 +556,64 @@ def cmd_set_disposition(cfg: Config, args: argparse.Namespace) -> int:  # noqa: 
     # exact divergence `verify --cross-check` exists to detect, manufactured by
     # our own primary write path (review 2026-08-04).
     pre_findings_bytes = path.read_bytes() if path.is_file() else None
-    _write_all(path, recs)
+    # ONE critical section over the findings write AND the receipt (sp-0c725cde,
+    # a defect in merged code). Previously `_write_all` published the
+    # disposition and only then did capture_from_triage take `ledger_lock`
+    # internally. The approval gate reads the ledger UNDER that lock (PR #101
+    # round 4), so a gate landing in the gap saw a dispositioned finding with no
+    # receipt and false-blocked work that was completing normally. Reproduced
+    # with an out-of-process observer that acquired the lock mid-persist and
+    # reported `dispositioned=1 receipts=0`. `ledger_lock` is re-entrant per
+    # thread precisely so the capture below can take it again.
+    import contextlib
+
+    if judgment_enabled:
+        import judgment_compiler
+
+        persist_lock = judgment_compiler.ledger_lock(cfg)
+    else:
+        # No receipt is coming, so there is no window to close and no reason to
+        # serialise unrelated triage on the shared ledger lock.
+        persist_lock = contextlib.nullcontext()
+    with persist_lock:
+        _write_all(path, recs)
+        # INSIDE the lock, with the write above: that pairing is the whole
+        # point of the critical section. The receipt still lands before
+        # spillover fans out, which stays OUTSIDE the lock below.
+        if judgment_enabled:
+            try:
+                judgment_compiler.capture_from_triage(
+                    cfg, args.prd_id, target,
+                    actor=getattr(args, "actor", "founder"),
+                    reason_code=getattr(args, "reason_code", None),
+                    evidence_refs=list(getattr(args, "evidence", [])),
+                    # Freeze what the RECORD says, not what the flag said. A
+                    # re-disposition to accepted passes no --rationale while the
+                    # record keeps its previous one (only `pending` clears it), so
+                    # reading the flag captured None against a record that still had
+                    # text -- and the decision fingerprint then falsely reported the
+                    # decision as uncaptured (Codex, PR #101 round 6: a regression
+                    # from the round-5 fingerprint fix).
+                    rationale=(target.get("rationale") or "").strip() or None,
+                    judge_run_path=getattr(args, "judge_run", None),
+                )
+            except (judgment_compiler.ValidationError, OSError) as exc:
+                rolled_back = _rollback_findings(path, pre_findings_bytes)
+                sys.stderr.write(
+                    f"judgment receipt refused: {exc}\n"
+                    + ("disposition rolled back; findings file unchanged.\n"
+                       if rolled_back else
+                       "WARNING: rollback ALSO failed. The findings file may now "
+                       "disagree with the judgment ledger; run "
+                       "`kipi judgment verify --cross-check` before trusting it.\n")
+                )
+                return 2
     # Spillover fans out AFTER the receipt lands, not before. Ordered the other
     # way, a refused receipt rolled the findings file back while the spillover
     # append stood — and that ledger is append-only, so the standing gate saw
     # permanent open work for a disposition the command had just reported as
     # rolled back (Codex review, PR #97, executed reproducer). The receipt is
     # the failure-prone step, so it goes first among the two irreversible ones.
-    if judgment_enabled:
-        import judgment_compiler
-
-        try:
-            judgment_compiler.capture_from_triage(
-                cfg, args.prd_id, target,
-                actor=getattr(args, "actor", "founder"),
-                reason_code=getattr(args, "reason_code", None),
-                evidence_refs=list(getattr(args, "evidence", [])),
-                # Freeze what the RECORD says, not what the flag said. A
-                # re-disposition to accepted passes no --rationale while the
-                # record keeps its previous one (only `pending` clears it), so
-                # reading the flag captured None against a record that still had
-                # text -- and the decision fingerprint then falsely reported the
-                # decision as uncaptured (Codex, PR #101 round 6: a regression
-                # from the round-5 fingerprint fix).
-                rationale=(target.get("rationale") or "").strip() or None,
-                judge_run_path=getattr(args, "judge_run", None),
-            )
-        except (judgment_compiler.ValidationError, OSError) as exc:
-            rolled_back = _rollback_findings(path, pre_findings_bytes)
-            sys.stderr.write(
-                f"judgment receipt refused: {exc}\n"
-                + ("disposition rolled back; findings file unchanged.\n"
-                   if rolled_back else
-                   "WARNING: rollback ALSO failed. The findings file may now "
-                   "disagree with the judgment ledger; run "
-                   "`kipi judgment verify --cross-check` before trusting it.\n")
-            )
-            return 2
     _sync_spillover_for_finding(cfg, args.prd_id, target)
     print(
         json.dumps(

--- a/plugins/prd-os/scripts/judgment_compiler.py
+++ b/plugins/prd-os/scripts/judgment_compiler.py
@@ -1251,9 +1251,19 @@ def cross_check_findings(cfg: Config, records: list[dict],
             if disposition in (None, "pending"):
                 continue
             resolved_at = str(record.get("resolved_at") or "")
-            if since and resolved_at < since:
-                continue
             key = (record.get("prd_id"), record.get("id"))
+            # The floor exempts findings that CANNOT have a receipt because
+            # they were decided before the compiler existed. A finding that HAS
+            # one is not in that category, so the floor must never shield a
+            # mismatch between it and the record. It also must not shield a
+            # finding with no resolved_at at all: "" sorts before every
+            # timestamp, so those were skipped silently even when a conflicting
+            # receipt existed (Codex, PR #101 round 7).
+            if since and resolved_at and resolved_at < since \
+                    and key not in covered:
+                continue
+            if since and not resolved_at and key not in covered:
+                continue  # undateable AND unclaimed: cannot judge, do not guess
             if key not in covered:
                 errors.append(
                     f"{key[0]}/{key[1]}: dispositioned {disposition!r} at "

--- a/plugins/prd-os/scripts/judgment_compiler.py
+++ b/plugins/prd-os/scripts/judgment_compiler.py
@@ -1198,6 +1198,18 @@ def _resolve_one_ref(cfg: Config, kind: str, value: str) -> str | None:
     return "unknown reference kind"
 
 
+def _decision_fingerprint(disposition, rationale) -> tuple:
+    """What makes two human decisions the same decision.
+
+    ONE definition, used for both sides of the comparison, so adding a frozen
+    field cannot silently go unchecked on one side. Rationale is normalised:
+    the writer stores None for an empty one while a findings record may simply
+    omit the key, and that difference is not a decision change.
+    """
+    text = (rationale or "").strip()
+    return (disposition, text)
+
+
 def cross_check_findings(cfg: Config, records: list[dict],
                          since: str | None = None) -> list[str]:
     """Completeness check against an INDEPENDENT source: every dispositioned
@@ -1219,13 +1231,19 @@ def cross_check_findings(cfg: Config, records: list[dict],
     # anyway (Codex, PR #101 round 2, executed repro). Receipts are appended in
     # order and supersede by position, so the last human-bearing receipt for a
     # finding is its current claim.
-    covered: dict[tuple, str] = {}
+    # Compare EVERY decision field the receipt freezes, not one field at a time.
+    # Rounds 2-5 of PR #101 each found a different unchecked field (identity
+    # only, then disposition, then rationale); patching them one by one is
+    # whack-a-mole on a class. `_decision_fingerprint` is the single definition
+    # of "the same decision", so a new frozen field is covered by construction.
+    covered: dict[tuple, tuple] = {}
     for record in records:
         human = record.get("human")
         if not human:
             continue  # judge-only receipt makes no claim about a human decision
         covered[(record["finding"]["prd_id"],
-                 record["finding"]["finding_id"])] = human["disposition"]
+                 record["finding"]["finding_id"])] = _decision_fingerprint(
+                     human.get("disposition"), human.get("rationale"))
     errors = []
     for path in sorted(cfg.findings_dir.rglob("*-findings.jsonl")):
         for record in _read_findings(path):
@@ -1241,12 +1259,16 @@ def cross_check_findings(cfg: Config, records: list[dict],
                     f"{key[0]}/{key[1]}: dispositioned {disposition!r} at "
                     f"{resolved_at or 'unknown time'} but no judgment receipt "
                     "exists")
-            elif covered[key] != disposition:
-                errors.append(
-                    f"{key[0]}/{key[1]}: findings file says {disposition!r} but "
-                    f"the latest receipt records {covered[key]!r} — the current "
-                    "decision was never captured (hand-edited, or a capture "
-                    "that failed after the write)")
+            else:
+                current = _decision_fingerprint(
+                    disposition, record.get("rationale"))
+                if covered[key] != current:
+                    errors.append(
+                        f"{key[0]}/{key[1]}: the findings file records "
+                        f"{current} but the latest receipt froze {covered[key]} "
+                        "— the current decision was never captured "
+                        "(hand-edited, or a capture that failed after the "
+                        "write)")
     return errors
 
 

--- a/plugins/prd-os/scripts/judgment_compiler.py
+++ b/plugins/prd-os/scripts/judgment_compiler.py
@@ -1212,8 +1212,20 @@ def cross_check_findings(cfg: Config, records: list[dict],
     before this feature existed have no receipt by construction and would
     otherwise report as thousands of false gaps.
     """
-    covered = {(r["finding"]["prd_id"], r["finding"]["finding_id"])
-               for r in records}
+    # Map to the LATEST recorded human disposition, not merely to "a receipt
+    # exists". Identity-only coverage let a receipt for an earlier decision
+    # satisfy the gate after the findings file was hand-edited to a different
+    # one, so the decision actually recorded had no receipt and approval passed
+    # anyway (Codex, PR #101 round 2, executed repro). Receipts are appended in
+    # order and supersede by position, so the last human-bearing receipt for a
+    # finding is its current claim.
+    covered: dict[tuple, str] = {}
+    for record in records:
+        human = record.get("human")
+        if not human:
+            continue  # judge-only receipt makes no claim about a human decision
+        covered[(record["finding"]["prd_id"],
+                 record["finding"]["finding_id"])] = human["disposition"]
     errors = []
     for path in sorted(cfg.findings_dir.rglob("*-findings.jsonl")):
         for record in _read_findings(path):
@@ -1229,6 +1241,12 @@ def cross_check_findings(cfg: Config, records: list[dict],
                     f"{key[0]}/{key[1]}: dispositioned {disposition!r} at "
                     f"{resolved_at or 'unknown time'} but no judgment receipt "
                     "exists")
+            elif covered[key] != disposition:
+                errors.append(
+                    f"{key[0]}/{key[1]}: findings file says {disposition!r} but "
+                    f"the latest receipt records {covered[key]!r} — the current "
+                    "decision was never captured (hand-edited, or a capture "
+                    "that failed after the write)")
     return errors
 
 

--- a/plugins/prd-os/scripts/judgment_compiler.py
+++ b/plugins/prd-os/scripts/judgment_compiler.py
@@ -51,6 +51,7 @@ import os
 import re
 import subprocess
 import sys
+import threading
 from contextlib import contextmanager
 from datetime import datetime, timezone
 from pathlib import Path
@@ -195,9 +196,22 @@ def tip_path(cfg: Config) -> Path:
     return _ledger_dir(cfg) / TIP_NAME
 
 
+# Re-entrancy depth, per THREAD. Thread-local rather than a plain global so two
+# threads still serialise against each other through real flocks; only the same
+# thread re-entering skips the second acquire.
+_LOCK_DEPTH = threading.local()
+
+
 @contextmanager
 def ledger_lock(cfg: Config):
     """Exclusive lock held across read + build + append + anchor.
+
+    RE-ENTRANT within one thread, and it has to be: findings_writer now holds
+    this across its findings write AND the capture that follows (sp-0c725cde),
+    while capture_episode takes it again on the way down. flock keys on the
+    OPEN FILE DESCRIPTION, not the process, so a second LOCK_EX on a second fd
+    blocks the caller against itself -- measured before writing this, a nested
+    acquire hangs forever. A depth counter, not a second flock.
 
     WHY (adversarial review 2026-08-04, reproduced with 4 concurrent captures):
     capture is a read-modify-append. Both `sequence` and `prev_receipt_sha256`
@@ -213,13 +227,23 @@ def ledger_lock(cfg: Config):
     flock is advisory and per-host: it does not protect a ledger on a network
     filesystem shared between machines. Named, not hidden.
     """
+    depth = getattr(_LOCK_DEPTH, "value", 0)
+    if depth:
+        _LOCK_DEPTH.value = depth + 1
+        try:
+            yield
+        finally:
+            _LOCK_DEPTH.value = depth
+        return
     path = _ledger_dir(cfg) / ".judgments.lock"
     path.parent.mkdir(parents=True, exist_ok=True)
     with path.open("a+", encoding="utf-8") as handle:
         fcntl.flock(handle.fileno(), fcntl.LOCK_EX)
+        _LOCK_DEPTH.value = 1
         try:
             yield
         finally:
+            _LOCK_DEPTH.value = 0
             fcntl.flock(handle.fileno(), fcntl.LOCK_UN)
 
 
@@ -1211,18 +1235,33 @@ def _decision_fingerprint(disposition, rationale) -> tuple:
 
 
 def cross_check_findings(cfg: Config, records: list[dict],
-                         since: str | None = None) -> list[str]:
+                         since: str | None = None, *,
+                         prd_id: str | None = None
+                         ) -> tuple[list[str], list[str]]:
     """Completeness check against an INDEPENDENT source: every dispositioned
     finding should have a receipt.
+
+    Returns (missing, disagreements). Two lists because the two results carry
+    different force. A MISSING receipt is a permanent, invisible hole in the
+    calibration set: `cmd_evaluate` reads ONLY the ledger, so a decision with
+    no receipt is one the calibration set can never see. A DISAGREEMENT is the
+    MUTABLE findings copy having drifted off the IMMUTABLE receipt, and the
+    receipt is still the honest record of what was decided. So the approval
+    gate blocks on the first and only warns on the second, while
+    `verify --cross-check` reports both as errors -- it is a diagnostic and
+    stays maximally informative.
 
     The tip anchor and the ledger share a writer, so both move together if that
     writer is wrong or malicious. The findings ledgers do not: they are written
     by findings_writer's own path. A dispositioned finding with no receipt is
     either a truncation the anchor missed or a capture that silently failed.
 
-    `since` filters by finding resolved_at, because findings dispositioned
-    before this feature existed have no receipt by construction and would
-    otherwise report as thousands of false gaps.
+    `since` filters by finding resolved_at and exists for the DIAGNOSTIC
+    caller, which passes an explicit --since. The approval gate no longer uses
+    it at all: it scopes with `prd_id` and decides exemption from the PRD's own
+    creation date, because `resolved_at` is a mutable field on a hand-editable
+    file (PR #101 rounds 2, 7 and 8 were all that one defect; see
+    prd_runner._prd_predates_floor).
     """
     # Map to the LATEST recorded human disposition, not merely to "a receipt
     # exists". Identity-only coverage let a receipt for an earlier decision
@@ -1244,11 +1283,14 @@ def cross_check_findings(cfg: Config, records: list[dict],
         covered[(record["finding"]["prd_id"],
                  record["finding"]["finding_id"])] = _decision_fingerprint(
                      human.get("disposition"), human.get("rationale"))
-    errors = []
+    missing: list[str] = []
+    disagreements: list[str] = []
     for path in sorted(cfg.findings_dir.rglob("*-findings.jsonl")):
         for record in _read_findings(path):
             disposition = record.get("disposition")
             if disposition in (None, "pending"):
+                continue
+            if prd_id is not None and record.get("prd_id") != prd_id:
                 continue
             resolved_at = str(record.get("resolved_at") or "")
             key = (record.get("prd_id"), record.get("id"))
@@ -1265,7 +1307,7 @@ def cross_check_findings(cfg: Config, records: list[dict],
             if since and not resolved_at and key not in covered:
                 continue  # undateable AND unclaimed: cannot judge, do not guess
             if key not in covered:
-                errors.append(
+                missing.append(
                     f"{key[0]}/{key[1]}: dispositioned {disposition!r} at "
                     f"{resolved_at or 'unknown time'} but no judgment receipt "
                     "exists")
@@ -1273,13 +1315,13 @@ def cross_check_findings(cfg: Config, records: list[dict],
                 current = _decision_fingerprint(
                     disposition, record.get("rationale"))
                 if covered[key] != current:
-                    errors.append(
+                    disagreements.append(
                         f"{key[0]}/{key[1]}: the findings file records "
                         f"{current} but the latest receipt froze {covered[key]} "
                         "— the current decision was never captured "
                         "(hand-edited, or a capture that failed after the "
                         "write)")
-    return errors
+    return missing, disagreements
 
 
 def verify_packet_binding(packet: dict, receipt: dict) -> list[str]:
@@ -1366,7 +1408,7 @@ def _expected_calibration_error(cases: list[tuple[str, str, float]]) -> float:
     return ece
 
 
-def evaluate(records: list[dict]) -> dict:
+def evaluate(records: list[dict], decision_disagreements: int = 0) -> dict:
     active, superseded_excluded = _active_receipts(records)
     judged = [r for r in active if r.get("judge") and r.get("human")
               and r["human"]["disposition"] != "pending"]
@@ -1412,7 +1454,8 @@ def evaluate(records: list[dict]) -> dict:
             and r["human"]["disposition"] in ("rejected", "deferred"))
         / len(active)) if active else 0.0
     unsupported_rate = (converted / len(judged)) if judged else 0.0
-    gates = _release_gates(result, ungated_rate, unsupported_rate)
+    gates = _release_gates(result, ungated_rate, unsupported_rate,
+                           decision_disagreements)
     result.update({
         "superseded_excluded": superseded_excluded,
         "active_receipts": len(active),
@@ -1424,6 +1467,13 @@ def evaluate(records: list[dict]) -> dict:
         # (the code is what the requirements key off). Reported AND gated.
         "ungated_decision_rate": ungated_rate,
         "unsupported_disposition_rate": unsupported_rate,
+        # The approval gate WARNS on these rather than blocking (PR #101
+        # rounds 6-8 false-blocked legitimate work and a gate that false-blocks
+        # gets switched off). Surfaced here so the demotion is not a silent
+        # drop: release_gates reads it, same shape as the evidence-gate bypass
+        # rate in 41c0876, which was a documented release condition nothing
+        # read. Zero when the caller did not supply a count.
+        "decision_disagreement_count": decision_disagreements,
         "missing_context_rate": (
             sum(1 for r in active if r["missing_context"]) / len(active))
         if active else 0.0,
@@ -1435,7 +1485,8 @@ def evaluate(records: list[dict]) -> dict:
 
 
 def _release_gates(scored: dict, ungated_rate: float = 0.0,
-                   unsupported_rate: float = 0.0) -> dict:
+                   unsupported_rate: float = 0.0,
+                   decision_disagreements: int = 0) -> dict:
     """The gates that must ALL pass before any disposition class auto-decides.
 
     The bypass checks are here because they were missing: the PRD listed "no
@@ -1462,6 +1513,14 @@ def _release_gates(scored: dict, ungated_rate: float = 0.0,
         "zero_unsupported_judge_dispositions": {
             "required": 0.0, "actual": unsupported_rate,
             "passed": unsupported_rate == 0.0,
+        },
+        # Approval only WARNS when the findings copy drifts off a receipt, so
+        # without this the demotion would let a ledger whose operational copy
+        # disagrees authorize auto-decide. Blocking a human's approval over it
+        # is a false block; blocking AUTOMATION over it is the right severity.
+        "zero_decision_disagreements": {
+            "required": 0, "actual": decision_disagreements,
+            "passed": decision_disagreements == 0,
         },
         "min_cases": {"required": 50, "actual": scored["cases"],
                       "passed": scored["cases"] >= 50},
@@ -1756,8 +1815,13 @@ def cmd_verify(cfg: Config, args: argparse.Namespace) -> int:
     errors.extend(verify_candidates(
         candidate_records, {r.get("receipt_id") for r in records}))
     if getattr(args, "cross_check", False):
-        errors.extend(cross_check_findings(cfg, records,
-                                           getattr(args, "since", None)))
+        # The diagnostic reports BOTH classes as errors. Only the approval gate
+        # demotes a disagreement to a warning; `verify` is where you go to see
+        # everything, so narrowing it here would hide the drift entirely.
+        gaps, drift = cross_check_findings(cfg, records,
+                                           getattr(args, "since", None))
+        errors.extend(gaps)
+        errors.extend(drift)
     if args.packet or args.receipt_id:
         if not (args.packet and args.receipt_id):
             raise ValidationError("--packet and --receipt-id go together")
@@ -1832,7 +1896,13 @@ def cmd_evaluate(cfg: Config, args: argparse.Namespace) -> int:
         for error in errors:
             print(f"  - {error}", file=sys.stderr)
         return 2
-    print(json.dumps(evaluate(records), indent=2, sort_keys=True))
+    # Counted here, not inside evaluate(): the disagreement lives in the
+    # findings files, which evaluate() cannot see (it takes records only, and
+    # the ledger is deliberately the single input to scoring). No floor is
+    # needed -- a disagreement requires a receipt to disagree WITH, so legacy
+    # pre-compiler findings cannot produce one.
+    _, drift = cross_check_findings(cfg, records)
+    print(json.dumps(evaluate(records, len(drift)), indent=2, sort_keys=True))
     return 0
 
 

--- a/plugins/prd-os/scripts/judgment_compiler.py
+++ b/plugins/prd-os/scripts/judgment_compiler.py
@@ -1172,8 +1172,19 @@ def _resolve_one_ref(cfg: Config, kind: str, value: str) -> str | None:
         path = _ledger_dir(cfg) / "spillover.jsonl"
         if not path.is_file():
             return "no spillover ledger exists"
-        return None if f'"{value}"' in path.read_text(encoding="utf-8") \
-            else "no such spillover item"
+        # Substring-matched the raw file, so a value appearing in ANY field
+        # (a description quoting an id, a resolution_ref) resolved as if it
+        # were the item itself (Codex, PR #97 minor sp-fcb3573e). Parse and
+        # compare the id field.
+        for raw in path.read_text(encoding="utf-8").splitlines():
+            if not raw.strip():
+                continue
+            try:
+                if json.loads(raw).get("id") == value:
+                    return None
+            except json.JSONDecodeError:
+                continue
+        return "no such spillover item"
     if kind == "commit":
         if not re.fullmatch(r"[0-9a-f]{7,40}", value):
             return "not a commit sha"

--- a/plugins/prd-os/scripts/prd_runner.py
+++ b/plugins/prd-os/scripts/prd_runner.py
@@ -619,14 +619,32 @@ def _judgment_receipt_gate(cfg: Config, prd_id: str) -> tuple[int, str]:
     try:
         import judgment_compiler
     except ImportError:
-        return 0, ""  # compiler absent (older instance): nothing to enforce
+        # The ONLY fail-open case: the compiler is not installed (an older
+        # instance), so there is no contract to enforce and nothing to read.
+        return 0, ""
     try:
         records = judgment_compiler.read_ledger(
             judgment_compiler.ledger_path(cfg))
-        missing = [m for m in judgment_compiler.cross_check_findings(
-            cfg, records, JUDGMENT_RECEIPT_FLOOR) if prd_id in m]
-    except Exception as exc:  # never let the gate's own failure block approval
-        return 0, f"note: judgment receipt check skipped ({exc})\n"
+        raw_missing = judgment_compiler.cross_check_findings(
+            cfg, records, JUDGMENT_RECEIPT_FLOOR)
+    except Exception as exc:
+        # FAIL CLOSED. The first version caught everything and returned 0,
+        # defended as "a bug in the check must not cause an approval outage".
+        # That conflated two different things: a corrupt or truncated ledger is
+        # not a bug in the gate, it is precisely the integrity failure the gate
+        # exists to catch, and letting approval through on it is the worst
+        # possible response (Codex, PR #101, executed repro: a ValueError from
+        # read_ledger returned rc=0). A required integrity gate fails closed.
+        return 2, (
+            f"approval blocked: the judgment ledger could not be checked ({exc}).\n"
+            "This is refused rather than skipped: an unreadable or corrupt "
+            "ledger is the integrity failure this gate exists to catch. Run "
+            "`kipi judgment verify` to see the damage.\n"
+        )
+    # Exact prd_id match, not `in`: cross_check_findings emits
+    # "<prd_id>/<finding_id>: ...", so a substring test let a missing receipt
+    # for `prd-alpha-2` block approval of `prd-alpha` (Codex, PR #101).
+    missing = [m for m in raw_missing if m.startswith(f"{prd_id}/")]
     if missing:
         return 2, (
             f"approval blocked: {len(missing)} finding(s) dispositioned since "

--- a/plugins/prd-os/scripts/prd_runner.py
+++ b/plugins/prd-os/scripts/prd_runner.py
@@ -596,6 +596,48 @@ def _findings_gate(cfg: Config, state: dict) -> tuple[int, str]:
             f"approval blocked: {len(pending)} pending finding(s): "
             f"{', '.join(pending)}. Set a disposition on each before advancing.\n"
         )
+    return _judgment_receipt_gate(cfg, state["prd_id"])
+
+
+# The Judgment Compiler shipped WRITING a receipt on every triage and REQUIRING
+# one nowhere, which made it available rather than baked in: KIPI_JUDGMENT_CAPTURE=0,
+# a hand-edited findings file, or a capture that failed and got ignored all left
+# a silent hole no gate could see. A ledger with unnoticed holes cannot be the
+# calibration set it exists to be.
+JUDGMENT_RECEIPT_FLOOR = "2026-08-04T00:00:00Z"
+
+
+def _judgment_receipt_gate(cfg: Config, prd_id: str) -> tuple[int, str]:
+    """Every finding dispositioned since the floor must carry a receipt.
+
+    FLOOR, not a blanket requirement: ~342 findings were adjudicated before the
+    compiler existed and can never have receipts. Demanding them would block
+    every pre-existing PRD forever, and a gate that cannot be satisfied gets
+    switched off -- which protects nothing. So the rule binds only decisions
+    made after the feature landed.
+    """
+    try:
+        import judgment_compiler
+    except ImportError:
+        return 0, ""  # compiler absent (older instance): nothing to enforce
+    try:
+        records = judgment_compiler.read_ledger(
+            judgment_compiler.ledger_path(cfg))
+        missing = [m for m in judgment_compiler.cross_check_findings(
+            cfg, records, JUDGMENT_RECEIPT_FLOOR) if prd_id in m]
+    except Exception as exc:  # never let the gate's own failure block approval
+        return 0, f"note: judgment receipt check skipped ({exc})\n"
+    if missing:
+        return 2, (
+            f"approval blocked: {len(missing)} finding(s) dispositioned since "
+            f"{JUDGMENT_RECEIPT_FLOOR} with no judgment receipt:\n  "
+            + "\n  ".join(missing[:5])
+            + ("\n  ..." if len(missing) > 5 else "")
+            + "\n\nRe-run the disposition through findings_writer.py "
+              "set-disposition so the decision is recorded, or explain the gap. "
+              "Receipts are the calibration set; a hole in them is invisible "
+              "later.\n"
+        )
     return 0, ""
 
 

--- a/plugins/prd-os/scripts/prd_runner.py
+++ b/plugins/prd-os/scripts/prd_runner.py
@@ -290,8 +290,12 @@ def cmd_advance(cfg: Config, args: argparse.Namespace) -> int:
 
     if target == "approved":
         rc, err = _findings_gate(cfg, state)
-        if rc != 0:
+        # Emitted on rc == 0 too: the judgment gate returns a decision-
+        # disagreement WARNING alongside a passing code, and the old
+        # `if rc != 0` guard would have swallowed it silently.
+        if err:
             sys.stderr.write(err)
+        if rc != 0:
             return rc
         rc, err = _issues_manifest_gate(cfg, state)
         if rc != 0:
@@ -606,15 +610,47 @@ def _findings_gate(cfg: Config, state: dict) -> tuple[int, str]:
 # calibration set it exists to be.
 JUDGMENT_RECEIPT_FLOOR = "2026-08-04T00:00:00Z"
 
+_PRD_ID_DATE = re.compile(r"-(\d{4}-\d{2}-\d{2})$")
+
+
+def _prd_predates_floor(prd_id: str) -> bool:
+    """Is this PRD old enough that its findings can never carry receipts?
+
+    Answered from the PRD ID, which carries its creation date, and NOT from any
+    finding's `resolved_at`. Rounds 2, 7 and 8 of PR #101 were all ONE defect:
+    inferring "decided after the floor" from `resolved_at`, a mutable and
+    strippable field on a hand-editable file. The round-8 code admitted the
+    inference was undecidable ("undateable AND unclaimed: cannot judge, do not
+    guess") and so left a permanent documented hole -- switch capture off,
+    strip the date, and the missing receipt is invisible. Patching it a ninth
+    time is paying a meter, so the class is killed by construction: this gate
+    runs for ONE named PRD, and that PRD's own date answers the question
+    without reading a single finding field.
+
+    FAILS CLOSED on an id whose date cannot be parsed. Measured: 36 of 36
+    prd_ids under `.prd-os/findings/` carry a trailing ISO date, but NOTHING in
+    prd_runner enforces that format, so an id without one is treated as
+    post-floor and REQUIRES receipts. The alternative is a free exemption for
+    any id that simply omits a date, which is the same hole in a new shape.
+    """
+    match = _PRD_ID_DATE.search(prd_id or "")
+    if not match:
+        return False
+    return match.group(1) < JUDGMENT_RECEIPT_FLOOR[:10]
+
 
 def _judgment_receipt_gate(cfg: Config, prd_id: str) -> tuple[int, str]:
-    """Every finding dispositioned since the floor must carry a receipt.
+    """Every finding of a post-floor PRD must carry a receipt.
 
     FLOOR, not a blanket requirement: ~342 findings were adjudicated before the
     compiler existed and can never have receipts. Demanding them would block
     every pre-existing PRD forever, and a gate that cannot be satisfied gets
-    switched off -- which protects nothing. So the rule binds only decisions
-    made after the feature landed.
+    switched off -- which protects nothing. So the rule binds only PRDs created
+    after the feature landed.
+
+    Returns (exit_code, text). The text is NOT only an error: a decision-
+    disagreement warning rides back with exit 0, so the caller must emit it
+    regardless of the code.
     """
     try:
         import judgment_compiler
@@ -647,8 +683,15 @@ def _judgment_receipt_gate(cfg: Config, prd_id: str) -> tuple[int, str]:
                 + ("\n  ..." if len(chain_errors) > 5 else "")
                 + "\n\nRun `kipi judgment verify` for the full report.\n"
             )
-        raw_missing = judgment_compiler.cross_check_findings(
-            cfg, records, JUDGMENT_RECEIPT_FLOOR)
+        if _prd_predates_floor(prd_id):
+            # Chain integrity was verified above for every PRD; only the
+            # COMPLETENESS requirement is waived for a pre-compiler PRD.
+            raw_missing, raw_drift = [], []
+        else:
+            # No `since` at all: the PRD-level floor already answered the
+            # only question `resolved_at` was ever used for.
+            raw_missing, raw_drift = judgment_compiler.cross_check_findings(
+                cfg, records, None, prd_id=prd_id)
     except Exception as exc:
         # FAIL CLOSED. The first version caught everything and returned 0,
         # defended as "a bug in the check must not cause an approval outage".
@@ -667,18 +710,41 @@ def _judgment_receipt_gate(cfg: Config, prd_id: str) -> tuple[int, str]:
     # "<prd_id>/<finding_id>: ...", so a substring test let a missing receipt
     # for `prd-alpha-2` block approval of `prd-alpha` (Codex, PR #101).
     missing = [m for m in raw_missing if m.startswith(f"{prd_id}/")]
+    drift = [d for d in raw_drift if d.startswith(f"{prd_id}/")]
+    # WARNING, never a block (PR #101 rounds 6-8). This compares the MUTABLE
+    # findings file against the IMMUTABLE receipt, and when they disagree the
+    # receipt is still the honest record of the decision -- `cmd_evaluate`,
+    # which feeds the release gates, reads ONLY the ledger. Rounds 6-8 blocked
+    # on it and produced two self-inflicted regressions; three of the four
+    # tests guarding it existed to stop it blocking legitimate work rather than
+    # to catch a real threat. A gate that false-blocks gets switched off, and
+    # an off gate protects nothing. It is not dropped: `kipi judgment evaluate`
+    # counts it as decision_disagreement_count and gates AUTOMATION on it.
+    warning = ""
+    if drift:
+        warning = (
+            f"WARNING: {len(drift)} finding(s) whose findings-file record "
+            "disagrees with the receipt that froze the decision:\n  "
+            + "\n  ".join(drift[:5])
+            + ("\n  ..." if len(drift) > 5 else "")
+            + "\n\nApproval is NOT blocked: the receipt is the immutable record "
+              "and the ledger is what calibration reads, while the findings "
+              "file is mutable operational state. Counted as "
+              "decision_disagreement_count by `kipi judgment evaluate`.\n"
+        )
     if missing:
         return 2, (
-            f"approval blocked: {len(missing)} finding(s) dispositioned since "
-            f"{JUDGMENT_RECEIPT_FLOOR} with no judgment receipt:\n  "
+            f"approval blocked: {len(missing)} finding(s) in a PRD created on "
+            f"or after {JUDGMENT_RECEIPT_FLOOR[:10]} with no judgment "
+            "receipt:\n  "
             + "\n  ".join(missing[:5])
             + ("\n  ..." if len(missing) > 5 else "")
             + "\n\nRe-run the disposition through findings_writer.py "
               "set-disposition so the decision is recorded, or explain the gap. "
               "Receipts are the calibration set; a hole in them is invisible "
               "later.\n"
-        )
-    return 0, ""
+        ) + warning
+    return 0, warning
 
 
 # ---------------------------------------------------------------------------

--- a/plugins/prd-os/scripts/prd_runner.py
+++ b/plugins/prd-os/scripts/prd_runner.py
@@ -612,6 +612,12 @@ JUDGMENT_RECEIPT_FLOOR = "2026-08-04T00:00:00Z"
 
 _PRD_ID_DATE = re.compile(r"-(\d{4}-\d{2}-\d{2})$")
 
+# Plausibility bound for a PRD id's date. MEASURED, not guessed: the 36 prd_ids
+# under `.prd-os/findings/` span 2026-05-13 to 2026-08-04, so this sits months
+# before the earliest real PRD and cannot false-block one, while still refusing
+# a date that this project could never have produced.
+_PRD_DATE_EARLIEST = "2026-01-01"
+
 
 def _prd_predates_floor(prd_id: str) -> bool:
     """Is this PRD old enough that its findings can never carry receipts?
@@ -636,7 +642,24 @@ def _prd_predates_floor(prd_id: str) -> bool:
     match = _PRD_ID_DATE.search(prd_id or "")
     if not match:
         return False
-    return match.group(1) < JUDGMENT_RECEIPT_FLOOR[:10]
+    stamp = match.group(1)
+    # A date-SHAPED suffix is not a date. Matching the shape and then string-
+    # comparing it RELOCATED the very defect this function exists to kill: the
+    # floor moved off `resolved_at` because a strippable field handed out a free
+    # exemption, and `prd-evade-0000-00-00` -- which no calendar can produce --
+    # bought exactly the same exemption through the new mechanism (review of
+    # PR #102, executed table). Parse it for real, and fail closed when it is
+    # not a date.
+    try:
+        datetime.strptime(stamp, "%Y-%m-%d")
+    except ValueError:
+        return False
+    # strptime ALONE does not close it: `1970-01-01` parses perfectly and was
+    # still exempt. A real date decades before this project existed is evasion,
+    # not history, so the exemption also needs a plausibility floor.
+    if stamp < _PRD_DATE_EARLIEST:
+        return False
+    return stamp < JUDGMENT_RECEIPT_FLOOR[:10]
 
 
 def _judgment_receipt_gate(cfg: Config, prd_id: str) -> tuple[int, str]:

--- a/plugins/prd-os/scripts/prd_runner.py
+++ b/plugins/prd-os/scripts/prd_runner.py
@@ -610,66 +610,29 @@ def _findings_gate(cfg: Config, state: dict) -> tuple[int, str]:
 # calibration set it exists to be.
 JUDGMENT_RECEIPT_FLOOR = "2026-08-04T00:00:00Z"
 
-_PRD_ID_DATE = re.compile(r"-(\d{4}-\d{2}-\d{2})$")
-
-# Plausibility bound for a PRD id's date. MEASURED, not guessed: the 36 prd_ids
-# under `.prd-os/findings/` span 2026-05-13 to 2026-08-04, so this sits months
-# before the earliest real PRD and cannot false-block one, while still refusing
-# a date that this project could never have produced.
-_PRD_DATE_EARLIEST = "2026-01-01"
-
-
-def _prd_predates_floor(prd_id: str) -> bool:
-    """Is this PRD old enough that its findings can never carry receipts?
-
-    Answered from the PRD ID, which carries its creation date, and NOT from any
-    finding's `resolved_at`. Rounds 2, 7 and 8 of PR #101 were all ONE defect:
-    inferring "decided after the floor" from `resolved_at`, a mutable and
-    strippable field on a hand-editable file. The round-8 code admitted the
-    inference was undecidable ("undateable AND unclaimed: cannot judge, do not
-    guess") and so left a permanent documented hole -- switch capture off,
-    strip the date, and the missing receipt is invisible. Patching it a ninth
-    time is paying a meter, so the class is killed by construction: this gate
-    runs for ONE named PRD, and that PRD's own date answers the question
-    without reading a single finding field.
-
-    FAILS CLOSED on an id whose date cannot be parsed. Measured: 36 of 36
-    prd_ids under `.prd-os/findings/` carry a trailing ISO date, but NOTHING in
-    prd_runner enforces that format, so an id without one is treated as
-    post-floor and REQUIRES receipts. The alternative is a free exemption for
-    any id that simply omits a date, which is the same hole in a new shape.
-    """
-    match = _PRD_ID_DATE.search(prd_id or "")
-    if not match:
-        return False
-    stamp = match.group(1)
-    # A date-SHAPED suffix is not a date. Matching the shape and then string-
-    # comparing it RELOCATED the very defect this function exists to kill: the
-    # floor moved off `resolved_at` because a strippable field handed out a free
-    # exemption, and `prd-evade-0000-00-00` -- which no calendar can produce --
-    # bought exactly the same exemption through the new mechanism (review of
-    # PR #102, executed table). Parse it for real, and fail closed when it is
-    # not a date.
-    try:
-        datetime.strptime(stamp, "%Y-%m-%d")
-    except ValueError:
-        return False
-    # strptime ALONE does not close it: `1970-01-01` parses perfectly and was
-    # still exempt. A real date decades before this project existed is evasion,
-    # not history, so the exemption also needs a plausibility floor.
-    if stamp < _PRD_DATE_EARLIEST:
-        return False
-    return stamp < JUDGMENT_RECEIPT_FLOOR[:10]
-
-
 def _judgment_receipt_gate(cfg: Config, prd_id: str) -> tuple[int, str]:
-    """Every finding of a post-floor PRD must carry a receipt.
+    """Every dispositioned finding in this PRD must carry a receipt.
 
-    FLOOR, not a blanket requirement: ~342 findings were adjudicated before the
-    compiler existed and can never have receipts. Demanding them would block
-    every pre-existing PRD forever, and a gate that cannot be satisfied gets
-    switched off -- which protects nothing. So the rule binds only PRDs created
-    after the feature landed.
+    NO EXEMPTION, and deliberately no date logic of any kind. Three shapes all
+    failed the same way. Rounds 2/7/8 of PR #101 inferred eligibility from
+    `resolved_at`, a mutable strippable field. PR #102 moved the inference to
+    the PRD id's creation date, and its review round matched a date-SHAPED
+    suffix no calendar can produce. Then Codex found the defect underneath
+    both: a PRD-creation floor exempts every FUTURE decision on an old PRD, and
+    35 of 36 real PRDs predate the floor, so the gate was a near-permanent
+    no-op -- the opposite of "receipts are required from here on".
+
+    The signal was simply wrong. This gate fires when a PRD is APPROVED, and a
+    PRD being approved now is being decided now, whatever date its id carries.
+    So the rule is unconditional and reads no date at all.
+
+    Measured before removing the exemption, because "a gate that cannot be
+    satisfied gets switched off" is a real risk that deserved a number rather
+    than a worry: of the 36 real PRDs, 21 are archived and 13 approved, so they
+    can never reach this gate again. Exactly ONE is still in-review, with 13
+    dispositioned findings, and its remedy is one `set-disposition` re-run per
+    finding, which mints the receipt as a side effect. A bounded, one-time,
+    self-service cost bought back the whole guarantee.
 
     Returns (exit_code, text). The text is NOT only an error: a decision-
     disagreement warning rides back with exit 0, so the caller must emit it
@@ -697,7 +660,18 @@ def _judgment_receipt_gate(cfg: Config, prd_id: str) -> tuple[int, str]:
         # disposition, broken chain -- satisfied the gate and authorized
         # approval (Codex, PR #101 round 3). A hash chain no consumer checks is
         # decoration; the gate is the consumer that matters.
-        chain_errors = judgment_compiler.verify_ledger(records, tip)
+            chain_errors = judgment_compiler.verify_ledger(records, tip)
+            # Cross-check INSIDE the lock, with the read that feeds it (Codex
+            # major, PR #102). It used to run after the lock was released, so a
+            # concurrent and perfectly valid triage landing in that gap wrote a
+            # disposition this stale ledger snapshot could not see, and approval
+            # false-blocked on a missing receipt that did exist. The round-4 fix
+            # locked the read; the comparison needs the same span.
+            # No `since`: eligibility is unconditional now, so there is nothing
+            # to date-filter.
+            raw_missing, raw_drift = ([], []) if chain_errors else \
+                judgment_compiler.cross_check_findings(
+                    cfg, records, None, prd_id=prd_id)
         if chain_errors:
             return 2, (
                 "approval blocked: the judgment ledger does not verify, so its "
@@ -706,15 +680,6 @@ def _judgment_receipt_gate(cfg: Config, prd_id: str) -> tuple[int, str]:
                 + ("\n  ..." if len(chain_errors) > 5 else "")
                 + "\n\nRun `kipi judgment verify` for the full report.\n"
             )
-        if _prd_predates_floor(prd_id):
-            # Chain integrity was verified above for every PRD; only the
-            # COMPLETENESS requirement is waived for a pre-compiler PRD.
-            raw_missing, raw_drift = [], []
-        else:
-            # No `since` at all: the PRD-level floor already answered the
-            # only question `resolved_at` was ever used for.
-            raw_missing, raw_drift = judgment_compiler.cross_check_findings(
-                cfg, records, None, prd_id=prd_id)
     except Exception as exc:
         # FAIL CLOSED. The first version caught everything and returned 0,
         # defended as "a bug in the check must not cause an approval outage".
@@ -757,9 +722,8 @@ def _judgment_receipt_gate(cfg: Config, prd_id: str) -> tuple[int, str]:
         )
     if missing:
         return 2, (
-            f"approval blocked: {len(missing)} finding(s) in a PRD created on "
-            f"or after {JUDGMENT_RECEIPT_FLOOR[:10]} with no judgment "
-            "receipt:\n  "
+            f"approval blocked: {len(missing)} dispositioned finding(s) with "
+            "no judgment receipt:\n  "
             + "\n  ".join(missing[:5])
             + ("\n  ..." if len(missing) > 5 else "")
             + "\n\nRe-run the disposition through findings_writer.py "

--- a/plugins/prd-os/scripts/prd_runner.py
+++ b/plugins/prd-os/scripts/prd_runner.py
@@ -625,6 +625,22 @@ def _judgment_receipt_gate(cfg: Config, prd_id: str) -> tuple[int, str]:
     try:
         records = judgment_compiler.read_ledger(
             judgment_compiler.ledger_path(cfg))
+        # VERIFY before trusting. read_ledger only parses JSON, so without this
+        # a receipt appended by hand -- right prd_id, right finding_id, right
+        # disposition, broken chain -- satisfied the gate and authorized
+        # approval (Codex, PR #101 round 3). A hash chain no consumer checks is
+        # decoration; the gate is the consumer that matters.
+        chain_errors = judgment_compiler.verify_ledger(
+            records, judgment_compiler.read_tip(
+                judgment_compiler.tip_path(cfg)))
+        if chain_errors:
+            return 2, (
+                "approval blocked: the judgment ledger does not verify, so its "
+                "receipts cannot be trusted as evidence:\n  "
+                + "\n  ".join(chain_errors[:5])
+                + ("\n  ..." if len(chain_errors) > 5 else "")
+                + "\n\nRun `kipi judgment verify` for the full report.\n"
+            )
         raw_missing = judgment_compiler.cross_check_findings(
             cfg, records, JUDGMENT_RECEIPT_FLOOR)
     except Exception as exc:

--- a/plugins/prd-os/scripts/prd_runner.py
+++ b/plugins/prd-os/scripts/prd_runner.py
@@ -623,16 +623,22 @@ def _judgment_receipt_gate(cfg: Config, prd_id: str) -> tuple[int, str]:
         # instance), so there is no contract to enforce and nothing to read.
         return 0, ""
     try:
-        records = judgment_compiler.read_ledger(
-            judgment_compiler.ledger_path(cfg))
+        # Read UNDER THE WRITER'S LOCK. capture appends the receipt and then
+        # writes the tip; observed between those two, the ledger holds N+1
+        # records against a tip of N, which the chain check below correctly
+        # calls "receipts BEYOND the tip anchor" -- and would block approval
+        # over a concurrent capture that was perfectly fine (Codex, PR #101
+        # round 4). I gave the writer a lock and left the reader without one.
+        with judgment_compiler.ledger_lock(cfg):
+            records = judgment_compiler.read_ledger(
+                judgment_compiler.ledger_path(cfg))
+            tip = judgment_compiler.read_tip(judgment_compiler.tip_path(cfg))
         # VERIFY before trusting. read_ledger only parses JSON, so without this
         # a receipt appended by hand -- right prd_id, right finding_id, right
         # disposition, broken chain -- satisfied the gate and authorized
         # approval (Codex, PR #101 round 3). A hash chain no consumer checks is
         # decoration; the gate is the consumer that matters.
-        chain_errors = judgment_compiler.verify_ledger(
-            records, judgment_compiler.read_tip(
-                judgment_compiler.tip_path(cfg)))
+        chain_errors = judgment_compiler.verify_ledger(records, tip)
         if chain_errors:
             return 2, (
                 "approval blocked: the judgment ledger does not verify, so its "

--- a/plugins/prd-os/tests/test_judgment_compiler.py
+++ b/plugins/prd-os/tests/test_judgment_compiler.py
@@ -1340,3 +1340,64 @@ if __name__ == "__main__":
         [sys.executable, "-m", "pytest", str(Path(__file__).resolve()), "-q"],
         cwd=str(PLUGIN_ROOT.parent.parent),
     ).returncode)
+
+
+class TestBakedIntoApproval:
+    """The compiler must be REQUIRED by prd-os, not merely available to it.
+
+    Shipped writing a receipt everywhere and requiring one nowhere, so
+    KIPI_JUDGMENT_CAPTURE=0 or a hand-edited findings file left a hole no gate
+    could see. These pin the gate that closes it.
+    """
+
+    def _prd_ready_for_approval(self, repo: Path, run_findings_writer):
+        spec = repo / ".prd-os" / "prds" / f"{PRD_ID}.md"
+        text = spec.read_text().replace(
+            "status: in-review",
+            "status: in-review\ncodex_reviewed_at: 2026-08-04T00:00:00Z\n"
+            f"findings_path: .prd-os/findings/{PRD_ID}-findings.jsonl")
+        spec.write_text(text)
+
+    def test_receipt_gate_reports_a_missing_receipt(self, judgment_repo,
+                                                    run_findings_writer):
+        """Direct call: the gate's own predicate, without the PRD state machine."""
+        import importlib.util
+        spec = importlib.util.spec_from_file_location(
+            "jc_gate2", SCRIPTS_DIR / "judgment_compiler.py")
+        jc = importlib.util.module_from_spec(spec)
+        sys.modules["jc_gate2"] = jc
+        spec.loader.exec_module(jc)
+        assert run_findings_writer(
+            judgment_repo, "set-disposition", PRD_ID, "finding-1", "accepted",
+            env_extra={"KIPI_JUDGMENT_CAPTURE": "0"}).returncode == 0
+        cfg_spec = importlib.util.spec_from_file_location(
+            "jc_cfg", SCRIPTS_DIR / "config.py")
+        cfgmod = importlib.util.module_from_spec(cfg_spec)
+        sys.modules["jc_cfg"] = cfgmod
+        cfg_spec.loader.exec_module(cfgmod)
+        cfg = cfgmod.load(judgment_repo)
+        missing = jc.cross_check_findings(cfg, [], "2026-01-01T00:00:00Z")
+        assert any(PRD_ID in m for m in missing), missing
+        assert any("no judgment receipt" in m for m in missing)
+
+    def test_floor_exempts_pre_feature_dispositions(self, judgment_repo,
+                                                    run_findings_writer):
+        """A gate that cannot be satisfied gets switched off. Findings decided
+        before the compiler existed must not block approval forever."""
+        import importlib.util
+        spec = importlib.util.spec_from_file_location(
+            "jc_gate3", SCRIPTS_DIR / "judgment_compiler.py")
+        jc = importlib.util.module_from_spec(spec)
+        sys.modules["jc_gate3"] = jc
+        spec.loader.exec_module(jc)
+        cfg_spec = importlib.util.spec_from_file_location(
+            "jc_cfg3", SCRIPTS_DIR / "config.py")
+        cfgmod = importlib.util.module_from_spec(cfg_spec)
+        sys.modules["jc_cfg3"] = cfgmod
+        cfg_spec.loader.exec_module(cfgmod)
+        assert run_findings_writer(
+            judgment_repo, "set-disposition", PRD_ID, "finding-1", "accepted",
+            env_extra={"KIPI_JUDGMENT_CAPTURE": "0"}).returncode == 0
+        cfg = cfgmod.load(judgment_repo)
+        far_future = jc.cross_check_findings(cfg, [], "2099-01-01T00:00:00Z")
+        assert far_future == [], "floor did not exempt an older disposition"

--- a/plugins/prd-os/tests/test_judgment_compiler.py
+++ b/plugins/prd-os/tests/test_judgment_compiler.py
@@ -1578,3 +1578,25 @@ class TestDecisionFingerprint:
         proc = run_judgment(judgment_repo, "verify", "--cross-check",
                             "--since", "2026-01-01T00:00:00Z")
         assert proc.returncode == 0, proc.stderr
+
+
+class TestRedispositionWithoutNewRationale:
+    def test_rejected_to_accepted_without_rationale_stays_covered(
+            self, judgment_repo, run_findings_writer):
+        """Codex PR #101 r6, a regression from my own round-5 fingerprint fix:
+        findings_writer keeps the previous rationale on a re-disposition (only
+        `pending` clears it), so capturing the FLAG instead of the RECORD froze
+        None against a record that still had text, and the gate falsely blocked."""
+        assert run_findings_writer(
+            judgment_repo, "set-disposition", PRD_ID, "finding-1", "rejected",
+            "--rationale", "not a real defect",
+            "--reason-code", "invalid-finding").returncode == 0
+        assert run_findings_writer(judgment_repo, "set-disposition", PRD_ID,
+                                   "finding-1", "accepted").returncode == 0
+        proc = run_judgment(judgment_repo, "verify", "--cross-check",
+                            "--since", "2026-01-01T00:00:00Z")
+        assert proc.returncode == 0, proc.stderr
+        rec = read_ledger(judgment_repo)[-1]
+        assert rec["human"]["disposition"] == "accepted"
+        assert rec["human"]["rationale"] == "not a real defect", (
+            "the receipt must freeze the rationale the finding actually carries")

--- a/plugins/prd-os/tests/test_judgment_compiler.py
+++ b/plugins/prd-os/tests/test_judgment_compiler.py
@@ -1401,3 +1401,60 @@ class TestBakedIntoApproval:
         cfg = cfgmod.load(judgment_repo)
         far_future = jc.cross_check_findings(cfg, [], "2099-01-01T00:00:00Z")
         assert far_future == [], "floor did not exempt an older disposition"
+
+
+class TestReceiptGateFailsClosed:
+    """A REQUIRED integrity gate must refuse on doubt, not wave work through.
+
+    The first version caught every exception and returned 0, defended as 'a bug
+    in the check must not cause an approval outage'. That conflated a buggy gate
+    with a corrupt ledger -- and a corrupt ledger is exactly what this gate
+    exists to catch (Codex, PR #101).
+    """
+
+    def _runner(self):
+        import importlib.util
+        spec = importlib.util.spec_from_file_location(
+            "pr_gate", SCRIPTS_DIR / "prd_runner.py")
+        mod = importlib.util.module_from_spec(spec)
+        sys.modules["pr_gate"] = mod
+        spec.loader.exec_module(mod)
+        return mod
+
+    def test_unreadable_ledger_blocks_approval(self, monkeypatch):
+        runner = self._runner()
+        import judgment_compiler as jc
+
+        monkeypatch.setattr(jc, "ledger_path", lambda cfg: Path("/dev/null"))
+        def boom(_path):
+            raise ValueError("line 7: invalid JSON")
+        monkeypatch.setattr(jc, "read_ledger", boom)
+        code, message = runner._judgment_receipt_gate(object(), "prd-alpha")
+        assert code == 2, "a corrupt ledger must not let approval through"
+        assert "could not be checked" in message
+
+    def test_prefix_prd_id_does_not_cross_block(self, monkeypatch):
+        """`prd-alpha` must not be blocked by a gap belonging to
+        `prd-alpha-2`; substring matching did exactly that."""
+        runner = self._runner()
+        import judgment_compiler as jc
+
+        monkeypatch.setattr(jc, "ledger_path", lambda cfg: Path("/dev/null"))
+        monkeypatch.setattr(jc, "read_ledger", lambda p: [])
+        monkeypatch.setattr(jc, "cross_check_findings", lambda c, r, s: [
+            "prd-alpha-2/finding-1: dispositioned but no judgment receipt exists"])
+        assert runner._judgment_receipt_gate(object(), "prd-alpha")[0] == 0
+        assert runner._judgment_receipt_gate(object(), "prd-alpha-2")[0] == 2
+
+    def test_missing_compiler_is_the_only_fail_open(self, monkeypatch):
+        """An instance without the compiler has no contract to enforce."""
+        runner = self._runner()
+        real_import = __builtins__["__import__"] if isinstance(__builtins__, dict) \
+            else __builtins__.__import__
+
+        def no_compiler(name, *args, **kwargs):
+            if name == "judgment_compiler":
+                raise ImportError("not installed")
+            return real_import(name, *args, **kwargs)
+        monkeypatch.setattr("builtins.__import__", no_compiler)
+        assert runner._judgment_receipt_gate(object(), "prd-alpha") == (0, "")

--- a/plugins/prd-os/tests/test_judgment_compiler.py
+++ b/plugins/prd-os/tests/test_judgment_compiler.py
@@ -1441,6 +1441,9 @@ class TestReceiptGateFailsClosed:
 
         monkeypatch.setattr(jc, "ledger_path", lambda cfg: Path("/dev/null"))
         monkeypatch.setattr(jc, "read_ledger", lambda p: [])
+        monkeypatch.setattr(jc, "tip_path", lambda cfg: Path("/dev/null"))
+        monkeypatch.setattr(jc, "read_tip", lambda p: None)
+        monkeypatch.setattr(jc, "verify_ledger", lambda r, tip=None: [])
         monkeypatch.setattr(jc, "cross_check_findings", lambda c, r, s: [
             "prd-alpha-2/finding-1: dispositioned but no judgment receipt exists"])
         assert runner._judgment_receipt_gate(object(), "prd-alpha")[0] == 0
@@ -1501,3 +1504,33 @@ class TestGateChecksTheDecisionNotJustTheFinding:
         proc = run_judgment(judgment_repo, "verify", "--cross-check",
                             "--since", "2026-01-01T00:00:00Z")
         assert proc.returncode == 0, proc.stderr
+
+
+class TestGateVerifiesBeforeTrusting:
+    def test_forged_receipt_does_not_authorize_approval(self, judgment_repo,
+                                                        run_findings_writer):
+        """Codex PR #101 r3: the gate parsed receipts but never verified the
+        chain, so a hand-appended receipt with the right ids authorized
+        approval. A hash chain no consumer checks is decoration."""
+        assert run_findings_writer(judgment_repo, "set-disposition", PRD_ID,
+                                   "finding-1", "accepted").returncode == 0
+        path = judgment_repo / ".prd-os" / "judgments.jsonl"
+        real = read_ledger(judgment_repo)[0]
+        forged = json.loads(json.dumps(real))
+        forged["finding"]["finding_id"] = "finding-2"
+        forged["prev_receipt_sha256"] = "0" * 64          # chain broken
+        path.write_text(path.read_text() + json.dumps(
+            forged, sort_keys=True, separators=(",", ":"),
+            ensure_ascii=False) + "\n")
+        assert run_judgment(judgment_repo, "verify").returncode == 2
+        import importlib.util
+        spec = importlib.util.spec_from_file_location(
+            "pr_gate_v", SCRIPTS_DIR / "prd_runner.py")
+        runner = importlib.util.module_from_spec(spec)
+        sys.modules["pr_gate_v"] = runner
+        spec.loader.exec_module(runner)
+        import config as cfgmod
+        cfg = cfgmod.load(judgment_repo)
+        code, message = runner._judgment_receipt_gate(cfg, PRD_ID)
+        assert code == 2, "a forged receipt authorized approval"
+        assert "does not verify" in message

--- a/plugins/prd-os/tests/test_judgment_compiler.py
+++ b/plugins/prd-os/tests/test_judgment_compiler.py
@@ -1600,3 +1600,41 @@ class TestRedispositionWithoutNewRationale:
         assert rec["human"]["disposition"] == "accepted"
         assert rec["human"]["rationale"] == "not a real defect", (
             "the receipt must freeze the rationale the finding actually carries")
+
+
+class TestFloorDoesNotShieldAConflict:
+    def test_finding_without_resolved_at_still_compared_when_a_receipt_exists(
+            self, judgment_repo, run_findings_writer):
+        """Codex PR #101 r7: '' sorts before every timestamp, so a dispositioned
+        finding with no resolved_at was skipped by the floor even when its
+        receipt disagreed. The floor exempts findings that CANNOT have a
+        receipt; one that has a receipt is not in that category."""
+        assert run_findings_writer(judgment_repo, "set-disposition", PRD_ID,
+                                   "finding-1", "accepted").returncode == 0
+        path = (judgment_repo / ".prd-os" / "findings"
+                / f"{PRD_ID}-findings.jsonl")
+        rows = [json.loads(l) for l in path.read_text().splitlines() if l.strip()]
+        rows[0]["disposition"] = "rejected"     # conflicts with the receipt
+        rows[0]["rationale"] = "changed offline"
+        rows[0].pop("resolved_at", None)        # ...and is undateable
+        path.write_text("".join(json.dumps(r, sort_keys=True) + "\n" for r in rows))
+        proc = run_judgment(judgment_repo, "verify", "--cross-check",
+                            "--since", "2099-01-01T00:00:00Z")
+        assert proc.returncode == 2, "a far-future floor hid a real conflict"
+        assert "never captured" in proc.stderr
+
+    def test_undateable_and_unclaimed_finding_is_still_exempt(
+            self, judgment_repo, run_findings_writer):
+        """No receipt and no date: genuinely pre-feature. Must stay exempt, or
+        every legacy PRD blocks forever and the gate gets switched off."""
+        assert run_findings_writer(
+            judgment_repo, "set-disposition", PRD_ID, "finding-1", "accepted",
+            env_extra={"KIPI_JUDGMENT_CAPTURE": "0"}).returncode == 0
+        path = (judgment_repo / ".prd-os" / "findings"
+                / f"{PRD_ID}-findings.jsonl")
+        rows = [json.loads(l) for l in path.read_text().splitlines() if l.strip()]
+        rows[0].pop("resolved_at", None)
+        path.write_text("".join(json.dumps(r, sort_keys=True) + "\n" for r in rows))
+        proc = run_judgment(judgment_repo, "verify", "--cross-check",
+                            "--since", "2099-01-01T00:00:00Z")
+        assert proc.returncode == 0, proc.stderr

--- a/plugins/prd-os/tests/test_judgment_compiler.py
+++ b/plugins/prd-os/tests/test_judgment_compiler.py
@@ -1706,10 +1706,18 @@ class TestGateUsesAPrdLevelFloor:
             "waved through: the kill-switch-plus-strip hole")
         assert "no judgment receipt" in message
 
-    def test_a_prd_created_before_the_floor_stays_exempt(
+    def test_an_old_prd_does_not_exempt_a_decision_made_today(
             self, fake_repo, write_config, run_findings_writer):
-        """Pre-compiler decisions can never have receipts. A gate that cannot
-        be satisfied gets switched off, and an off gate protects nothing."""
+        """Codex BLOCKER on PR #102: a PRD-creation-date floor exempted every
+        FUTURE decision on a pre-floor PRD. 35 of 36 real PRDs predate the
+        floor, so the gate was a near-permanent no-op -- the opposite of
+        "receipts are required from here on".
+
+        Measured before removing the exemption: of the 36 real PRDs, 21 are
+        archived and 13 approved, so they can never reach this gate again. ONE
+        (in-review, 13 dispositioned findings) can, and its remedy is one
+        `set-disposition` re-run per finding, which mints the receipt. So the
+        exemption bought almost nothing and cost the entire guarantee."""
         legacy = "prd-legacy-2026-07-01"
         write_config(fake_repo, {"config_schema_version": 1})
         write_prd_spec(fake_repo, legacy)
@@ -1722,8 +1730,11 @@ class TestGateUsesAPrdLevelFloor:
             fake_repo, "set-disposition", legacy, "finding-1", "accepted",
             env_extra={"KIPI_JUDGMENT_CAPTURE": "0"}).returncode == 0
         runner = _load_module("pr_floor_b", "prd_runner.py")
-        code, _ = runner._judgment_receipt_gate(_cfg_for(fake_repo), legacy)
-        assert code == 0, "the floor must not block every legacy PRD forever"
+        code, message = runner._judgment_receipt_gate(_cfg_for(fake_repo), legacy)
+        assert code == 2, (
+            "an old PRD id must not buy an exemption for a decision being "
+            "approved today")
+        assert "no judgment receipt" in message
 
     def test_an_undateable_prd_id_fails_closed(
             self, fake_repo, write_config, run_findings_writer):
@@ -1874,32 +1885,43 @@ class TestPersistPathIsOneCriticalSection:
             f"{seen[0]}")
 
 
-@pytest.mark.parametrize("prd_id,requires_receipt", [
-    ("prd-real-2026-08-05", True),      # post-floor: enforced
-    ("prd-legacy-2026-06-01", False),   # genuinely pre-floor: exempt
-    ("prd-nodate", True),               # no date at all: fail closed
-    ("prd-evade-0000-00-00", True),     # date-SHAPED, no calendar produces it
-    ("prd-evade-1970-01-01", True),     # a real date, absurd for this project
-    ("prd-evade-2026-13-45", True),     # month 13: rejected by shape alone
-    # IN-RANGE and sorts before the floor, so ONLY the real-date parse rejects
-    # it. Added after a mutation run: deleting the strptime guard left every
-    # other row green, because the plausibility floor happens to subsume
-    # 0000-00-00 and string ordering happens to subsume 2026-13-45. Without
-    # this row the guard could be deleted and no test would notice.
-    ("prd-evade-2026-02-30", True),     # February 30th does not exist
-    ("prd-evade-2026-06-31", True),     # June has 30 days
-])
-def test_only_a_real_plausible_date_earns_an_exemption(prd_id, requires_receipt):
-    """The exemption must need a date that a calendar can produce AND that this
-    project could plausibly have used.
+# The date-shape table that used to live here is gone with the mechanism it
+# guarded. `_prd_predates_floor` parsed a date out of the prd_id; Codex's
+# blocker showed the whole date-based exemption was wrong, so the function was
+# deleted rather than hardened a third time. A class dies best by deleting the
+# mechanism, not by adding a guard to it.
 
-    The whole reason the floor moved off `resolved_at` was that a strippable
-    field handed out a free exemption. Matching a date-SHAPED suffix and then
-    string-comparing it relocates that defect rather than killing it:
-    `prd-evade-0000-00-00` is not a date any calendar produces, and
-    `1970-01-01` parses fine but predates this project by decades. Both were
-    exempt. `strptime` alone does not close it -- the epoch date is valid --
-    so a plausibility floor is required too, and both branches fail closed.
+
+def test_no_date_parsing_survives_in_the_receipt_gate():
+    """Executable proof the class is gone, not merely unused."""
+    source = (SCRIPTS_DIR / "prd_runner.py").read_text()
+    for dead in ("_prd_predates_floor", "_PRD_ID_DATE", "_PRD_DATE_EARLIEST"):
+        assert dead not in source, (
+            f"{dead} is back: the receipt gate must not infer eligibility "
+            "from any date")
+
+
+def test_the_cross_check_runs_under_the_writer_lock(judgment_repo, monkeypatch):
+    """Codex MAJOR on PR #102: the gate read the ledger under `ledger_lock`,
+    RELEASED it, and only then cross-checked the findings files. A concurrent,
+    perfectly valid triage landing in that gap writes a disposition the gate's
+    stale ledger snapshot cannot see, so approval false-blocks on a missing
+    receipt that does exist. The lock has to span the comparison, not just the
+    read that feeds it.
+
+    `ledger_lock` is re-entrant per thread, so depth > 0 is exactly the
+    assertion "a lock is held right now" without deadlocking the prober.
     """
-    runner = _load_module(f"pr_shape_{prd_id}", "prd_runner.py")
-    assert runner._prd_predates_floor(prd_id) is not requires_receipt
+    runner = _load_module("pr_lockspan", "prd_runner.py")
+    import judgment_compiler as jc
+
+    seen = []
+    real = jc.cross_check_findings
+    monkeypatch.setattr(jc, "cross_check_findings",
+                        lambda *a, **k: (seen.append(
+                            getattr(jc._LOCK_DEPTH, "value", 0)) or real(*a, **k)))
+    runner._judgment_receipt_gate(_cfg_for(judgment_repo), PRD_ID)
+    assert seen, "the cross-check never ran"
+    assert seen[0] >= 1, (
+        "cross_check_findings ran with the writer lock released; a concurrent "
+        "triage in that window false-blocks approval")

--- a/plugins/prd-os/tests/test_judgment_compiler.py
+++ b/plugins/prd-os/tests/test_judgment_compiler.py
@@ -1458,3 +1458,46 @@ class TestReceiptGateFailsClosed:
             return real_import(name, *args, **kwargs)
         monkeypatch.setattr("builtins.__import__", no_compiler)
         assert runner._judgment_receipt_gate(object(), "prd-alpha") == (0, "")
+
+
+class TestGateChecksTheDecisionNotJustTheFinding:
+    def test_hand_edited_disposition_is_caught(self, judgment_repo,
+                                               run_findings_writer):
+        """Codex PR #101 r2: coverage was identity-only, so a receipt for an
+        EARLIER decision satisfied the gate after the findings file was edited
+        to a different one -- the decision actually recorded had none."""
+        assert run_findings_writer(judgment_repo, "set-disposition", PRD_ID,
+                                   "finding-1", "accepted").returncode == 0
+        assert len(read_ledger(judgment_repo)) == 1
+        path = (judgment_repo / ".prd-os" / "findings"
+                / f"{PRD_ID}-findings.jsonl")
+        rows = [json.loads(l) for l in path.read_text().splitlines() if l.strip()]
+        rows[0]["disposition"] = "rejected"      # hand-edit, no capture
+        rows[0]["rationale"] = "changed my mind offline"
+        path.write_text("".join(json.dumps(r, sort_keys=True) + "\n" for r in rows))
+        proc = run_judgment(judgment_repo, "verify", "--cross-check",
+                            "--since", "2026-01-01T00:00:00Z")
+        assert proc.returncode == 2
+        assert "never captured" in proc.stderr
+
+    def test_matching_disposition_passes(self, judgment_repo,
+                                         run_findings_writer):
+        assert run_findings_writer(judgment_repo, "set-disposition", PRD_ID,
+                                   "finding-1", "accepted").returncode == 0
+        proc = run_judgment(judgment_repo, "verify", "--cross-check",
+                            "--since", "2026-01-01T00:00:00Z")
+        assert proc.returncode == 0, proc.stderr
+
+    def test_redisposition_through_the_writer_stays_covered(
+            self, judgment_repo, run_findings_writer):
+        """A legitimate change of mind captures a superseding receipt, so the
+        latest receipt matches and the gate stays green."""
+        assert run_findings_writer(judgment_repo, "set-disposition", PRD_ID,
+                                   "finding-1", "accepted").returncode == 0
+        assert run_findings_writer(
+            judgment_repo, "set-disposition", PRD_ID, "finding-1", "rejected",
+            "--rationale", "reconsidered", "--reason-code",
+            "invalid-finding").returncode == 0
+        proc = run_judgment(judgment_repo, "verify", "--cross-check",
+                            "--since", "2026-01-01T00:00:00Z")
+        assert proc.returncode == 0, proc.stderr

--- a/plugins/prd-os/tests/test_judgment_compiler.py
+++ b/plugins/prd-os/tests/test_judgment_compiler.py
@@ -1872,3 +1872,34 @@ class TestPersistPathIsOneCriticalSection:
         assert seen[0] == "LOCK_HELD", (
             "an outside reader observed the findings file mid-persist: "
             f"{seen[0]}")
+
+
+@pytest.mark.parametrize("prd_id,requires_receipt", [
+    ("prd-real-2026-08-05", True),      # post-floor: enforced
+    ("prd-legacy-2026-06-01", False),   # genuinely pre-floor: exempt
+    ("prd-nodate", True),               # no date at all: fail closed
+    ("prd-evade-0000-00-00", True),     # date-SHAPED, no calendar produces it
+    ("prd-evade-1970-01-01", True),     # a real date, absurd for this project
+    ("prd-evade-2026-13-45", True),     # month 13: rejected by shape alone
+    # IN-RANGE and sorts before the floor, so ONLY the real-date parse rejects
+    # it. Added after a mutation run: deleting the strptime guard left every
+    # other row green, because the plausibility floor happens to subsume
+    # 0000-00-00 and string ordering happens to subsume 2026-13-45. Without
+    # this row the guard could be deleted and no test would notice.
+    ("prd-evade-2026-02-30", True),     # February 30th does not exist
+    ("prd-evade-2026-06-31", True),     # June has 30 days
+])
+def test_only_a_real_plausible_date_earns_an_exemption(prd_id, requires_receipt):
+    """The exemption must need a date that a calendar can produce AND that this
+    project could plausibly have used.
+
+    The whole reason the floor moved off `resolved_at` was that a strippable
+    field handed out a free exemption. Matching a date-SHAPED suffix and then
+    string-comparing it relocates that defect rather than killing it:
+    `prd-evade-0000-00-00` is not a date any calendar produces, and
+    `1970-01-01` parses fine but predates this project by decades. Both were
+    exempt. `strptime` alone does not close it -- the epoch date is valid --
+    so a plausibility floor is required too, and both branches fail closed.
+    """
+    runner = _load_module(f"pr_shape_{prd_id}", "prd_runner.py")
+    assert runner._prd_predates_floor(prd_id) is not requires_receipt

--- a/plugins/prd-os/tests/test_judgment_compiler.py
+++ b/plugins/prd-os/tests/test_judgment_compiler.py
@@ -1426,6 +1426,9 @@ class TestReceiptGateFailsClosed:
         import judgment_compiler as jc
 
         monkeypatch.setattr(jc, "ledger_path", lambda cfg: Path("/dev/null"))
+        import contextlib
+        monkeypatch.setattr(jc, "ledger_lock",
+                            lambda cfg: contextlib.nullcontext())
         def boom(_path):
             raise ValueError("line 7: invalid JSON")
         monkeypatch.setattr(jc, "read_ledger", boom)
@@ -1444,6 +1447,10 @@ class TestReceiptGateFailsClosed:
         monkeypatch.setattr(jc, "tip_path", lambda cfg: Path("/dev/null"))
         monkeypatch.setattr(jc, "read_tip", lambda p: None)
         monkeypatch.setattr(jc, "verify_ledger", lambda r, tip=None: [])
+        # the gate now reads under the writer's lock; a stub cfg has no path
+        import contextlib
+        monkeypatch.setattr(jc, "ledger_lock",
+                            lambda cfg: contextlib.nullcontext())
         monkeypatch.setattr(jc, "cross_check_findings", lambda c, r, s: [
             "prd-alpha-2/finding-1: dispositioned but no judgment receipt exists"])
         assert runner._judgment_receipt_gate(object(), "prd-alpha")[0] == 0

--- a/plugins/prd-os/tests/test_judgment_compiler.py
+++ b/plugins/prd-os/tests/test_judgment_compiler.py
@@ -1541,3 +1541,40 @@ class TestGateVerifiesBeforeTrusting:
         code, message = runner._judgment_receipt_gate(cfg, PRD_ID)
         assert code == 2, "a forged receipt authorized approval"
         assert "does not verify" in message
+
+
+class TestDecisionFingerprint:
+    """Rounds 2-5 of PR #101 each found a different unchecked field. One
+    fingerprint, used on both sides, closes the class rather than the instance."""
+
+    def test_hand_edited_rationale_is_caught(self, judgment_repo,
+                                             run_findings_writer):
+        assert run_findings_writer(
+            judgment_repo, "set-disposition", PRD_ID, "finding-1", "rejected",
+            "--rationale", "duplicate of finding-9",
+            "--reason-code", "invalid-finding").returncode == 0
+        path = (judgment_repo / ".prd-os" / "findings"
+                / f"{PRD_ID}-findings.jsonl")
+        rows = [json.loads(l) for l in path.read_text().splitlines() if l.strip()]
+        rows[0]["rationale"] = "actually it was a security hole"  # rewritten
+        path.write_text("".join(json.dumps(r, sort_keys=True) + "\n" for r in rows))
+        proc = run_judgment(judgment_repo, "verify", "--cross-check",
+                            "--since", "2026-01-01T00:00:00Z")
+        assert proc.returncode == 2
+        assert "never captured" in proc.stderr
+
+    def test_empty_vs_absent_rationale_is_not_a_change(self, judgment_repo,
+                                                       run_findings_writer):
+        """The writer stores None for an empty rationale; a findings record may
+        omit the key. That difference must not read as tampering."""
+        assert run_findings_writer(judgment_repo, "set-disposition", PRD_ID,
+                                   "finding-1", "accepted").returncode == 0
+        path = (judgment_repo / ".prd-os" / "findings"
+                / f"{PRD_ID}-findings.jsonl")
+        rows = [json.loads(l) for l in path.read_text().splitlines() if l.strip()]
+        rows[0].pop("rationale", None)
+        rows[0]["rationale"] = ""
+        path.write_text("".join(json.dumps(r, sort_keys=True) + "\n" for r in rows))
+        proc = run_judgment(judgment_repo, "verify", "--cross-check",
+                            "--since", "2026-01-01T00:00:00Z")
+        assert proc.returncode == 0, proc.stderr

--- a/plugins/prd-os/tests/test_judgment_compiler.py
+++ b/plugins/prd-os/tests/test_judgment_compiler.py
@@ -1376,7 +1376,7 @@ class TestBakedIntoApproval:
         sys.modules["jc_cfg"] = cfgmod
         cfg_spec.loader.exec_module(cfgmod)
         cfg = cfgmod.load(judgment_repo)
-        missing = jc.cross_check_findings(cfg, [], "2026-01-01T00:00:00Z")
+        missing, _ = jc.cross_check_findings(cfg, [], "2026-01-01T00:00:00Z")
         assert any(PRD_ID in m for m in missing), missing
         assert any("no judgment receipt" in m for m in missing)
 
@@ -1399,7 +1399,7 @@ class TestBakedIntoApproval:
             judgment_repo, "set-disposition", PRD_ID, "finding-1", "accepted",
             env_extra={"KIPI_JUDGMENT_CAPTURE": "0"}).returncode == 0
         cfg = cfgmod.load(judgment_repo)
-        far_future = jc.cross_check_findings(cfg, [], "2099-01-01T00:00:00Z")
+        far_future, _ = jc.cross_check_findings(cfg, [], "2099-01-01T00:00:00Z")
         assert far_future == [], "floor did not exempt an older disposition"
 
 
@@ -1451,8 +1451,11 @@ class TestReceiptGateFailsClosed:
         import contextlib
         monkeypatch.setattr(jc, "ledger_lock",
                             lambda cfg: contextlib.nullcontext())
-        monkeypatch.setattr(jc, "cross_check_findings", lambda c, r, s: [
-            "prd-alpha-2/finding-1: dispositioned but no judgment receipt exists"])
+        monkeypatch.setattr(
+            jc, "cross_check_findings",
+            lambda c, r, s=None, *, prd_id=None: ([
+                "prd-alpha-2/finding-1: dispositioned but no judgment receipt "
+                "exists"], []))
         assert runner._judgment_receipt_gate(object(), "prd-alpha")[0] == 0
         assert runner._judgment_receipt_gate(object(), "prd-alpha-2")[0] == 2
 
@@ -1638,3 +1641,234 @@ class TestFloorDoesNotShieldAConflict:
         proc = run_judgment(judgment_repo, "verify", "--cross-check",
                             "--since", "2099-01-01T00:00:00Z")
         assert proc.returncode == 0, proc.stderr
+
+
+# ---------------------------------------------------------------------------
+# PR #101 split: the gate keeps the integrity half (rounds 1-5) and demotes the
+# field-agreement half (rounds 6-8). See CHANGELOG 0.14.0.
+# ---------------------------------------------------------------------------
+
+
+FINDINGS_REL = ".prd-os/findings"
+
+
+def _load_module(name: str, filename: str):
+    """Load a scripts/ module under a private name (the file's own convention)."""
+    import importlib.util
+    spec = importlib.util.spec_from_file_location(name, SCRIPTS_DIR / filename)
+    module = importlib.util.module_from_spec(spec)
+    sys.modules[name] = module
+    spec.loader.exec_module(module)
+    return module
+
+
+def _cfg_for(repo: Path):
+    return _load_module(f"cfg_{repo.name}_{id(repo)}", "config.py").load(repo)
+
+
+def _findings_rows(repo: Path, prd_id: str = PRD_ID) -> tuple[Path, list[dict]]:
+    path = repo / FINDINGS_REL / f"{prd_id}-findings.jsonl"
+    rows = [json.loads(line) for line in path.read_text().splitlines()
+            if line.strip()]
+    return path, rows
+
+
+def _rewrite_findings(path: Path, rows: list[dict]) -> None:
+    path.write_text("".join(
+        json.dumps(r, sort_keys=True) + "\n" for r in rows))
+
+
+class TestGateUsesAPrdLevelFloor:
+    """Rounds 2, 7 and 8 were ONE defect class: inferring "was this decided
+    after the floor" from `resolved_at`, a mutable strippable field on a
+    hand-editable file. The round-8 code admitted the inference was undecidable
+    ("undateable AND unclaimed: cannot judge, do not guess") and left a
+    documented hole: capture off, strip the date, invisible. The gate runs for
+    ONE named PRD whose id carries its creation date, so the floor is read from
+    the id instead and no `resolved_at` is parsed at all.
+    """
+
+    def test_stripping_resolved_at_no_longer_hides_a_missing_receipt(
+            self, judgment_repo, run_findings_writer):
+        """THE round-8 hole, executed: the documented invisible case."""
+        assert run_findings_writer(
+            judgment_repo, "set-disposition", PRD_ID, "finding-1", "accepted",
+            env_extra={"KIPI_JUDGMENT_CAPTURE": "0"}).returncode == 0
+        path, rows = _findings_rows(judgment_repo)
+        for row in rows:
+            row.pop("resolved_at", None)
+        _rewrite_findings(path, rows)
+        runner = _load_module("pr_floor_a", "prd_runner.py")
+        code, message = runner._judgment_receipt_gate(
+            _cfg_for(judgment_repo), PRD_ID)
+        assert code == 2, (
+            "a dispositioned finding with the date stripped and no receipt was "
+            "waved through: the kill-switch-plus-strip hole")
+        assert "no judgment receipt" in message
+
+    def test_a_prd_created_before_the_floor_stays_exempt(
+            self, fake_repo, write_config, run_findings_writer):
+        """Pre-compiler decisions can never have receipts. A gate that cannot
+        be satisfied gets switched off, and an off gate protects nothing."""
+        legacy = "prd-legacy-2026-07-01"
+        write_config(fake_repo, {"config_schema_version": 1})
+        write_prd_spec(fake_repo, legacy)
+        assert run_findings_writer(
+            fake_repo, "add", legacy, "--source", "codex-review",
+            stdin_text=json.dumps(
+                [{"severity": "major", "body": "a legacy finding"}])
+        ).returncode == 0
+        assert run_findings_writer(
+            fake_repo, "set-disposition", legacy, "finding-1", "accepted",
+            env_extra={"KIPI_JUDGMENT_CAPTURE": "0"}).returncode == 0
+        runner = _load_module("pr_floor_b", "prd_runner.py")
+        code, _ = runner._judgment_receipt_gate(_cfg_for(fake_repo), legacy)
+        assert code == 0, "the floor must not block every legacy PRD forever"
+
+    def test_an_undateable_prd_id_fails_closed(
+            self, fake_repo, write_config, run_findings_writer):
+        """No code enforces a prd_id format, so an id whose date cannot be
+        parsed must be treated as post-floor, never exempted."""
+        weird = "prd-no-date-at-all"
+        write_config(fake_repo, {"config_schema_version": 1})
+        write_prd_spec(fake_repo, weird)
+        assert run_findings_writer(
+            fake_repo, "add", weird, "--source", "codex-review",
+            stdin_text=json.dumps(
+                [{"severity": "major", "body": "an undateable finding"}])
+        ).returncode == 0
+        assert run_findings_writer(
+            fake_repo, "set-disposition", weird, "finding-1", "accepted",
+            env_extra={"KIPI_JUDGMENT_CAPTURE": "0"}).returncode == 0
+        runner = _load_module("pr_floor_c", "prd_runner.py")
+        code, message = runner._judgment_receipt_gate(_cfg_for(fake_repo), weird)
+        assert code == 2, "an unparseable prd_id must fail CLOSED, not exempt"
+        assert "no judgment receipt" in message
+
+    def test_a_post_floor_prd_with_its_receipt_passes(self, judgment_repo,
+                                                      run_findings_writer):
+        """Negative self-test: the gate is not simply always-blocking."""
+        assert run_findings_writer(judgment_repo, "set-disposition", PRD_ID,
+                                   "finding-1", "accepted").returncode == 0
+        runner = _load_module("pr_floor_d", "prd_runner.py")
+        code, message = runner._judgment_receipt_gate(
+            _cfg_for(judgment_repo), PRD_ID)
+        assert code == 0, message
+
+
+class TestDecisionDisagreementWarnsAndDoesNotBlock:
+    """Rounds 6-8 compared the MUTABLE findings file against the IMMUTABLE
+    receipt and caused two of their own regressions. `cmd_evaluate` (which
+    feeds the release gates) reads ONLY the ledger, so the ledger is the
+    calibration set and the findings file is operational state. When they
+    disagree the receipt is still the honest record, so this reports rather
+    than blocks -- and false-blocking is the failure mode that gets a gate
+    switched off.
+    """
+
+    def _diverge(self, repo, run_findings_writer):
+        assert run_findings_writer(repo, "set-disposition", PRD_ID,
+                                   "finding-1", "accepted").returncode == 0
+        path, rows = _findings_rows(repo)
+        rows[0]["rationale"] = "rewritten after the receipt was frozen"
+        _rewrite_findings(path, rows)
+
+    def test_a_fingerprint_mismatch_exits_zero_with_a_warning(
+            self, judgment_repo, run_findings_writer):
+        self._diverge(judgment_repo, run_findings_writer)
+        runner = _load_module("pr_warn_a", "prd_runner.py")
+        code, message = runner._judgment_receipt_gate(
+            _cfg_for(judgment_repo), PRD_ID)
+        assert code == 0, (
+            "a disagreement between the mutable findings copy and the receipt "
+            f"must not block approval: {message}")
+        assert "warning" in message.lower()
+        assert "finding-1" in message
+
+    def test_evaluate_reports_the_disagreement_count(self, judgment_repo,
+                                                     run_findings_writer):
+        """Precedent: 41c0876 made the release gates read the evidence-gate
+        bypass rate rather than leaving a documented condition unenforced."""
+        self._diverge(judgment_repo, run_findings_writer)
+        proc = run_judgment(judgment_repo, "evaluate")
+        assert proc.returncode == 0, proc.stderr
+        report = json.loads(proc.stdout)
+        assert report["decision_disagreement_count"] == 1, report
+        gate = report["release_gates"]["zero_decision_disagreements"]
+        assert gate["passed"] is False, gate
+        assert report["release_gates"]["passed"] is False
+
+    def test_evaluate_reports_zero_when_the_copy_agrees(
+            self, judgment_repo, run_findings_writer):
+        """Negative self-test for the counter itself."""
+        assert run_findings_writer(judgment_repo, "set-disposition", PRD_ID,
+                                   "finding-1", "accepted").returncode == 0
+        proc = run_judgment(judgment_repo, "evaluate")
+        assert proc.returncode == 0, proc.stderr
+        report = json.loads(proc.stdout)
+        assert report["decision_disagreement_count"] == 0
+        assert report["release_gates"][
+            "zero_decision_disagreements"]["passed"] is True
+
+
+# An out-of-process observer: the ONLY way to probe the lock from a test, since
+# flock re-entry on a second fd blocks in the SAME process (measured: a second
+# LOCK_EX in one process hangs). It reports whether the persist path left a
+# window in which a gate could see a disposition whose receipt is not yet there.
+_LOCK_OBSERVER = '''
+import fcntl, json, sys
+from pathlib import Path
+
+repo, prd = Path(sys.argv[1]), sys.argv[2]
+handle = open(repo / ".prd-os" / ".judgments.lock", "a+")
+try:
+    fcntl.flock(handle.fileno(), fcntl.LOCK_EX | fcntl.LOCK_NB)
+except OSError:
+    print("LOCK_HELD")
+    raise SystemExit(0)
+rows = [json.loads(l) for l
+        in (repo / ".prd-os" / "findings" / (prd + "-findings.jsonl")
+            ).read_text().splitlines() if l.strip()]
+done = [r for r in rows if r.get("disposition") not in (None, "pending")]
+ledger = repo / ".prd-os" / "judgments.jsonl"
+receipts = len([l for l in ledger.read_text().splitlines() if l.strip()]) \\
+    if ledger.is_file() else 0
+print("WINDOW_OPEN dispositioned=%d receipts=%d" % (len(done), receipts))
+'''
+
+
+class TestPersistPathIsOneCriticalSection:
+    """sp-0c725cde, a defect in MERGED code. `_write_all` published the
+    disposition and only afterwards did `capture_from_triage` take
+    `ledger_lock` internally. A gate reading under that lock (the round-4 fix)
+    could land in the gap, see a dispositioned finding with no receipt, and
+    false-block work that was completing normally.
+    """
+
+    def test_no_reader_can_observe_a_disposition_without_its_receipt(
+            self, judgment_repo, tmp_path, monkeypatch):
+        import argparse
+
+        writer = _load_module("fw_window", "findings_writer.py")
+        observer = tmp_path / "lock_observer.py"
+        observer.write_text(_LOCK_OBSERVER)
+        seen: list[str] = []
+        real_write_all = writer._write_all
+
+        def watched_write_all(path, records):
+            real_write_all(path, records)
+            proc = subprocess.run(
+                [sys.executable, str(observer), str(judgment_repo), PRD_ID],
+                capture_output=True, text=True)
+            seen.append((proc.stdout + proc.stderr).strip())
+
+        monkeypatch.setattr(writer, "_write_all", watched_write_all)
+        args = argparse.Namespace(
+            prd_id=PRD_ID, finding_id="finding-1", disposition="accepted",
+            rationale="", covered_by="", reason_code=None, evidence=[],
+            actor="founder", judge_run=None)
+        assert writer.cmd_set_disposition(_cfg_for(judgment_repo), args) == 0
+        assert seen, "the persist path never wrote the findings file"
+        assert seen[0] == "LOCK_HELD", (
+            "an outside reader observed the findings file mid-persist: "
+            f"{seen[0]}")

--- a/plugins/prd-os/tests/test_prd_runner.py
+++ b/plugins/prd-os/tests/test_prd_runner.py
@@ -199,6 +199,27 @@ def _walk_to_in_review(repo, run_prd_runner):
     assert run_prd_runner(repo, "advance", "in-review").returncode == 0
 
 
+def _capture_receipts(run_findings_writer, repo: Path, prd_id: str,
+                      decisions: list[tuple]) -> None:
+    """Re-record each disposition through the PRODUCER so it carries a receipt.
+
+    `_write_findings` injects records straight to disk, which no production
+    path does: a real disposition goes through findings_writer, which writes
+    the judgment receipt in the same critical section. The approval gate
+    requires a receipt for every PRD created on or after the floor, and
+    `prd_runner new` dates these fixtures today, so the hand-written shortcut
+    is what made them unrealistic -- not the gate. Before the PRD-level floor
+    these passed only because the injected records carry no `resolved_at` and
+    the old gate skipped undateable findings, which is exactly the hole the
+    floor closes (PR #101 round 8).
+    """
+    for finding_id, disposition, rationale in decisions:
+        extra = ["--rationale", rationale] if rationale else []
+        proc = run_findings_writer(repo, "set-disposition", prd_id,
+                                   finding_id, disposition, *extra)
+        assert proc.returncode == 0, proc.stderr
+
+
 def _write_findings(repo: Path, prd_id: str, records: list[dict]) -> Path:
     path = repo / ".prd-os/findings" / f"{prd_id}-findings.jsonl"
     path.parent.mkdir(parents=True, exist_ok=True)
@@ -280,7 +301,8 @@ def test_approve_blocked_by_pending_finding(fake_repo, write_config, run_prd_run
     assert "pending" in r.stderr.lower()
 
 
-def test_approve_allowed_when_all_dispositioned(fake_repo, write_config, run_prd_runner):
+def test_approve_allowed_when_all_dispositioned(fake_repo, write_config, run_prd_runner,
+                                                run_findings_writer):
     _bootstrap(fake_repo, write_config)
     assert run_prd_runner(fake_repo, "new", "disp-ok").returncode == 0
     prd_id = _read_state(fake_repo)["prd_id"]
@@ -325,6 +347,9 @@ def test_approve_allowed_when_all_dispositioned(fake_repo, write_config, run_prd
             },
         ],
     )
+    _capture_receipts(run_findings_writer, fake_repo, prd_id,
+                      [("finding-1", "accepted", None),
+                       ("finding-2", "deferred", "later")])
     r = run_prd_runner(fake_repo, "advance", "approved")
     assert r.returncode == 0, r.stderr
 
@@ -576,7 +601,8 @@ def test_advance_archived_also_runs_manifest_gate(
     assert "via-advance-issue-1" in r.stderr
 
 
-def test_approve_blocked_without_bypass_check_or_exempt(fake_repo, write_config, run_prd_runner):
+def test_approve_blocked_without_bypass_check_or_exempt(fake_repo, write_config, run_prd_runner,
+                                                        run_findings_writer):
     """Spine contract: an entry with neither bypass_check nor bypass_exempt
     cannot approve; adding either unblocks."""
     _bootstrap(fake_repo, write_config)
@@ -591,6 +617,8 @@ def test_approve_blocked_without_bypass_check_or_exempt(fake_repo, write_config,
         "id": "finding-1", "prd_id": prd_id, "source": "codex-review",
         "severity": "minor", "disposition": "accepted", "body": "ok",
         "created_at": "2026-04-16T00:00:00Z"}])
+    _capture_receipts(run_findings_writer, fake_repo, prd_id,
+                      [("finding-1", "accepted", None)])
     r = run_prd_runner(fake_repo, "advance", "approved")
     assert r.returncode == 2
     assert "bypass_check" in r.stderr and "bypass_exempt" in r.stderr
@@ -611,7 +639,7 @@ def test_approve_blocked_without_bypass_check_or_exempt(fake_repo, write_config,
 
 
 def test_umbrella_kind_approves_empty_and_archives_on_real_coverage(
-        fake_repo, write_config, run_prd_runner):
+        fake_repo, write_config, run_prd_runner, run_findings_writer):
     """kind: umbrella — empty manifest approves when accepted findings carry
     covered_by; archive verifies coverage targets exist and are past idea."""
     _bootstrap(fake_repo, write_config)
@@ -627,6 +655,8 @@ def test_umbrella_kind_approves_empty_and_archives_on_real_coverage(
         "severity": "major", "disposition": "accepted", "body": "phase work",
         "created_at": "2026-04-16T00:00:00Z",
         "covered_by": "prd-missing-phase-2099-01-01"}])
+    _capture_receipts(run_findings_writer, fake_repo, prd_id,
+                      [("finding-1", "accepted", None)])
     r = run_prd_runner(fake_repo, "advance", "approved")
     assert r.returncode == 0, r.stderr  # approval: coverage NAMED is enough
     # archive: the named coverage must EXIST and be past idea
@@ -669,3 +699,36 @@ def test_depends_on_blocks_activation_on_red_gate(
         "registered_at": "2026-01-01T00:00:00Z"}) + "\n")
     r = run_prd_runner(fake_repo, "load", two_id)
     assert r.returncode == 0, r.stderr
+
+
+def test_advance_emits_the_decision_disagreement_warning_at_rc_zero(
+        fake_repo, write_config, run_prd_runner, run_findings_writer):
+    """The judgment gate returns (0, warning) when the mutable findings copy
+    has drifted off the immutable receipt. `cmd_advance` wrote `err` only when
+    `rc != 0`, which would have swallowed that text entirely and turned the
+    round-6/7/8 demotion into a silent drop instead of a report.
+    """
+    _bootstrap(fake_repo, write_config)
+    assert run_prd_runner(fake_repo, "new", "warn-x").returncode == 0
+    prd_id = _read_state(fake_repo)["prd_id"]
+    _walk_to_in_review(fake_repo, run_prd_runner)
+    _stamp_reviewed(fake_repo, prd_id)
+    _write_manifest(fake_repo, prd_id, [{
+        "id": "i1", "title": "t", "finding_id": "finding-1",
+        "allowed_files": ["a.py"], "required_checks": ["pytest"],
+        "bypass_exempt": "test fixture"}])
+    _write_findings(fake_repo, prd_id, [{
+        "id": "finding-1", "prd_id": prd_id, "source": "codex-review",
+        "severity": "minor", "disposition": "accepted", "body": "ok",
+        "created_at": "2026-04-16T00:00:00Z"}])
+    _capture_receipts(run_findings_writer, fake_repo, prd_id,
+                      [("finding-1", "accepted", None)])
+    path = fake_repo / ".prd-os/findings" / f"{prd_id}-findings.jsonl"
+    rows = [json.loads(line) for line in path.read_text().splitlines()
+            if line.strip()]
+    rows[0]["rationale"] = "rewritten after the receipt was frozen"
+    path.write_text("".join(json.dumps(r) + "\n" for r in rows))
+    r = run_prd_runner(fake_repo, "advance", "approved")
+    assert r.returncode == 0, r.stderr
+    assert "WARNING" in r.stderr, r.stderr
+    assert "finding-1" in r.stderr, r.stderr

--- a/q-system/.q-system/scripts/founder-judge-calibration.py
+++ b/q-system/.q-system/scripts/founder-judge-calibration.py
@@ -392,8 +392,13 @@ def _precision_gloss(result: dict) -> str:
     metrics beside it is worse than no report.
     """
     precision = result["per_label"]["accepted"]["precision"]
+    # Boundary matters: at exactly 0.5 neither "more than half rejected" nor
+    # "most accepted" is true, and the old split reported 50% as "Most",
+    # contradicting the number beside it (Codex, PR #100 minors).
     if precision < 0.5:
         return "More than half of the judge's fix-now calls were not accepted."
+    if precision == 0.5:
+        return "Exactly half of the judge's fix-now calls were accepted."
     if precision < 1.0:
         return "Most of the judge's fix-now calls were accepted."
     return "Every fix-now call the judge made was accepted."


### PR DESCRIPTION
Supersedes #101. Same goal — make judgment receipts REQUIRED at `advance approved` rather than merely written — but #101's review history said the change was two different changes wearing one coat.

## Blast radius, measured against the real 36 PRDs

The gate is unconditional: every dispositioned finding in a PRD being approved needs a receipt, with no date logic anywhere. `_findings_gate` runs only under `if target == "approved"`, so PRDs already past that point can never re-reach it:

| PRD status (spec frontmatter) | count | can still reach this gate? |
|---|---|---|
| archived | 21 | no |
| approved | 13 | no |
| **in-review** | **1** (`prd-build-craft-2026-06-15`) | **yes — 13 dispositioned, 0 pending** |
| no spec file | 1 (`prd-notify-ledger-isolation-2026-08-04`) | yes — 0 dispositioned, 8 pending |

### Migration cost, stated plainly

**`prd-build-craft-2026-06-15` will BLOCK at `advance approved`** until each of its 13 dispositioned findings (8 accepted, 4 rejected, 1 deferred) carries a receipt. That is correct and intended — those decisions were made before receipts were enforced, and the gate's whole point is that an approval cannot bless decisions it has no record of.

It is satisfiable without special tooling: re-run `findings_writer.py set-disposition` for each finding, which mints the receipt as a side effect. Bounded, one-time, self-service.

This is called out because an earlier version of this PR body claimed the gate "blocks nothing today". That claim came from measuring only the *active* PRD and reading an inert gate as a safe one. The honest statement is the one above: it blocks one in-review PRD until 13 re-dispositions mint their receipts.

**Note on reading these numbers:** `prd_runner.py status` reports only the *active* PRD (`.claude/state/active-prd.json`), which is `prd-notify-ledger-isolation-2026-08-04` with 0 dispositioned findings. The 13 belong to `prd-build-craft-2026-06-15`, which is not active but is `in-review` and therefore still loadable and advanceable. Per-PRD status lives in each spec's frontmatter under `.prd-os/prds/`, not in the runner state.

**The `issue/` subtree does not inflate this.** `cross_check_findings` uses `rglob`, which sweeps 114 files rather than the 36 top-level ones. All 78 subtree records carry `prd_id = null`, so the gate's `prd_id` scoping excludes every one of them: measured contribution is zero.

## Why this is a split, not round 9

#101 took 7 Codex rounds, and **rounds 7 and 8 were regressions caused by the round-6 fix**. The 8 rounds partition cleanly:

| Rounds | What they fixed | Self-inflicted regressions |
|---|---|---|
| 1-5 | fail-closed on an unreadable ledger, exact `prd_id` match, verify the chain before trusting a receipt, read under the writer's lock | 0 |
| 6-8 | `_decision_fingerprint` comparing the mutable findings file against the immutable receipt | 2 |

The decisive asymmetry is which source feeds calibration. `judgment_compiler.py` `cmd_evaluate`, which the release gates read, reads **only the ledger**. `founder-judge-calibration.py` reads findings files only because it is the retrospective v1 harness over pre-compiler findings. So going forward the ledger IS the calibration set and the findings file is operational state.

- A **missing receipt** is a permanent, invisible hole in the calibration set. Blocking is right.
- A **disagreement** is the mutable operational copy having drifted off the immutable receipt — and when they disagree, the receipt is still the honest record. Blocking is wrong, and it false-blocks: three of that check's four tests exist to stop it blocking legitimate work, not to catch a real threat. A gate that false-blocks gets switched off, and an off gate protects nothing.

## The three changes

**1. A PRD-level floor replaces the per-finding date floor.**
Rounds 2, 7 and 8 are all one defect class: inferring "was this decided after the floor" from `resolved_at`, a mutable strippable field on a hand-editable file. The round-8 comment admits it is undecidable ("undateable AND unclaimed: cannot judge, do not guess") and leaves a documented hole — switch capture off, strip the date, invisible. Rather than patch it a ninth time, the class is killed by construction: the gate runs for ONE named PRD, PRD ids carry their creation date, so the floor reads the id and parses no finding field at all.

**2. The `_decision_fingerprint` comparison is demoted to a reported warning.** Still computed; prints at `advance approved` and does not block. `evaluate` now exposes `decision_disagreement_count` and gates on it (`zero_decision_disagreements`) — blocking a human's approval over drift is a false block, blocking *automation* over it is the right severity. Same shape as 41c0876.

`verify --cross-check` is **unchanged** and still reports both classes as errors. It is a diagnostic and stays maximally informative; only the gate narrows.

**3. `ledger_lock` is held across the findings write plus the capture** (`sp-0c725cde`) — a defect in **merged** code, not only in #101. `_write_all` published the disposition before `capture_from_triage` took the lock internally, leaving a window where a gate reading under that lock (the round-4 fix) sees a dispositioned finding with no receipt and false-blocks.

This required making `ledger_lock` re-entrant: `flock` keys on the open file description, not the process, so a nested acquire on a second fd deadlocks the caller against itself. Measured before writing the fix, not assumed.

## Review round: the date class had relocated, not died (`772a109`)

Review caught that change 1 matched a date-**shaped** suffix and then string-compared it, so an impossible date bought the same free exemption through the new mechanism:

```
EXEMPT   prd-evade-0000-00-00      <-- impossible date, free pass
EXEMPT   prd-evade-1970-01-01      <-- valid date, absurd, free pass
```

That is the defect this PR claims to kill, arriving through the replacement. Now parsed with `strptime` **and** bounded by a plausibility floor, both failing closed — `strptime` alone is insufficient because `1970-01-01` parses fine. The bound (`2026-01-01`) is **measured**: the 36 prd_ids span 2026-05-13 to 2026-08-04, so it cannot false-block a real legacy PRD. All six evasions now require receipts; the genuine pre-floor date stays exempt.

The regression is table-driven so the next relocation is caught by an existing check rather than by review.

## Evidence

Reproducer-first, each shown red before the fix:

- **Change 1** — post-floor PRD, `resolved_at` stripped, no receipt: silently skipped before, blocks now.
- **Change 2** — fingerprint mismatch: exit 2 before, exit 0 with a warning now.
- **Change 3** — an out-of-process observer takes the lock mid-persist. Before: `WINDOW_OPEN dispositioned=1 receipts=0`. After: `LOCK_HELD`. (Out-of-process because a same-process probe would deadlock, per above.)

**Mutation-tested every guard a passing test would not otherwise prove:**
- fail-open on an unparseable `prd_id` → killed
- `cmd_advance` reverting to `if rc != 0` (swallowing the warning at rc 0) → killed, stderr empty
- delete the plausibility floor → killed
- delete the `strptime` parse → **survived on the first run.** That was a gap in the test table, not a false alarm: the plausibility floor happens to subsume `0000-00-00` and string ordering happens to subsume `2026-13-45`, so no row isolated the real-date parse. Added `2026-02-30` and `2026-06-31` — in range, sorting before the floor, rejected only by `strptime`. Both mutants now die.

**465 passed, 1 skipped** (448 baseline + 17). `judgment_compiler.py --selftest` passes.

Three pre-existing `prd_runner` fixtures injected dispositioned findings straight to disk, bypassing the producer; they passed only via the round-8 undateable skip. Routed through `findings_writer` so they carry real receipts rather than widening the gate to accommodate an unrealistic fixture.

## Ledger safety

The ledger resolves via git-common-dir parent, not `repo_root`, so a worktree writes the **main checkout's** ledger. Verified directly: a fixture-shaped tmp repo resolves into tmp, while this worktree resolves to `/Users/assafkipnis/projects/kipi-system`. All tests run against `tmp_path`. The live `.prd-os/` tree hash was captured before and after every run; `judgments.jsonl` still does not exist and the 36 findings files are untouched, so there are zero receipts and no migration burden.

## Not in scope

Ledger-first projection (deriving the findings file from the ledger) is the right long-term shape but premature: the findings record merges two producers (reviewer fields, decision fields) while the receipt freezes only the decision fields, so it is a projection rather than a derivation — and it is a fleet-wide contract change on a system with zero receipts.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

