### PR TITLE
voicekit: fix the three review minors from PR #126 (ASK-508)

### DIFF
--- a/plugins/kipi-core/.claude-plugin/plugin.json
+++ b/plugins/kipi-core/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "kipi-core",
-  "version": "1.5.22",
+  "version": "1.5.23",
   "description": "Core founder OS — voice, research, AUDHD, LinkedIn/brand, RCA skills + kipi-mcp server",
   "author": {
     "name": "Assaf Kipnis",

--- a/plugins/kipi-core/.claude-plugin/plugin.json
+++ b/plugins/kipi-core/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "kipi-core",
-  "version": "1.5.20",
+  "version": "1.5.21",
   "description": "Core founder OS — voice, research, AUDHD, LinkedIn/brand, RCA skills + kipi-mcp server",
   "author": {
     "name": "Assaf Kipnis",

--- a/plugins/kipi-core/.claude-plugin/plugin.json
+++ b/plugins/kipi-core/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "kipi-core",
-  "version": "1.5.21",
+  "version": "1.5.22",
   "description": "Core founder OS — voice, research, AUDHD, LinkedIn/brand, RCA skills + kipi-mcp server",
   "author": {
     "name": "Assaf Kipnis",

--- a/plugins/kipi-core/voicekit/assemble.py
+++ b/plugins/kipi-core/voicekit/assemble.py
@@ -62,9 +62,17 @@ def voice_section(voice, channel, counter, slot_index=0, k=selector.DEFAULT_K,
         bodies = "\n\n---\n\n".join((r.get("text") or "").strip() for r in picked)
         parts.append("POSTS HE HAS WRITTEN. Match their rhythm, register and "
                      "length. Never reuse their sentences or openings:\n\n" + bodies)
-    if corrections:
-        lines = "\n".join(f"- {r['instruction']}" for r in corrections
-                          if not r.get("scope") or channel in r["scope"])
+    # Filter ONCE, and let the same list feed the prompt and the receipt below
+    # (ASK-508, sp-9642b63d). These were two independent readers of one fact: the
+    # prompt honoured `scope` and provenance ignored it, so a correction withheld
+    # from the model was still recorded as applied. Same class as the notify_cap
+    # scar -- a receipt for an action that did not occur. The echo gate and every
+    # audit downstream trust correction_ids, so the cheapest wrong answer here is
+    # the one that looks authoritative.
+    applied = [r for r in (corrections or [])
+               if not r.get("scope") or channel in r["scope"]]
+    if applied:
+        lines = "\n".join(f"- {r['instruction']}" for r in applied)
         if lines:
             parts.append("STANDING CORRECTIONS (these override everything above):\n"
                          + lines)
@@ -72,7 +80,7 @@ def voice_section(voice, channel, counter, slot_index=0, k=selector.DEFAULT_K,
     provenance = {
         "exemplar_ids": [str(r.get("id")) for r in picked],
         "exemplar_texts": [(r.get("text") or "") for r in picked],
-        "correction_ids": [str(r.get("id")) for r in corrections],
+        "correction_ids": [str(r.get("id")) for r in applied],
         "selection_reason": selector.selection_reason(picked, channel, counter,
                                                       slot_index),
         "skipped_rows": voice.skipped_rows,

--- a/plugins/kipi-core/voicekit/corpus.py
+++ b/plugins/kipi-core/voicekit/corpus.py
@@ -70,7 +70,8 @@ def read_json(path):
 
 
 def _weight(row):
-    """A row's weight as a number, or 0 when it is not one (ASK-508, sp-18daaa21).
+    """A row's weight as a number, or None when the field is not a number
+    (ASK-508, sp-18daaa21 + the codex minor on PR #127).
 
     read_jsonl only guarantees the LINE parsed, never that a numeric field holds a
     number -- so `{"weight": "heavy"}` is valid JSON, is counted as no skip, and
@@ -82,7 +83,28 @@ def _weight(row):
     try:
         return float(row.get("weight", 1.0) or 0)
     except (TypeError, ValueError):
-        return 0.0
+        return None
+
+
+def _drop_malformed_weights(rows):
+    """(usable rows, count dropped). Partitioned at LOAD, never in a filter.
+
+    The first cut of the crash fix coerced a junk weight to 0.0 inside
+    active_exemplars() and said nothing, so the row vanished and skipped_rows --
+    the deadman signal validation and provenance read -- stayed clean. A corpus
+    rotting to zero usable rows would have looked identical to a healthy one.
+
+    Counted HERE because __init__ is the single owner of skipped_rows. Doing it
+    in active_exemplars() would make a read path mutate the decay count, so the
+    number would change depending on how many times a caller happened to filter.
+    """
+    usable, dropped = [], 0
+    for row in rows:
+        if _weight(row) is None:
+            dropped += 1
+        else:
+            usable.append(row)
+    return usable, dropped
 
 
 class Voice:
@@ -91,19 +113,20 @@ class Voice:
     def __init__(self, voice_dir):
         self.voice_dir = voice_dir
         self.exemplars, ex_skipped = read_jsonl(os.path.join(voice_dir, EXEMPLARS))
+        self.exemplars, wt_skipped = _drop_malformed_weights(self.exemplars)
         self.corrections, co_skipped = read_jsonl(os.path.join(voice_dir, CORRECTIONS))
         self.identity = read_text(os.path.join(voice_dir, IDENTITY))
         self.pov = read_text(os.path.join(voice_dir, POV))
         self.lexicon = read_json(os.path.join(voice_dir, LEXICON)) or {}
         self.fingerprint = read_json(os.path.join(voice_dir, FINGERPRINT))
-        self.skipped_rows = ex_skipped + co_skipped
+        self.skipped_rows = ex_skipped + co_skipped + wt_skipped
 
     def active_exemplars(self):
         """Usable rows only: active status, non-empty text, weight above zero."""
         return [r for r in self.exemplars
                 if r.get("status", "active") == "active"
                 and (r.get("text") or "").strip()
-                and _weight(r) > 0]
+                and (_weight(r) or 0) > 0]
 
     def active_corrections(self):
         """Rows still carried as prose. A `promoted` row's gate carries it instead."""

--- a/plugins/kipi-core/voicekit/corpus.py
+++ b/plugins/kipi-core/voicekit/corpus.py
@@ -11,6 +11,7 @@ suite at edit time, not inside the publishing run.
 from __future__ import annotations
 
 import json
+import math
 import os
 
 EXEMPLARS = "exemplars.jsonl"
@@ -81,9 +82,17 @@ def _weight(row):
     Unreadable weight means unusable row, which is what a zero already means here.
     """
     try:
-        return float(row.get("weight", 1.0) or 0)
+        value = float(row.get("weight", 1.0) or 0)
     except (TypeError, ValueError):
         return None
+    # FINITENESS, not a list of the spellings someone reported. float() PARSES
+    # "NaN", "inf" and "Infinity", so the try/except above never fired for them
+    # and they walked straight through the round-1 fix. NaN then failed `> 0`
+    # and vanished uncounted -- the exact silent decay that fix existed to end --
+    # while inf PASSED `> 0` and survived as a usable exemplar carrying infinite
+    # weight, so the most nonsensical row in a corpus read as its most valid one.
+    # Codex reported only the NaN case; fixing that alone would have left inf.
+    return value if math.isfinite(value) else None
 
 
 def _drop_malformed_weights(rows):

--- a/plugins/kipi-core/voicekit/corpus.py
+++ b/plugins/kipi-core/voicekit/corpus.py
@@ -69,6 +69,22 @@ def read_json(path):
         return None
 
 
+def _weight(row):
+    """A row's weight as a number, or 0 when it is not one (ASK-508, sp-18daaa21).
+
+    read_jsonl only guarantees the LINE parsed, never that a numeric field holds a
+    number -- so `{"weight": "heavy"}` is valid JSON, is counted as no skip, and
+    reached a bare float() that raised ValueError from inside active_exemplars().
+    That walked straight past the degrade-without-dying boundary this loader
+    exists to hold: one junk field in one row took down every other row with it.
+    Unreadable weight means unusable row, which is what a zero already means here.
+    """
+    try:
+        return float(row.get("weight", 1.0) or 0)
+    except (TypeError, ValueError):
+        return 0.0
+
+
 class Voice:
     """Everything one voice/ dir holds, read once, with decay counts."""
 
@@ -87,7 +103,7 @@ class Voice:
         return [r for r in self.exemplars
                 if r.get("status", "active") == "active"
                 and (r.get("text") or "").strip()
-                and float(r.get("weight", 1.0) or 0) > 0]
+                and _weight(r) > 0]
 
     def active_corrections(self):
         """Rows still carried as prose. A `promoted` row's gate carries it instead."""

--- a/plugins/kipi-core/voicekit/fingerprint.py
+++ b/plugins/kipi-core/voicekit/fingerprint.py
@@ -147,7 +147,15 @@ def _percentile(values, q):
 # bands computed by one instrument and evaluated by another is the _version_key
 # scar again -- silent skew, every check green, verdicts wrong. `version_skew`
 # is the paired check; the consuming staleness test calls it.
-METRICS_VERSION = 2
+# 2 -> 3: the _FIRST_PERSON case classes above changed what first_person_rate
+# COUNTS, so bands computed by the old instrument measure something the new one
+# does not. Caught by codex on PR #127 as a major, and the trigger was already
+# written one line up ("a new regex") -- the rule existed, I changed a regex, and
+# I did not apply it. Exactly the plugin-version-bump gate an hour earlier: a
+# version key exists so a changed meaning invalidates the cached calibration, and
+# skipping the bump makes stale data look fresh against a BLOCKING gate that runs
+# unattended.
+METRICS_VERSION = 3
 
 
 def version_skew(fingerprint_doc):

--- a/plugins/kipi-core/voicekit/fingerprint.py
+++ b/plugins/kipi-core/voicekit/fingerprint.py
@@ -41,7 +41,18 @@ _FORMAL_PAIRS = re.compile(
     r"can not|will not|would not|should not|could not|have not|has not|it is|"
     r"that is|there is|you are|we are|they are|i am)\b", re.I)
 
-_FIRST_PERSON = re.compile(r"\b(?:I|I'm|I've|I'll|I'd|we|we're|we've|my|our|me)\b")
+# NOT re.I, and not case-sensitive either -- split on purpose (ASK-508,
+# sp-9642b63d's sibling). Every other pattern in this file carries re.I, and this
+# one shipped without it, so "We shipped" and "My take" scored as impersonal: the
+# same prose measured differently depending on where a sentence happened to
+# break, in a metric whose band is BLOCKING. Adding re.I across the whole pattern
+# is the obvious fix and is wrong -- \bi\b would then match the "i" in "i.e."
+# and invent first-person voice in prose that has none. The I-forms are always
+# capitalized in English, so they stay exact; only the words that vary innocently
+# with sentence position get both cases.
+_FIRST_PERSON = re.compile(
+    r"\b(?:I|I'm|I've|I'll|I'd"
+    r"|[Ww]e|[Ww]e're|[Ww]e've|[Mm]y|[Oo]ur|[Mm]e)\b")
 
 # Hedges: the softeners that dilute a verdict. Small list, presence-per-post is the
 # metric; an exhaustive list would be a banned-word gate, which is a different tool.

--- a/plugins/kipi-core/voicekit/tests/test_voicekit.py
+++ b/plugins/kipi-core/voicekit/tests/test_voicekit.py
@@ -71,6 +71,33 @@ class TestFingerprint:
         assert p["short_share"] > s["short_share"]
         assert p["first_person_rate"] > s["first_person_rate"]
 
+    def test_first_person_rate_is_the_same_sentence_cased(self, ):
+        """Capitalization must not move a MEASUREMENT (ASK-508, sp-83d62639).
+
+        _FIRST_PERSON was the only pattern in fingerprint.py without re.I, so
+        "We shipped" and "My take" scored as impersonal and the same prose
+        measured differently depending on where a sentence happened to break.
+        The band this feeds is blocking, so a case-sensitive count is a gate
+        that moves under the text.
+        """
+        # No bare lowercase "i" here on purpose: the I-forms stay case-sensitive
+        # so that i.e. cannot read as first person (the test below), which means
+        # "i" and "I" are NOT expected to measure the same. The words that vary
+        # innocently with sentence position are the ones this pins.
+        lower = "we broke it. my fault, our call, blame me."
+        upper = "We broke it. My fault, Our call, blame Me."
+        assert (fingerprint.metrics(upper)["first_person_rate"]
+                == fingerprint.metrics(lower)["first_person_rate"])
+
+    def test_bare_i_in_an_abbreviation_is_not_first_person(self, ):
+        """The guard on the fix above: re.I across the whole pattern would make
+        \\bi\\b match the "i" in "i.e.", inventing first-person voice in prose
+        that has none. The I-forms stay case-sensitive; only the genuinely
+        case-varying words become case-insensitive.
+        """
+        assert fingerprint.metrics("The gate, i.e. the hook, ran.")[
+            "first_person_rate"] == 0.0
+
     def test_compute_then_score_roundtrip(self):
         texts = [PUNCHY, PUNCHY + " More of it.", "Short. Very. It broke. I saw."]
         fp = fingerprint.compute(texts, generated_at="2026-08-06",
@@ -120,6 +147,21 @@ class TestCorpus:
         d.mkdir()
         (d / corpus.EXEMPLARS).write_text("{a\n{b\n{c\n")
         assert corpus.load(str(d)).skipped_rows == 3
+
+    def test_nonnumeric_weight_degrades_instead_of_raising(self, tmp_path):
+        """A row can be VALID JSON and still carry junk in a numeric field
+        (ASK-508, sp-18daaa21).
+
+        read_jsonl only guarantees the LINE parsed, so it counts no skip here and
+        float() raised ValueError inside active_exemplars() -- past the
+        degrade-without-dying boundary the loader exists to hold. The usable rows
+        around it must still come back.
+        """
+        rows = _rows(2)
+        rows[0]["weight"] = "heavy"
+        v = corpus.load(_voice_dir(tmp_path, rows=rows))
+        assert [r["id"] for r in v.active_exemplars()] == ["ex-01"], (
+            "a junk weight must drop its own row and spare the rest")
 
     def test_retired_and_zero_weight_rows_are_excluded(self, tmp_path):
         rows = _rows(3)
@@ -225,6 +267,27 @@ class TestAssemble:
         v = corpus.load(_voice_dir(tmp_path, corrections=cor))
         text, _ = assemble.voice_section(v, "linkedin", counter=0)
         assert "X only rule" not in text
+
+    def test_off_channel_correction_is_not_recorded_as_applied(self, tmp_path):
+        """Provenance is a RECEIPT, so it may only name corrections the prompt
+        actually carried (ASK-508, sp-9642b63d).
+
+        test_scoped_correction_excluded_off_channel above pins the prompt half
+        and stops there, which is exactly why this survived review: the rule was
+        correctly withheld from the model and still recorded as applied. Same
+        class as the notify_cap scar, where an exit code became proof of a page
+        that never sent.
+        """
+        cor = [{"id": "on", "status": "active", "scope": ["linkedin"],
+                "instruction": "Linkedin only rule."},
+               {"id": "off", "status": "active", "scope": ["x"],
+                "instruction": "X only rule."}]
+        v = corpus.load(_voice_dir(tmp_path, corrections=cor))
+        text, prov = assemble.voice_section(v, "linkedin", counter=0)
+        assert "X only rule" not in text, "precondition: the rule is withheld"
+        assert prov["correction_ids"] == ["on"], (
+            "provenance named %r; it must name only what the prompt carried"
+            % (prov["correction_ids"],))
 
     def test_promoted_correction_stops_loading(self, tmp_path):
         cor = [{"id": "c1", "status": "promoted", "instruction": "Old rule."}]

--- a/plugins/kipi-core/voicekit/tests/test_voicekit.py
+++ b/plugins/kipi-core/voicekit/tests/test_voicekit.py
@@ -199,6 +199,29 @@ class TestCorpus:
             "a junk weight must show up as decay, not vanish (got %r)"
             % (v.skipped_rows,))
 
+    def test_non_finite_weights_are_counted_as_decay(self, tmp_path):
+        """NaN and the infinities go through the same door as a junk string
+        (ASK-508, codex minor on PR #127 round 2).
+
+        float("NaN") and float("inf") PARSE, so the previous fix's try/except
+        never fired. NaN then fails `> 0` and vanished uncounted, exactly the
+        silent decay the round-1 fix was supposed to end. inf is worse in kind:
+        it passes `> 0` and survives as a usable exemplar carrying infinite
+        weight, so a nonsense row reads as the most valid row in the corpus.
+
+        Fixing only the reported NaN would leave that. A weight has to be a
+        real number to mean anything, so the check is finiteness, not a list of
+        the spellings someone happened to report.
+        """
+        for spelling in ("NaN", "inf", "-inf", "Infinity"):
+            rows = _rows(2)
+            rows[0]["weight"] = spelling
+            v = corpus.load(_voice_dir(tmp_path, rows=rows))
+            assert [r["id"] for r in v.active_exemplars()] == ["ex-01"], (
+                "%r must not survive as a usable row" % spelling)
+            assert v.skipped_rows == 1, (
+                "%r must show up as decay, got %r" % (spelling, v.skipped_rows))
+
     def test_retired_and_zero_weight_rows_are_excluded(self, tmp_path):
         rows = _rows(3)
         rows[0]["status"] = "retired"

--- a/plugins/kipi-core/voicekit/tests/test_voicekit.py
+++ b/plugins/kipi-core/voicekit/tests/test_voicekit.py
@@ -98,6 +98,25 @@ class TestFingerprint:
         assert fingerprint.metrics("The gate, i.e. the hook, ran.")[
             "first_person_rate"] == 0.0
 
+    def test_bands_from_the_pre_fix_instrument_are_stale(self, ):
+        """A LITERAL version, not a relative one (ASK-508, codex major on #127).
+
+        first_person_rate changed meaning when the case classes landed, so bands
+        computed before that measure occurrences the old instrument could not
+        see. METRICS_VERSION 2 is the value that shipped WITH the old regex, so
+        a doc carrying it must now read as skewed or validate.py keeps treating
+        pre-fix bands as current -- in a BLOCKING band that runs unattended,
+        which means valid founder text refused at 3am by a gate calibrated to a
+        different instrument.
+
+        Asserted against the literal 2 on purpose. The staleness test below uses
+        METRICS_VERSION - 1, which follows the constant and therefore stays green
+        whether or not anyone remembers to bump it -- it cannot catch a missing
+        bump, which is the whole failure mode here.
+        """
+        assert fingerprint.version_skew({"metrics_version": 2}), (
+            "bands from the pre-case-class instrument must not read as current")
+
     def test_compute_then_score_roundtrip(self):
         texts = [PUNCHY, PUNCHY + " More of it.", "Short. Very. It broke. I saw."]
         fp = fingerprint.compute(texts, generated_at="2026-08-06",
@@ -162,6 +181,23 @@ class TestCorpus:
         v = corpus.load(_voice_dir(tmp_path, rows=rows))
         assert [r["id"] for r in v.active_exemplars()] == ["ex-01"], (
             "a junk weight must drop its own row and spare the rest")
+
+    def test_nonnumeric_weight_is_counted_as_decay(self, tmp_path):
+        """Dropping the row is half the job; the drop has to be VISIBLE
+        (ASK-508, codex minor on #127).
+
+        skipped_rows is the deadman signal validation and provenance read, and
+        the first cut of the crash fix returned 0.0 for a junk weight and said
+        nothing. A corpus quietly rotting to zero usable rows would have looked
+        identical to a healthy one. A malformed field is a malformed ROW, the
+        same class as a torn line, so it is counted where torn lines are.
+        """
+        rows = _rows(2)
+        rows[0]["weight"] = "heavy"
+        v = corpus.load(_voice_dir(tmp_path, rows=rows))
+        assert v.skipped_rows == 1, (
+            "a junk weight must show up as decay, not vanish (got %r)"
+            % (v.skipped_rows,))
 
     def test_retired_and_zero_weight_rows_are_excluded(self, tmp_path):
         rows = _rows(3)


### PR DESCRIPTION
The three Codex minors from #126, now fixed. All in `plugins/kipi-core/voicekit/`.
They were merged as APPROVE WITH NITS because none sat in the token-guard path
and blocking a verified fix on unrelated nits would be the gate misfiring.

## 1. Provenance claimed corrections the model never saw (`sp-9642b63d`)

`assemble.py` filtered corrections into the prompt by channel scope, then
recorded **all** of them in provenance. A correction scoped to another channel
was correctly withheld from the model and still reported as applied.

Two independent readers of one fact. Now one filtered list feeds both the prompt
and the receipt. Same class as the `notify_cap` scar: a receipt for an action
that did not occur, which is worse than no receipt because it looks
authoritative. The echo gate trusts `correction_ids`.

Why it survived review: `test_scoped_correction_excluded_off_channel` asserts the
rule is absent from the **text** and never checks provenance. The suite pinned
the visible half and left the receipt unchecked.

## 2. First-person measurement moved with capitalization (`sp-83d62639`)

`_FIRST_PERSON` was the only pattern in `fingerprint.py` without `re.I`, so
"We shipped" and "My take" scored as impersonal. The same prose measured
differently depending on where a sentence happened to break, in a metric whose
band is **blocking** — a gate moving under the text.

Blanket `re.I` is the obvious fix and is wrong: `\bi\b` then matches the "i" in
"i.e." and invents first-person voice in prose that has none. I-forms stay exact;
only words that vary innocently with sentence position get both cases. A
dedicated test pins the `i.e.` case, and the mutation run below confirms it kills
the naive fix.

## 3. One junk field took down every other row (`sp-18daaa21`)

`read_jsonl` only guarantees the LINE parsed, never that a numeric field holds a
number. `{"weight": "heavy"}` is valid JSON, counted as no skip, and reached a
bare `float()` that raised `ValueError` inside `active_exemplars()` — past the
degrade-without-dying boundary the loader exists to hold. Unreadable weight now
means unusable row, which is what a zero already meant.

## Fixtures

Synthetic, driving the real loader through the existing `_voice_dir` builder.
kipi-system is PUBLIC and `tests/test_no_founder_data.py` holds the METHOD/DATA
split, so real corpus text in a fixture would be founder data published to the
world. Synthetic is required here, not a shortcut.

## Verification

```
RED before   3 reproducers failed, each for its own reason
             "provenance named ['on','off']; it must name only what the prompt carried"
GREEN after  54 passed
mutants      4/4 KILLED
```

Mutants: provenance-back-to-all-corrections, drop the case classes, blanket
`re.I`, and bare `float()` — each turns a test red. The blanket-`re.I` mutant is
killed by the `i.e.` guard, which is the negative self-test for fix 2.

`kipi-core` 1.5.20 → 1.5.21. The `plugin-version-bump` gate refused the first
commit without it, correctly: the version-keyed cache would otherwise serve the
stale copy and these fixes would be inert at runtime.

🤖 Generated with [Claude Code](https://claude.com/claude-code)