### PR TITLE
Verify a launchd job's paused/running state against declared intent (ASK-447, sp-2c7e5819)

### DIFF
--- a/q-system/.q-system/capability-manifest.json
+++ b/q-system/.q-system/capability-manifest.json
@@ -2,12 +2,41 @@
   "schema_version": 1,
   "expected_tests": [
     {
+      "path": "plugins/kipi-design/hooks/test_dogfood_gate.py",
+      "runner": "python3"
+    },
+    {
+      "path": "plugins/kipi-dsse/scripts/test_computed_receipts.py",
+      "runner": "python3",
+      "timeout_s": 180
+    },
+    {
+      "path": "plugins/kipi-dsse/scripts/test_scope_hook_fails_closed.py",
+      "runner": "python3",
+      "timeout_s": 120
+    },
+    {
       "path": "plugins/prd-os/scripts/test/test_spillover_ledger_root.py",
       "runner": "python3"
     },
     {
+      "path": "plugins/prd-os/skills/fable-discipline/scripts/test_fable_discipline_lint.py",
+      "runner": "python3",
+      "timeout_s": 120
+    },
+    {
+      "path": "plugins/prd-os/tests/test_judgment_compiler.py",
+      "runner": "python3",
+      "timeout_s": 240
+    },
+    {
       "path": "plugins/prd-os/tests/test_prd_split_from_linear.py",
       "runner": "python3"
+    },
+    {
+      "path": "plugins/prd-os/tests/test_virgin_repo_lifecycle.py",
+      "runner": "python3",
+      "timeout_s": 120
     },
     {
       "path": "q-system/.q-system/scripts/test-ripple.py",
@@ -28,6 +57,10 @@
     {
       "path": "q-system/.q-system/scripts/test/test-capability-gate-reap.sh",
       "runner": "bash"
+    },
+    {
+      "path": "q-system/.q-system/scripts/test/test-capability-map-wiring.py",
+      "runner": "python3"
     },
     {
       "path": "q-system/.q-system/scripts/test/test-ci-redrive.sh",
@@ -59,19 +92,6 @@
     },
     {
       "path": "q-system/.q-system/scripts/test/test-findings-block-reader.sh",
-      "runner": "bash"
-    },
-    {
-      "path": "q-system/.q-system/scripts/test/test-pr-review-root-guard.sh",
-      "runner": "bash",
-      "timeout_s": 120
-    },
-    {
-      "path": "q-system/.q-system/scripts/test/test-review-plan-echo-gate.sh",
-      "runner": "bash"
-    },
-    {
-      "path": "q-system/.q-system/scripts/test/test-repo-preflight.sh",
       "runner": "bash"
     },
     {
@@ -121,6 +141,11 @@
     {
       "path": "q-system/.q-system/scripts/test/test-kipi-update-leak-preflight.sh",
       "runner": "bash"
+    },
+    {
+      "path": "q-system/.q-system/scripts/test/test-kipi-update-owned-deletion-guard.sh",
+      "runner": "bash",
+      "timeout_s": 300
     },
     {
       "path": "q-system/.q-system/scripts/test/test-kipi-update-preservation-failure.sh",
@@ -223,12 +248,13 @@
       "runner": "bash"
     },
     {
-      "path": "q-system/.q-system/scripts/test/test-prompt-only-enforcement-guard-stderr.sh",
-      "runner": "bash"
+      "path": "q-system/.q-system/scripts/test/test-pr-review-root-guard.sh",
+      "runner": "bash",
+      "timeout_s": 120
     },
     {
-      "path": "plugins/kipi-design/hooks/test_dogfood_gate.py",
-      "runner": "python3"
+      "path": "q-system/.q-system/scripts/test/test-prompt-only-enforcement-guard-stderr.sh",
+      "runner": "bash"
     },
     {
       "path": "q-system/.q-system/scripts/test/test-propagation-entrypoints.py",
@@ -251,6 +277,10 @@
       "runner": "bash"
     },
     {
+      "path": "q-system/.q-system/scripts/test/test-repo-preflight.sh",
+      "runner": "bash"
+    },
+    {
       "path": "q-system/.q-system/scripts/test/test-review-comment-body.sh",
       "runner": "bash"
     },
@@ -259,7 +289,19 @@
       "runner": "bash"
     },
     {
+      "path": "q-system/.q-system/scripts/test/test-review-gate-no-fake-green.sh",
+      "runner": "bash"
+    },
+    {
       "path": "q-system/.q-system/scripts/test/test-review-invoker-provenance.sh",
+      "runner": "bash"
+    },
+    {
+      "path": "q-system/.q-system/scripts/test/test-review-plan-echo-gate.sh",
+      "runner": "bash"
+    },
+    {
+      "path": "q-system/.q-system/scripts/test/test-review-redrive.sh",
       "runner": "bash"
     },
     {
@@ -267,12 +309,12 @@
       "runner": "bash"
     },
     {
-      "path": "q-system/.q-system/scripts/test/test-runtime-plugin-freshness.sh",
+      "path": "q-system/.q-system/scripts/test/test-runtime-plugin-freshness-wired.sh",
       "runner": "bash",
       "timeout_s": 120
     },
     {
-      "path": "q-system/.q-system/scripts/test/test-runtime-plugin-freshness-wired.sh",
+      "path": "q-system/.q-system/scripts/test/test-runtime-plugin-freshness.sh",
       "runner": "bash",
       "timeout_s": 120
     },
@@ -318,6 +360,14 @@
       "runner": "python3"
     },
     {
+      "path": "q-system/.q-system/scripts/test/test-verdict-statement-shape.sh",
+      "runner": "bash"
+    },
+    {
+      "path": "q-system/.q-system/scripts/test/test-verdict-usability.sh",
+      "runner": "bash"
+    },
+    {
       "path": "q-system/.q-system/scripts/test/test-voice-enforcement-rule-wired.sh",
       "runner": "bash"
     },
@@ -338,11 +388,20 @@
       "runner": "bash"
     },
     {
+      "path": "q-system/.q-system/scripts/test/test-zero-safe-count-idiom.sh",
+      "runner": "bash",
+      "timeout_s": 60
+    },
+    {
       "path": "q-system/.q-system/scripts/test_autocapture_e2e.py",
       "runner": "python3"
     },
     {
       "path": "q-system/.q-system/scripts/test_autocapture_wiring.py",
+      "runner": "python3"
+    },
+    {
+      "path": "q-system/.q-system/scripts/test_blocked_claim_evidence_lint.py",
       "runner": "python3"
     },
     {
@@ -368,6 +427,10 @@
     },
     {
       "path": "q-system/.q-system/scripts/test_launchd_health_check.py",
+      "runner": "python3"
+    },
+    {
+      "path": "q-system/.q-system/scripts/test_launchd_intent_verify.py",
       "runner": "python3"
     },
     {
@@ -457,65 +520,6 @@
     {
       "path": "q-system/.q-system/tests/test_fable_escalation.py",
       "runner": "python3"
-    },
-    {
-      "path": "q-system/.q-system/scripts/test/test-capability-map-wiring.py",
-      "runner": "python3"
-    },
-    {
-      "path": "q-system/.q-system/scripts/test_blocked_claim_evidence_lint.py",
-      "runner": "python3"
-    },
-    {
-      "path": "q-system/.q-system/scripts/test/test-review-gate-no-fake-green.sh",
-      "runner": "bash"
-    },
-    {
-      "path": "q-system/.q-system/scripts/test/test-verdict-usability.sh",
-      "runner": "bash"
-    },
-    {
-      "path": "q-system/.q-system/scripts/test/test-review-redrive.sh",
-      "runner": "bash"
-    },
-    {
-      "path": "q-system/.q-system/scripts/test/test-verdict-statement-shape.sh",
-      "runner": "bash"
-    },
-    {
-      "path": "plugins/prd-os/tests/test_judgment_compiler.py",
-      "runner": "python3",
-      "timeout_s": 240
-    },
-    {
-      "path": "q-system/.q-system/scripts/test/test-kipi-update-owned-deletion-guard.sh",
-      "runner": "bash",
-      "timeout_s": 300
-    },
-    {
-      "path": "plugins/prd-os/tests/test_virgin_repo_lifecycle.py",
-      "runner": "python3",
-      "timeout_s": 120
-    },
-    {
-      "path": "plugins/kipi-dsse/scripts/test_computed_receipts.py",
-      "runner": "python3",
-      "timeout_s": 180
-    },
-    {
-      "path": "plugins/kipi-dsse/scripts/test_scope_hook_fails_closed.py",
-      "runner": "python3",
-      "timeout_s": 120
-    },
-    {
-      "path": "plugins/prd-os/skills/fable-discipline/scripts/test_fable_discipline_lint.py",
-      "runner": "python3",
-      "timeout_s": 120
-    },
-    {
-      "path": "q-system/.q-system/scripts/test/test-zero-safe-count-idiom.sh",
-      "runner": "bash",
-      "timeout_s": 60
     }
   ],
   "required_data": [],

--- a/q-system/.q-system/scripts/launchd-health-check.py
+++ b/q-system/.q-system/scripts/launchd-health-check.py
@@ -390,6 +390,73 @@ def linear_report_line(outcome, dry_run):
             f"already-tracked={outcome['existing']} unfiled={unfiled_count(outcome)}")
 
 
+_INTENT = None
+
+
+def _intent_module():
+    """Lazily load launchd-intent-verify.py (sp-2c7e5819). Same importlib shape as
+    _fleet_health: loaded on demand, and its absence cannot stop the watchdog."""
+    global _INTENT
+    if _INTENT is None:
+        import importlib.util
+
+        spec = importlib.util.spec_from_file_location(
+            "iv", HERE / "launchd-intent-verify.py")
+        module = importlib.util.module_from_spec(spec)
+        spec.loader.exec_module(module)
+        _INTENT = module
+    return _INTENT
+
+
+def run_intent_check(dry_run):
+    """Verify declared intent against launchd's override DB; print, ping, file.
+
+    Never raises. A watchdog that dies because the intent manifest is malformed
+    stops watching launchd, which is the silent death it exists to catch -- the
+    same contract `file_linear_findings` keeps for Linear.
+
+    The result is REPORTED even when it could not run. An intent verifier that
+    fails to parse `launchctl print-disabled` and prints nothing is
+    indistinguishable from one that found no drift, and the second reading is the
+    one a reader defaults to (the `unfiled=` scar on `linear_report_line`, ASK-181).
+    """
+    try:
+        intent = _intent_module()
+    except Exception as exc:  # noqa: BLE001
+        print(f"intent verification unavailable: {exc}", file=sys.stderr)
+        return
+    try:
+        findings, due, (declared, total) = intent.check(dry_run=dry_run)
+    except Exception as exc:  # noqa: BLE001
+        print(f"intent verification COULD NOT RUN: {exc}", file=sys.stderr)
+        return
+
+    for label, kind, detail in findings:
+        print(f"INTENT-{kind.upper()}: {label} -- {detail}")
+    print(f"intent coverage: {declared}/{total} installed jobs declared")
+
+    if not due:
+        return
+    if dry_run:
+        print(f"[dry] would ping intent drift for {len(due)} job(s)")
+        return
+
+    drift = [(label, kind, detail) for label, kind, detail, _ in due]
+    try:
+        outcome = _fleet_health().file_findings(
+            intent.linear_findings(drift, _fleet_health().finding_key),
+            apply=True, filer="launchd-intent-verify.py")
+        unfiled = max(len(drift) - sum(outcome.get(b, 0) for b in LANDED_BUCKETS), 0)
+    except Exception as exc:  # noqa: BLE001
+        print(f"intent findings NOT filed to Linear: {exc}", file=sys.stderr)
+        unfiled = len(drift)
+
+    message = intent.ping_message(due)
+    if unfiled:
+        message += f" [NOT filed to Linear: {unfiled}]"
+    send_ping(message)
+
+
 def problems_to_ping(problems, state, now):
     """Problems whose kind changed since the last ping, or whose last ping is
     older than the TTL (dedupe spam, but re-ping when failing -> not_loaded)."""
@@ -410,6 +477,13 @@ def problems_to_ping(problems, state, now):
 
 
 def run(dry_run):
+    # BEFORE the early return below, not after. `problems` is empty exactly when
+    # every watched job is loaded and healthy -- which is the state a job running
+    # against an explicit pause decision produces. Wiring the intent check after
+    # the `if not problems: return` would make it dead on the only fleet state it
+    # exists to judge.
+    run_intent_check(dry_run)
+
     problems = discover_problems()
 
     if not problems:

--- a/q-system/.q-system/scripts/launchd-health-check.py
+++ b/q-system/.q-system/scripts/launchd-health-check.py
@@ -426,7 +426,7 @@ def run_intent_check(dry_run):
         print(f"intent verification unavailable: {exc}", file=sys.stderr)
         return
     try:
-        findings, due, (declared, total) = intent.check(dry_run=dry_run)
+        findings, due, (declared, total), commit = intent.check(dry_run=dry_run)
     except Exception as exc:  # noqa: BLE001
         print(f"intent verification COULD NOT RUN: {exc}", file=sys.stderr)
         return
@@ -435,10 +435,17 @@ def run_intent_check(dry_run):
         print(f"INTENT-{kind.upper()}: {label} -- {detail}")
     print(f"intent coverage: {declared}/{total} installed jobs declared")
 
+    # `commit` records the consecutive-run counts and is deliberately called
+    # AFTER delivery on every path that has one. Recording first meant a crash
+    # between the write and send_ping suppressed an alert that was never sent
+    # (see check()'s docstring). Nothing to deliver commits immediately: the
+    # counts still have to advance for a job that stopped drifting.
     if not due:
+        commit()
         return
     if dry_run:
         print(f"[dry] would ping intent drift for {len(due)} job(s)")
+        commit()  # a no-op in dry mode; called so the paths stay symmetrical
         return
 
     drift = [(label, kind, detail) for label, kind, detail, _ in due]
@@ -455,6 +462,7 @@ def run_intent_check(dry_run):
     if unfiled:
         message += f" [NOT filed to Linear: {unfiled}]"
     send_ping(message)
+    commit()
 
 
 def problems_to_ping(problems, state, now):

--- a/q-system/.q-system/scripts/launchd-intent-verify.py
+++ b/q-system/.q-system/scripts/launchd-intent-verify.py
@@ -211,8 +211,33 @@ def diff_intent(intent, overrides, installed_labels):
         want = intent[label]
         installed = label in installed_labels
         actual = effective_state(label, overrides)
-        if not installed and label not in overrides:
-            findings.append((label, "orphan", f"declared {want}, no plist and no override"))
+        # No plist on disk settles it ALONE. An override row is a statement about
+        # the override database, never evidence that anything is running -- there
+        # is nothing left to run. It is surfaced in the detail, not in the kind.
+        #
+        # Scar (measured 2026-08-06, found by populating intent from the real
+        # 2026-08-01 jobs audit instead of a synthetic manifest): this guard read
+        # `not installed and label not in overrides`. The audit retired
+        # com.kipi.fractional-cxo.opp-scan by renaming its plist, but launchd kept
+        # `"com.kipi.fractional-cxo.opp-scan" => enabled`. The second clause was
+        # False, so the label fell through to the drift branch below and paged
+        # running_but_paused for a job with no executable. Its sibling
+        # bolt-on-discovery, retired the same way but with no leftover row, was
+        # classified correctly -- the two differed only by the stale row.
+        #
+        # Third instance of one class: a signal read on only one side of a branch.
+        # 4f6bf61f (ASK-113) nested the pause-ledger read INSIDE the not_loaded
+        # arm, whose own scar was 26 false pings for jobs the founder had
+        # deliberately stopped. Same shape, same harm: the guard exists, the
+        # compound condition stops the path from reaching it.
+        if not installed:
+            detail = f"declared {want}, no plist and no override"
+            if label in overrides:
+                detail = (
+                    f"declared {want}, no plist; "
+                    f"stale override row says {overrides[label]}"
+                )
+            findings.append((label, "orphan", detail))
             continue
         if want == actual:
             continue

--- a/q-system/.q-system/scripts/launchd-intent-verify.py
+++ b/q-system/.q-system/scripts/launchd-intent-verify.py
@@ -353,17 +353,60 @@ def installed_labels():
     return {p.stem for p in LAUNCH_AGENTS.glob("*.plist")}
 
 
+def launchctl_print_disabled(run=None):
+    """stdout of `launchctl print-disabled`, or IntentError. `run` is injected.
+
+    Every non-answer is refused here rather than handed on as text, because the
+    empty string is a VALID parse that means something dangerous.
+
+    Scar (this file, caught in review before it ever ran): this call used to read
+    `.stdout` and never look at `.returncode`. A launchctl that exits nonzero
+    prints nothing on stdout; `parse_print_disabled("")` legitimately returns {};
+    an empty override map means "no label has an override", which
+    `effective_state` correctly reads as EVERY label enabled. Measured on the
+    shipped code with a stubbed exit 113: five intended-paused jobs produced five
+    `running_but_paused` findings, five founder pages, and five PERMANENT Linear
+    issues about a machine nobody had touched.
+
+    That is the exact false-alarm storm `parse_print_disabled` refuses a format
+    change to prevent. The guard was real; the failure entered one layer below
+    it, where a broken producer is indistinguishable from a quiet one. So the
+    producer has to prove it answered:
+
+      - a nonzero exit is a refusal, not an empty database
+      - a raise from the subprocess layer (launchctl absent, timeout) is a
+        refusal, not a fallthrough
+      - rc 0 with blank stdout is a refusal too: a real success always prints the
+        `disabled services = { ... }` block, so silence is the same lie told
+        more quietly.
+    """
+    import os
+    import subprocess
+
+    if run is None:
+        run = subprocess.run
+    try:
+        proc = run(
+            ["launchctl", "print-disabled", f"gui/{os.getuid()}"],
+            capture_output=True, text=True, timeout=20,
+        )
+    except (OSError, subprocess.SubprocessError) as exc:
+        raise IntentError(f"launchctl print-disabled could not run: {exc}") from exc
+    if proc.returncode != 0:
+        detail = (proc.stderr or "").strip().splitlines()[:1]
+        raise IntentError(
+            f"launchctl print-disabled exited {proc.returncode}"
+            + (f": {detail[0]}" if detail else "")
+        )
+    if not proc.stdout.strip():
+        raise IntentError("launchctl print-disabled exited 0 but printed nothing")
+    return proc.stdout
+
+
 def read_overrides(runner=None):
     """The override DB. `runner` is injected by tests so nothing shells launchctl."""
     if runner is None:
-        import subprocess
-
-        def runner():
-            import os
-            return subprocess.run(
-                ["launchctl", "print-disabled", f"gui/{os.getuid()}"],
-                capture_output=True, text=True, timeout=20,
-            ).stdout
+        runner = launchctl_print_disabled
     return parse_print_disabled(runner())
 
 
@@ -380,10 +423,27 @@ def write_state(state):
 
 
 def check(dry_run=False, overrides=None, labels=None):
-    """Run the verification. Returns (findings, due, coverage_tuple).
+    """Run the verification. Returns (findings, due, coverage_tuple, commit).
 
     Raises IntentError when ground truth could not be established -- the caller
     must report that as a broken check, never as a clean one.
+
+    `commit` is a zero-argument callable that persists the run counts, and the
+    caller invokes it ONLY AFTER the alert has been delivered.
+
+    Scar (this file, caught in review before it ever ran): check() used to
+    write_state() before returning, so a run was recorded as "seen" the instant it
+    was computed -- before the Linear issue was filed and before send_ping ran.
+    Anything that killed the process in between (a launchd timeout, a raise inside
+    the filer, the machine sleeping) left runs=1 on disk with nothing delivered.
+    The next run then computed runs=2, which is neither 1 nor a multiple of
+    REPEAT_EVERY_RUNS, so ping_decision returned nothing. Probed on the shipped
+    code: one skipped delivery turned a real drift into runs 2, 3, 4 and 5 all
+    silent -- a week of a phone that looks exactly like a clean fleet.
+
+    Deliver-then-record is the only ordering where a crash costs a DUPLICATE ping
+    instead of a MISSING one, and a duplicate is the failure this system is
+    allowed to have.
     """
     intent, conflicts = load_intent(
         read_text(INTENT_MANIFEST),
@@ -395,11 +455,14 @@ def check(dry_run=False, overrides=None, labels=None):
         labels = installed_labels()
     findings = diff_intent(intent, overrides, labels)
     due, new_state = ping_decision(findings, load_state())
-    if not dry_run:
-        write_state(new_state)
+
+    def commit():
+        if not dry_run:
+            write_state(new_state)
+
     for label in conflicts:
         findings.append((label, "conflict", "manifest says enabled, pause ledger lists it"))
-    return findings, due, coverage(intent, labels)
+    return findings, due, coverage(intent, labels), commit
 
 
 def main(argv):
@@ -409,7 +472,7 @@ def main(argv):
         print(f"unrecognised flag(s): {' '.join(unrecognized)} -- refusing to run.")
         return 0
     try:
-        findings, due, (declared, total) = check(dry_run=dry)
+        findings, due, (declared, total), commit = check(dry_run=dry)
     except IntentError as exc:
         print(f"launchd intent verification COULD NOT RUN: {exc}")
         return 0
@@ -417,6 +480,8 @@ def main(argv):
         print(f"{kind.upper()}: {label} -- {detail}")
     print(f"intent coverage: {declared}/{total} installed jobs declared")
     print(f"would ping: {len(due)}" if dry else f"ping-worthy: {len(due)}")
+    # Printing IS this entry point's delivery, so the record follows it.
+    commit()
     return 0
 
 

--- a/q-system/.q-system/scripts/launchd-intent-verify.py
+++ b/q-system/.q-system/scripts/launchd-intent-verify.py
@@ -1,0 +1,401 @@
+#!/usr/bin/env python3
+"""Verify that every launchd job's paused/running state matches a DECLARED intent.
+
+The gap this closes (sp-2c7e5819, measured 2026-08-06): nothing anywhere asserted
+that the enabled set matches the intended set. `launchd-health-check.py` catches a
+job that is FAILING or DARK, and it reads the pause ledger only to SUPPRESS a ping
+for a job that is intentionally dark. That makes the ledger a one-way silencer:
+
+    discover_problems() appends only when job_status() is 'failing' or
+    'not_loaded'. A label the ledger declares paused, which is actually loaded and
+    healthy, returns ('ok', 0) and produces NOTHING.
+
+Reproduced by executing that function, not by reading it: with one paused-ledger
+label and job_status stubbed to ('ok', 0), `discover_problems()` returned `[]`.
+So "this job should be stopped and is running" was structurally undetectable, and
+"this job is running and should be" was indistinguishable from it -- both are
+silence. The only reason anyone noticed the podcast jobs' split state was that a
+generated feed dirtied a git tree.
+
+This script supplies the missing half: an intended-state manifest diffed against
+the launchd override database (`launchctl print-disabled`), reported in BOTH
+directions plus a coverage number.
+
+## Why the override DB and not `launchctl list`
+
+They answer different questions and they disagree. `launchctl list` reports what is
+bootstrapped right now; `print-disabled` reports the persistent override record
+that survives reboots and is what `launchctl disable` writes. Measured 2026-08-06:
+`com.cole.pause-resume` is `=> enabled` in the override DB, exits 113 (not loaded)
+from `launchctl list`, and has no plist on disk at all. Intent is a statement about
+the persistent record, so the persistent record is what it is checked against.
+
+## Where the manifest lives, and why not in this repo
+
+`~/.config/kipi/launchd-intent.json`, in the founder's live env, NOT in the
+skeleton -- the same placement as `launchd-watch-prefixes.txt` and the pause
+ledger, for the same stated reason: this script propagates fleet-wide via
+`kipi update` and must carry no single instance's brand names. The repo ships the
+verifier; the machine holds the data.
+
+Usage:
+  launchd-intent-verify.py            # check, print, exit 0
+  launchd-intent-verify.py --dry      # same, but never writes the state file
+"""
+import json
+import re
+from pathlib import Path
+
+HERE = Path(__file__).resolve().parent
+
+INTENT_MANIFEST = Path.home() / ".config" / "kipi" / "launchd-intent.json"
+STATE_FILE = Path.home() / ".config" / "kipi" / "launchd-intent-state.json"
+LAUNCH_AGENTS = Path.home() / "Library" / "LaunchAgents"
+
+# The pause ledgers `launchd-health-check.py` already reads. Treated here as an
+# IMPLICIT "intent: disabled" for every label they list, so this verifier works on
+# day one against the ledger that already exists -- no migration, and no job
+# touched. An explicit manifest entry overrides a ledger line, and the
+# disagreement is reported rather than silently resolved.
+LEGACY_PAUSED_FILES = (
+    Path.home() / ".config" / "kipi" / "launchd-paused.txt",
+    Path.home() / ".config" / "kipi" / "cole-pause.state",
+)
+
+ENABLED = "enabled"
+DISABLED = "disabled"
+
+# `launchctl print-disabled` vocabulary. Measured on Darwin 25.3.0 (2026-08-06) as
+# `"<label>" => disabled` / `=> enabled`; older macOS prints `=> true` / `=> false`.
+# Both are accepted. An UNRECOGNISED token is refused rather than guessed -- see
+# parse_print_disabled for why a silent default here is the dangerous branch.
+DISABLED_TOKENS = frozenset({"disabled", "true", "1"})
+ENABLED_TOKENS = frozenset({"enabled", "false", "0"})
+
+_ENTRY_RE = re.compile(r'"(?P<label>[^"]+)"\s*=>\s*(?P<value>[^\s;,}]+)')
+
+# Findings that reach the founder's phone. `undeclared` and `orphan` are printed
+# and counted but never pinged: they are manifest hygiene, and 40 of them exist on
+# day one (65 watched plists, 25 declared). Paging on coverage is the alert-fatigue
+# mechanism that teaches the founder to ignore this channel.
+PINGABLE_KINDS = ("running_but_paused", "paused_but_intended_running")
+
+# Re-ping a still-drifting job every Nth CONSECUTIVE run, counted by this script.
+#
+# Scar (ASK-283 alert audit, 2026-08-02): the sibling watchdog guards its re-ping
+# with FAIL_PING_TTL_SECONDS = 6h while its installed plist runs at 09:30 and
+# 21:30 -- 12h apart. The window can never elapse-check to False, so it suppresses
+# nothing and reads as protection. A wall-clock window has to be re-checked against
+# the schedule every time either one moves. A run COUNTER cannot drift out of sync
+# with the schedule, because the schedule is the only thing that increments it.
+# At the current 2 runs/day this is one re-ping per week.
+REPEAT_EVERY_RUNS = 14
+
+
+class IntentError(Exception):
+    """The verifier could not establish ground truth and must not report 'clean'."""
+
+
+# --- reading the override database -------------------------------------------
+
+def parse_print_disabled(text):
+    """`launchctl print-disabled` output -> {label: 'enabled'|'disabled'}.
+
+    Raises IntentError when the output has the shape of a real answer but nothing
+    parsed, or when a value token is unrecognised.
+
+    Why it refuses instead of returning {}: an empty override map means "no label
+    has an override", and `effective_state` correctly reads that as everything
+    being ENABLED. So a parser that silently fails on a future macOS format change
+    would flip every intended-paused job into a `running_but_paused` finding at
+    once -- 25 of them on this machine today -- and page the founder about a job
+    nobody touched. The failure mode of a silent parse miss here is a false alarm
+    storm, which is worse than the outage it would be reporting.
+    """
+    entries = {}
+    unknown = []
+    for match in _ENTRY_RE.finditer(text):
+        value = match.group("value").strip().lower()
+        if value in DISABLED_TOKENS:
+            entries[match.group("label")] = DISABLED
+        elif value in ENABLED_TOKENS:
+            entries[match.group("label")] = ENABLED
+        else:
+            unknown.append(f'{match.group("label")} => {match.group("value")}')
+    if unknown:
+        raise IntentError(
+            "unrecognised print-disabled value(s): " + ", ".join(sorted(unknown)[:5])
+        )
+    if not entries and "disabled services" in text:
+        raise IntentError("print-disabled produced a services block but no entries parsed")
+    return entries
+
+
+def effective_state(label, overrides):
+    """The override DB's answer for one label.
+
+    A label ABSENT from print-disabled is not unknown -- it has no override
+    recorded, and launchd runs it. Measured 2026-08-06: 65 watched plists on disk,
+    32 labels present in print-disabled, so absence is the common case and
+    treating it as 'unknown' would leave two thirds of the fleet unverified.
+    """
+    return overrides.get(label, ENABLED)
+
+
+# --- reading declared intent --------------------------------------------------
+
+def load_intent(manifest_text=None, paused_texts=()):
+    """Resolve declared intent from the manifest plus the legacy pause ledgers.
+
+    ONE reader for both sources on purpose. Two call-sites each resolving intent
+    their own way is how the pause ledger became a suppression list in one place
+    and a source of truth in another.
+
+    Returns (intent, conflicts). `conflicts` names every label the manifest and a
+    ledger disagree about; the manifest wins (explicit beats implicit) and the
+    disagreement is surfaced, never silently resolved.
+    """
+    ledger = set()
+    for text in paused_texts:
+        for line in text.splitlines():
+            entry = line.split("#", 1)[0].strip()
+            if entry:
+                ledger.add(entry)
+
+    declared = {}
+    if manifest_text:
+        try:
+            data = json.loads(manifest_text)
+        except json.JSONDecodeError as exc:
+            raise IntentError(f"launchd-intent.json is not valid JSON: {exc}") from exc
+        jobs = data.get("jobs")
+        if not isinstance(jobs, list):
+            raise IntentError("launchd-intent.json has no 'jobs' list")
+        for row in jobs:
+            label = (row or {}).get("label")
+            intent = (row or {}).get("intent")
+            if not label:
+                raise IntentError("a launchd-intent.json job row has no 'label'")
+            if intent not in (ENABLED, DISABLED):
+                raise IntentError(
+                    f"{label}: intent must be {ENABLED!r} or {DISABLED!r}, got {intent!r}"
+                )
+            declared[label] = intent
+
+    conflicts = sorted(
+        label for label in ledger
+        if declared.get(label) == ENABLED
+    )
+    intent = {label: DISABLED for label in ledger}
+    intent.update(declared)
+    return intent, conflicts
+
+
+# --- the diff -----------------------------------------------------------------
+
+def diff_intent(intent, overrides, installed_labels):
+    """(label, kind, detail) for every disagreement between intent and reality.
+
+    kinds:
+      running_but_paused          declared disabled, override DB says enabled.
+                                  THE DIRECTION NOTHING ELSE SEES -- the sibling
+                                  watchdog reports nothing at all for a healthy job.
+      paused_but_intended_running declared enabled, override DB says disabled.
+      orphan                      declared, but no plist on disk. A manifest line
+                                  about a job that no longer exists.
+      undeclared                  plist on disk, no intent recorded. Coverage, not
+                                  drift; never pinged.
+    """
+    findings = []
+    for label in sorted(intent):
+        want = intent[label]
+        installed = label in installed_labels
+        actual = effective_state(label, overrides)
+        if not installed and label not in overrides:
+            findings.append((label, "orphan", f"declared {want}, no plist and no override"))
+            continue
+        if want == actual:
+            continue
+        kind = "running_but_paused" if want == DISABLED else "paused_but_intended_running"
+        findings.append((label, kind, f"declared {want}, launchd says {actual}"))
+    for label in sorted(installed_labels - set(intent)):
+        findings.append((label, "undeclared", "no declared intent"))
+    return findings
+
+
+def coverage(intent, installed_labels):
+    """(declared_and_installed, installed). Printed on every run.
+
+    Without this number a manifest covering 25 of 65 jobs reports "no drift" and
+    reads exactly like full verification. The count is the difference between
+    "nothing is wrong" and "nothing that is checked is wrong".
+    """
+    return (len(installed_labels & set(intent)), len(installed_labels))
+
+
+# --- alerting -----------------------------------------------------------------
+
+def ping_decision(findings, state):
+    """(due, new_state). Ping the TRANSITION into drift, not the drift.
+
+    A label is due when its kind changed since the last run (a new bad state), or
+    when it has now been in that same bad state for a multiple of
+    REPEAT_EVERY_RUNS consecutive runs. Each due entry carries its consecutive-run
+    count so the message says how long, per founder-notifications.md: repeating an
+    unchanged state every cycle is noise, not a ping.
+    """
+    new_state = {}
+    due = []
+    for label, kind, detail in findings:
+        if kind not in PINGABLE_KINDS:
+            continue
+        prev = state.get(label) or {}
+        runs = prev.get("runs", 0) + 1 if prev.get("kind") == kind else 1
+        new_state[label] = {"kind": kind, "runs": runs, "detail": detail}
+        if runs == 1 or runs % REPEAT_EVERY_RUNS == 0:
+            due.append((label, kind, detail, runs))
+    return due, new_state
+
+
+def ping_message(due):
+    """One Slack line for the whole run. One ping per run, never one per finding."""
+    parts = []
+    for label, kind, detail, runs in due:
+        what = ("running but declared paused" if kind == "running_but_paused"
+                else "paused but declared running")
+        age = "new" if runs == 1 else f"{runs} runs"
+        parts.append(f"{label} ({what}, {age})")
+    return f"launchd intent drift: {len(due)} job(s) -- " + ", ".join(parts)
+
+
+# --- Linear rendering ---------------------------------------------------------
+# Built here rather than in fleet-health-daily.py's `launchd_finding`: that
+# function is an if-chain that RAISES on an unknown detector id, on purpose, so a
+# caller cannot file an empty body under a key the other filer also writes. Adding
+# a branch there would put this script's rendering inside the file whose own
+# absence the sibling watchdog has to be able to report. `file_findings` takes
+# plain dicts, so the seam that does not require that coupling is the dict.
+LINEAR_DETECTOR = "launchd-intent-drift"
+
+_LINEAR_BODY = {
+    "running_but_paused": (
+        "`{label}` is declared **disabled** in `~/.config/kipi/launchd-intent.json` "
+        "(or the pause ledger) but launchd's override database reports it "
+        "**enabled**, so it is running.\n\n"
+        "Nothing else in the fleet detects this direction: the launchd watchdog "
+        "reports only failing and dark jobs, and a healthy job produces silence.\n\n"
+        "## Action\n"
+        "- If running is correct, change this label's intent to `enabled` with a reason.\n"
+        "- If the pause was intended: `launchctl disable gui/$(id -u)/{label}`"
+    ),
+    "paused_but_intended_running": (
+        "`{label}` is declared **enabled** but launchd's override database reports "
+        "it **disabled**, so it has silently stopped running.\n\n"
+        "## Action\n"
+        "- Resume: `launchctl enable gui/$(id -u)/{label}`\n"
+        "- Or record the decision by setting this label's intent to `disabled`."
+    ),
+}
+
+
+def linear_findings(findings, finding_key):
+    """Finding dicts ready for fleet-health-daily.file_findings, pingable kinds only."""
+    out = []
+    for label, kind, detail in findings:
+        body = _LINEAR_BODY.get(kind)
+        if body is None:
+            continue
+        out.append({
+            "subject": label,
+            "title": f"launchd intent drift: {label} ({detail})",
+            "body": body.format(label=label),
+            "key": finding_key(LINEAR_DETECTOR, label),
+            "detector": LINEAR_DETECTOR,
+        })
+    return out
+
+
+# --- I/O edges ----------------------------------------------------------------
+
+def read_text(path):
+    try:
+        return path.read_text()
+    except (FileNotFoundError, NotADirectoryError, IsADirectoryError):
+        return ""
+
+
+def installed_labels():
+    return {p.stem for p in LAUNCH_AGENTS.glob("*.plist")}
+
+
+def read_overrides(runner=None):
+    """The override DB. `runner` is injected by tests so nothing shells launchctl."""
+    if runner is None:
+        import subprocess
+
+        def runner():
+            import os
+            return subprocess.run(
+                ["launchctl", "print-disabled", f"gui/{os.getuid()}"],
+                capture_output=True, text=True, timeout=20,
+            ).stdout
+    return parse_print_disabled(runner())
+
+
+def load_state():
+    try:
+        return json.loads(STATE_FILE.read_text())
+    except Exception:  # noqa: BLE001 - a missing/corrupt state file is a fresh start
+        return {}
+
+
+def write_state(state):
+    STATE_FILE.parent.mkdir(parents=True, exist_ok=True)
+    STATE_FILE.write_text(json.dumps(state, indent=2))
+
+
+def check(dry_run=False, overrides=None, labels=None):
+    """Run the verification. Returns (findings, due, coverage_tuple).
+
+    Raises IntentError when ground truth could not be established -- the caller
+    must report that as a broken check, never as a clean one.
+    """
+    intent, conflicts = load_intent(
+        read_text(INTENT_MANIFEST),
+        [read_text(p) for p in LEGACY_PAUSED_FILES],
+    )
+    if overrides is None:
+        overrides = read_overrides()
+    if labels is None:
+        labels = installed_labels()
+    findings = diff_intent(intent, overrides, labels)
+    due, new_state = ping_decision(findings, load_state())
+    if not dry_run:
+        write_state(new_state)
+    for label in conflicts:
+        findings.append((label, "conflict", "manifest says enabled, pause ledger lists it"))
+    return findings, due, coverage(intent, labels)
+
+
+def main(argv):
+    dry = any(a in ("--dry", "--dry-run", "-n") for a in argv)
+    unrecognized = [a for a in argv if a not in ("--dry", "--dry-run", "-n")]
+    if unrecognized:
+        print(f"unrecognised flag(s): {' '.join(unrecognized)} -- refusing to run.")
+        return 0
+    try:
+        findings, due, (declared, total) = check(dry_run=dry)
+    except IntentError as exc:
+        print(f"launchd intent verification COULD NOT RUN: {exc}")
+        return 0
+    for label, kind, detail in findings:
+        print(f"{kind.upper()}: {label} -- {detail}")
+    print(f"intent coverage: {declared}/{total} installed jobs declared")
+    print(f"would ping: {len(due)}" if dry else f"ping-worthy: {len(due)}")
+    return 0
+
+
+if __name__ == "__main__":
+    import sys
+
+    sys.exit(main(sys.argv[1:]))

--- a/q-system/.q-system/scripts/test_launchd_intent_verify.py
+++ b/q-system/.q-system/scripts/test_launchd_intent_verify.py
@@ -309,6 +309,61 @@ check("body names the label", "`a`" in lf[0]["body"], True)
 
 
 # =============================================================================
+# 8b. REPRODUCER: a launchctl that FAILED is not an override DB with no rows
+# =============================================================================
+# The default runner returned `.stdout` and never looked at `.returncode`. A
+# launchctl that exits nonzero prints nothing on stdout, `parse_print_disabled("")`
+# legitimately returns {}, and an empty override map means "no label has an
+# override" -- which `effective_state` correctly reads as EVERYTHING ENABLED. So a
+# broken launchctl produced one `running_but_paused` finding per intended-paused
+# job: a Slack page and a PERMANENT Linear issue per job, about a machine nobody
+# touched. That is the same false-alarm storm `parse_print_disabled` refuses a
+# format change to avoid; the failure just entered one layer lower, where the
+# guard could not see it.
+class _Proc:
+    def __init__(self, returncode, stdout, stderr=""):
+        self.returncode = returncode
+        self.stdout = stdout
+        self.stderr = stderr
+
+
+check_raises("a nonzero launchctl is refused, not read as an empty DB", iv.IntentError,
+             lambda: iv.launchctl_print_disabled(
+                 run=lambda *a, **k: _Proc(113, "", "Could not find domain")))
+
+# rc 0 with no output is the same lie in a quieter form: a real success always
+# prints the `disabled services = { ... }` block.
+check_raises("a silent success is refused too", iv.IntentError,
+             lambda: iv.launchctl_print_disabled(run=lambda *a, **k: _Proc(0, "  \n")))
+
+
+def _explode(*a, **k):
+    raise FileNotFoundError("launchctl")
+
+
+check_raises("launchctl missing from PATH is refused", iv.IntentError,
+             lambda: iv.launchctl_print_disabled(run=_explode))
+
+check("a real answer is returned unchanged",
+      iv.launchctl_print_disabled(run=lambda *a, **k: _Proc(0, REAL_OUTPUT)),
+      REAL_OUTPUT)
+
+# The harm, end to end: read_overrides must inherit that refusal from its DEFAULT
+# runner, because that is the one the installed job uses.
+check("read_overrides defaults to the guarded runner",
+      iv.read_overrides.__defaults__, (None,))
+check_raises("and so a failed launchctl cannot reach diff_intent", iv.IntentError,
+             lambda: iv.read_overrides(
+                 runner=lambda: iv.launchctl_print_disabled(
+                     run=lambda *a, **k: _Proc(1, ""))))
+
+# Negative self-test: prove the probe above can pass. Without the returncode
+# guard, this same input returns {} and the check_raises calls go red.
+check("an unguarded read of the same input yields the empty map that caused it",
+      iv.parse_print_disabled(_Proc(113, "", "boom").stdout), {})
+
+
+# =============================================================================
 # 9. check() -- the wiring, against a tmpdir, with injected launchd state
 # =============================================================================
 _home = Path(tempfile.mkdtemp())
@@ -317,7 +372,7 @@ iv.STATE_FILE = _home / "state.json"
 iv.LEGACY_PAUSED_FILES = (_home / "paused.txt",)
 (_home / "paused.txt").write_text("com.kipi.paused-job\n")
 
-findings, due, cov = iv.check(
+findings, due, cov, commit = iv.check(
     overrides={"com.kipi.paused-job": "enabled"},
     labels={"com.kipi.paused-job", "com.kipi.other"},
 )
@@ -326,14 +381,55 @@ check("check() surfaces the drift",
       [("com.kipi.paused-job", "running_but_paused")])
 check("check() pings the transition", [d[0] for d in due], ["com.kipi.paused-job"])
 check("check() reports partial coverage", cov, (1, 2))
-check("check() persisted the run count", json.loads(iv.STATE_FILE.read_text())
-      ["com.kipi.paused-job"]["runs"], 1)
+check("check() does not persist before the caller has delivered",
+      iv.STATE_FILE.exists(), False)
+commit()
+check("check() persisted the run count once committed",
+      json.loads(iv.STATE_FILE.read_text())["com.kipi.paused-job"]["runs"], 1)
 
 # dry mode must not advance the counter that decides future pings.
 before = iv.STATE_FILE.read_text()
-iv.check(dry_run=True, overrides={"com.kipi.paused-job": "enabled"},
-         labels={"com.kipi.paused-job"})
+_, _, _, _dry_commit = iv.check(
+    dry_run=True, overrides={"com.kipi.paused-job": "enabled"},
+    labels={"com.kipi.paused-job"})
+_dry_commit()
 check("dry run writes no state", iv.STATE_FILE.read_text(), before)
+
+
+# =============================================================================
+# 9b. REPRODUCER: a crash between persisting and delivering ate the alert
+# =============================================================================
+# check() used to write_state() before returning, so the run was recorded as
+# "seen" the instant it was computed -- before the caller filed the Linear issue
+# and before send_ping ran. Anything that killed the process in between (launchd
+# timeout, an exception in the filer, the machine sleeping) left runs=1 on disk
+# with nothing delivered. The NEXT run then computed runs=2, which is not
+# 1 and not a multiple of REPEAT_EVERY_RUNS, so ping_decision returned nothing.
+# One transient crash silently converted a real drift into 14 runs (a week) of
+# silence, and the founder's phone showed the same thing a clean fleet shows.
+_crash = Path(tempfile.mkdtemp())
+iv.INTENT_MANIFEST = _crash / "launchd-intent.json"
+iv.STATE_FILE = _crash / "state.json"
+iv.LEGACY_PAUSED_FILES = (_crash / "paused.txt",)
+(_crash / "paused.txt").write_text("com.kipi.drifting\n")
+
+_args = {"overrides": {"com.kipi.drifting": "enabled"},
+         "labels": {"com.kipi.drifting"}}
+
+_, due_a, _, _commit_a = iv.check(**_args)
+check("run 1 computes a due alert", [d[0] for d in due_a], ["com.kipi.drifting"])
+# The crash: _commit_a is never called, because delivery never happened.
+check("and nothing was recorded on the way out", iv.STATE_FILE.exists(), False)
+
+_, due_b, _, _commit_b = iv.check(**_args)
+check("run 2 still owes the founder that alert",
+      [d[0] for d in due_b], ["com.kipi.drifting"])
+_commit_b()  # this time delivery succeeded
+
+_, due_c, _, _commit_c = iv.check(**_args)
+check("and once delivered it is not re-sent", due_c, [])
+check("the committed count is 1 run, not 3", json.loads(iv.STATE_FILE.read_text())
+      ["com.kipi.drifting"]["runs"], 1)
 
 
 # =============================================================================

--- a/q-system/.q-system/scripts/test_launchd_intent_verify.py
+++ b/q-system/.q-system/scripts/test_launchd_intent_verify.py
@@ -181,6 +181,76 @@ check("a plist with no declared intent is undeclared coverage",
 
 
 # =============================================================================
+# 5b. A RETIRED job with a stale override row is an orphan, not a running job
+# =============================================================================
+# Found by populating intent from the real 2026-08-01 jobs audit instead of a
+# synthetic manifest. The audit KILLED two fractional-cxo jobs by renaming their
+# plists to `.plist.retired-2026-08-01`; `installed_labels()` globs `*.plist`, so
+# neither is installed (verified: the glob returns only the un-renamed sibling).
+#
+# launchd kept an override row for exactly one of them. Measured 2026-08-06 from
+# `launchctl print-disabled gui/$(id -u)`:
+#
+#     "com.kipi.fractional-cxo.opp-scan" => enabled     <- row survived the retire
+#     (com.kipi.fractional-cxo.bolt-on-discovery)       <- no row at all
+#
+# Two jobs, same retirement, differing only by that leftover row. The orphan
+# branch was guarded by `not installed AND label not in overrides`; the second
+# clause is False for opp-scan, so it fell through to the drift branch and paged
+# `running_but_paused` for a job with no executable on disk. A stale override row
+# is a statement about the override DB, never evidence that anything is running.
+#
+# Class scar: the third instance of a signal read on only one side of a branch.
+# 4f6bf61f (ASK-113) nested `if label in paused` INSIDE the not_loaded arm, so a
+# paused-and-healthy job reached no branch at all -- and its own scar was 26 false
+# pings for jobs the founder had deliberately stopped. Same harm, same shape: the
+# guard exists, the compound condition stops the path from reaching it.
+RETIRED_STALE = "com.kipi.fractional-cxo.opp-scan"
+RETIRED_CLEAN = "com.kipi.fractional-cxo.bolt-on-discovery"
+
+# Both retired, both declared disabled by the audit, NEITHER installed.
+_retired_intent = {RETIRED_STALE: "disabled", RETIRED_CLEAN: "disabled"}
+_retired_findings = iv.diff_intent(_retired_intent, {RETIRED_STALE: "enabled"}, set())
+
+check("a retired job whose override row survived is an orphan, not drift",
+      _retired_findings,
+      [(RETIRED_CLEAN, "orphan", "declared disabled, no plist and no override"),
+       (RETIRED_STALE, "orphan",
+        "declared disabled, no plist; stale override row says enabled")])
+
+# The harm this actually prevents: the founder's phone. Before the fix the stale
+# row produced `running_but_paused`, which IS in PINGABLE_KINDS, so a job with no
+# executable rang a phone. Asserting the kind alone would not have caught the
+# consequence if PINGABLE_KINDS ever grew.
+check("and it therefore never reaches the founder's phone",
+      iv.ping_decision(_retired_findings, {})[0], [])
+
+# The THIRD orphan shape, and on this machine the most common one: no plist, and
+# an override row that AGREES with the declared intent. Added after a mutant
+# survived the two cases above -- a variant guarding the orphan branch with
+# `not installed and want != effective_state(...)` passed both, because in both
+# the override disagrees with the intent. Where they agree it falls through to
+# the `want == actual: continue` line and the job vanishes from the report
+# entirely: not a wrong kind, no finding at all.
+#
+# Measured 2026-08-06 (44 override rows, 45 installed plists, 4 retired-renamed
+# files). Labels with an override row and no plist on disk:
+#     disabled  com.ask.ai-podcast
+#     disabled  com.cole.linkedin-loop-watchdog
+#     disabled  com.cole.linkedin-session
+#     enabled   com.cole.pause-resume
+#     enabled   com.kipi.fractional-cxo.opp-scan
+# Three of five agree with a 'disabled' intent, so the untested sub-shape was the
+# MAJORITY of the real population. A retired job is an orphan because there is no
+# plist, never because the override happens to disagree.
+check("a retired job whose override AGREES with intent is still an orphan",
+      iv.diff_intent({"com.ask.ai-podcast": "disabled"},
+                     {"com.ask.ai-podcast": "disabled"}, set()),
+      [("com.ask.ai-podcast", "orphan",
+        "declared disabled, no plist; stale override row says disabled")])
+
+
+# =============================================================================
 # 6. coverage -- the number that separates "nothing wrong" from "nothing checked"
 # =============================================================================
 check("coverage counts installed-and-declared over installed",

--- a/q-system/.q-system/scripts/test_launchd_intent_verify.py
+++ b/q-system/.q-system/scripts/test_launchd_intent_verify.py
@@ -1,0 +1,324 @@
+#!/usr/bin/env python3
+"""Regression tests for launchd-intent-verify.py (sp-2c7e5819).
+
+Test 1 is the reproducer and it runs BOTH halves: it calls the shipping
+`launchd-health-check.discover_problems()` on a paused-but-running job and asserts
+it returns nothing (the blind spot, executed rather than described), then asserts
+the new `diff_intent` reports it. If someone closes the gap in the watchdog
+instead, assertion one goes red and this file is the thing that says so.
+
+Every fixture is a string or a dict. Nothing here reads ~/.config/kipi or
+~/Library/LaunchAgents; the two I/O edges (`read_overrides`, `check`) take
+injected values and a tmpdir.
+
+Run: python3 test_launchd_intent_verify.py   (exit 0 = pass, 1 = fail)
+"""
+import importlib.util
+import json
+import sys
+import tempfile
+from pathlib import Path
+
+HERE = Path(__file__).resolve().parent
+
+
+def _load(filename, name):
+    spec = importlib.util.spec_from_file_location(name, HERE / filename)
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module
+
+
+iv = _load("launchd-intent-verify.py", "iv")
+wd = _load("launchd-health-check.py", "wd")
+
+failures = []
+
+
+def check(name, got, want):
+    if got != want:
+        failures.append(f"{name}: got {got!r}, want {want!r}")
+
+
+def check_raises(name, exc_type, fn):
+    try:
+        fn()
+    except exc_type:
+        return
+    except Exception as exc:  # noqa: BLE001
+        failures.append(f"{name}: raised {type(exc).__name__}, want {exc_type.__name__}")
+        return
+    failures.append(f"{name}: did not raise {exc_type.__name__}")
+
+
+# =============================================================================
+# 1. THE REPRODUCER: a job declared paused, actually running.
+# =============================================================================
+# Half A -- the shipping watchdog is blind to it. discover_problems() appends only
+# for 'failing' and 'not_loaded'; a healthy job hits neither branch, so a job the
+# pause ledger says is stopped, which is actually up, produces no finding, no
+# Slack ping and no Linear issue. Executed, not asserted from reading the source.
+_tmp = Path(tempfile.mkdtemp())
+_agents = _tmp / "LaunchAgents"
+_agents.mkdir()
+(_agents / "com.kipi.zzz-should-be-paused.plist").write_text("<plist/>")
+_ledger = _tmp / "paused.txt"
+_ledger.write_text("com.kipi.zzz-should-be-paused\n")
+
+wd.LAUNCH_AGENTS = _agents
+wd.PAUSED_LABEL_FILES = (_ledger,)
+wd.EXTRA_PREFIXES_FILE = _tmp / "no-such-file.txt"
+wd.job_status = lambda label: ("ok", 0)  # loaded and healthy == running
+
+check("REPRODUCER half A: watchdog sees a paused-but-running job as nothing",
+      wd.discover_problems(), [])
+
+# Half B -- the verifier reports it, in the direction nothing else covers.
+_intent, _conflicts = iv.load_intent(None, ["com.kipi.zzz-should-be-paused\n"])
+check("REPRODUCER half B: verifier reports running_but_paused",
+      iv.diff_intent(_intent, {"com.kipi.zzz-should-be-paused": "enabled"},
+                     {"com.kipi.zzz-should-be-paused"}),
+      [("com.kipi.zzz-should-be-paused", "running_but_paused",
+        "declared disabled, launchd says enabled")])
+
+# Half B', the same job with NO override row at all. This is the common case: 65
+# watched plists on disk, 32 override rows (measured 2026-08-06). If absence were
+# read as 'unknown' instead of 'enabled', two thirds of the fleet would go
+# unverified and this finding would vanish.
+check("REPRODUCER half B': absent override still reports drift",
+      iv.diff_intent(_intent, {}, {"com.kipi.zzz-should-be-paused"}),
+      [("com.kipi.zzz-should-be-paused", "running_but_paused",
+        "declared disabled, launchd says enabled")])
+
+
+# =============================================================================
+# 2. parse_print_disabled -- fixture captured from the real producer
+# =============================================================================
+# Verbatim from `launchctl print-disabled gui/$(id -u)` on Darwin 25.3.0,
+# 2026-08-06, tabs and all. An invented fixture would only test my assumption
+# about the format; this one is what the machine actually printed.
+REAL_OUTPUT = '''
+	disabled services = {
+		"com.docker.helper" => enabled
+		"com.cole.content-brain" => disabled
+		"com.cole.daily-podcast" => enabled
+		"com.apple.Siri.agent" => disabled
+		"com.kipi.fractional-cxo.opp-scan" => enabled
+	}
+'''
+check("parses the real producer's output", iv.parse_print_disabled(REAL_OUTPUT), {
+    "com.docker.helper": "enabled",
+    "com.cole.content-brain": "disabled",
+    "com.cole.daily-podcast": "enabled",
+    "com.apple.Siri.agent": "disabled",
+    "com.kipi.fractional-cxo.opp-scan": "enabled",
+})
+
+# Older macOS prints true/false for the same field.
+check("parses the true/false vocabulary",
+      iv.parse_print_disabled('"a" => true\n"b" => false\n'),
+      {"a": "disabled", "b": "enabled"})
+
+# A value token this parser does not know is REFUSED, never guessed. If it were
+# skipped, the label would fall through to the absence default (enabled) and a
+# genuinely disabled job would read as running.
+check_raises("unknown value token refuses", iv.IntentError,
+             lambda: iv.parse_print_disabled('"a" => perhaps\n'))
+
+# A services block that parsed to nothing is a format change, not an empty DB.
+# Returning {} here would mark EVERY declared-disabled job as drift at once --
+# 25 false pages on this machine today.
+check_raises("shaped-but-empty output refuses", iv.IntentError,
+             lambda: iv.parse_print_disabled("\tdisabled services = {\n\t}\n"))
+
+# A genuinely empty answer (no block at all) is not an error.
+check("truly empty output is empty, not an error", iv.parse_print_disabled(""), {})
+
+
+# =============================================================================
+# 3. effective_state -- absence means no override recorded, which launchd runs
+# =============================================================================
+check("absent label defaults to enabled", iv.effective_state("nope", {}), "enabled")
+check("present disabled label", iv.effective_state("a", {"a": "disabled"}), "disabled")
+
+
+# =============================================================================
+# 4. load_intent -- one reader for the manifest and the legacy ledgers
+# =============================================================================
+check("ledger lines are implicit intent:disabled",
+      iv.load_intent(None, ["a\nb  # comment\n\n# whole line\n"])[0],
+      {"a": "disabled", "b": "disabled"})
+
+MANIFEST = json.dumps({"schema_version": 1, "jobs": [
+    {"label": "a", "intent": "enabled", "reason": "founder confirmed 2026-08-06"},
+    {"label": "c", "intent": "disabled"},
+]})
+_i, _c = iv.load_intent(MANIFEST, ["a\nb\n"])
+check("manifest overrides the ledger", _i, {"a": "enabled", "b": "disabled", "c": "disabled"})
+check("and the disagreement is reported, not swallowed", _c, ["a"])
+
+check_raises("invalid JSON refuses", iv.IntentError, lambda: iv.load_intent("{oops", []))
+check_raises("missing jobs list refuses", iv.IntentError, lambda: iv.load_intent("{}", []))
+check_raises("a row with no label refuses", iv.IntentError,
+             lambda: iv.load_intent('{"jobs":[{"intent":"enabled"}]}', []))
+check_raises("an unknown intent value refuses", iv.IntentError,
+             lambda: iv.load_intent('{"jobs":[{"label":"a","intent":"paused"}]}', []))
+
+
+# =============================================================================
+# 5. diff_intent -- all four kinds, and agreement producing silence
+# =============================================================================
+check("intent matching reality reports nothing",
+      iv.diff_intent({"a": "enabled"}, {"a": "enabled"}, {"a"}), [])
+check("declared enabled, launchd disabled",
+      iv.diff_intent({"a": "enabled"}, {"a": "disabled"}, {"a"}),
+      [("a", "paused_but_intended_running", "declared enabled, launchd says disabled")])
+check("declared but no plist and no override is an orphan",
+      iv.diff_intent({"a": "disabled"}, {}, set()),
+      [("a", "orphan", "declared disabled, no plist and no override")])
+check("a plist with no declared intent is undeclared coverage",
+      iv.diff_intent({}, {}, {"z"}), [("z", "undeclared", "no declared intent")])
+
+
+# =============================================================================
+# 6. coverage -- the number that separates "nothing wrong" from "nothing checked"
+# =============================================================================
+check("coverage counts installed-and-declared over installed",
+      iv.coverage({"a": "enabled", "gone": "disabled"}, {"a", "b", "c"}), (1, 3))
+
+
+# =============================================================================
+# 7. ping_decision -- transition plus a consecutive count, never the state
+# =============================================================================
+DRIFT = [("a", "running_but_paused", "d")]
+
+due, state = iv.ping_decision(DRIFT, {})
+check("first sighting pings", due, [("a", "running_but_paused", "d", 1)])
+check("and records one run", state, {"a": {"kind": "running_but_paused", "runs": 1, "detail": "d"}})
+
+due, state = iv.ping_decision(DRIFT, state)
+check("second consecutive run is silent", due, [])
+check("but the count still advances", state["a"]["runs"], 2)
+
+# Walk to the repeat threshold. The count is what re-fires, so this cannot be
+# defeated by a schedule change the way a wall-clock TTL was (ASK-283).
+s = {"a": {"kind": "running_but_paused", "runs": iv.REPEAT_EVERY_RUNS - 1}}
+due, _ = iv.ping_decision(DRIFT, s)
+check("re-pings at the consecutive-run threshold",
+      due, [("a", "running_but_paused", "d", iv.REPEAT_EVERY_RUNS)])
+
+# A different bad state is a new transition and pings immediately.
+s = {"a": {"kind": "paused_but_intended_running", "runs": 9}}
+due, _ = iv.ping_decision(DRIFT, s)
+check("a changed kind re-pings and resets the count",
+      due, [("a", "running_but_paused", "d", 1)])
+
+# Coverage findings never reach the phone.
+check("undeclared is never pingable",
+      iv.ping_decision([("z", "undeclared", "no declared intent")], {})[0], [])
+check("orphan is never pingable",
+      iv.ping_decision([("z", "orphan", "x")], {})[0], [])
+
+# One line for the whole run, not one ping per finding.
+msg = iv.ping_message([("a", "running_but_paused", "d", 1),
+                       ("b", "paused_but_intended_running", "d", 14)])
+check("one message names both jobs", msg.count("--"), 1)
+check("message says what drifted", "running but declared paused" in msg, True)
+check("message carries the consecutive count", "14 runs" in msg, True)
+
+
+# =============================================================================
+# 8. linear_findings -- pingable kinds only, keyed through the shared keyer
+# =============================================================================
+lf = iv.linear_findings(
+    [("a", "running_but_paused", "d"), ("z", "undeclared", "x")],
+    lambda detector, subject: f"fleet-health/{detector}/{subject}")
+check("only drift kinds are filed", [f["subject"] for f in lf], ["a"])
+check("filed under the intent-drift detector", lf[0]["detector"], "launchd-intent-drift")
+check("body names the label", "`a`" in lf[0]["body"], True)
+
+
+# =============================================================================
+# 9. check() -- the wiring, against a tmpdir, with injected launchd state
+# =============================================================================
+_home = Path(tempfile.mkdtemp())
+iv.INTENT_MANIFEST = _home / "launchd-intent.json"
+iv.STATE_FILE = _home / "state.json"
+iv.LEGACY_PAUSED_FILES = (_home / "paused.txt",)
+(_home / "paused.txt").write_text("com.kipi.paused-job\n")
+
+findings, due, cov = iv.check(
+    overrides={"com.kipi.paused-job": "enabled"},
+    labels={"com.kipi.paused-job", "com.kipi.other"},
+)
+check("check() surfaces the drift",
+      [(l, k) for l, k, _ in findings if k in iv.PINGABLE_KINDS],
+      [("com.kipi.paused-job", "running_but_paused")])
+check("check() pings the transition", [d[0] for d in due], ["com.kipi.paused-job"])
+check("check() reports partial coverage", cov, (1, 2))
+check("check() persisted the run count", json.loads(iv.STATE_FILE.read_text())
+      ["com.kipi.paused-job"]["runs"], 1)
+
+# dry mode must not advance the counter that decides future pings.
+before = iv.STATE_FILE.read_text()
+iv.check(dry_run=True, overrides={"com.kipi.paused-job": "enabled"},
+         labels={"com.kipi.paused-job"})
+check("dry run writes no state", iv.STATE_FILE.read_text(), before)
+
+
+# =============================================================================
+# 10. WIRING -- the verifier is actually CALLED by the installed job
+# =============================================================================
+# The unit tests above all pass with the call-site deleted. This is the one that
+# goes red if run_intent_check() is never reached. It asserts the call happens on
+# an EMPTY problem list on purpose: run() returns early when nothing is failing,
+# and a healthy fleet is exactly the state a job running against its own pause
+# decision produces. Wired after that return, the whole feature would be dead.
+_called = []
+wd.run_intent_check = lambda dry: _called.append(dry)
+wd.discover_problems = lambda: []
+wd.STATE_FILE = _tmp / "never-written.json"
+wd.run(dry_run=True)
+check("run() calls the intent check even when no job is failing", _called, [True])
+
+# And run_intent_check swallows a broken manifest instead of taking the watchdog
+# down with it -- a watchdog that dies stops watching.
+#
+# The verifier is INJECTED, not reloaded. The first version of this test reloaded
+# launchd-health-check.py and called the real function: the fresh copy built its
+# own `iv` with the real INTENT_MANIFEST and LAUNCH_AGENTS, so it read the live
+# machine and never parsed the malformed JSON at all. It passed, green, having
+# tested nothing -- and it read a live data path to do it.
+_wd2 = _load("launchd-health-check.py", "wd2")
+
+
+class _ExplodingVerifier:
+    @staticmethod
+    def check(dry_run=False):
+        raise iv.IntentError("launchd-intent.json is not valid JSON: line 1")
+
+
+_wd2._INTENT = _ExplodingVerifier
+_err = []
+try:
+    _wd2.run_intent_check(dry_run=True)
+except Exception as exc:  # noqa: BLE001
+    _err.append(repr(exc))
+check("a malformed manifest does not raise out of the watchdog", _err, [])
+
+# Negative self-test: prove that assertion can fail. Without the try/except in
+# run_intent_check, the same input propagates and the check above goes red.
+_leaked = []
+try:
+    _ExplodingVerifier.check()
+except iv.IntentError:
+    _leaked.append("raises")
+check("the injected verifier really does raise", _leaked, ["raises"])
+
+if failures:
+    print("FAIL")
+    for line in failures:
+        print("  " + line)
+    sys.exit(1)
+print("PASS: launchd-intent-verify")
+sys.exit(0)

--- a/q-system/lessons/a-guard-the-compound-condition-never-reaches-is-not-a-guar.md
+++ b/q-system/lessons/a-guard-the-compound-condition-never-reaches-is-not-a-guar.md
@@ -1,0 +1,30 @@
+---
+id: a-guard-the-compound-condition-never-reaches-is-not-a-guar
+kind: pattern
+title: A guard the compound condition never reaches is not a guard
+date: 2026-08-06
+---
+
+The guard is written, it is correct, and it never runs. Not because it was deleted or misplaced, but because the branch it lives in is entered through a compound condition, and one of the other clauses is False in exactly the situation the guard exists for. Reviewers read the guard, confirm the logic inside it, and move on. The bug is not in the guard. It is in the reachability of the guard, which is a different question and one that reading the guard cannot answer.
+
+This has now happened three times in one file's history, which is what makes it a class rather than a bug:
+
+1. A pause ledger was read to decide "this job is dark on purpose, do not page". The read sat nested inside the `not_loaded` arm. A job that was paused-and-healthy hit no arm at all, so the ledger was consulted only for jobs already failing. The signal was a one-way silencer, never a detector.
+2. A run function returned early when its problem list was empty. The one state the new check existed to judge was exactly the state that produced an empty list, so the check was wired after the return that made it unreachable.
+3. An orphan branch was guarded by `not installed and label not in overrides`. A retired job whose stale override row survived satisfied the first clause and failed the second, so it fell past the orphan branch into the drift branch and paged about a job with no executable on disk. Its sibling, retired identically but with no leftover row, classified correctly. The two inputs differed by one clause.
+
+Notice what all three share: the guard is a **signal read on only one side of a branch**. The information is available, the code that uses it is right, and the control flow routes the interesting case around it. Notice also the harm is always the same two shapes, and both are bad: a real condition goes undetected (1 and 2), or a benign condition gets reported as the alarming one (3). Both read as the system working.
+
+HOW to build against it:
+
+1. **Ask what makes the branch fire, not what it does.** For every `and` in a branch condition, name an input where that clause alone is False. If you cannot name one, the clause is either dead or load-bearing in a way you have not understood. In case 3 the clause `label not in overrides` was False for two of the five real orphans on the machine, which was discoverable in one read-only command.
+
+2. **Decide which single fact settles the classification, and let it settle alone.** "No plist on disk" settles that a job cannot be running; an override row is a statement about a different database. When a second signal is genuinely relevant, it belongs in the DETAIL of the finding, not in the CONDITION that selects the finding. Mixing an informational signal into a classifying condition is how this class gets created.
+
+3. **Test with two inputs that differ by exactly the extra clause.** The reproducer that caught case 3 put both retired siblings in one call: same intent, same absence from disk, differing only by the stale row. One classified right and one classified wrong in the same output line, which makes the clause the only possible explanation. A single-input test would have shown a wrong answer without showing why.
+
+4. **Derive the mutants from the branch's own history, then check the population.** Transplanting case 1's shape into case 3's code produced a mutant that SURVIVED the first suite: it only altered behaviour when intent and reality AGREE, and the tests happened to cover only disagreement. Measuring the real population showed 3 of 5 orphans were in that untested majority. The mutation did not just grade the test, it named the missing case.
+
+5. **Prefer the early, unconditional exit.** `if not installed: classify and continue` cannot develop this defect, because there is no second clause to be False. Every additional term in a classifying condition is a future instance of this lesson.
+
+The general form: reading a guard tells you what it does when it runs. It tells you nothing about whether it runs. Those are separate proofs and the second one is the one people skip.


### PR DESCRIPTION
Closes `sp-2c7e5819`. Nothing anywhere asserted that the enabled set of launchd jobs matches the intended set.

## The defect, reproduced by execution

`discover_problems()` appends only in the `failing` and `not_loaded` branches. The pause ledger is read *inside* the `not_loaded` arm, which makes it a one-way silencer: a label the ledger declares paused, which is actually loaded and healthy, hits neither branch.

Stubbing `job_status` to `('ok', 0)` with one ledger label:

```
discover_problems() -> []
```

Zero finding, zero ping, zero Linear issue. "This job should be stopped and is running" was structurally undetectable, and indistinguishable from "this job is running and should be" — both are silence. The only reason the podcast split state was noticed is that a generated feed dirtied a git tree.

## What this adds

`launchd-intent-verify.py` diffs declared intent against the launchd override database in **both** directions, plus a coverage count.

- **`launchctl print-disabled`, not `launchctl list`.** They disagree: `com.cole.pause-resume` is `=> enabled` in the override DB, exits 113 from `list`, and has no plist on disk at all. Intent is a statement about the persistent record, so that is what it is checked against.
- **Absence means enabled.** Measured 2026-08-06: 65 watched plists, 32 override rows. Absence is the majority case; reading it as "unknown" would leave two thirds of the fleet unverified.
- **Coverage is printed every run.** A manifest covering 25 of 45 jobs otherwise reports "no drift" and reads exactly like full verification.
- **Re-ping is a consecutive-run count, not a wall-clock TTL.** The sibling's `FAIL_PING_TTL_SECONDS = 6h` runs on a 12h schedule (09:30/21:30), so it can never suppress — ASK-283. A counter cannot drift out of sync with the schedule that increments it.
- **Wired before `run()`'s early return.** `problems` is empty exactly when a job runs against its own pause decision. Wired after, the feature would be dead on the only state it judges.
- **Manifest lives in `~/.config/kipi/`, not this repo** — this script propagates fleet-wide via `kipi update` and must carry no instance's brand names, per the constraint the sibling file already states.

**No launchd job was touched.** The founder confirmed the two enabled podcast jobs are deliberate; the defect is the absent verification, not the current state.

## Load-path: this is INERT until merged, and that is not obvious from the diff

The installed plist `com.kipi.launchd-health` runs from the **main checkout**:

```
/Users/assafkipnis/projects/kipi-system/q-system/.q-system/scripts/launchd-health-check.py
```

That checkout currently sits on `sana/bake-in-and-cleanup`, where `launchd-intent-verify.py` does not exist:

```
ls: .../launchd-intent-verify.py: No such file or directory
```

So this does nothing until it merges to `main` **and** the main checkout is on a branch carrying it. `_intent_module()` swallows the ImportError, so today's 09:30/21:30 runs print one stderr line and are otherwise unaffected — but shipping does not equal running here, and a reader will assume it does.

## Verification (local only — GitHub assigns no runners, so no CI result exists)

- New suite: `python3 q-system/.q-system/scripts/test_launchd_intent_verify.py` → PASS
- Sibling regression: `test_launchd_health_check.py` → PASS
- All 7 pre-commit gates green (blocked-paths, large-files, settings-template-sync, instruction-budget, receipts-ledger, plugin-version-bump, gitleaks)
- Registered in `capability-manifest.json` (127 expected tests)

### Mutation: 5/5 killed, each derived from a real prior defect

| Mutant | Historical ancestor | Verdict |
|---|---|---|
| M1 one-sided intent | `4f6bf61f` (ASK-113) nested `if label in paused` inside the `not_loaded` branch — transplanted literally | KILLED |
| M2 absence means paused | absence-at-one-path-is-not-absence | KILLED |
| M3 repeat can never fire | #116's `[ "$DRY_RUN" != "1" ]`; ASK-283's dead TTL | KILLED |
| M4 unknown token guessed | #117's `model_rsync_excludes()` basename assumption | KILLED |
| M5 coverage always full | #115's docstring claiming coverage it lacked | KILLED |
| **C1 control** (expect NOT-A-MUTANT) | proves axis B can return False | NOT-A-MUTANT |
| **C2 control** (expect SURVIVED) | proves axis C can return False | SURVIVED |

Three axes per mutant: applied on disk, behaviour changed against a probe **independent of the suite**, suite red. The two controls exist because a harness that has only ever emitted `KILLED` cannot distinguish a real kill from a mutant that never applied. All three verdicts are now demonstrated, which is what makes the five KILLEDs mean anything.

My first C1 guess was wrong — I predicted the mutant was inert, the probe showed it observable — so it was replaced with a genuine no-op rather than kept.

## One bug caught in my own test

The first malformed-manifest test reloaded `launchd-health-check.py` and called the real function. The fresh copy rebuilt its verifier against the real `~/Library/LaunchAgents` and `~/.config/kipi`, so it read a live data path and never parsed the malformed JSON. Green, testing nothing. Replaced with an injected verifier plus a negative self-test that proves the injected stub really raises.

## Spillover captured

`sp-52fe0615` (override rows for labels with no plist are invisible), `sp-ab583f1d` (intent coverage 25/45 — populate from the 2026-08-01 jobs audit with provenance, do not snapshot current state), `sp-41409ffe` (the 6h/12h TTL is a filed lesson but was never fixed in code).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01WZeGrz117RS1ZxNmGpQk4W
