### PR TITLE
Arm the spillover ratchet: the conveyor's missing producer (ASK-457)

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -238,6 +238,10 @@
           },
           {
             "type": "command",
+            "command": "test -f \"$CLAUDE_PROJECT_DIR/q-system/.q-system/scripts/spillover-ratchet.py\" && python3 \"$CLAUDE_PROJECT_DIR/q-system/.q-system/scripts/spillover-ratchet.py\""
+          },
+          {
+            "type": "command",
             "command": "python3 \"$CLAUDE_PROJECT_DIR/q-system/.q-system/scripts/settings-template-sync-check.py\"",
             "timeout": 5
           }

--- a/q-system/.q-system/capability-manifest.json
+++ b/q-system/.q-system/capability-manifest.json
@@ -516,6 +516,10 @@
       "path": "q-system/.q-system/scripts/test/test-zero-safe-count-idiom.sh",
       "runner": "bash",
       "timeout_s": 60
+    },
+    {
+      "path": "q-system/.q-system/scripts/test_spillover_promote_selection.py",
+      "runner": "python3"
     }
   ],
   "required_data": [],
@@ -623,6 +627,11 @@
       "path": "q-system/.q-system/scripts/verify-containment-export.py",
       "reason": "built for prd-skeleton-data-containment's export/quarantine flow and never wired",
       "spillover_id": "sp-0f773063"
+    },
+    {
+      "path": "q-system/.q-system/scripts/spillover-promote.py",
+      "reason": "restored from origin/sana/ask-312 (ASK-451) and now files a SELECTABLE issue (owner:sana + project), proven end to end on ASK-456. Deliberately hand-invoked for now: its automatic caller is spillover-ratchet.py, which is still stranded on the same branch. Wiring the ratchet is sp-186312b0, not this issue -- promoting 591 open items on a conveyor nobody has watched run once is the failure mode this whole effort exists to avoid",
+      "spillover_id": "sp-186312b0"
     }
   ],
   "uncovered_known": [

--- a/q-system/.q-system/capability-manifest.json
+++ b/q-system/.q-system/capability-manifest.json
@@ -520,6 +520,10 @@
     {
       "path": "q-system/.q-system/scripts/test_spillover_promote_selection.py",
       "runner": "python3"
+    },
+    {
+      "path": "q-system/.q-system/scripts/test_spillover_ratchet.py",
+      "runner": "python3"
     }
   ],
   "required_data": [],
@@ -627,11 +631,6 @@
       "path": "q-system/.q-system/scripts/verify-containment-export.py",
       "reason": "built for prd-skeleton-data-containment's export/quarantine flow and never wired",
       "spillover_id": "sp-0f773063"
-    },
-    {
-      "path": "q-system/.q-system/scripts/spillover-promote.py",
-      "reason": "restored from origin/sana/ask-312 (ASK-451) and now files a SELECTABLE issue (owner:sana + project), proven end to end on ASK-456. Deliberately hand-invoked for now: its automatic caller is spillover-ratchet.py, which is still stranded on the same branch. Wiring the ratchet is sp-186312b0, not this issue -- promoting 591 open items on a conveyor nobody has watched run once is the failure mode this whole effort exists to avoid",
-      "spillover_id": "sp-186312b0"
     }
   ],
   "uncovered_known": [

--- a/q-system/.q-system/scripts/spillover-promote.py
+++ b/q-system/.q-system/scripts/spillover-promote.py
@@ -25,11 +25,13 @@ Usage:
   spillover-promote.py <id> --title "..." --dor "..." --dry-run
 """
 import argparse
+import contextlib
 import importlib.util
 import json
 import os
 import sys
 from pathlib import Path
+from types import SimpleNamespace
 
 HERE = Path(__file__).resolve()
 SKELETON = HERE.parents[3]
@@ -79,18 +81,69 @@ def ledger_root(repo_root: Path) -> Path:
     # inside the tree whose identity we are trying to resolve is the same
     # chicken-and-egg the bug came from -- it fell back to the per-worktree root
     # and looked fixed. repo_root stays as the fallback for an odd layout.
+    m = prd_runner(repo_root)
+    if m is None:
+        return Path(repo_root)
+    try:
+        return Path(m._ledger_root(Path(repo_root)))
+    except Exception:
+        return Path(repo_root)
+
+
+def prd_runner(repo_root):
+    """Load prd_runner, or None when it is not on disk. Never raises."""
     candidates = [SKELETON / "plugins" / "prd-os" / "scripts" / "prd_runner.py",
                   Path(repo_root) / "plugins" / "prd-os" / "scripts" / "prd_runner.py"]
     runner = next((c for c in candidates if c.is_file()), None)
     if runner is None:
-        return Path(repo_root)
+        return None
     try:
         spec = importlib.util.spec_from_file_location("prd_runner_root", runner)
         m = importlib.util.module_from_spec(spec)
         spec.loader.exec_module(m)
-        return Path(m._ledger_root(Path(repo_root)))
+        return m
     except Exception:
-        return Path(repo_root)
+        return None
+
+
+@contextlib.contextmanager
+def ledger_lock(repo_root: Path):
+    """Serialize check -> create -> append against every other ledger writer.
+
+    why (Codex major, PR #120): those three steps were unserialized, so two runs
+    both read `open`, both called issueCreate, and both appended. The ratchet
+    makes that ordinary rather than exotic -- it fires PostToolUse in every agent
+    session, and since the git-common-dir fix every worktree in the set shares
+    ONE ledger. A duplicate Linear issue is permanent: nothing downstream
+    de-duplicates, and the worker would dispatch two runs at one fix.
+
+    IMPORTED from prd_runner, never reimplemented -- same rule as `ledger_root`
+    above, and for the same reason. `_spillover_lock` already guards
+    resolve/reclassify on the SAME `spillover.jsonl.lock` path, so importing it
+    (rather than opening a private second lock) is what makes promote serialize
+    against a concurrent resolve too. A second lock file would serialize
+    promotions against each other and against nothing else.
+
+    It only reads `cfg.repo_root`, so a namespace carrying that one field is the
+    whole contract; building a real Config here would couple this script to a
+    constructor it has no other use for.
+
+    DEGRADES, NEVER REFUSES, inherited deliberately: `_spillover_lock` warns to
+    stderr and proceeds unlocked when the directory is read-only (Codex sandboxes
+    are read-only here routinely). A promotion that cannot lock is still better
+    than a conveyor that stops; the re-read below still closes the window for
+    every sequential caller.
+    """
+    m = prd_runner(repo_root)
+    if m is None or not hasattr(m, "_spillover_lock"):
+        sys.stderr.write(
+            "WARNING: prd_runner._spillover_lock is unavailable; promoting "
+            "UNLOCKED. Two concurrent promotions could file two issues for one "
+            "finding.\n")
+        yield
+        return
+    with m._spillover_lock(SimpleNamespace(repo_root=Path(repo_root))):
+        yield
 
 
 def linear_module():
@@ -194,12 +247,43 @@ def main() -> int:
             "You have the file open. You are the cheapest person to write this.\n")
         return 2
 
+    args._dor = dor      # the transaction rebuilds the body from the FRESH row
     body = build_body(rec, dor, root.name)
     if args.dry_run:
         print(f"WOULD CREATE in team {TEAM_KEY}: {args.title}\n")
         print(body[:900])
         print(f"\nDRY RUN. {ledger} unchanged.")
         return 0
+
+    # EVERYTHING FROM HERE IS ONE TRANSACTION. The status re-read, the create
+    # and the append are the three steps Codex found unserialized on PR #120;
+    # a lock around the append alone still lets two runs both pass the check.
+    with ledger_lock(root):
+        return promote_locked(args, root, ledger, rec)
+
+
+def promote_locked(args, root: Path, ledger: Path, rec: dict) -> int:
+    """The transaction. Called ONLY with the ledger lock held.
+
+    Split out rather than indented in place so the lock's span is one line to
+    read: everything this function does happens inside it, and nothing outside
+    it writes.
+    """
+    # RE-READ UNDER THE LOCK. The pre-lock check above is a fast refusal for the
+    # ordinary case; it is not the decision. Between it and here another run may
+    # have promoted this same finding, and its ledger append is the only record
+    # of that. Trusting the earlier read is precisely the check-then-act the
+    # duplicate came from.
+    fresh = load_rows(ledger).get(args.finding_id)
+    if not fresh or fresh.get("status") != "open":
+        status = (fresh or {}).get("status", "gone from the ledger")
+        sys.stderr.write(
+            f"refused: {args.finding_id} is '{status}', not open.\n"
+            "Another run promoted or resolved it while this one was starting.\n"
+            "One finding gets ONE issue; nothing downstream de-duplicates.\n")
+        return 2
+    rec = fresh
+    body = build_body(rec, args._dor, root.name)
 
     ls = linear_module()
     tid = ls.graphql('query{teams(filter:{key:{eq:"%s"}}){nodes{id}}}' % TEAM_KEY,

--- a/q-system/.q-system/scripts/spillover-promote.py
+++ b/q-system/.q-system/scripts/spillover-promote.py
@@ -1,0 +1,214 @@
+#!/usr/bin/env python3
+"""Turn a confirmed spillover finding into a fully-scoped Linear issue (ASK-344).
+
+why: the ratchet delivers a note to the agent editing its file, and the agent
+confirms it is still true. Then what? Before this, nothing -- a confirmed note
+stayed a note. Triage with no address is just re-reading the pile.
+
+This is the address. A confirmed finding becomes a Linear issue the autonomous
+worker can actually pick up, and the ledger row stops firing.
+
+THE BAR: no Definition of Ready, no issue. `linear-worker.sh` refuses any issue
+without one, so promoting without a DoR would file something nothing can work --
+the 137-issue queue that started this whole PRD. Refusing here is the only place
+that cannot be forgotten later.
+
+The DoR is written by the agent that CONFIRMED the finding, because it has the
+file open and the context loaded. Nobody will ever be cheaper.
+
+The row moves to `promoted`, not `resolved`. Resolution still requires the
+Linear issue to actually close -- promoting is not fixing, and a status that
+claimed otherwise would let the pile launder itself clean.
+
+Usage:
+  spillover-promote.py <id> --title "..." --dor-file dor.md
+  spillover-promote.py <id> --title "..." --dor "..." --dry-run
+"""
+import argparse
+import importlib.util
+import json
+import os
+import sys
+from pathlib import Path
+
+HERE = Path(__file__).resolve()
+SKELETON = HERE.parents[3]
+TEAM_KEY = os.environ.get("KIPI_LINEAR_TEAM", "ASK")
+
+# The sections a DoR must carry for linear-worker to have anything to act on.
+# Not cosmetic: an issue missing "what files" or "how do I know it is done" is
+# one the worker either refuses or guesses at, and guessing is worse.
+REQUIRED_DOR = ("allowed files", "acceptance")
+
+# THE ISSUE MUST BE SELECTABLE, NOT MERELY CREATED (ASK-451).
+# linear-worker.sh `ready()` refuses anything without `owner:sana`, and its
+# `in_this_repo()` treats an UNSET project as "not this repo" -- deliberately,
+# because "target unknown" and "target is here" are different claims. This
+# script filed issues with neither for its whole life, so every promotion
+# landed in a queue that structurally could not see it. Both halves were
+# individually tested and individually fine; nothing tested the handoff.
+REQUIRED_LABELS = ("owner:sana",)
+
+LABEL_BY_NAME = 'query($name:String!){issueLabels(filter:{name:{eq:$name}}){nodes{id name}}}'
+PROJECT_BY_NAME = 'query($name:String!){projects(filter:{name:{eq:$name}}){nodes{id name}}}'
+
+
+def linear_module():
+    spec = importlib.util.spec_from_file_location("ls", HERE.parent / "linear-sync.py")
+    m = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(m)
+    return m
+
+
+def load_rows(ledger: Path) -> dict:
+    rows = {}
+    if not ledger.is_file():
+        return rows
+    for line in ledger.read_text().splitlines():
+        line = line.strip()
+        if line:
+            try:
+                r = json.loads(line)
+            except json.JSONDecodeError:
+                continue
+            if "id" in r:
+                rows[r["id"]] = r
+    return rows
+
+
+def validate_dor(text: str) -> list:
+    """Missing required sections. Empty list means the DoR is workable."""
+    low = (text or "").lower()
+    missing = [s for s in REQUIRED_DOR if s not in low]
+    if len((text or "").strip()) < 120:
+        missing.append("substance (under 120 chars is not a scope)")
+    return missing
+
+
+def resolve_one(ls, query: str, name: str, kind: str):
+    """Look up a Linear id by name. Returns None when the name does not exist.
+
+    Refusing on a miss (rather than dropping the field) is the whole point: an
+    issue created without the label or project is INVISIBLE to the worker, and
+    an invisible issue reads exactly like an empty board. A loud refusal here
+    costs one promotion; a silent one costs the conveyor.
+    """
+    nodes = (ls.graphql(query, {"name": name}) or {}).get(kind, {}).get("nodes") or []
+    return nodes[0]["id"] if nodes else None
+
+
+def build_body(rec: dict, dor: str, repo: str) -> str:
+    return (
+        f"Promoted from spillover `{rec['id']}` (severity: {rec.get('severity')}, "
+        f"source: `{rec.get('source')}`, repo: `{repo}`).\n\n"
+        f"## The finding\n\n{rec.get('description', '')}\n\n"
+        f"## Definition of Ready\n\n{dor}\n\n"
+        f"---\n*Confirmed still-true at the moment its file was edited, then "
+        f"promoted. Resolve the ledger row with "
+        f"`prd_runner.py spillover resolve {rec['id']} --resolution-ref <this issue>` "
+        f"once this closes.*"
+    )
+
+
+def main() -> int:
+    ap = argparse.ArgumentParser()
+    ap.add_argument("finding_id")
+    ap.add_argument("--title", required=True)
+    ap.add_argument("--dor", help="Definition of Ready, inline")
+    ap.add_argument("--dor-file", help="Definition of Ready, from a file")
+    ap.add_argument("--repo-root", default=str(SKELETON))
+    ap.add_argument("--priority", type=int, default=3)
+    ap.add_argument("--dry-run", action="store_true")
+    args = ap.parse_args()
+
+    root = Path(args.repo_root).resolve()
+    ledger = root / ".prd-os" / "spillover.jsonl"
+    rows = load_rows(ledger)
+    rec = rows.get(args.finding_id)
+    if not rec:
+        sys.stderr.write(f"unknown finding: {args.finding_id}\n")
+        return 2
+    if rec.get("status") != "open":
+        sys.stderr.write(f"{args.finding_id} is '{rec.get('status')}', not open\n")
+        return 2
+
+    dor = args.dor or ""
+    if args.dor_file:
+        dor = Path(args.dor_file).read_text()
+    missing = validate_dor(dor)
+    if missing:
+        sys.stderr.write(
+            f"refused: the Definition of Ready is missing {', '.join(missing)}.\n\n"
+            "linear-worker.sh will not touch an issue without a workable DoR, so\n"
+            "promoting without one files something nothing can work. That is the\n"
+            "137-issue queue this whole effort started from.\n\n"
+            "A DoR needs at least:\n"
+            "  **Allowed files** -- explicit paths the fix may touch\n"
+            "  **Acceptance**    -- checkboxes, including how a failure would show\n"
+            "You have the file open. You are the cheapest person to write this.\n")
+        return 2
+
+    body = build_body(rec, dor, root.name)
+    if args.dry_run:
+        print(f"WOULD CREATE in team {TEAM_KEY}: {args.title}\n")
+        print(body[:900])
+        print(f"\nDRY RUN. {ledger} unchanged.")
+        return 0
+
+    ls = linear_module()
+    tid = ls.graphql('query{teams(filter:{key:{eq:"%s"}}){nodes{id}}}' % TEAM_KEY,
+                     {})["teams"]["nodes"][0]["id"]
+    # Resolved BEFORE the create, so a bad name costs nothing. Resolving after
+    # would leave an unlabelled issue on the board that nothing drains and
+    # nobody is looking for.
+    label_ids = []
+    for name in REQUIRED_LABELS:
+        lid = resolve_one(ls, LABEL_BY_NAME, name, "issueLabels")
+        if not lid:
+            sys.stderr.write(
+                f"refused: label '{name}' does not exist on this Linear workspace.\n"
+                "linear-worker.sh ready() requires it, so the issue would be filed\n"
+                "into a queue that cannot see it. Create the label, then re-run.\n")
+            return 2
+        label_ids.append(lid)
+
+    # Same derivation ORDER as linear-worker.sh: explicit env override, then the
+    # checkout basename. The worker has a third step (instance-registry lookup)
+    # that this does not replicate -- duplicating that rule would give one
+    # decision two writers and they would drift. See the spillover item filed
+    # with this change: on the three instances whose project name is not their
+    # basename, set KIPI_LINEAR_PROJECT until the derivation is shared.
+    project_name = os.environ.get("KIPI_LINEAR_PROJECT") or root.name
+    pid = resolve_one(ls, PROJECT_BY_NAME, project_name, "projects")
+    if not pid:
+        sys.stderr.write(
+            f"refused: no Linear project named '{project_name}'.\n"
+            "in_this_repo() treats an unset or foreign project as NOT this repo,\n"
+            "so this issue would never be picked by any worker. Set\n"
+            "KIPI_LINEAR_PROJECT to the project this checkout maps to.\n")
+        return 2
+
+    res = ls.graphql(ls.ISSUE_CREATE, {"input": {
+        "teamId": tid, "title": args.title, "description": body,
+        "priority": args.priority,
+        "labelIds": label_ids, "projectId": pid}})
+    issue = (res.get("issueCreate") or {}).get("issue") or {}
+    ident = issue.get("identifier")
+    if not ident:
+        sys.stderr.write(f"Linear create failed: {json.dumps(res)[:300]}\n")
+        return 1
+
+    # `promoted`, never `resolved`. Promoting is not fixing; a status claiming
+    # otherwise would let the pile launder itself clean without a single fix.
+    promoted = dict(rec)
+    promoted.update({"status": "promoted", "linear_ref": ident,
+                     "promoted_from_ratchet": True})
+    with ledger.open("a") as fh:
+        fh.write(json.dumps(promoted) + "\n")
+        fh.flush()
+    print(json.dumps({"finding": rec["id"], "linear": ident, "status": "promoted"}))
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/q-system/.q-system/scripts/spillover-promote.py
+++ b/q-system/.q-system/scripts/spillover-promote.py
@@ -53,6 +53,46 @@ LABEL_BY_NAME = 'query($name:String!){issueLabels(filter:{name:{eq:$name}}){node
 PROJECT_BY_NAME = 'query($name:String!){projects(filter:{name:{eq:$name}}){nodes{id name}}}'
 
 
+def ledger_root(repo_root: Path) -> Path:
+    """Resolve the ledger root the way prd_runner does -- by CALLING prd_runner.
+
+    why: `*.jsonl` is gitignored, so the spillover ledger is never shared through
+    git. Resolving it from the per-worktree root gives every worktree its own
+    private ledger: 26 of them holding 71 findings the main checkout could not
+    see, measured 2026-07-30. prd_runner._ledger_root resolves via
+    `git rev-parse --git-common-dir` instead, which is the same directory from
+    every worktree in the set.
+
+    This script had exactly that bug. Run from a worktree it read a ledger that
+    does not exist, so `load_rows` came back empty and EVERY promotion exited 2
+    with "unknown finding". An automatic caller would have done nothing forever
+    while looking healthy -- silent absence, which is worse than the visible
+    unlabelled issue this file was fixed for.
+
+    IMPORTED, never reimplemented. Two derivations of one rule is how the ledger
+    got split in the first place, and a private copy here would drift the same
+    way. On failure we fall back to repo_root, which is safe because it fails
+    LOUD: the finding is not found and nothing is written.
+    """
+    # Located next to THIS SCRIPT first, not under repo_root. repo_root may be a
+    # worktree that never checked the plugin out, and looking for the resolver
+    # inside the tree whose identity we are trying to resolve is the same
+    # chicken-and-egg the bug came from -- it fell back to the per-worktree root
+    # and looked fixed. repo_root stays as the fallback for an odd layout.
+    candidates = [SKELETON / "plugins" / "prd-os" / "scripts" / "prd_runner.py",
+                  Path(repo_root) / "plugins" / "prd-os" / "scripts" / "prd_runner.py"]
+    runner = next((c for c in candidates if c.is_file()), None)
+    if runner is None:
+        return Path(repo_root)
+    try:
+        spec = importlib.util.spec_from_file_location("prd_runner_root", runner)
+        m = importlib.util.module_from_spec(spec)
+        spec.loader.exec_module(m)
+        return Path(m._ledger_root(Path(repo_root)))
+    except Exception:
+        return Path(repo_root)
+
+
 def linear_module():
     spec = importlib.util.spec_from_file_location("ls", HERE.parent / "linear-sync.py")
     m = importlib.util.module_from_spec(spec)
@@ -122,11 +162,17 @@ def main() -> int:
     args = ap.parse_args()
 
     root = Path(args.repo_root).resolve()
-    ledger = root / ".prd-os" / "spillover.jsonl"
+    ledger = ledger_root(root) / ".prd-os" / "spillover.jsonl"
     rows = load_rows(ledger)
     rec = rows.get(args.finding_id)
     if not rec:
-        sys.stderr.write(f"unknown finding: {args.finding_id}\n")
+        # Name the ledger. "unknown finding" against a ledger that does not
+        # exist and "unknown finding" against the right one are different
+        # problems, and the first is how the worktree bug stayed invisible.
+        sys.stderr.write(
+            f"unknown finding: {args.finding_id}\n"
+            f"  ledger: {ledger} ({'exists' if ledger.is_file() else 'MISSING'}, "
+            f"{len(rows)} findings)\n")
         return 2
     if rec.get("status") != "open":
         sys.stderr.write(f"{args.finding_id} is '{rec.get('status')}', not open\n")

--- a/q-system/.q-system/scripts/spillover-ratchet.py
+++ b/q-system/.q-system/scripts/spillover-ratchet.py
@@ -1,0 +1,224 @@
+#!/usr/bin/env python3
+"""Surface a minor spillover finding at the moment someone edits its file (ASK-343).
+
+why: 510 of 532 open findings are `minor`. They are real, but they are not a
+queue -- nobody will ever sit down and work a 510-item list, and after ASK-341
+they no longer block the gate. So they had no delivery mechanism at all, which
+makes keeping them identical to deleting them.
+
+This gives them one. A minor finding is a note left for THE NEXT PERSON TO TOUCH
+THIS FILE. So it fires then, and only then.
+
+Same shape as portability-lint.sh, which sp-db43af2f documents: wired as a
+RATCHET on the file being edited, so pre-existing findings surface when a file
+is next touched rather than turning a gate red on items nobody is working on
+today.
+
+Consequence, deliberately: a finding about a file nobody ever touches again
+never fires. That is correct. If the file is dead, the finding was too.
+
+PostToolUse on Edit/Write. Exits 2 ONCE per file per day, because the hook
+contract is exit 2 = stderr fed to Claude, exit 0 = pass. An exit-0 hook writes
+to a stderr nobody reads -- the first version of this file did exactly that and
+was inert on arrival, which is the same defect the whole ledger suffered from.
+
+The ask is NOT "fix this". Fixing an adjacent bug mid-task is scope creep and
+the repo rules forbid it. The ask is "is this still true?" -- an agent with the
+file already open is the cheapest verifier that will ever exist, and a confirm
+or a void drains the pile one note at a time without a cleanup day.
+
+Once per file per day, so a file with 17 notes interrupts once, not 17 times
+and not on every edit. The marker is a date-stamped file; a new day re-asks,
+which is correct for a note that was deferred rather than resolved.
+
+Usage (hook): reads the tool payload on stdin.
+Usage (manual): spillover-ratchet.py <path>
+"""
+import importlib.util
+import json
+import os
+import re
+import subprocess
+import sys
+from pathlib import Path
+
+HERE = Path(__file__).resolve()
+SKELETON = HERE.parents[3]
+MAX_SHOWN = 3
+ACK_DIR = Path.home() / ".config" / "kipi" / "spillover-ratchet-ack"
+PROMOTER = HERE.parent / "spillover-promote.py"
+
+
+def ledger_root(root: Path) -> Path:
+    """The ONE ledger directory, shared by every worktree in the set (ASK-457).
+
+    why: measured before wiring, from a worktree off main -- `repo_root_for`
+    returned the WORKTREE root, whose `.prd-os/spillover.jsonl` does not exist,
+    because `*.jsonl` is gitignored and so the ledger never travels through git.
+    Result: 0 rows and 0 findings on `linear-worker.sh`, a file carrying 57 real
+    open notes. Agents do their work in worktrees, so arming the hook without
+    this would have armed it exactly where it can never fire -- a switch that
+    reports itself on while protecting nothing, which is the failure this whole
+    ledger exists to stop.
+
+    IMPORTED from spillover-promote.py, never reimplemented. That function in
+    turn imports `prd_runner._ledger_root` (git-common-dir), so there is one
+    derivation of "where does the ledger live" for the whole conveyor. Two
+    private copies of that rule is literally how the ledger got split.
+
+    Falls back to the passed-in root when the promoter is missing (an instance
+    that has not synced yet). Degraded, not silent: the fallback reads a
+    non-existent ledger and simply finds nothing, same as today.
+    """
+    if not PROMOTER.is_file():
+        return root
+    try:
+        spec = importlib.util.spec_from_file_location("sp_ledger_root", PROMOTER)
+        m = importlib.util.module_from_spec(spec)
+        spec.loader.exec_module(m)
+        return Path(m.ledger_root(root))
+    except Exception:
+        return root
+
+
+def ledger_rows(root: Path) -> list:
+    """Open MINOR findings only. Blocking ones go through the gate, not here."""
+    p = root / ".prd-os" / "spillover.jsonl"
+    if not p.is_file():
+        return []
+    rows = {}
+    try:
+        for line in p.read_text().splitlines():
+            line = line.strip()
+            if line:
+                try:
+                    r = json.loads(line)
+                except json.JSONDecodeError:
+                    continue
+                if "id" in r:
+                    rows[r["id"]] = r
+    except OSError:
+        return []
+    return [r for r in rows.values()
+            if r.get("status") == "open"
+            and (r.get("severity") or "minor").lower() == "minor"]
+
+
+def repo_root_for(path: Path) -> Path:
+    try:
+        out = subprocess.run(["git", "rev-parse", "--show-toplevel"],
+                             cwd=str(path.parent if path.is_file() else path),
+                             capture_output=True, text=True, timeout=10)
+        if out.returncode == 0 and out.stdout.strip():
+            return Path(out.stdout.strip())
+    except (OSError, subprocess.TimeoutExpired):
+        pass
+    return SKELETON
+
+
+def findings_for(filename: str, rows: list) -> list:
+    """Findings whose text names this file.
+
+    Matches the BASENAME, not the full path: a finding written from another
+    checkout names `capability-gate.py`, not the path you happen to be editing
+    it through. Word-boundary anchored so `gate.py` does not match
+    `capability-gate.py`.
+    """
+    base = os.path.basename(filename)
+    if not base or len(base) < 4:
+        return []
+    stem, ext = os.path.splitext(base)
+    # The SAME cry-wolf guard the stem path already carries, applied to the
+    # basename path -- where the hole had simply relocated (ASK-457). Measured
+    # against the live ledger before wiring: editing the repo-root `kipi` CLI
+    # matched 148 findings, every sampled one a false positive, because the bare
+    # word "kipi" appears in prose about `kipi update` in half the ledger. Same
+    # for `claude` (72), `repo` (61), `main` (45), `config` (23), `HEAD` (17),
+    # `python3`, `description`, `exclude` -- 395 bogus interruptions across 9
+    # names, and `kipi` is a file people edit.
+    #
+    # A basename is a NAME only when something marks it as one: an extension
+    # (`capability-gate.py`), a separator (`linear-worker`), or a leading dot
+    # (`.gitignore`). A bare dictionary word is a word, and a ratchet that fires
+    # 148 notes on the main CLI is a ratchet switched off by lunchtime -- the
+    # exact fate this file's README guard was written to avoid.
+    if not ext and "-" not in base and "_" not in base and not base.startswith("."):
+        return []
+    pat = re.compile(r"(?<![\w/-])" + re.escape(base) + r"(?![\w])")
+    # Stem matching only for DISTINCTIVE stems, i.e. ones carrying a separator
+    # ("capability-gate", "linear_dor_drafter"). Caught 2026-08-03: matching any
+    # stem over 4 chars made README.md fire, because "README" appears in dozens
+    # of unrelated descriptions. A ratchet that cries wolf on README is a ratchet
+    # someone switches off, and then it protects nothing.
+    distinctive = ("-" in stem or "_" in stem) and len(stem) > 4
+    spat = re.compile(r"(?<![\w.-])" + re.escape(stem) + r"(?![\w-])") if distinctive else None
+    hits = []
+    for r in rows:
+        d = r.get("description", "") or ""
+        if pat.search(d) or (spat and spat.search(d)):
+            hits.append(r)
+    return hits
+
+
+def main() -> int:
+    if len(sys.argv) > 1:
+        target = sys.argv[1]
+    else:
+        try:
+            payload = json.load(sys.stdin)
+        except (json.JSONDecodeError, ValueError):
+            return 0
+        target = (payload.get("tool_input") or {}).get("file_path") or ""
+    if not target:
+        return 0
+
+    p = Path(target)
+    rows = ledger_rows(ledger_root(repo_root_for(p)))
+    hits = findings_for(target, rows)
+    if not hits:
+        return 0
+
+    # One interruption per file per day. Without this, a file with 17 notes
+    # would block every edit 17 times and the hook would be switched off within
+    # the hour -- which is how a gate that protects nothing gets created.
+    import datetime
+    stamp = os.environ.get("KIPI_RATCHET_DATE") or datetime.date.today().isoformat()
+    key = re.sub(r"[^A-Za-z0-9_.-]", "_", f"{stamp}-{os.path.basename(target)}")
+    ack = ACK_DIR / key
+    if ack.exists():
+        return 0
+    try:
+        ACK_DIR.mkdir(parents=True, exist_ok=True)
+        ack.write_text("")
+    except OSError:
+        pass   # an unwritable marker must not turn one note into a loop
+
+    print(f"\n[spillover] {len(hits)} open note(s) about {os.path.basename(target)}.",
+          file=sys.stderr)
+    print("These were left by whoever last worked here. You have the file open, "
+          "so you are the cheapest person to check them.", file=sys.stderr)
+    for r in hits[:MAX_SHOWN]:
+        print(f"\n  {r['id']} (src {r.get('source')}):\n    "
+              f"{(r.get('description') or '')[:260]}", file=sys.stderr)
+    if len(hits) > MAX_SHOWN:
+        print(f"\n  ...and {len(hits) - MAX_SHOWN} more "
+              f"(`prd_runner.py spillover list --open`)", file=sys.stderr)
+    # The promoter is named by RESOLVED PATH, not bare basename. It is not on
+    # PATH, and the agent reading this is usually in a worktree where a relative
+    # guess misses. An address the reader cannot dial is not an address, which is
+    # the same defect as a finding with no address (ASK-457).
+    print("\n  DO NOT fix them here -- that is scope creep. Decide, and give each "
+          "an ADDRESS:\n"
+          "    STALE     -> prd_runner.py spillover resolve <id> --void \"<reason>\"\n"
+          f"    STILL TRUE-> {PROMOTER} <id> --title \"...\" --dor-file <f>\n"
+          "                 makes a Linear issue the worker can pick up. It REFUSES\n"
+          "                 without allowed-files + acceptance, because an issue\n"
+          "                 nothing can work is the queue this all started from.\n"
+          "  A confirmed note with no address is just the pile, re-read.\n"
+          "  Then continue your task. This fires once per file per day.\n",
+          file=sys.stderr)
+    return 2     # the ONLY exit code whose stderr reaches the agent
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/q-system/.q-system/scripts/test_spillover_promote_selection.py
+++ b/q-system/.q-system/scripts/test_spillover_promote_selection.py
@@ -317,6 +317,71 @@ class TestPromotedIssueIsSelectable(unittest.TestCase):
             self.assertEqual(rc, 2, "unknown label should refuse")
             self.assertIsNone(stub.created)
 
+    def test_promoting_from_a_worktree_uses_the_shared_ledger(self):
+        """The ledger is per-worktree-set, not per-worktree (sp-d3bdbdc9).
+
+        Driven from a REAL `git worktree`, because the whole defect is that
+        repo_root and the git-common-dir parent are the same directory in the
+        main checkout and only diverge in a worktree. A test run from the main
+        checkout passes against the broken code.
+        """
+        import shutil
+        import subprocess
+        with tempfile.TemporaryDirectory() as tmp:
+            main = Path(tmp) / "mainrepo"
+            (main / ".prd-os").mkdir(parents=True)
+            subprocess.run(["git", "init", "-q", str(main)], check=True)
+            subprocess.run(["git", "-C", str(main), "commit", "-q", "--allow-empty",
+                            "-m", "x"], check=True,
+                           env={**os.environ, "GIT_AUTHOR_NAME": "t",
+                                "GIT_AUTHOR_EMAIL": "t@t", "GIT_COMMITTER_NAME": "t",
+                                "GIT_COMMITTER_EMAIL": "t@t"})
+            # The REAL prd_runner, so the resolution under test is the shipped
+            # rule and not a stand-in that agrees with me.
+            dst = main / "plugins" / "prd-os" / "scripts"
+            dst.parent.mkdir(parents=True)
+            shutil.copytree(HERE.parents[2] / "plugins" / "prd-os" / "scripts", dst)
+
+            (main / ".prd-os" / "spillover.jsonl").write_text(json.dumps({
+                "id": "sp-wt01", "status": "open", "severity": "major",
+                "source": "ASK-451", "description": "shared ledger"}) + "\n")
+
+            wt = Path(tmp) / "wt"
+            r = subprocess.run(["git", "-C", str(main), "worktree", "add", "-q",
+                                str(wt), "HEAD"], capture_output=True, text=True)
+            # Prove the setup, or a failed worktree add silently relocates this
+            # test back into the main checkout, where broken code passes.
+            self.assertEqual(r.returncode, 0, f"worktree add failed: {r.stderr}")
+            self.assertTrue((wt / ".git").exists(), "no worktree at the target")
+            self.assertFalse((wt / ".prd-os" / "spillover.jsonl").exists(),
+                             "fixture invalid: the worktree already has a ledger")
+
+            dor = Path(tmp) / "dor.md"
+            dor.write_text(DOR)
+            mod = load_promote()
+            stub = RecordingLinear()
+            mod.linear_module = lambda: stub
+            old_argv, old_env = sys.argv, dict(os.environ)
+            sys.argv = ["spillover-promote.py", "sp-wt01", "--title", "wt",
+                        "--dor-file", str(dor), "--repo-root", str(wt)]
+            os.environ["KIPI_LINEAR_PROJECT"] = "kipi-system"
+            err = io.StringIO()
+            try:
+                with contextlib.redirect_stderr(err):
+                    rc = mod.main()
+            finally:
+                sys.argv = old_argv
+                os.environ.clear()
+                os.environ.update(old_env)
+
+            self.assertEqual(rc, 0, f"promote from a worktree failed: {err.getvalue()}")
+            self.assertFalse((wt / ".prd-os" / "spillover.jsonl").exists(),
+                             "wrote a PRIVATE ledger inside the worktree")
+            rows = [json.loads(l) for l in
+                    (main / ".prd-os" / "spillover.jsonl").read_text().splitlines() if l.strip()]
+            self.assertEqual(rows[-1]["status"], "promoted",
+                             "the shared ledger did not receive the promotion")
+
     def test_ledger_row_says_promoted_not_resolved(self):
         """Promoting is not fixing. A `resolved` here would launder the pile."""
         with tempfile.TemporaryDirectory() as tmp:

--- a/q-system/.q-system/scripts/test_spillover_promote_selection.py
+++ b/q-system/.q-system/scripts/test_spillover_promote_selection.py
@@ -32,6 +32,8 @@ import json
 import os
 import sys
 import tempfile
+import threading
+import time
 import unittest
 from pathlib import Path
 
@@ -391,6 +393,104 @@ class TestPromotedIssueIsSelectable(unittest.TestCase):
                     (root / ".prd-os" / "spillover.jsonl").read_text().splitlines() if l.strip()]
             self.assertEqual(rows[-1]["status"], "promoted")
             self.assertEqual(rows[-1]["linear_ref"], "ASK-999")
+
+
+class ConcurrentPromotionTest(unittest.TestCase):
+    """One finding may become ONE issue, even when two runs promote it at once.
+
+    Codex major on PR #120: the open-state read, the issueCreate and the ledger
+    append were three separate steps with nothing serializing them. The ratchet
+    makes that concurrency ordinary rather than exotic -- it fires PostToolUse in
+    every agent session, and after the git-common-dir fix every worktree in the
+    set shares ONE ledger. Two agents editing the same file both see `open` and
+    both file. A duplicate Linear issue is permanent: nothing in the conveyor
+    de-duplicates, and the worker would dispatch two runs at the same fix.
+
+    The race is made deterministic rather than raced for. Both threads are held
+    at a barrier until each has passed the status check, then the create is slow
+    enough that the second is inside the window while the first is still in it.
+    Unlocked that yields two creates every run; there is no timing in which it
+    yields one.
+    """
+
+    def _run_two(self, tmp):
+        root = Path(tmp)
+        (root / ".prd-os").mkdir(parents=True, exist_ok=True)
+        (root / ".prd-os" / "spillover.jsonl").write_text(json.dumps({
+            "id": "sp-test01", "status": "open", "severity": "major",
+            "source": "ASK-451", "description": "the conveyor is dead"}) + "\n")
+        dor = root / "dor.md"
+        dor.write_text(DOR)
+
+        creates = []
+        creates_lock = threading.Lock()
+        start = threading.Barrier(2)
+
+        class SlowLinear(RecordingLinear):
+            """Widens the create window; the barrier decides the interleaving."""
+
+            def graphql(self, query, variables):
+                if "issueCreate" in " ".join(query.split()):
+                    time.sleep(0.4)
+                    with creates_lock:
+                        creates.append(variables["input"]["title"])
+                        n = len(creates)
+                    return {"issueCreate": {
+                        "success": True,
+                        "issue": {"id": f"i{n}", "identifier": f"ASK-99{n}"}}}
+                return super().graphql(query, variables)
+
+        mod = load_promote()
+        mod.linear_module = lambda: SlowLinear()
+
+        sys.argv = ["spillover-promote.py", "sp-test01", "--title", "conveyor test",
+                    "--dor-file", str(dor), "--repo-root", str(root)]
+        os.environ["KIPI_LINEAR_PROJECT"] = "kipi-system"
+
+        rcs = {}
+
+        def promote(tag):
+            # Both threads clear the status check before either can create.
+            # Without that barrier this would be a coin flip on scheduler luck,
+            # and a reproducer that only sometimes reproduces is not one.
+            start.wait(timeout=10)
+            buf = io.StringIO()
+            with contextlib.redirect_stdout(buf), contextlib.redirect_stderr(buf):
+                rcs[tag] = mod.main()
+
+        threads = [threading.Thread(target=promote, args=(i,)) for i in range(2)]
+        old_argv, old_env = sys.argv, dict(os.environ)
+        try:
+            for t in threads:
+                t.start()
+            for t in threads:
+                t.join(timeout=30)
+                self.assertFalse(t.is_alive(), "a promotion never finished (deadlock?)")
+        finally:
+            sys.argv = old_argv
+            os.environ.clear()
+            os.environ.update(old_env)
+        return creates, rcs, root
+
+    def test_two_concurrent_promotions_create_one_issue(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            creates, rcs, root = self._run_two(tmp)
+            self.assertEqual(len(creates), 1,
+                             f"{len(creates)} Linear issues for one finding: the "
+                             "check/create/append is not serialized")
+            self.assertEqual(sorted(rcs.values()), [0, 2],
+                             "the loser must REFUSE (exit 2), not report success")
+
+    def test_the_loser_appends_no_second_promoted_row(self):
+        """A second `promoted` row would make the ledger claim two promotions."""
+        with tempfile.TemporaryDirectory() as tmp:
+            _, _, root = self._run_two(tmp)
+            rows = [json.loads(l) for l in
+                    (root / ".prd-os" / "spillover.jsonl").read_text().splitlines()
+                    if l.strip()]
+            promoted = [r for r in rows if r.get("status") == "promoted"]
+            self.assertEqual(len(promoted), 1,
+                             f"{len(promoted)} promoted rows for one finding")
 
 
 if __name__ == "__main__":

--- a/q-system/.q-system/scripts/test_spillover_promote_selection.py
+++ b/q-system/.q-system/scripts/test_spillover_promote_selection.py
@@ -1,0 +1,332 @@
+#!/usr/bin/env python3
+"""The conveyor test: does what spillover-promote.py FILES get PICKED UP? (ASK-451)
+
+why this shape: spillover-promote.py and linear-worker.sh were each tested alone
+and each passed, while the thing they exist to do -- move a confirmed finding
+into a queue a machine actually drains -- was broken the whole time. A producer
+test that asserts "an issue was created" and a consumer test that asserts "a
+correctly-labelled issue is picked" are both green against a payload the
+consumer would silently drop. That gap is the entire defect.
+
+So this test refuses to own a copy of either side:
+
+  * `ready()` / `in_this_repo()` are AST-extracted from the SHIPPED
+    linear-worker.sh heredoc and executed. Rename or re-scope the predicate and
+    the extractor fails loudly instead of testing a stale duplicate.
+  * the payload is whatever the SHIPPED spillover-promote.py main() hands to
+    issueCreate, captured by stubbing the ONE seam that reaches the network
+    (`linear_module`). No live Linear call, and no hand-written payload that
+    could agree with my assumption instead of with the code.
+
+The id->name inversion is deliberately strict. `ready()` reads label and project
+NAMES; the payload carries UUIDs. If the script ever puts an id in the payload
+it did not resolve by name through the stub, the inversion raises rather than
+guessing a name -- otherwise this test could manufacture the very selection it
+is supposed to be measuring.
+"""
+import ast
+import contextlib
+import importlib.util
+import io
+import json
+import os
+import sys
+import tempfile
+import unittest
+from pathlib import Path
+
+HERE = Path(__file__).resolve().parent
+PROMOTE = HERE / "spillover-promote.py"
+WORKER = HERE / "linear-worker.sh"
+
+# Measured from the live board 2026-08-06 (read-only MCP list calls), not
+# invented: team ASK carries label `owner:sana` and project `kipi-system`.
+# A fixture I make up tests my assumption; these came from the producer.
+LABEL_IDS = {"owner:sana": "a90dd212-40ec-4996-975a-9afce63f505d"}
+PROJECT_IDS = {"kipi-system": "00bec4fd-cdd1-4d5a-992a-4ae3319c2d0a"}
+TEAM_ID = "team-ask-uuid"
+
+# A new Linear issue lands in the team default state. Every state on team ASK
+# that a CREATE can produce is Backlog(backlog) or Todo(unstarted), both of
+# which ready() accepts; the started/completed/canceled types are only
+# reachable by a later transition. Enumerated from list_issue_statuses, so this
+# is the measured set and not a guess at "probably backlog".
+CREATE_STATE_TYPES = ("backlog", "unstarted")
+
+
+# --------------------------------------------------------------------------
+# Drive the SHIPPED consumer predicates, do not reimplement them.
+# --------------------------------------------------------------------------
+def worker_predicates(repo_project: str):
+    """AST-extract ready()/in_this_repo()/project_of() out of linear-worker.sh."""
+    text = WORKER.read_text()
+    blocks, cur = [], None
+    for line in text.splitlines():
+        if cur is None:
+            if line.rstrip().endswith("<<'PY'"):
+                cur = []
+            continue
+        if line.strip() == "PY":
+            blocks.append("\n".join(cur))
+            cur = None
+        else:
+            cur.append(line)
+    hits = [b for b in blocks if "def ready(" in b]
+    if len(hits) != 1:
+        raise AssertionError(
+            f"expected exactly 1 heredoc defining ready() in {WORKER}, found "
+            f"{len(hits)}. The consumer moved; this test is measuring nothing.")
+
+    tree = ast.parse(hits[0])
+    want = {"project_of", "in_this_repo", "ready"}
+    keep = [n for n in tree.body
+            if isinstance(n, ast.FunctionDef) and n.name in want]
+    missing = want - {n.name for n in keep}
+    if missing:
+        raise AssertionError(f"linear-worker.sh no longer defines {missing}")
+
+    ns = {"os": os, "repo_project": repo_project}
+    exec(compile(ast.Module(body=keep, type_ignores=[]), str(WORKER), "exec"), ns)
+    return ns
+
+
+# --------------------------------------------------------------------------
+# Drive the SHIPPED producer, stubbing only the network seam.
+# --------------------------------------------------------------------------
+class RecordingLinear:
+    """Stands in for linear-sync.py. Records every query; serves known names."""
+
+    ISSUE_CREATE = "mutation($input: IssueCreateInput!) { issueCreate(input: $input) }"
+
+    def __init__(self):
+        self.created = None
+        self.resolved_labels = {}   # id -> name, only for names actually asked for
+        self.resolved_projects = {}
+
+    def graphql(self, query, variables):
+        q = " ".join(query.split())
+        if "teams(" in q and "issueLabels" not in q:
+            return {"teams": {"nodes": [{"id": TEAM_ID}]}}
+        if "issueLabels" in q:
+            name = variables.get("name")
+            node = ([{"id": LABEL_IDS[name], "name": name}]
+                    if name in LABEL_IDS else [])
+            for n in node:
+                self.resolved_labels[n["id"]] = n["name"]
+            return {"issueLabels": {"nodes": node}}
+        if "projects(" in q:
+            name = variables.get("name")
+            node = ([{"id": PROJECT_IDS[name], "name": name}]
+                    if name in PROJECT_IDS else [])
+            for n in node:
+                self.resolved_projects[n["id"]] = n["name"]
+            return {"projects": {"nodes": node}}
+        if "issueCreate" in q:
+            self.created = variables["input"]
+            return {"issueCreate": {"success": True,
+                                    "issue": {"id": "i1", "identifier": "ASK-999"}}}
+        raise AssertionError(f"stub got an unhandled query: {q[:120]}")
+
+
+def load_promote():
+    spec = importlib.util.spec_from_file_location("spillover_promote", PROMOTE)
+    m = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(m)
+    return m
+
+
+DOR = (
+    "**Allowed files** -- q-system/.q-system/scripts/spillover-promote.py\n"
+    "**Acceptance** -- [ ] the promoted issue is selected by linear-worker.\n"
+    "[ ] a failure shows as the worker reporting 0 ready while the issue exists.\n")
+
+
+def run_promote(tmp, repo_project=None, extra_env=None):
+    """Run the real main() against a real ledger; return (rc, stub)."""
+    root = Path(tmp)
+    (root / ".prd-os").mkdir(parents=True, exist_ok=True)
+    (root / ".prd-os" / "spillover.jsonl").write_text(json.dumps({
+        "id": "sp-test01", "status": "open", "severity": "major",
+        "source": "ASK-451", "description": "the conveyor is dead"}) + "\n")
+
+    mod = load_promote()
+    stub = RecordingLinear()
+    mod.linear_module = lambda: stub
+
+    dor = root / "dor.md"
+    dor.write_text(DOR)
+
+    argv = ["spillover-promote.py", "sp-test01", "--title", "conveyor test",
+            "--dor-file", str(dor), "--repo-root", str(root)]
+    old_argv, old_env = sys.argv, dict(os.environ)
+    sys.argv = argv
+    if repo_project is not None:
+        os.environ["KIPI_LINEAR_PROJECT"] = repo_project
+    else:
+        os.environ.pop("KIPI_LINEAR_PROJECT", None)
+    os.environ.update(extra_env or {})
+    try:
+        rc = mod.main()
+    finally:
+        sys.argv = old_argv
+        os.environ.clear()
+        os.environ.update(old_env)
+    return rc, stub, root
+
+
+def issue_as_worker_sees_it(stub, state_type="backlog"):
+    """Invert the payload's UUIDs back through names the script actually resolved."""
+    p = stub.created
+    assert p is not None, "spillover-promote.py never called issueCreate"
+
+    labels = []
+    for lid in p.get("labelIds", []):
+        if lid not in stub.resolved_labels:
+            raise AssertionError(
+                f"payload carries label id {lid} that was never resolved by name; "
+                "refusing to invent a name for it")
+        labels.append(stub.resolved_labels[lid])
+
+    pid = p.get("projectId")
+    if pid is None:
+        project = None
+    elif pid not in stub.resolved_projects:
+        raise AssertionError(
+            f"payload carries project id {pid} that was never resolved by name")
+    else:
+        project = stub.resolved_projects[pid]
+
+    return {
+        "identifier": "ASK-999",
+        "title": p.get("title"),
+        "description": p.get("description") or "",
+        "state": {"name": state_type, "type": state_type},
+        "project": ({"name": project} if project else None),
+        "labels": {"nodes": [{"name": n} for n in labels]},
+    }
+
+
+def why_not_ready(issue):
+    labels = {l["name"] for l in issue["labels"]["nodes"]}
+    reasons = []
+    if "owner:sana" not in labels:
+        reasons.append("missing label owner:sana")
+    if (issue.get("project") or {}).get("name") is None:
+        reasons.append("project unset (worker: unset project is NOT this repo)")
+    if "Definition of Ready" not in issue["description"]:
+        reasons.append("no Definition of Ready in description")
+    return reasons
+
+
+class TestPromotedIssueIsSelectable(unittest.TestCase):
+
+    def test_promoted_issue_is_picked_up_by_the_worker(self):
+        """The end-to-end claim: what the producer files, the consumer picks."""
+        with tempfile.TemporaryDirectory() as tmp:
+            rc, stub, _ = run_promote(tmp, repo_project="kipi-system")
+            self.assertEqual(rc, 0, "promote did not succeed")
+            preds = worker_predicates("kipi-system")
+            for st in CREATE_STATE_TYPES:
+                issue = issue_as_worker_sees_it(stub, st)
+                self.assertTrue(
+                    preds["ready"](issue),
+                    f"linear-worker.sh would DROP the promoted issue "
+                    f"(state={st}): {'; '.join(why_not_ready(issue)) or 'unknown'}")
+
+    def test_issue_for_another_repo_is_not_selected_here(self):
+        """A promotion aimed at another repo must not be drained by this checkout."""
+        with tempfile.TemporaryDirectory() as tmp:
+            rc, stub, _ = run_promote(tmp, repo_project="kipi-system")
+            self.assertEqual(rc, 0)
+            issue = issue_as_worker_sees_it(stub)
+            preds = worker_predicates("some-other-repo")
+            self.assertFalse(preds["ready"](issue),
+                             "a kipi-system issue was selected by another repo")
+
+    def test_promoting_twice_creates_one_issue(self):
+        """Idempotency: the second run must refuse, not file a duplicate."""
+        with tempfile.TemporaryDirectory() as tmp:
+            rc1, stub1, root = run_promote(tmp, repo_project="kipi-system")
+            self.assertEqual(rc1, 0)
+            self.assertIsNotNone(stub1.created)
+
+            mod = load_promote()
+            stub2 = RecordingLinear()
+            mod.linear_module = lambda: stub2
+            dor = root / "dor.md"
+            old_argv, old_env = sys.argv, dict(os.environ)
+            sys.argv = ["spillover-promote.py", "sp-test01", "--title", "again",
+                        "--dor-file", str(dor), "--repo-root", str(root)]
+            # The project MUST resolve on the second run too. Without this the
+            # rerun refused because root.name is a tmpdir that matches no Linear
+            # project -- a rc==2 that had nothing to do with idempotency. The
+            # M6 mutant (neutering the already-promoted check) SURVIVED against
+            # that version: the assertion was green for the wrong reason.
+            os.environ["KIPI_LINEAR_PROJECT"] = "kipi-system"
+            err = io.StringIO()
+            try:
+                with contextlib.redirect_stderr(err):
+                    rc2 = mod.main()
+            finally:
+                sys.argv = old_argv
+                os.environ.clear()
+                os.environ.update(old_env)
+            self.assertEqual(rc2, 2, "second promote should refuse")
+            self.assertIn("promoted", err.getvalue(),
+                          "refusal must be the already-promoted guard, not "
+                          f"some other refusal: {err.getvalue()!r}")
+            self.assertIsNone(stub2.created,
+                              "second promote created a DUPLICATE issue")
+
+    def test_unknown_project_refuses_instead_of_filing_an_invisible_issue(self):
+        """The guard that costs one promotion instead of the conveyor."""
+        with tempfile.TemporaryDirectory() as tmp:
+            rc, stub, root = run_promote(tmp, repo_project="no-such-project")
+            self.assertEqual(rc, 2, "unknown project should refuse")
+            self.assertIsNone(stub.created,
+                              "filed an issue no worker could ever see")
+            rows = [json.loads(l) for l in
+                    (root / ".prd-os" / "spillover.jsonl").read_text().splitlines() if l.strip()]
+            self.assertEqual(rows[-1]["status"], "open",
+                             "refused promotion must leave the row open")
+
+    def test_unknown_label_refuses(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            root = Path(tmp)
+            (root / ".prd-os").mkdir(parents=True)
+            (root / ".prd-os" / "spillover.jsonl").write_text(json.dumps({
+                "id": "sp-test01", "status": "open", "severity": "major",
+                "source": "ASK-451", "description": "x"}) + "\n")
+            dor = root / "dor.md"
+            dor.write_text(DOR)
+            mod = load_promote()
+            stub = RecordingLinear()
+            mod.linear_module = lambda: stub
+            # Drives the REAL resolve+refuse path with a name the board lacks.
+            mod.REQUIRED_LABELS = ("owner:nobody",)
+            old_argv, old_env = sys.argv, dict(os.environ)
+            sys.argv = ["spillover-promote.py", "sp-test01", "--title", "t",
+                        "--dor-file", str(dor), "--repo-root", str(root)]
+            os.environ["KIPI_LINEAR_PROJECT"] = "kipi-system"
+            try:
+                rc = mod.main()
+            finally:
+                sys.argv = old_argv
+                os.environ.clear()
+                os.environ.update(old_env)
+            self.assertEqual(rc, 2, "unknown label should refuse")
+            self.assertIsNone(stub.created)
+
+    def test_ledger_row_says_promoted_not_resolved(self):
+        """Promoting is not fixing. A `resolved` here would launder the pile."""
+        with tempfile.TemporaryDirectory() as tmp:
+            rc, _, root = run_promote(tmp, repo_project="kipi-system")
+            self.assertEqual(rc, 0)
+            rows = [json.loads(l) for l in
+                    (root / ".prd-os" / "spillover.jsonl").read_text().splitlines() if l.strip()]
+            self.assertEqual(rows[-1]["status"], "promoted")
+            self.assertEqual(rows[-1]["linear_ref"], "ASK-999")
+
+
+if __name__ == "__main__":
+    unittest.main(verbosity=2)

--- a/q-system/.q-system/scripts/test_spillover_ratchet.py
+++ b/q-system/.q-system/scripts/test_spillover_ratchet.py
@@ -1,0 +1,235 @@
+#!/usr/bin/env python3
+"""Tests for spillover-ratchet.py (ASK-343).
+
+Two properties decide whether this hook is worth having at all:
+
+  1. It must EXIT 2. The hook contract is exit 2 = stderr fed to Claude,
+     exit 0 = pass. The first version of this file exited 0, so it wrote to a
+     stderr nobody read -- inert on arrival, the same defect the ledger had.
+  2. It must not cry wolf. A ratchet that fires on README.md gets switched off,
+     and a switched-off gate protects nothing.
+
+Temp ledgers only, never the live one.
+"""
+import importlib.util
+import json
+import os
+import subprocess
+import sys
+import tempfile
+import unittest
+from pathlib import Path
+
+SCRIPT = Path(__file__).resolve().parent / "spillover-ratchet.py"
+spec = importlib.util.spec_from_file_location("sr", SCRIPT)
+sr = importlib.util.module_from_spec(spec)
+spec.loader.exec_module(sr)
+
+ROWS = [
+    {"id": "sp-aaa", "status": "open", "severity": "minor", "source": "s",
+     "description": "capability-gate.py reports a timeout as RED"},
+    {"id": "sp-bbb", "status": "open", "severity": "major", "source": "s",
+     "description": "capability-gate.py has a second, blocking problem"},
+    {"id": "sp-ccc", "status": "resolved", "severity": "minor", "source": "s",
+     "description": "capability-gate.py had a third, already handled"},
+    {"id": "sp-ddd", "status": "open", "severity": "minor", "source": "s",
+     "description": "see the README for the full context of this unrelated note"},
+]
+
+
+class MatchTest(unittest.TestCase):
+    def rows(self):
+        return [r for r in ROWS
+                if r["status"] == "open" and r["severity"] == "minor"]
+
+    def test_matches_the_named_file(self):
+        hits = sr.findings_for("q-system/.q-system/scripts/capability-gate.py", self.rows())
+        self.assertEqual([h["id"] for h in hits], ["sp-aaa"])
+
+    def test_matches_on_basename_not_full_path(self):
+        """A finding written from another checkout names the file, not your path."""
+        hits = sr.findings_for("/somewhere/else/entirely/capability-gate.py", self.rows())
+        self.assertEqual([h["id"] for h in hits], ["sp-aaa"])
+
+    def test_generic_stem_does_not_cry_wolf(self):
+        """README appears in unrelated prose everywhere. Firing on it is how a
+        ratchet gets switched off."""
+        self.assertEqual(sr.findings_for("README.md", self.rows()), [])
+
+    def test_partial_name_does_not_match(self):
+        """gate.py must not match capability-gate.py."""
+        self.assertEqual(sr.findings_for("gate.py", self.rows()), [])
+
+    def test_blocking_severities_are_not_delivered_here(self):
+        """major/blocker go through `gates run`, not the ratchet. Delivering them
+        twice trains people to dismiss both."""
+        rows = sr.ledger_rows(Path("/nonexistent"))
+        self.assertEqual(rows, [])
+        self.assertNotIn("sp-bbb", [h["id"] for h in
+                                    sr.findings_for("capability-gate.py", self.rows())])
+
+    def test_resolved_findings_are_not_delivered(self):
+        self.assertNotIn("sp-ccc", [h["id"] for h in
+                                    sr.findings_for("capability-gate.py", self.rows())])
+
+
+class ExitCodeTest(unittest.TestCase):
+    def setUp(self):
+        self.tmp = tempfile.TemporaryDirectory()
+        self.root = Path(self.tmp.name)
+        (self.root / ".prd-os").mkdir(parents=True)
+        (self.root / ".prd-os" / "spillover.jsonl").write_text(
+            "".join(json.dumps(r) + "\n" for r in ROWS))
+        (self.root / "capability-gate.py").write_text("# x\n")
+        subprocess.run(["git", "init", "-q"], cwd=self.root, capture_output=True)
+        self.home = tempfile.TemporaryDirectory()
+
+    def tearDown(self):
+        self.tmp.cleanup()
+        self.home.cleanup()
+
+    def run_hook(self, target, day="d1"):
+        env = dict(os.environ, HOME=self.home.name, KIPI_RATCHET_DATE=day)
+        return subprocess.run([sys.executable, str(SCRIPT), str(target)],
+                              capture_output=True, text=True, env=env, cwd=self.root)
+
+    # --- THE PROPERTY THAT MAKES IT NOT INERT ------------------------------
+    def test_exits_2_so_the_agent_actually_sees_it(self):
+        r = self.run_hook(self.root / "capability-gate.py")
+        self.assertEqual(r.returncode, 2,
+                         "exit 0 means stderr is discarded and the hook is inert")
+        self.assertIn("sp-aaa", r.stderr)
+
+    def test_asks_for_triage_not_a_fix(self):
+        """Fixing an adjacent bug mid-task is scope creep, which the repo rules
+        forbid. The ask has to be 'is this still true'."""
+        r = self.run_hook(self.root / "capability-gate.py")
+        self.assertIn("DO NOT fix", r.stderr)
+        self.assertIn("STILL TRUE", r.stderr)
+
+    def test_fires_once_per_file_per_day(self):
+        first = self.run_hook(self.root / "capability-gate.py", day="d1")
+        second = self.run_hook(self.root / "capability-gate.py", day="d1")
+        self.assertEqual(first.returncode, 2)
+        self.assertEqual(second.returncode, 0, "a second edit must not re-interrupt")
+
+    def test_a_new_day_re_asks(self):
+        self.run_hook(self.root / "capability-gate.py", day="d1")
+        third = self.run_hook(self.root / "capability-gate.py", day="d2")
+        self.assertEqual(third.returncode, 2, "a deferred note should come back")
+
+    def test_file_with_no_notes_is_silent(self):
+        (self.root / "quiet_file.py").write_text("# x\n")
+        r = self.run_hook(self.root / "quiet_file.py")
+        self.assertEqual(r.returncode, 0)
+        self.assertEqual(r.stderr.strip(), "")
+
+    # --- THE PROPERTY THAT MAKES IT NOT INERT, PART 2 (ASK-457) ------------
+    def test_fires_through_the_stdin_payload_the_hook_actually_uses(self):
+        """argv is the MANUAL path. PostToolUse feeds JSON on stdin, and that is
+        the only path the wired hook ever takes -- so testing argv alone would
+        have left the shipped invocation untested."""
+        env = dict(os.environ, HOME=self.home.name, KIPI_RATCHET_DATE="dstdin")
+        payload = json.dumps({"tool_name": "Edit", "tool_input": {
+            "file_path": str(self.root / "capability-gate.py")}})
+        r = subprocess.run([sys.executable, str(SCRIPT)], input=payload,
+                           capture_output=True, text=True, env=env, cwd=self.root)
+        self.assertEqual(r.returncode, 2, "the wired hook path must reach exit 2")
+        self.assertIn("sp-aaa", r.stderr)
+
+    def test_promoter_is_named_by_a_path_that_exists(self):
+        """An address the reader cannot dial is not an address. The promoter is
+        not on PATH, so a bare basename leaves the agent guessing from whatever
+        worktree it is in."""
+        r = self.run_hook(self.root / "capability-gate.py", day="dpath")
+        self.assertIn(str(SCRIPT.parent / "spillover-promote.py"), r.stderr)
+
+
+class BareWordTest(unittest.TestCase):
+    """A bare dictionary word is a word, not a filename (ASK-457).
+
+    Measured against the live ledger before wiring: `kipi` matched 148 findings,
+    every sampled one a false positive. A ratchet that dumps 148 notes when you
+    edit the main CLI is a ratchet someone switches off, and an off gate protects
+    nothing -- the same reasoning as the README guard above, one hole over.
+    """
+    ROWS = [
+        {"id": "sp-bare", "status": "open", "severity": "minor", "source": "s",
+         "description": "kipi update rsyncs into main from the repo config at HEAD"},
+        {"id": "sp-real", "status": "open", "severity": "minor", "source": "s",
+         "description": "linear-worker.sh ready() refuses an unlabelled issue"},
+        {"id": "sp-dot", "status": "open", "severity": "minor", "source": "s",
+         "description": ".gitignore excludes *.jsonl so the ledger never travels"},
+    ]
+
+    def test_bare_words_do_not_fire(self):
+        for word in ("kipi", "main", "repo", "config", "HEAD", "claude"):
+            with self.subTest(word=word):
+                self.assertEqual(sr.findings_for(word, self.ROWS), [],
+                                 f"{word!r} is a word, not a filename")
+
+    def test_a_separator_still_makes_it_a_name(self):
+        hits = sr.findings_for("linear-worker.sh", self.ROWS)
+        self.assertEqual([h["id"] for h in hits], ["sp-real"])
+
+    def test_a_dotfile_is_still_a_name(self):
+        """`.gitignore` has no extension and no separator, but the leading dot
+        marks it as a filename. Suppressing it would be the fix overshooting."""
+        hits = sr.findings_for(".gitignore", self.ROWS)
+        self.assertEqual([h["id"] for h in hits], ["sp-dot"])
+
+
+class WorktreeLedgerTest(unittest.TestCase):
+    """The ledger lives in ONE place for the whole worktree set (ASK-457).
+
+    Measured before wiring: run from a worktree, the ratchet saw 0 rows on a file
+    carrying 57 real notes, because `*.jsonl` is gitignored and so each worktree
+    has its own (absent) copy. Agents work in worktrees. Arming the hook without
+    this would have armed it precisely where it can never fire.
+    """
+    def setUp(self):
+        self.tmp = tempfile.TemporaryDirectory()
+        self.home = tempfile.TemporaryDirectory()
+        self.main = Path(self.tmp.name) / "checkout"
+        self.main.mkdir()
+        run = lambda *a: subprocess.run(list(a), cwd=self.main,
+                                        capture_output=True, text=True)
+        run("git", "init", "-q", "-b", "main")
+        run("git", "config", "user.email", "t@t")
+        run("git", "config", "user.name", "t")
+        (self.main / "capability-gate.py").write_text("# x\n")
+        run("git", "add", "-A")
+        run("git", "commit", "-qm", "init")
+        # The ledger exists ONLY in the main checkout, exactly as in real life.
+        (self.main / ".prd-os").mkdir()
+        (self.main / ".prd-os" / "spillover.jsonl").write_text(
+            "".join(json.dumps(r) + "\n" for r in ROWS))
+        self.wt = Path(self.tmp.name) / "wt"
+        add = run("git", "worktree", "add", "-q", "-b", "side", str(self.wt))
+        # A failed `git worktree add` would leave cwd falling back to the MAIN
+        # checkout, where the ledger is present and the test passes from code
+        # without the fix. Assert the setup landed before trusting the result.
+        self.assertEqual(add.returncode, 0, f"worktree setup failed: {add.stderr}")
+        self.assertTrue((self.wt / "capability-gate.py").is_file())
+        self.assertFalse((self.wt / ".prd-os" / "spillover.jsonl").exists(),
+                         "the worktree must NOT have its own ledger copy")
+
+    def tearDown(self):
+        subprocess.run(["git", "worktree", "remove", "--force", str(self.wt)],
+                       cwd=self.main, capture_output=True)
+        self.tmp.cleanup()
+        self.home.cleanup()
+
+    def test_a_worktree_edit_still_sees_the_shared_ledger(self):
+        env = dict(os.environ, HOME=self.home.name, KIPI_RATCHET_DATE="dwt")
+        target = self.wt / "capability-gate.py"
+        r = subprocess.run([sys.executable, str(SCRIPT), str(target)],
+                           capture_output=True, text=True, env=env, cwd=self.wt)
+        self.assertEqual(
+            r.returncode, 2,
+            f"inert in the worktree the work happens in (ran in {self.wt}): {r.stderr!r}")
+        self.assertIn("sp-aaa", r.stderr)
+
+
+if __name__ == "__main__":
+    unittest.main(verbosity=2)

--- a/settings-template.json
+++ b/settings-template.json
@@ -229,6 +229,10 @@
           },
           {
             "type": "command",
+            "command": "test -f \"$CLAUDE_PROJECT_DIR/q-system/.q-system/scripts/spillover-ratchet.py\" && python3 \"$CLAUDE_PROJECT_DIR/q-system/.q-system/scripts/spillover-ratchet.py\""
+          },
+          {
+            "type": "command",
             "command": "test -f \"$CLAUDE_PROJECT_DIR/q-system/.q-system/scripts/lessons-validator.py\" && python3 \"$CLAUDE_PROJECT_DIR/q-system/.q-system/scripts/lessons-validator.py\""
           },
           {


### PR DESCRIPTION
Closes ASK-457.

`spillover-promote.py` works and is proven end to end (ASK-456), but nothing called it. The producer is `spillover-ratchet.py`, a PostToolUse hook that surfaces a minor finding to the agent that already has the file open, and prints the promote command as an instruction. That is an agent path end to end; the founder is never in it. It was stranded on `origin/sana/ask-312`.

Extracted byte-identical (`git show <ref>:<path> > <path>`, sha256 verified), then fixed three defects that measurement found before arming it.

### 1. Inert in every worktree
Ledger root came from the per-worktree git toplevel. `*.jsonl` is gitignored, so the ledger never travels. Measured from a worktree: **0 rows on `linear-worker.sh`, a file carrying 57 open notes.** Agents work in worktrees, so wiring it unchanged would have armed it exactly where it can never fire. Now imports `spillover-promote.ledger_root` -> `prd_runner._ledger_root` (git-common-dir). One derivation, not three.

### 2. Cried wolf on bare words
The README guard covered the stem path only; the hole had relocated to the basename path. Editing the repo-root `kipi` CLI matched **148 findings, every sampled one a false positive** on prose about `kipi update`. Same for `claude` (72), `repo` (61), `main` (45), `config` (23), `HEAD` (17) - 395 bogus interruptions across 9 names. A basename is a name only when an extension, a separator, or a leading dot marks it as one.

### 3. Named an undialable address
The printed promote command was a bare basename; the promoter is not on PATH. Now the resolved path.

## Wiring
Both `.claude/settings.json` and `settings-template.json`. Template-only ships the switch dead to the skeleton; runtime-only ships the script to the fleet with the switch dead, which is the scar `settings-template-sync-check.py` exists for.

## Scope note on the DoR
The Linear DoR specced a scheduled job and a rate cap. There is no bulk run to cap - the ratchet fires per edit, once per file per day, max 3 shown. No launchd, no cron, no cap. The 570 open items drain as files are touched rather than arriving as 570 issues.

## Verification (all local; this repo creates zero GitHub workflow runs)

Red -> green on the running system, same prompt and same model, branch as the only variable:

| | ratchet on disk | wired | `[spillover]` fired | ack marker |
|---|---|---|---|---|
| `origin/main` | no | 0 / 0 | no | absent |
| this branch | yes | 1 / 1 | 22 notes | written |

The firing run read 22 findings from the MAIN checkout's ledger while editing inside a worktree that has none - fix 1 proven on the running system, not just in tests - and printed the resolved promoter path (fix 3).

- `test_spillover_ratchet.py` 17/17, up from 11 (worktree ledger, stdin payload, bare words, dotfile, promoter path).
- 5 mutants, each validated as actually applied, all killed: `ledger_root` reverted -> worktree test red; bare-word guard -> 5 red; promoter path -> red; entry dropped from either settings file -> sync-check exit 2 naming the script.
- `capability-manifest.json`: the promoter's `declared_inert` entry removed (it has a caller now), ratchet test registered.

Routed to spillover, not fixed here: `sp-002b954a` (two manifest entries claim wiring is a "founder product decision"), `sp-61faebb3` (9 open low/medium findings the minor-only filter cannot deliver), `sp-ea84c86b` (557 tracked review-scratch files inflating the fire population).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01WZeGrz117RS1ZxNmGpQk4W