### PR TITLE
grep -c ... || echo 0 is not a zero-safe count (ASK-402)

### DIFF
--- a/plugins/prd-os/.claude-plugin/plugin.json
+++ b/plugins/prd-os/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "prd-os",
-  "version": "0.22.0",
+  "version": "0.23.0",
   "description": "PRD operating system: capture rough ideas, draft reviewable PRDs, run standard and adversarial review (Codex or a Claude senior-staff-engineer subagent, recorded truthfully), triage findings, decompose approved PRDs into atomic issue specs, and execute those issues with scope enforcement, stop-gate receipts, and reviewer-attributed findings.",
   "author": {
     "name": "Assaf Kipnis"

--- a/plugins/prd-os/.claude-plugin/plugin.json
+++ b/plugins/prd-os/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "prd-os",
-  "version": "0.25.0",
+  "version": "0.25.1",
   "description": "PRD operating system: capture rough ideas, draft reviewable PRDs, run standard and adversarial review (Codex or a Claude senior-staff-engineer subagent, recorded truthfully), triage findings, decompose approved PRDs into atomic issue specs, and execute those issues with scope enforcement, stop-gate receipts, and reviewer-attributed findings.",
   "author": {
     "name": "Assaf Kipnis"

--- a/plugins/prd-os/.claude-plugin/plugin.json
+++ b/plugins/prd-os/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "prd-os",
-  "version": "0.24.0",
+  "version": "0.25.0",
   "description": "PRD operating system: capture rough ideas, draft reviewable PRDs, run standard and adversarial review (Codex or a Claude senior-staff-engineer subagent, recorded truthfully), triage findings, decompose approved PRDs into atomic issue specs, and execute those issues with scope enforcement, stop-gate receipts, and reviewer-attributed findings.",
   "author": {
     "name": "Assaf Kipnis"

--- a/plugins/prd-os/.claude-plugin/plugin.json
+++ b/plugins/prd-os/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "prd-os",
-  "version": "0.23.0",
+  "version": "0.24.0",
   "description": "PRD operating system: capture rough ideas, draft reviewable PRDs, run standard and adversarial review (Codex or a Claude senior-staff-engineer subagent, recorded truthfully), triage findings, decompose approved PRDs into atomic issue specs, and execute those issues with scope enforcement, stop-gate receipts, and reviewer-attributed findings.",
   "author": {
     "name": "Assaf Kipnis"

--- a/plugins/prd-os/scripts/prd_runner.py
+++ b/plugins/prd-os/scripts/prd_runner.py
@@ -1423,6 +1423,49 @@ def cmd_spillover(cfg: Config, args) -> int:
         })
         print(json.dumps({"id": sid, "status": "open"}))
         return 0
+    if sub == "reclassify":
+        # Correct a severity through a NEW EVENT, never a mutation. Approved
+        # PRD prd-spillover-current-state-2026-07-24: "correct severity through
+        # new events only", "preserve append-only history"; editing a prior
+        # event is an explicit non-goal there.
+        #
+        # This verb did not exist, and its absence was the real blocker on the
+        # backlog: 549 of 559 open items sit at the `minor` DEFAULT (untriaged,
+        # not assessed), `gates run` blocks only on blocker/major/high, and
+        # nothing could raise or lower an item once written.
+        severity = (args.severity or "").strip().lower()
+        if severity not in SPILLOVER_KNOWN_SEVERITIES:
+            sys.stderr.write(
+                f"--severity must be one of {SPILLOVER_KNOWN_SEVERITIES}; "
+                f"got {args.severity!r}. The standing gate reads this field, so "
+                "an unknown value would silently stop blocking.\n")
+            return 2
+        if not (args.reason or "").strip():
+            sys.stderr.write(
+                "--reason is required: a severity change with no stated reason "
+                "is the hand-clear this ledger refuses everywhere else.\n")
+            return 2
+        items = _read_spillover(cfg)
+        current = items.get(args.id)
+        if current is None:
+            sys.stderr.write(
+                f"unknown spillover id: {args.id!r}. Reclassify never creates an "
+                "item -- a typo must not invent open work.\n")
+            return 2
+        # Carry the whole prior record forward and move ONE field, so a
+        # reclassify can never drop the description or resolve by side effect.
+        new_rec = dict(current)
+        prior = current.get("severity")
+        new_rec.update({
+            "severity": severity,
+            "reclassified_at": _now_iso(),
+            "reclassified_from": prior,
+            "reclassify_reason": args.reason,
+        })
+        _spillover_append(cfg, new_rec)
+        print(json.dumps({"id": args.id, "severity": severity,
+                          "was": prior, "status": new_rec.get("status")}))
+        return 0
     if sub == "list":
         items = list(_read_spillover(cfg).values())
         if args.open_only:
@@ -1662,6 +1705,13 @@ def main(argv: list[str] | None = None) -> int:
     sp_list = spill_sub.add_parser("list")
     sp_list.add_argument("--open", dest="open_only", action="store_true", help="only open items")
     sp_list.add_argument("--json", dest="as_json", action="store_true")
+    sp_recl = spill_sub.add_parser(
+        "reclassify", help="correct an item's severity via a new append-only event")
+    sp_recl.add_argument("id")
+    sp_recl.add_argument("--severity", required=True)
+    sp_recl.add_argument("--reason", required=True,
+                         help="why the severity is wrong; recorded on the event")
+
     spill_sub.add_parser("check")
     spill_sub.add_parser("triage", help="read-only: open items grouped by severity and by source")
     sp_res = spill_sub.add_parser("resolve")

--- a/plugins/prd-os/scripts/prd_runner.py
+++ b/plugins/prd-os/scripts/prd_runner.py
@@ -1280,16 +1280,41 @@ def _spillover_lock(cfg: Config):
 
     A sibling .lock file rather than the ledger itself: flock on the ledger
     would be released by any unrelated reader closing its own handle.
+
+    DEGRADES, NEVER REFUSES. Taking the lock needs to CREATE a file, so it
+    needs write permission on the DIRECTORY -- while appending to the existing
+    ledger only needs it on the FILE. A read-only `.prd-os` therefore turned a
+    working `resolve` into a PermissionError traceback the moment this lock was
+    added, and read-only sandboxes are real here (every Codex round this
+    session reported one).
+
+    So a lock we cannot take degrades to the unlocked behaviour that shipped
+    for months, loudly, rather than becoming a new hard failure. The race it
+    protects against costs a FALSE RED gate, which is recoverable; refusing to
+    resolve at all is not. Same rule the review gate uses when Codex is down:
+    degrade and say so out loud.
     """
     path = _spillover_path(cfg)
-    path.parent.mkdir(parents=True, exist_ok=True)
     lock_path = path.with_name(path.name + ".lock")
-    with lock_path.open("w") as fh:
+    fh = None
+    try:
+        path.parent.mkdir(parents=True, exist_ok=True)
+        fh = lock_path.open("w")
         fcntl.flock(fh.fileno(), fcntl.LOCK_EX)
-        try:
-            yield
-        finally:
-            fcntl.flock(fh.fileno(), fcntl.LOCK_UN)
+    except OSError as exc:
+        if fh is not None:
+            fh.close()
+        sys.stderr.write(
+            f"WARNING: could not lock the spillover ledger ({exc}); proceeding "
+            "UNLOCKED.\nA concurrent resolve/reclassify could resurrect a "
+            "resolved item into the standing gate.\n")
+        yield
+        return
+    try:
+        yield
+    finally:
+        fcntl.flock(fh.fileno(), fcntl.LOCK_UN)
+        fh.close()
 
 
 def _spillover_append(cfg: Config, record: dict) -> None:

--- a/plugins/prd-os/scripts/prd_runner.py
+++ b/plugins/prd-os/scripts/prd_runner.py
@@ -38,6 +38,8 @@ layer in step 6 where both runners are orchestrated.
 from __future__ import annotations
 
 import argparse
+import contextlib
+import fcntl
 import json
 import os
 import re
@@ -1260,6 +1262,36 @@ def _spillover_open(cfg: Config) -> list:
     return [r for r in _read_spillover(cfg).values() if r.get("status") == "open"]
 
 
+@contextlib.contextmanager
+def _spillover_lock(cfg: Config):
+    """Serialize read-modify-append on the ledger across PROCESSES.
+
+    `resolve` and `reclassify` both read a record, copy it, and append the
+    copy, while `_read_spillover` is last-write-wins on the WHOLE record. So
+    two concurrent runs interleave as: reclassify reads (status=open), resolve
+    appends (status=resolved), reclassify appends its stale copy (status=open)
+    -- and the resolved item is RESURRECTED into the standing gate. Codex found
+    it on PR #112 with an executed reproducer.
+
+    This is the single-writer chokepoint rule applied where it was skipped: two
+    writers to one file is a corruption waiting for a race. The lock spans the
+    READ as well as the write, because a lock around the append alone still
+    lets the stale copy be formed.
+
+    A sibling .lock file rather than the ledger itself: flock on the ledger
+    would be released by any unrelated reader closing its own handle.
+    """
+    path = _spillover_path(cfg)
+    path.parent.mkdir(parents=True, exist_ok=True)
+    lock_path = path.with_name(path.name + ".lock")
+    with lock_path.open("w") as fh:
+        fcntl.flock(fh.fileno(), fcntl.LOCK_EX)
+        try:
+            yield
+        finally:
+            fcntl.flock(fh.fileno(), fcntl.LOCK_UN)
+
+
 def _spillover_append(cfg: Config, record: dict) -> None:
     path = _spillover_path(cfg)
     path.parent.mkdir(parents=True, exist_ok=True)
@@ -1419,8 +1451,13 @@ def _print_reclassifications(items: list) -> None:
     gate's reported bucket -- but the ACT of demoting it is the thing an
     operator needs to see, because that is what moved the gate.
     """
-    rank = {s: i for i, s in enumerate(
-        SPILLOVER_NONBLOCKING_SEVERITIES + SPILLOVER_BLOCKING_SEVERITIES)}
+    # EXPLICIT order. The first version built this by concatenating
+    # NONBLOCKING + BLOCKING, which assumed those tuples were ordered by
+    # severity. They are not -- `blocker` sits at index 0 of its tuple and
+    # `high` at 2 -- so `blocker -> high` reported as a RAISE and
+    # `low -> minor` as a gate-affecting downgrade (Codex, PR #112, minor).
+    # A membership set is not a scale; reusing one as a scale is the bug.
+    rank = {s: i for i, s in enumerate(SPILLOVER_SEVERITY_ORDER)}
     changed = [r for r in items if r.get("reclassified_from")]
     if not changed:
         return
@@ -1484,24 +1521,27 @@ def cmd_spillover(cfg: Config, args) -> int:
                 "--reason is required: a severity change with no stated reason "
                 "is the hand-clear this ledger refuses everywhere else.\n")
             return 2
-        items = _read_spillover(cfg)
-        current = items.get(args.id)
-        if current is None:
-            sys.stderr.write(
-                f"unknown spillover id: {args.id!r}. Reclassify never creates an "
-                "item -- a typo must not invent open work.\n")
-            return 2
-        # Carry the whole prior record forward and move ONE field, so a
-        # reclassify can never drop the description or resolve by side effect.
-        new_rec = dict(current)
-        prior = current.get("severity")
-        new_rec.update({
-            "severity": severity,
-            "reclassified_at": _now_iso(),
-            "reclassified_from": prior,
-            "reclassify_reason": args.reason,
-        })
-        _spillover_append(cfg, new_rec)
+        # READ AND APPEND UNDER ONE LOCK. Reading outside it lets a concurrent
+        # `resolve` land between the two and be overwritten by this stale copy.
+        with _spillover_lock(cfg):
+            items = _read_spillover(cfg)
+            current = items.get(args.id)
+            if current is None:
+                sys.stderr.write(
+                    f"unknown spillover id: {args.id!r}. Reclassify never creates an "
+                    "item -- a typo must not invent open work.\n")
+                return 2
+            # Carry the whole prior record forward and move ONE field, so a
+            # reclassify can never drop the description or resolve by side effect.
+            new_rec = dict(current)
+            prior = current.get("severity")
+            new_rec.update({
+                "severity": severity,
+                "reclassified_at": _now_iso(),
+                "reclassified_from": prior,
+                "reclassify_reason": args.reason,
+            })
+            _spillover_append(cfg, new_rec)
         print(json.dumps({"id": args.id, "severity": severity,
                           "was": prior, "status": new_rec.get("status")}))
         return 0
@@ -1543,33 +1583,40 @@ def cmd_spillover(cfg: Config, args) -> int:
         _print_reclassifications(openv)
         return 0
     if sub == "resolve":
-        rec = _read_spillover(cfg).get(args.id)
-        if not rec:
-            sys.stderr.write(f"unknown spillover id: {args.id}\n")
-            return 2
-        if not args.resolution_ref and not args.void:
-            sys.stderr.write("resolve requires --resolution-ref <issue-id> or --void <reason>\n")
-            return 2
-        new = dict(rec)
-        if args.void:
-            new.update(status="resolved", void_reason=args.void, resolved_at=_now_iso())
-        else:
-            try:
-                evidence = _verify_resolution_ref(cfg, args.resolution_ref)
-            except LinearRefError as exc:
-                sys.stderr.write(f"cannot resolve {args.id}: {exc}\n")
+        # Same chokepoint as reclassify. This read-modify-append was
+        # ALREADY unlocked before PR #112; reclassify only added a third
+        # writer to it. A `with` block, not a manual enter/exit: two of
+        # the refusal paths below return early and would leak the lock.
+        with _spillover_lock(cfg):
+            # Same chokepoint as reclassify: this read-modify-append was already
+            # unlocked before PR #112: reclassify only added a third writer to it.
+            rec = _read_spillover(cfg).get(args.id)
+            if not rec:
+                sys.stderr.write(f"unknown spillover id: {args.id}\n")
                 return 2
-            new.update(status="resolved", resolution_ref=args.resolution_ref,
-                       resolved_at=_now_iso(), **evidence)
-            if args.evidence:
-                # Operator-supplied context (PR, merge commit). Recorded for the
-                # next reader, never consulted above: it is a note attached to a
-                # verified resolution, not a substitute for verifying one.
-                new["resolution_evidence"] = args.evidence
-        _spillover_append(cfg, new)
-        print(json.dumps({"id": args.id, "status": "resolved"}))
-        return 0
-    sys.stderr.write(f"unknown spillover subcommand: {sub}\n")
+            if not args.resolution_ref and not args.void:
+                sys.stderr.write("resolve requires --resolution-ref <issue-id> or --void <reason>\n")
+                return 2
+            new = dict(rec)
+            if args.void:
+                new.update(status="resolved", void_reason=args.void, resolved_at=_now_iso())
+            else:
+                try:
+                    evidence = _verify_resolution_ref(cfg, args.resolution_ref)
+                except LinearRefError as exc:
+                    sys.stderr.write(f"cannot resolve {args.id}: {exc}\n")
+                    return 2
+                new.update(status="resolved", resolution_ref=args.resolution_ref,
+                           resolved_at=_now_iso(), **evidence)
+                if args.evidence:
+                    # Operator-supplied context (PR, merge commit). Recorded for the
+                    # next reader, never consulted above: it is a note attached to a
+                    # verified resolution, not a substitute for verifying one.
+                    new["resolution_evidence"] = args.evidence
+            _spillover_append(cfg, new)
+            print(json.dumps({"id": args.id, "status": "resolved"}))
+            return 0
+        sys.stderr.write(f"unknown spillover subcommand: {sub}\n")
     return 2
 
 
@@ -1594,6 +1641,10 @@ SPILLOVER_BLOCKING_SEVERITIES = ("blocker", "major", "high")
 # louder the label the quieter the gate got. Fail-closed here and validate at the
 # CLI: an unknown severity is a triage failure, never a silent pass (ASK-402).
 SPILLOVER_NONBLOCKING_SEVERITIES = ("minor", "low", "medium")
+# Least -> most severe. Separate from the membership tuples above ON PURPOSE:
+# those answer "does this block?", this answers "which way did it move?", and
+# conflating the two is how `blocker -> high` read as a raise.
+SPILLOVER_SEVERITY_ORDER = ("low", "minor", "medium", "high", "major", "blocker")
 SPILLOVER_KNOWN_SEVERITIES = (
     SPILLOVER_BLOCKING_SEVERITIES + SPILLOVER_NONBLOCKING_SEVERITIES)
 

--- a/plugins/prd-os/scripts/prd_runner.py
+++ b/plugins/prd-os/scripts/prd_runner.py
@@ -1405,6 +1405,45 @@ def _spillover_group_counts(items: list, field: str) -> list:
     return sorted(counts.items(), key=lambda pair: (-pair[1], pair[0]))
 
 
+def _print_reclassifications(items: list) -> None:
+    """Surface severity changes, and DOWNGRADES loudest.
+
+    `reclassify` writes `reclassified_from` / `reclassify_reason` and, until
+    this function existed, nothing anywhere read them. A sanctioned way to stop
+    the standing gate blocking, whose use no report ever shows, is not an
+    audited escape hatch -- it is an unaudited one with a paper trail nobody
+    opens. Same shape as the void hatch, same requirement: a writer needs a
+    reader (ASK-402, PR #112 review).
+
+    A downgraded item is NOT invisible -- it stays open and still counts in the
+    gate's reported bucket -- but the ACT of demoting it is the thing an
+    operator needs to see, because that is what moved the gate.
+    """
+    rank = {s: i for i, s in enumerate(
+        SPILLOVER_NONBLOCKING_SEVERITIES + SPILLOVER_BLOCKING_SEVERITIES)}
+    changed = [r for r in items if r.get("reclassified_from")]
+    if not changed:
+        return
+    lowered, raised = [], []
+    for r in changed:
+        before = rank.get((r.get("reclassified_from") or "").lower(), -1)
+        after = rank.get((r.get("severity") or "").lower(), -1)
+        (lowered if after < before else raised).append(r)
+
+    def show(group, label):
+        if not group:
+            return
+        print(f"\n{label} ({len(group)}):")
+        for r in group:
+            print(f"  {r['id']}: {r.get('reclassified_from')} -> "
+                  f"{r.get('severity')}  ({(r.get('reclassify_reason') or '')[:70]})")
+
+    # Lowered first and named as gate-affecting: that is the direction that
+    # stops the gate blocking, so it is the direction someone must review.
+    show(lowered, "severity LOWERED (these stopped blocking the gate)")
+    show(raised, "severity raised")
+
+
 def _print_spillover_groups(items: list, field: str, heading: str) -> None:
     print(f"\nby {heading} ({len(_spillover_group_counts(items, field))} group(s)):")
     for value, count in _spillover_group_counts(items, field):
@@ -1501,6 +1540,7 @@ def cmd_spillover(cfg: Config, args) -> int:
         print(f"{len(openv)} open spillover item(s)")
         _print_spillover_groups(openv, "severity", "severity")
         _print_spillover_groups(openv, "source", "source")
+        _print_reclassifications(openv)
         return 0
     if sub == "resolve":
         rec = _read_spillover(cfg).get(args.id)

--- a/plugins/prd-os/tests/test_spillover.py
+++ b/plugins/prd-os/tests/test_spillover.py
@@ -97,6 +97,17 @@ def test_check_red_while_open_green_when_none(repo):
     assert run(repo, "spillover", "check").returncode == 1  # open item = red
 
 
+def _ledger_lines(repo):
+    """Raw ledger lines, for asserting append-only behaviour.
+
+    A missing file is zero events, not an error: a refused command must leave
+    no ledger at all, and that is a state this helper has to be able to report.
+    """
+    path = repo / ".prd-os" / "spillover.jsonl"
+    if not path.is_file():
+        return []
+    return [l for l in path.read_text().splitlines() if l.strip()]
+
 def test_gates_run_red_while_a_blocking_severity_item_is_open(repo):
     # No registered gates at all, but an open BLOCKING-severity spillover item
     # must still make the STANDING re-proof fail. The can't-be-forgotten
@@ -488,3 +499,109 @@ def test_cli_refuses_an_unrecognized_severity_at_the_door():
         capture_output=True, text=True)
     assert proc.returncode != 0, "CLI accepted an unrecognized severity"
     assert "critical" in (proc.stderr + proc.stdout)
+
+
+# ---------------------------------------------------------------------------
+# reclassify: correct a severity through a NEW event, never a mutation
+# ---------------------------------------------------------------------------
+#
+# 549 of 559 open items sit at the `minor` DEFAULT, i.e. untriaged. `gates run`
+# now blocks only on blocker/major/high, so triaging that backlog is the work
+# that makes the gate mean something -- and there was no verb to do it with.
+# `add`, `list`, `check`, `triage` (read-only), `resolve`. Nothing could raise
+# an item.
+#
+# Shape per the approved PRD prd-spillover-current-state-2026-07-24: "correct
+# severity through new events only", "preserve append-only history", "editing
+# or deleting prior spillover events" is an explicit non-goal.
+
+def test_reclassify_raises_severity_and_blocks_the_gate(repo):
+    run(repo, "spillover", "add", "--source", "s", "--desc", "real bug", "--id", "sp1")
+    assert run(repo, "gates", "run").returncode == 0, "precondition: minor is not blocking"
+    r = run(repo, "spillover", "reclassify", "sp1", "--severity", "major",
+            "--reason", "deletes founder data on an empty-prefix instance")
+    assert r.returncode == 0, r.stderr
+    assert run(repo, "gates", "run").returncode != 0, (
+        "reclassify to major did not make the standing gate block"
+    )
+
+
+def test_reclassify_appends_and_never_rewrites_history(repo):
+    run(repo, "spillover", "add", "--source", "s", "--desc", "d", "--id", "sp1")
+    before = _ledger_lines(repo)
+    run(repo, "spillover", "reclassify", "sp1", "--severity", "high", "--reason", "why")
+    after = _ledger_lines(repo)
+    assert after[:len(before)] == before, "reclassify rewrote prior events"
+    assert len(after) == len(before) + 1, "reclassify did not append exactly one event"
+    assert json.loads(after[-1])["severity"] == "high"
+
+
+def test_reclassify_records_the_reason(repo):
+    """A severity change with no stated reason is the hand-clear this ledger
+    refuses everywhere else."""
+    run(repo, "spillover", "add", "--source", "s", "--desc", "d", "--id", "sp1")
+    bad = run(repo, "spillover", "reclassify", "sp1", "--severity", "major")
+    assert bad.returncode != 0, "reclassify accepted a severity change with no reason"
+    ok = run(repo, "spillover", "reclassify", "sp1", "--severity", "major",
+             "--reason", "it can delete data")
+    assert ok.returncode == 0
+    assert "it can delete data" in _ledger_lines(repo)[-1]
+
+
+def test_reclassify_refuses_an_unknown_severity(repo):
+    run(repo, "spillover", "add", "--source", "s", "--desc", "d", "--id", "sp1")
+    r = run(repo, "spillover", "reclassify", "sp1", "--severity", "urgent",
+            "--reason", "x")
+    assert r.returncode != 0, "unknown severity accepted; the gate reads this field"
+
+
+def test_reclassify_refuses_an_unknown_id(repo):
+    """Negative-fire: a typo must not silently create a new open item.
+
+    Asserts the MESSAGE, not just a nonzero exit. Mutation showed exit-code-only
+    could not tell a clean refusal from a TypeError crash -- dropping the guard
+    made `dict(None)` raise, which is also nonzero, so the test passed while the
+    behaviour was a stack trace."""
+    r = run(repo, "spillover", "reclassify", "sp-nope", "--severity", "major",
+            "--reason", "x")
+    assert r.returncode != 0, "reclassify invented an item that never existed"
+    assert "unknown spillover id" in r.stderr, (
+        f"refused, but not cleanly -- stderr was: {r.stderr!r}")
+    assert "Traceback" not in r.stderr, "refusal is a crash, not a decision"
+    assert not _ledger_lines(repo), "a refused reclassify still wrote an event"
+
+
+def test_reclassify_refuses_a_whitespace_only_reason(repo):
+    """argparse `required=True` already rejects a MISSING --reason, so the
+    in-code check is only reachable via whitespace. Mutation proved the earlier
+    test never exercised it: deleting the check left the suite green because
+    argparse fired first."""
+    run(repo, "spillover", "add", "--source", "s", "--desc", "d", "--id", "sp1")
+    r = run(repo, "spillover", "reclassify", "sp1", "--severity", "major",
+            "--reason", "   ")
+    assert r.returncode != 0, "a whitespace-only reason was accepted as a reason"
+    assert "--reason is required" in r.stderr
+
+
+def test_reclassify_preserves_status_and_description(repo):
+    """Only severity moves. A reclassify that drops the description would make
+    the ledger unreadable, and one that flips status would resolve by side
+    effect."""
+    run(repo, "spillover", "add", "--source", "s", "--desc", "the original text",
+        "--id", "sp1")
+    run(repo, "spillover", "reclassify", "sp1", "--severity", "major", "--reason", "r")
+    rec = json.loads(_ledger_lines(repo)[-1])
+    assert rec["description"] == "the original text"
+    assert rec["status"] == "open"
+    assert rec["source"] == "s"
+
+
+def test_reclassify_can_lower_severity_too(repo):
+    """Triage runs both ways: an over-flagged item must be demotable, or the
+    only safe move is to leave everything blocking."""
+    run(repo, "spillover", "add", "--source", "s", "--desc", "d", "--id", "sp1",
+        "--severity", "blocker")
+    assert run(repo, "gates", "run").returncode != 0
+    run(repo, "spillover", "reclassify", "sp1", "--severity", "minor",
+        "--reason", "reread it: cosmetic, no data path")
+    assert run(repo, "gates", "run").returncode == 0

--- a/plugins/prd-os/tests/test_spillover.py
+++ b/plugins/prd-os/tests/test_spillover.py
@@ -605,3 +605,78 @@ def test_reclassify_can_lower_severity_too(repo):
     run(repo, "spillover", "reclassify", "sp1", "--severity", "minor",
         "--reason", "reread it: cosmetic, no data path")
     assert run(repo, "gates", "run").returncode == 0
+
+
+# ---------------------------------------------------------------------------
+# Gaps found reviewing PR #112 (ASK-402).
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize("typed", ["MAJOR", "  Major  ", "MaJoR", "major\t"])
+def test_reclassify_normalizes_case_and_whitespace(repo, typed):
+    """The normalization was UNTESTED: replacing
+    `(args.severity or "").strip().lower()` with the raw value survived
+    mutation, because every existing case passed an already-canonical string.
+
+    It matters in both directions. Un-normalized, a user typing MAJOR is
+    refused with a confusing message; worse, the STORED value is what
+    `_is_blocking_severity` reads, so a variant that ever slipped past the
+    membership check would sit in the ledger looking severe and blocking
+    nothing.
+    """
+    run(repo, "spillover", "add", "--source", "s", "--desc", "d",
+        "--id", "sp-case", "--severity", "minor")
+    r = run(repo, "spillover", "reclassify", "sp-case",
+            "--severity", typed, "--reason", "case probe")
+    assert r.returncode == 0, r.stderr
+    rec = json.loads(_ledger_lines(repo)[-1])
+    assert rec["severity"] == "major", f"{typed!r} stored as {rec['severity']!r}"
+    # ...and the GATE must agree, not just the stored string.
+    assert run(repo, "gates", "run").returncode != 0, (
+        f"{typed!r} normalized in the record but did not block the gate"
+    )
+
+
+def test_reclassify_refuses_an_unknown_severity_cleanly(repo):
+    """The sibling refusals assert their message; this one asserted only a
+    non-zero exit, which is the shape that let two other guards pass while
+    the behaviour was a stack trace."""
+    run(repo, "spillover", "add", "--source", "s", "--desc", "d",
+        "--id", "sp-u", "--severity", "minor")
+    r = run(repo, "spillover", "reclassify", "sp-u",
+            "--severity", "critical", "--reason", "sounds urgent")
+    assert r.returncode != 0
+    assert "--severity must be one of" in r.stderr, r.stderr
+    assert "Traceback" not in r.stderr, "refusal is a crash, not a decision"
+
+
+def test_triage_surfaces_a_downgrade(repo):
+    """A writer with no reader is not an audited escape hatch.
+
+    `reclassified_from` and `reclassify_reason` were written and read by
+    nothing, so the one action that can stop the standing gate blocking
+    appeared in no report.
+    """
+    run(repo, "spillover", "add", "--source", "s", "--desc", "d",
+        "--id", "sp-down", "--severity", "blocker")
+    assert run(repo, "gates", "run").returncode != 0, "precondition: it blocks"
+    run(repo, "spillover", "reclassify", "sp-down", "--severity", "minor",
+        "--reason", "reviewed, it is cosmetic")
+    assert run(repo, "gates", "run").returncode == 0, "precondition: now green"
+
+    out = run(repo, "spillover", "triage").stdout
+    assert "LOWERED" in out, f"triage hides the downgrade that moved the gate:\n{out}"
+    assert "sp-down" in out
+    assert "blocker -> minor" in out
+    assert "cosmetic" in out, "the stated reason is not surfaced with the change"
+
+
+def test_triage_does_not_cry_downgrade_over_a_raise(repo):
+    """The negative half. Without it, labelling every change LOWERED passes."""
+    run(repo, "spillover", "add", "--source", "s", "--desc", "d",
+        "--id", "sp-up", "--severity", "minor")
+    run(repo, "spillover", "reclassify", "sp-up", "--severity", "major",
+        "--reason", "it is worse than filed")
+    out = run(repo, "spillover", "triage").stdout
+    assert "severity raised" in out, out
+    assert "LOWERED" not in out, f"a raise was reported as a downgrade:\n{out}"

--- a/plugins/prd-os/tests/test_spillover.py
+++ b/plugins/prd-os/tests/test_spillover.py
@@ -747,3 +747,30 @@ def test_every_known_severity_has_a_rank(repo):
     missing = [s for s in m.SPILLOVER_KNOWN_SEVERITIES
                if s not in m.SPILLOVER_SEVERITY_ORDER]
     assert not missing, f"known severities absent from the rank order: {missing}"
+
+
+def test_ledger_lock_degrades_when_it_cannot_be_taken(repo):
+    """A lock that cannot be TAKEN must not become a new hard failure.
+
+    Taking it CREATES a file, so it needs write permission on the DIRECTORY,
+    while appending to the existing ledger only needs it on the FILE. Adding
+    the lock therefore turned a working `resolve` into a PermissionError
+    traceback under a read-only `.prd-os` -- and read-only sandboxes are real
+    here. The race it protects against costs a false RED gate, which is
+    recoverable; refusing to resolve at all is not.
+    """
+    run(repo, "spillover", "add", "--source", "s", "--desc", "d",
+        "--id", "sp-ro", "--severity", "minor")
+    d = Path(repo) / ".prd-os"
+    mode = d.stat().st_mode
+    d.chmod(0o555)
+    try:
+        r = run(repo, "spillover", "resolve", "sp-ro", "--void", "read-only probe")
+    finally:
+        d.chmod(mode)
+    assert "Traceback" not in r.stderr, f"the lock crashed instead of degrading:\n{r.stderr}"
+    assert r.returncode == 0, f"a read-only ledger dir broke resolve: {r.stderr}"
+    assert "could not lock" in r.stderr, (
+        "it degraded SILENTLY -- an unlocked write with no warning is the "
+        "failure mode nobody notices")
+    assert json.loads(_ledger_lines(repo)[-1])["status"] == "resolved"

--- a/plugins/prd-os/tests/test_spillover.py
+++ b/plugins/prd-os/tests/test_spillover.py
@@ -680,3 +680,70 @@ def test_triage_does_not_cry_downgrade_over_a_raise(repo):
     out = run(repo, "spillover", "triage").stdout
     assert "severity raised" in out, out
     assert "LOWERED" not in out, f"a raise was reported as a downgrade:\n{out}"
+
+
+def test_concurrent_resolve_and_reclassify_cannot_resurrect(repo):
+    """Codex, PR #112, with an executed repro.
+
+    `resolve` and `reclassify` both read a record, copy it, and append the
+    copy, and `_read_spillover` is last-write-wins on the WHOLE record. The
+    interleaving is: reclassify reads (status=open), resolve appends
+    (status=resolved), reclassify appends its STALE copy (status=open) -- and
+    a resolved item is back in the standing gate.
+
+    Stress rather than a staged interleave: the race is between two OS
+    processes, so there is no seam to patch. 25 rounds reproduces it reliably
+    without the lock; the loop is the reproducer.
+    """
+    import concurrent.futures as cf
+    resurrected = []
+    for n in range(25):
+        sid = f"sp-race{n}"
+        run(repo, "spillover", "add", "--source", "s", "--desc", "d",
+            "--id", sid, "--severity", "minor")
+        with cf.ThreadPoolExecutor(max_workers=2) as ex:
+            a = ex.submit(run, repo, "spillover", "resolve", sid, "--void", "not real")
+            b = ex.submit(run, repo, "spillover", "reclassify", sid,
+                          "--severity", "blocker", "--reason", "raising it")
+            a.result(); b.result()
+        rec = json.loads([l for l in _ledger_lines(repo)
+                          if json.loads(l).get("id") == sid][-1])
+        if rec.get("status") == "open":
+            resurrected.append((sid, rec.get("severity")))
+    assert not resurrected, (
+        f"{len(resurrected)}/25 resolved items were resurrected into the gate "
+        f"by a concurrent reclassify: {resurrected[:5]}")
+
+
+@pytest.mark.parametrize("before,after,expect", [
+    ("blocker", "high", "LOWERED"),      # blocker is MORE severe than high
+    ("high", "blocker", "severity raised"),
+    ("major", "minor", "LOWERED"),
+    ("minor", "major", "severity raised"),
+])
+def test_triage_labels_the_direction_correctly(repo, before, after, expect):
+    """The first rank was built by concatenating the two MEMBERSHIP tuples,
+    which are not ordered by severity: `blocker` is index 0 of its tuple and
+    `high` index 2, so `blocker -> high` reported as a RAISE (Codex, minor).
+    A membership set is not a scale."""
+    run(repo, "spillover", "add", "--source", "s", "--desc", "d",
+        "--id", "sp-dir", "--severity", before)
+    run(repo, "spillover", "reclassify", "sp-dir", "--severity", after,
+        "--reason", "direction probe")
+    out = run(repo, "spillover", "triage").stdout
+    assert expect in out, f"{before} -> {after} not reported as {expect}:\n{out}"
+    if expect == "severity raised":
+        assert "LOWERED" not in out, f"{before} -> {after} called a downgrade:\n{out}"
+
+
+def test_every_known_severity_has_a_rank(repo):
+    """A severity missing from the order defaults to -1 and silently reads as
+    the least severe thing there is."""
+    import importlib.util
+    from pathlib import Path as _P
+    spec = importlib.util.spec_from_file_location(
+        "pr_rank", _P(__file__).resolve().parents[1] / "scripts/prd_runner.py")
+    m = importlib.util.module_from_spec(spec); spec.loader.exec_module(m)
+    missing = [s for s in m.SPILLOVER_KNOWN_SEVERITIES
+               if s not in m.SPILLOVER_SEVERITY_ORDER]
+    assert not missing, f"known severities absent from the rank order: {missing}"

--- a/q-system/.q-system/capability-manifest.json
+++ b/q-system/.q-system/capability-manifest.json
@@ -507,6 +507,11 @@
       "path": "plugins/prd-os/skills/fable-discipline/scripts/test_fable_discipline_lint.py",
       "runner": "python3",
       "timeout_s": 120
+    },
+    {
+      "path": "q-system/.q-system/scripts/test/test-zero-safe-count-idiom.sh",
+      "runner": "bash",
+      "timeout_s": 60
     }
   ],
   "required_data": [],

--- a/q-system/.q-system/scripts/test/test-linear-worker-parallel.sh
+++ b/q-system/.q-system/scripts/test/test-linear-worker-parallel.sh
@@ -128,7 +128,12 @@ run_worker() {
   echo "$?" > "$WORK/$label.rc"
 }
 
-worked_count() { grep -c . "$WORK/worked.txt" 2>/dev/null || echo 0; }
+# `grep -c` prints 0 AND exits 1 on a zero count, so a bare `|| echo 0`
+# APPENDED a second 0 and the value became "0\n0": that breaks `-eq` with
+# "integer expression expected" and makes a legitimate `= "0"` assertion
+# fail on correct behaviour. `| head -1` keeps whichever 0 arrived first.
+# Missing file: grep prints nothing and the fallback supplies the only 0.
+worked_count() { { grep -c . "$WORK/worked.txt" 2>/dev/null || echo 0; } | head -1; }
 
 # --- 1. TWO DIFFERENT ISSUES, CONCURRENTLY: both must reach the work phase ---
 # A is held inside its work phase while B runs start-to-finish, so this is the

--- a/q-system/.q-system/scripts/test/test-review-tree-guard.sh
+++ b/q-system/.q-system/scripts/test/test-review-tree-guard.sh
@@ -341,7 +341,7 @@ PYEOF
 SYNC_LOG="$W/sync-calls.log"; : > "$SYNC_LOG"
 SYNC_CALL_LOG="$SYNC_LOG" run_case postone "$REAL_HEAD" --post --issue ASK-901
 
-CALLS="$(grep -c . "$SYNC_LOG" 2>/dev/null || echo 0)"
+CALLS="$({ grep -c . "$SYNC_LOG" 2>/dev/null || echo 0; } | head -1)"
 [ "$CALLS" -eq 1 ] \
   || fail "THE DEFECT: the success path made $CALLS calls to linear-sync.py, not 1. Each one is a
       PERMANENT comment on the issue. Calls were:

--- a/q-system/.q-system/scripts/test/test-severity-floor.sh
+++ b/q-system/.q-system/scripts/test/test-severity-floor.sh
@@ -492,7 +492,7 @@ grep -q "conflict round(s) -- a human resolves this one" "$W2/cap1.out" \
       not at gate 20 (unreviewed). The worker said: $(grep -i skip "$W2/cap1.out" | head -1)"
 ok "it stopped at the conflict cap, not as unreviewed"
 
-PAGES="$(grep -c . "$W2/pages.txt" 2>/dev/null || echo 0)"
+PAGES="$({ grep -c . "$W2/pages.txt" 2>/dev/null || echo 0; } | head -1)"
 [ "$PAGES" = "1" ] \
   || fail "expected EXACTLY 1 page across 2 runs at the cap, got $PAGES: $(cat "$W2/pages.txt")"
 grep -q "needs a human" "$W2/pages.txt" || fail "the page does not say a human is needed"
@@ -1594,7 +1594,7 @@ grep -q "drift round(s) -- a human resolves this one" "$W2/p3-5.out" \
       gate 10 or gate 20. It said: $(grep -i skip "$W2/p3-5.out" | head -1)"
 ok "it stopped at the drift cap, not as approved or unreviewed"
 
-PAGES="$(grep -c . "$W2/pages.txt" 2>/dev/null || echo 0)"
+PAGES="$({ grep -c . "$W2/pages.txt" 2>/dev/null || echo 0; } | head -1)"
 [ "$PAGES" = "1" ] \
   || fail "expected EXACTLY 1 founder page across 5 runs at the drift cap, got $PAGES. Zero means
       unreviewed code sits at the head of an approved PR with nobody told; more than one is the
@@ -1789,7 +1789,7 @@ ok "an unreadable head does not refill the drift budget"
       the round-2 major this budget was added to fix, wearing a gh hiccup as a coat."
 ok "the drift cap holds across runs whose head could not be read"
 
-P8_PAGES="$(grep -c . "$W2/pages.txt" 2>/dev/null || echo 0)"
+P8_PAGES="$({ grep -c . "$W2/pages.txt" 2>/dev/null || echo 0; } | head -1)"
 [ "$P8_PAGES" = "1" ] \
   || fail "expected EXACTLY 1 founder page across 9 runs, got $P8_PAGES. Zero means the cap was
       never reached, so unreviewed code sits at the head of an approved PR with nobody told. More
@@ -1970,7 +1970,12 @@ run_engine_reviewer() {
   RC=$?
 }
 
-pages_in() { grep -c . "$1/pages.txt" 2>/dev/null || echo 0; }
+# `grep -c` prints 0 AND exits 1 on a zero count, so a bare `|| echo 0`
+# APPENDED a second 0 and the value became "0\n0": that breaks `-eq` with
+# "integer expression expected" and makes a legitimate `= "0"` assertion
+# fail on correct behaviour. `| head -1` keeps whichever 0 arrived first.
+# Missing file: grep prints nothing and the fallback supplies the only 0.
+pages_in() { { grep -c . "$1/pages.txt" 2>/dev/null || echo 0; } | head -1; }
 
 # --- Q1. an approving codex review posts kipi/codex-approved on the read sha ---
 Q1="$W2/eng-approve"

--- a/q-system/.q-system/scripts/test/test-zero-safe-count-idiom.sh
+++ b/q-system/.q-system/scripts/test/test-zero-safe-count-idiom.sh
@@ -1,0 +1,77 @@
+#!/usr/bin/env bash
+# `grep -c ... || echo 0` is not a zero-safe count. Pins the corrected idiom
+# and refuses the broken one from coming back (sp-762c7d6b).
+#
+# THE DEFECT. `grep -c` prints the count AND exits 1 when that count is zero.
+# So `n=$(grep -c PATTERN FILE || echo 0)` appends a SECOND zero and n becomes
+# the two-line string "0\n0". Measured:
+#
+#     file with 2 matches -> "2"      correct
+#     file, zero matches  -> "0\n0"   BROKEN
+#     missing file        -> "0"      correct (grep printed nothing)
+#
+# It only bites when the file EXISTS and is EMPTY, which is why six sites
+# carried it unnoticed.
+#
+# WHY IT MATTERS, and it is not cosmetic. `[ "$n" -eq 1 ]` aborts with
+# "integer expression expected", and `[ "$n" = "0" ]` -- a legitimate
+# expect-zero assertion, e.g. test-severity-floor.sh's "no page was sent" case
+# -- compares "0\n0" against "0" and FAILS on correct behaviour. A false
+# failure in a test suite is worse than a missed one: it trains the reader to
+# discount red.
+#
+# THE FIX. `{ grep -c ... || echo 0; } | head -1` keeps whichever zero arrived
+# first, and the fallback still covers the missing-file case where grep prints
+# nothing at all.
+set -uo pipefail
+ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/../../../.." && pwd)"
+TESTDIR="$ROOT/q-system/.q-system/scripts/test"
+PASS=0; FAIL=0
+ok()  { echo "PASS: $1"; PASS=$((PASS+1)); }
+bad() { echo "FAIL: $1" >&2; FAIL=$((FAIL+1)); }
+
+WORK="$(mktemp -d)"
+trap 'python3 -c "import shutil,sys;shutil.rmtree(sys.argv[1],ignore_errors=True)" "$WORK"' EXIT
+printf 'a\nb\n' > "$WORK/two.txt"
+: > "$WORK/empty.txt"
+
+count() { { grep -c . "$1" 2>/dev/null || echo 0; } | head -1; }
+
+# --- 1. the idiom is correct on all three input states ---------------------
+for case in "two.txt 2" "empty.txt 0" "missing.txt 0"; do
+  set -- $case
+  got="$(count "$WORK/$1")"
+  [ "$got" = "$2" ] && ok "count($1) = $2" || bad "count($1) = '$got', want '$2'"
+done
+
+# --- 2. the result is ONE line, which is the whole defect ------------------
+lines="$(count "$WORK/empty.txt" | wc -l | tr -d ' ')"
+[ "$lines" = "1" ] && ok "zero count is a single line" \
+  || bad "zero count spans $lines lines (the \"0\\n0\" defect)"
+
+# --- 3. it survives the comparisons that the broken form breaks ------------
+n="$(count "$WORK/empty.txt")"
+if [ "$n" -eq 0 ] 2>/dev/null; then ok "numeric -eq works on a zero count"
+else bad "numeric -eq still errors on a zero count"; fi
+[ "$n" = "0" ] && ok "string = \"0\" works on a zero count" \
+  || bad "expect-zero assertion still fails on correct behaviour"
+
+# --- 4. the broken form really is broken (the check can fail) --------------
+# Without this the suite above could pass against a no-op "fix".
+broken="$(grep -c . "$WORK/empty.txt" 2>/dev/null || echo 0)"
+[ "$(printf '%s' "$broken" | wc -l | tr -d ' ')" = "1" ] \
+  && ok "control: the OLD idiom does produce a second line" \
+  || bad "control failed -- grep here does not behave as the defect describes, "\
+"so the rest of this file proves nothing"
+
+# --- 5. no site regresses to the broken form ------------------------------
+# The idiom is easy to retype from memory; this is what stops it returning.
+residual="$(grep -rn 'grep -c [^|]* || echo 0' "$TESTDIR"/*.sh 2>/dev/null \
+            | grep -v 'head -1' | grep -v 'test-zero-safe-count-idiom.sh' || true)"
+if [ -z "$residual" ]; then ok "no test script carries the unguarded idiom"
+else bad "unguarded \`grep -c ... || echo 0\` is back:
+$residual"; fi
+
+echo
+echo "passed=$PASS failed=$FAIL"
+[ "$FAIL" -eq 0 ] || exit 1


### PR DESCRIPTION
Closes `sp-762c7d6b`. Six sites across three suites.

## The defect

`grep -c` prints the count **and** exits 1 when that count is zero. So `n=$(grep -c PATTERN FILE || echo 0)` appends a second zero and `n` becomes the two-line string `"0\n0"`.

Measured in this shell:

| input | result | |
|---|---|---|
| file with 2 matches | `"2"` | correct |
| file, zero matches | `"0\n0"` | **broken** |
| missing file | `"0"` | correct (grep printed nothing) |

It only bites when the file **exists and is empty**, which is why six sites carried it unnoticed.

## Why it is not cosmetic

`[ "$n" -eq 1 ]` aborts with `integer expression expected`, and `[ "$n" = "0" ]` — a legitimate expect-zero assertion — compares `"0\n0"` against `"0"` and **fails on correct behaviour**.

`test-severity-floor.sh:1996` is exactly that shape:

```sh
[ "$(pages_in "$Q1")" = "0" ]   # "no page was sent"
```

That passes today only because the file happens not to exist yet. The moment it is created and left empty, the suite reports a defect that is not there. A false failure is worse than a missed one — it trains the reader to discount red.

## The fix

`{ grep -c ... || echo 0; } | head -1` keeps whichever zero arrived first, and the fallback still covers the missing-file case where grep prints nothing.

Verified against all three input states through the **real** helper functions (`pages_in`, `worked_count`), not a retyped copy.

## Two checks that exist because the others could pass against a no-op

- **A control** asserting the OLD idiom really does emit a second line in this shell. Without it the whole file proves nothing on a platform where grep behaves differently.
- **A residual scan** over `test/*.sh`, because the broken form is easy to retype from memory. Mutation: restoring it at a real site turns the suite red.

## Verification

`test-linear-worker-parallel` PASS · `test-review-tree-guard` PASS · `test-severity-floor` 198/198 PASS · new suite 8/8. Registered in the capability manifest.

**Noted, not fixed here:** `test-severity-floor` leaves a process alive after its last check prints. That is `sp-063fc932` (`run_bounded` kills the watchdog subshell but not its `sleep` child) — pre-existing and unrelated.

🤖 Generated with [Claude Code](https://claude.com/claude-code)