### PR TITLE
Refuse a review root that is not a git repo root (ASK-363)

### DIFF
--- a/q-system/.q-system/capability-manifest.json
+++ b/q-system/.q-system/capability-manifest.json
@@ -62,6 +62,11 @@
       "runner": "bash"
     },
     {
+      "path": "q-system/.q-system/scripts/test/test-pr-review-root-guard.sh",
+      "runner": "bash",
+      "timeout_s": 120
+    },
+    {
       "path": "q-system/.q-system/scripts/test/test-review-plan-echo-gate.sh",
       "runner": "bash"
     },

--- a/q-system/.q-system/scripts/pr-review-agent.sh
+++ b/q-system/.q-system/scripts/pr-review-agent.sh
@@ -65,6 +65,47 @@ set -uo pipefail
 
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 SKEL="$(cd "$SCRIPT_DIR/../../.." && pwd)"
+
+# REFUSE unless SKEL is actually a repo root. `../../..` encodes "this script
+# lives exactly 3 levels below the root" and nothing ever asserted it. A copy
+# dropped 2 levels deep (.pr28rev/scripts/) overshoots by one and lands OUTSIDE
+# the repo: on 2026-08-04 one resolved to /Users/assafkipnis/projects, which is
+# not a git repo, so `gh pr diff` returned nothing and the model formed a
+# verdict from the prompt alone -- then that empty review was posted as a
+# passing commit status. Measured 2026-08-05: 79 of 102 copies on this box
+# resolve SKEL to a non-repo.
+#
+# Every downstream check that could have caught it degrades to "warn and
+# proceed" (a reviewer that cannot fetch should not wedge the loop), and codex's
+# own repo check is disabled by --skip-git-repo-check. So the assertion has to
+# be here, at the point of resolution, and it has to REFUSE. Reviewing nothing
+# and reporting APPROVE is worse than not running: it manufactures evidence.
+#
+# Compares against the toplevel rather than just `rev-parse` succeeding, because
+# a path merely INSIDE a repo would otherwise pass while reviewing a subtree.
+#
+# Both sides are resolved to PHYSICAL paths before comparing. `pwd` keeps
+# symlinks while git reports the real path, so on macOS a repo under /var
+# resolves to /var/... on one side and /private/var/... on the other and a naive
+# string compare refuses a perfectly good canonical checkout. A guard that false
+# -refuses gets switched off, and a gate that is off protects nothing. Caught by
+# this guard's own test on first run (2026-08-05).
+_SKEL_TOPLEVEL="$(git -C "$SKEL" rev-parse --show-toplevel 2>/dev/null || true)"
+if [ -n "$_SKEL_TOPLEVEL" ]; then
+  _SKEL_TOPLEVEL="$(cd "$_SKEL_TOPLEVEL" 2>/dev/null && pwd -P || echo "$_SKEL_TOPLEVEL")"
+fi
+_SKEL_PHYS="$(cd "$SKEL" && pwd -P)"
+if [ -z "$_SKEL_TOPLEVEL" ] || [ "$_SKEL_TOPLEVEL" != "$_SKEL_PHYS" ]; then
+  echo "REFUSING: resolved review root is not a git repository root." >&2
+  echo "  script:        ${BASH_SOURCE[0]}" >&2
+  echo "  resolved root: $SKEL" >&2
+  echo "  git toplevel:  ${_SKEL_TOPLEVEL:-<not a git repository>}" >&2
+  echo "This script must live exactly 3 levels below the repo root" >&2
+  echo "(<repo>/q-system/.q-system/scripts/). Run the canonical copy, not a" >&2
+  echo "copy inside a review-scratch tree." >&2
+  exit 2
+fi
+unset _SKEL_TOPLEVEL _SKEL_PHYS
 SYNC="$SCRIPT_DIR/linear-sync.py"
 OUT_DIR="$HOME/.config/kipi/pr-reviews"
 TIMEOUT_SECONDS=2400

--- a/q-system/.q-system/scripts/pr-review-agent.sh
+++ b/q-system/.q-system/scripts/pr-review-agent.sh
@@ -69,7 +69,8 @@ SKEL="$(cd "$SCRIPT_DIR/../../.." && pwd)"
 # REFUSE unless SKEL is actually a repo root. `../../..` encodes "this script
 # lives exactly 3 levels below the root" and nothing ever asserted it. A copy
 # dropped 2 levels deep (.pr28rev/scripts/) overshoots by one and lands OUTSIDE
-# the repo: on 2026-08-04 one resolved to /Users/assafkipnis/projects, which is
+# the repo: on 2026-08-04 one resolved to the checkout's PARENT directory (the
+# one holding every project), which is
 # not a git repo, so `gh pr diff` returned nothing and the model formed a
 # verdict from the prompt alone -- then that empty review was posted as a
 # passing commit status. Measured 2026-08-05: 79 of 102 copies on this box

--- a/q-system/.q-system/scripts/test/test-pr-review-root-guard.sh
+++ b/q-system/.q-system/scripts/test/test-pr-review-root-guard.sh
@@ -2,7 +2,7 @@
 # Pairs with the review-root guard in q-system/.q-system/scripts/pr-review-agent.sh.
 #
 # Scar (2026-08-04): a copy of the review agent at .pr28rev/scripts/ resolved its
-# review root to /Users/assafkipnis/projects -- not a git repo -- so there was no
+# review root to the checkout's PARENT directory -- not a git repo -- so there was no
 # diff, the model formed a verdict from the prompt alone, and that empty review
 # was posted as a passing status. `../../..` assumed a depth nothing asserted.
 #

--- a/q-system/.q-system/scripts/test/test-pr-review-root-guard.sh
+++ b/q-system/.q-system/scripts/test/test-pr-review-root-guard.sh
@@ -1,0 +1,87 @@
+#!/usr/bin/env bash
+# Pairs with the review-root guard in q-system/.q-system/scripts/pr-review-agent.sh.
+#
+# Scar (2026-08-04): a copy of the review agent at .pr28rev/scripts/ resolved its
+# review root to /Users/assafkipnis/projects -- not a git repo -- so there was no
+# diff, the model formed a verdict from the prompt alone, and that empty review
+# was posted as a passing status. `../../..` assumed a depth nothing asserted.
+#
+# Hermetic: every case builds its own repo under mktemp and copies the real
+# script to a chosen depth. Nothing here touches a live repo or the network; the
+# guard sits above argument parsing, so the script is invoked with no args and
+# refuses before it can reach `gh`.
+set -euo pipefail
+
+ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/../../../.." && pwd)"
+AGENT="$ROOT/q-system/.q-system/scripts/pr-review-agent.sh"
+fail() { echo "FAIL: $1" >&2; exit 1; }
+
+[ -f "$AGENT" ] || fail "review agent missing at $AGENT"
+
+G() { git -c user.email=t@t.t -c user.name=test -c commit.gpgsign=false "$@"; }
+OUTFILE="$(mktemp)"
+
+# Places the real script at $2 (relative to repo $1), runs it, sets RC/OUT.
+# Not `OUT=$(run_at ...)`: command substitution is a subshell and RC would be
+# discarded, which silently turned an earlier suite green.
+run_at() {
+  local repo="$1" rel="$2" dir
+  dir="$repo/$rel"
+  mkdir -p "$dir"
+  cp "$AGENT" "$dir/pr-review-agent.sh"
+  chmod +x "$dir/pr-review-agent.sh"
+  set +e
+  bash "$dir/pr-review-agent.sh" > "$OUTFILE" 2>&1
+  RC=$?
+  set -e
+  OUT="$(cat "$OUTFILE")"
+}
+
+mkrepo() { local d; d="$(mktemp -d)"; ( cd "$d" && G init -q && printf 'x\n' > f.md && G add -A && G commit -qm base ); echo "$d"; }
+
+# --- POSITIVE: canonical depth inside a real repo -> guard must NOT fire ------
+REPO="$(mkrepo)"
+run_at "$REPO" "q-system/.q-system/scripts"
+case "$OUT" in
+  *REFUSING*) fail "guard fired on the CANONICAL depth-3 layout: $OUT";;
+esac
+
+# --- NEGATIVE-1: the literal 2026-08-04 shape --------------------------------
+# .pr28rev/scripts/ is 2 levels deep, so ../../.. overshoots one level and lands
+# on the PARENT of the repo. This is the case that reviewed a non-repo.
+REPO="$(mkrepo)"
+run_at "$REPO" ".pr28rev/scripts"
+[ "$RC" -eq 2 ] || fail "depth-2 scratch copy must exit 2, got $RC: $OUT"
+case "$OUT" in *REFUSING*) :;; *) fail "depth-2 copy did not refuse: $OUT";; esac
+PARENT="$(cd "$REPO/.." && pwd)"
+case "$OUT" in *"$PARENT"*) :;; *) fail "refusal did not report the overshot root $PARENT: $OUT";; esac
+
+# --- NEGATIVE-2: correct depth, but nothing above it is a repo ---------------
+BARE="$(mktemp -d)"
+run_at "$BARE" "q-system/.q-system/scripts"
+[ "$RC" -eq 2 ] || fail "non-repo root must exit 2, got $RC: $OUT"
+case "$OUT" in *"not a git repository"*) :;; *) fail "non-repo refusal lacks the reason: $OUT";; esac
+
+# --- NEGATIVE-3: inside a repo, but NOT at its root --------------------------
+# Mutation guard for the toplevel comparison specifically. A weaker guard that
+# only asks whether `git rev-parse` SUCCEEDS passes this case, because a
+# subdirectory of a repo is still "in a repo" -- and the agent would then review
+# a subtree while believing it held the whole repo. Only the ==-toplevel form
+# catches it, so this case is what keeps that comparison honest.
+REPO="$(mkrepo)"
+run_at "$REPO" "sub/dir/q-system/.q-system/scripts"
+[ "$RC" -eq 2 ] || fail "root inside-but-not-top of a repo must exit 2, got $RC: $OUT"
+case "$OUT" in *REFUSING*) :;; *) fail "subtree root did not refuse: $OUT";; esac
+
+# --- the guard runs BEFORE argument parsing / any network --------------------
+# If it drifted below arg parsing, a no-arg invocation would die on usage first
+# and the refusal text would never appear -- which is exactly how a guard stops
+# protecting anything without anyone noticing.
+REPO="$(mkrepo)"
+run_at "$REPO" ".pr28rev/scripts"
+case "$OUT" in
+  *REFUSING*) :;;
+  *) fail "guard no longer precedes arg parsing (no refusal on a no-arg run): $OUT";;
+esac
+
+echo "PASS: refuses a depth-2 scratch copy (the 2026-08-04 shape), a non-repo root, and a non-toplevel root; stays silent on the canonical layout; fires before arg parsing"

--- a/q-system/.q-system/scripts/test/test-verdict-usability.sh
+++ b/q-system/.q-system/scripts/test/test-verdict-usability.sh
@@ -53,10 +53,26 @@ fi
 chmod +x "$AGENT"
 # The agent sources the lib from its own directory, so both copies must sit
 # together. Verify-against-a-copy: the live checkout is never the thing driven.
-mkdir -p "$WORK/scripts"
-cp "$AGENT" "$WORK/scripts/pr-review-agent.sh"
-cp "$LIB" "$WORK/scripts/pr-verdict-lib.sh"
-AGENT="$WORK/scripts/pr-review-agent.sh"
+#
+# THE COPY MUST SIT AT THE CALLER'S REAL DEPTH, IN A REAL REPO. This used to be a
+# flat "$WORK/scripts", so the agent's own `SKEL=$SCRIPT_DIR/../../..` resolved to
+# the parent of a bare mktemp dir -- not a repository, and two levels shallower
+# than any real install. That went unnoticed while nothing asserted the depth. The
+# review-root guard added in this same change asserts it, and this fixture was the
+# first thing it caught: three cases went <<NORECORD>> because the agent refused
+# before it could write a verdict, which reads as "the usable key is a constant"
+# rather than "the harness is shaped wrong".
+#
+# Reproducing the caller's shape is the fix, NOT relaxing the guard. A fixture the
+# guard would refuse in production is a fixture testing a layout that cannot ship,
+# and the whole defect class here is a test whose environment does not match the
+# real one.
+REPO_FIXTURE="$WORK/repo"
+mkdir -p "$REPO_FIXTURE/q-system/.q-system/scripts"
+git -C "$REPO_FIXTURE" init -q 2>/dev/null || { echo "FATAL: could not git-init the fixture repo" >&2; exit 1; }
+cp "$AGENT" "$REPO_FIXTURE/q-system/.q-system/scripts/pr-review-agent.sh"
+cp "$LIB" "$REPO_FIXTURE/q-system/.q-system/scripts/pr-verdict-lib.sh"
+AGENT="$REPO_FIXTURE/q-system/.q-system/scripts/pr-review-agent.sh"
 
 # --- stubs: the engine and gh are the seams, and both are stubbed ------------
 # NOT a sandboxed HOME alone. A quiet run because a dependency silently no-ops


### PR DESCRIPTION
## The defect

On 2026-08-04 a copy of the review agent at `.pr28rev/scripts/` reviewed `/Users/assafkipnis/projects` — **not a git repository**. No diff existed, so the model formed a verdict from the prompt alone, and that empty review was posted as a **passing commit status**.

## Root cause

Line 67, unchanged since inception: `SKEL` is "3 directories above wherever this file sits." Nothing ever asserted the depth. The canonical copy lives at `<repo>/q-system/.q-system/scripts` (depth 3) so it works. A copy dropped **2** levels deep overshoots by exactly one and walks out of the repo:

```
.pr28rev/scripts   ->  ..       = .pr28rev
                       ../..    = <repo root>
                       ../../.. = <PARENT of repo>   <-- SKEL lands here
```

Measured 2026-08-05: **79 of 102 copies** on this box resolve `SKEL` to a non-repo. The `SCRIPT_DIR`/`SKEL` pair is **byte-identical in all 102**, so this is not a mutated shadow — every revision hardcodes the same assumption.

## Why the fix is here and not in a cleanup

Deleting copies does not fix arithmetic that is identical in all of them, and copies were still being created *during* the investigation (92 to 102 in twelve minutes). Any fix keyed to a copy list is stale before it lands. The assertion belongs at the point of resolution.

It **refuses** rather than warns. Every downstream check that could have caught this degrades to warn-and-proceed by design (a reviewer that cannot fetch should not wedge the loop), and codex's own repo check is disabled by `--skip-git-repo-check`. Reviewing nothing and reporting APPROVE is worse than not running: it manufactures evidence.

## Evidence

Cases: canonical depth-3 stays silent; the literal depth-2 shape refuses with exit 2 and names the overshot parent; a non-repo root refuses; a path inside-but-not-atop a repo refuses; and the guard is asserted to fire *before* argument parsing.

- **Mutation**: dropping the toplevel equality (keeping only `rev-parse` success) turns the suite **red** on the subtree case; restoring turns it **green**. The comparison is load-bearing.
- The test caught a real false-positive in the guard on first run: `pwd` keeps symlinks while git reports the real path, so macOS `/var` vs `/private/var` refused a good checkout. Both sides now resolve to physical paths. A guard that false-refuses gets switched off.

## Adjacent, captured not bundled

The engine label is chosen at parse time, so an Opus-fallback review is written under `codex/` and recorded `"engine": "codex"` with no `degraded` key in the record.

🤖 Generated with [Claude Code](https://claude.com/claude-code)