### PR TITLE
voicekit: state the property instead of listing the reported spellings (ASK-512)

### DIFF
--- a/plugins/kipi-core/.claude-plugin/plugin.json
+++ b/plugins/kipi-core/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "kipi-core",
-  "version": "1.5.25",
+  "version": "1.5.26",
   "description": "Core founder OS — voice, research, AUDHD, LinkedIn/brand, RCA skills + kipi-mcp server",
   "author": {
     "name": "Assaf Kipnis",

--- a/plugins/kipi-core/.claude-plugin/plugin.json
+++ b/plugins/kipi-core/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "kipi-core",
-  "version": "1.5.23",
+  "version": "1.5.24",
   "description": "Core founder OS — voice, research, AUDHD, LinkedIn/brand, RCA skills + kipi-mcp server",
   "author": {
     "name": "Assaf Kipnis",

--- a/plugins/kipi-core/.claude-plugin/plugin.json
+++ b/plugins/kipi-core/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "kipi-core",
-  "version": "1.5.24",
+  "version": "1.5.25",
   "description": "Core founder OS — voice, research, AUDHD, LinkedIn/brand, RCA skills + kipi-mcp server",
   "author": {
     "name": "Assaf Kipnis",

--- a/plugins/kipi-core/voicekit/corpus.py
+++ b/plugins/kipi-core/voicekit/corpus.py
@@ -88,7 +88,14 @@ def _weight(row):
     if isinstance(raw, bool):
         return None
     try:
-        value = float(raw or 0)
+        # float(raw), NOT float(raw or 0). The `or 0` conflated FALSY with ZERO,
+        # so [], {}, "" and null each became 0.0: retained on the row, excluded
+        # from active_exemplars by `> 0`, and never counted as decay (codex
+        # minor, PR #128). float() rejects all of them on its own -- TypeError
+        # for the containers and null, ValueError for the empty string -- while
+        # a real 0 still parses to 0.0 and stays a deliberate zero rather than
+        # damage.
+        value = float(raw)
     except (TypeError, ValueError, OverflowError):
         # OverflowError is the one ASK-508 missed (ASK-512): a plain JSON
         # integer like 10**400 is valid, parses as JSON, and blows up in float()

--- a/plugins/kipi-core/voicekit/corpus.py
+++ b/plugins/kipi-core/voicekit/corpus.py
@@ -81,9 +81,19 @@ def _weight(row):
     exists to hold: one junk field in one row took down every other row with it.
     Unreadable weight means unusable row, which is what a zero already means here.
     """
+    raw = row.get("weight", 1.0)
+    # A JSON boolean is a TYPE error, not a magnitude, and it has to be rejected
+    # BEFORE float() because bool subclasses int in Python: float(True) is 1.0,
+    # so `{"weight": true}` would otherwise read as a perfectly ordinary row.
+    if isinstance(raw, bool):
+        return None
     try:
-        value = float(row.get("weight", 1.0) or 0)
-    except (TypeError, ValueError):
+        value = float(raw or 0)
+    except (TypeError, ValueError, OverflowError):
+        # OverflowError is the one ASK-508 missed (ASK-512): a plain JSON
+        # integer like 10**400 is valid, parses as JSON, and blows up in float()
+        # without being either a TypeError or a ValueError -- so the
+        # degrade-only loader still died on one row of valid input.
         return None
     # FINITENESS, not a list of the spellings someone reported. float() PARSES
     # "NaN", "inf" and "Infinity", so the try/except above never fired for them

--- a/plugins/kipi-core/voicekit/fingerprint.py
+++ b/plugins/kipi-core/voicekit/fingerprint.py
@@ -52,7 +52,13 @@ _FORMAL_PAIRS = re.compile(
 # with sentence position get both cases.
 _FIRST_PERSON = re.compile(
     r"\b(?:I|I'm|I've|I'll|I'd"
-    r"|[Ww]e|[Ww]e're|[Ww]e've|[Mm]y|[Oo]ur|[Mm]e)\b")
+    # A SCOPED flag, not more spellings (ASK-512). [Ww]e covered sentence-case
+    # and lowercase and still missed ALL-CAPS, so a headline or an emphatic line
+    # measured as impersonal in a BLOCKING band. Enumerating the casings a
+    # reviewer happened to name is what left the hole; (?i: ...) states the
+    # property instead, and keeps the I-forms outside it so "i.e." is still not
+    # first person.
+    r"|(?i:we|we're|we've|my|our|me))\b")
 
 # Hedges: the softeners that dilute a verdict. Small list, presence-per-post is the
 # metric; an exhaustive list would be a banned-word gate, which is a different tool.

--- a/plugins/kipi-core/voicekit/fingerprint.py
+++ b/plugins/kipi-core/voicekit/fingerprint.py
@@ -161,7 +161,20 @@ def _percentile(values, q):
 # version key exists so a changed meaning invalidates the cached calibration, and
 # skipping the bump makes stale data look fresh against a BLOCKING gate that runs
 # unattended.
-METRICS_VERSION = 3
+# 3 -> 4: the (?i: ...) scoped flag above changed what first_person_rate COUNTS
+# again. Measured, not assumed: "WE SHIPPED MY CODE. WE DID." reads 0.0 under
+# v3 and 50.0 under v4, so a v3 fingerprint's bands describe a different
+# instrument.
+#
+# THIRD MISS OF THIS RULE IN ONE SESSION, all mine: plugin-version-bump caught
+# an unbumped kipi-core, then caught it again on the commit whose own subject
+# was forgetting a version key, and codex caught this one on the PR that FIXED a
+# METRICS_VERSION bug. The rule was written directly above this constant the
+# whole time. A constant a human has to remember to hand-bump is the wrong
+# mechanism for an invariant a blocking unattended gate depends on; a
+# deterministic check that fails when a metric's computation changes without its
+# version moving is captured in the ledger rather than bolted onto this PR.
+METRICS_VERSION = 4
 
 
 def version_skew(fingerprint_doc):

--- a/plugins/kipi-core/voicekit/tests/test_voicekit.py
+++ b/plugins/kipi-core/voicekit/tests/test_voicekit.py
@@ -258,14 +258,36 @@ class TestCorpus:
         loader dead. Listing the shapes someone reported is what left it, so
         this walks the scalar space instead.
         """
-        junk = ["heavy", "NaN", "inf", "-inf", "Infinity", 10 ** 400,
-                -(10 ** 400), None, True, [], {}, "", "1e999"]
-        for bad in junk:
+        # TWO assertions per shape, because the first cut made only the first
+        # one and was structurally blind to the codex nit on PR #128: a falsy
+        # malformed weight ([], {}, "", null) hit `float(raw or 0)`, became 0.0,
+        # failed `> 0`, and so satisfied "not usable" while being RETAINED and
+        # never counted as decay. A table that asserts one half of a property is
+        # the same defect as the METRICS_VERSION - 1 test replaced this round.
+        malformed = ["heavy", "NaN", "inf", "-inf", "Infinity", 10 ** 400,
+                     -(10 ** 400), None, True, False, [], {}, "", "1e999"]
+        for bad in malformed:
             rows = _rows(2)
             rows[0]["weight"] = bad
             v = corpus.load(_voice_dir(tmp_path, rows=rows))
             assert [r["id"] for r in v.active_exemplars()] == ["ex-01"], (
                 "weight=%r must not survive as usable" % (bad,))
+            assert v.skipped_rows == 1, (
+                "weight=%r is malformed, so it must show as decay (got %r)"
+                % (bad, v.skipped_rows))
+
+        # The other side of the boundary: a real zero is a DECISION, not damage.
+        # Without this the fix could over-reach and start counting deliberate
+        # zero-weight rows as corpus decay, which would fire the deadman signal
+        # on a healthy corpus.
+        for legit in (0, 0.0, "0"):
+            rows = _rows(2)
+            rows[0]["weight"] = legit
+            v = corpus.load(_voice_dir(tmp_path, rows=rows))
+            assert [r["id"] for r in v.active_exemplars()] == ["ex-01"]
+            assert v.skipped_rows == 0, (
+                "weight=%r is a deliberate zero, not decay (got %r)"
+                % (legit, v.skipped_rows))
 
     def test_retired_and_zero_weight_rows_are_excluded(self, tmp_path):
         rows = _rows(3)

--- a/plugins/kipi-core/voicekit/tests/test_voicekit.py
+++ b/plugins/kipi-core/voicekit/tests/test_voicekit.py
@@ -133,8 +133,15 @@ class TestFingerprint:
         whether or not anyone remembers to bump it -- it cannot catch a missing
         bump, which is the whole failure mode here.
         """
-        assert fingerprint.version_skew({"metrics_version": 2}), (
-            "bands from the pre-case-class instrument must not read as current")
+        # A TABLE of literals, one per version that shipped a DIFFERENT
+        # first_person_rate. Grown, never rewritten: 2 shipped the no-re.I
+        # regex, 3 shipped [Ww]e (which measured ALL-CAPS as impersonal --
+        # "WE SHIPPED MY CODE. WE DID." reads 0.0 under 3 and 50.0 under 4).
+        # Each new row is the receipt that a measurement change was noticed.
+        for shipped in (2, 3):
+            assert fingerprint.version_skew({"metrics_version": shipped}), (
+                "bands computed by instrument v%d measure something this "
+                "version does not; they must not read as current" % shipped)
 
     def test_compute_then_score_roundtrip(self):
         texts = [PUNCHY, PUNCHY + " More of it.", "Short. Very. It broke. I saw."]

--- a/plugins/kipi-core/voicekit/tests/test_voicekit.py
+++ b/plugins/kipi-core/voicekit/tests/test_voicekit.py
@@ -89,6 +89,25 @@ class TestFingerprint:
         assert (fingerprint.metrics(upper)["first_person_rate"]
                 == fingerprint.metrics(lower)["first_person_rate"])
 
+    def test_capitalization_never_moves_the_measurement(self, ):
+        """The PROPERTY, across a case table, not the spellings a reviewer named
+        (ASK-512).
+
+        ASK-508 fixed "We shipped" and shipped [Ww]e, which still missed
+        ALL-CAPS -- so a headline or emphatic line measured as impersonal in a
+        BLOCKING band. Enumerating shapes is what left the hole; the invariant
+        is that case carries no information about first person, so every casing
+        of the same sentence must land on the same number.
+        """
+        variants = ["we broke it and my call cost us our week",
+                    "We broke it and My call cost us Our week",
+                    "WE BROKE IT AND MY CALL COST US OUR WEEK",
+                    "wE bRoKe It AnD mY cAlL cOsT uS oUr WeEk"]
+        rates = {v: fingerprint.metrics(v)["first_person_rate"] for v in variants}
+        assert len(set(rates.values())) == 1, (
+            "capitalization moved the measurement: %r" % rates)
+        assert all(r > 0 for r in rates.values()), "precondition: some matched"
+
     def test_bare_i_in_an_abbreviation_is_not_first_person(self, ):
         """The guard on the fix above: re.I across the whole pattern would make
         \\bi\\b match the "i" in "i.e.", inventing first-person voice in prose
@@ -221,6 +240,25 @@ class TestCorpus:
                 "%r must not survive as a usable row" % spelling)
             assert v.skipped_rows == 1, (
                 "%r must show up as decay, got %r" % (spelling, v.skipped_rows))
+
+    def test_no_json_scalar_weight_can_crash_the_loader(self, tmp_path):
+        """The PROPERTY: a weight is a finite number or the row is decay, for
+        every scalar JSON can carry (ASK-512).
+
+        ASK-508 caught non-numeric strings and the non-finite floats, then
+        missed a plain integer too big for a float -- float(10**400) raises
+        OverflowError, which (TypeError, ValueError) does not catch. Valid JSON,
+        loader dead. Listing the shapes someone reported is what left it, so
+        this walks the scalar space instead.
+        """
+        junk = ["heavy", "NaN", "inf", "-inf", "Infinity", 10 ** 400,
+                -(10 ** 400), None, True, [], {}, "", "1e999"]
+        for bad in junk:
+            rows = _rows(2)
+            rows[0]["weight"] = bad
+            v = corpus.load(_voice_dir(tmp_path, rows=rows))
+            assert [r["id"] for r in v.active_exemplars()] == ["ex-01"], (
+                "weight=%r must not survive as usable" % (bad,))
 
     def test_retired_and_zero_weight_rows_are_excluded(self, tmp_path):
         rows = _rows(3)


### PR DESCRIPTION
Follow-on to ASK-508 (#127, merged `71912fac`). Both fixes there closed the
instance Codex named and left the class open.

Found in the **spillover ledger at closeout**, not in any handoff. The reviewer
auto-captured them across #127 rounds and they sat open while I merged claiming
those classes were shut. That is the no-orphan-findings rule doing its job, and
the reason to read the ledger directly rather than a summary of it.

## 1. The degrade-only loader still died on valid JSON

```
>>> float(10**400)
OverflowError            # not a TypeError, not a ValueError
```

So one oversized integer weight still took the loader down — the exact
degrade-without-dying breach ASK-508 said it closed.

A JSON boolean was the other half: `bool` subclasses `int`, so `float(True)` is
`1.0` and `{"weight": true}` read as a perfectly ordinary row. Rejected before
`float()` now, because after it there is nothing left to see.

## 2. First-person measurement still moved under ALL-CAPS

```
"WE SHIPPED MY CODE"  -> []                first_person_rate 0.0
"We shipped my code"  -> ['We', 'my']
```

`[Ww]e` covers sentence-case and lowercase. A headline, an acronym-heavy line or
emphatic prose still measured as impersonal in a **blocking** band.

Replaced with the scoped flag `(?i:we|we're|we've|my|our|me)`, which keeps the
I-forms case-sensitive so `i.e.` is still not first person.

## The through-line is the method, not the two bugs

ASK-508's own commit message argued for *"finiteness, not a list of the
spellings someone happened to report"* — and then shipped a list of the
spellings someone happened to report. Naming the principle is not applying it.

So both reproducers now assert the **property** over a shape table:

- every casing of one sentence must land on the same number
- no JSON scalar may crash the loader (`"heavy"`, `NaN`, `inf`, `-inf`,
  `Infinity`, `10**400`, `-(10**400)`, `null`, `true`, `[]`, `{}`, `""`,
  `"1e999"`)

which covers the next unlisted shape by construction rather than by my
remembering it.

## Verification

```
RED before   2 failed, incl. a real OverflowError traceback at corpus.py:85
GREEN after  59 passed
mutants      control 59 passed; all 4 KILLED
             scoped flag -> [Ww]e spellings, OverflowError dropped from the
             except, bool rejection dropped, finiteness check dropped
```

Mutation harness gives every run its own `PYTHONPYCACHEPREFIX` and reports a
passing control — a same-size one-character mutant otherwise leaves stale
bytecode that makes the restored code test as the mutant.

kipi-core 1.5.23 → 1.5.24.

🤖 Generated with [Claude Code](https://claude.com/claude-code)