### PR TITLE
Recover 17 work-product files that existed only in a dirty checkout (ASK-363)

### DIFF
--- a/q-system/output/claude-judgment-compiler-handoff-2026-08-04.md
+++ b/q-system/output/claude-judgment-compiler-handoff-2026-08-04.md
@@ -21,14 +21,31 @@ The missing layer is the decision context required to calibrate that judge again
 
 We tested whether finding text and severity alone could predict Assaf's final workflow disposition. The result was conclusive: they cannot.
 
-Read these artifacts before designing anything:
+Read these artifacts before designing anything. **In the repo:**
 
 - `q-system/output/founder-judge-calibration-v1-report.md`
-- `q-system/output/founder-judge-calibration-v1.jsonl`
-- `q-system/output/founder-judge-calibration-v1-run.json`
 - `q-system/.q-system/scripts/founder-judge-calibration.py`
 - `q-system/output/rca/rca-founder-judge-calibration-context-and-temp-2026-08-03.md`
 - `q-system/output/prd-founder-judge-calibration-2026-08-03.md`
+
+**Local run output, NOT in the repo** — these two are the frozen dataset and the
+hash-bound run receipt. They live only on the machine that ran v1:
+
+- `q-system/output/founder-judge-calibration-v1.jsonl` (ignored by `.gitignore:36`, `*.jsonl`)
+- `q-system/output/founder-judge-calibration-v1-run.json` (ignored by `.gitignore:17`, `q-system/output/*.json`)
+
+So **the v1 benchmark cannot be re-verified or re-run from a fresh clone**, and
+the numbers below are read from the report, not reproducible by a reader who does
+not have those two files. Do not write a plan whose first step assumes otherwise.
+
+That exclusion is deliberate, not an oversight in the recovery (codex review of
+PR #106, major). Each dataset row carries a `founder_rationale` free-text field —
+Assaf's own words on 50 real triage decisions — and this repo is PUBLIC. Two
+standing ignore rules already cover run output; overriding both to publish
+founder free-text is a blast-radius decision that earns its own issue, not a
+side effect of recovering work-product docs. If v1 must become reproducible, the
+options are a redacted dataset (drop `founder_rationale`, keep the labels) or a
+private location the checker can point at. Both are real work; neither is this PR.
 
 The verified v1 result:
 
@@ -371,4 +388,3 @@ At completion, report only:
 Do not claim the judge is calibrated before prospective evidence meets the gates.
 
 ---
-

--- a/q-system/output/claude-judgment-compiler-handoff-2026-08-04.md
+++ b/q-system/output/claude-judgment-compiler-handoff-2026-08-04.md
@@ -1,5 +1,14 @@
 # Claude implementation brief: bake the Judgment Compiler into Kipi
 
+> **Recovered work-product — a point-in-time snapshot, not current documentation.**
+> This file existed only in a dirty checkout and was recovered on 2026-08-05
+> (PR #106, ASK-363). Every claim about system state was true at this document's
+> own date and may not be true now. In particular, "wired" here means *merged in
+> this repository*; whether the RUNNING copy loads it is a separate question that
+> `q-system/.q-system/scripts/runtime-plugin-freshness.py` answers, because the
+> two came apart for a full day during this very build. Read it as a record of
+> what was decided and why, and verify current state against the code.
+
 Copy everything below into Claude from the repository root:
 
 ---

--- a/q-system/output/claude-judgment-compiler-handoff-2026-08-04.md
+++ b/q-system/output/claude-judgment-compiler-handoff-2026-08-04.md
@@ -1,0 +1,374 @@
+# Claude implementation brief: bake the Judgment Compiler into Kipi
+
+Copy everything below into Claude from the repository root:
+
+---
+
+You are working in `/Users/assafkipnis/projects/kipi-system`.
+
+Build the Kipi Judgment Compiler end to end. This is a system change, not a concept memo. Inspect the repository, create the required PRD, implement it, test it, wire it into the existing PRD review and triage flow, and leave evidence that it works.
+
+Do not stop after producing a plan or PRD. Continue through implementation, deterministic tests, integration verification, Codex review, and wiring checks. Follow every applicable `AGENTS.md`, `CLAUDE.md`, repository rule, and PRD OS contract. Do not overwrite or clean unrelated worktree changes.
+
+## Why this exists
+
+Kipi already has two parts of Airbnb's evaluation framework:
+
+1. Cheap deterministic checks first: hooks, scripts, validators, required checks, tests, and gates.
+2. An LLM judge second: Codex review and finding generation.
+
+The missing layer is the decision context required to calibrate that judge against founder decisions.
+
+We tested whether finding text and severity alone could predict Assaf's final workflow disposition. The result was conclusive: they cannot.
+
+Read these artifacts before designing anything:
+
+- `q-system/output/founder-judge-calibration-v1-report.md`
+- `q-system/output/founder-judge-calibration-v1.jsonl`
+- `q-system/output/founder-judge-calibration-v1-run.json`
+- `q-system/.q-system/scripts/founder-judge-calibration.py`
+- `q-system/output/rca/rca-founder-judge-calibration-context-and-temp-2026-08-03.md`
+- `q-system/output/prd-founder-judge-calibration-2026-08-03.md`
+
+The verified v1 result:
+
+- 50 cases, balanced as 20 accepted, 20 rejected, and 10 deferred
+- 40% exact agreement
+- 35% balanced accuracy
+- 0.239 macro F1
+- 0.032 Cohen's kappa
+- Judge predictions: 45 accepted, 0 rejected, 5 deferred
+- Accepted recall: 95%
+- Rejected recall: 0%
+- Deferred recall: 10%
+- Mean confidence: 92.2%
+- Mean confidence on wrong predictions: 91.1%
+- 10-bin expected calibration error: 0.522
+- 18 of 38 predictions at or above 90% confidence were correct
+- Post-stratified accuracy estimate: 73.3%
+- Historical accept-all baseline: 76.6%
+
+The judge was confident and worse than the historical accept-all baseline. The issue was not simply the prompt. The input contract was incomplete.
+
+Assaf's disposition depends on state the blind judge did not receive:
+
+- Whether the finding duplicates another finding or issue
+- Whether the problem was already fixed
+- Whether a different PRD already owns the work
+- Whether scope changed after the finding was written
+- Whether the relevant issue was removed, reordered, or superseded
+- Which remediation receipts exist
+- Which commit, PRD revision, and issue manifest were current at decision time
+- Whether the objection is technically valid but belongs later
+
+The core lesson is:
+
+> A disposition is not a property of an objection. It is a property of an objection inside workflow state.
+
+## Objective
+
+Build an append-only Judgment Compiler that captures the complete decision episode, separates technical judgment from workflow disposition, evaluates agreement against prospective human decisions, and turns repeated override patterns into deterministic policy candidates.
+
+The loop must be:
+
+```text
+agent finding
+  -> deterministic checks
+  -> decision context assembler
+  -> LLM technical judgment + workflow recommendation
+  -> human calibration sample
+  -> append-only decision receipt
+  -> repeated-pattern detection
+  -> reviewed executable gate
+  -> deterministic checks
+```
+
+Human decisions calibrate the judge. Humans should not manually grade every output. Repeated decisions should reduce future human work by becoming deterministic checks.
+
+## Required system behavior
+
+### 1. Immutable triage episode receipt
+
+Create a versioned, append-only receipt for each adjudicated finding. Use the repository's existing receipt and ledger patterns where possible. Do not create a competing storage convention without proving the current one cannot support this.
+
+Each receipt must freeze at least:
+
+- Receipt ID and schema version
+- Capture timestamp
+- Finding ID, exact finding text, severity, and hash
+- Review provider and review run ID
+- Repository, branch, commit SHA, and dirty-state marker
+- PRD path, PRD hash, PRD status, and revision identity
+- Issue ID and exact issue-manifest snapshot or hash
+- Current scope declaration
+- Dependency and issue-ordering state
+- Candidate duplicate findings and their stable IDs
+- Existing remediation receipts and evidence references
+- Related PRDs or issues that may own the work
+- Deterministically assembled context facts
+- Missing-context markers
+- Judge model, prompt hash, input hash, and output hash
+- Human actor or founder identity
+- Human decision timestamp
+- Human disposition
+- Structured human reason code
+- Evidence IDs supporting the disposition
+- Previous receipt hash or another integrity mechanism consistent with Kipi's ledger design
+
+Never mutate old receipts to reflect current state. A later correction must append a superseding receipt that points to the original.
+
+### 2. Deterministic decision-context assembler
+
+Before asking an LLM for a workflow recommendation, assemble repository state with deterministic code.
+
+At minimum, resolve or explicitly mark unknown:
+
+- Duplicate or cross-PRD ownership matches
+- Existing remediation evidence
+- Current in-scope or out-of-scope status
+- PRD and issue status
+- Issue ordering and dependencies
+- Superseding decisions
+- Receipt state
+- Exact source revisions and hashes
+
+Do not let the LLM invent these facts. The LLM may reason over recorded facts. It may not manufacture missing workflow state.
+
+Every context fact must include its source path, stable ID, query, or receipt reference. Missing evidence must remain `unknown`, not become `false`.
+
+### 3. Split the judge output into two decisions
+
+The judge contract must produce separate fields:
+
+```json
+{
+  "technical_validity": "valid | invalid | uncertain",
+  "technical_reason": "...",
+  "workflow_disposition": "fix-now | already-remediated | duplicate | scope-removed | out-of-scope | defer | invalid | needs-human",
+  "workflow_reason_code": "...",
+  "evidence_refs": ["..."],
+  "missing_context": ["..."],
+  "confidence": 0.0
+}
+```
+
+Technical validity and workflow disposition cannot be collapsed into one accepted, rejected, or deferred label. A finding can be technically valid and still be a duplicate, already fixed, out of scope, or intentionally deferred.
+
+Use one canonical reason-code enum. Start with:
+
+- `valid-fix-now`
+- `already-remediated`
+- `duplicate`
+- `owned-by-other-prd`
+- `scope-removed`
+- `out-of-scope`
+- `superseded`
+- `defer-dependency`
+- `defer-ordering`
+- `invalid-finding`
+- `insufficient-context`
+- `needs-human`
+
+Change this list only when repository evidence proves a different taxonomy is required. Record the reason in the PRD.
+
+### 4. Deterministic disposition evidence gate
+
+Unsupported workflow dispositions must not pass as facts.
+
+Enforce at least:
+
+- `already-remediated` requires a remediation receipt or exact code/test evidence.
+- `duplicate` requires a stable reference to the owning finding or issue.
+- `owned-by-other-prd` requires a stable PRD and issue reference.
+- `scope-removed` and `out-of-scope` require a cited scope record.
+- `superseded` requires the superseding decision receipt.
+- A missing required reference converts the recommendation to `needs-human` or causes deterministic validation to fail. Choose the behavior based on the existing Kipi contract and document it.
+- Confidence must be finite and between 0 and 1.
+- Extra fields, missing fields, unknown enums, stale hashes, duplicate receipt IDs, and broken references must fail validation.
+
+Prompt instructions alone are not enforcement. Implement the contract in code with tests.
+
+### 5. Prospective calibration dataset
+
+Create a v2 dataset from new, immutable, context-complete decisions.
+
+Do not reconstruct current context for the old 50 cases and claim it was the context available at the historical decision. Keep v1 as a context-free stress-test and regression artifact.
+
+The v2 dataset must bind:
+
+- Exact judge input
+- Context snapshot
+- Schema
+- Prompt
+- Model
+- Prediction
+- Human disposition
+- Evidence references
+- All relevant hashes
+
+The evaluator must report:
+
+- Exact agreement
+- Cohen's kappa
+- Balanced accuracy
+- Macro F1
+- Per-class precision and recall
+- Confusion matrix
+- Confidence calibration and 10-bin ECE
+- Human-review rate
+- Unsupported-disposition rate
+- Missing-context rate
+- Results by reason code
+- Population baseline and class distribution
+
+The evaluator must work in a read-only environment. Preserve and extend the current hash verification and blind-run protections.
+
+### 6. Human calibration and live sampling
+
+Wire calibration into the real review workflow.
+
+- During initial calibration, collect at least 50 prospective context-complete human decisions.
+- After calibration, deterministically sample 5% of live eligible decisions for human review.
+- Sampling must be reproducible and auditable, not `random()` with no seed or receipt.
+- Escalate all `needs-human`, missing-context, invalid-schema, and unsupported-evidence cases regardless of the 5% sample.
+- Never silently auto-decide a class that has not passed its release threshold.
+
+Use these as Kipi release gates, not as claims about Airbnb's exact thresholds:
+
+- At least 88% exact agreement
+- Cohen's kappa at least 0.80
+- At least 80% recall for every automated workflow disposition
+- No schema or evidence-gate bypasses
+- Every automated disposition produces a valid receipt
+
+Until all applicable gates pass, the judge recommends. It does not make the final workflow decision.
+
+### 7. Repeated-pattern detector and policy candidates
+
+Analyze human overrides by structured reason code and context fact.
+
+When the same deterministic pattern recurs, produce a policy candidate containing:
+
+- Pattern definition
+- Supporting receipt IDs
+- Case count
+- Counterexamples
+- Proposed deterministic rule
+- Proposed tests
+- Expected false-positive risk
+- Exact integration point
+
+Do not automatically install a new gate from model output. Policy promotion requires repository review, deterministic tests, and the existing approval path. Once approved, the new rule must execute before the LLM judge.
+
+## Integration requirements
+
+- Find the existing PRD review, Codex review, finding ledger, remediation receipt, delivery truth, and command wiring before selecting file locations.
+- Extend existing canonical paths and schemas where they fit.
+- Add CLI commands only through the existing Kipi command architecture.
+- Prefer names that express behavior. Recommended user-facing concept: `Judgment Compiler`.
+- Suggested command shapes are `kipi judgment capture`, `kipi judgment evaluate`, `kipi judgment verify`, and `kipi judgment policy-candidates`. Use different names if the existing CLI grammar requires them.
+- The real integration point is the PRD finding disposition flow. A standalone script with no caller is not done.
+- Update folder-structure rules, command discovery, help text, schemas, and propagation wiring when applicable.
+- If skeleton-owned files change, run the required `kipi update --dry`, propagation, and validation flow defined by repository rules.
+- Preserve backward compatibility for v1 benchmark artifacts.
+
+## PRD and implementation discipline
+
+Create the product/system PRD using:
+
+`q-system/marketing/templates/prd.md`
+
+Save it as:
+
+`q-system/output/prd-judgment-compiler-2026-08-04.md`
+
+The PRD must explicitly include:
+
+- Evidence from the verified v1 benchmark
+- The incomplete-input-contract root cause
+- In-scope and out-of-scope boundaries
+- Receipt schema
+- Context assembler contract
+- Judge schema
+- Evidence gate
+- Prospective v2 calibration
+- Sampling behavior
+- Policy-candidate behavior
+- Migration and backward compatibility
+- Negative and bypass tests
+- Wiring checklist
+- Rollback plan
+
+Do not add unrelated refactors or general eval infrastructure. Build only what this closed loop requires.
+
+## Required test-first verification
+
+Before implementation, add deterministic repros for the current gaps. They must demonstrate that the current system cannot:
+
+1. Preserve immutable decision-time workflow context.
+2. Distinguish technical validity from workflow disposition.
+3. Reject `duplicate`, `already-remediated`, or `out-of-scope` without evidence.
+4. Reproduce and verify a context-complete judge run from hashes.
+5. Sample live decisions reproducibly.
+
+Then implement until the repros pass.
+
+Required negative tests include:
+
+- Duplicate without an owning reference
+- Already remediated without a receipt
+- Scope removal without a scope record
+- Missing context represented as false
+- Changed PRD after receipt capture
+- Mutated historical receipt
+- Duplicate receipt ID
+- Broken previous-receipt hash
+- Unknown reason code
+- Confidence outside 0 to 1
+- Judge output with extra fields
+- Reconstructed historical context presented as original context
+- A policy candidate with no counterexample search
+- A policy candidate becoming an active gate without review
+
+Required regression checks include:
+
+- Existing v1 self-test still passes.
+- Existing v1 dataset verification still passes.
+- Existing PRD review behavior remains available.
+- Existing finding and remediation receipt readers still work.
+- New tests pass in a read-only execution environment.
+- `kipi check` passes.
+- The repository wiring check passes.
+
+## Definition of done
+
+This work is done only when all of these are true:
+
+- The PRD is complete and marked Done.
+- The context assembler is deterministic and source-backed.
+- The receipt is append-only, versioned, hash-verifiable, and supersedable without mutation.
+- Technical validity and workflow disposition are separate contracts.
+- Unsupported dispositions are blocked by executable validation.
+- The v2 evaluator can score context-complete prospective cases.
+- Live sampling is reproducible and recorded.
+- Policy candidates are evidence-backed and cannot self-install.
+- The feature is called by the real PRD triage workflow.
+- All new and regression tests pass.
+- The implementation survives read-only verification.
+- Codex review returns clean or every finding has a recorded disposition and receipt.
+- The mandatory wiring checklist is complete.
+- A concise operator guide shows Assaf the exact commands and outputs.
+
+At completion, report only:
+
+- What changed
+- Exact files changed
+- Commands run and their results
+- Where the Judgment Compiler enters the existing workflow
+- Current calibration status and how many prospective cases exist
+- Anything still blocked by missing real human decisions
+
+Do not claim the judge is calibrated before prospective evidence meets the gates.
+
+---
+

--- a/q-system/output/founder-judge-calibration-v1-report.md
+++ b/q-system/output/founder-judge-calibration-v1-report.md
@@ -1,0 +1,74 @@
+# Founder-Judge Context-Free Triage Stress Test v1
+
+## Result
+
+- Cases: 50
+- Exact agreement: 20/50 (40.0%)
+- Balanced accuracy: 35.0%
+- Macro F1: 0.239
+- Cohen's kappa: 0.032
+- Balanced-set majority baseline: 40.0%
+- Historical-ledger majority baseline: 76.6%
+- Post-stratified accuracy estimate: 73.3%
+- Judge predictions: 45 accepted, 0 rejected, 5 deferred
+
+This is a deliberately balanced stress test. It measures whether finding text and severity alone can predict Assaf's workflow disposition. It does not measure clean-pass quality, objection-finding recall, or factual validity. The historical ledger is not balanced, so the exact agreement above is not an operational accuracy estimate.
+
+## Assessment
+
+- Accepted recall: 95.0%. The judge matched 19 of 20 accepted findings.
+- Accepted precision: 42.2%. More than half of the judge's fix-now calls were not accepted by Assaf.
+- Rejected recall: 0.0%.
+- Deferred recall: 10.0%.
+- The judge predicted `accepted` for 45 of 50 supplied objections. It is not a calibrated proxy for founder triage.
+- Reweighted to the historical class mix, estimated accuracy is 73.3%, below the 76.6% always-accepted baseline.
+- Hidden workflow context sets many labels. Duplicate status, prior remediation, issue ordering, and scope removal are absent from the blind input.
+- Near-identical empty-manifest findings received different founder dispositions because the surrounding PRD state differed.
+
+## Confidence calibration
+
+- Mean confidence: 92.2%
+- Mean confidence on wrong predictions: 91.1%
+- 10-bin expected calibration error: 0.522
+- Predictions at or above 90% confidence: 18/38 correct
+
+## Confusion matrix
+
+| Founder \ Judge | accepted | rejected | deferred |
+|---|---:|---:|---:|
+| accepted | 19 | 0 | 1 |
+| rejected | 17 | 0 | 3 |
+| deferred | 9 | 0 | 1 |
+
+## Disagreements
+
+- `fjc-v1-001` None/finding-1: founder `rejected`, judge `accepted`. The restoration would remove required schema structure, so the current PRD should preserve those sections with safe placeholders.
+- `fjc-v1-005` prd-voice-refresh-monthly-2026-07-04/finding-10: founder `rejected`, judge `deferred`. Freshness and growth targets are useful operational metrics, but they are not necessary to establish the current automation flow.
+- `fjc-v1-008` prd-memory-autocapture-2026-07-04/finding-7: founder `rejected`, judge `accepted`. The fallback changes the meaning of a core measurement proxy without defined validation, so its semantics need coverage.
+- `fjc-v1-010` prd-capability-approval-token-2026-06-16/finding-8: founder `rejected`, judge `deferred`. Broader portability and migration across tool layouts are valid concerns but likely outside a PRD targeting the founder's current environment.
+- `fjc-v1-013` None/finding-1: founder `deferred`, judge `accepted`. An uncalled semantic scanner leaves the advertised production validation unenforced.
+- `fjc-v1-014` prd-cross-instance-learning-2026-06-19/finding-3: founder `deferred`, judge `accepted`. The rollback contract must address already-propagated sensitive data, not only the repository copy.
+- `fjc-v1-015` prd-terminal-state-redrive-2026-08-01/finding-6: founder `rejected`, judge `accepted`. A rebase changes the reviewed diff, so approval must be refreshed and pinned to the final head.
+- `fjc-v1-019` prd-build-craft-2026-06-15/finding-3: founder `rejected`, judge `accepted`. The issue combines several independently testable responsibilities and should be decomposed within the PRD.
+- `fjc-v1-020` prd-voice-refresh-monthly-2026-07-04/finding-1: founder `rejected`, judge `accepted`. The empty formal manifest prevents splitting and omits required execution boundaries.
+- `fjc-v1-021` prd-capability-token-signing-2026-06-16/finding-5: founder `rejected`, judge `accepted`. The signer must bind visible approval to the exact payload or the proposed authorization mechanism remains vulnerable to prompt confusion.
+- `fjc-v1-022` prd-capability-token-signing-2026-06-16/finding-7: founder `rejected`, judge `accepted`. The install and migration sequence needs deterministic recovery behavior for partial failure and stale-token states.
+- `fjc-v1-023` prd-capability-approval-token-2026-06-16/finding-2: founder `rejected`, judge `accepted`. The legacy environment bypass directly contradicts the one-approval-per-command security target.
+- `fjc-v1-024` None/finding-1: founder `deferred`, judge `accepted`. A required bypass check that fails against the PRD's own gate invalidates current acceptance.
+- `fjc-v1-026` prd-terminal-state-redrive-2026-08-01/finding-5: founder `rejected`, judge `accepted`. The escalation does not add an independent actor or mitigation and therefore cannot satisfy the claimed recovery behavior.
+- `fjc-v1-027` prd-planning-personas-2026-05-13/finding-4: founder `rejected`, judge `accepted`. The command's core behavior depends on an active-PRD contract that must be defined or explicitly required.
+- `fjc-v1-028` prd-cross-instance-learning-2026-06-19/finding-2: founder `deferred`, judge `accepted`. The primary promotion rule is not implementable or auditable until instance relatedness is defined and recorded.
+- `fjc-v1-030` prd-planning-personas-2026-05-13/finding-6: founder `deferred`, judge `accepted`. The experiment needs a defined way to identify superficial answers or it cannot test the command's core thesis.
+- `fjc-v1-031` prd-memory-autocapture-2026-07-04/finding-1: founder `rejected`, judge `accepted`. The empty Issues manifest omits the independently executable units required for approval.
+- `fjc-v1-032` prd-canonical-writeback-contract-2026-07-24/finding-8: founder `accepted`, judge `deferred`. Graph compaction and large-scale boot-cost bounds are valid lifecycle concerns but can follow an initial bounded implementation.
+- `fjc-v1-033` prd-capability-approval-token-2026-06-16/finding-3: founder `deferred`, judge `accepted`. The admitted filesystem-write bypass contradicts the PRD's core phase-one security claim and must be resolved or the claim narrowed.
+- `fjc-v1-036` prd-enforcement-instruction-contract-2026-07-24/finding-7: founder `rejected`, judge `deferred`. The implementation already belongs to an existing P0 issue; this PRD should retain only the dependency and enforcement contract.
+- `fjc-v1-038` prd-reorg-stale-ref-remediation-2026-07-06/finding-10: founder `rejected`, judge `accepted`. Conflicting evidence counts weaken the PRD's factual basis and should be reconciled in the current document.
+- `fjc-v1-040` prd-reorg-stale-ref-remediation-2026-07-06/finding-3: founder `rejected`, judge `accepted`. The audit map structurally misses a class of in-scope moves and can incorrectly return success.
+- `fjc-v1-042` prd-cross-instance-learning-2026-06-19/finding-1: founder `deferred`, judge `accepted`. The enforceable validator does not substantiate the PRD's central confidentiality guarantee.
+- `fjc-v1-043` prd-silent-absence-capability-gate-2026-07-23/finding-9: founder `deferred`, judge `accepted`. The advertised repository-wide invariant is materially broader than actual discovery and must be expanded or explicitly narrowed.
+- `fjc-v1-045` prd-silent-absence-capability-gate-2026-07-23/finding-14: founder `rejected`, judge `accepted`. Required-data scope should encode the intended capability contract rather than merely mirror today's observed file placement.
+- `fjc-v1-046` prd-build-craft-2026-06-15/finding-12: founder `deferred`, judge `accepted`. The detector produces an in-scope false positive because substring matching does not establish actual fixture isolation.
+- `fjc-v1-047` prd-lint-hook-ownership-dedupe-2026-07-02/finding-1: founder `rejected`, judge `accepted`. The empty manifest lacks all required execution, verification, and bypass-check structure.
+- `fjc-v1-048` prd-fable-discipline-2026-07-04/finding-1: founder `rejected`, judge `accepted`. The PRD fails atomic decomposition requirements because its Issues manifest is empty.
+- `fjc-v1-049` prd-lint-hook-ownership-dedupe-2026-07-02/finding-3: founder `rejected`, judge `accepted`. The cross-cutting hook invariant needs canonical path-resolution semantics or it will be both bypassable and prone to overblocking.

--- a/q-system/output/founder-judge-calibration-v1-report.md
+++ b/q-system/output/founder-judge-calibration-v1-report.md
@@ -1,5 +1,14 @@
 # Founder-Judge Context-Free Triage Stress Test v1
 
+> **Recovered work-product — a point-in-time snapshot, not current documentation.**
+> This file existed only in a dirty checkout and was recovered on 2026-08-05
+> (PR #106, ASK-363). Every claim about system state was true at this document's
+> own date and may not be true now. In particular, "wired" here means *merged in
+> this repository*; whether the RUNNING copy loads it is a separate question that
+> `q-system/.q-system/scripts/runtime-plugin-freshness.py` answers, because the
+> two came apart for a full day during this very build. Read it as a record of
+> what was decided and why, and verify current state against the code.
+
 ## Result
 
 - Cases: 50

--- a/q-system/output/handoff-judgment-compiler-2026-08-04.md
+++ b/q-system/output/handoff-judgment-compiler-2026-08-04.md
@@ -1,5 +1,14 @@
 # Handoff: Judgment Compiler (ASK-363) — updated 2026-08-05
 
+> **Recovered work-product — a point-in-time snapshot, not current documentation.**
+> This file existed only in a dirty checkout and was recovered on 2026-08-05
+> (PR #106, ASK-363). Every claim about system state was true at this document's
+> own date and may not be true now. In particular, "wired" here means *merged in
+> this repository*; whether the RUNNING copy loads it is a separate question that
+> `q-system/.q-system/scripts/runtime-plugin-freshness.py` answers, because the
+> two came apart for a full day during this very build. Read it as a record of
+> what was decided and why, and verify current state against the code.
+
 Supersedes the 2026-08-04 14:51 version, which described a state that no longer
 exists. If you are reading that version anywhere, discard it: it says zero
 receipts exist and that PR #101 is the open question. Both are wrong.

--- a/q-system/output/handoff-judgment-compiler-2026-08-04.md
+++ b/q-system/output/handoff-judgment-compiler-2026-08-04.md
@@ -1,0 +1,160 @@
+# Handoff: Judgment Compiler (ASK-363) — updated 2026-08-05
+
+Supersedes the 2026-08-04 14:51 version, which described a state that no longer
+exists. If you are reading that version anywhere, discard it: it says zero
+receipts exist and that PR #101 is the open question. Both are wrong.
+
+---
+
+## Current state (verified 2026-08-05 by running, not recalling)
+
+**The work is DONE and MERGED. Nothing is in flight.**
+
+- `main` at `eaf8047`, prd-os **0.16.5**
+- **PR #102** merged (`a30311f`) — receipts required at `advance approved`
+- **PR #103** merged (`eaf8047`) — the judge runner + the `judge_view` chokepoint
+- **PR #101 CLOSED** as superseded by the split (see "the decision that was made")
+- **The ledger EXISTS**: `.prd-os/judgments.jsonl`, **21 receipts**, `VERIFY PASS,
+  chain intact`
+- `evaluate`: `judged_receipts 8`, `cases 3`, `needs_human 5`,
+  `population {accepted 16, rejected 4, deferred 1}`, **release gates FALSE**
+
+Red gates are the CORRECT result: 3 cases against a 50-case threshold, and kappa
+0 because the scoreable population is single-class. A green gate today would
+mean something was lying.
+
+---
+
+## What is wired (verified, not assumed)
+
+`/prd-triage` runs the blind judge BEFORE the author decides, once per finding,
+then passes `--judge-run` to `set-disposition`. The judge runs with tools OFF
+(`--tools ""`, NOT `--allowedTools`) and sees only the frozen context packet.
+If the judge call fails, triage continues WITHOUT a judge run rather than
+blocking the author.
+
+`judge_view(packet) -> (view, citable)` is the single constructor for both what
+the judge may perceive and what it may cite. The view is built from an
+ALLOWLIST, so a field a future assembler starts copying is invisible by default.
+Citable refs are a closed set derived from that same view, so relevance is
+structural: the judge can only cite what it was shown.
+
+---
+
+## The decision that was made, and why
+
+PR #101 was split. Its integrity half (chain verification, fail-closed on an
+unreadable ledger, exact prd_id match, reading under the writer's lock) shipped
+as blocking. Its field-level decision comparison was demoted to a counted
+warning.
+
+The deciding evidence: `evaluate` reads ONLY the ledger, so the ledger IS the
+calibration set and the findings file is operational state. The integrity half
+protects the data; the agreement half only guarded a mutable copy against
+drifting off it, and three of its four tests existed to stop it false-blocking
+legitimate work.
+
+**A design that was recommended and turned out wrong:** a receipt-requirement
+floor keyed to the PRD's creation date. It exempts every FUTURE decision on any
+pre-floor PRD, and 35 of 36 PRDs predated the floor, so the gate was
+near-permanently inert. The measurement showing "blocks nothing today" was read
+as *safe* when it equally meant *does nothing*. The mechanism was deleted
+entirely rather than hardened a fourth time.
+
+---
+
+## Known limits, stated plainly
+
+- **`gates run` is RED**: 524 open spillover items across 667 unique ids,
+  overwhelmingly pre-existing. A closeout claiming a clean ledger would be false.
+- **`capability-gate` is RED (1)**: a review-invoker provenance shell test takes
+  **66s against a 60s cap**, measured uncontended with all 7 sub-checks passing.
+  A timing problem in an unrelated test, not a correctness failure.
+- **`verify --cross-check` FAILS**: 659 dispositioned findings across ~34 other
+  PRDs have no receipts. All pre-date the compiler. Zero belong to the two PRDs
+  triaged here, and the approval gate filters by exact prd_id prefix, so approval
+  is unaffected. This is the system correctly reporting the historical gap it
+  exists because of.
+- **All 21 receipts froze a misleading `repo_state`** (`sp-8355de5b`): every one
+  records a branch that was merged and abandoned, at an old head, dirty. The
+  triage ran against `main` in a clean worktree. Cause: `repo_state` resolves to
+  the checkout that owns the ledger via git-common-dir, not the tree the work
+  happened in. Finding-specific context is correct; only `repo_state` is wrong.
+- **The ledger follows git-common-dir, NOT repo_root**, so one ledger serves a
+  whole worktree set and a sandbox that copies a `.git` writes the MAIN
+  checkout's ledger. Use a temp dir for tests, never the live `.prd-os/`.
+- **`owned-by-other-prd` now converts to `needs-human` 100% of the time by
+  construction** (`sp-4d545276`). A blind judge cannot know which issue owns a
+  finding. This is a capability boundary, not a model failure, and it puts a
+  permanent floor under the conversion rate.
+- The tip anchor is tamper-EVIDENT, not tamper-proof: the same writer owns both
+  files. Only `verify --cross-check` is independent.
+- `reanchor` refuses a MISSING anchor by design (`sp-3d2c8255`), so the first
+  receipt in a brand-new ledger has no automated recovery. It did not fire here.
+
+---
+
+## Open work
+
+**Linear ASK-363** is still open. **ASK-378** tracks everything gated on reaching
+50 cases. **ASK-379** was labelled a founder decision in the previous handoff and
+**is not one** — preserving the benchmark dataset anywhere private removes the
+single-disk risk with no disclosure decision at all. The public-repo framing was
+a false binary.
+
+**Spillover opened by this work** (all open; `resolve` requires a closed issue
+reference, so none could be cleared): `sp-320d30e3`, `sp-0c725cde`,
+`sp-f3aed16e`, `sp-892b1575`, `sp-c08e07ec`, `sp-2fc42d21`, `sp-f1d9c2b1`,
+`sp-5169a276`, `sp-b274084f`, `sp-1c92c78f`, `sp-9755c728`, `sp-cd46fd96`,
+`sp-4d545276`, `sp-3d2c8255`, `sp-a7b9d9ea`, `sp-33e98c0b`, `sp-8355de5b`.
+
+The highest-value ones: the class-diversity precondition on the release gates
+(`sp-f1d9c2b1`), the human-path self-citation gap (`sp-2fc42d21`), the
+misattributed `repo_state` (`sp-8355de5b`), and the stale review runners
+(`sp-5169a276`, `sp-b274084f`).
+
+---
+
+## What the first real triage found
+
+The PRD under review is **unbuildable as written**. No git ref in this repo
+contains the notifier script it targets; it cites line numbers past the end of
+the file that exists on `main`. It was written against an unmerged branch that no
+longer exists. All 8 findings accepted, two of them blockers.
+
+Findings 2 through 8 were deliberately NOT marked duplicates of finding 1 despite
+sharing a root cause, because `duplicate` maps to `rejected` and five of them
+survive a rebase. That distinction is exactly what the old ledger destroyed on
+every write, and it is now frozen in a receipt.
+
+The 13 findings on the older PRD were migrated WITHOUT judge runs. Those
+decisions were made in June; pairing today's workflow context to a June decision
+would manufacture the precise retroactive artifact this issue exists to prevent.
+A receipt with `human` and no `judge` satisfies the receipt gate while being
+excluded from calibration by construction.
+
+---
+
+## Lessons published
+
+Four written to `q-system/lessons/` (HOW-only, de-identified, validator-clean):
+
+- a check must be able to fail for the reason you care about
+- kill a defect class by deleting the mechanism, not by guarding it
+- a safety property enforced at N sites is not a chokepoint
+- an artifact must carry its own provenance, never inherit it
+
+The first has twelve instances from this work alone, split evenly between author
+and reviewer. That split is the point: it is not a competence gap, it is the
+default outcome of verifying the thing in front of you instead of the thing the
+conclusion requires.
+
+---
+
+## The single next action
+
+Nothing is blocked and nothing is running. The calibration clock is live, so the
+next meaningful event is **volume**: more real triage through the normal flow.
+At roughly 50 cases, ASK-378's questions become answerable. Until then the gates
+stay red, correctly, and the honest reading of a red gate here is
+"not yet measurable", not "failing".

--- a/q-system/output/linear-agent-guidance-2026-07-29.md
+++ b/q-system/output/linear-agent-guidance-2026-07-29.md
@@ -1,5 +1,14 @@
 # Linear Agent Guidance — paste into Settings → Agents → Additional guidance
 
+> **Recovered work-product — a point-in-time snapshot, not current documentation.**
+> This file existed only in a dirty checkout and was recovered on 2026-08-05
+> (PR #106, ASK-363). Every claim about system state was true at this document's
+> own date and may not be true now. In particular, "wired" here means *merged in
+> this repository*; whether the RUNNING copy loads it is a separate question that
+> `q-system/.q-system/scripts/runtime-plugin-freshness.py` answers, because the
+> two came apart for a full day during this very build. Read it as a record of
+> what was decided and why, and verify current state against the code.
+
 Everything below the line is the text to paste. It is the reviewer bar from
 `pr-review-agent.sh` (the persona, the severity anchors, and the reproducer rule),
 rewritten for Linear's native agent-guidance surface so every Codex run inherits

--- a/q-system/output/linear-agent-guidance-2026-07-29.md
+++ b/q-system/output/linear-agent-guidance-2026-07-29.md
@@ -1,0 +1,137 @@
+# Linear Agent Guidance — paste into Settings → Agents → Additional guidance
+
+Everything below the line is the text to paste. It is the reviewer bar from
+`pr-review-agent.sh` (the persona, the severity anchors, and the reproducer rule),
+rewritten for Linear's native agent-guidance surface so every Codex run inherits
+it without any shell glue.
+
+Why this file exists: Linear passes workspace-level agent guidance to every agent
+run automatically. That is the native home for the persona and the bar. The
+shell reviewer carried the same text inside a `PROMPT=` heredoc that only ran when
+the dispatcher shelled it.
+
+Two things this text deliberately does NOT try to do, because guidance is not
+enforcement: it cannot make a finding ship a reproducer, and it cannot stop an
+approval. Those need a gate (a required GitHub check). Guidance sets the bar;
+`prd_runner.py gates run` and the repo's CI are what refuse.
+
+---
+
+## Who you are when you review
+
+You are a SENIOR STAFF ENGINEER at Meta reviewing code you have never seen. You
+are ADVERSARIAL by default: your job is to find what is wrong, not to be
+agreeable.
+
+The author of the change is another AI agent (Sana) from a different lab. That
+matters in one specific direction: she and the code share one mental model, and
+you do not. Your value is the things she structurally cannot see, not a second
+opinion on the things she can.
+
+## What your fresh eyes are for
+
+You have no memory of why anything here is the way it is. That is the point. Do
+NOT accept a comment, a commit message, or a doc as evidence — those are the
+author's claims about the code, written by the same mind that wrote the bug. Read
+what the code DOES. Where a comment and the code disagree, the code is the truth
+and the comment is a finding.
+
+Be specifically suspicious of:
+
+- **Test fixtures the author invented.** A fixture built from the same mental
+  model as the code tests nothing. Check that every fixture's SHAPE matches what
+  the real producer actually emits. Two real events in this workspace: a mutex
+  whose remote half never fired because its fixture used a key no producer emits,
+  while the suite stayed green; and a filter whose test passed because the fixture
+  never contained the string the real prompt writes.
+- **Tests that could not fail.** For each new test ask: what would break to make
+  this red? If nothing plausible would, it is decoration.
+- **Claims of enforcement.** "This ensures X" in a comment is not enforcement.
+  Find the code path that refuses, or call it a finding.
+- **Error paths, retries, partial failure.** What is left behind when this dies
+  halfway? What does the operator see? A call whose result is discarded reports
+  success for work that did not happen.
+
+## The operational bar
+
+This workspace runs UNATTENDED agents on a schedule, against Linear issues that
+CANNOT BE DELETED, in a PUBLIC repo. Judge it that way:
+
+- What happens at 3am when this fires and nobody is watching?
+- What is the blast radius of it being wrong? What is permanent and unrecoverable?
+- What pages a human, and is that signal or noise? A checker that cries wolf
+  trains the operator to ignore it, which costs the real alert later.
+- Can this be rolled back? If not, say so loudly.
+- Concurrency: two of these running at once. What breaks?
+
+## What each severity means — use these anchors, not your feel for it
+
+Severity is BLAST RADIUS and RECOVERABILITY. Not how clever the finding is, how
+long it took to find, or how much the code annoyed you.
+
+- **blocker** — permanent or unrecoverable if it merges. Publishes a credential to
+  a Linear object that cannot be deleted. Destroys or overwrites founder work.
+  Silently disables the very detector the change adds. If the honest answer to
+  "can we undo this after it fires?" is no, it is a blocker.
+- **major** — wrong behavior unattended that a human must clean up, but CAN clean
+  up. Files duplicate permanent issues. Cries wolf on every run. Reports success
+  for work that did not happen.
+- **minor** — real, reproducible, and bounded. Log or help text that misstates what
+  the code does. A narrow false negative on an input shape nobody hits yet. It
+  should be fixed; it does not gate.
+- **nit** — style, naming, formatting, preference. Never gates anything.
+
+Two calibration checks before assigning a severity:
+
+1. If you cannot name what a human has to DO about it at 3am, it is not a blocker
+   or a major.
+2. If your reproducer only fails under inputs you had to construct and no producer
+   in this repo emits, drop the severity a level and say so.
+
+Inflating a minor to a major to make a review feel substantial is itself a defect:
+it wedges a change that should have shipped and burns the author's next round on
+work that did not need doing.
+
+## The standing rule
+
+EVERY finding MUST ship a RUNNABLE REPRODUCER that you ACTUALLY RAN, with its real
+output pasted. A finding with no executed repro is an opinion. If you cannot make
+it fail, DROP the finding and say you tried. Dropping a finding you could not
+reproduce is a SUCCESS of this process, not a failure of it.
+
+## How to report
+
+Comment on the issue. For each finding: severity, a one-sentence claim, the exact
+file:line, the reproducer command, and its real output.
+
+Then state **what is sound** — attacks you tried that the code survived, by name.
+A review that only lists faults is not calibrated and cannot be trusted on the
+faults either.
+
+Then the verdict, decided by this rule and not by feel:
+
+- any blocker or major → REQUEST CHANGES (BLOCK only if merging as-is would cause
+  permanent or unrecoverable damage)
+- only minor/nit → APPROVE WITH NITS
+- nothing survived reproduction → APPROVE
+
+A bar this high always finds something; that is what APPROVE WITH NITS is for.
+Using REQUEST CHANGES to log minors wedges the change forever and is itself a
+review defect.
+
+## Repeat rounds
+
+From round 2 on, a finding raised in an earlier round may be raised AGAIN only if
+your own reproducer shows it is STILL LIVE — paste that repro. A finding the author
+answered with a code citation is settled unless you can falsify the citation; say
+which citation you falsified and how. Do not escalate severity across rounds on the
+same underlying issue without naming a consequence nobody had seen.
+
+By round 3+, a change that keeps producing NEW blockers on UNCHANGED code means the
+earlier rounds were miscalibrated. Say so. That is a finding about the review
+process and it is worth more than another nit.
+
+## Scope
+
+Review only. Do not commit, do not push, do not modify the repo while reviewing.
+Reply on the issue so the author and the founder both read the same thread.

--- a/q-system/output/plans/codex-reviewer-land-2026-07-29.md
+++ b/q-system/output/plans/codex-reviewer-land-2026-07-29.md
@@ -1,0 +1,200 @@
+# Land the Codex reviewer in the unattended loop (ASK-221) — 2026-07-29
+
+## What / why
+
+Founder directive 2026-07-29: Codex reviews Sana's work, unattended. Decision already
+taken (this session): keep PR #34's `codex exec` engine, kill PR #45's Linear-agent
+delegation. This plan executes that decision end to end.
+
+The gap being closed: `linear-worker.sh:72` routes review through
+`pr-review-agent.sh`. PR #34 makes that script's PRIMARY engine codex, so the
+required `kipi/reviewer-approved` status becomes a Codex verdict. That is the whole
+objective.
+
+## Approach (the pick)
+
+Land #34, close #45, fix the one bash reader. Rejected alternatives and why, from
+verified reads:
+
+- **Reuse `codex-companion.mjs` from the worker.** Rejected. `--background` is parsed
+  at `codex-companion.mjs:718` and never read (`handleReviewCommand` always calls
+  `runForegroundCommand` at :739); job state lands in a purgeable
+  `os.tmpdir()/codex-companion` keyed on the *worktree* path (`state.mjs:29-42`,
+  `MAX_JOBS=50`); and `DEFAULT_INLINE_DIFF_MAX_FILES = 2` (`git.mjs:8`) with no CLI
+  override, so every real fleet PR would be reviewed with no inline diff.
+- **PR #45's Linear-agent delegation.** Rejected. Advisory status only (not a
+  required check, so it cannot gate), 5 failed live attempts on ASK-221, and it adds
+  a third verdict reader.
+
+## Findings to triage BEFORE landing (as the implementing agent)
+
+I did not author these commits. Verify each fix with a reproducer that fails on the
+parent commit and passes on the fix. A test that cannot fail is not a test.
+
+| # | From | Sev | Claim | Claimed fixed at |
+|---|------|-----|-------|------------------|
+| A | `dfacddd7` | minor | `--agent` matched the marker anywhere in the body | `de2a9c3` |
+| B | `6789ca54` | minor | first-line anchor still accepts `**sana** prose` (needs the full `**sana** · ` delimiter) | `403bc0b` |
+| C | `6789ca54` | major | no tree-vs-PR-head guard: Codex runs and derives a verdict when the reported PR head is not an ancestor of the working tree HEAD | `403bc0b` |
+
+C is the one that matters. Codex's own repro showed `codex_ran=yes` +
+`verdict: APPROVE` against a head that was not in the tree. If 403bc0b does not
+actually refuse before dispatch, it does not land.
+
+## Files to touch
+
+- `q-system/.q-system/scripts/pr-verdict-lib.sh` — sp-c0a9dac3: `verdict_from_findings`
+  uses `sed -n '/^FINDINGS:/,/^END FINDINGS/p'`, which concatenates every block and
+  runs to EOF when unclosed. Fix in this ONE reader. Do not add a second.
+- `q-system/.q-system/scripts/pr-review-agent.sh` — verify the tree-vs-head guard.
+- `q-system/.q-system/scripts/linear-sync.py` — verify the attribution prefix.
+- `q-system/.q-system/scripts/verify-codex-review-live.sh` — retarget from the dead
+  ASK-253 delegation path to the engine path that actually ships; it becomes the receipt.
+- `~/.claude/plugins/marketplaces/openai-codex/plugins/codex/prompts/adversarial-review.md`
+  — uncommitted edit to a live gate. Resolve.
+
+## Acceptance criteria
+
+- [~] Findings A, B, C each have a reproducer that FAILS before the fix and PASSES after
+      PARTIAL, and the gap is now on the ledger as `sp-600441d2`. Their reproducers live
+      in `test-severity-floor.sh`, which is the ONE suite with no pre-fix ref hatch, so
+      none of its 169 checks has ever been observed to fail. Passing is not evidence
+      there. Do not claim this one until the hatch exists.
+- [x] sp-c0a9dac3 reproducer: multi-block review where an early block's severity would
+      win under the old `sed` range; fails on current lib, passes after
+      `KIPI_TEST_LIB_REF=e5aa6bc bash test-findings-block-reader.sh`
+        -> `FAIL: THE DEFECT (sp-c0a9dac3): a review that explicitly REFUTED round 1's
+           blocker derived ...`; working tree -> `PASS: 9/9`
+- [x] Unclosed-block reproducer: truncated review does not derive APPROVE
+      `KIPI_TEST_LIB_REF=b281881 bash test-findings-block-reader.sh`
+        -> `FAIL: the lib has no has_complete_findings_block`; working tree -> `PASS: 9/9`
+      This is the finding found beyond the three that were handed over: an open FINDINGS
+      block at EOF used to read as an empty one and derive APPROVE, so a review truncated
+      mid-sentence approved the PR. Fixed in 1d5347d, reproducer above, and the ref hatch
+      is what makes it provable rather than asserted.
+- [x] `pr-verdict-lib.sh` still has exactly ONE findings-block reader (grep proves it)
+      asserted by the suite itself: `ok: the lib has exactly one findings-block reader`
+- [x] PR #34 checks green, verdict triaged, merged
+      Round 1 on `1d5347d`: REAL codex run, `REQUEST CHANGES`, two findings, both ACCEPTED
+      and fixed (`b090ba7`, `fa4608a`), triage posted as a PR comment. Merging `1d5347d`
+      would have broken the live loop.
+      Round 2 on `fa4608a`: REAL codex run, `degraded=0`, ONE minor, derived
+      `APPROVE WITH NITS`, `kipi/reviewer-approved=success` on that sha, `validate` pass.
+      Merged as `f277389` at 2026-07-30T04:22:55Z. Minor captured as `sp-583dc1a0`.
+- [x] The merge is LIVE in the copy launchd executes (not just in the repo)
+      The loaded plist runs `/Users/assafkipnis/projects/kipi-system/kipi-dispatch.sh`,
+      that checkout sat at `1597eaf`, and `kipi-dispatch.sh` has NO `git pull` -- so the
+      merge alone would have left the loop on the old Claude-only reviewer. This is the
+      exact scar the wiring rule names. Fast-forwarded (`merge --ff-only`, no collision
+      with the one dirty tracked file) to `f277389`; verified in the running copy:
+      `REVIEW_ROOT` at pr-review-agent.sh:222/240, `--engine codex` at
+      linear-worker.sh:1133.
+- [x] PR #45 closed unmerged with a reason on the PR
+- [x] Salvage follow-up issue filed (the 444c484 trigger measurement, the live-plist
+      load-path proof pattern, the last-block insight) — ASK-254
+- [x] Attribution correction posted on ASK-221 as one top-level comment,
+      `--agent claude-session`, naming `8a3ebf43…` (00:25:49Z) and `1b365138…`
+      (00:36:40Z), acceptances withdrawn; originals untouched
+- [x] `spillover add --source ASK-221` capture recorded
+      `sp-600441d2` (no ref hatch on the big suite), `sp-d8adb370` (voided into the
+      pre-existing `sp-d3a22cb6` with the stdin root cause attached)
+- [x] Marketplace prompt edit resolved, decision stated
+      reverted; `sp-c5a17b4a` voided — the shipping reviewer builds its prompt inline
+      and never loads that file
+- [~] **The objective proven by a RUN:** a real `pr-review-agent.sh --engine codex`
+      invocation whose output shows a Codex verdict, plus the verifier reporting the
+      live worker reaches that path. Not an assertion.
+      REVIEWER HALF: DONE, twice, for real. Round 1 wrote
+      `{"verdict":"REQUEST CHANGES","stated":"REQUEST CHANGES","derived":"REQUEST CHANGES",`
+      `"source":"findings","engine":"codex","head_sha":"1d5347d…"}` and posted
+      `kipi/reviewer-approved=failure` on that exact sha, `degraded=0`.
+      LIVE-DISPATCHER HALF: NOT DONE, and blocked tonight — see "Dispatcher proof" below.
+
+## PR #46, the follow-on the reviewer earned (2026-07-30)
+
+Built from `sp-583dc1a0`, the minor codex raised on #34 round 2: the reviewer's Linear
+post ended in `>/dev/null 2>&1 || true`, so a failed issue post printed nothing and the
+run still exited 0. Merged as `03e39ee`.
+
+Round 1 came back `REQUEST CHANGES` with two majors, **both mine, both real**:
+
+- **The success path posted to Linear TWICE.** My fix edited the TAIL of the existing
+  call; the opening lines stayed, and their trailing `\` continued into the new comment
+  block, so the original ran without `--agent` or `--evidence`. Two permanent comments
+  per review, the first misattributed. It reached ASK-221 before codex caught it. Case 5
+  was blind to it because case 5 only drives the FAILURE path. Case 6 now counts calls
+  with a logging stub, ordered AFTER case 5 so case 5's failure stays a real missing file.
+- **The failure path claimed a page it cannot confirm.** `slack-notify.sh` no-ops silently
+  when unconfigured (deliberate, per founder-notifications.md), so a zero exit is not
+  delivery. Now it attempts, reports what came back, and leaves the stderr WARN as the
+  always-written record.
+
+`KIPI_TEST_REVIEWER_REF=263d134 bash test-review-tree-guard.sh` -> `FAIL: the success
+path made 2 calls to linear-sync.py, not 1`; working tree -> `PASS: 24/24`.
+
+Round 2 on `1000890`: one minor, `APPROVE WITH NITS`, status success, `validate` pass.
+
+**The lesson worth keeping:** two of the three defects found tonight were introduced by
+the fix for the previous one, and each was caught only because a real reviewer read the
+real diff. Editing the tail of a multi-line shell invocation is how both happened.
+
+## Two traps found by watching the runs, not the diffs
+
+- **`sp-48688b24`** the PR comment posts the RAW review file, and codex output ran
+  278-435KB against GitHub's 65536 limit, so 3 of 4 rounds failed with
+  `Body is too long`. Round 2 of #46 was small enough and succeeded, so it is
+  size-dependent. I first filed this as "never works"; overstated, voided with the reason.
+- **`sp-bc42f1d3`** CAPTURE WAS MISSING THE LEDGER THE GATE READS.
+  `.prd-os/spillover.jsonl` is gitignored, so every worktree has its own. 13 items filed
+  from the `ask-221` worktree were invisible from the main checkout, where `gates run`
+  was green about work it could not see. Consolidated by hand (15 records appended,
+  backup in scratchpad). The load-path scar applied to the ledger itself.
+
+## Dispatcher proof (the half that is not done)
+
+Read from the LOADED plist, not the repo copy
+(`/usr/libexec/PlistBuddy -c "Print :EnvironmentVariables:…" ~/Library/LaunchAgents/com.kipi.dispatch.plist`):
+
+- `KIPI_DISPATCH_DAILY_MAX=3`, `KIPI_DISPATCH_RESET_HOUR=7`, `KIPI_DISPATCH_MAX=1`
+- `ProgramArguments` -> `/Users/assafkipnis/projects/kipi-system/kipi-dispatch.sh`
+  (the founder's MAIN checkout, not a worktree)
+- `launchctl print` -> `runs = 130`, `last exit code = 0`, job active
+- `~/.config/kipi/dispatch-count-2026-07-29` -> `3`. Cap fully spent.
+
+Two independent blockers, and the ordering between them is forced:
+
+1. **The cap is spent.** A budget day runs 07:00 -> 06:59, so the allowance refills at
+   07:00 local on 2026-07-30. The dispatcher keeps beating every 15 min until then
+   (`dispatch-lastbeat` moved at 20:50) and each tick is a no-op skip.
+2. **Main does not have this code yet.** `origin/main`'s `pr-review-agent.sh` (365
+   lines) has no `--engine`, no `CODEX_MODEL`, and no tree guard, and `main`'s worker
+   calls `$REVIEWER_CMD "$PR_NUM" --issue "$ISSUE" --post` with no engine flag. The
+   live loop reviews with Claude today. So a dispatcher run tonight could not exercise
+   the codex path even with budget: the merge is a PREREQUISITE for the proof, not a
+   consequence of it.
+
+What will happen at 07:00 local on 2026-07-30, once #34 is merged: the beat finds
+`dispatch-count-2026-07-30` absent, dispatches up to 3 issues, and the worker's
+`linear-worker.sh:1133` runs `pr-review-agent.sh --engine codex`. What would prove it:
+a `pr-<N>.verdict.json` with `"engine":"codex"` for a PR **this agent did not review by
+hand**, plus `kipi/reviewer-approved` on that PR's head, plus the matching
+`DISPATCH`/reviewer lines in `~/.config/kipi/dispatch.log`. Not the verifier script.
+
+## Patterns to follow (from this repo's own code)
+
+- Single reader of one input: `pr-verdict-lib.sh:72-78` states the doctrine. Three
+  readers is the defect PR #45 introduced; do not repeat it.
+- Verdict record is the chokepoint: `head_sha_from_record` + `verdict_from_record`,
+  written once, read by `linear-worker.sh:597-599` and `converge.sh:161-163`.
+- Load-path proof: `verify-codex-review-live.sh` resolves the LIVE plist
+  (`com.kipi.dispatch`, StartInterval 900) and asserts against the script the
+  scheduler will actually execute. Generalize this, do not delete it.
+- Test isolation: `test_linear_sync_comments.py` monkeypatches `graphql`. No live
+  Linear in tests, ever.
+
+## Constraints
+
+- Work in a git worktree. The founder's checkout is on `main`; a branch switch there
+  yanks their tree.
+- Destructive ops stay hook-blocked. If one is needed, name it and stop.
+- Do not merge red. Do not merge on an untriaged verdict.

--- a/q-system/output/plans/codex-reviewer-land-2026-07-29.md
+++ b/q-system/output/plans/codex-reviewer-land-2026-07-29.md
@@ -1,5 +1,14 @@
 # Land the Codex reviewer in the unattended loop (ASK-221) — 2026-07-29
 
+> **Recovered work-product — a point-in-time snapshot, not current documentation.**
+> This file existed only in a dirty checkout and was recovered on 2026-08-05
+> (PR #106, ASK-363). Every claim about system state was true at this document's
+> own date and may not be true now. In particular, "wired" here means *merged in
+> this repository*; whether the RUNNING copy loads it is a separate question that
+> `q-system/.q-system/scripts/runtime-plugin-freshness.py` answers, because the
+> two came apart for a full day during this very build. Read it as a record of
+> what was decided and why, and verify current state against the code.
+
 ## What / why
 
 Founder directive 2026-07-29: Codex reviews Sana's work, unattended. Decision already

--- a/q-system/output/plans/dor-dispatcher-capability-drift-2026-08-03.md
+++ b/q-system/output/plans/dor-dispatcher-capability-drift-2026-08-03.md
@@ -1,0 +1,55 @@
+# DoR: the dispatcher must notice when a selector it had is gone
+
+## Problem
+
+`kipi-dispatch.sh` runs from the working tree (`launchd` ProgramArguments point at
+`/Users/assafkipnis/projects/kipi-system/kipi-dispatch.sh`, verified 2026-08-03).
+So *which branch is checked out* decides what the 15-minute heartbeat can do.
+
+During ASK-352 the reviewer-redrive selector drove the real loop from an unmerged
+branch. Any branch switch in that checkout silently reverts the wiring mid-flight,
+and the dispatcher keeps exiting 0 while doing strictly less than it did a minute
+earlier.
+
+Nothing detects this. The capability manifest checks declared-vs-actual per test
+file; it does not ask whether the RUNNING dispatcher still has a call site it had
+before. The failure is additive-loss, not corruption, which is exactly why it is
+invisible: no error, no red gate, no page. The loop just quietly does less.
+
+This is the same class as ASK-353's unresolved `tree-position-refused` state.
+
+## Why it is not just "merge faster"
+
+"We'll merge soon" is not a consumer. The window recurs on every agent branch, and
+the checkout is shared between sessions (see the parallel-sessions scar). A guard is
+cheap; noticing this by accident is not.
+
+## Acceptance criteria
+
+- [ ] The dispatcher records, at each run, which redrive selectors it resolved
+      (path exists AND is referenced from a live call site), into a state file
+      written through a single writer.
+- [ ] On a run where a selector that was present on the previous run is now
+      absent, it pages ONCE via `slack-notify.sh`, naming the selector and the
+      current branch/HEAD. It does not page again while the state is unchanged.
+- [ ] Recovery is reported too: the selector coming back pages once. An operator
+      who never hears the recovery cannot tell a degraded loop from a healthy one
+      (same posture as `note_degraded_transition` in `pr-review-agent.sh`).
+- [ ] A reproducer drives the REAL `kipi-dispatch.sh` with a selector removed
+      between two runs and asserts exactly one page, read off the notify stub's
+      own record, never off stderr.
+- [ ] Mutation check: deleting the page call makes a case go red; making it page
+      every run makes a different case go red.
+- [ ] The test never touches the real `slack-notify.sh`.
+
+## Allowed files
+
+- `kipi-dispatch.sh`
+- `q-system/.q-system/scripts/test/test-dispatch-capability-drift.sh` (new)
+- `q-system/.q-system/capability-manifest.json`
+
+## Out of scope
+
+- Changing where the dispatcher runs from (repo-root vs a pinned checkout). That is
+  a bigger call and belongs with ASK-353's `tree-position-refused`.
+- Any change to `review-redrive.py` or `ci-redrive.py` themselves.

--- a/q-system/output/plans/dor-dispatcher-capability-drift-2026-08-03.md
+++ b/q-system/output/plans/dor-dispatcher-capability-drift-2026-08-03.md
@@ -1,5 +1,14 @@
 # DoR: the dispatcher must notice when a selector it had is gone
 
+> **Recovered work-product — a point-in-time snapshot, not current documentation.**
+> This file existed only in a dirty checkout and was recovered on 2026-08-05
+> (PR #106, ASK-363). Every claim about system state was true at this document's
+> own date and may not be true now. In particular, "wired" here means *merged in
+> this repository*; whether the RUNNING copy loads it is a separate question that
+> `q-system/.q-system/scripts/runtime-plugin-freshness.py` answers, because the
+> two came apart for a full day during this very build. Read it as a record of
+> what was decided and why, and verify current state against the code.
+
 ## Problem
 
 `kipi-dispatch.sh` runs from the working tree (`launchd` ProgramArguments point at

--- a/q-system/output/plans/dor-extract-verdict-prompt-echo-2026-08-03.md
+++ b/q-system/output/plans/dor-extract-verdict-prompt-echo-2026-08-03.md
@@ -1,0 +1,92 @@
+# DoR: extract_verdict reads the reviewer's verdict out of the echoed prompt
+
+## The defect
+
+`codex exec` echoes the entire prompt to stdout. The reviewer prompt contains its
+own grading rule:
+
+```
+- **VERDICT:** decided by THIS RULE, not by feel:
+    - any blocker or major finding      => REQUEST CHANGES
+```
+
+`extract_verdict()` anchors on the first line matching `VERDICT` and takes the
+first verdict token in the next 3 lines (`head -1`). In every codex review that
+first match is the echoed grading rule, so it returns **REQUEST CHANGES** no
+matter what the reviewer concluded.
+
+Measured 2026-08-03: **40 of 46** codex-engine verdict records carry
+`stated = REQUEST CHANGES`.
+
+Clean proof on PR #91 round 3:
+
+| | |
+|---|---|
+| first `VERDICT` match | line 121, the echoed prompt's grading rule |
+| reviewer's own answer | line 4402, `VERDICT: APPROVE` |
+| `extract_verdict` | `REQUEST CHANGES` |
+| `verdict_from_findings` | `APPROVE` (empty findings block, reviewer found nothing) |
+| recorded / posted | `REQUEST CHANGES` -> `kipi/reviewer-approved=failure` |
+
+## Why it is urgent now
+
+On its own this was mostly latent: before ASK-312, `VERDICT="$DERIVED_VERDICT"`
+unconditionally, so the derived value won and the poisoned `stated` was only
+recorded, not acted on.
+
+ASK-312 (PR #89, merged 2415fcd) changed that to
+`resolve_verdict "$STATED" "$DERIVED"`, which takes the **harsher**. That fix is
+correct and should stay. But combined with this bug it means:
+
+> every codex-reviewed PR is now held at REQUEST CHANGES regardless of what the
+> reviewer actually said.
+
+`kipi/reviewer-approved` is a required context on `main`, so this blocks the
+entire merge pipeline. PR #91 has been through three rounds and cannot go green.
+
+This is not a regression *in* ASK-312; it is a pre-existing bug that ASK-312
+promoted from cosmetic to blocking.
+
+## The fix direction (not prescriptive)
+
+`findings_block()` already solved the same problem for its own marker and wrote
+down the reasoning: **LAST, NOT FIRST** — the echoed prompt arrives BEFORE the
+model's answer, so the last complete occurrence is the real one. `extract_verdict`
+should take the reviewer's LAST verdict statement, not the first.
+
+Do not simply swap `head -1` for `tail -1` without reading that function's scars:
+the `head -1` there is load-bearing for a *different* real payload (`**REQUEST
+CHANGES** (not BLOCK -- ...)`, PR #11 round 4), where the verdict is stated first
+and qualified after. Those are two different axes — which BLOCK of text, and which
+token WITHIN a line — and the fix must keep the second while fixing the first.
+
+## Acceptance criteria
+
+- [ ] A reproducer using the REAL captured PR #91 round 3 payload (scrubbed of the
+      founder home path and any skill bodies, per ASK-345) asserts
+      `extract_verdict` returns `APPROVE`.
+- [ ] It fails against the current `pr-verdict-lib.sh` via the `REPRO_REF` hatch
+      and passes after.
+- [ ] The PR #11 round-4 qualified-verdict case (`**REQUEST CHANGES** (not BLOCK
+      -- ...)`) still returns `REQUEST CHANGES`. Both cases in one file.
+- [ ] A case where the review states NO verdict still returns empty, so unstated
+      keeps holding the PR.
+- [ ] Mutation: reverting to the first-match form makes the #91 case go red;
+      taking the last TOKEN on the line instead of the last BLOCK makes the #11
+      case go red.
+- [ ] Re-run the sweep over all verdict records and report how many `stated`
+      values change, so the blast radius is measured and not assumed.
+
+## Allowed files
+
+- `q-system/.q-system/scripts/pr-verdict-lib.sh`
+- `q-system/.q-system/scripts/test/test-severity-floor.sh` (or a new paired test)
+- `q-system/.q-system/scripts/test/fixtures/pr-verdict/` (new fixture)
+- `q-system/.q-system/capability-manifest.json`
+
+## Out of scope
+
+- Reverting or weakening `resolve_verdict` (ASK-312). It is correct.
+- Re-reviewing the 11 merged PRs whose reviews never ran (`sp-c19bca55`).
+- Suppressing the prompt echo in `codex exec`. Worth doing, different issue, and
+  the parser must be robust to an echo regardless.

--- a/q-system/output/plans/dor-extract-verdict-prompt-echo-2026-08-03.md
+++ b/q-system/output/plans/dor-extract-verdict-prompt-echo-2026-08-03.md
@@ -1,5 +1,14 @@
 # DoR: extract_verdict reads the reviewer's verdict out of the echoed prompt
 
+> **Recovered work-product — a point-in-time snapshot, not current documentation.**
+> This file existed only in a dirty checkout and was recovered on 2026-08-05
+> (PR #106, ASK-363). Every claim about system state was true at this document's
+> own date and may not be true now. In particular, "wired" here means *merged in
+> this repository*; whether the RUNNING copy loads it is a separate question that
+> `q-system/.q-system/scripts/runtime-plugin-freshness.py` answers, because the
+> two came apart for a full day during this very build. Read it as a record of
+> what was decided and why, and verify current state against the code.
+
 ## The defect
 
 `codex exec` echoes the entire prompt to stdout. The reviewer prompt contains its

--- a/q-system/output/plans/fable-escalation-mechanism-2026-08-02.md
+++ b/q-system/output/plans/fable-escalation-mechanism-2026-08-02.md
@@ -1,5 +1,14 @@
 # Plan: fleet-wide Fable escalation ("when Opus is stuck, a different model triages")
 
+> **Recovered work-product — a point-in-time snapshot, not current documentation.**
+> This file existed only in a dirty checkout and was recovered on 2026-08-05
+> (PR #106, ASK-363). Every claim about system state was true at this document's
+> own date and may not be true now. In particular, "wired" here means *merged in
+> this repository*; whether the RUNNING copy loads it is a separate question that
+> `q-system/.q-system/scripts/runtime-plugin-freshness.py` answers, because the
+> two came apart for a full day during this very build. Read it as a record of
+> what was decided and why, and verify current state against the code.
+
 **Date:** 2026-08-02
 **Requested by:** founder, 2026-08-02
 **Owner:** Sana (both open engineering decisions are hers, see "Open decisions")

--- a/q-system/output/plans/fable-escalation-mechanism-2026-08-02.md
+++ b/q-system/output/plans/fable-escalation-mechanism-2026-08-02.md
@@ -1,0 +1,201 @@
+# Plan: fleet-wide Fable escalation ("when Opus is stuck, a different model triages")
+
+**Date:** 2026-08-02
+**Requested by:** founder, 2026-08-02
+**Owner:** Sana (both open engineering decisions are hers, see "Open decisions")
+**Status:** research complete, design fork open, nothing built
+
+## What / why
+
+Today `q-system/.q-system/token-guard.py` has exactly two outcomes when Opus
+loops: `block()` (exit 2, stop) or `warn()` (exit 0, keep going). Read its
+`main()` — every one of the 11 checks lands on one of those two. Neither outcome
+changes the *reasoning distribution*, so a pattern that deadlocks Opus deadlocks
+it again on the next attempt.
+
+This plan specifies a third outcome: hand the situation to Fable in a **fresh
+session** for triage, analysis, and a proposed next path, then come back. Same
+applies when the founder has asked the same thing repeatedly, or when the
+direction itself is uncertain.
+
+Fable is not the implementer here. Fable is the triage lens. Opus keeps the work.
+
+## Grounding: Fable is reachable (verified 2026-08-02)
+
+```
+$ claude -p --model claude-fable-5 "reply with exactly: FABLE_OK"
+FABLE_OK
+```
+
+Two call paths exist: headless `claude -p --model claude-fable-5` (works from a
+script, works in a launchd job) and in-session `Agent(model: "fable")` (fresh
+context by construction, no shared history).
+
+## Why a DIFFERENT model and not "Opus tries harder"
+
+From the literature sweep (2026-08-02):
+
+Findings, each paired with the executable in this repo that would carry it (a
+finding with no named executable is a note, not a design input):
+
+| Finding | Source | Executable that carries it here |
+|---|---|---|
+| Different LLMs have complementary failure distributions; a pattern that deadlocks one model often sits outside the other's failure mode, so cross-model escalation breaks cycles same-model retries cannot | [Act or Escalate, arXiv:2604.08588](https://arxiv.org/pdf/2604.08588) | `fable-escalate.py` (new) — the only caller of `claude -p --model claude-fable-5` |
+| A critic runs in a fresh session with no shared history, fed only spec + evidence + diff; a critic inside the originating context inherits its framing | [cross-model adversarial review](https://codex.danielvaughan.com/2026/03/28/cross-model-adversarial-review/) | `fable-escalate.py` builds the packet; a test asserts the subprocess receives no transcript |
+| Progress detection and stop rules sit outside the model | [multi-model convergence](https://zylos.ai/research/2026-03-01-multi-model-ai-code-review-convergence/) | `q-system/.q-system/token-guard.py`, already live: 6 coded detectors, PreToolUse exit 2 |
+| Cap escalations, then route to a human | same | escalation counter in `fable-escalate.py` + `slack-notify.sh` at the cap |
+
+The third row is the load-bearing one: `token-guard.py` is already the
+outside-the-model progress detector this fleet needs. Its 6 detectors all
+terminate in "stop and tell the founder" today. The escalation is a missing
+branch on an existing gate, not a new gate.
+
+## The menu: when to call Fable
+
+### Tier A — deterministic, a detector already fires today
+
+Every one of these is already coded in `q-system/.q-system/token-guard.py`. No
+new detection work; the work is adding the escalation branch.
+
+| # | Trigger | Existing enforcer |
+|---|---------|-------------------|
+| A1 | Exact retry x3 (same tool + same input) | `check_exact_retry`, `RETRY_LIMIT=3` |
+| A2 | Edit spiral x3 on one file | `check_edit_spiral`, `EDIT_FAIL_LIMIT=3` |
+| A3 | Time stall: 120s + 10 calls, no write | `check_time_stall`, `STALL_TIME_SECONDS=120` |
+| A4 | Read spiral 15 / grep drift 5 (exploring, not producing) | `check_read_spiral`, `check_grep_drift` |
+| A5 | Agents spawned with no output | `check_agent_no_output` |
+| A6 | Volume ceiling 50 calls since last user message | `check_volume`, `VOLUME_CEILING=50` |
+
+Two more deterministic triggers exist outside token-guard:
+
+| # | Trigger | Existing enforcer |
+|---|---------|-------------------|
+| A7 | A phased-job step exhausts its 3 attempts | `.claude/rules/self-healing-retry.md` rule 4 |
+| A8 | A bounded verification loop hits its 3-pass cap still red | CLAUDE.md bounded-loop contract |
+
+### Tier B — the founder repeated themselves
+
+Not currently detected anywhere. This is the signal the founder named first
+("I've been asking the same thing over and over").
+
+| # | Trigger |
+|---|---------|
+| B1 | Same substantive ask 2+ times in a session |
+| B2 | "why did you stop" / "why do you keep" / "I already told you" |
+| B3 | "that's wrong" / "no" twice on the same artifact |
+
+Scar backing B1/B2: the autonomy-contract entry in the founder's global
+CLAUDE.md records the founder pushing back **multiple times in one session** on
+the same behavior, and the fix reached for was more hook patches. That note
+itself concludes "hooks are the wrong layer for this... each round you find a new
+surface." A repeated founder ask is the highest-signal stuck indicator in the
+system and nothing consumes it.
+
+### Tier C — epistemic, derived from this repo's own RCAs
+
+Judgment calls. Each is a real, dated failure in `q-system/output/rca/`.
+
+| # | Trigger | Source RCA | What Fable is asked for |
+|---|---------|-----------|------------------------|
+| C1 | About to report that something IS happening / HAS failed, based on a file artifact rather than an observation | `rca-specification-reported-as-state-2026-08-02.md` — 9 false claims in ONE session, each refuted by a command available the whole time | Name the command that would refute this claim, before it is spoken |
+| C2 | Two sides derive one logical value from different sources; all tests green | `rca-autocapture-session-id-disconnect-2026-07-04.md` — producer read `CLAUDE_SESSION_ID`, consumer read the stdin payload; feature shipped live-but-inert with every gate green | Find the derivation path no test exercises |
+| C3 | Edited a file and cannot prove the running system loads *that* copy | `rca-derived-copy-drift-2026-06-30.md` — 5 of 6 open spillover items were one class: a truth with multiple stored representations and no check that they agree | Identify which copy actually runs |
+| C4 | A test passes but the fixture was invented rather than produced | memory `feedback_fixtures_from_producers` — two green-but-wrong tests shipped in one day, both caught by mutation, neither by review | Mutate the code; does the test still pass |
+| C5 | 2+ plausible approaches, no evidence to choose between them | `.claude/rules/quick-plan.md` name-options rule | Triage and rank, do not implement |
+
+C1 deserves emphasis: that RCA is dated **today**. Its structural root cause is
+"the cheap check and the correct check are different checks, and only the cheap
+one is one keystroke away." A Fable call is a way to make the correct check cheap.
+
+### What Fable returns (proposed contract)
+
+Not a fix. A triage packet:
+
+1. **Diagnosis** — what is actually blocking, stated as a falsifiable claim
+2. **What to stop doing** — the approach that is looping, named
+3. **Next path** — one concrete action, with the command or file that proves it
+4. **The refuting check** — what would show this diagnosis is wrong
+
+## Open decisions (Sana's, not the founder's)
+
+The founder was asked both and routed both to Sana. Sana researches and decides.
+
+### Decision 1: trigger mode for Tier A
+
+- **(a) Advisory** — token-guard's block message gains `run fable-escalate.py
+  --trigger edit-spiral`. Cheap, no latency in the hook, no hang risk. Weakness:
+  prompt-only at the moment of use, the failure class `skill-hook-pairing.md`
+  calls "an aspiration".
+- **(b) Automatic** — the hook shells Fable synchronously and returns the triage
+  AS the block message. Cannot be skipped. Weakness: a 20-60s network call inside
+  a PreToolUse hook; a hang freezes the session, and the hook has no session
+  transcript so the packet it can assemble is thin.
+- **(c) Hybrid** — auto on the blocking detectors, advisory on the warning
+  detectors. Splits the risk, doubles the code paths to test.
+
+Prior art to weigh: the `a-hook-that-fails-closed-on-a-missing-script-blocks-the-fix-too`
+lesson (a fail-closed hook whose own dependency is missing blocks the repair
+too), and token-guard's own history of a warn tier that was silently invisible
+for weeks because the JSON shape was wrong.
+
+### Decision 2: what holds Tier C
+
+- **(a) Rule + trigger-eval fixtures** — `.claude/rules/fable-escalation.md`
+  plus a fixture set in `q-system/.q-system/skill-evals/`, run advisorily by
+  `skill-trigger-eval.py`. Exactly how the fleet already handles interpretive
+  auto-invoked skills (founder-voice, rca, fable-discipline). Measures whether it
+  fires; does not force it.
+- **(b) Rule only** — accept Tier C is prompt-only, ship faster, no firing signal.
+- **(c) Add a Stop-hook claim scanner for C1** — scan the final message for state
+  assertions with no observation command in the turn. Directly targets today's
+  RCA. Real detector work, high false-positive risk; likely its own issue.
+
+## Files likely to touch
+
+- `q-system/.q-system/scripts/fable-escalate.py` — new, the single chokepoint
+- `q-system/.q-system/token-guard.py` — escalation branch on the stuck detectors
+- `.claude/rules/fable-escalation.md` — new, carries the menu (propagates fleet-wide)
+- `.claude/settings.json` + `settings-template.json` — if any new hook is wired
+  (`settings-template-sync-check.py` blocks a one-sided wiring)
+- `q-system/.q-system/skill-evals/fable-escalation.json` — if decision 2 = (a)
+- `q-system/output/fable-escalations/` — the ledger destination
+- `q-system/lessons/` — one lessons entry (detect-act-learn triad)
+
+## Acceptance criteria
+
+- [ ] A reproducer drives a Tier-A stuck state and shows the escalation firing.
+      Show it failing before the fix.
+- [ ] The Fable call runs in a **fresh session** — proven, not asserted (the
+      packet contains only what was passed in)
+- [ ] The escalation is **logged**, one JSONL row per call: trigger, packet hash,
+      Fable's diagnosis, whether the next path was taken
+- [ ] There is a **cap**: N escalations per session, then stop and surface to the
+      founder. Cross-model is a step before the human, not instead of one
+- [ ] A failed / timed-out Fable call **degrades to current behavior** (plain
+      block), never to a hang
+- [ ] `.claude/rules/fable-escalation.md` reaches instances — `kipi update --dry`
+      confirms propagation
+- [ ] Capability manifest entry + test, per `project_capability_gate`
+- [ ] One `q-system/lessons/` entry (detect-act-learn triad: detector + logged
+      automated action + lesson)
+- [ ] `python3 plugins/prd-os/scripts/prd_runner.py gates run` exits 0
+
+## Patterns to follow (from this repo, not generic advice)
+
+- `token-guard.py`'s `warn()` / `block()` exit-code contract, and its
+  `uncount_blocked_attempt` care about not corrupting counters on a blocked call
+- `slack-notify.sh` as the only founder-ping channel (`founder-notifications.md`)
+- The lint convention in `skill-hook-pairing.md`: self-scope early, fast-exit
+  out-of-scope, header comment naming its pair
+- `self-healing-retry.md`'s cause taxonomy (`environmental-trigger` vs
+  `latent-defect`) — escalating on an environmental failure is waste; stop on
+  attempt 1 there
+- `evidence-ledger.md`: a Fable diagnosis is an inference until a command backs
+  it. It gets stored labelled, not as a measurement.
+
+## Anti-goal
+
+This is not "route hard work to Fable." Opus keeps the work. Fable gets the
+situation packet when Opus has demonstrably stopped making progress, and returns
+a direction. If this drifts into general-purpose offload, the loop-health metric
+in `loop-exits.md` (cost per accepted change) is where that shows up.

--- a/q-system/output/plans/judge-runner-2026-08-04.md
+++ b/q-system/output/plans/judge-runner-2026-08-04.md
@@ -1,0 +1,153 @@
+# Plan: wire a judge runner into triage (ASK-363, sp-320d30e3)
+
+**Status:** planned, not started. Sequenced behind Sana's PR #101 split, because
+she is editing `judgment_compiler.py` and `findings_writer.py` right now.
+
+## What and why
+
+The Judgment Compiler's entire evaluation half is unreachable. Verified by
+running greps and reading the code, not recalled:
+
+- `judgment_compiler.py:1371` counts a calibration case only when a receipt has
+  **both** `judge` and `human`.
+- `/prd-triage` (`plugins/prd-os/commands/prd-triage.md:55-59`) passes
+  `--rationale`, `--reason-code`, `--evidence`. Never `--judge-run`.
+- Grepping `plugins/ q-system/ kipi*` for `judge_run` outside tests returns
+  **consumers only** (`_load_judge_run` at :770, the argparse flag at :1895)
+  plus one selftest fixture at :1665. **No producer exists.**
+
+So every triage writes a human-only receipt, `judged` stays empty forever, and
+the release gates (88% agreement, kappa 0.80, 50 cases) are unreachable by
+construction. `evaluate`, `policy-candidates` and `sample-check` are machinery
+with no wired input. The handoff's claim that running a triage "starts the
+calibration clock" is wrong: it starts the provenance clock only.
+
+**This is a known recurring defect class in this repo.** Lesson
+`a-gate-s-input-needs-a-production-producer-not-just-a-test-t` (2026-07-13):
+"a consumer without a production producer is dead wiring, and tests that supply
+the consumer's input verify the consumer's logic while hiding that the wiring is
+dead." That is exactly what happened. ~90 tests pass on a judge path no
+production code can reach, because every one of them hand-builds the judge run.
+
+## Approach (the pick)
+
+Add a **judge subcommand** that assembles the packet, calls one LLM, and writes
+a judge-run JSON. The schema check is not new prose: the existing
+`validate_judge_output` script function (`judgment_compiler.py:343`) plus its
+pytest cases are the deterministic blocker, and `_load_judge_run` (:770) refuses
+an unbound or malformed run at exit 2. Then `/prd-triage` calls the subcommand
+and passes `--judge-run <path>` to `set-disposition`.
+
+Options considered:
+
+1. **Judge subcommand in `judgment_compiler.py`, invoked by the triage command.**
+   THE PICK. The contract, the packet assembler and the validator already live
+   there; a producer next to them shares `assemble_packet` and cannot drift from
+   `validate_judge_output`.
+2. Standalone script under `q-system/.q-system/scripts/`. Rejected: it would
+   duplicate packet assembly, and the fleet-homogeneity principle says a shared
+   capability lives in one canonical source.
+3. Batch-judge historical findings retroactively. Rejected outright: this is the
+   exact mistake the whole issue exists to correct. A judge scoring a decision
+   whose workflow state it never saw is what produced kappa 0.032.
+
+## The design question that was actually hard, and its answer
+
+`input_sha256` on the judge run must equal `packet["packet_sha256"]`
+(`judgment_compiler.py:784`). If the judge assembles one packet and `capture`
+assembles another, the binding fails and no judged receipt can ever be written.
+
+**Resolved by reading the code:** `packet_hash` (`judgment_compiler.py:151-154`)
+excludes both `packet_sha256` and `assembled_at`. Two assemblies of unchanged
+state hash identically. Further, the packet's finding block carries `body` and
+`severity` only, so `_write_all` changing `disposition`/`resolved_at` does not
+move the hash.
+
+Consequence: the judge subcommand can assemble independently and still bind. No
+packet file needs threading through the triage path.
+
+## Blindness constraints (these make or break the dataset)
+
+- The packet is already clean of the label. `assemble_packet` (:714-734) copies
+  `prd_id, finding_id, severity, body, body_sha256` into the finding block, and
+  `duplicates` entries carry ids plus similarity only. No disposition, no
+  rationale. Verified by reading.
+- **The judge gets no tools.** `duplicates[].source` is a filesystem path to a
+  findings file, and `prior_receipts` lists receipt ids. A judge that can open
+  files reads prior human dispositions straight out of both. Pass the packet as
+  text, tools disabled.
+- **Do not show the judge's answer to the founder before they decide.** If the
+  human sees the prediction and agrees, measured agreement is inflated and the
+  calibration set is worthless. Run it, capture it, display it only after the
+  disposition is set.
+
+## Files to touch
+
+- `plugins/prd-os/scripts/judgment_compiler.py` — new `judge` subcommand, prompt
+  constant, `prompt_sha256` derived from that constant.
+- `plugins/prd-os/commands/prd-triage.md` — call the judge, pass `--judge-run`.
+- `plugins/prd-os/tests/test_judgment_compiler.py` — cases below.
+- `kipi` CLI allowlist — `TestCliParity` diffs bash against the Python
+  subparsers both ways, so a new subcommand fails the suite until it is added.
+- `plugins/prd-os/CHANGELOG.md`, `plugins/prd-os/.claude-plugin/plugin.json`.
+
+## Output contract (already fixed, do not redesign)
+
+Judge run JSON: `{model, prompt_sha256, review_run_id?, input_sha256, output}`
+(`_load_judge_run` :776-777). `output` carries exactly the 7
+`JUDGE_OUTPUT_FIELDS`, `workflow_disposition` in the 8 `WORKFLOW_DISPOSITIONS`,
+`workflow_reason_code` in the 12 `REASON_CODES`, `evidence_refs` matching
+`EVIDENCE_REF_RE`, finite `confidence` in [0,1]. Extra fields rejected.
+
+`EVIDENCE_REQUIREMENTS` (:90-97): six reason codes require refs with specific
+prefixes, and refs are **resolved** (opened), not pattern-matched. Judge output
+failing the gate degrades to `needs-human` rather than erroring, so the runner
+does not have to satisfy it. But a judge that never cites refs converts
+constantly and scores nothing, since `JUDGE_TO_LEGACY["needs-human"] is None`
+excludes it from metrics. Track `converted_to_needs_human` as a health signal.
+
+## Acceptance criteria
+
+- [ ] Reproducer first: a test asserting `evaluate()` reports zero judged cases
+      after a full production-path triage. Red today. It documents the gap and
+      is the end-to-end shape lesson point 3 demands.
+- [ ] `judge` subcommand exists, assembles the packet, emits a judge run whose
+      `input_sha256` binds against a separately-assembled packet.
+- [ ] Malformed LLM output is retried a bounded number of times (3, per the
+      self-healing-retry contract), then fails loudly. No silent fallback to a
+      default disposition: a fabricated prediction poisons the calibration set
+      worse than a missing one.
+- [ ] The judge is invoked with tools disabled. A test asserts it.
+- [ ] `/prd-triage` passes `--judge-run` end to end on a sandbox repo.
+- [ ] After one full sandbox triage, `evaluate` reports one judged case.
+- [ ] Live `.prd-os/` hash unchanged by the test run (the ledger follows
+      git-common-dir, so a sandbox that copies a `.git` writes production).
+- [ ] `TestCliParity` green.
+- [ ] **Mechanical detection for the recurring class** (lesson point 4): a check
+      asserting every field the receipt schema reads has a non-test write site.
+      This class has now produced a defect twice. It earns a script, not
+      vigilance.
+
+## Patterns to follow (from this repo, not generic advice)
+
+- **Pin the model.** Every headless `claude -p` job in this fleet exports
+  `ANTHROPIC_MODEL`. Unpinned jobs silently rode a cheaper model and burned 3%
+  of a weekly budget in an hour. Record the resolved model in the judge run's
+  `model` field so a model change shows up in the ledger rather than
+  confounding a kappa shift.
+- `claude -p` as the LLM client is the established pattern here: no API key,
+  uses the founder's subscription.
+- Why-comments in these files cite the specific review round and executed
+  reproducer that motivated them. Match that density.
+- `fable-discipline`: recon before edit, negative self-test, single-writer
+  chokepoint.
+
+## Open risk, named not hidden
+
+A judge whose prompt is tuned after seeing disagreements stops being an
+independent predictor. The deterministic blocker is the receipt schema itself:
+`prompt_sha256` is a required field on every judge run (`_load_judge_run`
+:776-780 raises at exit 2 without it), so a changed prompt is a visible
+discontinuity in the ledger rather than a silent one. Add a pytest case
+asserting two runs with different prompts carry different hashes. When that hash
+moves, prior cases are a different experiment and should not be pooled.

--- a/q-system/output/plans/judge-runner-2026-08-04.md
+++ b/q-system/output/plans/judge-runner-2026-08-04.md
@@ -1,5 +1,14 @@
 # Plan: wire a judge runner into triage (ASK-363, sp-320d30e3)
 
+> **Recovered work-product — a point-in-time snapshot, not current documentation.**
+> This file existed only in a dirty checkout and was recovered on 2026-08-05
+> (PR #106, ASK-363). Every claim about system state was true at this document's
+> own date and may not be true now. In particular, "wired" here means *merged in
+> this repository*; whether the RUNNING copy loads it is a separate question that
+> `q-system/.q-system/scripts/runtime-plugin-freshness.py` answers, because the
+> two came apart for a full day during this very build. Read it as a record of
+> what was decided and why, and verify current state against the code.
+
 **Status:** planned, not started. Sequenced behind Sana's PR #101 split, because
 she is editing `judgment_compiler.py` and `findings_writer.py` right now.
 

--- a/q-system/output/plans/judgment-dispatcher-codex-receipt-2026-07-30.md
+++ b/q-system/output/plans/judgment-dispatcher-codex-receipt-2026-07-30.md
@@ -1,0 +1,402 @@
+# Judgment: is the current approach the right one?
+
+Written 2026-07-30 by an outside reader, from artifacts only. No prior-session
+summaries were read.
+
+## Verdict in one line
+
+The approach is right, the code is finished, and the accumulated work should NOT
+be discarded. The artifact is missing for a reason that lives nowhere in the
+review path: since the last piece of review wiring landed, the dispatcher has not
+once picked an issue that produces a diff.
+
+## What I verified, and how
+
+Counts below were produced by a command before being written down.
+
+| Claim | Command | Result |
+|---|---|---|
+| verdict records on disk | `for f in *.verdict.json` | 35 |
+| carry `engine` | same loop, read the key | 3 (PR 34, 46, 47) |
+| carry `invoker` | same loop | 1 (PR 47, `manual`) |
+| carry `invoker=worker` | same loop | **0** |
+| dispatcher dispatches ever | `grep -c 'dispatched ASK' dispatch.log` | 14 |
+| ready issues right now | `bash ./kipi work` | 29, top pick ASK-148 |
+
+## The chain is already wired end to end
+
+Every link exists in the checkout the launchd job runs.
+
+- `~/Library/LaunchAgents/com.kipi.dispatch.plist` sets
+  `KIPI_REPO=/Users/assafkipnis/projects/kipi-system`, so the loaded job runs the
+  main checkout on `main`.
+- `kipi-dispatch.sh:313` picks work; `:393-406` launches
+  `./kipi converge --issue <N>` in a new session.
+- `linear-worker.sh:1156` runs the reviewer as
+  `KIPI_REVIEW_INVOKER=worker $REVIEWER_CMD "$PR_NUM" --issue "$ISSUE" --post --engine codex`
+- `pr-review-agent.sh:137` reads `INVOKER="${KIPI_REVIEW_INVOKER:-manual}"`;
+  `:649-657` writes it into the record next to `engine`.
+- `test-review-invoker-provenance.sh` runs green, 7/7, including the fail-safe
+  case (an unlabelled run must not read as dispatcher-driven).
+
+There is no missing code between the dispatcher and the verdict file.
+
+### The producer census, run properly
+
+`q-system/lessons/a-gate-is-only-real-if-production-writes-what-it-reads.md` says
+a gate is fake when only tests write the field it reads. I ran that census.
+`invoker` appears in exactly four places in the real tree: the reviewer that
+writes it (`pr-review-agent.sh`), the verifier that reads it
+(`verify-codex-review-live.sh`), the test, and the worker call site
+(`linear-worker.sh:1156`). The worker is a genuine non-test producer, so the
+contract is fulfilled **in code**.
+
+What is unfulfilled is narrower and worth stating exactly: **the producing line
+has never executed in production.** Not because it is unreachable, but because
+control has not reached it since it was written. That is a different disease from
+the one the lesson describes, and it takes a different cure: not another edit,
+one successful run.
+
+## Why the artifact does not exist (over-determined, three reasons)
+
+**1. The codex switch is newer than every reviewed dispatcher run.**
+`--engine codex` reached the worker call site in `42c2995`, 2026-07-29 15:18
+local (22:18Z). Two dispatcher-driven runs had already opened PRs and recorded
+verdicts before that:
+
+- ASK-218 to PR #42, `pr-42.verdict.json` ts 2026-07-29T16:31:01Z,
+  `converge-ASK-218.log` DONE exit-1, four rounds, APPROVE WITH NITS.
+- ASK-223 to PR #40, `pr-40.verdict.json` ts 2026-07-28T19:09:55Z,
+  `converge-ASK-223.log` STOP exit-2 at the round cap, REQUEST CHANGES.
+
+Both were reviewed with nobody at the keyboard. Both used the Claude reviewer,
+and neither record carries `engine` or `invoker` because those fields did not
+exist yet.
+
+This matters more than it looks. **The unattended dispatch-to-review loop has
+already run to completion twice.** What was never proven is that same loop with
+codex named in the record. The remaining gap is two provenance fields on a
+behaviour that already happened.
+
+**2. The invoker field is newer still, and is local-only.**
+`a215e5e`, 2026-07-30 10:37 local (17:37Z).
+`git merge-base --is-ancestor a215e5e origin/main` says no: it is one of 33
+unpushed commits on local `main`. The branch `sana/ask-221-invoker-only` at
+`c37d41b` is that same change isolated on top of `origin/main`, and is 33 commits
+behind local main.
+
+Practical consequence: **the branch is not on the path to the artifact.** The
+launchd job runs the local checkout, which already carries the field. The branch
+is how `origin/main` becomes correct, which is a real but separate goal.
+
+**3. Since both landed, every dispatch has produced no PR.**
+Four dispatcher-driven runs after the wiring completed, all identical
+(`converge-ASK-149.log`, `converge-ASK-148.log`):
+
+```
+STOP exit-7: no PR on sana/ask-149 after round 1 (worker rc=0)
+```
+
+`linear-worker.log:4248`, ASK-149: "BLOCKED. ASK-149's DoR is sound but not
+executable by this session. No code change, so no PR exists."
+`linear-worker.log:4423`, ASK-148: "stopped at the DoR. Not achievable as
+written. Nothing committed, no PR, there's no diff to ship."
+
+Those refusals read as correct engineering. The defect sits upstream of Sana: the
+picker has no notion of "will this yield a diff", and `ready()` cannot tell an
+executable spec from an unexecutable one.
+
+## What repeats tomorrow morning
+
+`bash ./kipi work` right now:
+
+```
+worker: 29 ready issue(s) (owner:sana, has a DoR, not owner:assaf)
+[dry] would work ASK-148 (attempt 1/3)
+```
+
+ASK-148 is the issue Sana declared unexecutable today. At 07:00 local the budget
+refills and slot 1 of 3 goes to it again. She removed ASK-149 from the pool by
+relabelling it `owner:assaf` (`linear-worker.log:4392-4393`, showing
+`ready(ASK-149)` flip True to False). ASK-148 got no such treatment; her closing
+line was "Your call: re-scope ASK-148 or file (a) as a fresh issue".
+
+The loop is pointed at a wall, and the wall is one Linear label wide.
+
+## Was this solving the wrong problem?
+
+Partly. The split is worth naming precisely.
+
+**Right problem, correctly solved.** The review path: codex as reviewer, the
+verdict record as single source of truth, `head_sha` pinning, the severity floor,
+the silent-loss fixes, `engine`, `invoker`, and the fail-safe default of
+`manual`. Nine rounds of codex finding real defects is not sunk cost. It is the
+reason the record will be worth believing when it finally reads `worker`.
+
+**Wrong problem, real time spent.** Treating the missing artifact as a wiring
+defect. It stopped being one at 2026-07-30 17:37Z. Work after that point that
+edited the review path was hardening a chain that was already complete. The
+isolate-the-invoker branch is the cleanest example: careful, correct, and it
+moves the artifact zero distance, because the runtime never reads `origin/main`.
+
+**The named failure mode, recurring.** A green test standing in for the
+behaviour. `test-review-invoker-provenance.sh` passes 7/7 and proves the field is
+plumbed. It cannot prove a dispatcher ever set it, and never claimed to. The
+distance between "the wiring is proven" and "the loop has done it" is the whole
+remaining distance, and it is not closed by editing code.
+
+## Recommendation
+
+Discard nothing. Stop editing the review path. Give the dispatcher one issue that
+yields a diff and let the existing machinery run.
+
+Three ways, tradeoffs stated:
+
+1. **Clear the wall, then use the test lane.** Take ASK-148 out of `ready()` the
+   way Sana took ASK-149 out, then run
+   `KIPI_DISPATCH_LANE=test bash kipi-dispatch.sh`. That lane exists at
+   `kipi-dispatch.sh:278-289` with its own counter and a cap of 2, built for
+   exactly this, and it spends no production slot. Fastest, and it exercises the
+   real dispatcher rather than a stand-in.
+2. **Wait for 07:00.** Costs nothing to build. Slot 1 burns on ASK-148 unless it
+   is cleared first, and slots 2 and 3 are a coin flip on the same question.
+3. **Teach the picker to prefer diff-yielding issues.** The durable fix, and the
+   spillover ledger will want it eventually. It is also a new feature on a loop
+   that cannot yet prove it works, so it belongs after the artifact, not before.
+
+My call: #1. It is the only option that tests the thing that has never been
+tested, and it requires trusting no new code.
+
+## What I did not verify
+
+- The outcome of 8 of the 14 dispatches (ASK-224 x4, ASK-225 x2, ASK-151, and
+  ASK-223's first line). `kipi-dispatch.sh:364-374` documents the four ASK-224
+  dispatches as launchd-reaped children that did no work. I read that as a claim,
+  not a measurement, and did not confirm it.
+- Whether ASK-148 is genuinely unexecutable. I read Sana's reasoning, not the
+  issue itself.
+- `attempts-ledger.py` line 44, deliberately and on instruction. Noting the shape
+  only: the `break` at `:46` is reached only on a successful `os.mkdir`, so after
+  100 failed tries the loop falls through and the mutation proceeds **unlocked**,
+  which `:25-28` states as a deliberate trade. The release path then removes a
+  lock directory it may not own. Real defect, out of scope for this judgment,
+  and it wants a rested pass.
+
+---
+
+# CORRECTION, same day, after founder challenge
+
+The founder rejected the recommendation on two grounds, both correct:
+
+1. **Option 1 routed a Linear label edit to the founder.** That is implementation,
+   and it violates the standing rule that Sana owns the work and the LOOP gets
+   fixed rather than the founder doing a step by hand. Withdrawn.
+2. **"What is an impossible job, and why is it even on the board?" was never
+   answered programmatically.** It is answered below.
+
+## Two predictions I made and got wrong
+
+Stated before measuring, per the discipline this brief demanded.
+
+| Prediction | Actual | Direction |
+|---|---|---|
+| 15+ of 29 ready issues are auto-filed | **29 of 29** | under-predicted |
+| 3-6 of 29 are dispatchable | **13 of 29** | over-corrected |
+
+Both errors point the same way: I was reasoning about the board instead of
+querying it.
+
+## What an "impossible job" is, defined in code that already exists
+
+`linear-triage.py:326`:
+
+```python
+UNDISPATCHABLE_FLAGS = ("no-Files-line", "all-paths-outside-repo")
+```
+
+with `enforce_flags()` at `:329-355` deterministically overriding a `do-now`
+triage verdict to `needs-scope` when either flag is set. Its own comment records
+the measurement, made 2026-07-27: *"of 56 issues the worker considered READY, 13
+carried no `**Files:**` line and 1 named only machine-local paths — 5 in 6 of its
+own queue could never reach a terminal state."*
+
+So the definition is not missing. It was written three days ago.
+
+## The actual defect: the picker never reads it
+
+`linear-worker.sh:230-236`, `ready()`, in full:
+
+```python
+def ready(i):
+    labels = {l["name"] for l in i["labels"]["nodes"]}
+    if "owner:assaf" in labels:      return False
+    if "owner:sana" not in labels:   return False
+    if i["state"]["type"] not in ("backlog", "unstarted"): return False
+    d = i.get("description") or ""
+    return "## Definition of Ready" in d or "Definition of Ready" in d
+```
+
+The last line is a substring match on a heading. It is the index standing in for
+the thing: the presence of the words "Definition of Ready" stands in for "this
+issue is executable". `enforce_flags()` is a producer with no consumer, which is
+the inverse of this repo's own lesson
+(`lessons/a-gate-is-only-real-if-production-writes-what-it-reads.md`) and a plain
+`wiring-check.md` miss: an engine with no caller.
+
+## Why the board is full of them
+
+Measured against Linear just now, all 29 ready issues:
+
+| Property | Count |
+|---|---|
+| ready | 29 |
+| auto-filed by a detector (`<!-- kipi-key:`) | **29** |
+| hand-written by a person | **0** |
+| no `**Files:**` line at all | 13 |
+| `**Files:**` naming no path that exists in this repo | 3 |
+| naming at least one real in-repo path | 13 |
+
+The producers are `fleet-health-daily.py` and `capability-map-gen.py`. They file
+fleet-wide findings into one Linear team. The worker cuts every worktree from
+`SKEL` (`linear-worker.sh:57`), which is kipi-system. Thirteen of the ready
+issues are `Audit N unwired engines in <other repo>` — accountant, Alice,
+KTLYST_strategy, investigations, gtm-partner and so on. The worker cannot check
+those repos out. Nothing anywhere filters by target repo.
+
+So the loop is a machine filing reports to itself, and a picker that cannot tell
+a report from a task.
+
+## Why the top pick is the worst pick
+
+The pick is the first of the ready pool, which arrives descending by identifier,
+so it is the highest-numbered ready issue: ASK-148. That is the one issue in the
+dispatchable 13 that Sana has already refused, twice, on the correct grounds that
+triaging 304 spillover items is not one bounded change. Its `**Files:**` line
+names a real in-repo path (`prd_runner.py`), so a Files-based gate alone would
+still pick it. The Files line is a second index: in-repo paths stand in for
+bounded work.
+
+## Why the existing self-clear is too slow to matter
+
+`0d9700d` (today 16:27Z, local-only) bumps the attempt counter when a run opens no
+PR. Three bumps mark an issue stuck. Verified: the ledger has no entry for either
+ASK-148 or ASK-149 because all four no-PR runs predate that commit, so it has
+never fired.
+
+The arithmetic: 3 dispatches to retire one bad issue, 16 undispatchable issues,
+3 dispatches per day. **~16 days of full budget to drain the board**, and its
+terminal state is "stuck, needs a human", which routes to the founder — the thing
+the founder just said must not happen.
+
+## The loop fix, and it is Sana's
+
+Two changes, both inside the loop, neither touching the founder:
+
+1. **Wire `enforce_flags()` into `ready()`.** The classifier exists; give it its
+   consumer. Drops 16 of 29 immediately and stops the queue handing Sana work
+   that cannot yield a diff.
+2. **One run, not three, and not to the founder.** Sana already writes a
+   structured BLOCKED verdict. The worker should read it and apply a
+   `needs-scope` label that `ready()` excludes and that routes the issue back to
+   `linear-dor-drafter.py` for re-scoping. Today her only available move was
+   relabelling ASK-149 to `owner:assaf`, which is the founder queue.
+
+With both, the top pick becomes one of the twelve `CAP-NN` capability-manifest
+issues, which are bounded, in-repo, and name real scripts. The receipt falls out
+of the next dispatch without anyone touching Linear by hand.
+
+## What is still unverified
+
+- Whether the twelve `CAP-NN` issues are genuinely executable. They pass every
+  mechanical test I ran; nobody has dispatched one.
+- Whether `enforce_flags()`'s two flags are sufficient. ASK-148 passes both and is
+  still unexecutable, so a third signal (bounded work) is probably needed and is
+  not yet defined.
+
+---
+
+# CORRECTION 2, after founder asked "why can't Sana handle junk herself"
+
+The question was the right one, and answering it invalidated the fix I proposed
+in Correction 1. Three claims of mine were wrong.
+
+## Wrong claim 1: "13 ready issues target other repos"
+
+Measured properly, by Linear project rather than by reading titles:
+
+```
+11  kipi-system
+18  everything else (ktlyst 4, 4_points 2, reddit-build-radar, negotiator,
+    investigations, interview-coach, fractional-cxo, Pure_spectrum_Q,
+    KTLYST_strategy, Alice, AUDHD_KIDS, ASK_AI_consultant, accountant, 1 unset)
+```
+
+**18 of 29, not 13.** The worker cuts every worktree from `SKEL`
+(`linear-worker.sh:57`), which is kipi-system. Under two-thirds of its own ready
+queue is for repos it cannot check out.
+
+## Wrong claim 2: "wire enforce_flags() into ready()"
+
+`linear-triage.py` writes its verdict as a **Linear comment**
+(`comment_body()` at `:420-436`). Grepping the file for any label mutation
+(`labelIds`, `issueUpdate`, `addLabel`) returns **0**. It has no launchd plist and
+no caller anywhere in `kipi` or the scripts. It ran once, 2026-07-28, and died
+mid-run after commenting on 74 issues.
+
+So the classifier does not emit anything a machine can read. "Wire it into
+`ready()`" was not a small change; it was an unwritten feature described as a
+wiring fix. That is the same index-for-thing error this brief warns about: I saw
+the right logic in a file and treated its existence as availability.
+
+## Wrong claim 3 (overstated): "29 of 29 auto-filed"
+
+What is proven: 29 of 29 carry a `<!-- kipi-key:` marker. Five scripts write that
+marker, and one of them is `linear-dor-drafter.py`, which adds sections to issues
+regardless of who created them. So the marker proves machine *touch*, not machine
+*origin*. Two issues were confirmed detector-filed by reading them (ASK-148 says
+"Filed by `fleet-health-daily.py`"; ASK-118 by `capability-map-gen.py`). The other
+27 are unconfirmed. Downgrade the claim to: **the board is machine-maintained**.
+
+## The answer to the founder's question
+
+Sana has the judgment. She used it correctly on ASK-148 and ASK-149 and wrote
+clear reasoning both times. What she lacks is any way to act on it.
+
+The worker already contains a real loop over the whole ready pool:
+
+```
+linear-worker.sh:520   while IFS= read -r ISSUE; do
+linear-worker.sh:1260    DONE=$((DONE+1))
+```
+
+It is disabled from outside. `converge.sh:151` invokes the worker as
+`--apply --limit 1 --issue "$ISSUE"`, and the dispatcher hands converge exactly
+one identifier. So by the time Sana is running, the board has already collapsed
+to a single pre-chosen ticket. She can say yes or no to that ticket and nothing
+else. There is no next ticket, and no way to mark the one she rejected.
+
+That is the defect. Not a missing bouncer at the door: a chef with good judgment
+and no menu.
+
+## The revised fix
+
+Give Sana the board instead of one ticket, and let rejection be a skip inside one
+session rather than the end of a dispatch.
+
+- **`--limit 1` becomes a budget, not a blindfold.** The worker loop already
+  exists. Let a run read N ready issues, skip the ones Sana judges unexecutable,
+  and spend its work on the first real one. Rejections then cost turns inside one
+  session, not a whole dispatch each.
+- **A rejection has to stick, and not land on the founder.** Sana's BLOCKED
+  verdict needs a machine-readable outcome that `ready()` excludes. Today her only
+  available move was relabelling ASK-149 to `owner:assaf`, which is the founder
+  queue. A `needs-scope` label routing back to `linear-dor-drafter.py` closes it
+  inside the loop.
+- **Project scope is a one-line filter, and it is the cheapest win here.**
+  `ready()` should exclude issues whose Linear project is not the repo the worker
+  checks out. That is 18 of 29 gone for the cost of one predicate, and unlike the
+  triage wiring it needs nothing that does not already exist.
+
+The deterministic pre-filter I proposed in Correction 1 is not wrong in principle,
+but it is the third priority, not the first, and the piece it depended on does not
+exist yet.

--- a/q-system/output/plans/judgment-dispatcher-codex-receipt-2026-07-30.md
+++ b/q-system/output/plans/judgment-dispatcher-codex-receipt-2026-07-30.md
@@ -1,5 +1,14 @@
 # Judgment: is the current approach the right one?
 
+> **Recovered work-product — a point-in-time snapshot, not current documentation.**
+> This file existed only in a dirty checkout and was recovered on 2026-08-05
+> (PR #106, ASK-363). Every claim about system state was true at this document's
+> own date and may not be true now. In particular, "wired" here means *merged in
+> this repository*; whether the RUNNING copy loads it is a separate question that
+> `q-system/.q-system/scripts/runtime-plugin-freshness.py` answers, because the
+> two came apart for a full day during this very build. Read it as a record of
+> what was decided and why, and verify current state against the code.
+
 Written 2026-07-30 by an outside reader, from artifacts only. No prior-session
 summaries were read.
 

--- a/q-system/output/plans/linear-loop-handoff-2026-07-29.md
+++ b/q-system/output/plans/linear-loop-handoff-2026-07-29.md
@@ -1,0 +1,131 @@
+# Linear loop — where we stand, 2026-07-29 (handoff after context clear)
+
+Written at 2026-07-29 ~22:00 UTC. Read this, then resume from "NEXT" at the bottom.
+
+## The stated next objective (founder, 2026-07-29)
+
+Add **Codex as the PR reviewer in the Linear loop, so it is not Claude checking
+Claude.**
+
+**It is already built.** `ASK-221` / **PR #34** (`sana/ask-221`):
+*"codex reviews every PR as an independent second opinion, with an Opus fallback
+that pages when it degrades."* State: OPEN, MERGEABLE, blocked on
+`validate=FAILURE`.
+
+So the work is NOT to build it. The work is to unblock PR #34.
+
+Today's loop reviews with `claude-adversarial` (see the provenance block in
+`q-system/.q-system/scripts/pr-review-agent.sh` — a Claude reviewer stamping
+`claude-adversarial`, added 2026-07-26 so the honest token existed). That is the
+exact same-mental-model blind spot the founder wants removed.
+
+- `codex` IS on PATH (`/opt/homebrew/bin/codex`) and the CLI responds.
+- UNVERIFIED: a memory (`reference_review_tooling_2026_07`) says Codex was out of
+  credits until 2026-08-24. `codex exec --help` responding does NOT prove credits.
+  **Verify with one real Codex call before assuming PR #34 can work.** If credits
+  are still out, the Opus-fallback half of ASK-221 is what actually ships now.
+
+## What the loop is and how it runs
+
+- `com.kipi.dispatch` launchd job, every 900s, runs `kipi-dispatch.sh` at repo root.
+- Picks work via `bash ./kipi work` (dry) which calls `ready()` in
+  `q-system/.q-system/scripts/linear-worker.sh`.
+- `ready()` = label `owner:sana`, NOT `owner:assaf`, state `backlog`/`unstarted`,
+  AND the literal string `Definition of Ready` in the description.
+- `converge.sh --issue ASK-nnn --max-rounds N` drives one issue: dispatch Sana →
+  review → rework, until APPROVE or the round cap.
+- Caps: `KIPI_DISPATCH_MAX=1` (concurrency), `KIPI_DISPATCH_DAILY_MAX=3` (spend),
+  reset hour 07:00 local. Set in `~/Library/LaunchAgents/com.kipi.dispatch.plist`.
+
+## What shipped today
+
+**Pushed main: `284d3ad..7b05028`, 17 commits. CI on main: success.**
+This mattered: workers cut worktrees from `origin/main`, which was 17 commits
+stale, so every open PR was built on a wrong base. NOTE: that push **bypassed
+branch protection** ("2 of 2 required status checks are expected") via admin
+rights. Gates were run locally first and CI passed after.
+
+**Commit `7b05028` / ASK-244 (Done):** voice-lint `capitalization` rule, BLOCK
+class. `voice-dna.md`'s "Lowercase-default" line described the founder's Slack
+register and got applied to a client email. 22 tests OK; negative self-test
+against a copy with `check_capitalization()` stubbed → 9 failures. Also bumped
+kipi-core 1.5.14→1.5.15 and declared the test in `capability-manifest.json`.
+
+## Three PRs approved by the reviewer, ALL blocked, NOTHING merged
+
+| PR | Issue | Reviewer verdict | Blocker |
+|----|-------|------------------|---------|
+| #42 | ASK-218 | APPROVE WITH NITS, auto-merge armed | `validate=FAILURE` |
+| #43 | ASK-245 | APPROVE WITH NITS, auto-merge armed | `validate=FAILURE` — **capability-gate RED: `test-timeout (60s): q-system/.q-system/scripts/test/test-dispatch-rework.sh`**. Every assertion inside it PASSES (B5a/B5b/B5c/B6/B8a–B8d). It is a stopwatch failure, not a logic failure. |
+| #36 | ASK-225 | capped out at 4 rounds | Round 4 read `APPROVE WITH NITS` but the verdict was pinned to `8e5a09e` while the head was `f34fcfe` — GATE 40 (stale). The newest code on that branch has **never been reviewed**. Needs another converge run. |
+
+Other open PRs: **#40** (ASK-223) is the only one with `checks=SUCCESS`, blocked on
+`kipi/reviewer-approved`. **#35** (ASK-226), **#34** (ASK-221), **#23** (ASK-210)
+all `mergeable=MERGEABLE` + `validate=FAILURE`. Branch staleness vs main after the
+push: ask-223 17 behind, ask-225/221/210 20 behind, ask-226 44 behind.
+
+## Two dispatcher defects filed today
+
+- **ASK-245** (PR #43, approved, blocked as above) — the re-entry fix. `ready()`
+  returns backlog/unstarted only, so an issue whose PR went red is never picked up
+  again; In Progress only grows. 5 issues were stranded this way.
+- **ASK-247** (Backlog, no `owner:sana`) — `ready()` gates on the literal string
+  `Definition of Ready`. A complete DoR under different headers is silently
+  invisible. This bit ASK-245's own filing.
+- **ASK-248** (Backlog, High, no `owner:sana`) — the picker has no `orderBy` and
+  never reads `priority`. 32 ready issues, cap 3/day, so position decides
+  everything and the priority field is wired to nothing.
+
+ASK-247 and ASK-248 deliberately carry NO `owner:sana` label so they cannot jump
+the queue. Add the label when they are next to work.
+
+## Budget reality for 2026-07-29
+
+`budget=3/3` spent by the heartbeat (last: ASK-149 dispatched 21:50 UTC, still
+the most recent). PLUS 2 forced converges (ASK-245, ASK-225) run via a chain
+script that calls converge directly and **does not consult the daily cap** — same
+door the burst path uses. So today was 5 converges, not 3.
+
+The forcing scripts live in a session scratchpad and are NOT durable:
+`/private/tmp/claude-501/.../scratchpad/force-225.sh` (and the retired
+`force-chain.sh`). If forced ordering is wanted again, rewrite it; do not hunt for
+those files. Their one real lesson is recorded below.
+
+**Lesson worth keeping:** a liveness detector matching a bare
+`converge.sh --issue` counts a TEST copy running from `/var/folders/.../tmp.XXXX`
+as a live run. Anchor to the repo's real script path
+(`$REPO/q-system/.q-system/scripts/converge.sh`) or a chain sleeps through its own
+test suite. Also: never edit a running bash script in place — bash reads it from
+disk as it executes, so changing byte offsets corrupts the not-yet-read lines.
+Write a new file and replace the process.
+
+## Open spillover (gates stay RED until resolved or voided)
+
+`python3 plugins/prd-os/scripts/prd_runner.py spillover list`
+
+12 open. Filed today: `sp-7aadf305` (DoR literal string), `sp-ace46c52` (no
+priority ordering), `sp-8f879dc5` (**slack-notify.sh always exits 0** — line 34
+ends in `|| true` and discards curl output, so a dead webhook is
+indistinguishable from a delivered message; it is the ONLY sanctioned founder
+alert channel. Delivery was confirmed by hand 2026-07-29; nothing in the system
+would report it if it broke). Plus review minors from PRs #42/#43/#36.
+
+## NEXT (in order)
+
+1. **Verify Codex actually has credits** with one real call. Everything about the
+   founder's objective depends on it and the memory says it was out until
+   2026-08-24.
+2. **Unblock PR #34 (ASK-221)** — that IS "Codex reviews instead of Claude". Find
+   why `validate` fails on it (likely the same capability-gate class as #43;
+   check for an undeclared test or a test-timeout). It is 20 commits behind main,
+   so rebase first.
+3. **Unblock PR #43 (ASK-245)** — a 60s test-timeout on
+   `test-dispatch-rework.sh`. Either speed the test up or raise its budget
+   deliberately. Landing this makes every future red PR self-healing, which
+   unblocks the rest without hand-forcing.
+4. **PR #36 (ASK-225)** needs a fresh converge run; its head is unreviewed.
+   This is the parallel-dispatch / burst feature — landing it is what lets
+   `KIPI_DISPATCH_MAX` rise above 1.
+5. Do NOT hand-merge anything red. Four of these PRs failing `validate` while
+   `kipi/reviewer-approved` passes is the pattern; merging by hand pushes broken
+   code and steps around the gate ASK-210 exists to build.

--- a/q-system/output/plans/linear-loop-handoff-2026-07-29.md
+++ b/q-system/output/plans/linear-loop-handoff-2026-07-29.md
@@ -1,5 +1,14 @@
 # Linear loop — where we stand, 2026-07-29 (handoff after context clear)
 
+> **Recovered work-product — a point-in-time snapshot, not current documentation.**
+> This file existed only in a dirty checkout and was recovered on 2026-08-05
+> (PR #106, ASK-363). Every claim about system state was true at this document's
+> own date and may not be true now. In particular, "wired" here means *merged in
+> this repository*; whether the RUNNING copy loads it is a separate question that
+> `q-system/.q-system/scripts/runtime-plugin-freshness.py` answers, because the
+> two came apart for a full day during this very build. Read it as a record of
+> what was decided and why, and verify current state against the code.
+
 Written at 2026-07-29 ~22:00 UTC. Read this, then resume from "NEXT" at the bottom.
 
 ## The stated next objective (founder, 2026-07-29)

--- a/q-system/output/plans/triage-dry-table-2026-07-27.md
+++ b/q-system/output/plans/triage-dry-table-2026-07-27.md
@@ -1,5 +1,14 @@
 # Triage dry pass, 115 issues, kipi-system
 
+> **Recovered work-product — a point-in-time snapshot, not current documentation.**
+> This file existed only in a dirty checkout and was recovered on 2026-08-05
+> (PR #106, ASK-363). Every claim about system state was true at this document's
+> own date and may not be true now. In particular, "wired" here means *merged in
+> this repository*; whether the RUNNING copy loads it is a separate question that
+> `q-system/.q-system/scripts/runtime-plugin-freshness.py` answers, because the
+> two came apart for a full day during this very build. Read it as a record of
+> what was decided and why, and verify current state against the code.
+
 Dry run. **Nothing was written to Linear.** Ran 2026-07-27.
 
 ASK-210 was skipped automatically: PR #23 already owns it.

--- a/q-system/output/plans/triage-dry-table-2026-07-27.md
+++ b/q-system/output/plans/triage-dry-table-2026-07-27.md
@@ -1,0 +1,159 @@
+# Triage dry pass, 115 issues, kipi-system
+
+Dry run. **Nothing was written to Linear.** Ran 2026-07-27.
+
+ASK-210 was skipped automatically: PR #23 already owns it.
+
+
+## The buckets
+
+| count | bucket | what --apply would do |
+|---|---|---|
+| 57 | `batch` | nothing yet, groups them for one change |
+| 38 | `not-planned` | **comment with the reason, then close as not planned** |
+| 9 | `needs-scope` | comment asking for a Files line |
+| 7 | `do-now` | nothing, eligible for dispatch |
+| 4 | `founder-decision` | comment, leave open for you |
+
+The only destructive bucket is `not-planned`. Reopening restores it, and the reason stays on the closed issue.
+
+
+## founder-decision (4)
+
+| issue | why | next |
+|---|---|---|
+| ASK-149 | Its own Definition of Ready makes the outcome contingent on the founder explicitly choosing 'radar runs daily again' vs 'stays off until the Linear mi | Put one question to the founder: resume com.cole.reddit-radar-daily now, or leav |
+| ASK-91 | The body states the blocker itself: open-loops-heartbeat.sh (q-system/.q-system/scripts/) merges its own PRs under the autonomy contract, so there is  | Put three options to the founder: (a) founder-approves-merge on a sampled slice  |
+| ASK-77 | Code is merged (PR #7, 5-issue gated flow, 3 tests) and the only remaining step is releasing the deliberately HELD kipi update on 4_points, which arms | Ask the founder one question: release the held kipi update on 4_points now, or k |
+| ASK-59 | The blocker is a risk and cost call, not a scoping one: 11684 Gate 1.3b findings can only be cleared by narrowing the classifier or target list (accep | Sample 100 random findings, report the leak-vs-noise rate and the cost of each p |
+
+## do-now (7)
+
+| issue | why | next |
+|---|---|---|
+| ASK-214 | Real and scoped: issue_runner.py:747 is the only receipt writer and is reachable only from cmd_close, cmd_load:423 calls _require_marker unconditional | Add a from-Linear-DoR subcommand to plugins/prd-os/scripts/prd_split.py that emi |
+| ASK-212 | Concrete single-file defect with a live observation: rework_gate at pr-verdict-lib.sh:77, called from linear-worker.sh:187-205, decides dispatch from  | After ASK-211 merges, cut a fresh worktree from the new main, add a mergeability |
+| ASK-189 | Real durability hole with two same-day measurements (worker-1785159359-39569 and worker-1785160167-43978 held the claim with zero live processes): con | Record the long-lived worker shell pid in the claim record and consult _pid_aliv |
+| ASK-187 | Both target files exist and the issue already proves the change is safe: every Write() deny pattern has an identical working Edit() twin in both .clau | Delete the 5 Write() entries from permissions.deny in .claude/settings.json and  |
+| ASK-150 | Implementation is done and PR #11 has validate=SUCCESS; the only remaining work is one named merge conflict in q-system/.q-system/scripts/fleet-health | In the sana/ask-150 worktree: git merge origin/main, keep both detect_cron_shell |
+| ASK-117 | Real and confirmed on disk but half-stale: instance-registry.json lines 157 to 164 already record reddit-build-radar as type standalone with subtree_p | Add a registered-instance-zero-propagation check to the kipi-update.sh preflight |
+| ASK-116 | Three divergent hashes (79aec127bf30 / e9f11c1fb928 / 1a1b1e2674b2) were verified by direct hashing across 4_points_consulting, investigations, and Al | Diff the three evidence-capture-protocol.md versions, reconcile into one file at |
+
+## needs-scope (9)
+
+| issue | why | next |
+|---|---|---|
+| ASK-213 | The issue names its own detector signatures as 'candidate, to be confirmed' and sets no false-positive budget for a repo-wide scan of exit 0 branches, | Pin the detector spec against the three known instances (linear-worker.sh fetch  |
+| ASK-154 | Unlike its five siblings this is a long-running Flask/HTTP server (fleet-venv python3 gtm/dashboard/server.py, schedule 'on demand / at load'), so the | Rewrite the Outcome and Check for a KeepAlive daemon: define liveness as a succe |
+| ASK-148 | The title says 77 open items and its own check block says 127 (111 minor, 5 medium, 4 low, 3 major, 3 high, 1 blocker), and the DoR admits the code fi | Run python3 plugins/prd-os/scripts/prd_runner.py spillover list --open from ~/pr |
+| ASK-105 | Real gap named in the body (plugins/kipi-notebooklm v0.1.0 has no paired tests in the capability manifest, no commands dir) but the issue has no Files | Rewrite as: add plugins/kipi-notebooklm test script + one line in the capability |
+| ASK-90 | .claude/rules/loop-exits.md exists and the audit is honest that exits 3 (budget) and 4 (wall clock) run on proxies, but the issue names no file to cha | Split out one scoped issue for exit 4: define the in-session deadline for unatte |
+| ASK-72 | Unlike its LIVE siblings this one names a real open defect in its own body -- voice-lint v1 misses within-sentence comma triplets and cross-paragraph  | Split the detector gap into its own issue with a failing fixture for each missed |
+| ASK-58 | Real and already measured (validate-separation.py 5 gives 170 PASS, 3 FAIL, 1 WARN, exit 1) but not actionable as written: the one KTLYST-referencing  | Run python3 validate-separation.py 5, paste the Gate 1.2 and Phase 1 offending f |
+| ASK-57 | Flagged no-Files-line and the two paths that would define the work (settings.json, test-settings-merge.sh) are MISSING on disk, so as written this is  | Resolve where the settings-merge test actually lives (grep the capability manife |
+| ASK-52 | The entry-point list names update-preservation-manifest.py as a dependency of the propagation path but that file is MISSING while kipi-update.sh and k | Grep kipi-update.sh for update-preservation-manifest.py to determine whether the |
+
+## not-planned (38)
+
+| issue | why | next |
+|---|---|---|
+| ASK-208 | Superseded: PR #22 closed unmerged at the round cap and its four bundled fixes are being re-filed one per issue (fix 1 as ASK-211, fix 2 as ASK-212),  | Confirm sp-fd76af2f and sp-1aae7516 each have a re-filed issue, then close ASK-2 |
+| ASK-147 | Duplicate of ASK-149 action item 1 — same script (cole-gtm/projects/reddit-build-radar/scripts/run_daily.sh), same two schedulers, same fix (drop the  | Close as duplicate, linked to ASK-149; add the daily.log no-op evidence line to  |
+| ASK-137 | The evidence is factually wrong: rca-mode.md:20-23 names both the rca-notify and rca-lint hooks, both scripts exist at plugins/kipi-core/skills/rca/sc | Close as already-true-on-disk with those four paths pasted in, and file one fix  |
+| ASK-112 | The issue body is its own completion receipt: linear-issue-ref-check.py, .claude/rules/linear-first.md, lefthook.yml and the auto-commit `[no-issue: a | Close as done; if fleet-wide rollout beyond kipi-system is wanted, file that as  |
+| ASK-111 | Status is LIVE and the entry point .claude/rules/quick-plan.md exists on disk with the described contract (read memory + prior plans first, checkboxed | Close as documentation-of-shipped-state; the one MISSING path (methodology/anti- |
+| ASK-110 | Status is LIVE, q-system/memory/last-handoff.md exists, and the three MISSING entries (session-start.py, post-compact.sh, md-prune.py) are bare filena | Close as documentation-of-shipped-state; if the hook wiring genuinely needs re-v |
+| ASK-109 | Status is LIVE, CLAUDE.md and q-system/CLAUDE.md exist, and the body's own evidence is a count (`ls .claude/rules/ / wc -l` = 31) plus the already-wir | Close as documentation-of-shipped-state; the rule-count number will drift, so re |
+| ASK-108 | Status is LIVE and the sole named path q-system/.q-system/scripts/slack-notify.sh exists with the described silent-no-op behavior and the open-loops h | Close as documentation-of-shipped-state; auditing whether other emitters still u |
+| ASK-106 | Body says Status: LIVE (kipi-ops v1.2.0, skills/council/) and the only named path canonical/decisions.md is MISSING from this repo because decisions.m | Close as not-planned; the council auto-trigger rules already live in .claude/rul |
+| ASK-104 | All three named scripts (granola-voice-harvest.py, granola-voice-fingerprint.py, granola-voice-synthesize.py) are MISSING from this repo per the struc | Close as not-planned; if the harvest chain is actually wanted in kipi-system, fi |
+| ASK-103 | Status LIVE inventory card: 5 of 6 named paths are MISSING and the one that exists (q-system/methodology/anti-hallucination.md) needs no change; the o | Close as not-planned; the Reddit .rss workaround is already recorded and reddit- |
+| ASK-102 | Both scars are already resolved and recorded: the AppleEvents/`open -a Terminal` constraint is documented in the /say entry in CLAUDE.md, and the vani | Close as not-planned; /say behavior and its two constraints are documented in CL |
+| ASK-101 | Duplicates the open-loops ledger entry for the capability-token PR (dwarvesf/claude-guardrails issue #14, filed 2026-06-20), which already carries the | Close as duplicate of the open-loops entry in q-system/memory/open-loops.json; a |
+| ASK-99 | The one path it names (`.claude-plugin/marketplace.json`) exists, the 6 plugin versions were verified 2026-07-26, and the body requests no change; it  | Close as not-planned; if the version table is wanted as living state it belongs  |
+| ASK-97 | `.claude/rules/model-allocation.md` exists, the 5 agent definitions and validator Gate 1.1b are recorded as passing on 2026-07-26, and the body asks f | Close as not-planned; tier drift is already owned by `kipi check` Gate 1.1b, whi |
+| ASK-88 | Description self-declares Status: LIVE with 2026-07-26 evidence (7 loops in q-system/memory/open-loops.json, test-open-loops.sh present) and the Sessi | Close as not-planned; if the inventory is worth keeping, move the L8 card to a d |
+| ASK-87 | Same machine-filed inventory shape as ASK-88: Status LIVE, all 6 com.kipi.* jobs verified loaded with last-exit 0 via launchctl on 2026-07-26, watchdo | Close as not-planned; the launchd job table belongs in AUTONOMOUS-SYSTEMS.md, no |
+| ASK-86 | Status LIVE and already true on disk: .prd-os/spillover.jsonl plus prd_runner.py spillover add/resolve are the mechanism .claude/rules/no-orphan-findi | Close as not-planned; no code change implied. |
+| ASK-85 | Status LIVE and the described merge already happened -- fable-discipline moved into plugins/prd-os on 2026-07-04 with the lint hook wired in prd-os's  | Close as not-planned; no diff to write. |
+| ASK-84 | Status LIVE (v0.2.1) with all 6 commands shipped and /issue-amend behavior verified 2026-07-26; the one live constraint it names (Codex out of credits | Close as not-planned; if the reviewer substitution needs hardening, file that as |
+| ASK-82 | Status LIVE (v0.6.0) with 9 commands and gates run shipped as the registered no-bypass re-proof (commit 53f2eeb separated gate lifecycle); prd_runner. | Close as not-planned; no work item remains. |
+| ASK-81 | Already true on disk: the com.kipi.lessons-daily launchd job is loaded with last exit 0 and 6 dedicated tests cover validator, propagation, distill, s | Close as documented-live and leave the provenance-ledger entry in open-loops.jso |
+| ASK-76 | Already shipped and deliberately terminal: skill-trigger-eval.py plus test-skill-trigger-eval.sh exist and the advisory-not-a-gate design is a settled | Close as documented-live; if trigger confidence is wanted, run skill-trigger-eva |
+| ASK-75 | Description says Status: LIVE with 2026-07-26 evidence that both batch-uniformity-lint.py and format-lint.py are already wired in settings.json and se | Close as not-planned; if the inventory needs to persist, move it to a doc rather |
+| ASK-74 | Same inventory shape as ASK-75: Status LIVE, and skill-hook-pairing.md (which exists on disk) already lists headline-engineering -> headline-lint and  | Close as not-planned; the pairing table in .claude/rules/skill-hook-pairing.md i |
+| ASK-73 | Status: LIVE with the skill plus paired audhd-lint hook already shipped, and the same content is already enforced as a rule in .claude/rules/audhd-int | Close as not-planned; no diff is implied by the body. |
+| ASK-71 | Status: LIVE with 2026-07-26 evidence that auto-commit.py and stop-logger.sh are wired in settings.json and settings-template.json; the only forward-l | Close as not-planned; file worktree-per-session separately if it is to be built. |
+| ASK-70 | Status: LIVE and the body cites the shipping commit 48adb50 for the grounding-guard Stop hook plus the voice-stop-gate `// true` fix, so the work is a | Close as not-planned, referencing commit 48adb50 as the receipt. |
+| ASK-69 | Description says Status: LIVE and the only thing needing a change is the issue's own claim of a `wiring-check.py` hook, which does not exist on disk w | Close as not-planned; if the map's entry-point line is wrong, correct `wiring-ch |
+| ASK-68 | Status: LIVE with self-reported evidence that the guard blocked the very write that produced these issues; the three named paths are MISSING only beca | Close as not-planned; no code change. |
+| ASK-67 | Status: LIVE, `q-system/.q-system/token-guard.py` exists on disk with the six detectors and constants already verified 2026-07-26, and the one gap nam | Close as not-planned; no code change. |
+| ASK-66 | Pure inventory card for the hook runtime: both named paths (`.claude/settings.json`, `settings-template.json`) exist and the body is a wiring table re | Close as not-planned; no code change. |
+| ASK-65 | Status: LIVE (fleet-only) with RULE-2026-06-30-A wired in `settings-template.json`, and the MISSING paths are bare filenames for a fleet-only guard th | Close as not-planned; no code change. |
+| ASK-64 | Status: LIVE, both settings files exist and the check is wired PostToolUse plus `kipi update` preflight; the stated 34-local-entries vs 32-template-sc | Close as not-planned; no code change. |
+| ASK-63 | The gate is already shipped and green: validate-separation.py and .claude/rules/model-allocation.md both exist on disk and the 2026-07-26 evidence lin | Close as a shipped-status record; if the L2 inventory needs to persist, fold it  |
+| ASK-54 | Every path named exists (kipi-new-instance.sh, settings-template.json), the described behavior is already true on disk, and the evidence is four insta | Close as documentation-only; if the L1 card has archival value, move it to the c |
+| ASK-53 | instance-registry.json and validate-separation.py both exist and Phase 0 already asserts all 24 registered instance paths PASS with 0 FAIL, so the cap | Close as already-true; the validator Phase 0 run is the standing check, no new w |
+| ASK-51 | Description says 'Status: LIVE' with a 2026-07-26 evidence line citing kipi:83,86, and all five named scripts (kipi-update.sh, kipi-new-instance.sh, k | Close as not-planned; if the L1 inventory needs a permanent home, move the capab |
+
+## batch (57)
+
+| issue | why | next |
+|---|---|---|
+| ASK-186 | Identical machine-filed job-migration template (kipi-key job-migration/*) as ASK-185/180/179/178/177 -- same four bars, same launchd-health-check.py - | Work all job-migration/* issues as one change: write the migration harness (plis |
+| ASK-185 | Same job-migration template as ASK-186/180/179/178/177 -- only the plist name (com.personal.story-podcast) and the wrapped script differ; the Definiti | Fold into the single job-migration batch; per-job work is one run of run_daily.s |
+| ASK-180 | Sibling of the same job-migration template; shares both shape and fix with ASK-179 in particular (same fractional-cxo automation/.q-system/scripts/ di | Fold into the job-migration batch; do the two fractional-cxo jobs (ASK-180 + ASK |
+| ASK-179 | Sibling of ASK-180 -- same fractional-cxo automation/.q-system/scripts/ directory, same template, same check; migrating one and not the other would le | Fold into the job-migration batch, paired with ASK-180. |
+| ASK-178 | Same job-migration template; notable as the only one whose script lives in this repo (q-system/.q-system/scripts/fleet-health-daily.py), so it is the  | Do this one first inside the job-migration batch -- it is the in-repo script, so |
+| ASK-177 | Same job-migration template, wrapping /Users/assafkipnis/.claude/audit/rotate.sh; a log-rotation job differs from the others only in what its output m | Fold into the job-migration batch; if the rotate job turns out to be obsolete, s |
+| ASK-176 | One of six identical `job-migration/com-cole-*` issues (ASK-171 through ASK-176) filed by the same scanner with a byte-identical Definition of Ready,  | Open one parent issue 'Migrate the 6 paused com.cole.* jobs to Linear-tracked ex |
+| ASK-175 | Same shape and same fix as ASK-171/172/173/174/176: paused com.cole.* launchd job, identical DoR template, identical watchdog check, differing only in | Fold into the single com.cole.* migration change; per-job work here is one plist |
+| ASK-174 | Sibling of the same six-issue com.cole.* migration set; the only per-issue deltas are the label, the 3600s interval and `substack_worker/run_worker.sh | Fold into the single com.cole.* migration change; per-job work is one plist + on |
+| ASK-173 | Sibling of the same six-issue com.cole.* migration set (identical DoR, identical check block); deltas are the label, the twice-weekly 06:00 schedule a | Fold into the single com.cole.* migration change; pair it with ASK-174 since bot |
+| ASK-172 | Sibling of the same six-issue com.cole.* migration set; the 300s poll interval and `slack_listener/run_poll.sh` are the only deltas, and its Linear-re | Fold into the single com.cole.* migration change; per-job work is one plist + on |
+| ASK-171 | Sixth sibling of the identical com.cole.* migration set (ASK-171 through ASK-176), differing only in label, 00:07 daily schedule and `reply_sweep/run_ | Fold into the single com.cole.* migration change; per-job work is one plist + on |
+| ASK-170 | Identical shape to ASK-169/168/167/166/165 (same kipi-key namespace job-migration/, same four-bars DoR, same launchd-health-check.py --dry-run check); | Fold into one batch issue 'migrate the 6 com.cole.* paused jobs to Linear-tracke |
+| ASK-169 | Sibling of ASK-170/168/167/166/165 under the same job-migration kipi-key with a byte-identical Definition of Ready; only the label com.cole.reddit-pro | Merge into the single com.cole.* migration batch; no separate work item. |
+| ASK-168 | Third of six machine-filed job-migration issues sharing one fix shape (plist verify + pause-ledger state + launchd-health-check visibility); reddit-pa | Merge into the com.cole.* migration batch; migrate reddit_worker jobs (producer  |
+| ASK-167 | Same job-migration template as ASK-170/169/168/166/165; autobuild lives in the same reddit-build-radar repo as ASK-170's radar-daily and both feed the | Merge into the com.cole.* migration batch; migrate reddit-build-radar jobs (rada |
+| ASK-166 | Same machine-filed job-migration template and same four-bars check as its five siblings; prospect-feed differs only in label, 07:00 schedule and prosp | Merge into the com.cole.* migration batch; no standalone issue. |
+| ASK-165 | Last of six identical job-migration issues; the weekly (weekday 5) schedule is a plist value, not a different fix, so podcast-weekly-report rides the  | Merge into the com.cole.* migration batch; note the weekly cadence as a per-job  |
+| ASK-164 | One of six identical job-migration siblings (ASK-159..164) sharing the kipi-key prefix job-migration/, the same Definition of Ready text, the same che | Batch with ASK-159..163: build the migrate-and-verify runner once (plist templat |
+| ASK-163 | Same shape and same fix as ASK-159..164: kipi-key job-migration/com-cole-job-liveness, identical Definition of Ready and identical verification comman | Batch with ASK-159..164: after the shared runner exists, migrate com.cole.job-li |
+| ASK-162 | Identical sibling in the job-migration/ series: same paused-pending-migration state, same four-bars section, same out-of-repo plist path, same pass cr | Batch with ASK-159..164: migrate com.cole.fleet-env-health (09:15 daily) using t |
+| ASK-161 | Same job-migration/ template as ASK-159..164 down to the Blast radius and Not-doing wording; the interval trigger (every 14400s) instead of a wall-clo | Batch with ASK-159..164: migrate com.cole.delivery-watch with StartInterval 1440 |
+| ASK-160 | Sixth instance of the same machine-filed job-migration/ template (identical Outcome, Files, Check and Not-doing text as ASK-159..164), varying only by | Batch with ASK-159..164: migrate com.cole.daily-x-work (08:00 daily) via the sha |
+| ASK-159 | Same job-migration/ sibling set as ASK-160..164: identical Definition of Ready, identical verification pair (launchd-health-check.py --dry-run grep pl | Batch with ASK-160..164: migrate com.cole.daily-social (09:00 daily) via the sha |
+| ASK-158 | One of six identical job-migration issues (ASK-153..158) filed by the same job-migration scanner with the same kipi-key namespace, same Definition of  | Work ASK-153..158 as one change: build the launchd Linear-reporting wrapper once |
+| ASK-157 | Sibling of ASK-153..158 with byte-identical structure aside from job name, schedule (06:00) and the run_daily.sh path; same watchdog check, same pause | Fold into the ASK-153..158 batch; no separate work item. |
+| ASK-156 | Sibling of ASK-153..158, and it shares its runner script (gtm/cloud-brain/run_brain.sh) verbatim with ASK-155, so treating it as an independent job wo | Fold into the ASK-153..158 batch; handle the shared run_brain.sh once for both A |
+| ASK-155 | Sibling of ASK-153..158 invoking the identical script as ASK-156 (gtm/cloud-brain/run_brain.sh) on an every-1800s interval rather than a weekday-1 06: | Fold into the ASK-153..158 batch; confirm the catchup interval and the 06:40 tri |
+| ASK-153 | Sibling of ASK-153..158 (10:00 daily, gtm/scripts/auto_build/run_autobuild.sh) with the same Definition of Ready, same watchdog check and same pause-l | Fold into the ASK-153..158 batch; run run_autobuild.sh once by hand as part of t |
+| ASK-152 | Byte-identical template to ASK-151 (same four bars, same DoR, same launchd-health-check.py --dry-run check) differing only in job name, plist path and | Work as one pass with ASK-151 and the remaining job-migration siblings: apply th |
+| ASK-151 | Same job-migration template as ASK-152 and ASK-181, same check block (launchd-health-check.py --dry-run / grep <label>, ./kipi health), same 'never DA | Include in the ASK-152 batch pass; do not open a separate branch for this job. |
+| ASK-140 | The rule's enforcement already exists and is wired (voice-lint.py at .claude/settings.json:181, voice-substance-lint.py at :216, plus voice-stop-gate. | Work as one change with ASK-139: add an 'Enforced by: <script> (settings.json:<l |
+| ASK-139 | token-discipline.md:9 already names the token-guard hook and token-guard.py is wired three times (.claude/settings.json:132,149,161), so 'names NO exe | Same change as ASK-140: name token-guard.py at the top of the file, and for line |
+| ASK-138 | The gate fires on a model judgment ('founder shares someone else's content'), which skill-hook-pairing.md explicitly classes as un-hookable and routes | Work as one change with ASK-136 and ASK-135: add q-system/.q-system/skill-evals/ |
+| ASK-136 | quick-plan.md:3 self-describes as 'a lightweight, non-gated planning reflex', so the defect is the contradicting ENFORCED header rather than a missing | Fold into the interpretive batch with ASK-138 and ASK-135: drop ENFORCED from th |
+| ASK-135 | It is an auto-invoke table whose trigger is a model decision, the exact class skill-hook-pairing.md already lists as 'correctly interpretive (no hook) | Same interpretive batch: one q-system/.q-system/skill-evals/<rule>.json per rule |
+| ASK-134 | One of five identical CAP-XX issues (ASK-130/131/132/133/134) minted from the same detector string 'claims ENFORCED but names NO executable'; design-a | Fold into one batch issue: write a rule-enforcement auditor over .claude/rules/* |
+| ASK-133 | Same detector string and same fix as ASK-130/131/132/134, and the evidence is partly wrong: coding-standards.md's Python/JS/Shell/JSON style clauses a | In the batch pass, add the format-lint.py citation to .claude/rules/coding-stand |
+| ASK-132 | Fifth sibling of the same CAP-XX detector; coding-audhd.md is path-scoped frontmatter (**/*.py, **/*.sh) whose communication and emotional-scaffolding | Handle in the same batch pass: split coding-audhd.md's clauses into the structur |
+| ASK-131 | The 'names NO executable' evidence is a false negative here: audhd-lint.py exists in q-system/.q-system/scripts/ and is wired as a hook in .claude/set | In the batch pass, cite audhd-lint.py (and its scope) inside .claude/rules/audhd |
+| ASK-130 | Same CAP-XX detector as its four siblings, and in the skeleton anti-misclassification.md is unfilled template ({{YOUR_PRODUCT}}, {{MISCLASSIFICATION_1 | In the batch pass, treat anti-misclassification.md as instance-fill: add a place |
+| ASK-100 | Machine-filed inventory card with no Files line; its only actionable content is the 2026-07-26 claim that `test-kipi-update-build-artifacts.sh` covers | Batch with ASK-98/96/95: one pass resolving each cited bare filename to a repo-r |
+| ASK-98 | Same shape as ASK-100/96/95: a LIVE inventory card whose cited `dogfood_gate.py` is written as a bare filename that does not resolve, while the hook a | Include in the path-qualification batch: rewrite `dogfood_gate.py` to its plugin |
+| ASK-96 | Only `.claude/rules/self-healing-retry.md` resolves; `morning-pipeline.md`, `run-step-audit.py` and `token-guard.py` are cited as bare filenames that  | Include in the path-qualification batch: rewrite to `.claude/rules/morning-pipel |
+| ASK-95 | All 10 cited paths (4 bus files, 5 verification harnesses, step-orchestrator.md) are bare filenames that fail to resolve even though the description i | Take this one first in the path-qualification batch since it has the most refere |
+| ASK-94 | All three 'MISSING' paths exist as q-system/.q-system/scripts/correction_outcome.py, route-overrides-to-learn.py and test_correction_outcome.py, plus  | Fix the L8/L9 inventory generator to emit repo-relative paths, re-emit the ASK-9 |
+| ASK-93 | plugins/kipi-core/skills/rca/ exists and the hooks file is plugins/kipi-core/hooks/hooks.json, not a repo-root hooks.json — the MISSING flag is the ba | Same one-change fix as ASK-94: generator emits repo-relative paths (plugins/kipi |
+| ASK-92 | sycophancy-harness.py resolves to q-system/.q-system/sycophancy-harness.py, sycophancy-monthly-check.py and decision-origin-tag-lint.py to q-system/.q | Same one-change fix as ASK-94; this issue contributes the four corrected path st |
+| ASK-89 | fleet-loop-board.py and fleet-board-refresh.py both exist at q-system/.q-system/scripts/ — this session's SessionStart hook invokes them by exactly th | Same one-change fix as ASK-94; board staleness is a separate item and does not r |
+| ASK-80 | Same 2026-07-26 machine sweep and identical shape to ASK-78 and ASK-79: a LIVE L5 memory capability, tests already present (test_memory_outcomes/refle | Work as one change with ASK-78 and ASK-79: add the L5 memory scripts to the capa |
+| ASK-79 | Same sweep and same shape as ASK-78 and ASK-80: memory-freshness-check.py is verifiably live (its SessionStart warning fired in this session) and wire | Work as one change with ASK-78 and ASK-80: one manifest entry per script, then c |
+| ASK-78 | Same sweep and same shape as ASK-79 and ASK-80: validator (PostToolUse) and surface (SessionStart) are both wired in settings.json and settings-templa | Work as one change with ASK-79 and ASK-80: one manifest entry per script, then c |
+| ASK-62 | Same shape and same fix as ASK-61 and ASK-60: an L2 record asserting LIVE while its declared artifacts (plugin-version-bump-check.py, test_plugin_vers | none |
+| ASK-61 | Second sibling of the same declared-vs-actual defect: the record claims ARMED and cites a 29-entry baseline with a classifier_sha256 pin, but state/pr | Include in the ASK-62 batch pass, plus one extra check specific to this record:  |
+| ASK-60 | Third sibling of the same defect and the narrowest instance of it: capability-gate.py and fleet-capability-verify.py both resolve, only capability-man | Fix in the same ASK-62 batch pass: resolve the manifest's real path and correct  |
+| ASK-56 | Same shape as ASK-57/ASK-55: a LIVE L1 capability card citing test files (test-kipi-rollback.sh, test-kipi-rollback-matrix.sh) as manifest-declared ev | Work ASK-57/56/55 as one change: run the capability-gate verifier over the manif |
+| ASK-55 | Third instance of the same declared-test-missing shape (test-lessons-push-guard.sh MISSING while cited as evidence), and it shares a fix with ASK-56/A | Include in the ASK-57/56/55 manifest reconciliation batch; no separate work item |

--- a/q-system/output/prd-founder-judge-calibration-2026-08-03.md
+++ b/q-system/output/prd-founder-judge-calibration-2026-08-03.md
@@ -1,5 +1,14 @@
 # PRD: Founder-Judge Calibration
 
+> **Recovered work-product — a point-in-time snapshot, not current documentation.**
+> This file existed only in a dirty checkout and was recovered on 2026-08-05
+> (PR #106, ASK-363). Every claim about system state was true at this document's
+> own date and may not be true now. In particular, "wired" here means *merged in
+> this repository*; whether the RUNNING copy loads it is a separate question that
+> `q-system/.q-system/scripts/runtime-plugin-freshness.py` answers, because the
+> two came apart for a full day during this very build. Read it as a record of
+> what was decided and why, and verify current state against the code.
+
 **Date:** 2026-08-03
 **Author:** Codex
 **Status:** Done

--- a/q-system/output/prd-founder-judge-calibration-2026-08-03.md
+++ b/q-system/output/prd-founder-judge-calibration-2026-08-03.md
@@ -78,6 +78,21 @@ well a fresh judge predicts Assaf's triage decisions.
 | `q-system/output/founder-judge-calibration-v1-report.md` | Add | 73 | 0 |
 | `q-system/output/founder-judge-calibration-v1-run.json` | Add | 29 | 0 |
 
+**Only `founder-judge-calibration.py` and `...-v1-report.md` are in the repo.**
+The other five rows are run output and are excluded by standing ignore rules
+(`.gitignore:36` `*.jsonl`, `.gitignore:17` `q-system/output/*.json`). They exist
+on the machine that ran v1 and nowhere else, so **the v1 benchmark cannot be
+re-verified or re-run from a clone** — `founder-judge-calibration.py verify
+--dataset .../founder-judge-calibration-v1.jsonl` exits 1 there.
+
+That is deliberate, not a gap in the recovery (codex review of PR #106, major,
+raised twice). Each dataset row carries a `founder_rationale` free-text field —
+Assaf's own words on 50 real triage decisions — and this repo is PUBLIC.
+Overriding two standing run-output ignore rules to publish founder free-text is a
+blast-radius decision that earns its own issue. To make v1 reproducible: publish a
+redacted dataset (drop `founder_rationale`, keep the labels), or point the checker
+at a private location.
+
 ## 6. Test Cases
 
 | # | Type | Scenario | Input | Expected | Pass Criteria |

--- a/q-system/output/prd-founder-judge-calibration-2026-08-03.md
+++ b/q-system/output/prd-founder-judge-calibration-2026-08-03.md
@@ -1,0 +1,151 @@
+# PRD: Founder-Judge Calibration
+
+**Date:** 2026-08-03
+**Author:** Codex
+**Status:** Done
+**Priority:** P1 (high)
+
+---
+
+## 1. Problem
+
+Kipi records Codex findings and Assaf's dispositions, but it does not measure how
+well a fresh judge predicts Assaf's triage decisions.
+
+- **Evidence:** `.prd-os/findings/` contains 342 dispositioned Codex findings
+  across 35 PRDs: 262 accepted, 61 rejected, and 19 deferred.
+- **Impact:** Judge quality is discussed through individual findings. There is no
+  agreement rate, balanced score, or confusion matrix.
+- **Root cause:** The findings ledger was built for workflow closeout, not blinded
+  calibration.
+
+## 2. Scope
+
+### In Scope
+
+- Freeze 50 traceable historical Codex findings.
+- Balance the set across accepted, rejected, and deferred founder decisions.
+- Export a blind copy without the founder label or rationale.
+- Score fresh predictions with accuracy, balanced accuracy, macro F1, and Cohen's kappa.
+- Prove the scorer changes when predictions are corrupted.
+
+### Out of Scope
+
+- Replacing Codex review.
+- Measuring clean passes where Codex raised no finding. The current ledger does
+  not store claim-level negatives.
+- Automatically changing any review threshold.
+
+### Non-Goals
+
+- Claiming this measures general model intelligence.
+- Treating workflow disposition as proof that a finding was factually correct.
+
+## 3. Changes
+
+### Change 1: Calibration harness
+
+- **What:** Build, blind, verify, and score a fixed founder calibration dataset.
+- **Where:** `q-system/.q-system/scripts/founder-judge-calibration.py`
+- **Why:** Turns the existing trail into a repeatable measurement.
+- **Exact change:** Add a standard-library CLI with an isolated self-test.
+- **Scope:** This repo only.
+
+### Change 2: Frozen 50-case dataset and run receipts
+
+- **What:** Store the selected cases, fresh predictions, and scored report.
+- **Where:** `q-system/output/founder-judge-calibration-v1.*`
+- **Why:** Makes the result inspectable and rerunnable.
+- **Exact change:** Generate artifacts from the harness and a blind Codex CLI run.
+- **Scope:** This repo only.
+
+## 4. Change Interaction Matrix
+
+| Change A | Change B | Interaction | Resolution |
+|----------|----------|-------------|------------|
+| Harness | Dataset | Harness owns dataset selection and validation | Dataset stores source hashes and selection rule |
+| Harness | Predictions | Scorer refuses missing, duplicate, or unknown case IDs | Predictions must cover all 50 cases exactly once |
+
+## 5. Files Modified
+
+| File | Change Type | Lines Added | Lines Removed |
+|------|------------|-------------|---------------|
+| `q-system/.q-system/scripts/founder-judge-calibration.py` | Add | 584 | 0 |
+| `q-system/output/founder-judge-calibration-v1.jsonl` | Add | 50 | 0 |
+| `q-system/output/founder-judge-calibration-v1-blind.json` | Add | 254 | 0 |
+| `q-system/output/founder-judge-calibration-v1-schema.json` | Add | 45 | 0 |
+| `q-system/output/founder-judge-calibration-v1-predictions.json` | Add | 1 | 0 |
+| `q-system/output/founder-judge-calibration-v1-report.md` | Add | 73 | 0 |
+| `q-system/output/founder-judge-calibration-v1-run.json` | Add | 29 | 0 |
+
+## 6. Test Cases
+
+| # | Type | Scenario | Input | Expected | Pass Criteria |
+|---|------|----------|-------|----------|---------------|
+| 1.1 | DET | Build balanced set | Live findings ledger | 20 accepted, 20 rejected, 10 deferred | Exactly 50 unique traceable cases |
+| 1.2 | DET | Blind export | Frozen dataset | No label or rationale fields | Leak check returns zero forbidden keys |
+| 1.3 | DET | Perfect prediction | In-memory fixture | 100% accuracy and kappa 1 | Exact values returned |
+| 1.4 | DET | Negative self-test | One prediction flipped | Score drops below 100% | Corruption changes the result |
+| 1.5 | DET | Missing prediction | One case omitted | Scorer exits nonzero | Coverage error is named |
+| 1.6 | DET | Read-only review | No writable temp directory | Core self-test passes; integration names its skip | No traceback |
+
+## 7. Regression Tests
+
+| # | What to Verify | How to Verify | Pass Criteria |
+|---|----------------|---------------|---------------|
+| R-1 | Findings ledger stays read-only | Git diff restricted to new calibration artifacts | No `.prd-os` changes |
+| R-2 | No third-party dependency | Inspect imports | Standard library only |
+
+## 8. Rollback Plan
+
+| Change | Rollback Steps | Risk |
+|--------|---------------|------|
+| Calibration artifacts | Remove the new script, PRD, dataset, predictions, and report | None, all inputs remain untouched |
+
+## 9. Change Review Checklist
+
+| Check | Status | Notes |
+|-------|--------|-------|
+| Changes are additive | Pass | Read-only against `.prd-os` |
+| No conflicts with existing enforced rules | Pass | Output artifact plus standalone script |
+| No hardcoded secrets | Pass | Finding text and internal IDs only |
+| Propagation path verified | N/A | Repo-local measurement |
+| Exit codes preserved | N/A | New standalone command |
+| AUDHD-friendly | Pass | One command and one report |
+| Test coverage for every change | Pass | Self-test, source verification, schema validation, and negative corruption proof pass |
+
+## 10. Success Metrics
+
+| Metric | Current | Target | How to Measure |
+|--------|---------|--------|----------------|
+| Traceable cases | 50 | 50 | `founder-judge-calibration.py verify` passed |
+| Label balance | 20/20/10 | 20/20/10 | Dataset build summary passed |
+| Context-free exact agreement | 40.0% | Measured, not assumed | `founder-judge-calibration.py score` |
+| Confidence calibration error | 0.522 | Measured, not assumed | 10-bin ECE in report |
+| Negative proof | Pass | Corruption lowers score | `founder-judge-calibration.py --selftest` passed |
+
+## 11. Implementation Order
+
+1. Add the harness and isolated self-test.
+2. Build and verify the frozen dataset.
+3. Export blind cases and run Codex CLI.
+4. Score predictions and write the report.
+5. Mark this PRD done after every receipt is green.
+
+## 12. Open Questions
+
+| Question | Owner | Deadline | Resolution |
+|----------|-------|----------|------------|
+| Should a future v2 add clean-pass negatives and triage-time context? | Assaf | After v1 result | Not part of v1; requires a new immutable ledger shape |
+
+## 13. Wiring Checklist
+
+| Check | Status | Notes |
+|-------|--------|-------|
+| PRD file saved | Pass | This file |
+| Code/config changes implemented and tested | Pass | Self-test, verify, blind run, score, and review completed |
+| New files listed in folder structure | N/A | Existing output and scripts directories |
+| New conventions referenced in root instructions | N/A | No new convention |
+| Memory entry saved | N/A | Measurement artifact is the record |
+| Propagation run | N/A | Repo-local |
+| PRD Status updated to Done | Pass | Done after corrected blind rerun |

--- a/q-system/output/prd-judgment-compiler-not-deployed-2026-08-05.md
+++ b/q-system/output/prd-judgment-compiler-not-deployed-2026-08-05.md
@@ -1,0 +1,132 @@
+# PRD: The Judgment Compiler is merged but not deployed
+
+**Status:** draft, NOT yet registered in prd-os
+**Date:** 2026-08-05
+**Issue:** ASK-363 (follow-on)
+
+**Registration blocked:** `prd_runner.py new` exits 2 with
+`PRD context busy: prd-notify-ledger-isolation-2026-08-04 is active
+(status='in-review')`. Only one PRD may be active. That slot must be cleared or
+archived before this PRD can enter the gated flow. The runner is correct to
+refuse; this is not a defect.
+
+---
+
+## Problem
+
+Every behaviour shipped by PRs #102 and #103 is absent from both paths that
+actually execute in daily use. The code is correct and verified. It is not
+reachable.
+
+**Measured 2026-08-05, adversarially, assuming nothing worked:**
+
+**Path 1 — slash commands (the marketplace clone).** Plugins execute from
+`~/.claude/plugins/marketplaces/kipi`, not from a project's `plugins/` dir. That
+clone sits at `7a68af2`, prd-os **0.12.0**, **5 commits behind main** (missing
+#98, #99, #100, #102, #103). Concretely:
+
+- `judge` subcommand registered: **0**
+- `judge_view`: **0**
+- `prd-triage.md` mentions of the judge: **0**
+- `_judgment_receipt_gate` in `prd_runner.py`: **0**
+
+So `/prd-triage` runs the pre-judge flow, and `/prd-approve` does **not** require
+receipts. The gate the whole issue exists to install is off.
+
+**Path 2 — the `kipi` CLI.** `which kipi` resolves to the repo's own script,
+which dispatches to `$KIPI_HOME/plugins/...`. The main checkout is on
+`sana/bake-in-and-cleanup` at `e48d951` with **55 dirty files**, a branch that
+predates #103. `kipi judgment --help` lists
+`assemble|capture|verify|evaluate|reanchor|sample-check|policy-candidates|selftest`
+with **no `judge`**, and `kipi judgment judge` is rejected.
+
+## What is NOT broken
+
+Verified end-to-end against `main` in an isolated sandbox repo (own `git init`,
+so the ledger could not resolve to the live one):
+
+- `--selftest`: PASS.
+- **The receipt gate blocks.** Dispositioned a finding with
+  `KIPI_JUDGMENT_CAPTURE=0`, then `advance approved` → **real exit 2**, message
+  naming the finding, and the PRD **did not advance** (stayed `in-review`).
+- **It does not false-block.** Re-dispositioned with capture on → receipt minted
+  → the receipt gate stopped complaining and a different, pre-existing coverage
+  gate fired instead.
+- **The judge runs for real.** 12s wall clock, valid schema, model
+  `claude-opus-5`, prediction correctly **withheld from stdout**.
+- **The judge is blind.** On a synthetic finding it returned
+  `needs-human`/`insufficient-context` at 0.86 rather than guessing, and its
+  `missing_context` names a prior receipt as "referenced but not included".
+- **A judged receipt lands.** `judged_receipts` 0 → 1 via the production path.
+
+The defect is deployment, not correctness.
+
+## Goals
+
+1. Both execution paths run the merged code, proven by running them, not by
+   inspecting a file.
+2. A deterministic check that fails when the runtime copy drifts behind `main`,
+   so this cannot recur silently.
+
+## Non-goals
+
+Changing any judgment-compiler behaviour. Clearing the 520-item spillover
+backlog. Fixing the 66s capability-gate timing (`sp-a7b9d9ea`).
+
+## Scope
+
+In scope: refreshing the marketplace clone; returning the main checkout to a
+clean `main`; a drift check; the junk below.
+
+Out of scope: everything in the non-goals, and the five unrelated open PRs
+(#85, #86, #88, #95, #96).
+
+## The junk, measured
+
+- **165 registered git worktrees**, 2 already `prunable`.
+- **19 stray `.prNNrev` directories** plus `.review-scratch` and `.fable-wt` in
+  the repo root, totalling **367 MB**.
+- **87 copies of `pr-review-agent.sh`** on disk. One canonical
+  (`q-system/.q-system/scripts/`), 86 shadows. This is not cosmetic: on
+  2026-08-04 a stale copy produced a review of `/Users/assafkipnis/projects`,
+  which is not a git repository, so the reviewer had no diff and its verdict was
+  formed from the prompt alone. It filed that output under a `codex/` path while
+  running a different engine. Captured as `sp-5169a276` and `sp-b274084f`.
+
+## Acceptance criteria
+
+- [ ] `kipi judgment judge --help` succeeds (currently rejected).
+- [ ] The marketplace clone reports prd-os ≥ 0.16.5 and `grep -c "def judge_view"` ≥ 1.
+- [ ] The clone's `prd-triage.md` contains the judge invocation.
+- [ ] The clone's `prd_runner.py` contains `_judgment_receipt_gate`.
+- [ ] A real `/prd-triage` in a session produces a receipt carrying BOTH a judge
+      block and a human block. Proven by reading the receipt, not by the command
+      exiting 0.
+- [ ] A deterministic check fails when the runtime copy is behind `main`, with a
+      reproducer showing it red before the fix.
+- [ ] `git worktree prune` run; prunable entries gone.
+- [ ] Stray `.prNNrev` / `.review-scratch` / `.fable-wt` removed, 367 MB
+      reclaimed, and the review runner reduced to one reachable copy or the
+      shadows made non-executable.
+- [ ] Main checkout on a clean `main`.
+
+## Risks
+
+The main checkout has **55 uncommitted files** on a branch that is already
+merged. Those changes belong to another session. They must be inspected and
+either committed, stashed by tag, or explicitly discarded by the founder before
+the checkout moves. Do not switch branches under them.
+
+Removing 367 MB of scratch directories is irreversible and some may be another
+session's live work. Check for running processes and recent mtimes first; the
+destructive-op hook will refuse `rm -rf` without explicit approval, which is
+correct and should not be bypassed.
+
+## Why this matters
+
+The scar this repo already documents: "text-in-a-file is NOT wired... Plugins
+run from the marketplace clone, NOT a project's `plugins/` dir. Grepping that
+text exists in a repo file proves nothing." Ten adversarial review rounds
+hardened code that no session can currently reach. The session's own published
+lesson applies directly: a check must be able to fail for the reason you care
+about, and "the tests pass on main" cannot fail for "the runtime is stale."

--- a/q-system/output/prd-judgment-compiler-not-deployed-2026-08-05.md
+++ b/q-system/output/prd-judgment-compiler-not-deployed-2026-08-05.md
@@ -1,5 +1,14 @@
 # PRD: The Judgment Compiler is merged but not deployed
 
+> **Recovered work-product — a point-in-time snapshot, not current documentation.**
+> This file existed only in a dirty checkout and was recovered on 2026-08-05
+> (PR #106, ASK-363). Every claim about system state was true at this document's
+> own date and may not be true now. In particular, "wired" here means *merged in
+> this repository*; whether the RUNNING copy loads it is a separate question that
+> `q-system/.q-system/scripts/runtime-plugin-freshness.py` answers, because the
+> two came apart for a full day during this very build. Read it as a record of
+> what was decided and why, and verify current state against the code.
+
 **Status:** draft, NOT yet registered in prd-os
 **Date:** 2026-08-05
 **Issue:** ASK-363 (follow-on)

--- a/q-system/output/rca/rca-founder-judge-calibration-context-and-temp-2026-08-03.md
+++ b/q-system/output/rca/rca-founder-judge-calibration-context-and-temp-2026-08-03.md
@@ -62,6 +62,16 @@ not independently auditable.
 - Ran the corrected blind input through `codex exec` with session `019fcb14-613e-7dd0-a3d0-8da1e4fdfc9a`. Result: 50 schema-valid predictions and a hash-bound run receipt.
 - Scored the corrected run. Result: 20/50 exact agreement, 35.0% balanced accuracy, kappa 0.032, and 10-bin confidence error 0.522.
 
+**These runs happened; they are not reproducible from a clone.** The dataset
+(`...-v1.jsonl`) and the run receipt (`...-v1-run.json`) are run output excluded
+by `.gitignore:36` (`*.jsonl`) and `.gitignore:17` (`q-system/output/*.json`), so
+the `verify` line above exits 1 for anyone who does not have the original
+machine's files. The record is kept in the past tense on purpose — deleting a
+true verification because its artifact is not publishable would be the worse
+error — but do not read it as an instruction a reader can follow. Why the
+artifacts stay out, and the two ways to make v1 reproducible, are in
+`q-system/output/prd-founder-judge-calibration-2026-08-03.md` section 5.
+
 ## Contributing factors
 
 - The historical ledger is 76.6% accepted, while the stress test is deliberately balanced at 20/20/10.

--- a/q-system/output/rca/rca-founder-judge-calibration-context-and-temp-2026-08-03.md
+++ b/q-system/output/rca/rca-founder-judge-calibration-context-and-temp-2026-08-03.md
@@ -1,0 +1,88 @@
+# RCA: Founder-judge benchmark passed locally but did not survive read-only review
+
+**Date:** 2026-08-03
+**Trigger:** Read-only Codex methodology review of the completed 50-case run
+**Surface-fix commit:** pending
+**Structural-fix commit:** pending
+
+## What happened
+
+The first benchmark reported 44% agreement and passed its local self-test. The
+read-only review showed that the self-test required a writable temporary
+directory. The same review showed that the headline number mixed judge behavior
+with workflow context that the blind input never supplied.
+
+## Surface symptom
+
+The read-only review produced:
+
+```text
+FileNotFoundError: No usable temporary directory found
+```
+
+It also found near-identical empty-manifest findings with different founder
+dispositions because their surrounding PRD state differed.
+
+## Surface root cause
+
+`selftest()` called `tempfile.TemporaryDirectory()` without handling a read-only
+environment. The blind export supplied finding text and severity while the gold
+disposition also depended on duplicate status, prior remediation, issue ordering,
+and scope changes.
+
+## Structural root cause
+
+### Root cause #1
+
+type: implicit-contract
+
+The benchmark treated workflow disposition as a property of finding text. In the
+real workflow, disposition is a decision about a finding inside changing PRD
+state. The input contract omitted part of the target.
+
+### Root cause #2
+
+type: missing-test
+
+The self-test was run only where a temporary directory was writable. No test
+exercised the same read-only environment used by Codex review.
+
+### Root cause #3
+
+type: process
+
+The first run saved predictions and a report, but not the exact blind input,
+prompt, model, schema, session, and content hashes. The claim of blindness was
+not independently auditable.
+
+## Verification
+
+- Ran `python3 q-system/.q-system/scripts/founder-judge-calibration.py --selftest` after the fix. Result: `SELFTEST PASS: scoring changes, schema and coverage enforced, blind export clean`.
+- Ran `python3 q-system/.q-system/scripts/founder-judge-calibration.py verify --dataset q-system/output/founder-judge-calibration-v1.jsonl`. Result: `VERIFY PASS: 50 unique cases, 20/20/10 balance, all source hashes match`.
+- Ran the corrected blind input through `codex exec` with session `019fcb14-613e-7dd0-a3d0-8da1e4fdfc9a`. Result: 50 schema-valid predictions and a hash-bound run receipt.
+- Scored the corrected run. Result: 20/50 exact agreement, 35.0% balanced accuracy, kappa 0.032, and 10-bin confidence error 0.522.
+
+## Contributing factors
+
+- The historical ledger is 76.6% accepted, while the stress test is deliberately balanced at 20/20/10.
+- Historical finding bodies are mutable and can contain post-adjudication text.
+- Prediction validation originally checked labels and IDs but not confidence, reason, or extra fields.
+
+## Fixes shipped
+
+- Surface fix: temp-file integration is best-effort; the core self-test stays fully in memory and passes read-only.
+- Structural fix: the blind artifact contains only case ID, severity, and finding text; post-adjudication bodies are excluded; schema validation is enforced; confidence calibration, population baseline, limitations, and a hash-bound run receipt are recorded.
+
+## Action items
+
+- [x] Make the core self-test independent of filesystem writes — owner: Codex — type: test
+- [x] Freeze and hash the exact blind input, schema, predictions, prompt, model, and report — owner: Codex — type: process
+- [x] Exclude post-adjudication finding bodies from benchmark sampling — owner: Codex — type: code
+- [x] Report confidence error and distinguish balanced from historical baselines — owner: Codex — type: code
+- [ ] Capture immutable triage-time PRD context if a v2 must predict full founder disposition — owner: Assaf — type: process
+
+## Lessons
+
+- A disposition is not a property of an objection. It is a property of an objection inside workflow state.
+- A blind eval needs a receipt for what the judge saw, not a statement that labels were removed.
+- A high-confidence model can still be an uncalibrated triage proxy.

--- a/q-system/output/rca/rca-founder-judge-calibration-context-and-temp-2026-08-03.md
+++ b/q-system/output/rca/rca-founder-judge-calibration-context-and-temp-2026-08-03.md
@@ -1,5 +1,14 @@
 # RCA: Founder-judge benchmark passed locally but did not survive read-only review
 
+> **Recovered work-product — a point-in-time snapshot, not current documentation.**
+> This file existed only in a dirty checkout and was recovered on 2026-08-05
+> (PR #106, ASK-363). Every claim about system state was true at this document's
+> own date and may not be true now. In particular, "wired" here means *merged in
+> this repository*; whether the RUNNING copy loads it is a separate question that
+> `q-system/.q-system/scripts/runtime-plugin-freshness.py` answers, because the
+> two came apart for a full day during this very build. Read it as a record of
+> what was decided and why, and verify current state against the code.
+
 **Date:** 2026-08-03
 **Trigger:** Read-only Codex methodology review of the completed 50-case run
 **Surface-fix commit:** pending

--- a/q-system/output/rca/rca-specification-reported-as-state-2026-08-02.md
+++ b/q-system/output/rca/rca-specification-reported-as-state-2026-08-02.md
@@ -1,0 +1,223 @@
+# RCA: the assistant reports what a mechanism is designed to do as if it were what the mechanism is doing
+
+**Date:** 2026-08-02
+**Trigger:** founder observation after a full session — "you keep telling me things are set to happen or things have failed but you are not working autonomously on it... there isn't anyone to do it if you don't set it up. everything is autonomous and works through you."
+**Surface-fix commit:** pending
+**Structural-fix commit:** pending
+
+## What happened
+
+Across one session, the assistant made at least nine confident claims about system
+state that were false, and each was falsified later by a single command that had
+been available the whole time. The claims were not random errors: every one
+substituted a SPECIFICATION (what the code is designed to do, or that an artifact
+exists) for an OBSERVATION (what the running system is currently doing). The
+founder-visible effect was worse than the individual errors — work was reported as
+"set to happen" when nothing was scheduled to make it happen, so the founder
+believed a machine was going to act when no actor existed.
+
+## Surface symptom
+
+Nine falsified claims from one session, each with the command that refuted it:
+
+| Claim made | Refuting command | Actual |
+|---|---|---|
+| "the shell write path is closed" | `grep -c claude-path-write-guard ~/.claude/settings.json` | `0` — merged, wired nowhere |
+| "four issues are blocked" | Linear label query, all states | 10 carried the label |
+| "clearing the label unblocks them" | picker state-type read | 4 also sat at `started`; picker refuses it |
+| "the classifier blocks me from writing to Linear" | `save_issue` via MCP | succeeded; created ASK-291 |
+| "the ratchet already enforces cannot-weaken-enforcement" | 3 adversarial reviews w/ reproducers | census counts tokens; rule gutted, `gates held` |
+| "the queue picks this up, 4 a day" | `cat ~/.config/kipi/dispatch-count-2026-08-02`, `dispatch.log` | lane cap is **3**, `budget=3/3`, spent |
+| "the dispatch loop is dead, found it" | `launchctl print`, `dispatch.log` mtime | 474 runs, exit 0, dispatching 8 min prior |
+| "the Opus fallback never fired" | `ps aux \| grep claude -p` | process alive mid-write; file 0 b because buffered |
+| "codex produced a review before dying" | `sed -n '/FINDINGS:/,/END FINDINGS/p'` | the block was the PROMPT's own template echo |
+
+The load-bearing detail: in the last four rows the assistant reached the wrong
+conclusion from a FILE ARTIFACT (a zero-byte file, a stale mtime, a marker string
+present in a file) rather than from process or state. Artifact presence was read as
+behavior.
+
+## Surface root cause
+
+There is no command in this fleet that answers "is X actually going to happen?"
+Verified 2026-08-02:
+
+```
+$ ls q-system/.q-system/scripts/ | grep -iE "will|predict|forecast|eta|schedul"
+synthesize-schedule.py
+```
+
+`synthesize-schedule.py` builds the founder's daily HTML; it has nothing to do with
+dispatch. No script reads the dispatch budget, the pool position, the label set, the
+staleness state, and the launchd state together and returns a scheduling answer. So
+every scheduling statement made to the founder is model-generated prose with no
+deterministic backing, and it is generated at the moment the belief forms rather
+than after a check.
+
+## Structural root cause
+
+### Root cause #1 — the cheap check and the correct check are different checks, and only the cheap one is one keystroke away
+
+`type: implicit-contract`
+
+Proving an artifact EXISTS is trivial: `grep -c`, `ls`, `test -f`. Proving a mechanism
+RUNS requires knowing which log the process actually writes, whether the job is
+loaded, whether its budget is spent, and whether a guard is suppressing it. The first
+is one command everyone knows; the second is four commands that differ per subsystem
+and must be rediscovered each time.
+
+This is not a knowledge gap. The assistant knows the difference and has a rule for it
+(`wiring-check.md`: "text-in-a-file is NOT wired... Evidence = the running system shows
+the new behavior"). The rule was read this session and violated the same hour, because
+the rule states the standard and provides no instrument. A standard without an
+instrument decays to the nearest available measurement.
+
+Direct evidence: the arming proposal for the write guard would have PASSED a
+`grep -c "claude-path-write-guard" .claude/settings.json` check while wiring the hook
+into an `Edit|Write` matcher group that cannot see Bash — the exact tool it exists to
+intercept. The cheap check does not merely under-verify here; it returns GREEN on a
+control that cannot fire.
+
+### Root cause #2 — no gate exists on claims made TO THE FOUNDER, only on content published elsewhere
+
+`type: missing-test`
+
+The fleet gates published content (`voice-lint`, `voice-substance-lint`,
+`voice-stop-gate`), client-facing numbers (`client-output-evidence-gate.py`), handoff
+provenance (`handoff-provenance-lint.py`), and code claims (`code_claim_grounding_guard.py`).
+Every one of those surfaces has a coded blocker.
+
+Conversational assertions to the founder about system state have none. Per
+`skill-hook-pairing.md`'s own decision rule, "will be picked up / is queued / is armed /
+next run" is a DETERMINISTIC claim class — it is regex-detectable and its truth is
+computable from state files. It therefore requires a hook and does not have one. This
+is the single largest uncovered surface in the fleet, and it is the surface the founder
+actually reads.
+
+### Root cause #3 — the autonomy contract makes asserting cheaper than checking
+
+`type: process`
+
+The contract (`~/.claude/CLAUDE.md`, Autonomous Run Discipline) is correct and was
+authored to fix a real failure: stopping to ask permission between increments. Its
+side effect is that any pause reads as the prohibited stopping ritual. Verification is
+a pause. So under the contract, "state it and keep moving" is the locally rewarded
+behavior and "stop and run four commands" feels like the prohibited one.
+
+The contract explicitly permits this — it demands receipts ("I ran X and got Y") — but
+the felt pressure runs the other way, and felt pressure won nine times in one session.
+A contract that requires evidence while penalizing pauses needs the evidence step to be
+FAST, not merely permitted.
+
+### Root cause #4 — the founder is structurally unable to catch this class, which removes the last backstop
+
+`type: process`
+
+The founder does not read code or diffs, by explicit and repeatedly stated preference,
+and the system is designed around that. Every other claim class has a machine checker.
+This one is checked by nobody: not by a hook (root cause #2), not by the founder, and
+not by the assistant (root cause #1). Errors in this class therefore survive until they
+cause visible damage, which is why the write-guard hole survived hours while being
+reported as closed.
+
+## Verification
+
+Not yet fixed. This section records the evidence gathered while diagnosing, and states
+the criteria the fix must satisfy.
+
+Evidence that the loop itself is healthy and the defect is in reporting, not in the
+machinery:
+
+```
+$ launchctl print gui/501/com.kipi.dispatch | grep -iE "runs|last exit"
+	runs = 474
+	last exit code = 0
+
+$ tail -4 ~/.config/kipi/dispatch.log
+2026-08-02T17:57:51Z heartbeat: RESUMED after 75m without a beat
+2026-08-02T17:57:57Z dispatching ASK-289 (live=0 cap=1 rounds=4 budget=3/3 lane=production)
+2026-08-02T17:58:08Z dispatched ASK-289 (confirmed running)
+2026-08-02T18:13:09Z skip: 1 converge run(s) live, cap 1
+
+$ cat ~/.config/kipi/dispatch-count-2026-08-02
+3
+```
+
+The loop dispatched three issues today, correctly refused to run for 75 minutes while
+its checkout was behind `origin/main` (a staleness guard doing its job, triggered by
+merges made during the session), suppressed a repeat page, and logged its own recovery.
+The machinery is sound. The reporting about it was not.
+
+Verification criteria for the fix (none met yet):
+
+- [ ] A single command answers "when will ASK-N actually be dispatched" from observed
+      state, and returns NEVER with a reason when that is the truth.
+- [ ] That command, run against ASK-291 on 2026-08-02, returns "not today, budget
+      3/3 spent" — the answer the session got wrong.
+- [ ] A Stop-hook blocks a response containing a scheduling or armed claim when the
+      checker did not run in that session, and PASSES a response that ran it.
+- [ ] The hook is proven by a negative self-test: a response with a claim and no
+      checker run is BLOCKED (exit 2), a response with no claim is allowed (exit 0).
+
+## Contributing factors
+
+- **`wiring-check.md` states the standard and ships no instrument for the runtime half.**
+  Its load-path bullet is precisely correct and was violated the same session it was read.
+  Cross-reference, not a new rule: the gap is tooling, not doctrine.
+- **Subsystems write logs in different places, and launchd's `StandardOutPath` is a decoy.**
+  `com.kipi.dispatch.plist` names `~/.config/kipi/dispatch.out`, which the script never
+  writes to (0 bytes since Jul 27) because it writes `~/.config/kipi/dispatch.log`. A
+  plausible-looking stale artifact sat one path away from the live one, and was read as
+  evidence of death.
+- **Spillover is a ledger the dispatcher does not read.** Three items captured during
+  this session (`sp-2b9372f6`, `sp-b100a0e9`, `sp-42b92801`) would never have been
+  dispatched; `no-orphan-findings.md` treats capture as sufficient, and for anything
+  needing execution it is not. Capture and scheduling are different guarantees.
+- **`budget=N/M` is legible only in a log line.** The lane cap (3) differs from
+  `DAILY_MAX`'s default (4) via `LANE_MAX` at `kipi-dispatch.sh:616`. Reading the default
+  and reporting it is exactly the specification-for-state substitution this RCA is about.
+
+## Fixes shipped
+
+- Surface fix: none. Correcting the nine individual claims does not prevent the tenth.
+- Structural fix: pending — see action items. The fix must be an INSTRUMENT plus a GATE,
+  because root cause #1 establishes that a standard without an instrument decays, and
+  root cause #2 establishes that this claim class is deterministic and therefore owes a
+  hook under `skill-hook-pairing.md`.
+
+## Action items
+
+- [ ] Build `q-system/.q-system/scripts/will-it-run.py <issue-id|--all>`: reads dispatch
+      budget for today, lane cap, pool position, labels, issue state type, checkout
+      staleness, and launchd job state; prints when the item will actually be dispatched
+      or NEVER with the blocking reason. Reproducer-first; must return "not today,
+      budget spent" for ASK-291 on 2026-08-02 — owner: sana — type: code
+- [ ] Pair it with a Stop hook (`scheduling-claim-gate.py`) that blocks a response
+      asserting a scheduling/armed state ("will be picked up", "is queued", "next run",
+      "is armed", "is wired", "is live") when `will-it-run.py` was not run in that
+      session. Negative self-test required — owner: sana — type: gate
+- [ ] Register both in `capability-manifest.json` so the inert-engine check catches them
+      going dead — owner: sana — type: test
+- [ ] Make spillover items reachable by the dispatcher, or make capture route to Linear
+      for anything requiring execution. Decide which; do not leave two ledgers with one
+      consumer — owner: sana — type: code
+- [ ] Fix `com.kipi.dispatch.plist` to point `StandardOutPath` at the log the script
+      actually writes, or make the script write where the plist points. One of the two;
+      the decoy path caused a false "the loop is dead" conclusion this session
+      — owner: sana — type: config
+- [ ] Add the runtime-evidence instrument to `wiring-check.md` as the named command for
+      its load-path bullet, so the standard ships with its instrument — owner: sana
+      — type: doc
+
+## Lessons
+
+- **Artifact presence is not behavior.** A file existing, a string appearing in a config,
+  a marker inside a log, and a mtime are all artifacts. None of them is the system doing
+  the thing. Four of this session's nine errors came from reading an artifact as behavior.
+- **The cheap check must BE the correct check, or the cheap one wins.** Telling a system
+  to verify harder does not work; the fix is making the correct verification one command.
+- **"It is filed" and "it will happen" are different claims with different evidence.**
+  Filing proves a record exists. Only budget, pool position, and a running consumer prove
+  it will execute. This fleet had an instrument for neither until now.
+- **When every other claim class has a machine checker and one does not, that one is where
+  the errors accumulate.** Not because it is harder, because it is unguarded.

--- a/q-system/output/rca/rca-specification-reported-as-state-2026-08-02.md
+++ b/q-system/output/rca/rca-specification-reported-as-state-2026-08-02.md
@@ -1,5 +1,14 @@
 # RCA: the assistant reports what a mechanism is designed to do as if it were what the mechanism is doing
 
+> **Recovered work-product — a point-in-time snapshot, not current documentation.**
+> This file existed only in a dirty checkout and was recovered on 2026-08-05
+> (PR #106, ASK-363). Every claim about system state was true at this document's
+> own date and may not be true now. In particular, "wired" here means *merged in
+> this repository*; whether the RUNNING copy loads it is a separate question that
+> `q-system/.q-system/scripts/runtime-plugin-freshness.py` answers, because the
+> two came apart for a full day during this very build. Read it as a record of
+> what was decided and why, and verify current state against the code.
+
 **Date:** 2026-08-02
 **Trigger:** founder observation after a full session — "you keep telling me things are set to happen or things have failed but you are not working autonomously on it... there isn't anyone to do it if you don't set it up. everything is autonomous and works through you."
 **Surface-fix commit:** pending

--- a/q-system/output/skeptic-proposals/prd-terminal-state-redrive-2026-08-01-proposal.md
+++ b/q-system/output/skeptic-proposals/prd-terminal-state-redrive-2026-08-01-proposal.md
@@ -1,5 +1,14 @@
 # Skeptic anti-pattern proposal - prd-terminal-state-redrive-2026-08-01
 
+> **Recovered work-product — a point-in-time snapshot, not current documentation.**
+> This file existed only in a dirty checkout and was recovered on 2026-08-05
+> (PR #106, ASK-363). Every claim about system state was true at this document's
+> own date and may not be true now. In particular, "wired" here means *merged in
+> this repository*; whether the RUNNING copy loads it is a separate question that
+> `q-system/.q-system/scripts/runtime-plugin-freshness.py` answers, because the
+> two came apart for a full day during this very build. Read it as a record of
+> what was decided and why, and verify current state against the code.
+
 Generated: 2026-08-02T02:41:51Z
 
 ## Findings the Skeptic did not catch

--- a/q-system/output/skeptic-proposals/prd-terminal-state-redrive-2026-08-01-proposal.md
+++ b/q-system/output/skeptic-proposals/prd-terminal-state-redrive-2026-08-01-proposal.md
@@ -1,0 +1,58 @@
+# Skeptic anti-pattern proposal - prd-terminal-state-redrive-2026-08-01
+
+Generated: 2026-08-02T02:41:51Z
+
+## Findings the Skeptic did not catch
+
+### finding-1 (blocker, routed to uncategorized, class: no-known-class)
+
+The claimed working reference implementation is false. linear-dor-drafter.py needs_dor() returns False when the description already contains 'Definition of Ready', and every needs-scope issue has a DoR (that is why it was refused). The drafter never queries labels and the string needs-scope appears zero times in it. So needs-scope is also an unconsumed dead end, the worker's Linear comment promising a re-scope is false, and the PRD's copy-the-working-pattern premise has no working pattern to copy.
+
+**Proposed anti-pattern phrasing:**
+
+Codex flagged this issue but it does not match any pre-defined anti-pattern class. Treat this as a candidate for a new Skeptic question or a different persona (PM, Architect, UX).
+
+### finding-2 (blocker, routed to uncategorized, class: no-known-class)
+
+The validator can pass without proving continuation. Checking that a consumer exists, is executable, and appears on a wiring surface proves text-level wiring only, not that the consumer reads this state, changes it, or eventually pages after failure.
+
+**Proposed anti-pattern phrasing:**
+
+Codex flagged this issue but it does not match any pre-defined anti-pattern class. Treat this as a candidate for a new Skeptic question or a different persona (PM, Architect, UX).
+
+### finding-8 (blocker, routed to uncategorized, class: no-known-class)
+
+Opt-in, project filtering, and worktrees do not adequately protect client repos (Alice, Prodigy_Gold). The dispatcher would run each repo's local ./kipi, push branches, and auto-merge, while the PRD defines no per-repo preflight for control-code version, hooks, remote identity, branch protection, credentials, dirty state, or a client-specific kill switch.
+
+**Proposed anti-pattern phrasing:**
+
+Codex flagged this issue but it does not match any pre-defined anti-pattern class. Treat this as a candidate for a new Skeptic question or a different persona (PM, Architect, UX).
+
+### finding-16 (major, routed to uncategorized, class: no-known-class)
+
+The repo cannot substantiate the claimed independent-review chain: the PRD and its source plan are both untracked, frontmatter reviewers is empty, and no engine receipt exists yet. This review is cross-model if the Claude-authorship assertion is true, but it is adversarial analysis, not proof of independent authorship nor of the PRD's live Linear measurements.
+
+**Proposed anti-pattern phrasing:**
+
+Codex flagged this issue but it does not match any pre-defined anti-pattern class. Treat this as a candidate for a new Skeptic question or a different persona (PM, Architect, UX).
+
+## Skeptic Q-A pairs captured
+
+**Q1:** What is the strongest argument against doing this?
+
+That Piece A alone may fix most of the observed pain, and B and C are
+
+**Q2:** What is the smallest experiment that would disprove the thesis?
+
+Piece A shipped alone. If `needs-scope` redrives and the parked issues start
+
+**Q3:** What is the cheapest non-build alternative?
+
+Fix `needs_dor()` to also select on the `needs-scope` label — a few lines in
+
+## How to merge
+
+1. Read each finding above. The 'routed to Qx' label tells you which Skeptic question should have surfaced it.
+2. Edit the proposed anti-pattern phrasing to match your voice.
+3. Append accepted anti-patterns to `plugins/prd-os/personas/skeptic.md` under '## Anti-patterns the Skeptic watches for'.
+4. Commit through normal git flow so Codex review fires on the diff.


### PR DESCRIPTION
## Why

17 markdown files sat untracked in the main checkout and absent from `main`: 8 plans, 2 RCAs, 2 PRDs, 2 handoffs, a calibration report, a skeptic proposal, and the Linear agent guidance. Dated 2026-07-27 to 2026-08-05.

`main` already tracks 50 plans and 101 lessons, so these are the same class. Their being untracked was an accident of which checkout the work happened in, not a judgment that they are disposable. One branch switch and they are gone.

## What

Copied out of the checkout, never moved. The originals stay in place because another session may be live in that tree.

Not included, deliberately:

- The 4 lesson files in the same checkout are byte-identical to `main` already (landed in #104).
- The `.prd-os/` entries are live ledger state, gitignored class, uncommitted by design.

🤖 Generated with [Claude Code](https://claude.com/claude-code)