### PR TITLE
review-redrive must see a reviewer slot that was NEVER POSTED (sp-d87c5416)

### DIFF
--- a/q-system/.q-system/capability-manifest.json
+++ b/q-system/.q-system/capability-manifest.json
@@ -516,6 +516,10 @@
       "path": "q-system/.q-system/scripts/test/test-zero-safe-count-idiom.sh",
       "runner": "bash",
       "timeout_s": 60
+    },
+    {
+      "path": "q-system/.q-system/scripts/test/test-review-redrive-absent.py",
+      "runner": "python3"
     }
   ],
   "required_data": [],

--- a/q-system/.q-system/scripts/review-redrive.py
+++ b/q-system/.q-system/scripts/review-redrive.py
@@ -156,12 +156,29 @@ def record_path(records_dir, pr):
     return os.path.join(records_dir, "pr-%s.verdict.json" % pr)
 
 
+# A THIRD answer, alongside a record and no record. json.JSONDecodeError IS a
+# ValueError, so the original `except (OSError, ValueError): return None`
+# reported a TRUNCATED record and an ABSENT one identically -- and every caller
+# then states, in the operator-facing reason, that no verdict exists. That is
+# the same false statement finding 1 was about, arriving through the other door.
+# Latent rather than live: 0 unparseable across 96 records sampled 2026-08-06.
+# (Independent probe on PR #123, sp-3e57348e.)
+CORRUPT_RECORD = object()
+
+
 def read_record(records_dir, pr):
+    """The verdict record, None if absent, CORRUPT_RECORD if unreadable."""
     try:
         with open(record_path(records_dir, pr)) as fh:
             return json.load(fh)
-    except (OSError, ValueError):
+    except FileNotFoundError:
         return None
+    except OSError:
+        # Unreadable for a reason that is not absence (permissions, a directory
+        # where a file belongs). Refusing beats claiming the review never ran.
+        return CORRUPT_RECORD
+    except ValueError:
+        return CORRUPT_RECORD
 
 
 def usable_from_lib(review_file):
@@ -340,27 +357,47 @@ def candidates(repo_dir, records_dir):
             if reviewer_slot_posted(pr_obj):
                 # A gating verdict exists and is not failing. Nothing to redrive.
                 continue
+            if record is CORRUPT_RECORD:
+                # Say what is true: the record is there and unreadable. Naming it
+                # "never posted" would send the operator after a producer bug.
+                sys.stderr.write(
+                    "review-redrive: PR #%s has a verdict record that will not "
+                    "parse -- refusing to call it absent. Left alone.\n" % pr)
+                continue
             if record is not None:
                 # NO STATUS, BUT A VERDICT RECORD EXISTS. Not a virgin PR.
                 #
                 # pr-review-agent.sh writes the record unconditionally but posts
                 # the status only inside `if [ "$POST" = "1" ]` (:917, :975). So
-                # `kipi review <PR>` without --post, a failed status post (":915
-                # the review is recorded but NO gate moved"), or a missing head
-                # sha all leave exactly this shape, and OUT_DIR (:111) is the very
-                # directory read_record reads.
+                # `kipi review <PR>` without --post, the ":915 recorded but NO
+                # gate moved" branch, and the missing-head-sha branch all leave
+                # this shape, in the very directory read_record reads (:111).
                 #
-                # Treating it as absent would spend a review round manufacturing a
-                # second verdict while a usable one with findings sits on disk,
-                # and would tell the operator "never posted a verdict" about a PR
-                # that has one -- sending them after a producer bug that does not
-                # exist. Codex review of PR #123, finding 1 (major), reproduced
-                # before accepting.
-                #
-                # The circularity argument for skipping the lookup holds for a
-                # MISSING record, not a present one. Fall through to classify(),
-                # which already knows how to read one.
-                pass
+                # classify() answers "is this a refusal", which is the WRONG
+                # question here. It returns (None, ...) for any non-refusal, and
+                # the shared tail below does `if action is None: continue` -- so
+                # a review that PASSED but was never posted fell out silently.
+                # Sampled 2026-08-06 across 96 records: APPROVE WITH NITS 54,
+                # REQUEST CHANGES 23, APPROVE 17, BLOCK 1, empty 1. The dropped
+                # non-refusals are 71 of 96, the MAJORITY, and PR #23 is one --
+                # approved, never posted, auto-merge armed and waiting forever on
+                # a status nobody sends. The cheapest PR in the queue was the one
+                # the selector could not see. (Independent probe on PR #123.)
+                head_sha = pr_obj.get("headRefOid") or ""
+                action, reason = classify(record, head_sha)
+                if action is None:
+                    # A PASSING review with no status. Not a refusal, not virgin.
+                    action = REREVIEW
+                    reason = ("the review passed but its status was never "
+                              "posted (%s)" % (record.get("verdict") or "no verdict"))
+                out.append({
+                    "action": action, "reason": reason,
+                    "issue": issue, "agent": agent, "issue_source": source,
+                    "pr": pr, "url": pr_obj.get("url"),
+                    "branch": pr_obj.get("headRefName"),
+                    "head_sha": head_sha, "slots": [],
+                })
+                continue
             else:
                 # NEVER POSTED and never recorded -- the reviewer has not run
                 # against this PR at all.
@@ -388,6 +425,11 @@ def candidates(repo_dir, records_dir):
                     "slots": [],
                 })
                 continue
+        elif record is CORRUPT_RECORD:
+            sys.stderr.write(
+                "review-redrive: PR #%s has %s failing and an unreadable verdict "
+                "record -- refusing to guess. Left alone.\n" % (pr, ",".join(slots)))
+            continue
         elif record is None:
             # ABSENT, not FAILURE-with-no-record. Owned by ASK-318/ASK-313.
             sys.stderr.write(

--- a/q-system/.q-system/scripts/review-redrive.py
+++ b/q-system/.q-system/scripts/review-redrive.py
@@ -24,7 +24,9 @@ other's slot.
 
 THE THREE STATES A REQUIRED CONTEXT CAN BE IN, AND WHO OWNS EACH
 ----------------------------------------------------------------
-    ABSENT  (never posted)            -> ASK-318 producer + ASK-313 detector
+    ABSENT  (never posted)            -> HERE, as a first re-review (sp-d87c5416).
+                                         ASK-318/ASK-313 still own the PRODUCER
+                                         question of why it never posted.
     SUCCESS (but nothing merges)      -> ASK-310, pr-land-if-green.sh
     FAILURE (the reviewer refused)    -> here
 
@@ -72,11 +74,15 @@ the first; nothing bounds the second except the cap it would waste.
 
 WHAT IT REFUSES TO TOUCH
 ------------------------
-- A PR with no verdict record at all. That is ABSENT, and it belongs to
-  ASK-318/ASK-313. Manufacturing a review for a PR whose producer never ran would
-  paper over the missing producer, which is the harder and more important bug.
-- A PR whose reviewer slot is not currently FAILURE. A stale record next to a
-  green slot means a newer review already landed.
+- A PR whose slot is FAILING but has no verdict record. The producer ran, posted
+  a failure, and recorded nothing; re-reviewing that papers over a broken producer,
+  which is the harder and more important bug. Still ASK-318/ASK-313.
+  NOT the same as a slot that was NEVER POSTED -- there is no verdict to be
+  missing there, and since 2026-08-06 that case IS selected (sp-d87c5416). The
+  two were conflated while absence was rare; it is now 18 of 29 open PRs.
+- A PR whose reviewer slot is POSTED and not FAILURE. A stale record next to a
+  green slot means a newer review already landed. Note the word posted: the old
+  wording said "not currently FAILURE", which silently included never-posted.
 - A PR that is a draft, or not attributable to an agent+issue. Same rule as
   ci-redrive: an unrecognised branch owner is a human's branch, left alone.
 
@@ -225,6 +231,37 @@ def reviewer_slot_failing(pr_obj):
     return sorted(names)
 
 
+def reviewer_slot_posted(pr_obj):
+    """True if a reviewer slot appears in the rollup AT ALL, whatever its state.
+
+    The distinction reviewer_slot_failing() structurally cannot make. That
+    predicate is two-valued -- failing / not-failing -- over a three-valued
+    world: failing, passing, and NEVER POSTED. Callers that branch only on
+    `not failing` read the third state as the second, so silence becomes health.
+
+    Scar (sp-d87c5416, measured 2026-08-06): candidates() did
+    `if not slots: continue`, so a PR the reviewer had never run against was
+    skipped before its verdict record was even read. 18 of 29 open PRs were in
+    that state, which made the MAJORITY of the backlog invisible to the only
+    mechanism that could move it -- while `select` still printed 8 confident
+    rework candidates and read like a full account of the queue.
+
+    Deliberately state-blind: it answers "did the producer ever speak", never
+    "what did it say". Folding the state back in here would recreate the same
+    two-valued collapse one function further down.
+    """
+    for check in pr_obj.get("statusCheckRollup") or []:
+        if not isinstance(check, dict):
+            continue
+        if check.get("__typename") == "StatusContext":
+            name = check.get("context") or ""
+        else:
+            name = check.get("name") or ""
+        if CI.is_reviewer_slot(name):
+            return True
+    return False
+
+
 def classify(record, head_sha):
     """(action, reason) for a PR whose reviewer slot is failing.
 
@@ -275,9 +312,39 @@ def candidates(repo_dir, records_dir):
             continue
         issue, agent, source = attributed
         slots = reviewer_slot_failing(pr_obj)
-        if not slots:
-            continue
         pr = pr_obj.get("number")
+        if not slots:
+            if reviewer_slot_posted(pr_obj):
+                # A verdict exists and is not failing. Nothing to redrive.
+                continue
+            # NEVER POSTED -- the reviewer has not run against this PR at all.
+            #
+            # This is NOT the ASK-318 case refused below, and the difference is
+            # the whole point. There, a failing slot with no verdict record means
+            # the producer RAN and recorded nothing, so re-reviewing would paper
+            # over a broken producer. Here nothing ever claimed a review happened,
+            # so there is no verdict to be missing and no failure to mask.
+            # Requiring a verdict record before a PR may receive its FIRST review
+            # is circular, which is why the record lookup is skipped on this path.
+            #
+            # It emits the EXISTING re-review action on purpose. kipi-dispatch.sh
+            # :1000 matches that exact string to run pr-review-agent.sh --post;
+            # any other value falls through to `./kipi converge`, so a new
+            # vocabulary word would not be inert, it would silently buy a full
+            # rework round against a review that does not exist. The word already
+            # means "nobody read the code, there is no spec", which is precisely
+            # this state. The distinction rides in the reason, which is what
+            # select and the escalation message print.
+            out.append({
+                "action": REREVIEW,
+                "reason": "the reviewer has never posted a verdict for this PR",
+                "issue": issue, "agent": agent, "issue_source": source,
+                "pr": pr, "url": pr_obj.get("url"),
+                "branch": pr_obj.get("headRefName"),
+                "head_sha": pr_obj.get("headRefOid") or "",
+                "slots": [],
+            })
+            continue
         record = read_record(records_dir, pr)
         if record is None:
             # ABSENT, not FAILURE-with-no-record. Owned by ASK-318/ASK-313.
@@ -379,7 +446,7 @@ def escalate(path, cand):
         "review-redrive: %s PR #%s still has %s failing after the machine tier. "
         "What the machine tried: one %s at %s. The reviewer's record now reads "
         "%s. %s"
-        % (cand["issue"], cand["pr"], ", ".join(cand["slots"]), cand["action"],
+        % (cand["issue"], cand["pr"], (", ".join(cand["slots"]) or "(never posted)"), cand["action"],
            (cand["head_sha"] or "an unknown head")[:8], cand["reason"],
            cand["url"]))
     return True

--- a/q-system/.q-system/scripts/review-redrive.py
+++ b/q-system/.q-system/scripts/review-redrive.py
@@ -231,8 +231,29 @@ def reviewer_slot_failing(pr_obj):
     return sorted(names)
 
 
+# NOTE, unresolved on purpose (sp-833a2b76): should this be the GATING context
+# only, or any reviewer slot?
+#
+# pr-review-agent.sh:189 writes `kipi/reviewer-approved` for the PRIMARY engine
+# and an advisory `kipi/<engine>-approved` otherwise, and ci-redrive.py:202 says
+# the split exists so neither engine "can answer for the other".
+# CI.is_reviewer_slot matches `^kipi/[a-z0-9-]+-approved$`, i.e. BOTH, so a green
+# ADVISORY slot currently reports the GATE as spoken (codex review of PR #123,
+# finding 2, reproduced).
+#
+# It is left BROAD here because narrowing it flips an existing deliberate
+# assertion -- test-review-redrive.sh:157 fixtures `kipi/codex-approved` green
+# and requires "the live status must win over the record". Those two cannot both
+# hold, and picking between them is a scope call about which question this
+# predicate answers ("did SOME review land" vs "has the GATE spoken"), not a
+# detail of making absence visible. Unreachable today regardless:
+# KIPI_REVIEW_PRIMARY_ENGINE defaults to codex, so `kipi/codex-approved` needs a
+# hand-run with a non-default primary. Captured rather than decided here.
+GATING_SLOT = "kipi/reviewer-approved"  # named for the pending decision above
+
+
 def reviewer_slot_posted(pr_obj):
-    """True if a reviewer slot appears in the rollup AT ALL, whatever its state.
+    """True if the GATING reviewer slot appears in the rollup, whatever its state.
 
     The distinction reviewer_slot_failing() structurally cannot make. That
     predicate is two-valued -- failing / not-failing -- over a three-valued
@@ -257,6 +278,7 @@ def reviewer_slot_posted(pr_obj):
             name = check.get("context") or ""
         else:
             name = check.get("name") or ""
+        # BROAD on purpose, and this is contested -- see GATING_SLOT above.
         if CI.is_reviewer_slot(name):
             return True
     return False
@@ -313,40 +335,60 @@ def candidates(repo_dir, records_dir):
         issue, agent, source = attributed
         slots = reviewer_slot_failing(pr_obj)
         pr = pr_obj.get("number")
+        record = read_record(records_dir, pr)
         if not slots:
             if reviewer_slot_posted(pr_obj):
-                # A verdict exists and is not failing. Nothing to redrive.
+                # A gating verdict exists and is not failing. Nothing to redrive.
                 continue
-            # NEVER POSTED -- the reviewer has not run against this PR at all.
-            #
-            # This is NOT the ASK-318 case refused below, and the difference is
-            # the whole point. There, a failing slot with no verdict record means
-            # the producer RAN and recorded nothing, so re-reviewing would paper
-            # over a broken producer. Here nothing ever claimed a review happened,
-            # so there is no verdict to be missing and no failure to mask.
-            # Requiring a verdict record before a PR may receive its FIRST review
-            # is circular, which is why the record lookup is skipped on this path.
-            #
-            # It emits the EXISTING re-review action on purpose. kipi-dispatch.sh
-            # :1000 matches that exact string to run pr-review-agent.sh --post;
-            # any other value falls through to `./kipi converge`, so a new
-            # vocabulary word would not be inert, it would silently buy a full
-            # rework round against a review that does not exist. The word already
-            # means "nobody read the code, there is no spec", which is precisely
-            # this state. The distinction rides in the reason, which is what
-            # select and the escalation message print.
-            out.append({
-                "action": REREVIEW,
-                "reason": "the reviewer has never posted a verdict for this PR",
-                "issue": issue, "agent": agent, "issue_source": source,
-                "pr": pr, "url": pr_obj.get("url"),
-                "branch": pr_obj.get("headRefName"),
-                "head_sha": pr_obj.get("headRefOid") or "",
-                "slots": [],
-            })
-            continue
-        record = read_record(records_dir, pr)
-        if record is None:
+            if record is not None:
+                # NO STATUS, BUT A VERDICT RECORD EXISTS. Not a virgin PR.
+                #
+                # pr-review-agent.sh writes the record unconditionally but posts
+                # the status only inside `if [ "$POST" = "1" ]` (:917, :975). So
+                # `kipi review <PR>` without --post, a failed status post (":915
+                # the review is recorded but NO gate moved"), or a missing head
+                # sha all leave exactly this shape, and OUT_DIR (:111) is the very
+                # directory read_record reads.
+                #
+                # Treating it as absent would spend a review round manufacturing a
+                # second verdict while a usable one with findings sits on disk,
+                # and would tell the operator "never posted a verdict" about a PR
+                # that has one -- sending them after a producer bug that does not
+                # exist. Codex review of PR #123, finding 1 (major), reproduced
+                # before accepting.
+                #
+                # The circularity argument for skipping the lookup holds for a
+                # MISSING record, not a present one. Fall through to classify(),
+                # which already knows how to read one.
+                pass
+            else:
+                # NEVER POSTED and never recorded -- the reviewer has not run
+                # against this PR at all.
+                #
+                # NOT the ASK-318 case below. There, a FAILING slot with no record
+                # means the producer ran and recorded nothing, so re-reviewing
+                # papers over a broken producer. Here nothing ever claimed a
+                # review happened, so there is no verdict to be missing.
+                #
+                # It emits the EXISTING re-review action on purpose.
+                # kipi-dispatch.sh:1000 matches that exact string to run
+                # pr-review-agent.sh --post; any other value falls through to
+                # `./kipi converge`, so a new vocabulary word would not be inert,
+                # it would silently buy a full rework round against a review that
+                # does not exist. The word already means "nobody read the code,
+                # there is no spec", which is precisely this state. The
+                # distinction rides in the reason, which select prints.
+                out.append({
+                    "action": REREVIEW,
+                    "reason": "the reviewer has never posted a verdict for this PR",
+                    "issue": issue, "agent": agent, "issue_source": source,
+                    "pr": pr, "url": pr_obj.get("url"),
+                    "branch": pr_obj.get("headRefName"),
+                    "head_sha": pr_obj.get("headRefOid") or "",
+                    "slots": [],
+                })
+                continue
+        elif record is None:
             # ABSENT, not FAILURE-with-no-record. Owned by ASK-318/ASK-313.
             sys.stderr.write(
                 "review-redrive: PR #%s has %s failing but NO verdict record -- "

--- a/q-system/.q-system/scripts/test/test-review-redrive-absent.py
+++ b/q-system/.q-system/scripts/test/test-review-redrive-absent.py
@@ -147,6 +147,35 @@ check("CONTROL: an unattributable branch is left alone",
       offered([pr(999, ABSENT_ROLLUP, branch="dependabot/npm/lodash-4.17.21", title="Bump lodash from 4.17.20 to 4.17.21")]), [])
 
 # =============================================================================
+# 5b. A record ON DISK with no status posted is NOT a virgin PR.
+# =============================================================================
+# Codex review of PR #123, finding 1 (major), reproduced before accepting.
+# pr-review-agent.sh writes the verdict record unconditionally but posts the
+# status only inside `if [ "$POST" = "1" ]` (:917, :975). So `kipi review <PR>`
+# without --post, a failed status post (":915 recorded but NO gate moved"), or a
+# missing head sha all leave a usable REQUEST CHANGES record with an empty
+# rollup -- and OUT_DIR (:111) is the same dir read_record reads.
+#
+# The first version of this fix skipped read_record on the absent path, so this
+# shape was offered as re-review with the reason "the reviewer has never posted a
+# verdict", while classify() on that very record said rework. That spends a
+# review round manufacturing a second verdict next to a real one with findings,
+# and points the operator at a producer bug that does not exist.
+import json as _json
+_tmp = tempfile.mkdtemp()
+_sha = "b61f215a52007610ce66bf39c9b45ce0a837f838"
+Path(_tmp, "pr-121.verdict.json").write_text(_json.dumps({
+    "pr": 121, "issue": "ASK-447", "verdict": "REQUEST CHANGES",
+    "stated": "REQUEST CHANGES", "usable": True, "round": 1,
+    "review": "", "head_sha": _sha, "ts": "now"}))
+rr.CI.list_prs = lambda repo_dir: [pr(121, ABSENT_ROLLUP)]
+_got = rr.candidates("/nonexistent-repo", Path(_tmp))
+check("a verdict record with no posted status is rework, not a first review",
+      [(c["action"], c["reason"]) for c in _got],
+      [("rework", "reviewer said REQUEST CHANGES at the current head")])
+
+
+# =============================================================================
 # 6. NEGATIVE SELF-TEST: test 1's assertion must be able to fail.
 # =============================================================================
 # A green test 1 could mean "the absent slot is now seen" or "offered() returns

--- a/q-system/.q-system/scripts/test/test-review-redrive-absent.py
+++ b/q-system/.q-system/scripts/test/test-review-redrive-absent.py
@@ -1,0 +1,169 @@
+#!/usr/bin/env python3
+"""review-redrive must see a reviewer slot that was NEVER POSTED (sp-d87c5416).
+
+THE DEFECT
+----------
+`candidates()` did `slots = reviewer_slot_failing(pr_obj); if not slots: continue`.
+That predicate is two-valued (failing / not-failing) over a three-valued world:
+
+    failing        the reviewer objected or came back phantom   -> handled
+    passing        a verdict exists and is green                -> correctly skipped
+    NEVER POSTED   the reviewer has not run at all              -> ALSO skipped
+
+The third state is silence, and silence was read as health. Measured 2026-08-06:
+18 of 29 open PRs had no reviewer status context at all, so the majority of the
+backlog was invisible to the only mechanism that could move it.
+
+WHY THIS IS NOT THE ASK-318 CASE, WHICH STAYS REFUSED
+-----------------------------------------------------
+ASK-318 is "a FAILING slot with no verdict record on disk" -- the producer ran,
+posted a failure, and recorded nothing. Re-reviewing that papers over a broken
+producer, so the module refuses it, and TEST 3 holds that refusal in place.
+
+An ABSENT slot is a different animal: there is no verdict to be missing, because
+no review was ever claimed to have happened. Requiring a verdict record before
+a PR may receive its FIRST review is circular, so the absent path deliberately
+skips the record lookup.
+
+WHY IT EMITS `re-review` AND NOT A NEW ACTION NAME
+--------------------------------------------------
+kipi-dispatch.sh:1000 branches on the exact string "re-review" to run
+`pr-review-agent.sh <PR> --post`. ANY other action string falls through to
+`./kipi converge` -- a full rework round against a review that does not exist.
+So a new vocabulary word would not be a no-op, it would be an expensive wrong
+action. The existing word already means "nobody read the code; there is no
+spec", which is exactly true here. The distinction is carried in the REASON,
+which is what select and the escalation message print.
+
+Fixtures are the real producer's shapes, captured 2026-08-06 from
+`gh pr view <n> --json statusCheckRollup`:
+  PR #121 -> []                                              (the absent case)
+  PR #80  -> CheckRun validate SUCCESS
+             StatusContext kipi/reviewer-approved FAILURE
+Nothing here shells gh: CI.list_prs is replaced with a fixture list.
+
+Run: python3 test-review-redrive-absent.py   (exit 0 = pass, 1 = fail)
+"""
+import importlib.util
+import sys
+import tempfile
+from pathlib import Path
+
+HERE = Path(__file__).resolve().parent
+SCRIPTS = HERE.parent
+
+spec = importlib.util.spec_from_file_location("rr", SCRIPTS / "review-redrive.py")
+rr = importlib.util.module_from_spec(spec)
+spec.loader.exec_module(rr)
+
+failures = []
+
+
+def check(name, got, want):
+    if got != want:
+        failures.append("%s: got %r, want %r" % (name, got, want))
+
+
+# --- the real producer's rollup shapes -------------------------------------
+ABSENT_ROLLUP = []                      # verbatim from PR #121
+FAILING_ROLLUP = [
+    {"__typename": "CheckRun", "name": "validate",
+     "status": "COMPLETED", "conclusion": "SUCCESS"},
+    {"__typename": "StatusContext", "context": "kipi/reviewer-approved",
+     "state": "FAILURE"},
+]
+PASSING_ROLLUP = [
+    {"__typename": "StatusContext", "context": "kipi/reviewer-approved",
+     "state": "SUCCESS"},
+]
+
+
+def pr(number, rollup, branch="sana/ask-447-sweep", draft=False,
+       title="Verify a launchd job's paused/running state against declared "
+             "intent (ASK-447, sp-2c7e5819)"):
+    """A PR object shaped like the one gh actually returns.
+
+    `title` is NOT decoration. CI.attribute() reads the branch tail FIRST and
+    the PR title SECOND, and this branch (`sana/ask-447-sweep`, a real one)
+    yields nothing from its tail -- the issue id is only in the title. My first
+    fixture omitted the field, attribute() returned None, and the reproducer
+    stayed red for a reason that had nothing to do with the defect. An invented
+    fixture tests the invention; this one carries what the producer sends.
+    """
+    return {
+        "number": number, "isDraft": draft, "headRefName": branch,
+        "title": title,
+        "headRefOid": "b61f215a52007610ce66bf39c9b45ce0a837f838",
+        "url": "https://github.com/assafkip/kipi-system/pull/%s" % number,
+        "statusCheckRollup": rollup,
+    }
+
+
+def offered(pr_objs):
+    """candidates() over a fixture list. records_dir is an empty tmpdir, so every
+    read_record returns None -- which is the truth for all four fixtures."""
+    rr.CI.list_prs = lambda repo_dir: pr_objs
+    with tempfile.TemporaryDirectory() as records:
+        return rr.candidates("/nonexistent-repo", Path(records))
+
+
+# =============================================================================
+# 1. THE REPRODUCER: a PR whose reviewer slot was never posted.
+# =============================================================================
+got = offered([pr(121, ABSENT_ROLLUP)])
+check("REPRODUCER: an absent reviewer slot is offered", len(got), 1)
+if got:
+    check("REPRODUCER: and it is offered as re-review, the action dispatch "
+          "actually routes to pr-review-agent", got[0]["action"], "re-review")
+    check("REPRODUCER: the reason names the absence, so it is not confused "
+          "with a phantom review", "never" in got[0]["reason"].lower(), True)
+
+# =============================================================================
+# 2. CONTROL, MUST SURVIVE: a posted, passing slot is still left alone.
+# =============================================================================
+# This is the assertion the fix could most easily break: if "not failing" became
+# "offer it", every green PR in the fleet would be re-reviewed forever.
+check("CONTROL: a passing reviewer slot is not offered",
+      offered([pr(51, PASSING_ROLLUP)]), [])
+
+# =============================================================================
+# 3. CONTROL, MUST SURVIVE: the ASK-318 refusal is untouched.
+# =============================================================================
+# A FAILING slot with no verdict record is the absent-PRODUCER case and is
+# deliberately left alone. The fix must not swallow it into the absent path.
+check("CONTROL: failing slot with no verdict record is still refused (ASK-318)",
+      offered([pr(80, FAILING_ROLLUP)]), [])
+
+# =============================================================================
+# 4. CONTROL, MUST SURVIVE: a draft is still the author saying not yet.
+# =============================================================================
+check("CONTROL: a draft with no reviewer slot is not offered",
+      offered([pr(122, ABSENT_ROLLUP, draft=True)]), [])
+
+# =============================================================================
+# 5. An unattributable branch is a human's branch, absent slot or not.
+# =============================================================================
+check("CONTROL: an unattributable branch is left alone",
+      offered([pr(999, ABSENT_ROLLUP, branch="dependabot/npm/lodash-4.17.21", title="Bump lodash from 4.17.20 to 4.17.21")]), [])
+
+# =============================================================================
+# 6. NEGATIVE SELF-TEST: test 1's assertion must be able to fail.
+# =============================================================================
+# A green test 1 could mean "the absent slot is now seen" or "offered() returns
+# something for anything I hand it". Feed it a shape that must NOT be offered
+# and prove the same assertion goes the other way. Without this, test 1 is a
+# filter with an opinion rather than a filter with a rule.
+neg = offered([pr(51, PASSING_ROLLUP)])
+if len(neg) != 0:
+    failures.append("NEGATIVE SELF-TEST: offered() returned %d for a passing "
+                    "slot, so test 1's non-empty result proves nothing" % len(neg))
+else:
+    print("ok   negative self-test: the same call returns [] for a passing slot")
+
+if failures:
+    print("FAIL")
+    for f in failures:
+        print("  " + f)
+    sys.exit(1)
+print("PASS: review-redrive sees a never-posted reviewer slot")
+sys.exit(0)

--- a/q-system/.q-system/scripts/test/test-review-redrive-absent.py
+++ b/q-system/.q-system/scripts/test/test-review-redrive-absent.py
@@ -78,7 +78,7 @@ PASSING_ROLLUP = [
 ]
 
 
-def pr(number, rollup, branch="sana/ask-447-sweep", draft=False,
+def pr(number, rollup, branch="sana/ask-447-sweep", draft=False, headsha=None,
        title="Verify a launchd job's paused/running state against declared "
              "intent (ASK-447, sp-2c7e5819)"):
     """A PR object shaped like the one gh actually returns.
@@ -93,7 +93,7 @@ def pr(number, rollup, branch="sana/ask-447-sweep", draft=False,
     return {
         "number": number, "isDraft": draft, "headRefName": branch,
         "title": title,
-        "headRefOid": "b61f215a52007610ce66bf39c9b45ce0a837f838",
+        "headRefOid": headsha or "b61f215a52007610ce66bf39c9b45ce0a837f838",
         "url": "https://github.com/assafkip/kipi-system/pull/%s" % number,
         "statusCheckRollup": rollup,
     }
@@ -173,6 +173,59 @@ _got = rr.candidates("/nonexistent-repo", Path(_tmp))
 check("a verdict record with no posted status is rework, not a first review",
       [(c["action"], c["reason"]) for c in _got],
       [("rework", "reviewer said REQUEST CHANGES at the current head")])
+
+
+# =============================================================================
+# 5c. THE WHOLE VERDICT SPACE on the never-posted path, sampled not assumed.
+# =============================================================================
+# Every fixture in 5b used REQUEST CHANGES. The fall-through has two outcomes and
+# only one was asserted, so a review that PASSED but was never posted fell out
+# silently -- classify() returns (None, ...) for a non-refusal and the shared tail
+# does `if action is None: continue`. PR #23 was exactly that: approved,
+# never posted, auto-merge armed, waiting forever on a status nobody sends. The
+# cheapest PR in the queue was the one the selector could not see.
+#
+# The fixture had encoded an assumption about the population instead of sampling
+# it. This table is the sample, counted from ~/.config/kipi/pr-reviews on
+# 2026-08-06 (96 records): APPROVE WITH NITS 54, REQUEST CHANGES 23, APPROVE 17,
+# BLOCK 1, empty 1. The non-refusals are 71 of 96 -- the MAJORITY was the
+# unasserted branch. Re-sample before adding a verdict here.
+VERDICT_SPACE = [
+    # verdict,             observed, expected action, reason fragment
+    ("APPROVE WITH NITS",  54, "re-review", "passed but its status was never posted"),
+    ("REQUEST CHANGES",    23, "rework",    "reviewer said REQUEST CHANGES"),
+    ("APPROVE",            17, "re-review", "passed but its status was never posted"),
+    ("BLOCK",               1, "rework",    "reviewer said BLOCK"),
+    ("",                    1, "re-review", "states no verdict"),
+]
+for _verdict, _n, _want_action, _frag in VERDICT_SPACE:
+    _d = tempfile.mkdtemp()
+    Path(_d, "pr-23.verdict.json").write_text(_json.dumps({
+        "pr": 23, "verdict": _verdict, "stated": _verdict, "usable": True,
+        "round": 1, "review": "", "head_sha": _sha, "ts": "now"}))
+    rr.CI.list_prs = lambda repo_dir: [pr(23, ABSENT_ROLLUP, headsha=_sha)]
+    _out = rr.candidates("/nonexistent-repo", Path(_d))
+    check("no status + verdict %r (%d in the corpus) is offered"
+          % (_verdict, _n), len(_out), 1)
+    if _out:
+        check("no status + verdict %r routes to %s" % (_verdict, _want_action),
+              _out[0]["action"], _want_action)
+        check("no status + verdict %r reason names why" % _verdict,
+              _frag in _out[0]["reason"], True)
+
+
+# =============================================================================
+# 5d. An UNREADABLE record is never described as an absent one.
+# =============================================================================
+# json.JSONDecodeError is a ValueError, so read_record's original
+# `except (OSError, ValueError)` reported a truncated record and a missing one
+# identically -- and the never-posted reason then asserts no verdict exists.
+# Latent, not live: 0 unparseable across the 96 sampled records.
+_d = tempfile.mkdtemp()
+Path(_d, "pr-23.verdict.json").write_text('{"pr": 23, "verdict": "APPR')  # truncated
+rr.CI.list_prs = lambda repo_dir: [pr(23, ABSENT_ROLLUP, headsha=_sha)]
+check("a truncated verdict record is refused, not called absent",
+      rr.candidates("/nonexistent-repo", Path(_d)), [])
 
 
 # =============================================================================


### PR DESCRIPTION
Closes `sp-d87c5416`. The item gating PR #122.

## This is a design-level correction, not three bug fixes

`reviewer_slot_failing()` is **two-valued** — failing / not-failing — over a **three-valued** world: failing, passing, never posted. `candidates()` branched on `if not slots: continue`, so silence was read as health. **18 of 29 open PRs had no reviewer status at all**, making the majority of the backlog invisible to the only mechanism that could move it.

Fixing that exposed the same shape one layer down, and this is the part worth reading:

**`classify()` answers "is this a refusal". On the never-posted path that is simply the wrong question.** It returns `(None, ...)` for any non-refusal, and the caller dropped those silently. Sampled across 96 verdict records:

| verdict | count | |
|---|---|---|
| APPROVE WITH NITS | 54 | was dropped |
| REQUEST CHANGES | 23 | the only class the fixtures used |
| APPROVE | 17 | was dropped |
| BLOCK | 1 | |
| `""` | 1 | |

**71 of 96 (74%) were on the wrong side of that question.** Not an edge case — the majority class, on a keystone that decides which PRs get worked. PR #23 is the concrete cost: approved, status never posted, auto-merge armed, waiting forever on a status nobody sends. The cheapest item in the queue was the one the selector could not see.

The fixtures caused it: every one used `REQUEST CHANGES`. The fall-through had two outcomes, one was asserted, production held the other. **The fixture encoded an assumption about the population instead of sampling it.** The table is now sampled, with counts and date, and a note to re-sample before adding a verdict.

## What it does not change

The ASK-318 refusal is intact: a **failing** slot with no verdict record means the producer ran and recorded nothing, and re-reviewing papers over a broken producer. An **absent** slot has no verdict to be missing.

Emits the existing `re-review` action deliberately — `kipi-dispatch.sh:1000` matches that exact string; any other value falls through to `./kipi converge`, buying a rework round against a review that does not exist.

## Also fixed

`json.JSONDecodeError` **is** a `ValueError`, so `read_record` reported a truncated record and a missing one identically, and the reason then asserts no verdict exists. Now returns a third answer, `CORRUPT_RECORD`; both call sites refuse rather than claim absence. Latent, not live: 0 unparseable across 96 records. (`sp-3e57348e`)

Reproduced and **not** fixed: `reviewer_slot_posted` lets a green advisory slot answer for the gating one. Narrowing it flips an existing deliberate assertion (`test-review-redrive.sh:157`), so it is `sp-833a2b76` rather than a side effect here.

## Verification (local only — no CI result claimed)

- `test-review-redrive-absent.py` PASS · `test-review-redrive.sh` 30 passed · `test-ci-redrive.sh` 65 passed
- Every new assertion proven red against a reverting mutant first.

### Mutation, harness re-pointed at this head

| | verdict | killed by |
|---|---|---|
| MB — drop non-refusals again | KILLED | the `APPROVE WITH NITS` + `APPROVE` assertions |
| MA — collapse `CORRUPT_RECORD` to `None` | KILLED | the truncated-record assertion |
| M_ALL — offer everything | KILLED | "a passing reviewer slot is not offered" |
| M_NONE — offer nothing | KILLED | the reproducer |
| C_SURVIVE | SURVIVED | — |
| C_INERT | NOT-A-MUTANT | — |
| C_NOAPPLY | ERROR | anchor absent, reported not scored |

**M_ALL and M_NONE have disjoint killer sets**, so both directions of the new selection earn their keep rather than one assertion covering for both.

Anchors are asserted unique before any mutant runs — the previous harness was stale and had already landed a mutant in the wrong block. My first two attempts at `C_INERT` were themselves wrong (one deleted a word, one produced `never pposted`); the harness caught both.

## Measured, not derived

```
select --all: 21 candidates (13 re-review, 8 rework)
```

Counted from the command. The earlier "8 → 21" headline was arithmetic — `8 + count(never_posted)` — and it landed on the right number for the world *after* this fix while being computed in the world before it, where the true count was 20. A derived number that happens to be correct is worse than one visibly off, because nothing prompts the check. The missing one was PR #23.

## Remaining gap, not this PR

8 of 30 open PRs carry no issue id in branch tail or title (`sana/sp-*`, `docs/*`), so `CI.attribute` returns None and both selectors skip them under the deliberate rule that an unrecognised branch is a human's. `sp-d86bdc41`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01WZeGrz117RS1ZxNmGpQk4W