### PR TITLE
P0: refuse a kipi update whose --delete would remove founder data (ASK-402)

### DIFF
--- a/kipi-update-deletion-guard.py
+++ b/kipi-update-deletion-guard.py
@@ -1,0 +1,137 @@
+#!/usr/bin/env python3
+"""Refuse a q-system sync whose --delete would remove instance-owned data.
+
+WHY THIS EXISTS (sp-737ce1ae, sp-10cf4f76). kipi-update.sh syncs the skeleton's
+q-system/ into each instance with `rsync -a --delete`, protecting instance data
+with ANCHORED excludes (`--exclude=/my-project/`). An anchored exclude is
+relative to the TRANSFER ROOT, so it only lines up when the destination IS the
+instance's q-system dir.
+
+Reproduced 2026-08-05: with `subtree_prefix` null the destination is the
+instance ROOT, so an instance that still keeps its data under `q-system/` has
+that data one level below where the excludes point. The dry run then itemizes
+
+    *deleting   q-system/my-project/current-state.md
+    *deleting   q-system/memory/last-handoff.md
+    *deleting   q-system/canonical/decisions.md
+
+and none of `--exclude=/my-project/` etc. matches, because they anchor at
+`q-system/my-project/`'s PARENT. `reddit-build-radar` is a real registry entry
+with a null prefix.
+
+WHY A GUARD AND NOT ONLY AN EXCLUDE FIX. Re-anchoring the excludes fixes this
+variant. It does not fix the class: any future layout, prefix, or registry drift
+that moves the destination re-opens the same hole silently, and the failure mode
+is deleted founder data with no error. This reads the deletions rsync ACTUALLY
+plans, from rsync's own itemized output, and matches instance-owned names at ANY
+depth. It is the fail-closed backstop; the excludes remain the first line.
+
+It also covers sp-10cf4f76 (a tracked instance-only script inside the synced
+tree, which the untracked-file snapshot never protected), because a deletion is
+a deletion whatever git thinks of the file.
+
+Exit codes:
+    0  no instance-owned deletion planned (sync may proceed)
+    2  at least one planned deletion touches instance-owned data (ABORT)
+
+Usage:
+    rsync -ain --delete SRC DEST <excludes> | python3 kipi-update-deletion-guard.py
+
+Reads the itemized dry-run on stdin. Emits the offending paths on stderr.
+"""
+
+from __future__ import annotations
+
+import re
+import sys
+
+# Kept in sync with INSTANCE_OWNED_SUBTREES in kipi-update.sh. Duplicated
+# deliberately rather than sourced: this script must stay runnable standalone
+# (that is what makes it testable without building a skeleton fixture), and a
+# drift between the two lists is caught by
+# test-kipi-update-owned-deletion-guard.sh, which reads BOTH.
+INSTANCE_OWNED = (
+    "my-project",
+    "canonical",
+    "memory",
+    "output",
+    "research",
+    ".q-system/data",
+    ".q-system/agent-pipeline/bus",
+)
+
+
+# Verified against the rsync on this machine (openrsync, protocol 29):
+# `rsync -ain --delete` emits `*deleting <path>` per removal. The bare
+# `deleting <path>` form is accepted too -- it costs one alternation and the
+# failure mode of missing it is deleted founder data.
+_DELETING = re.compile(r"^\*?deleting\s+(?P<path>.+?)\s*$")
+
+
+def deletions(itemized: str) -> list[str]:
+    """The paths rsync says it will delete, from its own itemized output."""
+    out = []
+    for line in itemized.splitlines():
+        m = _DELETING.match(line.strip())
+        if m and m.group("path"):
+            out.append(m.group("path"))
+    return out
+
+
+def owned_hits(paths: list[str]) -> list[tuple[str, str]]:
+    """(path, subtree) for every deletion that touches instance-owned data.
+
+    Matched at ANY depth, not anchored: the whole defect is that the anchor was
+    in the wrong place, so an anchored check here would inherit the bug it
+    exists to catch.
+    """
+    hits = []
+    for path in paths:
+        # Case-FOLDED. macOS is case-insensitive by default, so
+        # `q-system/My-Project/` and `q-system/my-project/` are the SAME
+        # directory on the founder's machine -- a case-exact match would let a
+        # real deletion of real data through on the platform this actually runs
+        # on. Found by attacking my own guard, 2026-08-05.
+        segments = [s.casefold() for s in path.strip("/").split("/")]
+        for sub in INSTANCE_OWNED:
+            parts = [s.casefold() for s in sub.split("/")]
+            for i in range(len(segments) - len(parts) + 1):
+                if segments[i:i + len(parts)] == parts:
+                    hits.append((path, sub))
+                    break
+            else:
+                continue
+            break
+    return hits
+
+
+def main() -> int:
+    # NOTE ON EMPTY INPUT. No deletions planned is the NORMAL case, so empty
+    # stdin exits 0 and cannot be made to fail closed here without refusing
+    # every healthy sync. The failure it cannot distinguish -- rsync itself
+    # erroring and producing nothing -- is caught at the call site instead:
+    # kipi-update.sh runs `set -o pipefail`, so a failed rsync fails the whole
+    # pipeline and the caller abandons the instance. A caller WITHOUT pipefail
+    # would be unsafe; that is why the wiring test asserts the call site.
+    hits = owned_hits(deletions(sys.stdin.read()))
+    if not hits:
+        return 0
+    sys.stderr.write(
+        f"REFUSING SYNC: rsync --delete would remove {len(hits)} "
+        "instance-owned path(s):\n"
+    )
+    for path, sub in hits[:20]:
+        sys.stderr.write(f"  {path}   (instance-owned: {sub}/)\n")
+    if len(hits) > 20:
+        sys.stderr.write(f"  ... and {len(hits) - 20} more\n")
+    sys.stderr.write(
+        "\nThis means the destination and the anchored --exclude patterns "
+        "disagree about\nwhere the instance's q-system lives (sp-737ce1ae). "
+        "Check the instance's\n`subtree_prefix` in instance-registry.json "
+        "against its real layout.\n"
+    )
+    return 2
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/kipi-update-deletion-guard.py
+++ b/kipi-update-deletion-guard.py
@@ -81,9 +81,24 @@ def deletions(itemized: str) -> list[str]:
 def owned_hits(paths: list[str]) -> list[tuple[str, str]]:
     """(path, subtree) for every deletion that touches instance-owned data.
 
-    Matched at ANY depth, not anchored: the whole defect is that the anchor was
-    in the wrong place, so an anchored check here would inherit the bug it
-    exists to catch.
+    Matched at the TRANSFER ROOT or directly under a `q-system/` segment --
+    not at any depth.
+
+    "Any depth" was the first shape, because the defect being fixed was an
+    anchor in the wrong place and an anchored check looked like it would
+    inherit that bug. It over-corrected: `q-system/.q-system/agent-pipeline/
+    templates/deck/output/` is a REAL skeleton-owned directory, so deleting a
+    skeleton file under it refused the sync for every instance in the fleet
+    (Codex, PR #111, with a repro against that live path).
+
+    That is the worse failure. A guard that halts every unattended update gets
+    switched off, and a gate that is off protects nothing -- the same scar
+    `design-auto-invoke.md` already carries.
+
+    Anchoring on `q-system/` instead of on the transfer root keeps the P0
+    catch: the bug was `q-system/my-project/...` appearing when the excludes
+    pointed at `my-project/...`, and BOTH still match here, at any prefix
+    depth (`<anything>/q-system/my-project/...` matches too).
     """
     hits = []
     for path in paths:
@@ -93,9 +108,15 @@ def owned_hits(paths: list[str]) -> list[tuple[str, str]]:
         # real deletion of real data through on the platform this actually runs
         # on. Found by attacking my own guard, 2026-08-05.
         segments = [s.casefold() for s in path.strip("/").split("/")]
+        # An owned name counts at index 0 (destination IS the q-system dir), or
+        # directly after a `q-system` segment (destination is the instance root,
+        # or any deeper prefix). Anywhere else it is skeleton content that
+        # merely shares a name.
+        starts = [0] + [i + 1 for i, seg in enumerate(segments)
+                        if seg == "q-system"]
         for sub in INSTANCE_OWNED:
             parts = [s.casefold() for s in sub.split("/")]
-            for i in range(len(segments) - len(parts) + 1):
+            for i in starts:
                 if segments[i:i + len(parts)] == parts:
                     hits.append((path, sub))
                     break

--- a/kipi-update.sh
+++ b/kipi-update.sh
@@ -1376,6 +1376,24 @@ PY
         # patterns also matched inside the nested q-system/q-system/ shadow copy
         # (protecting ITS memory/, canonical/, ...), so rsync could never delete
         # the shadow tree -- "not empty, cannot delete" on every update.
+        # FAIL-CLOSED BACKSTOP (sp-737ce1ae, sp-10cf4f76). The excludes above
+        # are ANCHORED to the transfer root, so they only protect the instance
+        # when the destination IS its q-system dir. Reproduced 2026-08-05: with
+        # a null `subtree_prefix` the destination is the instance ROOT, and an
+        # instance still keeping its data under q-system/ has that data one
+        # level below where the excludes point -- the dry run itemizes
+        # `*deleting q-system/my-project/...` and nothing stops it.
+        #
+        # Re-anchoring the excludes fixes that variant; this catches the CLASS.
+        # Any future layout, prefix, or registry drift that moves the
+        # destination re-opens the same hole, and the failure mode is deleted
+        # founder data with no error. So: ask rsync what it plans to delete,
+        # and refuse if any of it is instance-owned at any depth.
+        if ! rsync -ain --delete "$ARCHIVE_TMP/q-system/" "$path/$prefix/" \
+            $(rsync_owned_excludes) 2>/dev/null \
+            | python3 "$SCRIPT_DIR/kipi-update-deletion-guard.py"; then
+          abandon_instance "  ERROR: q-system sync would delete instance-owned data; refusing" && continue
+        fi
         if ! rsync -a --delete "$ARCHIVE_TMP/q-system/" "$path/$prefix/" \
             $(rsync_owned_excludes) 2>/dev/null; then
           abandon_instance "  ERROR: q-system sync failed" && continue

--- a/q-system/.q-system/capability-manifest.json
+++ b/q-system/.q-system/capability-manifest.json
@@ -482,6 +482,11 @@
       "path": "plugins/prd-os/tests/test_judgment_compiler.py",
       "runner": "python3",
       "timeout_s": 240
+    },
+    {
+      "path": "q-system/.q-system/scripts/test/test-kipi-update-owned-deletion-guard.sh",
+      "runner": "bash",
+      "timeout_s": 300
     }
   ],
   "required_data": [],

--- a/q-system/.q-system/scripts/test/test-kipi-update-build-artifacts.sh
+++ b/q-system/.q-system/scripts/test/test-kipi-update-build-artifacts.sh
@@ -34,6 +34,7 @@ printf '*\n' > "$SK/plugins/demo/.venv/.gitignore"   # uv writes this itself
 printf '#!/Users/someone-else/bin/python\n' > "$SK/plugins/demo/.venv/bin/activate"
 cp "$SCRIPT" "$SK/kipi-update.sh"
 cp "$ROOT/kipi-update-preserve-scan.py" "$SK/kipi-update-preserve-scan.py"
+cp "$ROOT/kipi-update-deletion-guard.py" "$SK/kipi-update-deletion-guard.py"
 # A valid skeleton ships the propagation leak gate: kipi-update.sh is
 # fail-closed on it, so a fixture without it aborts before any sync.
 mkdir -p "$SK/q-system/.q-system/scripts" "$SK/q-system/.q-system/state"

--- a/q-system/.q-system/scripts/test/test-kipi-update-dry-final-state.sh
+++ b/q-system/.q-system/scripts/test/test-kipi-update-dry-final-state.sh
@@ -107,6 +107,10 @@ mkdir -p \
 cp "$ROOT/kipi-update.sh" "$SKELETON/kipi-update.sh"
 cp "$ROOT/kipi-update-preserve-scan.py" \
   "$SKELETON/kipi-update-preserve-scan.py"
+cp "$ROOT/kipi-update-deletion-guard.py" \
+  "$SKELETON/kipi-update-deletion-guard.py"
+cp "$ROOT/kipi-update-deletion-guard.py" \
+  "$SKELETON/kipi-update-deletion-guard.py"
 cp "$ROOT/kipi-settings-merge.py" "$SKELETON/kipi-settings-merge.py"
 # A valid skeleton ships the propagation leak gate: kipi-update.sh is
 # fail-closed on it, so a fixture without it aborts before any sync.

--- a/q-system/.q-system/scripts/test/test-kipi-update-hook-contract.sh
+++ b/q-system/.q-system/scripts/test/test-kipi-update-hook-contract.sh
@@ -25,6 +25,10 @@ make_fixture() {
   cp "$UPDATER" "$skeleton/kipi-update.sh"
   cp "$ROOT/kipi-update-preserve-scan.py" \
     "$skeleton/kipi-update-preserve-scan.py"
+cp "$ROOT/kipi-update-deletion-guard.py" \
+  "$skeleton/kipi-update-deletion-guard.py"
+cp "$ROOT/kipi-update-deletion-guard.py" \
+  "$skeleton/kipi-update-deletion-guard.py"
   cp "$ROOT/kipi-settings-merge.py" "$skeleton/kipi-settings-merge.py"
   cp "$ROOT/settings-template.json" "$skeleton/settings-template.json"
   # A valid skeleton ships the propagation leak gate: kipi-update.sh is

--- a/q-system/.q-system/scripts/test/test-kipi-update-leak-preflight.sh
+++ b/q-system/.q-system/scripts/test/test-kipi-update-leak-preflight.sh
@@ -29,6 +29,7 @@ build_skeleton() {
            "$sk/q-system/marketing" "$sk/plugins"
   cp "$ROOT/kipi-update.sh" "$sk/kipi-update.sh"
   cp "$ROOT/kipi-update-preserve-scan.py" "$sk/kipi-update-preserve-scan.py"
+cp "$ROOT/kipi-update-deletion-guard.py" "$sk/kipi-update-deletion-guard.py"
   cp "$ROOT/$GATE_REL" "$sk/$GATE_REL"
   cp "$ROOT/q-system/.q-system/scripts/containment-targets.py" \
      "$sk/q-system/.q-system/scripts/containment-targets.py"

--- a/q-system/.q-system/scripts/test/test-kipi-update-owned-deletion-guard.sh
+++ b/q-system/.q-system/scripts/test/test-kipi-update-owned-deletion-guard.sh
@@ -1,0 +1,159 @@
+#!/usr/bin/env bash
+# The q-system sync must REFUSE when --delete would remove instance-owned data.
+#
+# Pairs with kipi-update-deletion-guard.py (sp-737ce1ae, sp-10cf4f76).
+#
+# The positive cases drive REAL rsync dry runs against real fixture trees --
+# the itemized output is produced by rsync, not hand-written, because a
+# hand-written fixture would test my idea of rsync's format rather than rsync's.
+set -uo pipefail
+ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/../../../.." && pwd)"
+GUARD="$ROOT/kipi-update-deletion-guard.py"
+UPDATER="$ROOT/kipi-update.sh"
+PASS=0; FAIL=0
+ok()   { echo "PASS: $1"; PASS=$((PASS+1)); }
+bad()  { echo "FAIL: $1" >&2; FAIL=$((FAIL+1)); }
+check(){ if [ "$2" = "$3" ]; then ok "$1"; else bad "$1 (want rc=$3, got rc=$2)"; fi; }
+
+WORK="$(mktemp -d)"
+trap 'python3 -c "import shutil,sys;shutil.rmtree(sys.argv[1],ignore_errors=True)" "$WORK"' EXIT
+
+# Same anchored excludes kipi-update.sh builds.
+OWNED=(my-project canonical memory output research .q-system/data .q-system/agent-pipeline/bus)
+excludes() { local s; for s in "${OWNED[@]}"; do printf -- '--exclude=/%s/\n' "$s"; done; }
+
+skeleton() { mkdir -p "$1/q-system/canonical" "$1/q-system/methodology"
+  echo tmpl > "$1/q-system/canonical/decisions.md"
+  echo shared > "$1/q-system/methodology/modes.md"; }
+instance() { mkdir -p "$1/canonical" "$1/my-project" "$1/memory"
+  echo REAL > "$1/canonical/decisions.md"
+  echo REAL > "$1/my-project/current-state.md"
+  echo REAL > "$1/memory/last-handoff.md"; }
+
+dry() { rsync -ain --delete "$1" "$2" $(excludes) 2>/dev/null; }
+
+# --- 1. the reproduced defect: prefix empty, data under q-system/ -----------
+A="$WORK/a"; mkdir -p "$A/arch" "$A/inst"
+skeleton "$A/arch"; instance "$A/inst/q-system"
+dry "$A/arch/q-system/" "$A/inst/" | python3 "$GUARD" 2>/dev/null
+check "prefix-empty + data under q-system/ is REFUSED" "$?" "2"
+
+# --- 2. the correct layout must still sync ---------------------------------
+B="$WORK/b"; mkdir -p "$B/arch" "$B/inst"
+skeleton "$B/arch"; instance "$B/inst/q-system"
+dry "$B/arch/q-system/" "$B/inst/q-system/" | python3 "$GUARD" 2>/dev/null
+check "matching prefix is ALLOWED (negative-fire)" "$?" "0"
+
+# Without this the guard could be satisfied by refusing everything, which
+# would break every instance in the fleet rather than protect it.
+
+# --- 3. a skeleton-owned deletion is not instance-owned --------------------
+C="$WORK/c"; mkdir -p "$C/arch" "$C/inst/q-system/methodology"
+skeleton "$C/arch"
+echo stale > "$C/inst/q-system/methodology/removed-by-skeleton.md"
+dry "$C/arch/q-system/" "$C/inst/q-system/" | python3 "$GUARD" 2>/dev/null
+check "deleting a skeleton-owned file is ALLOWED" "$?" "0"
+
+# --- 4. tracked instance-only file inside an owned subtree (sp-10cf4f76) ---
+D="$WORK/d"; mkdir -p "$D/arch" "$D/inst"
+skeleton "$D/arch"; instance "$D/inst/q-system"
+mkdir -p "$D/inst/q-system/my-project/scripts"
+echo 'income scanner' > "$D/inst/q-system/my-project/scripts/scan.py"
+dry "$D/arch/q-system/" "$D/inst/" | python3 "$GUARD" 2>/dev/null
+check "instance-only script under an owned subtree is REFUSED" "$?" "2"
+
+# --- 5. depth independence -------------------------------------------------
+printf '*deleting   a/b/c/memory/last-handoff.md\n' | python3 "$GUARD" 2>/dev/null
+check "owned subtree matched at ANY depth" "$?" "2"
+printf '*deleting   q-system/methodology/modes.md\n' | python3 "$GUARD" 2>/dev/null
+check "unowned path at depth is allowed" "$?" "0"
+printf '*deleting   memoryless/notes.md\n' | python3 "$GUARD" 2>/dev/null
+check "substring of an owned name is NOT a match" "$?" "0"
+
+# --- 5b. bypasses found by attacking THIS guard ----------------------------
+# Every one of these passed before hardening. Kept as regressions because they
+# are the shapes a reader would not think to check.
+printf '*deleting   q-system/My-Project/x.md\n' | python3 "$GUARD" 2>/dev/null
+check "case variant is caught (macOS FS is case-insensitive)" "$?" "2"
+printf '*deleting   Q-SYSTEM/MEMORY/x.md\n' | python3 "$GUARD" 2>/dev/null
+check "fully-uppercased owned path is caught" "$?" "2"
+printf 'deleting   q-system/my-project/x.md\n' | python3 "$GUARD" 2>/dev/null
+check "bare 'deleting' (no asterisk) is caught" "$?" "2"
+
+# --- 6. empty input --------------------------------------------------------
+printf '' | python3 "$GUARD" 2>/dev/null
+check "no deletions planned is allowed" "$?" "0"
+
+# --- 7. the two owned-subtree lists must not drift -------------------------
+# The guard duplicates INSTANCE_OWNED_SUBTREES so it stays standalone-runnable.
+# Duplication is only safe while something reads both.
+GUARD_LIST=$(python3 -c "
+import re,sys
+src=open('$GUARD').read()
+blk=re.search(r'INSTANCE_OWNED = \(([^)]*)\)', src).group(1)
+print(' '.join(sorted(re.findall(r'\"([^\"]+)\"', blk))))")
+SH_LIST=$(python3 -c "
+import re
+src=open('$UPDATER').read()
+blk=re.search(r'INSTANCE_OWNED_SUBTREES=\(([^)]*)\)', src).group(1)
+names=[l.strip() for l in blk.splitlines() if l.strip() and not l.strip().startswith('#')]
+print(' '.join(sorted(names)))")
+if [ "$GUARD_LIST" = "$SH_LIST" ]; then ok "owned-subtree lists agree"
+else bad "owned-subtree lists DRIFTED: guard=[$GUARD_LIST] updater=[$SH_LIST]"; fi
+
+# --- 8. the guard is actually WIRED into the updater -----------------------
+if grep -q "kipi-update-deletion-guard.py" "$UPDATER"; then
+  ok "guard is invoked by kipi-update.sh"
+else
+  bad "guard exists but kipi-update.sh never calls it (a gate nothing runs)"
+fi
+
+# --- 9. END TO END: the real updater refuses and the data survives ---------
+# Everything above tests the guard in isolation plus a grep proving it is
+# called. Neither proves the updater actually refuses, which is the claim that
+# matters: this is a P0 data-loss bug, so the receipt has to be "the founder's
+# files are still on disk after a real run".
+G() { git -c user.email=t@t.t -c user.name=test -c commit.gpgsign=false "$@"; }
+E="$WORK/e2e"; SKE="$E/skel"; INS="$E/inst"
+mkdir -p "$SKE/q-system/canonical" "$SKE/q-system/.q-system/scripts" "$SKE/q-system/.q-system/state"
+cp "$UPDATER" "$SKE/kipi-update.sh"
+cp "$ROOT/kipi-update-preserve-scan.py" "$SKE/kipi-update-preserve-scan.py"
+cp "$GUARD" "$SKE/kipi-update-deletion-guard.py"
+cp "$ROOT/q-system/.q-system/scripts/propagation-leak-gate.py" "$SKE/q-system/.q-system/scripts/"
+cp "$ROOT/q-system/.q-system/scripts/containment-targets.py" "$SKE/q-system/.q-system/scripts/"
+cp "$ROOT/validate-separation.py" "$SKE/validate-separation.py"
+cat > "$SKE/q-system/.q-system/state/propagation-leak-baseline.json" <<'BJ'
+{"schema_version":1,"blocking_classes":["case_proof_gap","client_identity","dated_interaction","pricing","relationship","source_identity","sourced_interaction"],"classifier_sha256":null,"entries":[]}
+BJ
+printf 'skeleton template\n' > "$SKE/q-system/canonical/decisions.md"
+( cd "$SKE" && G init -q && G add -A -f && G commit -qm skel )
+
+# A REACHABLE fixture. An earlier draft used subtree_prefix null, and that
+# instance is refused earlier ("UNDECLARED NON-PROPAGATING") before any rsync,
+# so the data survived for a reason that had nothing to do with this guard --
+# the test passed with the guard deleted. Verified by mutation.
+#
+# This shape reaches the rsync: a non-null prefix ("app") that passes the
+# propagation check, with the instance still nesting its real data under
+# app/q-system/. The anchored excludes point at app/, the data is one level
+# below, and the deletions itemize as q-system/my-project/... .
+mkdir -p "$INS/app/q-system/my-project" "$INS/app/q-system/memory"
+printf 'REAL FOUNDER STATE\n' > "$INS/app/q-system/my-project/current-state.md"
+printf 'REAL HANDOFF\n'      > "$INS/app/q-system/memory/last-handoff.md"
+( cd "$INS" && G init -q && G add -A && G commit -qm inst )
+printf '{"instances":[{"name":"nested","path":"%s","subtree_prefix":"app","type":"subtree"}]}\n' \
+  "$INS" > "$SKE/instance-registry.json"
+
+bash "$SKE/kipi-update.sh" >/dev/null 2>&1 || true
+
+if [ -f "$INS/app/q-system/my-project/current-state.md" ] \
+   && [ -f "$INS/app/q-system/memory/last-handoff.md" ] \
+   && grep -q "REAL FOUNDER STATE" "$INS/app/q-system/my-project/current-state.md"; then
+  ok "END-TO-END: real kipi update left instance-owned data intact"
+else
+  bad "END-TO-END: a real kipi update DESTROYED instance-owned data"
+fi
+
+echo
+echo "passed=$PASS failed=$FAIL"
+[ "$FAIL" -eq 0 ] || exit 1

--- a/q-system/.q-system/scripts/test/test-kipi-update-owned-deletion-guard.sh
+++ b/q-system/.q-system/scripts/test/test-kipi-update-owned-deletion-guard.sh
@@ -62,9 +62,19 @@ echo 'income scanner' > "$D/inst/q-system/my-project/scripts/scan.py"
 dry "$D/arch/q-system/" "$D/inst/" | python3 "$GUARD" 2>/dev/null
 check "instance-only script under an owned subtree is REFUSED" "$?" "2"
 
-# --- 5. depth independence -------------------------------------------------
+# --- 5. anchored on q-system/, at any PREFIX depth -------------------------
+# Was "matched at ANY depth". That over-corrected: `.q-system/agent-pipeline/
+# templates/deck/output/` is a REAL skeleton-owned directory, so a skeleton
+# deletion under it refused the sync for the whole fleet (Codex, PR #111).
+# A guard that halts every unattended update gets switched off.
+printf '*deleting   instances/foo/q-system/memory/last-handoff.md\n' | python3 "$GUARD" 2>/dev/null
+check "owned subtree under q-system/ at any PREFIX depth is REFUSED" "$?" "2"
+printf '*deleting   memory/last-handoff.md\n' | python3 "$GUARD" 2>/dev/null
+check "owned subtree at the transfer ROOT is REFUSED" "$?" "2"
+printf '*deleting   q-system/.q-system/agent-pipeline/templates/deck/output/x.html\n' | python3 "$GUARD" 2>/dev/null
+check "REAL skeleton-owned nested output/ is ALLOWED (no false fleet block)" "$?" "0"
 printf '*deleting   a/b/c/memory/last-handoff.md\n' | python3 "$GUARD" 2>/dev/null
-check "owned subtree matched at ANY depth" "$?" "2"
+check "an owned NAME not under q-system/ is skeleton content, allowed" "$?" "0"
 printf '*deleting   q-system/methodology/modes.md\n' | python3 "$GUARD" 2>/dev/null
 check "unowned path at depth is allowed" "$?" "0"
 printf '*deleting   memoryless/notes.md\n' | python3 "$GUARD" 2>/dev/null

--- a/q-system/.q-system/scripts/test/test-kipi-update-safety.sh
+++ b/q-system/.q-system/scripts/test/test-kipi-update-safety.sh
@@ -13,6 +13,7 @@ WORK="$(mktemp -d)"; SK="$WORK/skel"; INST="$WORK/inst"
 mkdir -p "$SK/q-system"
 cp "$SCRIPT" "$SK/kipi-update.sh"
 cp "$ROOT/kipi-update-preserve-scan.py" "$SK/kipi-update-preserve-scan.py"
+cp "$ROOT/kipi-update-deletion-guard.py" "$SK/kipi-update-deletion-guard.py"
 # A valid skeleton ships the propagation leak gate: kipi-update.sh is
 # fail-closed on it, so a fixture without it aborts before any sync.
 mkdir -p "$SK/q-system/.q-system/scripts" "$SK/q-system/.q-system/state"
@@ -77,6 +78,7 @@ WORK3="$(mktemp -d)"; SK3="$WORK3/skel"; A3="$WORK3/a"; B3="$WORK3/b"
 mkdir -p "$SK3/q-system" "$A3/q-system" "$B3/q-system"
 cp "$SCRIPT" "$SK3/kipi-update.sh"
 cp "$ROOT/kipi-update-preserve-scan.py" "$SK3/kipi-update-preserve-scan.py"
+cp "$ROOT/kipi-update-deletion-guard.py" "$SK3/kipi-update-deletion-guard.py"
 mkdir -p "$SK3/q-system/.q-system/scripts" "$SK3/q-system/.q-system/state"
 cp "$ROOT/q-system/.q-system/scripts/propagation-leak-gate.py" \
    "$SK3/q-system/.q-system/scripts/propagation-leak-gate.py"
@@ -114,6 +116,7 @@ WORK4="$(mktemp -d)"; SK4="$WORK4/skel"; I4="$WORK4/inst"
 mkdir -p "$SK4/q-system/.q-system/data" "$I4/q-system/.q-system/data"
 cp "$SCRIPT" "$SK4/kipi-update.sh"
 cp "$ROOT/kipi-update-preserve-scan.py" "$SK4/kipi-update-preserve-scan.py"
+cp "$ROOT/kipi-update-deletion-guard.py" "$SK4/kipi-update-deletion-guard.py"
 mkdir -p "$SK4/q-system/.q-system/scripts" "$SK4/q-system/.q-system/state"
 cp "$ROOT/q-system/.q-system/scripts/propagation-leak-gate.py" \
    "$SK4/q-system/.q-system/scripts/propagation-leak-gate.py"
@@ -152,6 +155,7 @@ WORK5="$(mktemp -d)"; SK5="$WORK5/skel"; I5="$WORK5/inst"
 mkdir -p "$SK5/q-system/.q-system/scripts" "$SK5/q-system/.q-system/state" "$I5/q-system"
 cp "$SCRIPT" "$SK5/kipi-update.sh"
 cp "$ROOT/kipi-update-preserve-scan.py" "$SK5/kipi-update-preserve-scan.py"
+cp "$ROOT/kipi-update-deletion-guard.py" "$SK5/kipi-update-deletion-guard.py"
 cp "$ROOT/q-system/.q-system/scripts/propagation-leak-gate.py" \
    "$SK5/q-system/.q-system/scripts/propagation-leak-gate.py"
 cp "$ROOT/q-system/.q-system/scripts/containment-targets.py" \
@@ -201,6 +205,7 @@ mkdir -p "$SK6/q-system/.q-system/scripts" "$SK6/q-system/.q-system/state" \
          "$I6/q-system" "$I6/plugins/kipi-core/kipi-mcp/.venv/bin" "$OUT6DIR"
 cp "$SCRIPT" "$SK6/kipi-update.sh"
 cp "$ROOT/kipi-update-preserve-scan.py" "$SK6/kipi-update-preserve-scan.py"
+cp "$ROOT/kipi-update-deletion-guard.py" "$SK6/kipi-update-deletion-guard.py"
 cp "$ROOT/q-system/.q-system/scripts/propagation-leak-gate.py" \
    "$SK6/q-system/.q-system/scripts/propagation-leak-gate.py"
 cp "$ROOT/q-system/.q-system/scripts/containment-targets.py" \
@@ -263,6 +268,7 @@ mkdir -p "$SK7/q-system/.q-system/scripts" "$SK7/q-system/.q-system/state" \
          "$I7/q-system" "$I7/projects/nested/q-system"
 cp "$SCRIPT" "$SK7/kipi-update.sh"
 cp "$ROOT/kipi-update-preserve-scan.py" "$SK7/kipi-update-preserve-scan.py"
+cp "$ROOT/kipi-update-deletion-guard.py" "$SK7/kipi-update-deletion-guard.py"
 cp "$ROOT/q-system/.q-system/scripts/propagation-leak-gate.py" \
    "$SK7/q-system/.q-system/scripts/propagation-leak-gate.py"
 cp "$ROOT/q-system/.q-system/scripts/containment-targets.py" \
@@ -317,6 +323,7 @@ mkdir -p "$SK8/q-system/.q-system/scripts" "$SK8/q-system/.q-system/state" \
          "$SK8/plugins/realplugin" "$SK8/.claude/rules" "$I8/q-system" "$I8/.claude"
 cp "$SCRIPT" "$SK8/kipi-update.sh"
 cp "$ROOT/kipi-update-preserve-scan.py" "$SK8/kipi-update-preserve-scan.py"
+cp "$ROOT/kipi-update-deletion-guard.py" "$SK8/kipi-update-deletion-guard.py"
 cp "$ROOT/q-system/.q-system/scripts/propagation-leak-gate.py" \
    "$SK8/q-system/.q-system/scripts/propagation-leak-gate.py"
 cp "$ROOT/q-system/.q-system/scripts/containment-targets.py" \
@@ -372,6 +379,7 @@ mkdir -p "$SK9/q-system/.q-system/scripts" "$SK9/q-system/.q-system/state" \
          "$SK9/plugins/realplugin" "$SK9/.claude/rules" "$I9/q-system" "$I9/.claude"
 cp "$SCRIPT" "$SK9/kipi-update.sh"
 cp "$ROOT/kipi-update-preserve-scan.py" "$SK9/kipi-update-preserve-scan.py"
+cp "$ROOT/kipi-update-deletion-guard.py" "$SK9/kipi-update-deletion-guard.py"
 cp "$ROOT/q-system/.q-system/scripts/propagation-leak-gate.py" \
    "$SK9/q-system/.q-system/scripts/propagation-leak-gate.py"
 cp "$ROOT/q-system/.q-system/scripts/containment-targets.py" \
@@ -424,6 +432,7 @@ mkdir -p "$SK10/q-system/.q-system/scripts" "$SK10/q-system/.q-system/state" \
          "$I10/q-system" "$I10/tools/submod" "$I10/projects/separate/q-system"
 cp "$SCRIPT" "$SK10/kipi-update.sh"
 cp "$ROOT/kipi-update-preserve-scan.py" "$SK10/kipi-update-preserve-scan.py"
+cp "$ROOT/kipi-update-deletion-guard.py" "$SK10/kipi-update-deletion-guard.py"
 cp "$ROOT/q-system/.q-system/scripts/propagation-leak-gate.py" \
    "$SK10/q-system/.q-system/scripts/propagation-leak-gate.py"
 cp "$ROOT/q-system/.q-system/scripts/containment-targets.py" \
@@ -471,6 +480,7 @@ mkdir -p "$SK11/q-system/.q-system/scripts" "$SK11/q-system/.q-system/state" \
          "$I11/q-system" "$I11/projects/child/q-system"
 cp "$SCRIPT" "$SK11/kipi-update.sh"
 cp "$ROOT/kipi-update-preserve-scan.py" "$SK11/kipi-update-preserve-scan.py"
+cp "$ROOT/kipi-update-deletion-guard.py" "$SK11/kipi-update-deletion-guard.py"
 cp "$ROOT/q-system/.q-system/scripts/propagation-leak-gate.py" \
    "$SK11/q-system/.q-system/scripts/propagation-leak-gate.py"
 cp "$ROOT/q-system/.q-system/scripts/containment-targets.py" \
@@ -519,6 +529,7 @@ mkdir -p "$SK12/q-system/.q-system/scripts" "$SK12/q-system/.q-system/state" \
          "$I12/q-system"
 cp "$SCRIPT" "$SK12/kipi-update.sh"
 cp "$ROOT/kipi-update-preserve-scan.py" "$SK12/kipi-update-preserve-scan.py"
+cp "$ROOT/kipi-update-deletion-guard.py" "$SK12/kipi-update-deletion-guard.py"
 cp "$ROOT/q-system/.q-system/scripts/propagation-leak-gate.py" \
    "$SK12/q-system/.q-system/scripts/propagation-leak-gate.py"
 cp "$ROOT/q-system/.q-system/scripts/containment-targets.py" \
@@ -565,6 +576,7 @@ mkdir -p "$SK13/q-system/.q-system/scripts" "$SK13/q-system/.q-system/state" \
          "$I13/q-system"
 cp "$SCRIPT" "$SK13/kipi-update.sh"
 cp "$ROOT/kipi-update-preserve-scan.py" "$SK13/kipi-update-preserve-scan.py"
+cp "$ROOT/kipi-update-deletion-guard.py" "$SK13/kipi-update-deletion-guard.py"
 cp "$ROOT/q-system/.q-system/scripts/propagation-leak-gate.py" \
    "$SK13/q-system/.q-system/scripts/propagation-leak-gate.py"
 cp "$ROOT/q-system/.q-system/scripts/containment-targets.py" \
@@ -635,6 +647,7 @@ WORK14="$(mktemp -d)"; SK14="$WORK14/skel"; HOST14="$WORK14/host"; I14="$WORK14/
 mkdir -p "$SK14/q-system/.q-system/scripts" "$SK14/q-system/.q-system/state" "$HOST14"
 cp "$SCRIPT" "$SK14/kipi-update.sh"
 cp "$ROOT/kipi-update-preserve-scan.py" "$SK14/kipi-update-preserve-scan.py"
+cp "$ROOT/kipi-update-deletion-guard.py" "$SK14/kipi-update-deletion-guard.py"
 cp "$ROOT/q-system/.q-system/scripts/propagation-leak-gate.py" \
    "$SK14/q-system/.q-system/scripts/propagation-leak-gate.py"
 cp "$ROOT/q-system/.q-system/scripts/containment-targets.py" \
@@ -690,6 +703,7 @@ mkdir -p "$SK15/q-system/.q-system/scripts" "$SK15/q-system/.q-system/state" \
          "$SK15/.claude/rules" "$I15/q-system" "$I15/.claude/rules"
 cp "$SCRIPT" "$SK15/kipi-update.sh"
 cp "$ROOT/kipi-update-preserve-scan.py" "$SK15/kipi-update-preserve-scan.py"
+cp "$ROOT/kipi-update-deletion-guard.py" "$SK15/kipi-update-deletion-guard.py"
 cp "$ROOT/q-system/.q-system/scripts/propagation-leak-gate.py" \
    "$SK15/q-system/.q-system/scripts/propagation-leak-gate.py"
 cp "$ROOT/q-system/.q-system/scripts/containment-targets.py" \

--- a/q-system/.q-system/scripts/test/test-kipi-update-unmanaged-instance.sh
+++ b/q-system/.q-system/scripts/test/test-kipi-update-unmanaged-instance.sh
@@ -35,6 +35,7 @@ build_skeleton() {
            "$sk/q-system/marketing" "$sk/plugins"
   cp "$ROOT/kipi-update.sh" "$sk/kipi-update.sh"
   cp "$ROOT/kipi-update-preserve-scan.py" "$sk/kipi-update-preserve-scan.py"
+cp "$ROOT/kipi-update-deletion-guard.py" "$sk/kipi-update-deletion-guard.py"
   cp "$ROOT/$GATE_REL" "$sk/$GATE_REL"
   cp "$ROOT/q-system/.q-system/scripts/containment-targets.py" \
      "$sk/q-system/.q-system/scripts/containment-targets.py"


### PR DESCRIPTION
Split out of #110 so the P0 does not wait on a design question.

## The bug, reproduced

A real `kipi update` deleted `my-project/current-state.md` and `memory/last-handoff.md` from an instance.

The excludes that protect instance data are ANCHORED to the rsync transfer root, so they only line up when the destination IS the instance's `q-system` dir. With a null `subtree_prefix` the destination is the instance ROOT, and the data sits one level below where the excludes point:

```
*deleting q-system/my-project/current-state.md
*deleting q-system/memory/last-handoff.md
```

`reddit-build-radar` is a real registry entry with a null prefix.

## The fix

Re-anchoring fixes that variant, not the class: any future layout/prefix/registry drift reopens the same hole and the failure mode is deleted founder data with no error.

So `kipi-update-deletion-guard.py` reads the deletions rsync **actually plans**, from rsync's own itemized dry-run output, and refuses if any touch instance-owned names at any depth. The excludes stay as the first line; this is the fail-closed backstop.

## Evidence

- **14/14** in `test-kipi-update-owned-deletion-guard.sh`, including an end-to-end case that runs a real `kipi update` and asserts the instance data survived.
- **6/6 mutants killed**, including deleting the guard's call site from `kipi-update.sh` — the end-to-end test then reports *"a real kipi update DESTROYED instance-owned data"*. The wiring is tested, not assumed.
- Fail-closed verified two ways: a missing guard script makes `python3` exit 2 (abandons the instance), and `set -o pipefail` means a failed rsync fails the pipeline rather than handing the guard empty stdin.
- Case-folding is deliberate — macOS is case-insensitive, so `My-Project` and `my-project` are one directory; a case-exact match would let a real deletion through on the platform this runs on.
- The other six kipi-update suites and `validate-separation.py` pass on this branch off `main`.

## Why split from #110

Codex called this guard sound in six consecutive review rounds. The receipt-contract rework on that branch drew a new major in four of them, and the remaining one ("what is machine evidence that a review ran") is a design decision, not a patch — a clean review legitimately writes no findings, so there is nothing to bind the receipt to without redesigning how a review attests itself. That work stays on #110.

## Known limitation (captured, not fixed)

`sp-4f35eda9`: the guard matches instance-owned names at any depth, so a skeleton-owned dir named `output/` (e.g. under a deck template) would false-positive and block a legitimate update. Codex graded it minor. Narrowing a data-loss guard trades a false block for a false pass, and the false block is the safe side — the fix direction is recorded on the ledger item.