### PR TITLE
Land the least-code-bias rule that lived only in the runtime (ASK-363)

### DIFF
--- a/plugins/prd-os/.claude-plugin/plugin.json
+++ b/plugins/prd-os/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "prd-os",
-  "version": "0.16.5",
+  "version": "0.16.6",
   "description": "PRD operating system: capture rough ideas, draft reviewable PRDs, run standard and adversarial review (Codex or a Claude senior-staff-engineer subagent, recorded truthfully), triage findings, decompose approved PRDs into atomic issue specs, and execute those issues with scope enforcement, stop-gate receipts, and reviewer-attributed findings.",
   "author": {
     "name": "Assaf Kipnis"

--- a/plugins/prd-os/skills/fable-discipline/SKILL.md
+++ b/plugins/prd-os/skills/fable-discipline/SKILL.md
@@ -109,6 +109,12 @@ How to move through complex work without shipping a confident wrong answer.
    version; a cross-cutting invariant needs a written scope + a self-enumerating
    guard. Check only the classes the change touches.
 
+7. **Least-code bias.** Prefer the smallest change that solves it. Reach for
+   delete-and-reuse before you write new code; the best fix is often a line
+   removed, not a line added. When you catch yourself writing the third
+   near-identical thing, stop and generalize the mechanism instead of adding a
+   third copy.
+
 ---
 
 ## Consistency rules


### PR DESCRIPTION
## Why

This rule was hand-added directly to the marketplace clone and existed **nowhere on main**: live in every session, absent from the repo, one clone refresh from being gone. Recovered and stashed before the refresh on 2026-08-05.

## Decision: land it, not discard it

It is consistent with what the skill already teaches (recon before edit, scope discipline) and with the standing rule that a fix changes exactly what was flagged. It earns its place as rule 7 rather than duplicating an existing one. Numbering verified: it follows rule 6, no collision.

## What stops a fourth recurrence

This is the **third** time someone patched the live runtime directly; the two older drift stashes in that clone are dated 2026-06-21 and 2026-07-01. A stash is not a mechanism. The detector for this shape (marketplace clone carrying uncommitted edits to tracked files) ships with the runtime freshness check in #105, not as a note asking people to stop.

## Notes

- `plugin.json` bumped 0.16.5 -> 0.16.6 for the pre-commit version-bump gate.
- `export-fable-mirror.sh --check` gains a SKILL.md drift line, which is expected and clears on the next mirror export. The two other drift lines (`fable-discipline-lint.py`, its test) reproduce on untouched `origin/main` and are pre-existing, captured separately.

🤖 Generated with [Claude Code](https://claude.com/claude-code)