### PR TITLE
Publish four cross-instance lessons from the Judgment Compiler build (ASK-363)

### DIFF
--- a/q-system/lessons/a-check-must-be-able-to-fail-for-the-reason-you-care-abou.md
+++ b/q-system/lessons/a-check-must-be-able-to-fail-for-the-reason-you-care-abou.md
@@ -1,0 +1,21 @@
+---
+id: a-check-must-be-able-to-fail-for-the-reason-you-care-abou
+kind: pattern
+title: A check must be able to fail for the reason you care about, or it is decoration
+date: 2026-08-05
+---
+
+A test, gate, metric or diagnostic can pass while being structurally incapable of detecting the thing it was written to detect. It then reads as evidence of correctness and is worse than having no check at all, because it retires the question. The defect is not carelessness: checking a proxy for a property is easier than checking the property, and the proxy usually agrees, so nothing feels wrong.
+
+Observed twelve times in a single engineering session, split roughly evenly between the author and the reviewer. A test asserting a permission flag when the property was availability, controlled by a different flag. A table of malformed inputs where a coarse range guard already rejected every row, so the fine-grained parse could be deleted with the suite green. A binding test run against the one fixture shape structurally unable to exercise the binding. A measurement whose number equally supported "this is safe" and "this does nothing", read as the first. A process-matching pattern that could not distinguish the process to kill from the process to protect. A rate metric that by construction reports only on one subset of decisions, read as reporting on all of them. A pipeline whose exit status came from its final formatting command rather than the gate it wrapped, reporting success while the gate was red.
+
+How to apply:
+
+1. Before trusting a green result, name the concrete input that would make it RED for the reason you care about. If you cannot construct that input, the check is decoration. Delete it or rewrite it; do not leave it passing.
+2. Mutation-test the GUARD, not only the code it guards. Delete or invert the guard and confirm a test dies. A guard that can be removed with every test still green is not enforcing anything, and this is invisible to ordinary review.
+3. For races, timing and anything intermittent, a single run proves nothing in either direction: it can pass on broken code and fail on correct code. Iterate to N red before the fix and N green after, and use elapsed time as independent corroboration that the run actually exercised the path.
+4. Distrust the convenient explanation for an intermittent failure. "Contention", "flake", "transient" each cost one measured run to refute. Skipping that run converts a real defect into a false claim about a gate's state, which is worse than a wrong conclusion because it looks settled.
+5. Watch for the asymmetry of recomputing someone else's number while waving through your own. Both occurred in one session from the same engineer, who correctly named it afterward.
+6. Grade the INPUT before grading the source. A reviewer that read nothing is not weak evidence; it is not evidence at any strength, and its output should be discarded unread rather than triaged.
+
+The general contract: a check earns trust from the failure it can produce, never from the pass it did produce. State the red-making input first, and the pass becomes meaningful.

--- a/q-system/lessons/a-safety-property-enforced-at-n-sites-is-not-a-chokepoint.md
+++ b/q-system/lessons/a-safety-property-enforced-at-n-sites-is-not-a-chokepoint.md
@@ -1,0 +1,22 @@
+---
+id: a-safety-property-enforced-at-n-sites-is-not-a-chokepoint
+kind: pattern
+title: A safety property enforced at N sites is not a chokepoint; apply single-writer to invariants too
+date: 2026-08-05
+---
+
+Single-writer discipline is usually applied to data paths: one function owns the write, so the write cannot be inconsistent. The same reasoning applies to INVARIANTS, and it is easy to miss because an invariant does not look like a resource.
+
+Observed on a component required to stay blind to a value it was being measured against. Blindness was preserved at four independent seams: a runtime flag controlling capability, the content of a rendered prompt, what got printed to an interactive session, and how references were validated. Three of the four were wrong, each discovered in a separate review round, because each seam was a separate opportunity to get it right and nothing forced them to agree. The fix was one function constructing the entire view the component was permitted to see, plus one test asserting that view carries no forbidden field. Three of the four seams then became ordinary code that structurally could not leak.
+
+The same shape appeared in a two-phase write whose consistency was maintained by careful ordering plus rollback. Three rounds each moved a boundary and each left a different inconsistency reachable, because rollback cannot undo an append. Recovering forward from a single irreversible step, with everything after it recomputable, removed the class rather than guarding it.
+
+How to apply:
+
+1. When a property must hold, count the places that preserve it. More than one means more than one chance to be wrong, and review will find them one round at a time.
+2. Build one constructor that establishes the property, and write ONE test asserting the property of its output. Prefer an allowlist over deleting known-bad fields: a field a future contributor adds is then excluded by default rather than leaking until someone remembers to exclude it.
+3. Ask what the component may CITE or emit, not only what it may perceive. Both are the same invariant and both fail independently.
+4. In a multi-step write, make exactly one step irreversible. Everything before it is validated and reversible; everything after it must be derivable from what is already durable, so a late failure is recovered by recomputation rather than by an impossible rollback.
+5. A late-stage failure of a derived artifact must never escalate into refusing an operation that already succeeded. Report it, repair it inline if bounded, and let a separate verifier own the residual state.
+
+The general contract: if you would apply single-writer to a data path, apply it to the invariant. A property maintained by N cooperating precautions is a property waiting for the round that finds the N+1th seam.

--- a/q-system/lessons/an-artifact-must-carry-its-own-provenance-not-inherit-it.md
+++ b/q-system/lessons/an-artifact-must-carry-its-own-provenance-not-inherit-it.md
@@ -1,0 +1,22 @@
+---
+id: an-artifact-must-carry-its-own-provenance-not-inherit-it
+kind: pattern
+title: An artifact must carry its own provenance, never inherit it from where it was filed
+date: 2026-08-05
+---
+
+An output file whose identity comes from its location, its filename, or the intent of the script that produced it will eventually describe something it did not do. Nothing in the artifact itself contradicts the label, so the mismatch is invisible to every later reader.
+
+Observed when an automated review was run from a stale copy of a runner left behind in a scratch directory. The stale copy hardcoded three things: an output directory named after one engine while invoking a different one, a review root pointing at a parent directory that was not a repository at all, and a process name identical to the canonical runner's. The result was a file that looked like a review by one tool, was produced by another, contained a verdict formed with no diff available, and could not be distinguished from a real review by reading it. A process-level attempt to stop it would have matched the legitimate run instead.
+
+The same class explains a family of quieter failures: a prompt asserting that references are resolved when they are only pattern-matched, a note instructing a reader not to be shown a value printed directly beside it, and a validator whose documentation names a helper that has since been deleted. In each, an artifact asserted something about the system that the system did not do, and each satisfied whatever checker was watching.
+
+How to apply:
+
+1. Every generated artifact records, inside itself, what produced it: the tool actually invoked, the root it actually read, and the resolved identifier of the input it examined. A reader must never have to inspect an exited process to learn what a file means.
+2. Treat a directory name, a filename convention, or a script's stated intent as a hint, never as provenance. Where a label and the content disagree, the content is the truth and the label is a finding.
+3. Neutralise stale copies of executable tooling, and make surviving copies distinguishable at the process level, not merely absent from filesystem searches. Sharing a process name with the canonical runner makes targeted operations unsafe.
+4. Prose adjacent to a value does not constrain the value. A warning not to display something, printed next to the thing itself, has already failed. Move the enforcement into the code path that emits.
+5. When a comment names a helper, a flag, or a guarantee, it is a claim about the code and it decays. Prefer deriving documentation from the structures themselves, and treat a comment contradicted by the code as a defect rather than as stale text.
+
+The general contract: an artifact that inherits its identity from its context is a claim nobody verified. Make it self-describing, and a wrong run becomes self-evident instead of requiring forensics.

--- a/q-system/lessons/kill-a-defect-class-by-deleting-the-mechanism-not-by-guar.md
+++ b/q-system/lessons/kill-a-defect-class-by-deleting-the-mechanism-not-by-guar.md
@@ -1,0 +1,22 @@
+---
+id: kill-a-defect-class-by-deleting-the-mechanism-not-by-guar
+kind: pattern
+title: Kill a defect class by deleting the mechanism, not by adding a guard to it
+date: 2026-08-05
+---
+
+When successive review rounds keep finding NEW defects of the SAME class in the same code, each round is guarding one more instance of a class rather than removing the class. The signal is not "these are hard bugs"; it is that the mechanism producing them should not exist.
+
+Observed on a rule that decided an exemption by inferring a date from mutable, strippable state. Three separate hardenings shipped: first on one mutable field, then on a different identifier's embedded date, then on the format of that date. Each fix was correct about the instance it addressed and each left the class alive. A code comment written during the second attempt openly recorded that the inference was undecidable, and the third attempt was built on top of that admission. The resolution was to delete the exemption mechanism entirely so the rule consulted no date at all, which retired all three hardenings at once.
+
+The counter-case matters as much: deleting a mechanism is only correct when the thing it protected turns out to be unnecessary or obtainable another way. Measure that before deleting, rather than assuming.
+
+How to apply:
+
+1. Track defects by CLASS across rounds, not by count. Three findings that share a root cause are one signal about a surface; three unrelated findings are ordinary review. Only the first justifies restructuring.
+2. Distinguish self-inflicted from independent. A round finding a defect INTRODUCED by the previous round's fix means the loop is generating work faster than it removes it, and grinding is the wrong response. A round finding another pre-existing defect means review is working through a dense surface, which is review functioning.
+3. Before deleting a mechanism, measure what it actually protected. Enumerate the cases it currently exempts or handles, and confirm they are either unreachable or covered elsewhere. A deletion justified by argument rather than measurement is a new defect.
+4. When you do delete, delete the whole apparatus: the helper, its constants, its tests' reliance on it. Leave a test asserting the names stay gone, so a later change cannot quietly reintroduce the mechanism.
+5. Decide the restructure BEFORE the next round's verdict arrives. Deciding after means the verdict shapes the decision, and a clean round is not evidence of sufficiency for a class that has produced a defect every round so far.
+
+The general contract: a guard added to a bad mechanism inherits the mechanism's failure modes. Removing the mechanism is the only fix that cannot be followed by another instance of the same class.


### PR DESCRIPTION
Documentation only. Four HOW-only lessons written to `q-system/lessons/` via the skeleton-publisher path in `lessons/README.md`, all passing `lessons-validator.py`.

Closes the gap left when the ASK-363 run ended at the merge rather than at closeout: the reusable output existed only in Linear comments and code comments, not in the corpus other instances read from.

- **a check must be able to fail for the reason you care about** — twelve instances in one session, split evenly between author and reviewer. Carries two non-obvious practices: mutation-test the *guard* (twice a guard could have been deleted with the whole suite green), and distrust the convenient explanation for an intermittent failure (one timed run refuted "contention" on a test 10% over its cap).
- **kill a defect class by deleting the mechanism, not by guarding it** — three successive hardenings of a date inference that a code comment had already admitted was undecidable. Deleting the mechanism retired all three at once.
- **a safety property enforced at N sites is not a chokepoint** — blindness was preserved at four seams and three were wrong. Single-writer discipline applies to invariants, not only data paths.
- **an artifact must carry its own provenance, never inherit it** — a stale runner produced a review of the wrong tree, filed under the wrong engine's name, and was indistinguishable from a real review by reading it.

No executable behavior changes. 🤖 Generated with [Claude Code](https://claude.com/claude-code)