### PR TITLE
--dry stops manufacturing a failure out of a directory named build (sp-f6733ee3)

### DIFF
--- a/kipi-update.sh
+++ b/kipi-update.sh
@@ -242,9 +242,29 @@ model_rsync_excludes() {
   # and the instance reported FAILED in --dry while the real run had updated it
   # fine. So --dry manufactured a false failure out of disk pressure alone.
   # Every path here is regenerable by its own toolchain and gitignored.
+  # A BASENAME IS NOT A FACT ABOUT WHAT A DIRECTORY IS (sp-f6733ee3). The names
+  # below are a heuristic for "regenerable build cache", and it is right nearly
+  # every time -- which is why the exception stayed invisible. Measured
+  # 2026-08-06 on interview-coach: `design-room/build/gate-report.md` is AUTHORED
+  # gate output living under a directory that happens to be called `build`. The
+  # rsync skipped it while `.git` was copied verbatim, so the model saw a tracked
+  # DELETION, read the tree as dirty, and reported a healthy instance FAILED.
+  # Second time --dry has manufactured a false failure (the disk-pressure one
+  # above was the first), and a fleet health check driven off --dry would page on
+  # instances that are fine.
+  #
+  # SO ASK GIT, WHICH KNOWS. A directory holding tracked files is not a build
+  # cache whatever it is named -- the comment above already states the real
+  # predicate ("every path here is regenerable by its own toolchain AND
+  # GITIGNORED"), it just was not being checked. Tracked content is committed
+  # content, so copying it cannot reintroduce the 8.7G src-tauri/target problem:
+  # that tree was gitignored and stays excluded.
   MODEL_EXCLUDES=(--exclude=".git")
   local cache_dir
   for cache_dir in target node_modules .venv venv __pycache__ .next dist build .pytest_cache .mypy_cache .ruff_cache; do
+    if [ -n "$(git -C "$instance_root" ls-files -- "$cache_dir/*" "*/$cache_dir/*" 2>/dev/null | head -1)" ]; then
+      continue
+    fi
     MODEL_EXCLUDES+=(--exclude="$cache_dir/")
   done
   for nested_rel in ${MODEL_SKIPPED_PATHS[@]+"${MODEL_SKIPPED_PATHS[@]}"}; do

--- a/q-system/.q-system/capability-manifest.json
+++ b/q-system/.q-system/capability-manifest.json
@@ -489,6 +489,10 @@
       "timeout_s": 300
     },
     {
+      "path": "q-system/.q-system/scripts/test/test-kipi-update-dry-no-false-failure.sh",
+      "runner": "bash"
+    },
+    {
       "path": "plugins/prd-os/tests/test_virgin_repo_lifecycle.py",
       "runner": "python3",
       "timeout_s": 120

--- a/q-system/.q-system/scripts/test/test-kipi-update-dry-no-false-failure.sh
+++ b/q-system/.q-system/scripts/test/test-kipi-update-dry-no-false-failure.sh
@@ -1,0 +1,91 @@
+#!/usr/bin/env bash
+# Reproducer for sp-f6733ee3: `kipi update --dry` reported FAILED for a healthy
+# instance that merely had TRACKED content under a directory named `build`.
+#
+# Pairs with: the git-tracked check in model_rsync_excludes() (kipi-update.sh).
+#
+# THE MECHANISM. The model build rsyncs the instance into a throwaway clone
+# excluding any directory whose basename is a build-cache name, then copies
+# `.git` VERBATIM. A tracked file under such a directory is therefore absent
+# from the model worktree while still present in the model index, so git reports
+# a deletion, the tracked-changes predicate reads the tree as dirty, and the
+# instance is abandoned. Measured 2026-08-06 on interview-coach:
+# `D design-room/build/gate-report.md`, while live the file is tracked, present,
+# and the tree has zero tracked changes.
+#
+# WHY CASE 2 EXISTS. Case 1 alone passes if the fix simply stops refusing
+# anything -- deleting the dirty-tree predicate outright would make it green.
+# Case 2 holds the other side: an instance with a REAL tracked modification must
+# still be refused. A fix that satisfies one and not the other is not a fix.
+set -uo pipefail
+
+HERE="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+ROOT="$(cd "$HERE/../../../.." && pwd)"
+SCRIPT="${KIPI_UPDATE_UNDER_TEST:-$ROOT/kipi-update.sh}"
+[ -f "$SCRIPT" ] || { echo "missing $SCRIPT"; exit 1; }
+
+PASS=0; FAIL=0
+ok()  { PASS=$((PASS+1)); echo "  PASS: $1"; }
+bad() { FAIL=$((FAIL+1)); echo "  FAIL: $1"; }
+G() { git -c user.email=t@t.t -c user.name=test -c commit.gpgsign=false "$@"; }
+
+build_fixture() {  # build_fixture <workdir> <dirty:yes|no>
+  local W="$1" dirty="$2" SK="$1/skel" INST="$1/inst"
+  mkdir -p "$SK/q-system/.q-system/scripts" "$SK/q-system/.q-system/state"
+  cp "$SCRIPT" "$SK/kipi-update.sh"
+  cp "$ROOT/kipi-update-preserve-scan.py" "$ROOT/kipi-update-deletion-guard.py" \
+     "$ROOT/validate-separation.py" "$SK/"
+  cp "$ROOT/q-system/.q-system/scripts/propagation-leak-gate.py" \
+     "$ROOT/q-system/.q-system/scripts/containment-targets.py" \
+     "$SK/q-system/.q-system/scripts/"
+  cat > "$SK/q-system/.q-system/state/propagation-leak-baseline.json" <<'J'
+{"schema_version":1,"blocking_classes":["case_proof_gap","client_identity","dated_interaction","pricing","relationship","source_identity","sourced_interaction"],"classifier_sha256":null,"entries":[]}
+J
+  printf 'skeleton v2\n' > "$SK/q-system/tracked.md"
+  ( cd "$SK" && G init -q && G add -A && G commit -qm skel )
+  printf '{"instances":[{"name":"testinst","path":"%s","subtree_prefix":"q-system","type":"subtree"}]}\n' \
+    "$INST" > "$SK/instance-registry.json"
+
+  # THE DEFECT SHAPE: authored, TRACKED content under a `build/`-named dir.
+  mkdir -p "$INST/q-system" "$INST/design-room/build"
+  printf 'skeleton v1\n' > "$INST/q-system/tracked.md"
+  printf '# design-room gate report (authored, not a build cache)\n' \
+    > "$INST/design-room/build/gate-report.md"
+  ( cd "$INST" && G init -q && G add -A && G commit -qm inst )
+  # Case 2 only: a REAL tracked modification, which must still be refused.
+  if [ "$dirty" = "yes" ]; then
+    printf 'founder edit in progress\n' >> "$INST/q-system/tracked.md"
+  fi
+}
+
+# Reports FAILED (or refused) for testinst?
+refused() {  # refused <log>
+  grep -q 'dirty working tree; refusing' "$1" && echo yes || echo no
+}
+
+echo "== 1. THE DEFECT: tracked content under build/ must NOT fail a clean instance =="
+W1="$(mktemp -d)"; build_fixture "$W1" no
+bash "$W1/skel/kipi-update.sh" --dry-run >"$W1/out.log" 2>&1
+if [ "$(refused "$W1/out.log")" = "no" ]; then
+  ok "a clean instance with tracked design-room/build/ content is NOT refused"
+else
+  bad "THE DEFECT: healthy instance refused; model saw a phantom deletion"
+  grep -A4 'blocked by dirty' "$W1/out.log" | head -5 | sed 's/^/      /'
+fi
+
+echo
+echo "== 2. THE OTHER SIDE: a genuinely dirty instance must STILL be refused =="
+# Without this, deleting the dirty-tree predicate would satisfy case 1.
+W2="$(mktemp -d)"; build_fixture "$W2" yes
+bash "$W2/skel/kipi-update.sh" --dry-run >"$W2/out.log" 2>&1
+if [ "$(refused "$W2/out.log")" = "yes" ]; then
+  ok "a real tracked modification is still refused (the guard still guards)"
+else
+  bad "REGRESSION: a genuinely dirty instance was allowed through"
+fi
+
+echo
+echo "-------- $PASS passed, $FAIL failed --------"
+echo "  logs: $W1/out.log  $W2/out.log"
+[ "$FAIL" -eq 0 ] || exit 1
+echo "PASS: --dry refuses real dirt and only real dirt"


### PR DESCRIPTION
`model_rsync_excludes()` strips any directory whose **basename** is a build-cache name, then `.git` is copied verbatim. A **tracked** file under such a directory is absent from the model worktree but still in the model index — so git reports a deletion, the tracked-changes predicate reads the tree as dirty, and a healthy instance is abandoned.

Measured 2026-08-06 on `interview-coach`: the model printed `D design-room/build/gate-report.md` while live that file is **tracked, present, and the tree has zero tracked changes**. `design-room/build/` is authored gate output, not a build cache. The fleet census reported `Failed: 4` when only 3 were real.

Second time `--dry` has invented a failure. The disk-pressure one is already recorded three lines above in the same function.

## Model-only, not data loss

Checked in the *reassuring* direction on purpose — two claims earlier in this session were wrong in the alarming direction, which makes a comfortable conclusion the one most worth re-testing. Four ways:

1. `MODEL_EXCLUDES` appears in exactly two rsyncs, and `$path/` is the **source** in both
2. the real sync uses `rsync_owned_excludes` — a different function
3. `rsync_owned_excludes` contains **no** build-cache name
4. the real sync's destination is `$path/q-system/`; `design-room/` sits at instance root, outside it

## The fix asks git

A directory holding tracked files is not a build cache whatever it is named. The function's own comment already stated the real predicate — *"regenerable by its own toolchain AND gitignored"* — it just was not being checked.

This cannot reintroduce the 8.7G `src-tauri/target` problem that motivated the excludes: tracked content is committed content, and that tree is gitignored, so it stays excluded.

## Case 2 is the one that matters

Deleting the dirty-tree predicate outright would satisfy case 1. So case 2 holds the other side: an instance with a **real** tracked modification must still be refused.

| | Result |
|---|---|
| Control | 2/2 green |
| Tracked-check removed (pre-fix) | case 1 **RED**, printing the exact phantom `D design-room/build/gate-report.md`; case 2 still passes |

The mutant validates its own anchor before running.

## Third instance of one defect class

This is the same mistake as `INSTANCE_OWNED` (a name allowlist deciding what is founder data) and `[ "$DRY_RUN" != "1" ]` (a comparison that can never be false): **a name treated as a fact about what something is.** Written up as a lesson in #116 rather than patched a fourth time.

## Verified

Local only. **CI is down; nothing here is CI-verified.** 2/2 green, `bash -n` clean, manifest parses.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01WZeGrz117RS1ZxNmGpQk4W