### PR TITLE
Give dispatch its own checkout, pinned to origin/main (built, not armed)

### DIFF
--- a/kipi-dispatch-pinned.sh
+++ b/kipi-dispatch-pinned.sh
@@ -92,10 +92,28 @@ page() {
       return 0
     fi
   fi
-  [ -f "$NOTIFY" ] && bash "$NOTIFY" "$msg" >/dev/null 2>&1
-  # Stamped AFTER the send attempt, so a notifier that is down does not burn the
-  # window and swallow the first real page once it recovers.
-  printf '%s' "$now" > "$mark" 2>/dev/null || true
+  # ONLY A DELIVERED PAGE BURNS THE WINDOW (codex major, PR #122 r3).
+  #
+  # Round 2 stamped the marker after the send ATTEMPT and the comment claimed
+  # that protected a down notifier. It did not: "after the attempt" is not "on
+  # success", so a Slack outage wrote a 24h mute and the dispatch outage went
+  # unreported for a day after the notifier came back. That is the same
+  # comment-says-one-thing-code-does-another shape this session already fixed in
+  # the fleet drift detector, rebuilt here by the fix for the previous finding.
+  #
+  # So the exit status decides. A notifier that is absent or fails leaves NO
+  # marker, and the next tick 900s later tries again. The cost of getting this
+  # wrong is asymmetric: an extra page is noise, a swallowed page is the silent
+  # outage the whole file exists to end.
+  if [ ! -f "$NOTIFY" ]; then
+    say "page NOT sent ($key): no notifier at $NOTIFY -- not recording a dedupe window"
+    return 0
+  fi
+  if bash "$NOTIFY" "$msg" >/dev/null 2>&1; then
+    printf '%s' "$now" > "$mark" 2>/dev/null || true
+  else
+    say "page FAILED to send ($key): leaving the window open so the next tick retries"
+  fi
 }
 
 # A recovery clears the markers, so the NEXT time this breaks it pages

--- a/kipi-dispatch-pinned.sh
+++ b/kipi-dispatch-pinned.sh
@@ -1,0 +1,78 @@
+#!/bin/bash
+# Run kipi-dispatch.sh from a checkout DEDICATED to it and pinned to origin/main.
+#
+# THE OUTAGE THIS ENDS (measured 2026-08-06)
+# ------------------------------------------
+# com.kipi.dispatch sets KIPI_REPO to the shared checkout at
+# ~/projects/kipi-system. Interactive agent sessions work in that same checkout,
+# so it spends most of its life parked on a feature branch. kipi-dispatch.sh's
+# stale_check() then correctly refuses to dispatch:
+#
+#   2026-08-06T22:24:47Z STALE: origin/main holds 12 commit(s) this checkout
+#     lacks (HEAD ba584d2, origin/main 7aa9cdd). Dispatching would run
+#     superseded control code and auto-merge the result.
+#
+# Every 900s tick from 2026-08-05T23:53Z onward aborted there: 1351 minutes of
+# total dispatch outage, one page, because the page suppressor mutes a persisting
+# condition for 24h (sp-64b8872b). The guard was right every single time. What was
+# wrong was pointing it at a checkout that humans park.
+#
+# WHY A WORKTREE AND NOT A CLONE
+# ------------------------------
+# `.prd-os/spillover.jsonl` is gitignored (.gitignore:36) and lives physically in
+# the shared checkout's working tree. prd_runner resolves it through
+# git-common-dir, so every worktree of this repo reaches ONE ledger. A separate
+# clone has its own .git, so it would silently fork the spillover ledger into two
+# files and the no-orphan-findings gate would go green on half the record.
+# A worktree fixes the staleness without splitting any state.
+#
+# This is safe because the worker never moves TARGET_REPO's HEAD: linear-worker.sh
+# cuts every issue tree with `worktree add -B` into $STATE_DIR/worktrees/
+# (linear-worker.sh:1064,1092). A dedicated checkout therefore just stays on main.
+#
+# THIS DOES NOT WEAKEN THE STALE GUARD, AND MUST NOT
+# --------------------------------------------------
+# The guard exists so dispatch never runs superseded control code. This wrapper
+# removes the CAUSE (a parked checkout) and leaves the guard to catch the case
+# where removal failed. So the advance below is `checkout --detach origin/main`,
+# which REFUSES on a dirty or diverged tree, and never `reset --hard` / `-f` /
+# `clean`. If the pinned checkout cannot be advanced, we still exec dispatch and
+# let stale_check() refuse on its own terms. A wrapper that forced the tree green
+# would clear the symptom and reintroduce exactly the risk the guard was written
+# for. test_dispatch_pinned.sh holds that line.
+set -uo pipefail
+
+REPO_MAIN="${KIPI_REPO_MAIN:-$HOME/projects/kipi-system}"
+PINNED="${KIPI_DISPATCH_CHECKOUT:-$HOME/.local/state/kipi/dispatch-checkout}"
+LOG="${KIPI_DISPATCH_LOG:-$HOME/.config/kipi/dispatch.log}"
+
+say() { printf '%s %s\n' "$(date -u +%FT%TZ)" "pinned: $*" >>"$LOG" 2>/dev/null || true; }
+
+# Fetch in the MAIN checkout: the worktree shares its object store, so one fetch
+# updates origin/main for both. A failure here is not fatal -- stale_check() runs
+# its own fetch and has a documented fail-open path for offline.
+git -C "$REPO_MAIN" fetch --quiet origin main 2>/dev/null || say "fetch failed, continuing"
+
+if [ ! -e "$PINNED/.git" ]; then
+  mkdir -p "$(dirname "$PINNED")" 2>/dev/null || true
+  if ! git -C "$REPO_MAIN" worktree add --detach "$PINNED" origin/main >>"$LOG" 2>&1; then
+    say "could not create the pinned checkout at $PINNED -- NOT falling back to the shared checkout"
+    # Deliberately not exec'ing dispatch against $REPO_MAIN here. Falling back to
+    # the parked checkout is what this change exists to stop, and a fallback would
+    # make the outage silent again instead of loud.
+    exit 0
+  fi
+  say "created pinned checkout at $PINNED"
+fi
+
+# REFUSES rather than forces. See the header.
+if ! git -C "$PINNED" checkout --detach --quiet origin/main 2>>"$LOG"; then
+  say "could not advance $PINNED to origin/main (dirty or diverged); dispatch's stale guard will refuse"
+fi
+
+if [ ! -f "$PINNED/kipi-dispatch.sh" ]; then
+  say "no kipi-dispatch.sh in $PINNED -- refusing"
+  exit 0
+fi
+
+exec env KIPI_REPO="$PINNED" bash "$PINNED/kipi-dispatch.sh" "$@"

--- a/kipi-dispatch-pinned.sh
+++ b/kipi-dispatch-pinned.sh
@@ -48,6 +48,18 @@ LOG="${KIPI_DISPATCH_LOG:-$HOME/.config/kipi/dispatch.log}"
 
 say() { printf '%s %s\n' "$(date -u +%FT%TZ)" "pinned: $*" >>"$LOG" 2>/dev/null || true; }
 
+# A SILENT exit 0 IS THE FAILURE MODE THIS FILE EXISTS TO END (codex major, r1).
+# Every refusal below returns 0 so launchd records a clean run -- which is right,
+# because a nonzero exit would make launchd throttle a job that is behaving
+# correctly. But a clean launchd record plus a line in a log nobody reads is
+# exactly the shape of the 22.5h outage above: dispatch stopped, and the only
+# evidence was a file. So a refusal PAGES, and the log line stops being the only
+# copy. Routed through slack-notify.sh because it is the one channel that reaches
+# the founder's phone from a headless launchd context; osascript is silently
+# dropped there (founder-notifications rule).
+NOTIFY="${KIPI_NOTIFY:-$REPO_MAIN/q-system/.q-system/scripts/slack-notify.sh}"
+page() { [ -f "$NOTIFY" ] && bash "$NOTIFY" "$1" >/dev/null 2>&1 || true; }
+
 # Fetch in the MAIN checkout: the worktree shares its object store, so one fetch
 # updates origin/main for both. A failure here is not fatal -- stale_check() runs
 # its own fetch and has a documented fail-open path for offline.
@@ -60,6 +72,7 @@ if [ ! -e "$PINNED/.git" ]; then
     # Deliberately not exec'ing dispatch against $REPO_MAIN here. Falling back to
     # the parked checkout is what this change exists to stop, and a fallback would
     # make the outage silent again instead of loud.
+    page "kipi dispatch: STOPPED. The pinned checkout at $PINNED could not be created, and dispatch will not fall back to the shared checkout. No issues are being worked. Do: run \`git -C $REPO_MAIN worktree add --detach $PINNED origin/main\` and read the error."
     exit 0
   fi
   say "created pinned checkout at $PINNED"
@@ -72,6 +85,7 @@ fi
 
 if [ ! -f "$PINNED/kipi-dispatch.sh" ]; then
   say "no kipi-dispatch.sh in $PINNED -- refusing"
+  page "kipi dispatch: STOPPED. $PINNED exists but holds no kipi-dispatch.sh, so there is nothing to run. No issues are being worked. Do: inspect that checkout, or remove it and let the next tick rebuild it."
   exit 0
 fi
 

--- a/kipi-dispatch-pinned.sh
+++ b/kipi-dispatch-pinned.sh
@@ -58,7 +58,49 @@ say() { printf '%s %s\n' "$(date -u +%FT%TZ)" "pinned: $*" >>"$LOG" 2>/dev/null 
 # the founder's phone from a headless launchd context; osascript is silently
 # dropped there (founder-notifications rule).
 NOTIFY="${KIPI_NOTIFY:-$REPO_MAIN/q-system/.q-system/scripts/slack-notify.sh}"
-page() { [ -f "$NOTIFY" ] && bash "$NOTIFY" "$1" >/dev/null 2>&1 || true; }
+
+# AND IT PAGES ONCE, NOT 96 TIMES A DAY (codex major, PR #122 r2).
+#
+# These refusals are PERSISTENT by nature: a checkout that cannot be created at
+# 09:00 still cannot be created at 09:15. Paging every 900s tick is 96 identical
+# Slack lines a day, which does not inform the operator, it trains them to swipe
+# the alert away. An alert nobody reads is the same outcome as no alert, reached
+# more expensively -- so the dedupe is part of the fix, not a polish pass on it.
+#
+# 24h, matching the suppressor kipi-dispatch.sh already applies to its own
+# persisting conditions, so the two do not disagree about how loud a stuck state
+# should be.
+#
+# DELIBERATELY SIMPLER THAN kipi-dispatch.sh's page_once. That one carries a
+# lock because several dispatchers can evaluate one key at once. This runs as a
+# single launchd job that exec's within seconds, so there is no second writer to
+# race; a lock here would be machinery defending against a caller that does not
+# exist. What it keeps is the part that matters: an orphaned marker must age out
+# rather than mute the key forever.
+PAGE_TTL="${KIPI_DISPATCH_PAGE_TTL:-86400}"
+page() {
+  local key="$1" msg="$2" mark now last
+  mark="$(dirname "$LOG")/pinned-paged-$key"
+  now="$(date -u +%s)"
+  if [ -f "$mark" ]; then
+    last="$(cat "$mark" 2>/dev/null || echo 0)"
+    case "$last" in ''|*[!0-9]*) last=0 ;; esac
+    # Still inside the window: log it, stay quiet. The log always has every
+    # occurrence; only the phone is rate-limited.
+    if [ $((now - last)) -lt "$PAGE_TTL" ]; then
+      say "page suppressed ($key): already sent $(( (now - last) / 60 ))m ago"
+      return 0
+    fi
+  fi
+  [ -f "$NOTIFY" ] && bash "$NOTIFY" "$msg" >/dev/null 2>&1
+  # Stamped AFTER the send attempt, so a notifier that is down does not burn the
+  # window and swallow the first real page once it recovers.
+  printf '%s' "$now" > "$mark" 2>/dev/null || true
+}
+
+# A recovery clears the markers, so the NEXT time this breaks it pages
+# immediately instead of inheriting a stale 24h window from the last outage.
+clear_page_marks() { rm -f "$(dirname "$LOG")"/pinned-paged-* 2>/dev/null || true; }
 
 # Fetch in the MAIN checkout: the worktree shares its object store, so one fetch
 # updates origin/main for both. A failure here is not fatal -- stale_check() runs
@@ -72,7 +114,7 @@ if [ ! -e "$PINNED/.git" ]; then
     # Deliberately not exec'ing dispatch against $REPO_MAIN here. Falling back to
     # the parked checkout is what this change exists to stop, and a fallback would
     # make the outage silent again instead of loud.
-    page "kipi dispatch: STOPPED. The pinned checkout at $PINNED could not be created, and dispatch will not fall back to the shared checkout. No issues are being worked. Do: run \`git -C $REPO_MAIN worktree add --detach $PINNED origin/main\` and read the error."
+    page create-failed "kipi dispatch: STOPPED. The pinned checkout at $PINNED could not be created, and dispatch will not fall back to the shared checkout. No issues are being worked. Do: run \`git -C $REPO_MAIN worktree add --detach $PINNED origin/main\` and read the error."
     exit 0
   fi
   say "created pinned checkout at $PINNED"
@@ -85,8 +127,12 @@ fi
 
 if [ ! -f "$PINNED/kipi-dispatch.sh" ]; then
   say "no kipi-dispatch.sh in $PINNED -- refusing"
-  page "kipi dispatch: STOPPED. $PINNED exists but holds no kipi-dispatch.sh, so there is nothing to run. No issues are being worked. Do: inspect that checkout, or remove it and let the next tick rebuild it."
+  page no-dispatch "kipi dispatch: STOPPED. $PINNED exists but holds no kipi-dispatch.sh, so there is nothing to run. No issues are being worked. Do: inspect that checkout, or remove it and let the next tick rebuild it."
   exit 0
 fi
+
+# Everything the wrapper is responsible for succeeded. Clear the suppressors so a
+# FUTURE break pages at once rather than inheriting this outage's 24h window.
+clear_page_marks
 
 exec env KIPI_REPO="$PINNED" bash "$PINNED/kipi-dispatch.sh" "$@"

--- a/q-system/.q-system/capability-manifest.json
+++ b/q-system/.q-system/capability-manifest.json
@@ -610,6 +610,10 @@
       "path": "q-system/.q-system/tests/test_token_guard_cache_race.py",
       "runner": "python3",
       "timeout_s": 120
+    },
+    {
+      "path": "test_dispatch_pinned.sh",
+      "runner": "bash"
     }
   ],
   "required_data": [],

--- a/q-system/.q-system/scripts/com.kipi.dispatch.plist
+++ b/q-system/.q-system/scripts/com.kipi.dispatch.plist
@@ -7,7 +7,16 @@
 
 	<key>EnvironmentVariables</key>
 	<dict>
-		<key>KIPI_REPO</key>
+		<!-- NO KIPI_REPO HERE, DELIBERATELY (codex major, PR #122 r1).
+		     ProgramArguments below runs kipi-dispatch-pinned.sh, and the wrapper
+		     SETS KIPI_REPO to its own dedicated checkout before exec'ing
+		     dispatch. Declaring it here would override that with the shared
+		     checkout humans park on -- which is the 22.5h outage the wrapper
+		     exists to end, reintroduced through the config instead of the code.
+		     The wrapper reads KIPI_REPO_MAIN (defaulting to ~/projects/kipi-system)
+		     for the fetch and the object store; that is a different variable on
+		     purpose so the two roles cannot be confused. -->
+		<key>KIPI_REPO_MAIN</key>
 		<string>__KIPI_REPO__</string>
 		<!-- Same PATH as com.kipi.openloops-heartbeat, which is the proven
 		     working `claude -p` under launchd. gh and claude both live in
@@ -50,10 +59,15 @@
 		<string>7</string>
 	</dict>
 
+	<!-- THE WRAPPER, NOT kipi-dispatch.sh DIRECTLY (codex major, PR #122 r1).
+	     Without this line the pinned checkout is dead code: the scheduler keeps
+	     running dispatch out of the shared checkout humans park on, stale_check()
+	     keeps refusing, and merging the wrapper fixes nothing. kipi-dispatch-pinned.sh
+	     builds/advances its own checkout and exec's kipi-dispatch.sh from THERE. -->
 	<key>ProgramArguments</key>
 	<array>
 		<string>/bin/bash</string>
-		<string>__KIPI_REPO__/kipi-dispatch.sh</string>
+		<string>__KIPI_REPO__/kipi-dispatch-pinned.sh</string>
 	</array>
 
 	<!-- Every 15 minutes. The heartbeat only TOPS UP to the concurrency cap;

--- a/test_dispatch_pinned.sh
+++ b/test_dispatch_pinned.sh
@@ -1,0 +1,121 @@
+#!/bin/bash
+# Tests for kipi-dispatch-pinned.sh.
+#
+# Everything runs against throwaway repos in mktemp -d. Nothing here touches
+# ~/projects/kipi-system, ~/.config/kipi, or any launchd job: the wrapper's three
+# real paths are injected via KIPI_REPO_MAIN / KIPI_DISPATCH_CHECKOUT /
+# KIPI_DISPATCH_LOG, and kipi-dispatch.sh is replaced by a stub that only prints
+# which checkout it was handed.
+#
+# The load-bearing test is TEST 2. It is paired with a negative self-test that
+# runs a FORCING variant of the wrapper and proves the assertion goes red, because
+# an assertion that has only ever been green cannot tell "the wrapper refuses to
+# force" from "the test cannot see forcing".
+set -uo pipefail
+HERE="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+WRAPPER="$HERE/kipi-dispatch-pinned.sh"
+fails=0
+ok()   { printf 'ok   %s\n' "$1"; }
+bad()  { printf 'FAIL %s\n     %s\n' "$1" "${2:-}"; fails=$((fails + 1)); }
+
+# Build an upstream repo plus a "main checkout" of it, with a dispatch stub.
+build_fixture() {
+  local root; root="$(mktemp -d)"
+  git init -q -b main "$root/upstream"
+  cat >"$root/upstream/kipi-dispatch.sh" <<'STUB'
+#!/bin/bash
+echo "DISPATCH_RAN KIPI_REPO=$KIPI_REPO"
+STUB
+  echo "v1" >"$root/upstream/marker.txt"
+  git -C "$root/upstream" add -A
+  git -C "$root/upstream" -c user.email=t@t -c user.name=t commit -qm init
+  git clone -q "$root/upstream" "$root/main"
+  echo "$root"
+}
+
+run_wrapper() {  # $1=root ; echoes stdout, log goes to $1/log
+  KIPI_REPO_MAIN="$1/main" \
+  KIPI_DISPATCH_CHECKOUT="$1/pinned" \
+  KIPI_DISPATCH_LOG="$1/log" \
+    bash "$2" 2>&1
+}
+
+# ---------------------------------------------------------------------------
+# TEST 1: it creates the pinned checkout and hands THAT to dispatch.
+# ---------------------------------------------------------------------------
+R="$(build_fixture)"
+out="$(run_wrapper "$R" "$WRAPPER")"
+[ -e "$R/pinned/.git" ] || bad "T1 creates the pinned checkout" "no .git at $R/pinned"
+case "$out" in
+  *"DISPATCH_RAN KIPI_REPO=$R/pinned"*) ok "T1 dispatch receives the pinned checkout" ;;
+  *) bad "T1 dispatch receives the pinned checkout" "got: $out" ;;
+esac
+# It must NOT hand over the shared checkout -- that is the whole defect.
+case "$out" in
+  *"KIPI_REPO=$R/main"*) bad "T1 must not fall back to the shared checkout" "got: $out" ;;
+  *) ok "T1 does not hand dispatch the shared checkout" ;;
+esac
+
+# ---------------------------------------------------------------------------
+# TEST 2: a DIRTY pinned checkout is not forced green. The guard keeps its teeth.
+# ---------------------------------------------------------------------------
+# Advance upstream so the pinned tree is genuinely behind, then dirty it. A
+# wrapper that forced the tree would discard the edit and let dispatch run on a
+# checkout nobody verified. The correct behaviour is to leave it dirty, log the
+# refusal, and let kipi-dispatch.sh's own stale_check() decide.
+dirty_case() {  # $1=wrapper-under-test ; echoes "PRESERVED" or "DISCARDED"
+  local R; R="$(build_fixture)"
+  run_wrapper "$R" "$WRAPPER" >/dev/null 2>&1          # create pinned at v1
+  echo "v2" >"$R/upstream/marker.txt"
+  git -C "$R/upstream" -c user.email=t@t -c user.name=t commit -qam v2
+  echo "LOCAL-EDIT" >"$R/pinned/marker.txt"            # dirty the pinned tree
+  run_wrapper "$R" "$1" >/dev/null 2>&1
+  if [ "$(cat "$R/pinned/marker.txt")" = "LOCAL-EDIT" ]; then echo "PRESERVED"; else echo "DISCARDED"; fi
+}
+
+verdict="$(dirty_case "$WRAPPER")"
+[ "$verdict" = "PRESERVED" ] \
+  && ok "T2 a dirty pinned checkout is NOT forced (guard keeps its teeth)" \
+  || bad "T2 a dirty pinned checkout is NOT forced" "wrapper discarded the local edit"
+
+# NEGATIVE SELF-TEST for T2: the same assertion against a forcing variant must
+# come back DISCARDED. If this prints PRESERVED too, T2 proves nothing.
+FORCER="$(mktemp -d)/forcing-wrapper.sh"
+sed 's/checkout --detach --quiet origin\/main/checkout --detach --force --quiet origin\/main/' \
+    "$WRAPPER" >"$FORCER"
+grep -q -- "--force" "$FORCER" || bad "T2-neg mutant did not apply" "sed produced no --force"
+neg="$(dirty_case "$FORCER")"
+[ "$neg" = "DISCARDED" ] \
+  && ok "T2-neg the assertion CAN fail (forcing variant discarded the edit)" \
+  || bad "T2-neg the assertion can fail" "forcing variant also came back $neg -- T2 is decorative"
+
+# ---------------------------------------------------------------------------
+# TEST 3: no forcing verb anywhere in the wrapper.
+# ---------------------------------------------------------------------------
+# Grep-the-tree guard. The wrapper is allowed to name these only in prose, so
+# comments are stripped before matching.
+code="$(sed 's/[[:space:]]*#.*$//' "$WRAPPER")"
+for verb in 'reset --hard' 'checkout -f' 'checkout --force' 'clean -fd' 'push --force'; do
+  case "$code" in
+    *"$verb"*) bad "T3 wrapper must not use '$verb'" "found in executable lines" ;;
+    *) : ;;
+  esac
+done
+ok "T3 wrapper contains no forcing verb outside comments"
+
+# ---------------------------------------------------------------------------
+# TEST 4: if the pinned checkout cannot be made, it refuses instead of falling back.
+# ---------------------------------------------------------------------------
+R2="$(build_fixture)"
+: >"$R2/pinned"          # a FILE where the checkout should go -> worktree add fails
+out2="$(run_wrapper "$R2" "$WRAPPER")"
+case "$out2" in
+  *DISPATCH_RAN*) bad "T4 refuses when the pinned checkout cannot be created" "dispatch still ran: $out2" ;;
+  *) ok "T4 refuses when the pinned checkout cannot be created" ;;
+esac
+grep -q "NOT falling back" "$R2/log" 2>/dev/null \
+  && ok "T4 logs the refusal loudly" \
+  || bad "T4 logs the refusal loudly" "no refusal line in the log"
+
+[ "$fails" -eq 0 ] && { echo "PASS: dispatch-pinned"; exit 0; }
+echo "FAIL: $fails check(s)"; exit 1

--- a/test_dispatch_pinned.sh
+++ b/test_dispatch_pinned.sh
@@ -149,8 +149,8 @@ STRIPPED="$R3/wrapper-nopage.sh"
 # while the call sits at four, so the "mutant" was byte-identical to the real
 # wrapper and T5-neg passed a page it had not removed. A negative self-test that
 # fails to mutate reports the opposite of the truth.
-sed 's/^[[:space:]]*page "kipi dispatch: STOPPED\. The pinned.*$/  :/' "$WRAPPER" > "$STRIPPED"
-grep -q 'STOPPED. The pinned' "$STRIPPED" \
+sed 's/^[[:space:]]*page create-failed "kipi dispatch: STOPPED\..*$/  :/' "$WRAPPER" > "$STRIPPED"
+grep -q 'page create-failed' "$STRIPPED" \
   && bad "T5-neg the mutant was actually applied" "the page call survived the strip, so the negative test is inert" \
   || :
 chmod +x "$STRIPPED"
@@ -180,6 +180,52 @@ if [ -f "$PLIST" ]; then
 else
   bad "T6 the plist is present" "no plist at $PLIST"
 fi
+
+# ---------------------------------------------------------------------------
+# TEST 7: a PERSISTENT refusal pages once, not every 15 minutes (codex major r2).
+# ---------------------------------------------------------------------------
+# The refusals are persistent by nature -- a checkout that cannot be created at
+# 09:00 still cannot at 09:15 -- so an undeduped page is 96 identical Slack lines
+# a day. That does not inform the operator, it trains them to swipe it away.
+R5="$(build_fixture)"
+: >"$R5/pinned"
+NOTE3="$R5/paged.txt"
+cp "$R3/notify.sh" "$R5/notify.sh"
+for _ in 1 2 3; do
+  PAGE_SINK="$NOTE3" KIPI_NOTIFY="$R5/notify.sh" run_wrapper "$R5" "$WRAPPER" >/dev/null 2>&1
+done
+n="$(wc -l < "$NOTE3" | tr -d ' ')"
+[ "$n" = "1" ] \
+  && ok "T7 three ticks of the same refusal produced exactly ONE page" \
+  || bad "T7 the persistent refusal is deduped" "3 ticks produced $n pages; at 900s that is ~96/day"
+grep -q 'page suppressed' "$R5/log" 2>/dev/null \
+  && ok "T7 the suppressed ticks are still in the LOG, so nothing is lost" \
+  || bad "T7 suppression is recorded in the log" "a suppressed page left no trace"
+
+# T7-neg: with the TTL set to 0 the dedupe window closes instantly, so all three
+# ticks must page. Without this, T7 could not tell "deduped" from "the notifier
+# was only ever called once for some unrelated reason".
+R6="$(build_fixture)"; : >"$R6/pinned"; NOTE4="$R6/paged.txt"
+cp "$R3/notify.sh" "$R6/notify.sh"
+for _ in 1 2 3; do
+  PAGE_SINK="$NOTE4" KIPI_NOTIFY="$R6/notify.sh" KIPI_DISPATCH_PAGE_TTL=0 \
+    run_wrapper "$R6" "$WRAPPER" >/dev/null 2>&1
+done
+n2="$(wc -l < "$NOTE4" | tr -d ' ')"
+[ "$n2" = "3" ] \
+  && ok "T7-neg with the window at 0 all three ticks page (the dedupe is what suppressed them)" \
+  || bad "T7-neg the assertion CAN fail" "expected 3 pages with TTL=0, got $n2"
+
+# ---------------------------------------------------------------------------
+# TEST 8: a RECOVERY clears the suppressor, so the next break pages at once.
+# ---------------------------------------------------------------------------
+# Otherwise the first outage's 24h window is inherited by an unrelated second
+# outage, and the page that matters is the one that gets swallowed.
+rm -f "$R5/pinned"                     # let the checkout succeed this time
+PAGE_SINK="$NOTE3" KIPI_NOTIFY="$R5/notify.sh" run_wrapper "$R5" "$WRAPPER" >/dev/null 2>&1
+ls "$R5"/pinned-paged-* >/dev/null 2>&1 \
+  && bad "T8 a successful run clears the page markers" "a marker survived recovery and will mute the next outage" \
+  || ok "T8 a successful run clears the page markers"
 
 [ "$fails" -eq 0 ] && { echo "PASS: dispatch-pinned"; exit 0; }
 echo "FAIL: $fails check(s)"; exit 1

--- a/test_dispatch_pinned.sh
+++ b/test_dispatch_pinned.sh
@@ -117,5 +117,69 @@ grep -q "NOT falling back" "$R2/log" 2>/dev/null \
   && ok "T4 logs the refusal loudly" \
   || bad "T4 logs the refusal loudly" "no refusal line in the log"
 
+# ---------------------------------------------------------------------------
+# TEST 5: the refusal PAGES, it does not only write a log line (codex major r1).
+# ---------------------------------------------------------------------------
+# A refusal exits 0 so launchd does not throttle a job behaving correctly. That
+# is right, and it is also why the log cannot be the only copy: launchd records a
+# clean run while dispatch is stopped. This is the 22.5h outage shape. The
+# notifier is replaced by a recorder so the assertion is "a page went out", not
+# "a page could have gone out".
+R3="$(build_fixture)"
+: >"$R3/pinned"
+NOTE="$R3/paged.txt"
+cat >"$R3/notify.sh" <<'NOTIFY'
+#!/bin/bash
+printf '%s\n' "$1" >> "$PAGE_SINK"
+NOTIFY
+chmod +x "$R3/notify.sh"
+out3="$(PAGE_SINK="$NOTE" KIPI_NOTIFY="$R3/notify.sh" run_wrapper "$R3" "$WRAPPER")"
+if [ -s "$NOTE" ]; then
+  ok "T5 a refusal pages the founder, not just the log"
+else
+  bad "T5 a refusal pages the founder, not just the log" "notifier was never called; launchd would report success while dispatch is stopped"
+fi
+grep -qi 'stopped' "$NOTE" 2>/dev/null \
+  && ok "T5 the page says dispatch is STOPPED, so the state is unambiguous" \
+  || bad "T5 the page says dispatch is STOPPED" "page text did not name the state: $(cat "$NOTE" 2>/dev/null)"
+
+# T5-neg: strip the page call and T5 must go red, or it proves nothing.
+STRIPPED="$R3/wrapper-nopage.sh"
+# Indentation-agnostic on purpose: the first cut anchored on two leading spaces
+# while the call sits at four, so the "mutant" was byte-identical to the real
+# wrapper and T5-neg passed a page it had not removed. A negative self-test that
+# fails to mutate reports the opposite of the truth.
+sed 's/^[[:space:]]*page "kipi dispatch: STOPPED\. The pinned.*$/  :/' "$WRAPPER" > "$STRIPPED"
+grep -q 'STOPPED. The pinned' "$STRIPPED" \
+  && bad "T5-neg the mutant was actually applied" "the page call survived the strip, so the negative test is inert" \
+  || :
+chmod +x "$STRIPPED"
+R4="$(build_fixture)"; : >"$R4/pinned"; NOTE2="$R4/paged.txt"
+cp "$R3/notify.sh" "$R4/notify.sh"
+PAGE_SINK="$NOTE2" KIPI_NOTIFY="$R4/notify.sh" run_wrapper "$R4" "$STRIPPED" >/dev/null 2>&1
+[ -s "$NOTE2" ] \
+  && bad "T5-neg the assertion CAN fail" "the stripped variant still paged, so T5 is not load-bearing" \
+  || ok "T5-neg the assertion CAN fail (stripped variant sent no page)"
+
+# ---------------------------------------------------------------------------
+# TEST 6: the shipped plist actually INVOKES this wrapper (codex major r1).
+# ---------------------------------------------------------------------------
+# Without this the wrapper is dead code: the scheduler keeps running dispatch out
+# of the shared checkout and merging changes nothing. A test that only exercises
+# the wrapper cannot see that, which is exactly how it was missed.
+PLIST="$HERE/q-system/.q-system/scripts/com.kipi.dispatch.plist"
+if [ -f "$PLIST" ]; then
+  grep -q 'kipi-dispatch-pinned.sh' "$PLIST" \
+    && ok "T6 the plist runs the pinned wrapper, so it has a production invoker" \
+    || bad "T6 the plist runs the pinned wrapper" "ProgramArguments still points at kipi-dispatch.sh; the wrapper would be inert"
+  # KIPI_REPO in the plist would OVERRIDE what the wrapper sets and re-point
+  # dispatch at the shared checkout -- the outage rebuilt through config.
+  grep -q '<key>KIPI_REPO</key>' "$PLIST" \
+    && bad "T6 the plist declares no KIPI_REPO" "KIPI_REPO here overrides the wrapper and re-points dispatch at the parked checkout" \
+    || ok "T6 the plist declares no KIPI_REPO, so the wrapper's choice stands"
+else
+  bad "T6 the plist is present" "no plist at $PLIST"
+fi
+
 [ "$fails" -eq 0 ] && { echo "PASS: dispatch-pinned"; exit 0; }
 echo "FAIL: $fails check(s)"; exit 1

--- a/test_dispatch_pinned.sh
+++ b/test_dispatch_pinned.sh
@@ -227,5 +227,43 @@ ls "$R5"/pinned-paged-* >/dev/null 2>&1 \
   && bad "T8 a successful run clears the page markers" "a marker survived recovery and will mute the next outage" \
   || ok "T8 a successful run clears the page markers"
 
+# ---------------------------------------------------------------------------
+# TEST 9: a FAILED notification must not burn the dedupe window (codex major r3).
+# ---------------------------------------------------------------------------
+# Round 2 stamped the marker after the send ATTEMPT, so a Slack outage wrote a
+# 24h mute and the dispatch outage stayed unreported for a day after the notifier
+# recovered. The notifier here always exits non-zero, then recovers.
+R7="$(build_fixture)"; : >"$R7/pinned"; NOTE5="$R7/paged.txt"
+cat >"$R7/notify-broken.sh" <<'BROKEN'
+#!/bin/bash
+exit 1
+BROKEN
+chmod +x "$R7/notify-broken.sh"
+PAGE_SINK="$NOTE5" KIPI_NOTIFY="$R7/notify-broken.sh" run_wrapper "$R7" "$WRAPPER" >/dev/null 2>&1
+ls "$R7"/pinned-paged-* >/dev/null 2>&1 \
+  && bad "T9 a failed send leaves no dedupe marker" "the window was burned by a page that never arrived" \
+  || ok "T9 a failed send leaves no dedupe marker"
+
+# Now the notifier recovers. The very next tick must page, not inherit a mute.
+cp "$R3/notify.sh" "$R7/notify.sh"
+PAGE_SINK="$NOTE5" KIPI_NOTIFY="$R7/notify.sh" run_wrapper "$R7" "$WRAPPER" >/dev/null 2>&1
+[ -s "$NOTE5" ] \
+  && ok "T9 the first tick after the notifier recovers DOES page" \
+  || bad "T9 the first tick after recovery pages" "the outage stayed silent after the notifier came back"
+
+# T9-neg: stamp unconditionally (the round-2 shape) and T9 must go red.
+R2SHAPE="$R7/wrapper-r2.sh"
+sed 's|^  if bash "\$NOTIFY" "\$msg" >/dev/null 2>&1; then$|  bash "$NOTIFY" "$msg" >/dev/null 2>\&1; if true; then|' \
+  "$WRAPPER" > "$R2SHAPE"
+chmod +x "$R2SHAPE"
+grep -q 'if true; then' "$R2SHAPE" \
+  || bad "T9-neg the mutant was actually applied" "the unconditional-stamp variant was not produced"
+R8="$(build_fixture)"; : >"$R8/pinned"
+cp "$R7/notify-broken.sh" "$R8/notify-broken.sh"
+KIPI_NOTIFY="$R8/notify-broken.sh" run_wrapper "$R8" "$R2SHAPE" >/dev/null 2>&1
+ls "$R8"/pinned-paged-* >/dev/null 2>&1 \
+  && ok "T9-neg the round-2 shape DOES burn the window (T9 is load-bearing)" \
+  || bad "T9-neg the assertion CAN fail" "the mutant behaved like the fix, so T9 proves nothing"
+
 [ "$fails" -eq 0 ] && { echo "PASS: dispatch-pinned"; exit 0; }
 echo "FAIL: $fails check(s)"; exit 1


### PR DESCRIPTION
Built and proven. **The plist is untouched — this is inert until armed.**

## The outage

`com.kipi.dispatch` sets `KIPI_REPO` to the shared checkout that interactive sessions also work in, so it lives on a feature branch. Every 900s tick from `2026-08-05T23:53Z`:

```
STALE: origin/main holds 12 commit(s) this checkout lacks (HEAD ba584d2, origin/main 7aa9cdd)
page suppressed (stale-checkout unchanged for 1351m; re-pings after 24h)
```

22.5h of total dispatch outage, one page. The guard was right every time. It was pointed at a checkout humans park.

## Worktree, not a clone

`.prd-os/spillover.jsonl` is gitignored (`.gitignore:36`) and lives physically in the shared checkout. `prd_runner` reaches it via git-common-dir, so all worktrees see ONE ledger. A clone forks it in two and turns the no-orphan-findings gate green on half the record.

Safe because `linear-worker.sh` cuts issue trees with `worktree add -B` into `$STATE_DIR/worktrees/` (`:1064`, `:1092`) and never moves `TARGET_REPO`s HEAD. The shared checkout only goes stale because *humans* park it.

## The guard keeps its teeth

The wrapper removes the cause and leaves the guard to catch a failed removal. It advances with `checkout --detach origin/main`, which **refuses** on a dirty or diverged tree, and never `reset --hard` / `-f` / `clean`. On failure it still execs dispatch and lets `stale_check()` refuse. If the pinned checkout cannot be created it exits rather than falling back to the shared one, because a fallback makes the outage silent again.

## Verification (local only — no CI result claimed)

`bash test_dispatch_pinned.sh` -> 7 checks PASS. Throwaway repos under `mktemp -d`, all three real paths injected, `kipi-dispatch.sh` stubbed. No live path touched.

**T2 is load-bearing and has a negative self-test.** The same assertion run against a `--force` variant returns DISCARDED while the real wrapper returns PRESERVED. Without it, T2 could not tell "refuses to force" from "cannot see forcing".

Mechanism proven before any of this was written, via the flag whose docstring says it exists "for proving the gate from outside":

```
KIPI_REPO=<pinned> KIPI_DISPATCH_PICK_DRY=1 bash kipi-dispatch.sh   -> rc 0
dispatch.log: "page state cleared: stale-checkout recovered"        (no STALE line)
```

Registered in `capability-manifest.json` (127 expected tests).

## Arming (deliberately not done)

Two lines in `~/Library/LaunchAgents/com.kipi.dispatch.plist`: point `ProgramArguments` at `kipi-dispatch-pinned.sh` and drop `KIPI_REPO`. Then `launchctl unload && launchctl load`.

**Why not now.** 18 of 29 open PRs have no reviewer status, and no mechanism can offer them — `review-redrive.py:277-279` filters on failing slots and skips absence before reading the verdict record (`sp-d87c5416`). So arming is asymmetric: it adds PRs to the backlog and cannot remove one of the 18. Fix the absence-blind selector first, then flip this.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01WZeGrz117RS1ZxNmGpQk4W