### PR TITLE
Guards + voicekit onto main: ASK-471 / ASK-426 / ASK-503 / ASK-504 / ASK-505 / ASK-507

### DIFF
--- a/.claude/rules/no-orphan-findings.md
+++ b/.claude/rules/no-orphan-findings.md
@@ -31,8 +31,8 @@ There is no third way. You cannot hand-clear the gate.
 
 ## Deterministic backstops
 
-- A `deferred` triage disposition AUTO-creates an open spillover item
-  (findings_writer). Deferring is not a terminal state.
+- A `deferred` disposition AUTO-creates an open spillover item in BOTH findings
+  systems (findings_writer + issue_findings, sp-5bcfbfe8). Never terminal.
 - The fable-discipline lint blocks deferral language written into CODE without a
   capture (`# spillover-skip` acks an already-captured line).
 - `gates run` fails while any item is open (the enforcement of last resort).

--- a/plugins/kipi-core/.claude-plugin/plugin.json
+++ b/plugins/kipi-core/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "kipi-core",
-  "version": "1.5.15",
+  "version": "1.5.16",
   "description": "Core founder OS \u2014 voice, research, AUDHD, LinkedIn/brand, RCA skills + kipi-mcp server",
   "author": {
     "name": "Assaf Kipnis",

--- a/plugins/kipi-core/.claude-plugin/plugin.json
+++ b/plugins/kipi-core/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "kipi-core",
-  "version": "1.5.17",
+  "version": "1.5.18",
   "description": "Core founder OS — voice, research, AUDHD, LinkedIn/brand, RCA skills + kipi-mcp server",
   "author": {
     "name": "Assaf Kipnis",

--- a/plugins/kipi-core/.claude-plugin/plugin.json
+++ b/plugins/kipi-core/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "kipi-core",
-  "version": "1.5.19",
+  "version": "1.5.20",
   "description": "Core founder OS — voice, research, AUDHD, LinkedIn/brand, RCA skills + kipi-mcp server",
   "author": {
     "name": "Assaf Kipnis",

--- a/plugins/kipi-core/.claude-plugin/plugin.json
+++ b/plugins/kipi-core/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "kipi-core",
-  "version": "1.5.18",
+  "version": "1.5.19",
   "description": "Core founder OS — voice, research, AUDHD, LinkedIn/brand, RCA skills + kipi-mcp server",
   "author": {
     "name": "Assaf Kipnis",

--- a/plugins/kipi-core/.claude-plugin/plugin.json
+++ b/plugins/kipi-core/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "kipi-core",
-  "version": "1.5.16",
-  "description": "Core founder OS \u2014 voice, research, AUDHD, LinkedIn/brand, RCA skills + kipi-mcp server",
+  "version": "1.5.17",
+  "description": "Core founder OS — voice, research, AUDHD, LinkedIn/brand, RCA skills + kipi-mcp server",
   "author": {
     "name": "Assaf Kipnis",
     "email": "[REDACTED]"

--- a/plugins/kipi-core/kipi-mcp/src/kipi_mcp/linter.py
+++ b/plugins/kipi-core/kipi-mcp/src/kipi_mcp/linter.py
@@ -487,7 +487,11 @@ class Linter:
 
         question_count = body.count("?")
         if question_count > 1:
-            warnings.append(f"body has {question_count} question marks — consider a single CTA")
+            # NOT "consider a single CTA" (2026-08-06). The founder does not end on a CTA,
+            # and `ending_gate` in the content engine BLOCKS one. A linter nudging the writer
+            # toward the thing another gate rejects costs a slot every time it is obeyed.
+            warnings.append(f"body has {question_count} question marks — pick the one that "
+                            f"lands and cut the rest; never replace them with an ask")
 
         return {
             "pass": len(errors) == 0,

--- a/plugins/kipi-core/skills/founder-voice/SKILL.md
+++ b/plugins/kipi-core/skills/founder-voice/SKILL.md
@@ -44,8 +44,16 @@ If these files are empty/template, the voice skill cannot run. Ask the founder t
 - Questions should make the reader uncomfortable, not curious
 
 ### 7. Ending Pattern
-- Social posts: end with a direct question or sharp statement. Never "Thoughts?" or "Agree?"
-- Articles: end with a reflective question that reframes the whole piece
+- Social posts (LinkedIn, X, Substack): end on a VERDICT. NEVER a question.
+  Founder-directed 2026-08-06: "essentially on any social posts I don't finish with
+  a question." Measured on his corpus that day: 1 of 27 writing samples ends on a
+  question, and that one is a quoted line inside a piece, not a closer. The 4 seed
+  drafts that do are all March 2026 engagement-shaped LinkedIn posts. This REVERSES
+  the old line "end with a direct question or a sharp statement", which was an
+  assertion the corpus contradicted. Enforced by `ending_gate._closing_question_signals`
+  in the content engine, not by this bullet.
+- Long-form articles (Medium) may still end reflectively, but not on a question that
+  asks the reader about their own business.
 - Emails/DMs: end with one clear ask or one specific question
 
 ## Pre-Publish Check (BLOCKING)

--- a/plugins/kipi-core/skills/linkedin-brand/references/summary-frameworks.md
+++ b/plugins/kipi-core/skills/linkedin-brand/references/summary-frameworks.md
@@ -13,7 +13,10 @@ The About section is what ChatGPT, Claude, Gemini, and Perplexity pull when some
 - First word is "I."
 - Keyword-rich but natural. LLMs pull phrases, not just keywords.
 - Zero em-dashes. Zero rule-of-three lists. Zero AI filler.
-- One clear CTA at the end. Not three.
+- NO CTA at the end. Founder-directed 2026-08-06: "most critically - I dont want to
+  end with a CTA." Per the operator-vs-marketer rule the `ending_gate` enforces, an
+  operator ends "in nothing, or ONE SPECIFIC THING". A marketer "ends in a CTA to a
+  course/call". One specific thing is allowed. An ask is not.
 - Scar-anchored. Lead with a real moment, not a title.
 - Anti-misclassification line near the end (tells LLMs what you're NOT).
 
@@ -37,8 +40,9 @@ Concrete, not "disrupting" or "reinventing."
 [ANTI-MISCLASSIFICATION — 1 line]
 What you are NOT. Stops LLMs from slotting you into the wrong category.
 
-[CTA — 1 line]
-One specific ask. DM about X, book a call if Y, subscribe for Z.
+[CLOSE — 1 line]
+End on nothing, or on ONE SPECIFIC THING. Never an ask. No "DM me", no "book a
+call", no "subscribe".
 ```
 
 ## Framework 2: Passion / Execution
@@ -59,7 +63,7 @@ Who this brand is for. Helps humans and AI classify you correctly.
 
 [ANTI-MISCLASSIFICATION — 1 line]
 
-[CTA — 1 line]
+[CLOSE — 1 line]  (one specific thing, or nothing. Never an ask.)
 ```
 
 ## Framework 3: One-line hammer (for X/Twitter bio + GitHub)
@@ -103,7 +107,7 @@ Sub-patterns that work:
 3. At least one specific scar with company + what broke?
 4. Zero em-dashes, zero rule-of-three lists?
 5. Zero AI filler phrases?
-6. One CTA, not three?
+6. Zero CTAs? (ends on nothing, or one specific thing, never an ask)
 7. Anti-misclassification line present?
 8. 3+ keyword targets worked in naturally?
 9. Readable aloud without sounding like a press release?

--- a/plugins/kipi-core/voicekit/__init__.py
+++ b/plugins/kipi-core/voicekit/__init__.py
@@ -1,0 +1,13 @@
+"""voicekit: the METHOD half of the voice architecture. Fleet code, founder-agnostic.
+
+The split is deliberate and a test holds it (2026-08-06, voice-architecture PRD):
+
+- This package is MACHINERY: fingerprint math, corpus loading, deterministic exemplar
+  selection, prompt assembly, validators. It ships fleet-wide with kipi-core.
+- A founder's DATA -- exemplars, lexicon values, computed bands, corrections -- lives in
+  that founder's own instance repo (its `voice/` dir) and must never appear in this tree.
+  `tests/test_no_founder_data.py` fails this package if it ever quotes a corpus.
+
+Nothing here reads a network, calls a model, or knows a path outside the `voice_dir` it
+is handed. Pure functions of (files, counters), so every consumer can test offline.
+"""

--- a/plugins/kipi-core/voicekit/assemble.py
+++ b/plugins/kipi-core/voicekit/assemble.py
@@ -1,0 +1,80 @@
+#!/usr/bin/env python3
+"""Assemble the voice section of a generation prompt from a loaded Voice.
+
+Order is the design (voice-architecture PRD, 2026-08-06), and each position is a
+decision:
+
+    identity -> pov -> lexicon positives -> EXEMPLARS -> active corrections
+
+- Exemplars sit LAST-but-one, adjacent to the source material the caller appends:
+  the strong context position ("lost in the middle" is why 19k of samples inside a
+  57k prompt taught nothing).
+- Corrections load LAST: recency weight, the coded replacement for gotchas.md's
+  "loaded last, overrides" convention.
+- The lexicon contributes ONLY its positive slices (prefer/voiceprint_terms). The
+  banned lists live in gate scripts; restating them in the prompt is negative
+  priming, and `test_prompt_gate_coherence` in the consuming repo asserts absence.
+
+Returns (text, provenance). Provenance carries exemplar ids, correction ids, the
+selection reason and the exemplar BODIES -- the bodies feed the echo gate, which
+must compare the final text against exactly what the prompt showed the model.
+"""
+from __future__ import annotations
+
+from . import selector
+
+BUDGET_CHARS = 20000     # asserted by validate.feasible + the consumer's suite,
+                         # NEVER enforced by a runtime raise or slice (ASK-461:
+                         # a cap you cannot see is the same bug; a cap that kills
+                         # the daily job is a worse one).
+
+
+def _lexicon_positive(lexicon):
+    lines = []
+    prefer = lexicon.get("prefer") or []
+    if prefer:
+        pairs = ", ".join(f"{p.get('use')} (not {p.get('not')})"
+                          for p in prefer if p.get("use"))
+        if pairs:
+            lines.append(f"Words he reaches for: {pairs}.")
+    terms = lexicon.get("voiceprint_terms") or []
+    if terms:
+        lines.append("His recurring vocabulary: " + ", ".join(terms) + ".")
+    return "\n".join(lines)
+
+
+def voice_section(voice, channel, counter, slot_index=0, k=selector.DEFAULT_K,
+                  slot_kind="post"):
+    """(text, provenance) for one slot. Pure; empty Voice -> ('', empty provenance)."""
+    picked = selector.select(voice.active_exemplars(), channel, counter,
+                             slot_index=slot_index, k=k, slot_kind=slot_kind)
+    corrections = voice.active_corrections()
+
+    parts = []
+    if voice.identity.strip():
+        parts.append("WHO IS WRITING:\n" + voice.identity.strip())
+    if voice.pov.strip():
+        parts.append("WHAT HE WRITES ABOUT AND BELIEVES:\n" + voice.pov.strip())
+    lex = _lexicon_positive(voice.lexicon)
+    if lex:
+        parts.append(lex)
+    if picked:
+        bodies = "\n\n---\n\n".join((r.get("text") or "").strip() for r in picked)
+        parts.append("POSTS HE HAS WRITTEN. Match their rhythm, register and "
+                     "length. Never reuse their sentences or openings:\n\n" + bodies)
+    if corrections:
+        lines = "\n".join(f"- {r['instruction']}" for r in corrections
+                          if not r.get("scope") or channel in r["scope"])
+        if lines:
+            parts.append("STANDING CORRECTIONS (these override everything above):\n"
+                         + lines)
+
+    provenance = {
+        "exemplar_ids": [str(r.get("id")) for r in picked],
+        "exemplar_texts": [(r.get("text") or "") for r in picked],
+        "correction_ids": [str(r.get("id")) for r in corrections],
+        "selection_reason": selector.selection_reason(picked, channel, counter,
+                                                      slot_index),
+        "skipped_rows": voice.skipped_rows,
+    }
+    return "\n\n".join(parts), provenance

--- a/plugins/kipi-core/voicekit/corpus.py
+++ b/plugins/kipi-core/voicekit/corpus.py
@@ -1,0 +1,101 @@
+#!/usr/bin/env python3
+"""Read a founder's voice/ directory. Degrade, never die.
+
+The daily job that consumes this runs unattended in launchd. The contract, paid
+for by ASK-461 and its cousins: a missing file is LESS GUIDANCE, a corrupt JSONL
+row is SKIPPED AND COUNTED, and nothing on this read path raises. The counts ride
+back to the caller so a deadman check can surface decay instead of a crash hiding
+it. Loud failure belongs to the VALIDATOR (validate.py), which runs in a pytest
+suite at edit time, not inside the publishing run.
+"""
+from __future__ import annotations
+
+import json
+import os
+
+EXEMPLARS = "exemplars.jsonl"
+CORRECTIONS = "corrections.jsonl"
+IDENTITY = "identity.md"
+POV = "pov.md"
+LEXICON = "lexicon.json"
+FINGERPRINT = "fingerprint.json"
+
+EXEMPLAR_KINDS = ("post", "article-excerpt", "comment", "dm", "email")
+EXEMPLAR_CHANNELS = ("linkedin", "x", "substack", "medium", "any")
+
+
+def read_jsonl(path):
+    """(rows, skipped_count). Missing file = ([], 0): absence is a fact, not an error."""
+    if not os.path.exists(path):
+        return [], 0
+    rows, skipped = [], 0
+    try:
+        with open(path, encoding="utf-8", errors="replace") as handle:
+            for line in handle:
+                line = line.strip()
+                if not line:
+                    continue
+                try:
+                    row = json.loads(line)
+                except ValueError:
+                    skipped += 1       # a torn row loses ITS row, never the file
+                    continue
+                if isinstance(row, dict):
+                    rows.append(row)
+                else:
+                    skipped += 1
+    except OSError:
+        return [], 0
+    return rows, skipped
+
+
+def read_text(path):
+    """File content, or '' when missing/unreadable. Same errors= as the old loader:
+    a plugin update writing while we read must not kill the run on one bad byte."""
+    try:
+        with open(path, encoding="utf-8", errors="replace") as handle:
+            return handle.read()
+    except OSError:
+        return ""
+
+
+def read_json(path):
+    """Parsed JSON dict, or None. None means the consumer runs without this input."""
+    try:
+        with open(path, encoding="utf-8") as handle:
+            loaded = json.load(handle)
+        return loaded if isinstance(loaded, dict) else None
+    except (OSError, ValueError):
+        return None
+
+
+class Voice:
+    """Everything one voice/ dir holds, read once, with decay counts."""
+
+    def __init__(self, voice_dir):
+        self.voice_dir = voice_dir
+        self.exemplars, ex_skipped = read_jsonl(os.path.join(voice_dir, EXEMPLARS))
+        self.corrections, co_skipped = read_jsonl(os.path.join(voice_dir, CORRECTIONS))
+        self.identity = read_text(os.path.join(voice_dir, IDENTITY))
+        self.pov = read_text(os.path.join(voice_dir, POV))
+        self.lexicon = read_json(os.path.join(voice_dir, LEXICON)) or {}
+        self.fingerprint = read_json(os.path.join(voice_dir, FINGERPRINT))
+        self.skipped_rows = ex_skipped + co_skipped
+
+    def active_exemplars(self):
+        """Usable rows only: active status, non-empty text, weight above zero."""
+        return [r for r in self.exemplars
+                if r.get("status", "active") == "active"
+                and (r.get("text") or "").strip()
+                and float(r.get("weight", 1.0) or 0) > 0]
+
+    def active_corrections(self):
+        """Rows still carried as prose. A `promoted` row's gate carries it instead."""
+        return [r for r in self.corrections
+                if r.get("status") == "active"
+                and (r.get("instruction") or "").strip()]
+
+
+def load(voice_dir):
+    """The one entry point. Never raises on a readable-or-absent tree."""
+    return Voice(voice_dir)

--- a/plugins/kipi-core/voicekit/echo.py
+++ b/plugins/kipi-core/voicekit/echo.py
@@ -1,0 +1,78 @@
+#!/usr/bin/env python3
+"""Echo detection: the candidate must not parrot what its own prompt showed it.
+
+why this exists (2026-08-06, Stage 0 finding 2): 9 of 22 posts published in one day
+contained the literal sentence pair "Nothing was sent. Nothing was lost." -- the
+EXAMPLE ending inside `revise.RULE_GUIDANCE`. The reviser copied its own guidance
+example into published text, and nothing compared output against what the prompt
+carried. Loading exemplars into prompts (the whole voice architecture) makes this
+class WORSE unless it is gated, so the gate ships with the loader.
+
+Two checks, both pure text ops:
+
+- `prompt_echo`: any N-gram (default 8 words) shared between the candidate and any
+  text that rode in its prompt (exemplars, guidance examples). 8 is deliberate: long
+  enough that a shared idiom ("the same thing happened to us") cannot fire, short
+  enough that a lifted sentence cannot hide.
+- `opener_echo`: the candidate's first sentence shape vs recent published openers.
+  First-6-word overlap of 4+ tokens = the same opener. 7/22 posts opening "Three
+  receipts/drafts/duplicate..." is the measured failure.
+"""
+from __future__ import annotations
+
+import re
+
+NGRAM = 8
+OPENER_WORDS = 6
+OPENER_SHARED = 4
+
+_WORD = re.compile(r"[A-Za-z0-9']+")
+
+
+def _words(text):
+    return [w.lower() for w in _WORD.findall(text or "")]
+
+
+def ngrams(text, n=NGRAM):
+    words = _words(text)
+    return {tuple(words[i:i + n]) for i in range(len(words) - n + 1)}
+
+
+def prompt_echo(candidate, prompt_texts, n=NGRAM):
+    """Echoed n-grams between the candidate and the texts its prompt carried.
+
+    Returns a sorted list of the echoed word-tuples joined as strings; [] is a pass.
+    `prompt_texts` is the exemplar/guidance bodies only, never the instruction
+    boilerplate -- instructions repeat by design, and flagging them would make the
+    gate cry wolf until someone switches it off.
+    """
+    got = ngrams(candidate, n)
+    if not got:
+        return []
+    hits = set()
+    for source in prompt_texts or []:
+        hits |= got & ngrams(source, n)
+    return sorted(" ".join(gram) for gram in hits)
+
+
+def opener(text, k=OPENER_WORDS):
+    return _words(text)[:k]
+
+
+def opener_echo(candidate, recent_openers, k=OPENER_WORDS, shared=OPENER_SHARED):
+    """The recent opener this candidate repeats, or None.
+
+    `recent_openers` is a list of the last few published posts' opening words
+    (the caller reads them from the published-body archive). Position-wise
+    comparison: the same 4 of the first 6 words IN ORDER is the same opener shape.
+    """
+    mine = opener(candidate, k)
+    if not mine:
+        return None
+    for prev in recent_openers or []:
+        prev_words = [w.lower() for w in prev][:k] if isinstance(prev, (list, tuple)) \
+            else opener(str(prev), k)
+        same = sum(1 for a, b in zip(mine, prev_words) if a == b)
+        if same >= shared:
+            return " ".join(prev_words)
+    return None

--- a/plugins/kipi-core/voicekit/fingerprint.py
+++ b/plugins/kipi-core/voicekit/fingerprint.py
@@ -202,9 +202,14 @@ def _bounds(band):
     min/max are corpus observations, so every corpus member is inside its own
     bounds, which is exactly the property the control-set test asserts.
     """
-    lo = band["p10"] if band.get("min") is None else min(band["p10"], band["min"])
-    hi = band["p90"] if band.get("max") is None else max(band["p90"], band["max"])
-    return lo, hi
+    # Degrade-not-die on a partial band dict (voice-1 review, minor): a
+    # hand-migrated band can hold min without p10; min(None, x) raises. Every
+    # present bound participates; an absent one simply does not constrain.
+    lows = [v for v in (band.get("p10"), band.get("min")) if v is not None]
+    highs = [v for v in (band.get("p90"), band.get("max")) if v is not None]
+    if not lows or not highs:
+        return None, None
+    return min(lows), max(highs)
 
 
 def score(text, fingerprint):
@@ -222,6 +227,8 @@ def score(text, fingerprint):
         if value is None or band.get("p10") is None:
             continue
         lo, hi = _bounds(band)
+        if lo is None:
+            continue
         out[name] = {"value": value, "band": [band["p10"], band["p90"]],
                      "bounds": [lo, hi], "inside": lo <= value <= hi}
     return out
@@ -232,8 +239,13 @@ def out_of_band(text, fingerprint, tier="blocking"):
 
     Blocking entries carry a direction (above|below|both): a cap only fails
     ABOVE its widened bounds, a floor only BELOW. Legacy plain-string entries
-    mean both. Advisory tier entries are plain metric names (report-only, so
-    direction lives with the reader, not the gate).
+    mean both.
+
+    This function is GATE semantics. The advisory tier is report-only: read it
+    through `score()`, never through here -- passing tier="advisory" would
+    coerce report-only names into both-direction rejections (voice-1 review,
+    minor). The tier parameter exists for a future PROMOTED tier, not for
+    advisory reads.
     """
     got = metrics(text)
     bands = fingerprint.get("metrics") or {}
@@ -246,6 +258,8 @@ def out_of_band(text, fingerprint, tier="blocking"):
         if band is None or value is None or band.get("p10") is None:
             continue
         lo, hi = _bounds(band)
+        if lo is None:
+            continue
         too_high = direction in ("above", "both") and value > hi
         too_low = direction in ("below", "both") and value < lo
         if too_high or too_low:

--- a/plugins/kipi-core/voicekit/fingerprint.py
+++ b/plugins/kipi-core/voicekit/fingerprint.py
@@ -1,0 +1,260 @@
+#!/usr/bin/env python3
+"""Style fingerprint: measurable voice, computed from a corpus, scored on a candidate.
+
+why this exists (2026-08-06): a 55k-char prose style guide shipped in every generation
+prompt and the founder still read the output as "missing my voice as a grumpy engineer".
+Prose describing a distribution is a region; only numbers computed FROM the writing can
+say whether a candidate sits inside it. This module is the instrument: `compute()` builds
+percentile bands from real exemplars, `score()` reports where a candidate falls.
+
+Everything is pure text ops -- no model, no network, no clock. The metric set is the
+deterministic slice of the voice only. Whether a scar is true, whether a coined name is
+good, whether the humor lands: none of that is here, and any claim that a script scores
+"voice authenticity" would be prompt-only enforcement wearing a script's name.
+
+Band semantics: p10/p90 over the corpus, per metric. A candidate outside a band is
+FLAGGED, not judged -- the caller decides which metrics block (tight bands plus a known
+generator failure direction) and which stay advisory (real signal, too noisy to block on).
+That tiering lives in the instance's fingerprint.json, not in code, because the corpus
+owner is the one who can see false positives: a voice gate that rejects the founder's own
+writing gets switched off, which protects nothing.
+"""
+from __future__ import annotations
+
+import hashlib
+import json
+import re
+
+# A sentence boundary for STATISTICS, not for grammar. Naive on purpose: the same
+# splitter runs on corpus and candidate, so a systematic bias cancels in the comparison.
+_SENT_SPLIT = re.compile(r"[.!?]+[\s\"')\]]|[.!?]+$|\n+")
+_WORD = re.compile(r"[A-Za-z0-9']+")
+
+# Contraction FORMS, not an enumerated word list: the rate is the signal.
+_CONTRACTION = re.compile(r"\b\w+'(?:t|s|re|m|ve|ll|d)\b", re.I)
+
+# The formal pairs a model reaches for when it is being careful. Each has a contracted
+# form the founder actually uses; a high count is the "characterless" register in one
+# number. Word-boundary matched so "is not" inside "this nothing" cannot fire.
+_FORMAL_PAIRS = re.compile(
+    r"\b(?:do not|does not|did not|is not|are not|was not|were not|cannot|"
+    r"can not|will not|would not|should not|could not|have not|has not|it is|"
+    r"that is|there is|you are|we are|they are|i am)\b", re.I)
+
+_FIRST_PERSON = re.compile(r"\b(?:I|I'm|I've|I'll|I'd|we|we're|we've|my|our|me)\b")
+
+# Hedges: the softeners that dilute a verdict. Small list, presence-per-post is the
+# metric; an exhaustive list would be a banned-word gate, which is a different tool.
+_HEDGE = re.compile(
+    r"\b(?:probably|perhaps|maybe|might|somewhat|arguably|likely|generally|"
+    r"typically|often|tend to|seems? to|sort of|kind of)\b", re.I)
+
+
+def sentences(text):
+    """Sentence word-counts, in order. Empty segments dropped."""
+    counts = []
+    for seg in _SENT_SPLIT.split(text or ""):
+        if seg is None:
+            continue
+        words = _WORD.findall(seg)
+        if words:
+            counts.append(len(words))
+    return counts
+
+
+def paragraphs(text):
+    """Sentence counts per paragraph (blank-line separated)."""
+    out = []
+    for para in re.split(r"\n\s*\n", (text or "").strip()):
+        if para.strip():
+            out.append(max(1, len(sentences(para))))
+    return out
+
+
+def _word_count(text):
+    return len(_WORD.findall(text or ""))
+
+
+def _monotony_run(counts):
+    """Longest run of consecutive sentences within +-2 words of each other.
+
+    The uniformity tell: a model writes evenly, the founder does not. Measured on his
+    corpus the longest observed run is short; generated posts run long.
+    """
+    best = run = 1
+    for prev, cur in zip(counts, counts[1:]):
+        run = run + 1 if abs(cur - prev) <= 2 else 1
+        best = max(best, run)
+    return best if counts else 0
+
+
+def metrics(text):
+    """Every per-text metric, one dict. Pure; safe on empty input."""
+    text = (text or "").strip()
+    counts = sentences(text)
+    n_sent = len(counts) or 1
+    words = _word_count(text) or 1
+    paras = paragraphs(text)
+    mean = sum(counts) / n_sent
+    var = sum((c - mean) ** 2 for c in counts) / n_sent
+    body_questions = text.count("?")
+    # The FINAL sentence's question mark belongs to ending_gate, not to this metric.
+    if text.rstrip().endswith("?"):
+        body_questions -= 1
+    return {
+        "sentence_mean": round(mean, 2),
+        "sentence_stdev": round(var ** 0.5, 2),
+        "short_share": round(sum(1 for c in counts if c <= 6) / n_sent, 3),
+        "long_share": round(sum(1 for c in counts if c >= 25) / n_sent, 3),
+        "monotony_run": _monotony_run(counts),
+        "para_single_share": round(
+            sum(1 for p in paras if p == 1) / (len(paras) or 1), 3),
+        "para_max_sentences": max(paras) if paras else 0,
+        "contraction_rate": round(len(_CONTRACTION.findall(text)) * 100 / words, 2),
+        "formal_pair_count": len(_FORMAL_PAIRS.findall(text)),
+        "first_person_rate": round(len(_FIRST_PERSON.findall(text)) * 100 / words, 2),
+        "hedge_count": len(_HEDGE.findall(text)),
+        "midpost_questions": max(0, body_questions),
+        "colon_rate": round(text.count(":") * 100 / words, 2),
+    }
+
+
+METRIC_NAMES = sorted(metrics("x."))
+
+
+def _percentile(values, q):
+    """Nearest-rank percentile. No numpy: this runs inside a launchd job."""
+    if not values:
+        return None
+    ordered = sorted(values)
+    idx = min(len(ordered) - 1, max(0, round(q * (len(ordered) - 1))))
+    return ordered[idx]
+
+
+# Version of the METRIC DEFINITIONS, not the file format. Bumped whenever any
+# metric's computation changes (a splitter tweak, a new regex). Review finding-8:
+# bands computed by one instrument and evaluated by another is the _version_key
+# scar again -- silent skew, every check green, verdicts wrong. `version_skew`
+# is the paired check; the consuming staleness test calls it.
+METRICS_VERSION = 2
+
+
+def version_skew(fingerprint_doc):
+    """Truthy when the bands were computed by a different metrics version."""
+    return (fingerprint_doc or {}).get("metrics_version") != METRICS_VERSION
+
+
+def corpus_sha(texts):
+    """Identity of the corpus a fingerprint was computed from. Order-independent."""
+    digest = hashlib.sha256()
+    for t in sorted(" ".join((t or "").split()) for t in texts):
+        digest.update(t.encode("utf-8"))
+        digest.update(b"\x00")
+    return digest.hexdigest()[:32]
+
+
+def compute(texts, generated_at, scope=None, blocking=None, advisory=None):
+    """Percentile bands over a corpus. The ONLY producer of fingerprint.json content.
+
+    `generated_at` is injected, never read from a clock -- same doctrine as the postbook:
+    a writer that cannot invent a timestamp cannot produce a future-dated row.
+    """
+    if not texts:
+        raise ValueError("cannot fingerprint an empty corpus")
+    rows = [metrics(t) for t in texts]
+    bands = {}
+    for name in METRIC_NAMES:
+        values = [r[name] for r in rows]
+        bands[name] = {"p10": _percentile(values, 0.10),
+                       "p50": _percentile(values, 0.50),
+                       "p90": _percentile(values, 0.90),
+                       "min": min(values), "max": max(values)}
+    return {
+        "generated_at": generated_at,
+        "corpus_sha": corpus_sha(texts),
+        "corpus_size": len(texts),
+        "metrics_version": METRICS_VERSION,
+        "scope": scope or {},
+        "metrics": bands,
+        "blocking": [_norm_blocking(b) for b in (blocking or [])],
+        "advisory": list(advisory or []),
+    }
+
+
+def _norm_blocking(entry):
+    """{'metric', 'direction'} from either shape. Strings are legacy 'both'.
+
+    Direction is load-bearing (review finding-2): sentence_mean is a CAP -- the
+    founder's punchiest register sits BELOW the band and must never block.
+    """
+    if isinstance(entry, str):
+        return {"metric": entry, "direction": "both"}
+    return {"metric": entry.get("metric"),
+            "direction": entry.get("direction", "both")}
+
+
+def _bounds(band):
+    """The BLOCKING bounds: p10/p90 widened to the corpus extremes.
+
+    Review finding-1 (blocker): p10/p90 alone reject the corpus's own extreme
+    members on any small corpus -- the control-set requirement ("the gate must
+    never reject the voice it encodes") would be unsatisfiable by construction.
+    min/max are corpus observations, so every corpus member is inside its own
+    bounds, which is exactly the property the control-set test asserts.
+    """
+    lo = band["p10"] if band.get("min") is None else min(band["p10"], band["min"])
+    hi = band["p90"] if band.get("max") is None else max(band["p90"], band["max"])
+    return lo, hi
+
+
+def score(text, fingerprint):
+    """Where one candidate falls against the bands. Report, not verdict.
+
+    Returns {metric: {"value", "band", "inside"}}. `inside` uses the corpus MIN/MAX
+    widened to the band edges: outside [p10, p90] is out-of-band, but a candidate is only
+    flagged in a DIRECTION the corpus itself never reaches -- p10/p90 on n~30 are noisy,
+    and the caller's blocking tier is what turns a flag into a rejection.
+    """
+    got = metrics(text)
+    out = {}
+    for name, band in (fingerprint.get("metrics") or {}).items():
+        value = got.get(name)
+        if value is None or band.get("p10") is None:
+            continue
+        lo, hi = _bounds(band)
+        out[name] = {"value": value, "band": [band["p10"], band["p90"]],
+                     "bounds": [lo, hi], "inside": lo <= value <= hi}
+    return out
+
+
+def out_of_band(text, fingerprint, tier="blocking"):
+    """The named metrics from one tier that the candidate fails. [] is a pass.
+
+    Blocking entries carry a direction (above|below|both): a cap only fails
+    ABOVE its widened bounds, a floor only BELOW. Legacy plain-string entries
+    mean both. Advisory tier entries are plain metric names (report-only, so
+    direction lives with the reader, not the gate).
+    """
+    got = metrics(text)
+    bands = fingerprint.get("metrics") or {}
+    failed = []
+    for entry in fingerprint.get(tier) or []:
+        norm = _norm_blocking(entry)
+        name, direction = norm["metric"], norm["direction"]
+        band = bands.get(name)
+        value = got.get(name)
+        if band is None or value is None or band.get("p10") is None:
+            continue
+        lo, hi = _bounds(band)
+        too_high = direction in ("above", "both") and value > hi
+        too_low = direction in ("below", "both") and value < lo
+        if too_high or too_low:
+            failed.append(name)
+    return sorted(failed)
+
+
+def load(path):
+    """Read a fingerprint.json. Raises on malformed content -- the CALLER decides
+    whether a missing/broken file degrades (daily job: yes) or fails (validator: no)."""
+    with open(path, encoding="utf-8") as handle:
+        return json.load(handle)

--- a/plugins/kipi-core/voicekit/selector.py
+++ b/plugins/kipi-core/voicekit/selector.py
@@ -1,0 +1,79 @@
+#!/usr/bin/env python3
+"""Deterministic exemplar selection: which 3-5 pieces of real writing ride in THIS prompt.
+
+Selection exists because dumping the whole corpus recreates the monolith (Stage 0:
+55k of voice produced posts 21/22 outside the founder's own sentence-length band).
+Three properties, each load-bearing and each tested:
+
+- DETERMINISTIC: same (corpus, counter, slot) -> same selection. A test can assert
+  the exact ids; a provenance row can explain "why these" in one line.
+- ROTATING: keyed to a caller-supplied counter (the postbook's per-channel count),
+  plus the slot index within a multi-slot day. Consecutive posts get different
+  exemplar sets by construction -- the structural defense against the engine's
+  measured uniformity failure (7/22 posts opening "Three ...").
+- FORM-MATCHED: a post slot gets post-shaped exemplars first. Stage 0 measured why:
+  article excerpts teach article rhythm (mixed-corpus bands hid a 21/22 failure
+  that post-only bands exposed).
+"""
+from __future__ import annotations
+
+DEFAULT_K = 4
+
+# Kind eligibility per slot kind, strongest first. A post slot prefers real posts;
+# article excerpts pad only when the post pool is thin. Comments prefer comment/dm
+# rows, then short posts -- a 320-char comment should not be taught by 800-word prose.
+ELIGIBLE_KINDS = {
+    "post": (("post",), ("article-excerpt",)),
+    "comment": (("comment", "dm"), ("post",)),
+}
+
+
+def _channel_ok(row, channel):
+    return row.get("channel", "any") in (channel, "any")
+
+
+def eligible(rows, channel, slot_kind="post"):
+    """(primary, fallback) pools, each sorted by id for stable rotation."""
+    tiers = ELIGIBLE_KINDS.get(slot_kind, ELIGIBLE_KINDS["post"])
+    primary = sorted((r for r in rows if r.get("kind") in tiers[0]
+                      and _channel_ok(r, channel)), key=lambda r: str(r.get("id")))
+    fallback = sorted((r for r in rows if r.get("kind") in tiers[1]
+                       and _channel_ok(r, channel)), key=lambda r: str(r.get("id")))
+    return primary, fallback
+
+
+def select(rows, channel, counter, slot_index=0, k=DEFAULT_K, slot_kind="post"):
+    """The selection. Pure function of its arguments; no clock, no randomness.
+
+    `counter` is how many posts this channel has already published (the postbook is
+    the durable source); it advances the rotation so the next post sees a different
+    window. One `anchor: true` row is always included when any exists ("most Assaf"
+    pieces stay in every prompt), rotated rather than pinned -- a pinned anchor is
+    the same 3-exemplars-forever failure with extra steps.
+    """
+    primary, fallback = eligible(rows, channel, slot_kind)
+    pool = primary + [r for r in fallback if r not in primary]
+    if not pool:
+        return []
+    offset = (int(counter) + int(slot_index)) % len(pool)
+
+    anchors = [r for r in pool if r.get("anchor")]
+    picked = []
+    if anchors:
+        picked.append(anchors[offset % len(anchors)])
+
+    # k consecutive from the rotated pool, skipping what is already in.
+    idx = offset
+    while len(picked) < min(k, len(pool)):
+        row = pool[idx % len(pool)]
+        idx += 1
+        if row not in picked:
+            picked.append(row)
+    return picked
+
+
+def selection_reason(picked, channel, counter, slot_index=0):
+    """One line for the provenance row: why THESE exemplars, answerable from disk."""
+    ids = ",".join(str(r.get("id")) for r in picked)
+    return (f"channel={channel} counter={counter} slot={slot_index} "
+            f"rotation -> [{ids}]")

--- a/plugins/kipi-core/voicekit/tests/test_no_founder_data.py
+++ b/plugins/kipi-core/voicekit/tests/test_no_founder_data.py
@@ -1,0 +1,68 @@
+#!/usr/bin/env python3
+"""The METHOD/DATA boundary, held by a test and not a comment.
+
+Founder-decided split (voice-architecture PRD, 2026-08-06): the plugin ships the
+machinery fleet-wide; Assaf's corpus stays in his instance (`q-consult/voice/`).
+kipi-system is a PUBLIC repo, so a corpus line leaking into this tree is not just
+architecture drift, it is founder data published to the world.
+
+The check greps the voicekit tree for distinctive fingerprints of the private
+corpus: phrases from his real writing, his instance paths, and personal
+identifiers. Distinctive-but-harmless probes, chosen so the test itself does not
+become the leak it polices (the public-skeleton rule: name the data class, never
+quote the data at length).
+"""
+import os
+import sys
+
+sys.path.insert(0, os.path.dirname(os.path.dirname(os.path.dirname(
+    os.path.abspath(__file__)))))
+
+PKG = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
+
+# Fingerprints of the PRIVATE side. Short, distinctive, non-sensitive probes.
+FORBIDDEN = (
+    "q-consult",                 # his instance's content dir
+    "askconsulting",             # his business
+    "pig butchering",            # his corpus subject matter
+    "whac-a-mole",               # his coined metric name
+    "60 muscles",                # his known post
+    "Kipnis",                    # the founder
+)
+
+
+def _tree_files():
+    out = []
+    for root, dirs, files in os.walk(PKG):
+        dirs[:] = [d for d in dirs if d != "__pycache__"]
+        out.extend(os.path.join(root, f) for f in files
+                   if f.endswith((".py", ".json", ".jsonl", ".md")))
+    return out
+
+
+def test_the_tree_has_files_to_check():
+    """Vacuous-pass guard: if the walk breaks, this fails before the grep lies."""
+    assert len(_tree_files()) >= 7
+
+
+def test_no_founder_data_in_the_plugin_tree():
+    here = os.path.abspath(__file__)
+    for path in _tree_files():
+        if os.path.abspath(path) == here:
+            continue                     # the probe list itself lives here
+        with open(path, encoding="utf-8", errors="replace") as handle:
+            content = handle.read().lower()
+        for needle in FORBIDDEN:
+            assert needle.lower() not in content, (
+                f"{os.path.relpath(path, PKG)} contains {needle!r}: founder data "
+                f"or an instance path is inside the fleet plugin. The corpus "
+                f"lives in the instance's voice/ dir, never here.")
+
+
+def test_negative_selftest_the_probe_detects_a_planted_leak(tmp_path):
+    """Prove the predicate catches the thing it exists to catch."""
+    planted = tmp_path / "leak.md"
+    planted.write_text("notes on the pig butchering analysis")
+    with open(planted, encoding="utf-8") as handle:
+        content = handle.read().lower()
+    assert any(n.lower() in content for n in FORBIDDEN)

--- a/plugins/kipi-core/voicekit/tests/test_voicekit.py
+++ b/plugins/kipi-core/voicekit/tests/test_voicekit.py
@@ -347,3 +347,48 @@ class TestBlockingTierContract:
         stale = dict(fp, metrics_version=-1)
         assert fingerprint.version_skew(stale)
         assert not fingerprint.version_skew(fp)
+
+
+# --- voice-1 review round: the four findings, pinned -------------------------------
+
+class TestReviewRoundFixes:
+    def test_metrics_version_skew_is_caught_by_the_freshness_check(self, tmp_path):
+        """Review blocker: version_skew existed, nothing called it. Same corpus_sha,
+        stale metrics_version, and check_all reported healthy."""
+        rows = [{"id": f"r{i}", "kind": "post", "channel": "any", "status": "active",
+                 "anchor": False, "weight": 1.0,
+                 "text": f"Row {i}. It broke. I watched. We fixed it fast."}
+                for i in range(4)]
+        fp = fingerprint.compute([r["text"] for r in rows], generated_at="x")
+        fp["metrics_version"] = fingerprint.METRICS_VERSION - 1   # skew, sha intact
+        d = tmp_path / "voice"
+        d.mkdir()
+        (d / corpus.EXEMPLARS).write_text("\n".join(json.dumps(r) for r in rows))
+        (d / corpus.FINGERPRINT).write_text(json.dumps(fp))
+        v = corpus.load(str(d))
+        assert any("metrics_version" in p for p in validate.check_fingerprint_fresh(v))
+
+    def test_direction_below_actually_blocks_below(self):
+        """Review major: the below path had only a passing case. A floor must fire
+        under the bounds and stay silent above them."""
+        punchy_corpus = ["It broke. I saw. We fixed. Done. Fast.",
+                         "Short lines. Real scars. It failed twice. I was there.",
+                         "One look. One fix. The test went red. Then green."]
+        fp = fingerprint.compute(punchy_corpus, generated_at="x",
+                                 blocking=[{"metric": "short_share",
+                                            "direction": "below"}])
+        smooth = ("Every sentence in this candidate stretches onward comfortably "
+                  "past the six word threshold without a single short burst. "
+                  "Nothing here lands quickly or punches through the paragraph. "
+                  "The rhythm stays long and even throughout the entire text.")
+        assert fingerprint.out_of_band(smooth, fp) == ["short_share"]
+        punchier = "It broke. I saw. Fixed. Done. True. Fast. Real. Short."
+        assert fingerprint.out_of_band(punchier, fp) == [], (
+            "a floor must never fire ABOVE the band")
+
+    def test_partial_band_degrades_instead_of_raising(self):
+        fp = {"metrics": {"sentence_mean": {"p10": None, "p50": None, "p90": None,
+                                            "min": 3.0, "max": 9.0}},
+              "blocking": [{"metric": "sentence_mean", "direction": "above"}]}
+        assert fingerprint.out_of_band("Anything at all here.", fp) == []
+        assert fingerprint.score("Anything at all here.", fp) == {}

--- a/plugins/kipi-core/voicekit/tests/test_voicekit.py
+++ b/plugins/kipi-core/voicekit/tests/test_voicekit.py
@@ -1,0 +1,349 @@
+#!/usr/bin/env python3
+"""voicekit offline suite. No model calls, no network, tmp_path only.
+
+Every module gets a negative self-test: neuter the mechanism (or feed the known-bad
+input) and prove the check fails. A test that cannot fail is not a test.
+"""
+import json
+import os
+import sys
+
+import pytest
+
+sys.path.insert(0, os.path.dirname(os.path.dirname(os.path.dirname(
+    os.path.abspath(__file__)))))
+
+from voicekit import assemble, corpus, echo, fingerprint, selector, validate  # noqa: E402
+
+PUNCHY = ("I watched it break. Twice. The fix shipped in a day.\n\n"
+          "Nobody asked why. That was the tell. We built the check instead.")
+SMOOTH = ("In today's rapidly evolving landscape, organizations are increasingly "
+          "discovering that comprehensive solutions require careful consideration "
+          "of multiple interrelated factors. It is important to recognize that "
+          "sustainable outcomes depend on thoughtful analysis of the underlying "
+          "dynamics. Furthermore, teams that do not invest in robust processes "
+          "will not achieve the results that they are hoping to accomplish.")
+
+
+def _rows(n=6, kind="post", channel="any", anchor_every=None):
+    rows = []
+    for i in range(n):
+        rows.append({"id": f"ex-{i:02d}", "kind": kind, "channel": channel,
+                     "status": "active", "weight": 1.0,
+                     "anchor": bool(anchor_every and i % anchor_every == 0),
+                     "text": f"Body {i}. Short lines. It broke and I saw it break. "
+                             f"Number {i} of {n} systems failed."})
+    return rows
+
+
+def _voice_dir(tmp_path, rows=None, corrections=None, identity="The practitioner.",
+               pov="Learning disappears.", lexicon=None, fp=None):
+    d = tmp_path / "voice"
+    d.mkdir(exist_ok=True)
+    (d / corpus.EXEMPLARS).write_text(
+        "\n".join(json.dumps(r) for r in (rows if rows is not None else _rows())))
+    if corrections is not None:
+        (d / corpus.CORRECTIONS).write_text(
+            "\n".join(json.dumps(r) for r in corrections))
+    (d / corpus.IDENTITY).write_text(identity)
+    (d / corpus.POV).write_text(pov)
+    (d / corpus.LEXICON).write_text(json.dumps(lexicon or {
+        "prefer": [{"use": "use", "not": "leverage"}],
+        "voiceprint_terms": ["shelfware", "compound"]}))
+    if fp is not None:
+        (d / corpus.FINGERPRINT).write_text(json.dumps(fp))
+    return str(d)
+
+
+# --- fingerprint ------------------------------------------------------------------
+
+class TestFingerprint:
+    def test_metrics_are_pure_and_complete(self):
+        m = fingerprint.metrics(PUNCHY)
+        assert set(m) == set(fingerprint.METRIC_NAMES)
+        assert m == fingerprint.metrics(PUNCHY)
+
+    def test_punchy_and_smooth_separate_on_the_measured_axes(self):
+        """The Stage 0 result in miniature: the blocking metrics must point the
+        measured direction, or the gate built on them is theater."""
+        p, s = fingerprint.metrics(PUNCHY), fingerprint.metrics(SMOOTH)
+        assert p["sentence_mean"] < s["sentence_mean"]
+        assert p["short_share"] > s["short_share"]
+        assert p["first_person_rate"] > s["first_person_rate"]
+
+    def test_compute_then_score_roundtrip(self):
+        texts = [PUNCHY, PUNCHY + " More of it.", "Short. Very. It broke. I saw."]
+        fp = fingerprint.compute(texts, generated_at="2026-08-06",
+                                 blocking=["sentence_mean"])
+        verdict = fingerprint.score(texts[0], fp)
+        assert verdict["sentence_mean"]["inside"]
+
+    def test_out_of_band_names_the_failing_metric(self):
+        fp = fingerprint.compute([PUNCHY, "It broke. I watched. We fixed it fast."],
+                                 generated_at="2026-08-06",
+                                 blocking=["sentence_mean", "short_share"])
+        assert "sentence_mean" in fingerprint.out_of_band(SMOOTH, fp)
+
+    def test_negative_selftest_neutered_bands_pass_everything(self):
+        """Neuter the mechanism: with the blocking list emptied, even SMOOTH passes.
+        Proves the tier list is what rejects, not an accident elsewhere."""
+        fp = fingerprint.compute([PUNCHY], generated_at="2026-08-06", blocking=[])
+        assert fingerprint.out_of_band(SMOOTH, fp) == []
+
+    def test_empty_corpus_raises_loudly(self):
+        with pytest.raises(ValueError):
+            fingerprint.compute([], generated_at="2026-08-06")
+
+    def test_corpus_sha_is_order_independent(self):
+        assert fingerprint.corpus_sha(["a", "b"]) == fingerprint.corpus_sha(["b", "a"])
+
+
+# --- corpus (degrade, never die) --------------------------------------------------
+
+class TestCorpus:
+    def test_missing_dir_loads_empty_not_raising(self, tmp_path):
+        v = corpus.load(str(tmp_path / "nowhere"))
+        assert v.exemplars == [] and v.identity == "" and v.fingerprint is None
+
+    def test_corrupt_row_is_skipped_and_counted(self, tmp_path):
+        d = tmp_path / "voice"
+        d.mkdir()
+        good = json.dumps(_rows(1)[0])
+        (d / corpus.EXEMPLARS).write_text(good + "\n{torn json\n")
+        v = corpus.load(str(d))
+        assert len(v.exemplars) == 1
+        assert v.skipped_rows == 1, "the decay count is the deadman signal"
+
+    def test_negative_selftest_the_count_sees_a_real_tear(self, tmp_path):
+        """Prove the counter is wired to the parse, not a constant zero."""
+        d = tmp_path / "voice"
+        d.mkdir()
+        (d / corpus.EXEMPLARS).write_text("{a\n{b\n{c\n")
+        assert corpus.load(str(d)).skipped_rows == 3
+
+    def test_retired_and_zero_weight_rows_are_excluded(self, tmp_path):
+        rows = _rows(3)
+        rows[0]["status"] = "retired"
+        rows[1]["weight"] = 0
+        v = corpus.load(_voice_dir(tmp_path, rows=rows))
+        assert [r["id"] for r in v.active_exemplars()] == ["ex-02"]
+
+
+# --- selector ---------------------------------------------------------------------
+
+class TestSelector:
+    def test_deterministic(self):
+        rows = _rows(8, anchor_every=4)
+        a = selector.select(rows, "linkedin", counter=5)
+        b = selector.select(rows, "linkedin", counter=5)
+        assert [r["id"] for r in a] == [r["id"] for r in b]
+
+    def test_rotation_no_repeated_set_across_consecutive_states(self):
+        """The design's uniformity kill: 10 consecutive postbook states, no
+        identical selection twice in a row."""
+        rows = _rows(8)
+        prev = None
+        for counter in range(10):
+            ids = [r["id"] for r in selector.select(rows, "linkedin", counter)]
+            assert ids != prev, f"counter {counter} repeated {ids}"
+            prev = ids
+
+    def test_negative_selftest_without_the_counter_it_would_repeat(self):
+        """Neuter rotation (fixed counter): the selection IS identical, proving the
+        rotation test above is measuring the counter and nothing else."""
+        rows = _rows(8)
+        a = [r["id"] for r in selector.select(rows, "linkedin", 3)]
+        b = [r["id"] for r in selector.select(rows, "linkedin", 3)]
+        assert a == b
+
+    def test_anchor_always_present_and_rotating(self):
+        rows = _rows(9, anchor_every=3)          # anchors: ex-00, ex-03, ex-06
+        seen = set()
+        for counter in range(6):
+            picked = selector.select(rows, "linkedin", counter)
+            anchors = [r["id"] for r in picked if r["anchor"]]
+            assert anchors, "an anchor must ride in every selection"
+            seen.update(anchors)
+        assert len(seen) > 1, "the anchor must rotate, not pin"
+
+    def test_form_matching_prefers_post_rows_for_post_slots(self):
+        rows = _rows(3, kind="article-excerpt") + _rows(3)[0:3]
+        # ids collide across the two _rows calls; rebuild with distinct ids
+        rows = ([{**r, "id": f"art-{i}"} for i, r in enumerate(_rows(3, kind="article-excerpt"))]
+                + [{**r, "id": f"post-{i}"} for i, r in enumerate(_rows(3))])
+        picked = selector.select(rows, "linkedin", counter=0, k=3)
+        assert all(r["kind"] == "post" for r in picked), (
+            "with enough post rows, article excerpts must not pad a post slot")
+
+    def test_empty_pool_returns_empty(self):
+        assert selector.select([], "linkedin", 0) == []
+
+
+# --- echo -------------------------------------------------------------------------
+
+class TestEcho:
+    GUIDANCE = "Good shapes: Nothing was sent. Nothing was lost. The damage was trust."
+
+    def test_the_shipped_defect_is_caught(self):
+        """The Stage 0 live defect, verbatim: output carrying the guidance example."""
+        candidate = ("Our queue died quietly. Nothing was sent. Nothing was lost. "
+                     "The damage was trust. We rebuilt the receipts.")
+        assert echo.prompt_echo(candidate, [self.GUIDANCE])
+
+    def test_negative_selftest_clean_text_passes(self):
+        assert echo.prompt_echo(PUNCHY, [self.GUIDANCE]) == []
+
+    def test_short_shared_idiom_does_not_fire(self):
+        assert echo.prompt_echo("The same thing happened to us last week in prod.",
+                                ["the same thing happened to us"]) == []
+
+    def test_opener_echo_catches_the_three_receipts_shape(self):
+        recent = [["three", "receipts", "written", "out", "of", "five"]]
+        assert echo.opener_echo("Three receipts written out of order today.", recent)
+
+    def test_opener_echo_passes_a_fresh_opener(self):
+        recent = [["three", "receipts", "written", "out", "of", "five"]]
+        assert echo.opener_echo("I watched a deploy eat its own logs.", recent) is None
+
+
+# --- assemble ---------------------------------------------------------------------
+
+class TestAssemble:
+    def test_order_identity_pov_lexicon_exemplars_corrections(self, tmp_path):
+        cor = [{"id": "c1", "status": "active", "instruction": "Never open with a number."}]
+        v = corpus.load(_voice_dir(tmp_path, corrections=cor))
+        text, prov = assemble.voice_section(v, "linkedin", counter=0)
+        order = [text.find("WHO IS WRITING"), text.find("WHAT HE WRITES"),
+                 text.find("reaches for"), text.find("POSTS HE HAS WRITTEN"),
+                 text.find("STANDING CORRECTIONS")]
+        assert -1 not in order and order == sorted(order)
+        assert prov["exemplar_ids"] and prov["correction_ids"] == ["c1"]
+
+    def test_scoped_correction_excluded_off_channel(self, tmp_path):
+        cor = [{"id": "c1", "status": "active", "scope": ["x"],
+                "instruction": "X only rule."}]
+        v = corpus.load(_voice_dir(tmp_path, corrections=cor))
+        text, _ = assemble.voice_section(v, "linkedin", counter=0)
+        assert "X only rule" not in text
+
+    def test_promoted_correction_stops_loading(self, tmp_path):
+        cor = [{"id": "c1", "status": "promoted", "instruction": "Old rule."}]
+        v = corpus.load(_voice_dir(tmp_path, corrections=cor))
+        text, prov = assemble.voice_section(v, "linkedin", counter=0)
+        assert "Old rule" not in text and prov["correction_ids"] == []
+
+    def test_empty_voice_dir_yields_empty_section_not_a_raise(self, tmp_path):
+        v = corpus.load(str(tmp_path / "nowhere"))
+        text, prov = assemble.voice_section(v, "linkedin", counter=0)
+        assert text == "" and prov["exemplar_ids"] == []
+
+    def test_provenance_texts_match_prompt_exemplars(self, tmp_path):
+        """The echo gate compares output to prov['exemplar_texts']; they must be
+        the exact bodies the prompt carried."""
+        v = corpus.load(_voice_dir(tmp_path))
+        text, prov = assemble.voice_section(v, "linkedin", counter=2)
+        for body in prov["exemplar_texts"]:
+            assert body.strip() in text
+
+
+# --- validate ---------------------------------------------------------------------
+
+class TestValidate:
+    def _fresh_fp(self, rows):
+        texts = [r["text"] for r in rows if r["kind"] == "post"]
+        return fingerprint.compute(texts, generated_at="2026-08-06")
+
+    def test_healthy_corpus_passes(self, tmp_path):
+        rows = _rows(6)
+        d = _voice_dir(tmp_path, rows=rows, fp=self._fresh_fp(rows))
+        assert validate.check_all(d) == []
+
+    def test_negative_selftest_each_check_fires(self, tmp_path):
+        rows = _rows(6)
+        rows[1]["id"] = rows[0]["id"]                       # duplicate id
+        rows[2]["text"] = "an emdash — right here"          # banned char
+        d = _voice_dir(tmp_path, rows=rows, fp=self._fresh_fp(rows))
+        problems = "\n".join(validate.check_all(d))
+        assert "duplicate id" in problems and "emdash" in problems
+
+    def test_stale_fingerprint_is_red(self, tmp_path):
+        rows = _rows(6)
+        stale = self._fresh_fp(_rows(3))
+        d = _voice_dir(tmp_path, rows=rows, fp=stale)
+        assert any("stale" in p for p in validate.check_all(d))
+
+    def test_starved_pool_is_red(self, tmp_path):
+        rows = _rows(2)
+        d = _voice_dir(tmp_path, rows=rows, fp=self._fresh_fp(rows))
+        assert any("floor" in p for p in validate.check_all(d))
+
+    def test_budget_overflow_is_red(self, tmp_path):
+        rows = _rows(6)
+        for r in rows:
+            r["text"] = "Long. " * 2000
+        d = _voice_dir(tmp_path, rows=rows, fp=self._fresh_fp(rows))
+        assert any("budget" in p for p in validate.check_all(d))
+
+
+# --- voice-1-instrument: review findings 1, 2, 8 ----------------------------------
+
+class TestBlockingTierContract:
+    CORPUS = ["I saw it break. Twice. We fixed it.",
+              "Long sentences flow onward without any pause or breath at all in "
+              "this one here, and then some.",
+              "Short. It broke. I watched it happen live.",
+              "Mid length lines carry the middle of the band here.",
+              "Another corpus row with its own rhythm and length in it."]
+
+    def test_every_corpus_member_passes_its_own_blocking_tier(self):
+        """Review finding-1 (blocker). On a small corpus the p10/p90 extremes are
+        corpus members; blocking membership must widen to corpus min/max or the
+        control-set requirement is unsatisfiable by construction."""
+        fp = fingerprint.compute(self.CORPUS, generated_at="x",
+                                 blocking=[{"metric": "sentence_mean",
+                                            "direction": "above"},
+                                           {"metric": "short_share",
+                                            "direction": "below"}])
+        for text in self.CORPUS:
+            assert fingerprint.out_of_band(text, fp) == [], text
+
+    def test_direction_above_only_blocks_above(self):
+        """Review finding-2. sentence_mean is a CAP: below the band is the founder's
+        punchiest register and must never block."""
+        fp = fingerprint.compute(self.CORPUS, generated_at="x",
+                                 blocking=[{"metric": "sentence_mean",
+                                            "direction": "above"}])
+        punchier = "It broke. I saw. We fixed. Done. Fast. True."
+        assert fingerprint.out_of_band(punchier, fp) == []
+        rambler = ("This sentence keeps going far beyond anything the corpus ever "
+                   "did because it never stops to breathe or land a point at all "
+                   "and simply continues onward accumulating clauses forever more "
+                   "without any period in sight for dozens of words.")
+        assert fingerprint.out_of_band(rambler, fp) == ["sentence_mean"]
+
+    def test_negative_selftest_direction_both_still_blocks_below(self):
+        """Prove direction is the discriminator: the same punchy text DOES block
+        when the tier says both. Otherwise the above-only test passes vacuously."""
+        fp = fingerprint.compute(
+            ["Twelve words in every single sentence of this corpus row exactly here now.",
+             "Another twelve word sentence fills this corpus row from end to end today.",
+             "Yet more twelve word sentences occupy the entire corpus row right here."],
+            generated_at="x",
+            blocking=[{"metric": "sentence_mean", "direction": "both"}])
+        assert fingerprint.out_of_band("Short. Very. Tiny. Words. Only. Here.",
+                                       fp) == ["sentence_mean"]
+
+    def test_legacy_string_blocking_entries_still_work(self):
+        """A bands file written before direction support must not crash the gate."""
+        fp = fingerprint.compute(self.CORPUS, generated_at="x",
+                                 blocking=["sentence_mean"])
+        assert fingerprint.out_of_band(self.CORPUS[0], fp) == []
+
+    def test_metrics_version_recorded_and_checked(self):
+        """Review finding-8. Bands computed by one instrument version must not be
+        silently evaluated by another."""
+        fp = fingerprint.compute(self.CORPUS, generated_at="x")
+        assert fp["metrics_version"] == fingerprint.METRICS_VERSION
+        stale = dict(fp, metrics_version=-1)
+        assert fingerprint.version_skew(stale)
+        assert not fingerprint.version_skew(fp)

--- a/plugins/kipi-core/voicekit/tests/test_voicekit.py
+++ b/plugins/kipi-core/voicekit/tests/test_voicekit.py
@@ -441,3 +441,32 @@ class TestVoice2ReviewChecks:
             {"id": "c1", "instruction": "Do the thing.", "class": "deterministic",
              "status": "promoted", "scope": ["dm"]}))
         assert validate.check_corrections(str(d / corpus.CORRECTIONS)) == []
+
+
+class TestLoaderAdversarialScars:
+    """voice-3 review: two scars from the retired glob-loader suite were claimed
+    re-homed and were not. Pinned here against the corpus loader."""
+
+    def test_permission_denied_file_degrades_to_empty(self, tmp_path):
+        import os as _os
+        p = tmp_path / "identity.md"
+        p.write_text("secret")
+        _os.chmod(p, 0o000)
+        try:
+            assert corpus.read_text(str(p)) == ""
+            rows, skipped = corpus.read_jsonl(str(p))
+            assert rows == [] and skipped == 0
+        finally:
+            _os.chmod(p, 0o644)
+
+    def test_undecodable_byte_is_replaced_not_fatal(self, tmp_path):
+        """The ASK-461-era scar: a plugin update writing a file mid-read produced a
+        lone undecodable byte and UnicodeDecodeError killed the daily job."""
+        p = tmp_path / "pov.md"
+        p.write_bytes(b"good text \xff\xfe more text")
+        out = corpus.read_text(str(p))
+        assert "good text" in out and "more text" in out
+        j = tmp_path / "rows.jsonl"
+        j.write_bytes(b'{"id": "a", "text": "ok"}\n\xff{torn\n')
+        rows, skipped = corpus.read_jsonl(str(j))
+        assert [r["id"] for r in rows] == ["a"] and skipped == 1

--- a/plugins/kipi-core/voicekit/tests/test_voicekit.py
+++ b/plugins/kipi-core/voicekit/tests/test_voicekit.py
@@ -392,3 +392,52 @@ class TestReviewRoundFixes:
               "blocking": [{"metric": "sentence_mean", "direction": "above"}]}
         assert fingerprint.out_of_band("Anything at all here.", fp) == []
         assert fingerprint.score("Anything at all here.", fp) == {}
+
+
+class TestVoice2ReviewChecks:
+    """voice-2 review round: placeholder markers, hashtag tails, corrections schema."""
+
+    def test_placeholder_marker_is_red(self, tmp_path):
+        rows = _rows(6)
+        rows[0]["text"] += " 60% of their time {{UNVALIDATED}}"
+        d = _voice_dir(tmp_path, rows=rows)
+        assert any("placeholder" in p for p in
+                   validate.check_exemplars(str(tmp_path / "voice" / "exemplars.jsonl")))
+
+    def test_trailing_hashtag_line_is_red(self, tmp_path):
+        rows = _rows(6)
+        rows[0]["text"] += "\n\n#AI #BuildInPublic #FounderTools"
+        _voice_dir(tmp_path, rows=rows)
+        assert any("hashtag" in p for p in
+                   validate.check_exemplars(str(tmp_path / "voice" / "exemplars.jsonl")))
+
+    def test_hashtag_mid_text_is_not_flagged(self, tmp_path):
+        """The check must catch the TAIL, not any # -- '#1 priority' is prose."""
+        rows = _rows(6)
+        rows[0]["text"] = "It was the #1 priority. Nobody worked it. That was the tell."
+        _voice_dir(tmp_path, rows=rows)
+        assert not any("hashtag" in p for p in
+                       validate.check_exemplars(str(tmp_path / "voice" / "exemplars.jsonl")))
+
+    def test_corrections_schema_negative_selftest(self, tmp_path):
+        d = tmp_path / "voice"
+        d.mkdir()
+        (d / corpus.CORRECTIONS).write_text("\n".join([
+            json.dumps({"id": "c1", "instruction": "x", "class": "interpretive",
+                        "status": "active", "scope": ["linkedin"]}),
+            json.dumps({"id": "c1", "instruction": "", "class": "nonsense",
+                        "status": "weird", "scope": ["myspace"]}),
+            "{torn",
+        ]))
+        problems = "\n".join(validate.check_corrections(str(d / corpus.CORRECTIONS)))
+        for needle in ("duplicate id", "empty instruction", "class", "status",
+                       "unknown scope", "unparseable"):
+            assert needle in problems, needle
+
+    def test_clean_corrections_pass(self, tmp_path):
+        d = tmp_path / "voice"
+        d.mkdir()
+        (d / corpus.CORRECTIONS).write_text(json.dumps(
+            {"id": "c1", "instruction": "Do the thing.", "class": "deterministic",
+             "status": "promoted", "scope": ["dm"]}))
+        assert validate.check_corrections(str(d / corpus.CORRECTIONS)) == []

--- a/plugins/kipi-core/voicekit/validate.py
+++ b/plugins/kipi-core/voicekit/validate.py
@@ -1,0 +1,117 @@
+#!/usr/bin/env python3
+"""The LOUD half of the corpus contract. Runs in suites and CLIs, never in the daily job.
+
+corpus.py degrades so the publishing run cannot die; this module fails hard so decay
+cannot hide. Same file, two consumers, two postures -- the split IS the design
+(validate at edit time, degrade at run time).
+
+Returns problem strings rather than raising, so a pytest suite can assert `== []`
+and print every problem at once instead of dying on the first.
+"""
+from __future__ import annotations
+
+import json
+import os
+
+from . import assemble, corpus, fingerprint
+
+MIN_ROWS_PER_POOL = 3      # below this, selection silently narrows to repetition;
+                           # the fix is curation, so the message says so.
+
+
+def check_exemplars(path):
+    problems = []
+    if not os.path.exists(path):
+        return [f"{path}: missing"]
+    seen_ids = set()
+    with open(path, encoding="utf-8") as handle:
+        for lineno, line in enumerate(handle, 1):
+            line = line.strip()
+            if not line:
+                continue
+            try:
+                row = json.loads(line)
+            except ValueError as exc:
+                problems.append(f"line {lineno}: unparseable JSON ({exc})")
+                continue
+            rid = row.get("id")
+            if not rid:
+                problems.append(f"line {lineno}: no id")
+            elif rid in seen_ids:
+                problems.append(f"line {lineno}: duplicate id {rid!r}")
+            seen_ids.add(rid)
+            if row.get("kind") not in corpus.EXEMPLAR_KINDS:
+                problems.append(f"{rid}: kind {row.get('kind')!r} not in "
+                                f"{corpus.EXEMPLAR_KINDS}")
+            if row.get("channel") not in corpus.EXEMPLAR_CHANNELS:
+                problems.append(f"{rid}: channel {row.get('channel')!r} not in "
+                                f"{corpus.EXEMPLAR_CHANNELS}")
+            text = row.get("text") or ""
+            if not text.strip():
+                problems.append(f"{rid}: empty text")
+            if "—" in text:
+                problems.append(f"{rid}: emdash in text (the one character the "
+                                f"founder bans everywhere)")
+            if row.get("status", "active") not in ("active", "retired"):
+                problems.append(f"{rid}: status {row.get('status')!r}")
+    return problems
+
+
+def check_pools(voice):
+    """Selection starvation check: every (channel, kind) pool a slot can ask for."""
+    problems = []
+    rows = voice.active_exemplars()
+    for channel in ("linkedin", "x"):
+        for kind in ("post",):
+            n = sum(1 for r in rows if r.get("kind") == kind
+                    and r.get("channel", "any") in (channel, "any"))
+            if n < MIN_ROWS_PER_POOL:
+                problems.append(
+                    f"pool ({channel}, {kind}) has {n} active rows, floor is "
+                    f"{MIN_ROWS_PER_POOL}. Selection would repeat itself; the fix "
+                    f"is curating more rows, not loosening this check.")
+    return problems
+
+
+def check_fingerprint_fresh(voice):
+    """The bands must have been computed from THIS corpus. The canonical-digest
+    pattern: corpus changed but fingerprint.json not regenerated = a failure."""
+    if voice.fingerprint is None:
+        return ["fingerprint.json missing or unparseable"]
+    texts = [r.get("text") or "" for r in voice.active_exemplars()
+             if r.get("kind") == "post"]
+    want = fingerprint.corpus_sha(texts)
+    got = voice.fingerprint.get("corpus_sha")
+    if got != want:
+        return [f"fingerprint.json is stale: corpus_sha {got!r}, post-kind corpus "
+                f"is {want!r}. Recompute via the fingerprint CLI (its only writer)."]
+    return []
+
+
+def check_budget(voice, channels=("linkedin", "x")):
+    """The largest legal assembly must fit the budget. Suite-time, so the daily
+    job never needs a runtime cap -- the cap that failed loudly here cannot slice
+    silently there."""
+    problems = []
+    for channel in channels:
+        worst = 0
+        for counter in range(12):        # one rotation lap is enough to find the max
+            text, _ = assemble.voice_section(voice, channel, counter)
+            worst = max(worst, len(text))
+        if worst > assemble.BUDGET_CHARS:
+            problems.append(f"{channel}: largest assembly {worst} chars exceeds "
+                            f"budget {assemble.BUDGET_CHARS}")
+    return problems
+
+
+def check_all(voice_dir):
+    """Every check, one list. [] is a healthy corpus."""
+    voice = corpus.load(voice_dir)
+    problems = check_exemplars(os.path.join(voice_dir, corpus.EXEMPLARS))
+    problems += check_pools(voice)
+    problems += check_fingerprint_fresh(voice)
+    problems += check_budget(voice)
+    if voice.skipped_rows:
+        problems.append(f"{voice.skipped_rows} corrupt JSONL row(s) skipped by the "
+                        f"loader -- fix or remove them")
+    return problems

--- a/plugins/kipi-core/voicekit/validate.py
+++ b/plugins/kipi-core/voicekit/validate.py
@@ -12,6 +12,7 @@ from __future__ import annotations
 
 import json
 import os
+import re
 
 from . import assemble, corpus, fingerprint
 
@@ -54,6 +55,57 @@ def check_exemplars(path):
                                 f"founder bans everywhere)")
             if row.get("status", "active") not in ("active", "retired"):
                 problems.append(f"{rid}: status {row.get('status')!r}")
+            # voice-2 review: two seed rows shipped literal {{UNVALIDATED}}
+            # markers into the corpus -- template scaffolding presented as voice
+            # material. Any mustache placeholder in an exemplar is scaffolding.
+            if "{{" in text:
+                problems.append(f"{rid}: template placeholder in text")
+            # And several closed with campaign-hashtag tails, the exact register
+            # identity prose disavows. A trailing hashtag-only line is metadata,
+            # not voice.
+            last = text.strip().splitlines()[-1] if text.strip() else ""
+            if re.fullmatch(r"(#\w+[ \t]*)+", last):
+                problems.append(f"{rid}: trailing hashtag line in text")
+    return problems
+
+
+CORRECTION_CLASSES = ("deterministic", "interpretive")
+CORRECTION_STATUSES = ("active", "promoted", "retired")
+
+
+def check_corrections(path):
+    """corrections.jsonl schema health (voice-2 review: the ledger had no
+    validator at all, so a malformed or duplicate row passed the gate green)."""
+    if not os.path.exists(path):
+        return []                      # an absent ledger is a valid empty ledger
+    problems = []
+    seen = set()
+    with open(path, encoding="utf-8") as handle:
+        for lineno, line in enumerate(handle, 1):
+            line = line.strip()
+            if not line:
+                continue
+            try:
+                row = json.loads(line)
+            except ValueError as exc:
+                problems.append(f"corrections line {lineno}: unparseable ({exc})")
+                continue
+            rid = row.get("id")
+            if not rid:
+                problems.append(f"corrections line {lineno}: no id")
+            elif rid in seen:
+                problems.append(f"corrections line {lineno}: duplicate id {rid!r}")
+            seen.add(rid)
+            if not (row.get("instruction") or "").strip():
+                problems.append(f"{rid}: empty instruction")
+            if row.get("class") not in CORRECTION_CLASSES:
+                problems.append(f"{rid}: class {row.get('class')!r}")
+            if row.get("status") not in CORRECTION_STATUSES:
+                problems.append(f"{rid}: status {row.get('status')!r}")
+            for ch in row.get("scope") or []:
+                if ch not in ("linkedin", "x", "substack", "medium", "dm",
+                              "email", "comment"):
+                    problems.append(f"{rid}: unknown scope {ch!r}")
     return problems
 
 
@@ -119,6 +171,7 @@ def check_all(voice_dir):
     """Every check, one list. [] is a healthy corpus."""
     voice = corpus.load(voice_dir)
     problems = check_exemplars(os.path.join(voice_dir, corpus.EXEMPLARS))
+    problems += check_corrections(os.path.join(voice_dir, corpus.CORRECTIONS))
     problems += check_pools(voice)
     problems += check_fingerprint_fresh(voice)
     problems += check_budget(voice)

--- a/plugins/kipi-core/voicekit/validate.py
+++ b/plugins/kipi-core/voicekit/validate.py
@@ -78,14 +78,25 @@ def check_fingerprint_fresh(voice):
     pattern: corpus changed but fingerprint.json not regenerated = a failure."""
     if voice.fingerprint is None:
         return ["fingerprint.json missing or unparseable"]
+    problems = []
+    # Instrument skew FIRST (voice-1 review blocker): version_skew existed and
+    # nothing called it, so a metrics change with an unchanged corpus passed
+    # every check while the verdicts went wrong -- the exact scar the version
+    # exists for, reproduced by the reviewer against this very function.
+    if fingerprint.version_skew(voice.fingerprint):
+        problems.append(
+            f"fingerprint.json was computed by metrics_version "
+            f"{voice.fingerprint.get('metrics_version')!r} but this instrument is "
+            f"{fingerprint.METRICS_VERSION}. Recompute via the fingerprint CLI.")
     texts = [r.get("text") or "" for r in voice.active_exemplars()
              if r.get("kind") == "post"]
     want = fingerprint.corpus_sha(texts)
     got = voice.fingerprint.get("corpus_sha")
     if got != want:
-        return [f"fingerprint.json is stale: corpus_sha {got!r}, post-kind corpus "
-                f"is {want!r}. Recompute via the fingerprint CLI (its only writer)."]
-    return []
+        problems.append(
+            f"fingerprint.json is stale: corpus_sha {got!r}, post-kind corpus "
+            f"is {want!r}. Recompute via the fingerprint CLI (its only writer).")
+    return problems
 
 
 def check_budget(voice, channels=("linkedin", "x")):

--- a/q-system/.q-system/capability-manifest.json
+++ b/q-system/.q-system/capability-manifest.json
@@ -31,7 +31,8 @@
     },
     {
       "path": "q-system/.q-system/scripts/test/test-ci-redrive.sh",
-      "runner": "bash"
+      "runner": "bash",
+      "timeout_s": 240
     },
     {
       "path": "q-system/.q-system/scripts/test/test-claim-page-once-routing.sh",
@@ -51,11 +52,13 @@
     },
     {
       "path": "q-system/.q-system/scripts/test/test-dispatch-liveness.sh",
-      "runner": "bash"
+      "runner": "bash",
+      "timeout_s": 120
     },
     {
       "path": "q-system/.q-system/scripts/test/test-dispatch-stale-checkout.sh",
-      "runner": "bash"
+      "runner": "bash",
+      "timeout_s": 120
     },
     {
       "path": "q-system/.q-system/scripts/test/test-findings-block-reader.sh",
@@ -73,7 +76,7 @@
     {
       "path": "q-system/.q-system/scripts/test/test-repo-preflight.sh",
       "runner": "bash",
-      "timeout_s": 480
+      "timeout_s": 600
     },
     {
       "path": "q-system/.q-system/scripts/test/test-firecrawl-scrape.sh",
@@ -266,7 +269,8 @@
     },
     {
       "path": "q-system/.q-system/scripts/test/test-review-tree-guard.sh",
-      "runner": "bash"
+      "runner": "bash",
+      "timeout_s": 120
     },
     {
       "path": "q-system/.q-system/scripts/test/test-runtime-plugin-freshness.sh",
@@ -285,7 +289,7 @@
     {
       "path": "q-system/.q-system/scripts/test/test-severity-floor.sh",
       "runner": "bash",
-      "timeout_s": 420
+      "timeout_s": 600
     },
     {
       "path": "q-system/.q-system/scripts/test/test-skill-trigger-eval.sh",
@@ -309,11 +313,13 @@
     },
     {
       "path": "q-system/.q-system/scripts/test/test-update-preservation-manifest.py",
-      "runner": "python3"
+      "runner": "python3",
+      "timeout_s": 120
     },
     {
       "path": "q-system/.q-system/scripts/test/test-updater-issue-sequence.py",
-      "runner": "python3"
+      "runner": "python3",
+      "timeout_s": 240
     },
     {
       "path": "q-system/.q-system/scripts/test/test-updater-receipt-contract.py",
@@ -458,7 +464,8 @@
     },
     {
       "path": "q-system/.q-system/tests/test_fable_escalation.py",
-      "runner": "python3"
+      "runner": "python3",
+      "timeout_s": 180
     },
     {
       "path": "q-system/.q-system/tests/test_fable_cap_page_deleted.py",

--- a/q-system/.q-system/capability-manifest.json
+++ b/q-system/.q-system/capability-manifest.json
@@ -472,6 +472,11 @@
       "runner": "python3"
     },
     {
+      "path": "q-system/.q-system/tests/test_token_guard_cache_race.py",
+      "runner": "python3",
+      "timeout_s": 120
+    },
+    {
       "path": "q-system/.q-system/scripts/test/test-capability-map-wiring.py",
       "runner": "python3"
     },

--- a/q-system/.q-system/capability-manifest.json
+++ b/q-system/.q-system/capability-manifest.json
@@ -459,6 +459,10 @@
       "runner": "python3"
     },
     {
+      "path": "q-system/.q-system/tests/test_fable_cap_page_deleted.py",
+      "runner": "python3"
+    },
+    {
       "path": "q-system/.q-system/scripts/test/test-capability-map-wiring.py",
       "runner": "python3"
     },

--- a/q-system/.q-system/capability-manifest.json
+++ b/q-system/.q-system/capability-manifest.json
@@ -72,7 +72,8 @@
     },
     {
       "path": "q-system/.q-system/scripts/test/test-repo-preflight.sh",
-      "runner": "bash"
+      "runner": "bash",
+      "timeout_s": 480
     },
     {
       "path": "q-system/.q-system/scripts/test/test-firecrawl-scrape.sh",
@@ -260,7 +261,8 @@
     },
     {
       "path": "q-system/.q-system/scripts/test/test-review-invoker-provenance.sh",
-      "runner": "bash"
+      "runner": "bash",
+      "timeout_s": 240
     },
     {
       "path": "q-system/.q-system/scripts/test/test-review-tree-guard.sh",

--- a/q-system/.q-system/scripts/fable-escalate.py
+++ b/q-system/.q-system/scripts/fable-escalate.py
@@ -413,19 +413,36 @@ def escalate(trigger, reason, transcript_path, count, capped_notified,
         row = {"ts": _now(), "trigger": trigger, "capped": True,
                "fable_ok": False, "failure": result["failure"],
                "call_timeout_s": 0, "next_path_taken": None}
-        if not capped_notified:
-            record = notify_cap(trigger, count)
-            row.update(record)
-            # `notified` now means ATTEMPTED, and delivery is its own field.
-            # Collapsing the two is what made the old row a false receipt.
-            result["notified"] = record["notify_attempted"]
-            result["delivered"] = record["notify_delivered"]
-        else:
-            configured = notify_channel_configured()
-            row.update({"notify_attempted": False, "notify_exit": None,
-                        "notify_delivered": False,
-                        "notify_channel_configured": configured,
-                        "notify_note": "already paged for this episode"})
+        # THE CAP NO LONGER PAGES THE FOUNDER (ASK-504).
+        #
+        # This branch returns BEFORE call_fable, so the page it used to send
+        # could never carry a diagnosis. Measured over the whole ledger
+        # (63 rows, 2026-08-08): 6 capped rows, `diagnosis` None on all 6.
+        # Structurally always empty, not occasionally. The founder received
+        # "cross-model triage did not unstick this" with nothing about what was
+        # stuck, and called it useless.
+        #
+        # Worse, it was not even firing on stuckness. 4 of those 6 were
+        # `volume-ceiling` -- a token-BUDGET heuristic that trips on a long
+        # read-heavy session making steady progress. And two pairs share one
+        # timestamp with different triggers (08-04T03:35:31Z, 08-08T22:07:13Z):
+        # parallel PreToolUse hooks race token-guard's unlocked cache, so
+        # `capped_notified` was stale in both copies and BOTH paged.
+        #
+        # `founder-notifications.md` says do not ping for routine progress. So
+        # the mechanism is deleted rather than tuned -- guarding a page that can
+        # never have content just moves the noise. The refusal still reaches the
+        # founder through the agent's own reply, which the old cap message
+        # already conceded is the reliable route to a human.
+        #
+        # The ROW SURVIVES on purpose. A silent cap would be the worse defect;
+        # the episode stays auditable via `fable-escalate.py --report`.
+        row.update({"notify_attempted": False, "notify_exit": None,
+                    "notify_delivered": False,
+                    "notify_channel_configured": notify_channel_configured(),
+                    "notify_note": "cap reached; founder not paged by design "
+                                   "(ASK-504) -- this path never calls Fable, "
+                                   "so a page here carries no diagnosis"})
         log_row(row)
         return result
 

--- a/q-system/.q-system/scripts/test/test-repo-preflight.sh
+++ b/q-system/.q-system/scripts/test/test-repo-preflight.sh
@@ -36,6 +36,18 @@
 # is the exact thing under test.
 set -uo pipefail
 
+# COST, AND WHY THIS ENTRY CARRIES timeout_s=480 IN THE CAPABILITY MANIFEST
+# (ASK-505). This suite builds a fleet of real git repos under mktemp, and that
+# is the point -- see the fixture_git scar below. Measured on the founder's box
+# 2026-08-08: 228.60s real / 39.05s user, rc=0, "48 passed, 0 failed".
+#
+# The manifest gave this entry NO timeout_s, so it inherited the gate's
+# DEFAULT_TIMEOUT_S of 60 and was SIGKILLed at 60s on every run -- a green
+# 48-case suite reported by the capability gate as `test-timeout`, i.e. a
+# passing test indistinguishable from a broken one. It had never passed under
+# the gate. If this ever times out again, measure it before touching the
+# assertions: the cost is git fixture construction, so it tracks disk and load,
+# not the number of cases.
 HERE="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 # Derive the repo from the SCRIPT, never from $PWD -- a test that asks the checkout
 # it happens to run in proves nothing about the caller (test-dispatch-stale-checkout
@@ -677,7 +689,12 @@ if [ "$1" = "-f" ]; then
   exit $rc
 fi
 if [ "$1" = "-c" ]; then shift; fmt="$1"; shift
-  [ "$fmt" = "%Y" ] && { command stat -f %m "$1" 2>/dev/null || echo 1; exit 0; }
+  # Deliberate: this heredoc BUILDS a fake GNU stat (it answers -c %Y), and the
+  # BSD -f %m below is the real macOS stat it delegates to in order to fake that
+  # GNU answer. Making the line "portable" would break the stub it constructs.
+  # The marker must sit on the hit line itself (portability-lint.sh:54 matches
+  # the matched line, not the one above it).
+  [ "$fmt" = "%Y" ] && { command stat -f %m "$1" 2>/dev/null || echo 1; exit 0; } # portability-lint-skip
 fi
 exit 1
 GNUSTUB

--- a/q-system/.q-system/scripts/test/test-repo-preflight.sh
+++ b/q-system/.q-system/scripts/test/test-repo-preflight.sh
@@ -36,7 +36,7 @@
 # is the exact thing under test.
 set -uo pipefail
 
-# COST, AND WHY THIS ENTRY CARRIES timeout_s=480 IN THE CAPABILITY MANIFEST
+# COST, AND WHY THIS ENTRY CARRIES timeout_s=600 IN THE CAPABILITY MANIFEST
 # (ASK-505). This suite builds a fleet of real git repos under mktemp, and that
 # is the point -- see the fixture_git scar below. Measured on the founder's box
 # 2026-08-08: 228.60s real / 39.05s user, rc=0, "48 passed, 0 failed".
@@ -48,6 +48,11 @@ set -uo pipefail
 # the gate. If this ever times out again, measure it before touching the
 # assertions: the cost is git fixture construction, so it tracks disk and load,
 # not the number of cases.
+#
+# 600 is the manifest's TIMEOUT_MAX_S and this test needs the whole ceiling. The
+# budgets across the manifest were set from one whole-population sweep (all 117
+# declared tests, every one rc=0) at roughly 4x measured cost; at ~240s this is
+# the most expensive test declared, so it gets the cap instead of 4x.
 HERE="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 # Derive the repo from the SCRIPT, never from $PWD -- a test that asks the checkout
 # it happens to run in proves nothing about the caller (test-dispatch-stale-checkout

--- a/q-system/.q-system/scripts/test/test-review-invoker-provenance.sh
+++ b/q-system/.q-system/scripts/test/test-review-invoker-provenance.sh
@@ -15,6 +15,19 @@
 # hand-run, never as dispatcher-driven. Absent is not approved -- the same posture
 # the reviewer's commit status takes. Case 3 is that assertion, and it is the one
 # a careless default would break.
+# COST, AND WHY THIS ENTRY CARRIES timeout_s=240 IN THE CAPABILITY MANIFEST
+# (ASK-505). Cases 4, 5 and 6 each drive verify-codex-review-live.sh, and that
+# script shells `launchctl list` -- measured on the founder's box 2026-08-08 at
+# 21.56s / 29.45s / 23.92s per invocation, so this suite costs ~65-90s wall
+# against roughly 3s of CPU. It is waiting on launchd, not computing.
+#
+# The manifest gave this entry NO timeout_s, so it inherited the gate's
+# DEFAULT_TIMEOUT_S of 60. Three ~25s calls cannot fit in 60s, so the test was
+# killed mid-case-6 on every run: the capability gate reported a `test-timeout`
+# that read like a broken test, while the test itself passes in 65s standalone.
+# It had never passed under the gate. Do not "fix" a recurrence by shrinking the
+# assertions -- measure launchctl first, because the cost scales with how many
+# jobs are loaded on the machine and this box carries a lot of them.
 set -uo pipefail
 
 HERE="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"

--- a/q-system/.q-system/tests/test_fable_cap_page_deleted.py
+++ b/q-system/.q-system/tests/test_fable_cap_page_deleted.py
@@ -1,0 +1,140 @@
+#!/usr/bin/env python3
+"""Reproducer + regression pin for ASK-504: the escalation-cap page.
+
+THE DEFECT, measured not guessed (2026-08-08, 63 ledger rows):
+
+    capped rows      6
+    diagnosis on them  None, all 6
+
+`escalate()` returns at the cap BEFORE it ever calls Fable. So the page it
+sends can never carry a diagnosis -- not "usually empty", structurally always
+empty. The founder receives "cross-model triage did not unstick this" with zero
+content about what was stuck. That is what he called useless, and he is right.
+
+Two more facts from the same 63 rows:
+  - 4 of the 6 capped rows are `volume-ceiling`, a TOKEN-BUDGET heuristic that
+    fires on sessions making steady progress. Not a stuckness signal.
+  - two capped rows share one timestamp with different triggers
+    (2026-08-04T03:35:31Z, 2026-08-08T22:07:13Z). Parallel PreToolUse hooks
+    race an unlocked cache, so `capped_notified` is stale in both and BOTH page.
+
+`founder-notifications.md` says do not ping for routine progress. A content-free
+page fired by a budget heuristic off a race is exactly that. So the page is
+DELETED rather than tuned: the refusal already reaches the founder through the
+agent's own reply in-session, which the cap-path comment itself concedes is the
+reliable route to a human. The ledger row survives, so the episode stays
+auditable -- deleting the page is not deleting the record.
+
+ISOLATION: KIPI_FABLE_LEDGER_DIR and KIPI_FABLE_NOTIFY_CMD are redirected into a
+tempdir, so this suite never touches the live ledger and never reaches Slack.
+The cap path does not call Fable at all, so no run here can spend a real call.
+"""
+
+import json
+import os
+import subprocess
+import sys
+import tempfile
+import unittest
+from pathlib import Path
+
+HERE = Path(__file__).resolve().parent
+SCRIPT = HERE.parent / "scripts" / "fable-escalate.py"
+
+
+class CapPageTest(unittest.TestCase):
+    def setUp(self):
+        self.tmp = tempfile.TemporaryDirectory()
+        root = Path(self.tmp.name)
+        self.ledger = root / "ledger"
+        self.marker = root / "PAGED"
+        # A stub notifier that RECORDS being called. Asserting on the stub's own
+        # artifact, not on stderr text: an `or` across signals passes on the weak
+        # half and never tests the page (feedback_or_across_signals).
+        self.notify = root / "notify-stub.sh"
+        self.notify.write_text(
+            "#!/usr/bin/env bash\nprintf '%%s' \"$1\" > '%s'\nexit 0\n" % self.marker)
+        self.notify.chmod(0o755)
+        self.addCleanup(self.tmp.cleanup)
+
+    def _run(self, trigger="volume-ceiling", count=2, capped_notified=False):
+        env = dict(
+            os.environ,
+            KIPI_FABLE_LEDGER_DIR=str(self.ledger),
+            KIPI_FABLE_NOTIFY_CMD=str(self.notify),
+            KIPI_FABLE_CAP="2",
+        )
+        cmd = [sys.executable, str(SCRIPT), "--json", "--trigger", trigger,
+               "--reason", "reproducer", "--count", str(count)]
+        if capped_notified:
+            cmd.append("--capped-notified")
+        proc = subprocess.run(cmd, env=env, capture_output=True, text=True,
+                              timeout=60)
+        return proc
+
+    def _rows(self):
+        rows = []
+        if self.ledger.is_dir():
+            for name in sorted(os.listdir(self.ledger)):
+                for line in (self.ledger / name).read_text().splitlines():
+                    if line.strip():
+                        rows.append(json.loads(line))
+        return rows
+
+    # --- the assertion that was RED before the fix ---------------------------
+
+    def test_cap_does_not_page_the_founder(self):
+        """THE REPRODUCER. Before the fix the stub marker exists (a page went
+        out). After the fix it must not."""
+        self._run()
+        self.assertFalse(
+            self.marker.exists(),
+            "the cap path paged the founder; the page carries no diagnosis "
+            "because escalate() returns before calling Fable, so it is noise",
+        )
+
+    def test_cap_still_records_the_episode(self):
+        """Deleting the page must NOT delete the record. A silent cap would be a
+        worse defect than a noisy one -- the episode has to stay auditable."""
+        self._run()
+        rows = self._rows()
+        self.assertEqual(len(rows), 1, "the cap must still write exactly one row")
+        self.assertTrue(rows[0]["capped"])
+        self.assertEqual(rows[0]["trigger"], "volume-ceiling")
+
+    def test_row_states_no_page_was_attempted(self):
+        """The row must not claim a page. A receipt for an action that did not
+        occur is the rca-specification-reported-as-state class."""
+        self._run()
+        row = self._rows()[0]
+        self.assertFalse(row["notify_attempted"])
+        self.assertFalse(row["notify_delivered"])
+        self.assertIn("notify_note", row)
+
+    def test_json_result_reports_not_notified(self):
+        """token-guard reads this JSON. It must not be told a human was reached."""
+        proc = self._run()
+        out = json.loads(proc.stdout)
+        self.assertTrue(out["capped"])
+        self.assertFalse(out["notified"])
+        self.assertFalse(out["delivered"])
+
+    # --- negative self-test: prove the check can actually fail ---------------
+
+    def test_stub_notifier_is_wired_and_can_fire(self):
+        """NEGATIVE SELF-TEST. If the stub could never write its marker, every
+        assertion above would pass against a broken harness rather than against
+        a fixed one. Fire the stub directly and prove the marker appears.
+        (feedback_check_must_be_able_to_fail)"""
+        self.assertFalse(self.marker.exists())
+        subprocess.run([str(self.notify), "direct probe"], check=True, timeout=30)
+        self.assertTrue(
+            self.marker.exists(),
+            "the stub notifier never wrote its marker, so the no-page assertions "
+            "prove nothing",
+        )
+        self.assertEqual(self.marker.read_text(), "direct probe")
+
+
+if __name__ == "__main__":
+    unittest.main(verbosity=2)

--- a/q-system/.q-system/tests/test_fable_escalation.py
+++ b/q-system/.q-system/tests/test_fable_escalation.py
@@ -652,17 +652,18 @@ def test_escalations_stop_at_the_cap_and_page_once(actor, env):
     assert REQUEST_NOTE not in r.stderr, "escalated past the cap"
     assert "cap" in r.stderr.lower()
 
-    log = settle(lambda: open(env["_notify_log"]).read()
-                 if os.path.exists(env["_notify_log"]) else "")
-    assert "stuck" in log.lower(), f"the founder was not paged at the cap: {log!r}"
+    # THE CAP MUST NOT PAGE (ASK-504). This assertion was INVERTED until
+    # 2026-08-08: it required a page, so the suite pinned the noise as correct
+    # and the defect could never be "fixed" without turning the suite red. The
+    # cap path returns before call_fable, so that page was always content-free
+    # (6/6 capped ledger rows had diagnosis None).
+    settle(lambda: None, timeout=2.0)
+    log = open(env["_notify_log"]).read() if os.path.exists(env["_notify_log"]) else ""
+    assert log == "", f"the cap paged the founder with no diagnosis to carry: {log!r}"
     assert quiet_after_cap(env), "the model was called past the cap"
 
-    # a fourth block must not page again — one page per episode, not per call
-    seed(actor, edit_targets={"/tmp/spiral-target.py": EDIT_FAIL_LIMIT - 1},
-         fable_escalations=2, fable_capped_notified=True)
-    run_guard(edit_payload(actor), e)
-    settle(lambda: None, timeout=2.0)
-    assert open(env["_notify_log"]).read().count("\n") == 1, "paged twice"
+    # what the cap DOES still do: refuse, and leave an auditable row.
+    assert settled_rows(env)[-1]["capped"] is True, "the cap episode went unrecorded"
 
 
 def test_cap_row_does_not_claim_a_page_that_was_never_sent(actor, env, tmp_path):
@@ -709,9 +710,13 @@ def test_cap_row_does_not_claim_a_page_that_was_never_sent(actor, env, tmp_path)
 
 
 def test_cap_row_records_delivery_when_a_channel_exists(actor, env):
-    """The paired positive. Without it the assertion above would still pass if
-    notify_delivered were hardcoded False, which would make the field useless in
-    the one case it exists to report."""
+    """A CONFIGURED CHANNEL IS STILL NOT PAGED (ASK-504).
+
+    This is the case that actually reaches the founder's phone, so it is the one
+    worth pinning: a working webhook must NOT turn the cap into a page. The row
+    still reports the channel as configured, because that is a true fact about
+    the machine and suppressing it would hide why no page went out.
+    """
     e = guard_env(env)
     e["KIPI_FABLE_CAP"] = "1"
     seed(actor, edit_targets={"/tmp/spiral-target.py": EDIT_FAIL_LIMIT - 1},
@@ -721,13 +726,14 @@ def test_cap_row_records_delivery_when_a_channel_exists(actor, env):
 
     row = settled_rows(env)[0]
     assert row["capped"] is True
-    assert row["notify_channel_configured"] is True
-    assert row["notify_attempted"] is True
-    assert row["notify_exit"] == 0
-    assert row["notify_delivered"] is True
-    log = settle(lambda: open(env["_notify_log"]).read()
-                 if os.path.exists(env["_notify_log"]) else "")
-    assert "stuck" in log.lower()
+    assert row["notify_channel_configured"] is True, \
+        "the stub channel is not wired, so 'no page' here would prove nothing"
+    assert row["notify_attempted"] is False
+    assert row["notify_delivered"] is False
+    assert "ASK-504" in (row["notify_note"] or ""), "the row must say why no page"
+    settle(lambda: None, timeout=2.0)
+    log = open(env["_notify_log"]).read() if os.path.exists(env["_notify_log"]) else ""
+    assert log == "", f"a configured channel still got paged: {log!r}"
 
 
 def quiet_after_cap(env, grace=2.0):

--- a/q-system/.q-system/tests/test_token_guard_cache_race.py
+++ b/q-system/.q-system/tests/test_token_guard_cache_race.py
@@ -1,0 +1,293 @@
+"""The guard cache must survive parallel hook fires (sp-016776e6).
+
+WHAT THIS PINS, AND WHY IT IS ABOUT MONEY.
+
+`load_cache` / `save_cache` are a read-modify-write of one JSON file with no
+lock. Claude Code fires PreToolUse once per tool call, and parallel tool calls
+mean parallel guard processes on the SAME actor cache. Each reads the same
+pre-state, mutates its own copy, and the last writer wins -- every other
+process's mutation is silently lost.
+
+The lost mutation that costs real money is `fable_escalations`, the counter
+`request_escalation` reads to decide whether this actor has spent its
+KIPI_FABLE_CAP budget of cross-model triages. A lost increment means the next
+process reads a stale count, decides it is under the cap, and spends another
+billed `claude -p --model claude-fable-5` call.
+
+Measured over the shipped ledger (q-system/output/fable-escalations/*.jsonl,
+188 rows, 2026-08-08): 172 rows attempted a real call against a cap of 2 per
+actor. 90 of them landed in a second that already carried another real call,
+7 in the worst single second, and 8 distinct seconds carry two DIFFERENT
+triggers -- which only two concurrent guard processes can produce.
+
+NO REAL FABLE CALL IS EVER SPENT HERE. pytest exports PYTEST_CURRENT_TEST for
+the duration of every test and the detached child inherits it, so
+`call_fable`'s chokepoint refuses the live path and the child still writes its
+ledger row. The row is therefore a receipt for an ATTEMPT that would have been
+billed in production, which is exactly the quantity under test.
+"""
+
+import json
+import os
+import subprocess
+import sys
+import time
+import uuid
+
+import pytest
+
+GUARD = os.path.abspath(
+    os.path.join(os.path.dirname(__file__), "..", "token-guard.py"))
+VOLUME_CEILING = 50
+FABLE_CAP = 2
+PARALLEL_FIRES = 8
+
+# WHY A BARRIER AND NOT JUST N Popen CALLS.
+#
+# The first cut of this test fired 8 plain `python3 token-guard.py`
+# subprocesses and PASSED against the unfixed code -- 3/3 green on a defect
+# that provably exists. Interpreter startup is ~40ms and the guard's
+# read-modify-write window is under 1ms, so process 1 had finished before
+# process 8 had finished importing. The fires never overlapped; the test
+# measured scheduling luck, not locking.
+#
+# So each process imports the guard FIRST, then parks on a barrier file, and
+# the parent releases all of them at once. Interpreter startup is moved out of
+# the measured window instead of being allowed to serialize it. Nothing about
+# the code under test is softened: these are still N separate OS processes
+# running the real main() against the real cache path, which is exactly the
+# shape the hook runner produces on parallel tool calls.
+_BARRIER_RUNNER = '''
+import importlib.util, io, json, os, sys, time
+guard_path, payload_file, barrier = sys.argv[1], sys.argv[2], sys.argv[3]
+spec = importlib.util.spec_from_file_location("guard_under_test", guard_path)
+module = importlib.util.module_from_spec(spec)
+spec.loader.exec_module(module)
+payload = open(payload_file).read()
+while not os.path.exists(barrier):
+    time.sleep(0.001)
+sys.stdin = io.StringIO(payload)
+try:
+    module.main()
+except SystemExit:
+    pass
+'''
+
+
+def cache_file(actor_key):
+    return f"/tmp/claude-guard-{actor_key}.json"
+
+
+@pytest.fixture
+def actor(tmp_path):
+    """A unique actor key, its seeded cache, and cleanup.
+
+    Unique per run on purpose: the guard hardcodes its cache under /tmp, so
+    isolation comes from the key, not from the directory. A shared key would
+    make two test runs race each other -- the very defect under test.
+    """
+    key = "race-%s" % uuid.uuid4()
+    yield key
+    for path in (cache_file(key), f"/tmp/claude-fable-pending-{key}.json"):
+        try:
+            os.remove(path)
+        except OSError:
+            pass
+
+
+def seed_at_ceiling(actor_key):
+    """A cache parked exactly at the volume ceiling with no escalations spent.
+
+    `last_volume_reset` is NOW so the commit-progress valve cannot lift the
+    ceiling out from under the test: `reset_volume_if_committed` only fires on
+    a HEAD commit NEWER than that stamp, and no commit is in the future.
+    """
+    state = {
+        "actor_key": actor_key,
+        "tool_calls_since_user": VOLUME_CEILING,
+        "agent_calls_since_user": 0,
+        "mcp_timestamps": [],
+        "repeat_map": {},
+        "consecutive_reads": 0,
+        "warnings_issued": 0,
+        "file_read_counts": {},
+        "greps_since_write": 0,
+        "edit_targets": {},
+        "agents_without_write": 0,
+        "last_write_time": time.time(),
+        "calls_since_write": 0,
+        "last_volume_reset": time.time(),
+        "gate_grace_remaining": 0,
+        "gate_grace_gate": None,
+        "gate_grace_grants": 0,
+        "fable_escalations": 0,
+    }
+    with open(cache_file(actor_key), "w") as fh:
+        json.dump(state, fh)
+
+
+def read_ledger(directory):
+    rows = []
+    if not os.path.isdir(directory):
+        return rows
+    for name in sorted(os.listdir(directory)):
+        if not name.endswith(".jsonl"):
+            continue
+        with open(os.path.join(directory, name), encoding="utf-8") as fh:
+            for line in fh:
+                line = line.strip()
+                if line:
+                    try:
+                        rows.append(json.loads(line))
+                    except ValueError:
+                        pass
+    return rows
+
+
+def await_rows(directory, expected, deadline_s=30):
+    """Poll until `expected` ledger rows land, or the deadline passes.
+
+    Polled, never slept-for-a-guess: the children are detached, so a fixed
+    sleep would either flake or pad every run. Returning short is allowed --
+    the assertions, not this helper, decide whether short is a failure.
+    """
+    end = time.time() + deadline_s
+    rows = read_ledger(directory)
+    while len(rows) < expected and time.time() < end:
+        time.sleep(0.2)
+        rows = read_ledger(directory)
+    return rows
+
+
+def fire_parallel_blocks(actor_key, ledger_dir, tmp_path, count=PARALLEL_FIRES):
+    """`count` guard processes entering main() at the same instant.
+
+    Each is a real hook invocation of the real script against the real cache
+    path. See _BARRIER_RUNNER for why the release is synchronised.
+    """
+    env = dict(os.environ)
+    env.update({
+        "CLAUDECODE": "1",
+        "KIPI_FABLE_LEDGER_DIR": str(ledger_dir),
+        "KIPI_FABLE_CAP": str(FABLE_CAP),
+        "KIPI_FABLE_PENDING": str(tmp_path / "pending.json"),
+        # Not a git repo, so `_head_commit_epoch` returns None deterministically
+        # and the commit valve cannot reset the ceiling mid-test.
+        "CLAUDE_PROJECT_DIR": str(tmp_path),
+    })
+    runner = tmp_path / "barrier_runner.py"
+    runner.write_text(_BARRIER_RUNNER)
+    payload = tmp_path / "payload.json"
+    payload.write_text(json.dumps({
+        "session_id": actor_key,
+        "hook_event_name": "PreToolUse",
+        "tool_name": "Read",
+        "tool_input": {"file_path": "/etc/hostname"},
+        "transcript_path": "",
+    }))
+    barrier = tmp_path / "barrier"
+
+    procs = [
+        subprocess.Popen(
+            [sys.executable, str(runner), GUARD, str(payload), str(barrier)],
+            stdout=subprocess.DEVNULL, stderr=subprocess.DEVNULL, env=env)
+        for _ in range(count)
+    ]
+    _await_parked(procs)
+    barrier.write_text("go")
+    for proc in procs:
+        proc.wait(timeout=60)
+    return procs
+
+
+def _await_parked(procs, settle_s=1.5):
+    """Give every child time to finish importing and reach the barrier.
+
+    A generous fixed settle rather than a handshake: the cost of being early
+    is a test that silently stops overlapping (the exact failure this file was
+    rewritten to fix), so the check below turns "a child died before the
+    barrier" into a loud failure instead of a quiet non-overlap.
+    """
+    time.sleep(settle_s)
+    dead = [p.returncode for p in procs if p.poll() is not None]
+    assert not dead, (
+        "%d of %d children exited BEFORE the barrier was released (codes %r); "
+        "they never overlapped, so any green result below is meaningless"
+        % (len(dead), len(procs), dead))
+
+
+def test_parallel_fires_cannot_overspend_the_escalation_cap(actor, tmp_path):
+    """N concurrent ceiling blocks must spend at most FABLE_CAP real calls.
+
+    The assertion is on the LEDGER, not on the cache: a ledger row with
+    `capped: false` is a call that reached `call_fable`, i.e. one that
+    production would have billed. Counting the cache counter instead would
+    measure the symptom's cousin rather than the spend.
+    """
+    ledger = tmp_path / "ledger"
+    seed_at_ceiling(actor)
+    fire_parallel_blocks(actor, ledger, tmp_path)
+    rows = await_rows(ledger, PARALLEL_FIRES)
+
+    # Guard against the green-for-nothing hole: if the children never ran, the
+    # billed-call count is trivially 0 and the real assertion below proves
+    # nothing. Every fire must have left a receipt of SOME kind.
+    assert len(rows) == PARALLEL_FIRES, (
+        "expected one ledger row per fire, got %d of %d -- the spend assertion "
+        "below is only meaningful if every child actually ran"
+        % (len(rows), PARALLEL_FIRES))
+
+    billed = [r for r in rows if not r.get("capped")]
+    assert len(billed) <= FABLE_CAP, (
+        "%d of %d parallel fires reached call_fable against a cap of %d; the "
+        "escalation counter lost %d increment(s) to the unlocked cache "
+        "read-modify-write (sp-016776e6)"
+        % (len(billed), PARALLEL_FIRES, FABLE_CAP, len(billed) - FABLE_CAP))
+
+
+def test_parallel_fires_do_not_lose_the_escalation_counter(actor, tmp_path):
+    """The persisted counter must show the cap fully spent, not one increment.
+
+    Separate from the ledger assertion on purpose. The ledger proves what was
+    SPENT; this proves the guard's own memory of it survived, which is what
+    stops the next fire in the same session from spending again.
+    """
+    ledger = tmp_path / "ledger"
+    seed_at_ceiling(actor)
+    fire_parallel_blocks(actor, ledger, tmp_path)
+    await_rows(ledger, PARALLEL_FIRES)
+
+    with open(cache_file(actor)) as fh:
+        cache = json.load(fh)
+    assert cache.get("fable_escalations", 0) >= FABLE_CAP, (
+        "cache recorded %r escalations after %d parallel fires; concurrent "
+        "writers clobbered each other's increments (sp-016776e6)"
+        % (cache.get("fable_escalations"), PARALLEL_FIRES))
+
+
+def test_parallel_fires_do_not_lose_the_volume_counter(actor, tmp_path):
+    """The same lost update, on the counter every run touches.
+
+    The escalation counter is where the race costs money; this is where it
+    costs the ceiling its accuracy. Both are the one defect, so both are
+    pinned -- fixing only the expensive symptom would leave the class alive.
+    """
+    ledger = tmp_path / "ledger"
+    seed_at_ceiling(actor)
+    # Below the warning line, so no block fires and no child is spawned: this
+    # isolates the plain counter increment from the escalation path entirely.
+    with open(cache_file(actor)) as fh:
+        cache = json.load(fh)
+    cache["tool_calls_since_user"] = 0
+    with open(cache_file(actor), "w") as fh:
+        json.dump(cache, fh)
+
+    fire_parallel_blocks(actor, ledger, tmp_path)
+
+    with open(cache_file(actor)) as fh:
+        cache = json.load(fh)
+    assert cache.get("tool_calls_since_user") == PARALLEL_FIRES, (
+        "counted %r of %d parallel tool calls; the rest were lost to the "
+        "unlocked read-modify-write, so the ceiling undercounts a fan-out "
+        "exactly when it is most needed (sp-016776e6)"
+        % (cache.get("tool_calls_since_user"), PARALLEL_FIRES))

--- a/q-system/.q-system/tests/test_token_guard_cache_race.py
+++ b/q-system/.q-system/tests/test_token_guard_cache_race.py
@@ -291,3 +291,10 @@ def test_parallel_fires_do_not_lose_the_volume_counter(actor, tmp_path):
         "unlocked read-modify-write, so the ceiling undercounts a fan-out "
         "exactly when it is most needed (sp-016776e6)"
         % (cache.get("tool_calls_since_user"), PARALLEL_FIRES))
+
+
+if __name__ == "__main__":
+    # REQUIRED, not decoration. capability-gate.py runs a `runner: python3`
+    # entry as `python3 <file>`, so a pytest-only module would define its tests,
+    # call none of them, and exit 0 — registered, green, and enforcing nothing.
+    sys.exit(pytest.main([__file__, "-v"]))

--- a/q-system/.q-system/token-guard.py
+++ b/q-system/.q-system/token-guard.py
@@ -205,6 +205,14 @@ def save_cache(actor_key, cache):
 # just lost cleanly. The read and the write have to be inside one critical
 # section, which is what this is.
 #
+# LOST UPDATES WERE NOT THE WORST OF IT. save_cache truncates and rewrites in
+# place, so two concurrent writers can interleave: running the concurrency suite
+# against a no-lock mutant produced a cache whose JSON ended at byte 464 with a
+# longer writer's tail still after it. load_cache catches JSONDecodeError and
+# returns fresh defaults, so a torn write silently reset every counter this
+# guard owns — the ceiling, the retry map and the escalation budget all back to
+# zero, with nothing logged and nothing to see afterwards.
+#
 # WHY THE REGION HOLDS NO SUBPROCESS. This hook is wired at `timeout: 5` on all
 # three events fleet-wide, and a hook that overruns its timeout has its exit 2
 # DISCARDED (measured 2026-08-03; see the escalation block comment below). So a
@@ -219,10 +227,18 @@ LOCK_POLL_SECONDS = 0.002
 def lock_path(actor_key):
     """A sidecar, never the cache file itself.
 
-    save_cache reopens the cache with mode "w", which truncates and can hand
-    back a different file description — locking that same path would drop the
-    hold mid-region. A dedicated file also lets the lock exist before the cache
-    does, which is the common case on an actor's first tool call.
+    HONEST ABOUT WHY, because the first version of this comment was wrong.
+    It claimed save_cache's mode-"w" truncate would drop a lock taken on the
+    cache path; a mutant that pointed this function AT the cache file survived
+    the concurrency suite 8/8, because truncation keeps the same inode and flock
+    follows the inode. So that is not the reason.
+
+    The real reasons are narrower and both structural: the lock must exist
+    before the cache does (an actor's first tool call has no cache file yet, and
+    load_cache is happy to return defaults for one), and a sidecar cannot be
+    invalidated by any future change that REPLACES the cache rather than
+    rewriting it in place — an os.replace-based atomic write, the obvious next
+    edit here, swaps the inode and would silently orphan every held lock.
     """
     return f"/tmp/claude-guard-{actor_key}.lock"
 
@@ -1247,12 +1263,31 @@ def main():
                     grant_gate_grace(cache, gate)
         sys.exit(0)
 
+    # The commit probe shells out to git, so it runs BEFORE the lock is taken —
+    # holding the cache lock across a 3s subprocess could push a waiting hook
+    # past its own 5s timeout, and an overrun hook has its exit 2 discarded
+    # (sp-016776e6; see the chokepoint comment above reset_volume_if_committed).
+    #
+    # The peek deciding whether to pay for the probe is an unlocked read. Being
+    # wrong about it costs one wasted or one skipped probe on a single tool
+    # call, never correctness: the authoritative count is re-read under the lock
+    # on the very next line, and a missed reset lands on the following call.
+    head_epoch = None
+    if load_cache(actor).get("tool_calls_since_user", 0) >= VOLUME_WARNING:
+        head_epoch = _head_commit_epoch()
+
+    # Everything from here to process exit runs under this actor's lock, so the
+    # load-mutate-save below is one critical section rather than a race. The
+    # existing save_cache calls at each block/warn exit are unchanged; they now
+    # simply happen while the lock is held.
+    hold_actor_lock(actor)
+
     # Load cache, update counters from this invocation. The commit-progress
     # valve runs before the checks so a freshly-shipped commit lifts the
     # ceiling even when the PostToolUse event never arrived (wiring B).
     cache = load_cache(actor)
     cache = update_counters(tool_name, tool_input, cache)
-    cache = reset_volume_if_committed(cache)
+    cache = reset_volume_if_committed(cache, head_epoch)
 
     # A triage from an earlier stuck refusal, if the detached call has landed.
     # One cheap open() on the common path (the file is absent almost always).

--- a/q-system/.q-system/token-guard.py
+++ b/q-system/.q-system/token-guard.py
@@ -39,6 +39,8 @@ Exit codes:
   2 = block (stderr message goes to Claude as feedback)
 """
 
+import contextlib
+import fcntl
 import hashlib
 import json
 import os
@@ -127,7 +129,11 @@ def sweep_stale_caches(max_age_days=CACHE_TTL_DAYS):
     this sweep is their cleanup path."""
     import glob
     cutoff = time.time() - max_age_days * 86400
-    for path in glob.glob("/tmp/claude-guard-*.json"):
+    # Both patterns: the sidecar lock files (sp-016776e6) do not end in .json,
+    # so the original glob would have left one per actor in /tmp forever.
+    stale = glob.glob("/tmp/claude-guard-*.json") + glob.glob(
+        "/tmp/claude-guard-*.lock")
+    for path in stale:
         try:
             if os.path.getmtime(path) < cutoff:
                 os.remove(path)
@@ -171,6 +177,131 @@ def save_cache(actor_key, cache):
             json.dump(cache, f)
     except IOError:
         pass
+
+
+# --- The single-writer chokepoint (sp-016776e6) ------------------------------
+# load_cache/save_cache are a read-modify-write, and Claude Code fires this hook
+# once per tool call — so parallel tool calls mean parallel guard processes on
+# ONE actor's cache file. Unlocked, each read the same pre-state and the last
+# writer won; every other process's mutation was silently dropped.
+#
+# The lost mutation that cost real money is `fable_escalations`, the counter
+# request_escalation reads to decide whether this actor has spent its
+# KIPI_FABLE_CAP budget of billed `claude -p --model claude-fable-5` calls. A
+# dropped increment let the next process read a stale count, believe it was
+# under the cap, and buy another one.
+#
+# MEASURED over the shipped ledger before the fix (188 rows,
+# q-system/output/fable-escalations/, 2026-08-08): 172 rows attempted a real
+# call against a cap of 2 per actor. 90 landed in a second that already carried
+# another real call, 7 in the worst single second, and 8 distinct seconds carry
+# two DIFFERENT triggers — two concurrent guard processes is the only thing that
+# produces that. The two colliding CAPPED pairs are 2026-08-04T03:35:31Z and
+# 2026-08-08T22:07:13Z, each one `exact-retry` racing one `volume-ceiling`.
+#
+# WHY A LOCK AND NOT AN ATOMIC WRITE. tmpfile + os.replace was the tempting fix
+# and it does not work: it makes the WRITE atomic, not the read-modify-write.
+# Both processes still read the same pre-state, so the update is still lost —
+# just lost cleanly. The read and the write have to be inside one critical
+# section, which is what this is.
+#
+# WHY THE REGION HOLDS NO SUBPROCESS. This hook is wired at `timeout: 5` on all
+# three events fleet-wide, and a hook that overruns its timeout has its exit 2
+# DISCARDED (measured 2026-08-03; see the escalation block comment below). So a
+# lock held across `_head_commit_epoch`'s git call (capped at 3s) could turn
+# contention into a SPENT refusal — trading this defect for a worse one. The git
+# probe is therefore hoisted out of the region by main(), leaving only in-memory
+# work under the lock: microseconds, not milliseconds.
+LOCK_WAIT_SECONDS = 2.0     # unreachable in practice; the region is pure CPU
+LOCK_POLL_SECONDS = 0.002
+
+
+def lock_path(actor_key):
+    """A sidecar, never the cache file itself.
+
+    save_cache reopens the cache with mode "w", which truncates and can hand
+    back a different file description — locking that same path would drop the
+    hold mid-region. A dedicated file also lets the lock exist before the cache
+    does, which is the common case on an actor's first tool call.
+    """
+    return f"/tmp/claude-guard-{actor_key}.lock"
+
+
+def _acquire(handle, deadline_s=LOCK_WAIT_SECONDS):
+    """Bounded LOCK_EX. True if held, False if the wait ran out."""
+    end = time.time() + deadline_s
+    while True:
+        try:
+            fcntl.flock(handle.fileno(), fcntl.LOCK_EX | fcntl.LOCK_NB)
+            return True
+        except OSError:
+            if time.time() >= end:
+                return False
+            time.sleep(LOCK_POLL_SECONDS)
+
+
+# Holds the open lock handles for this process's lifetime. Module-level on
+# purpose: a handle kept only in a local could be garbage-collected, and closing
+# the fd releases the flock — silently, mid-region, with everything still
+# looking correct.
+_HELD_LOCKS = []
+
+
+def hold_actor_lock(actor_key):
+    """Take this actor's lock and keep it until the process exits.
+
+    The PreToolUse path cannot use a `with` block: every check ends in
+    block()/warn(), both of which sys.exit, and the path already saves the cache
+    itself at each of those exits. Rather than re-indent ~110 lines of checks
+    (a mechanical edit with plenty of room to hide a defect) the lock is simply
+    held for the rest of the invocation and released by the OS on process exit,
+    which is the one exit every path shares.
+
+    Fails open on purpose — see locked_cache.
+    """
+    try:
+        handle = open(lock_path(actor_key), "a+")
+    except OSError:
+        return False
+    _HELD_LOCKS.append(handle)
+    return _acquire(handle)
+
+
+@contextlib.contextmanager
+def locked_cache(actor_key):
+    """Yield this actor's cache under an exclusive lock; write it back on exit.
+
+    Every load-mutate-save site in this file goes through here — that is what
+    makes it a chokepoint rather than N per-site locks that the next new caller
+    forgets. The yielded dict is written back on exit, including when the body
+    raises SystemExit, which is how block() and warn() leave. Every mutator in
+    this file mutates in place and returns the same object, so rebinding the
+    name inside the body is safe.
+
+    FAILS OPEN, DELIBERATELY. If the lock cannot be taken the body still runs
+    unlocked — today's behaviour, no worse. This hook's whole job is refusing a
+    runaway loop, and a guard that withheld its refusal because it could not get
+    a lock would be a guard that fails closed on its own plumbing. Same posture
+    as request_escalation: the mechanism may only ADD to a refusal, never
+    withhold one.
+    """
+    handle = None
+    try:
+        handle = open(lock_path(actor_key), "a+")
+        _acquire(handle)
+    except OSError:
+        handle = None
+    cache = load_cache(actor_key)
+    try:
+        yield cache
+    finally:
+        save_cache(actor_key, cache)
+        if handle is not None:
+            try:
+                fcntl.flock(handle.fileno(), fcntl.LOCK_UN)
+            except OSError:
+                pass
+            handle.close()
 
 
 def update_counters(tool_name, tool_input, cache):
@@ -1020,16 +1151,22 @@ def _head_commit_epoch():
     return None
 
 
-def reset_volume_if_committed(cache):
+def reset_volume_if_committed(cache, head_epoch):
     """The commit-progress valve, PreToolUse side. A repo HEAD commit newer
     than the last volume reset means the run is shipping — zero the volume
     counters (gate lack-of-progress, not raw volume). Only consulted once the
     counter is near the ceiling, so the common path stays subprocess-free.
     Works even when PostToolUse delivery is missing (the dead-valve defect
-    this issue closes)."""
+    this issue closes).
+
+    `head_epoch` is PASSED IN, not read here (sp-016776e6). This function now
+    runs inside the cache lock, and _head_commit_epoch shells out to git with a
+    3s cap — long enough that holding the lock across it could push a waiting
+    hook past its own 5s timeout, at which point the runner discards its exit 2
+    and the refusal is lost. The subprocess stays outside the region; only the
+    comparison happens inside."""
     if cache.get("tool_calls_since_user", 0) < VOLUME_WARNING:
         return cache
-    head_epoch = _head_commit_epoch()
     if head_epoch and head_epoch > cache.get("last_volume_reset", 0):
         cache["tool_calls_since_user"] = 0
         cache["agent_calls_since_user"] = 0
@@ -1062,9 +1199,8 @@ def main():
     # Only the main actor receives this event; subagent caches age out via
     # the TTL sweep.
     if hook_event == "UserPromptSubmit":
-        cache = load_cache(actor)
-        cache = reset_per_message_counters(cache)
-        save_cache(actor, cache)
+        with locked_cache(actor) as cache:
+            reset_per_message_counters(cache)
         sweep_stale_caches()
         sys.exit(0)
 
@@ -1082,9 +1218,9 @@ def main():
                 isinstance(resp, str) and resp.strip().lower().startswith(
                     ("error", "edit failed", "no match", "string not found")))
             if not failed:
-                cache = load_cache(actor)
-                cache.get("edit_targets", {}).pop(tool_input.get("file_path", ""), None)
-                save_cache(actor, cache)
+                with locked_cache(actor) as cache:
+                    cache.get("edit_targets", {}).pop(
+                        tool_input.get("file_path", ""), None)
         # A SUCCESSFUL `git commit` is a durable check-in, so it resets the volume counter —
         # the same shape as the edit-spiral reset above (progress clears the counter). The
         # 50-call ceiling exists to catch a stuck/spinning run, NOT to punish a run that is
@@ -1093,13 +1229,12 @@ def main():
         # makes the guard gate lack-of-progress, not raw volume. (sr-staff call 2026-06-11.)
         elif tool_name == "Bash" and _is_successful_commit(
                 tool_input.get("command", ""), hook_input.get("tool_response")):
-            cache = load_cache(actor)
-            cache["tool_calls_since_user"] = 0
-            cache["agent_calls_since_user"] = 0
-            cache["warnings_issued"] = 0
-            cache["last_volume_reset"] = time.time()
-            cache = clear_gate_grace(cache)
-            save_cache(actor, cache)
+            with locked_cache(actor) as cache:
+                cache["tool_calls_since_user"] = 0
+                cache["agent_calls_since_user"] = 0
+                cache["warnings_issued"] = 0
+                cache["last_volume_reset"] = time.time()
+                clear_gate_grace(cache)
         # A commit REFUSED by a pre-commit gate is the other half of the valve.
         # It is not progress, so it must not reset the counter — but the gate's
         # precondition needs an Edit the ceiling blocks, so the run gets a bounded
@@ -1108,9 +1243,8 @@ def main():
             gate = _commit_gate_refusal(
                 tool_input.get("command", ""), hook_input.get("tool_response"))
             if gate:
-                cache = load_cache(actor)
-                cache = grant_gate_grace(cache, gate)
-                save_cache(actor, cache)
+                with locked_cache(actor) as cache:
+                    grant_gate_grace(cache, gate)
         sys.exit(0)
 
     # Load cache, update counters from this invocation. The commit-progress

--- a/q-system/canonical/decisions.md
+++ b/q-system/canonical/decisions.md
@@ -107,3 +107,76 @@ Monthly audit (1st of month): count decisions by origin tag. If >60% are rubber-
   and found no link had ever been sent. See `q-system/lessons/prove-a-negative-with-a-live-probe.md`.
 - **Date:** 2026-07-29
 - **Revisit:** Permanent
+
+### RULE-010: A Clean Review Round Is Not Evidence Of Sufficiency
+- **Origin:** [SYSTEM-INFERRED]
+- **Decision:** When a defect class has produced a finding every round on one surface,
+  restructure regardless of the next round's verdict, and decide it BEFORE that verdict
+  arrives so the outcome cannot shape the decision.
+- **Reason:** For a property enforced at N independent seams, a quiet round means one
+  reviewer did not find the N+1th seam. Blindness was enforced at four seams on the judge
+  and three were wrong. Validated twice: after the override, the very next round found a
+  real hole in the half already called stable and one commit from shipping.
+- **Date:** 2026-08-05
+- **Revisit:** Permanent
+
+### RULE-011: Kill A Defect Class By Deleting The Mechanism
+- **Origin:** [CLAUDE-RECOMMENDED -> MODIFIED]
+- **Decision:** Three successive hardenings of a date inference were retired by deleting
+  the exemption mechanism entirely, so the gate consults no date at all.
+- **Reason:** A creation-date floor exempted every FUTURE decision on any pre-floor PRD;
+  35 of 36 PRDs predated it, making the gate near-permanently inert. The recommendation
+  was mine and the measurement showing it was inert was in hand and misread as "safe".
+  Codex caught it. Before deleting, the protected set was measured, not assumed.
+- **Date:** 2026-08-05
+- **Revisit:** Permanent
+
+### RULE-012: The Runtime Is Not The Repo, And The Clone Is Not The Runtime
+- **Origin:** [CLAUDE-RECOMMENDED -> MODIFIED]
+- **Decision:** Verify the copy that actually loads. Plugins run from a version-pinned
+  cache registered in `installed_plugins.json`, not from the marketplace clone and not
+  from a project's `plugins/` dir. Refreshing the clone alone changes nothing.
+- **Reason:** After two days of merged work, the loaded plugin was version 0.1.0 from
+  April. My acceptance criteria targeted the clone, so following them would have gone
+  green over five-month-old code. Sana found the second layer. Detector shipped
+  (`runtime-plugin-freshness.py`), with the stated gap that version parity alone cannot
+  see commit drift.
+- **Date:** 2026-08-05
+- **Revisit:** When plugin loading changes
+
+### RULE-013: Migration Receipts Carry No Judge Run
+- **Origin:** [SYSTEM-INFERRED]
+- **Decision:** Re-dispositioning historical decisions to satisfy a receipt gate is done
+  WITHOUT a judge run, so the records satisfy the gate while being excluded from
+  calibration by construction.
+- **Reason:** Freezing today's workflow context against a decision made two months ago
+  manufactures precisely the retroactive artifact the whole system exists to prevent.
+  A receipt with `human` and no `judge` is excluded from scoring by construction.
+- **Date:** 2026-08-05
+- **Revisit:** Permanent
+
+### RULE-014: A Gate's Refusal Is Information, Not An Obstacle
+- **Origin:** [CLAUDE-RECOMMENDED -> MODIFIED]
+- **Decision:** An unbuildable PRD was released with `clear`, not `archive`, after the
+  archive gate refused. Its 8 accepted findings were NOT re-triaged to `rejected` to buy
+  the transition.
+- **Reason:** I recommended archive. Sana ran it to capture the real refusal: the findings
+  lack issue receipts and can never have them, because they INVALIDATE the PRD rather than
+  describe work. Archiving would assert "done and accounted for" about something never
+  built. Re-triaging would have erased a real review's conclusions for a state change.
+  Gate/model mismatch captured as `sp-8c286548` instead of papered over.
+- **Date:** 2026-08-05
+- **Revisit:** When prd-os gains a disposition for self-invalidating findings
+
+### RULE-015: Autonomous Is The Target; CLI Constraints Are Not Blockers
+- **Origin:** [USER-DIRECTED]
+- **Decision:** Rank runtime paths by who drives them. The agent/plugin/scheduled path is
+  the product; a hand-typed CLI is a convenience wrapper. A broken CLI is a footnote, not
+  an incident. "Needs a human decision" is a defective deferral, not a terminal state.
+- **Reason:** Founder, 2026-08-05: "The way this should work is completely autonomous so
+  I dont care about the cli and command constraints." I had elevated a broken CLI to equal
+  status with the agent path that actually executes the work. Safety holds (destructive
+  ops, another session's uncommitted work, irreversible deletions) are NOT overridden by
+  this; they get decided by an agent with evidence rather than escalated as questions.
+- **Date:** 2026-08-05
+- **Revisit:** Permanent

--- a/q-system/canonical/judgment-compiler-build-2026-08-05.md
+++ b/q-system/canonical/judgment-compiler-build-2026-08-05.md
@@ -1,0 +1,226 @@
+# Build Record: The Judgment Compiler (ASK-363), 2026-08-04 → 2026-08-05
+
+Canonical narrative of a two-day build. Written for reuse in building-in-public
+content: every number here was measured by running something, and the failures
+are recorded at the same resolution as the wins.
+
+Companion artifacts: `decisions.md` RULE-010 → RULE-015 (the durable rules),
+`q-system/lessons/` (four published HOW-only patterns), Linear ASK-363.
+
+---
+
+## What was built, in one paragraph
+
+Every time a reviewer objects to something in a plan, someone decides: accept,
+reject, defer. Those decisions were being overwritten and lost. A benchmark
+showed an AI given only the objection text predicted the founder's decision at
+**40% agreement, kappa 0.032** — worse than always guessing "accept" (76.6%
+baseline). The diagnosis: a disposition is not a property of an objection, it is
+a property of an objection **inside workflow state**, and the ledger destroyed
+that state on every write. The fix is an immutable, hash-chained receipt per
+decision, freezing the decision *and* the surrounding context.
+
+By the end: **21 real receipts, chain verified, 8 carrying an AI prediction**
+alongside the human answer. The calibration that was impossible is now a
+volume problem.
+
+---
+
+## The headline number
+
+**23 genuine defects** found by adversarial review across two days, on code that
+passed its own test suite every single time.
+
+Not one was caught by the tests. Every one required either an independent
+reviewer or someone deliberately trying to break the check itself.
+
+Eight of the 23 landed in a single ~700-line detector across ten review rounds,
+which is why that one was split rather than merged whole.
+
+---
+
+## The pattern underneath almost all of it
+
+**A check must be able to fail for the reason you care about.**
+
+Thirteen instances in two days, split roughly evenly between the coordinator and
+the engineers. That split is the point: it is not a competence gap, it is the
+default outcome of verifying the thing in front of you instead of the thing the
+conclusion requires.
+
+A representative sample, all real:
+
+- A test asserted `--allowedTools ""` when the property was tool *availability*,
+  controlled by `--tools`. The AI judge could read files the whole time. Had it
+  shipped, every measurement afterward would have been worthless and it would
+  have looked fine.
+- A six-row table of malformed dates where a coarse range guard already rejected
+  every row, so the fine-grained parse could be deleted with the suite green.
+- A hash-binding test run on the one fixture shape structurally unable to
+  exercise the binding.
+- A blast-radius measurement read as "this is safe" when the identical number
+  meant "this does nothing."
+- `cmd | tail` in a gate check: the pipeline's exit status is `tail`'s, so it
+  reported success while the gate was red.
+- "It was local contention" for a test **66s against a 60s cap**, measured idle.
+- A mutation test whose mutant never applied, because backticks executed as
+  command substitution. Counting it as a kill would have certified an untested
+  check.
+
+Two practices came out of it that are not obvious:
+
+1. **Mutation-test the guard, not just the code.** Twice a guard could have been
+   deleted with the entire suite still green.
+2. **Distrust the convenient explanation for anything intermittent.** One
+   measured run refutes it, and skipping that run converts a real defect into a
+   false claim about a gate's state — worse than a wrong conclusion, because it
+   looks settled.
+
+Published as `q-system/lessons/a-check-must-be-able-to-fail-for-the-reason-you-care-abou.md`.
+
+---
+
+## The path, in order
+
+**Day 1 opened** with PR #101 after seven review rounds and three options: split,
+keep grinding, or park.
+
+**Decision: split.** The deciding evidence was that `evaluate` reads only the
+ledger, so the ledger *is* the calibration set and the findings file is
+operational state. One half protected the data; the other guarded a mutable copy
+against drifting off it, and 3 of its 4 tests existed to stop it false-blocking
+legitimate work.
+
+**Then the finding that reframed everything.** No judge-run producer existed. The
+triage command never passed `--judge-run`, and `evaluate` counts a case only when
+a receipt carries *both* a judge prediction and a human decision. So every
+release gate was unreachable by construction, and roughly half the engine had no
+wired input. The handoff's closing line — "run a triage and the calibration clock
+starts" — was simply wrong.
+
+This was a **recurrence of a documented class**: a consumer with no production
+producer, invisible because ~90 tests hand-built the input.
+
+**PR #102** shipped the receipt gate. The design recommended for it — a floor
+keyed to the PRD's creation date — was wrong, and the measurement showing it was
+in hand and misread. It exempted every *future* decision on any pre-floor PRD,
+and 35 of 36 PRDs predated the floor. "Blocks nothing today" was read as *safe*
+when it equally meant *inert*. The mechanism was deleted rather than hardened a
+fourth time.
+
+**PR #103** took **ten rounds**. Rounds 1–6 and 8–9 each found something
+genuinely new. The most consequential:
+
+- The judge was not blind (the flag defect above).
+- Judge citations were never resolved, so a fabricated reference scored as
+  supported evidence.
+- The prediction printed into the founder's transcript *before* they decided —
+  next to a note saying not to show it.
+- Cross-PRD duplicates broke the hash binding outright, falsifying a premise the
+  coordinator had written into the plan and told the engineer not to re-derive.
+- A lost-update race: two writers, two successful receipts, one disposition
+  silently reverted, exit 0 on both.
+- A phantom receipt when the anchor write failed after the append.
+
+**The structural turn.** After round 4 it was decided — *before* the verdict
+arrived, so the outcome could not shape it — that the fix would be a refactor
+regardless. Reasoning: blindness was enforced at **four independent seams** and
+three were wrong. A property enforced at N sites is not a chokepoint. One
+constructor now owns the judge's entire view, built from an **allowlist**, so a
+field a future contributor adds is invisible by default.
+
+**The enumeration that validated itself.** Round 9 found an ambient reference
+accepted as duplicate evidence. Rather than patch instance nine, the class was
+enumerated: every source feeding the citable set classified as finding-dependent
+or ambient. The derived rule then **independently rediscovered a hole closed by
+hand several rounds earlier**, which it was never told about. A classifier
+reproducing known truth it was not given is the strongest evidence produced in
+the whole build.
+
+**Day 2 opened** with an adversarial test of everything, assuming nothing worked.
+
+**It didn't.** Not one line of two days' work was reachable. Plugins execute from
+a cached copy, and the registry pinned the plugin at **version 0.1.0, installed
+in April**. Five months stale, not the one day assumed. Worse: the acceptance
+criteria written for the fix pointed at the *downloaded* copy, not the *loaded*
+one — so following them literally would have turned everything green over
+five-month-old code. The lesson landed on the plan written about deployment.
+
+**Five follow-on PRs** landed the runtime fix, a freshness detector, 17 recovered
+work-product files that existed only in a dirty checkout, 537 scratch files
+untracked from git, and the root cause behind a review that had read the wrong
+directory entirely.
+
+---
+
+## Numbers worth quoting
+
+- **23** genuine defects, none caught by tests
+- **13** instances of "a check that cannot fail for the reason you care about"
+- **10** review rounds on one PR; **8** defects in one ~700-line detector
+- **40% / kappa 0.032** — the blind judge benchmark that started it
+- **35 of 36** PRDs exempted by the floor design that was recommended and wrong
+- **88 of 112** copies of one script resolved to the wrong root; that is why a
+  review ran against a directory that was not a repository, read no diff, and
+  produced a verdict from the prompt alone
+- **102 → 112** copies of that script *during a single session* — the generator
+  is still running
+- **537** scratch files silently committed by an unattended auto-commit
+- **21** receipts, **8** judged, **3** scoreable cases against a 50-case gate
+- Version parity alone still cannot see commit drift: one plugin reports the same
+  version string from a different commit. Stated in the PR body, not implied away.
+
+---
+
+## What the first real use found
+
+The plan under review turned out to be **unbuildable**. It targeted a script
+present in **no git ref**, citing line numbers past the end of the file that
+exists. It had been written against a branch that no longer exists.
+
+Eight findings accepted, two of them blockers. Notably, findings 2–8 were
+deliberately **not** marked duplicates of finding 1 despite a shared root cause,
+because `duplicate` maps to `rejected` and five of them survive a rebase. That
+distinction is exactly what the old ledger destroyed on every write, and it is
+now frozen in a receipt.
+
+---
+
+## Honest ledger of what the coordinator got wrong
+
+Recorded at the same resolution as the wins, because a build record that only
+lists wins is not calibrated and cannot be trusted on the wins.
+
+1. Recommended a floor design that protected almost nothing, holding the
+   measurement that said so.
+2. Specified a lock boundary covering the write but not the read — trading a
+   loud recoverable failure for silent data loss.
+3. Wrote a false premise into a plan and instructed the engineer not to
+   re-derive it.
+4. Approved a nine-row classification table, verified two rows, missed the one
+   carrying the defect just guarded against one field over.
+5. Reported that existing receipts carried reason codes, inferred from a metric
+   structurally incapable of reporting on them.
+6. Said "seven open items" when the ledger held 524.
+7. Wrote acceptance criteria pointing at the wrong copy of the runtime.
+8. Passed the founder a decision that was never theirs — a false binary
+   inherited from a handoff and never tested.
+9. Amplified a refutation as good judgment before it had been checked; the next
+   round disproved it.
+
+Every one was caught by someone verifying rather than trusting.
+
+---
+
+## The mechanic that made it work
+
+**Nobody accepted anyone else's "verified" as verified.**
+
+Each party was wrong in a way only another could see. The coordinator's
+measurement was corrected by the engineer; the engineer's classification was
+corrected by the coordinator; both were corrected by an independent adversarial
+reviewer; and the reviewer itself asserted, once, a consequence the code did not
+have — refuted with an executed reproducer rather than complied with.
+
+That is not redundancy. It is the only reason 23 defects surfaced before a
+permanently dishonest dataset existed.

--- a/remote-coverage-check.py
+++ b/remote-coverage-check.py
@@ -45,17 +45,29 @@ def git_out(args, cwd):
         return 1, ""
 
 
+def is_repo_root(path):
+    """True when `path` is the root of a git checkout.
+
+    `.git` is a DIRECTORY in a normal clone but a FILE ("gitdir: ...") in a git
+    worktree and in a submodule. Probing with isdir() therefore reported every
+    live worktree as "no enclosing git repo", which is the loudest possible
+    wrong answer: the gate told you to `git init` a fresh repo inside another
+    repo's checkout. Scar 2026-08-08 -- 8 kipi-system worktrees, 24 RED rows.
+    """
+    return os.path.exists(os.path.join(path, ".git"))
+
+
 def find_repos(root):
     repos = []
     if not os.path.isdir(root):
         return repos
-    if os.path.isdir(os.path.join(root, ".git")):
+    if is_repo_root(root):
         repos.append(root)
     for dirpath, dirnames, _ in os.walk(root):
         dirnames[:] = [d for d in dirnames if not skip_dir(d)]
         for d in list(dirnames):
             full = os.path.join(dirpath, d)
-            if os.path.isdir(os.path.join(full, ".git")):
+            if is_repo_root(full):
                 repos.append(full)
     return sorted(set(repos))
 
@@ -278,6 +290,40 @@ def self_test():
             ok = False
         else:
             print("  [b] tracked parent repo correctly NOT flagged")
+
+    # b3: a git WORKTREE of a covered repo. Its `.git` is a FILE ("gitdir: ..."),
+    # not a directory, so an isdir() probe reports "no enclosing git repo" and
+    # the gate demands you seed a new repo inside someone else's checkout.
+    # Scar 2026-08-08: 8 live kipi-system worktrees (24 rows) sat RED for a week
+    # for this reason alone, and a permanently-red gate is a gate nobody reads.
+    with tempfile.TemporaryDirectory() as tmp:
+        main_repo = os.path.join(tmp, "main-repo")
+        os.makedirs(main_repo)
+        for a in (["init", "-q"], ["config", "user.email", "t@t"],
+                  ["config", "user.name", "t"]):
+            git_out(a, main_repo)
+        open(os.path.join(main_repo, "CLAUDE.md"), "w").write("main")
+        git_out(["add", "."], main_repo)
+        git_out(["commit", "-qm", "seed"], main_repo)
+        git_out(["remote", "add", "origin",
+                 "https://github.com/example/fake.git"], main_repo)
+        wt = os.path.join(tmp, "main-repo-wt-feature")
+        git_out(["worktree", "add", "-q", "--detach", wt], main_repo)
+
+        cov, _, _, nonrepo = audit(tmp)
+        found = {r["path"] for r in nonrepo}
+        if wt in found:
+            print("FAIL: [b] a git WORKTREE of a covered repo was flagged as "
+                  "'not a git repo' -- .git is a file in a worktree, not a dir")
+            ok = False
+        else:
+            print("  [b] git worktree of a covered repo correctly NOT flagged")
+        if wt not in {r["path"] for r in cov}:
+            print("FAIL: [b] worktree not counted as a covered repo")
+            ok = False
+        else:
+            print("  [b] git worktree correctly counted as covered")
+
     print("SELF-TEST PASS" if ok else "SELF-TEST FAIL")
     return 0 if ok else 1
 


### PR DESCRIPTION
Replaces #125, which is permanently unmergeable. Same work, minus the part
that conflicts.

## Why this PR exists

#125 carried 21 commits and reported `CONFLICTING` with 6 conflicts, all in
`plugins/prd-os/`. Measured rather than inferred:

- All 6 conflicts come from the **8 oldest commits on that branch, every one of
  them ASK-363**.
- Main has since merged the same ASK-363 feature through 5 PRs (#102, #103,
  #108, #110, #112) and already carries `judgment_compiler.py`. So those
  conflicts are two implementations of one feature, not two features.
- The **13 newest commits touch nothing under `plugins/prd-os`** and are
  contiguous. Cherry-picked onto current main: `rc=0`, zero conflicts.

This PR is those 13.

The zero-checks problem on #125 was a **symptom of the same conflicts**, not an
independent blocker: `git ls-remote origin 'refs/pull/125/*'` returns only
`refs/pull/125/head` and no `/merge` ref, so GitHub cannot build the merge
commit that `on: pull_request` needs. This branch is conflict-free, so CI can
run here.

## What is in here

- **ASK-507** token-guard's actor cache had an unlocked read-modify-write.
  Parallel PreToolUse fires raced it and lost the `fable_escalations` counter,
  buying extra billed `claude -p --model claude-fable-5` calls: 172 of 188
  ledger rows attempted a real call against a cap of 2 per actor, 90 landing in
  a second that already carried another. Fixed with a single locked writer; the
  git commit probe is hoisted out of the critical section so a 3s subprocess
  can never push a waiting hook past its 5s timeout.
- **ASK-505** capability-gate timeouts budgeted per test, measured once.
- **ASK-504** the Fable escalation cap no longer pages the founder. `escalate()`
  returned at the cap *before* calling Fable, so the page could never carry a
  diagnosis; all 6 of 6 capped ledger rows had `diagnosis: None`. The paired
  test had asserted the page was present, which is why it was never caught.
- **ASK-503** remote-coverage-check `find_repos()` used
  `os.path.isdir(<dir>/.git)`; in a git worktree `.git` is a FILE, so 8 live
  worktrees were false-flagged.
- **ASK-471** (4 commits) voicekit voice METHOD package + corrections-ledger
  validation, loader scars pinned.
- **ASK-426 follow-through** removed the guidance demanding a CTA at the end.

## Verification

- `kipi check` PASS 173 / FAIL 0 / WARN 1, exit 0, on the pre-cherry-pick tree.
- On **this** tree (main + the 13): 46 passed across the guard and escalation
  suites, including the ASK-507 reproducer.
- ASK-507 reproducer `q-system/.q-system/tests/test_token_guard_cache_race.py`
  is registered in the capability manifest and was seen RED (`8 of 8 parallel
  fires reached call_fable against a cap of 2`) before GREEN.

## Known red, pre-existing, NOT from this PR

5 tests in `q-system/.q-system/tests/separation/` fail, and `kipi check` never
runs them, so its green is silence about them. Measured in clean detached
worktrees: identical `5 failed, 162 passed` at the pre-session baseline
`a474b2f0` and at `464be47a`. Tracked as `sp-ba004add`.

Not carried here: the 8 ASK-363 commits from #125. Whether their 7 follow-up
fixes are already present in main's merged ASK-363 line is an open question
tracked in the ledger; it needs recon of both implementations and must not be
resolved blind.

🤖 Generated with [Claude Code](https://claude.com/claude-code)