### PR TITLE
The version-bump gate compares against the merge base, not the moving tip (ASK-514)

### DIFF
--- a/.github/workflows/validate.yml
+++ b/.github/workflows/validate.yml
@@ -84,15 +84,23 @@ jobs:
       - name: Plugin version-bump guard (PR only)
         if: github.event_name == 'pull_request'
         run: |
-          # NOT --depth=1: that writes .git/shallow even into an already-complete
-          # clone, which silently undoes the `fetch-depth: 0` above and re-breaks
-          # the `merge-base --is-ancestor` probe in test-updater-issue-sequence.py.
-          # Today only step ORDER keeps that from firing (the capability gate runs
-          # earlier), and nothing encodes that dependency -- a reordering would
-          # quietly restore the original bug. History is already local, so there is
-          # nothing to shorten. Found by adversarial review 2026-07-26.
-          git fetch origin main || true
-          python3 q-system/.q-system/scripts/plugin-version-bump-check.py --against origin/main
+          # The base is GitHub's OWN base sha for this PR, not a fetched ref
+          # (ASK-514). `git fetch origin main || true` swallowed its failure and
+          # left origin/main STALE BUT RESOLVABLE, which is the dangerous shape:
+          # the gate's fail-closed guard never fires because the ref resolves,
+          # and version_at(stale base) then reads a HISTORICAL bump that makes
+          # the PR's own unbumped plugin look bumped. Measured on a scratch repo:
+          #     --against HEAD        -> exit 2   correctly refused
+          #     --against stale-main  -> exit 0   the violation was EXCUSED
+          #
+          # base.sha comes from the event payload, so it needs no network, always
+          # resolves, and cannot go stale. `fetch-depth: 0` on the checkout above
+          # is what guarantees the commit is present locally -- do not weaken it
+          # to --depth=1, which writes .git/shallow even into an already-complete
+          # clone and re-breaks the `merge-base --is-ancestor` probe in
+          # test-updater-issue-sequence.py (adversarial review 2026-07-26).
+          python3 q-system/.q-system/scripts/plugin-version-bump-check.py \
+            --against "${{ github.event.pull_request.base.sha }}"
         env:
           CI: true
 

--- a/plugins/kipi-design/.claude-plugin/plugin.json
+++ b/plugins/kipi-design/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "kipi-design",
-  "version": "1.2.8",
+  "version": "1.2.9",
   "description": "Brand, UI/UX, and design skills",
   "author": {
     "name": "Assaf Kipnis",

--- a/q-system/.q-system/scripts/plugin-version-bump-check.py
+++ b/q-system/.q-system/scripts/plugin-version-bump-check.py
@@ -34,6 +34,15 @@ def run(args):
     return subprocess.run(args, capture_output=True, text=True).stdout
 
 
+def run_ok(args):
+    """(succeeded, stdout). run() discards the return code, which is what let a
+    FAILED git command look identical to one that found nothing: `git diff
+    <bad-ref>` returns "", changed_files sees no files, and the gate exits 0
+    having verified nothing at all (codex major, PR #129)."""
+    p = subprocess.run(args, capture_output=True, text=True)
+    return p.returncode == 0, p.stdout
+
+
 def changed_files(diff_args):
     out = run(["git", "diff", "--name-only"] + diff_args)
     return [l for l in out.splitlines() if l.strip()]
@@ -62,8 +71,30 @@ def merge_base(ref):
     sha with no common ancestor) keeps the previous behaviour rather than
     crashing a blocking gate on an edge it cannot resolve.
     """
-    out = run(["git", "merge-base", ref, "HEAD"]).strip()
-    return out or ref
+    # FAIL CLOSED on a ref that does not resolve. A blocking gate that silently
+    # becomes NO gate is worse than no gate, because CI reports it green -- and
+    # the workflow makes this reachable rather than theoretical:
+    #     git fetch origin main || true
+    #     ... --against origin/main
+    # The `|| true` swallows a fetch failure, so on a runner whose fetch failed
+    # origin/main may not resolve, and every version-bump violation in the PR
+    # would sail through unexamined. Verified before the fix: `--against
+    # no-such-ref-xyz` exited 0 with a real unbumped plugin change in the tree.
+    resolves, _ = run_ok(["git", "rev-parse", "--verify", "--quiet",
+                          "%s^{commit}" % ref])
+    if not resolves:
+        sys.stderr.write(
+            "plugin-version-bump-check: cannot resolve --against ref %r, so the "
+            "version-bump check could not run. Refusing rather than passing "
+            "unchecked. If this is CI, the `git fetch` for that ref likely "
+            "failed.\n" % ref)
+        sys.exit(2)
+    ok, out = run_ok(["git", "merge-base", ref, "HEAD"])
+    base = out.strip()
+    # No merge base (unrelated histories) is NOT the same as an unresolvable
+    # ref: the ref exists, so comparing against it directly is still meaningful
+    # and is the behaviour that shipped. Only the missing-ref case refuses.
+    return base if ok and base else ref
 
 
 def plugins_touched(files):

--- a/q-system/.q-system/scripts/plugin-version-bump-check.py
+++ b/q-system/.q-system/scripts/plugin-version-bump-check.py
@@ -39,6 +39,33 @@ def changed_files(diff_args):
     return [l for l in out.splitlines() if l.strip()]
 
 
+def merge_base(ref):
+    """The commit this branch actually diverged at, or `ref` if git cannot say.
+
+    Scar (ASK-514, sp-05762519): this compared against the moving TIP of
+    origin/main, and it was wrong in BOTH directions at once.
+
+    Too loud: any plugin changed on main AFTER a PR branched shows up in
+    `git diff <tip>`, and its version matches on both sides because the PR never
+    touched it -- which is precisely the violation shape. PR #127 touched only
+    plugins/kipi-core and CI failed it for plugins/kipi-design; merging main in,
+    with no code change at all, turned it green.
+
+    Too quiet, and this is the half that is easy to miss: a version bump landing
+    on MAIN makes the PR's own unbumped plugin look bumped, because
+    version_at(tip) then differs from version_now() for a change the PR never
+    made. The gate excuses a real violation.
+
+    Both follow from one mistake, so both are fixed by one resolution: the
+    comparison point is where the branch diverged, not wherever main has got to.
+    Returning `ref` unchanged when merge-base fails (unrelated histories, a bare
+    sha with no common ancestor) keeps the previous behaviour rather than
+    crashing a blocking gate on an edge it cannot resolve.
+    """
+    out = run(["git", "merge-base", ref, "HEAD"]).strip()
+    return out or ref
+
+
 def plugins_touched(files):
     """Map plugin name -> True if any non-manifest file changed (needs a bump)."""
     touched = {}
@@ -95,7 +122,7 @@ def main():
         sys.exit(0)  # not the skeleton; nothing to check
 
     if "--against" in sys.argv:
-        ref = sys.argv[sys.argv.index("--against") + 1]
+        ref = merge_base(sys.argv[sys.argv.index("--against") + 1])
         diff_args = [ref, "--"]
     else:
         ref = "HEAD"

--- a/q-system/.q-system/scripts/test_plugin_version_bump_check.py
+++ b/q-system/.q-system/scripts/test_plugin_version_bump_check.py
@@ -215,18 +215,29 @@ def main():
     #     --against stale-main  -> exit 0   (the violation was EXCUSED)
     # github.event.pull_request.base.sha is the base GitHub itself computed for
     # the PR. It needs no fetch, always resolves, and cannot go stale.
+    # COMMENTS ARE STRIPPED FIRST, and that is the whole point of this block.
+    # The first cut scanned raw lines, so the explanatory comment above the step
+    # -- which quotes `--against HEAD` and `--against stale-main` -- kept the
+    # check green after the real argument was deleted. Verified by deleting it:
+    # the gate silently falls back to --staged mode and the test still printed
+    # "OK: all checks passed". A check that cannot fail for the reason it exists
+    # (codex minor, PR #129; same shape as METRICS_VERSION - 1 and case D).
     wf = os.path.join(HERE, "..", "..", "..", ".github", "workflows", "validate.yml")
     if os.path.isfile(wf):
-        text = open(wf).read()
-        invocations = [l for l in text.splitlines()
+        raw = open(wf).read().splitlines()
+        code = [l for l in raw if not l.strip().startswith("#")]
+        invocations = [l for l in code
                        if "plugin-version-bump-check.py" in l or "--against" in l]
         joined = "\n".join(invocations)
         check("H. CI passes an immutable base sha, not a fetched ref",
-              "--against" in joined and "origin/main" not in joined)
+              bool(invocations) and "--against" in joined
+              and "origin/main" not in joined)
+        # The fetch must not be re-added on an EXECUTABLE line near the gate.
+        idx = code.index(invocations[0]) if invocations else 0
+        near = code[max(0, idx - 6):idx + 1]
         check("I. CI does not swallow a failure on the line feeding the gate",
-              not any("|| true" in l and "fetch" in l for l in
-                      text.splitlines()[max(0, text.splitlines().index(invocations[0]) - 4):]
-                      ) if invocations else True)
+              bool(invocations)
+              and not any("|| true" in l and "fetch" in l for l in near))
 
     if failures:
         print(f"\nFAILED: {failures}")

--- a/q-system/.q-system/scripts/test_plugin_version_bump_check.py
+++ b/q-system/.q-system/scripts/test_plugin_version_bump_check.py
@@ -164,6 +164,45 @@ def main():
         check("D. a bump on MAIN does not excuse the PR's unbumped plugin",
               rc == 2 and "- foo" in err and "- bar" not in err)
 
+    # --- ASK-514: an unresolvable --against ref must FAIL CLOSED ---
+    #
+    # run() returns only stdout and throws the return code away, so a git
+    # command that FAILED was indistinguishable from one that found nothing:
+    # `git diff <bad-ref>` returned "", changed_files saw no files, and the gate
+    # exited 0 having verified nothing. A blocking check that silently becomes
+    # no check is worse than no check, because CI reports it green.
+    #
+    # The workflow makes this reachable rather than theoretical:
+    #     git fetch origin main || true
+    #     ... --against origin/main
+    # The `|| true` swallows a fetch failure, and on a runner whose fetch failed
+    # origin/main may not resolve at all.
+    with tempfile.TemporaryDirectory() as tmp:
+        git(tmp, "init", "-q")
+        git(tmp, "config", "user.email", "t@t")
+        git(tmp, "config", "user.name", "t")
+        write(os.path.join(tmp, "plugins/foo/.claude-plugin/plugin.json"),
+              manifest("1.0.0"))
+        write(os.path.join(tmp, "plugins/foo/cmd.md"), "v1\n")
+        git(tmp, "add", "-A"); git(tmp, "commit", "-qm", "init")
+
+        # A REAL violation is sitting in the tree the whole time, so a green
+        # result here can only mean the gate checked nothing at all.
+        write(os.path.join(tmp, "plugins/foo/cmd.md"), "v2\n")
+        rc, err = run_script_full(tmp, "--against", "no-such-ref-xyz")
+        check("E. an unresolvable --against ref fails CLOSED, naming the ref",
+              rc == 2 and "no-such-ref-xyz" in err)
+
+        # And the resolvable case must still work, so E is not just 'always 2'.
+        base = subprocess.run(["git", "rev-parse", "HEAD"], cwd=tmp,
+                              capture_output=True, text=True).stdout.strip()
+        check("F. a resolvable ref still evaluates normally -> exit 2",
+              run_script(tmp, "--against", base) == 2)
+        write(os.path.join(tmp, "plugins/foo/.claude-plugin/plugin.json"),
+              manifest("1.1.0"))
+        check("G. ...and still clears on a real bump -> exit 0",
+              run_script(tmp, "--against", base) == 0)
+
     if failures:
         print(f"\nFAILED: {failures}")
         sys.exit(1)

--- a/q-system/.q-system/scripts/test_plugin_version_bump_check.py
+++ b/q-system/.q-system/scripts/test_plugin_version_bump_check.py
@@ -40,6 +40,15 @@ def run_script(cwd, *args):
                           capture_output=True, text=True).returncode
 
 
+def run_script_full(cwd, *args):
+    """(returncode, stderr). Needed because an exit code alone cannot say WHICH
+    plugin was flagged, and case D below passed for the wrong plugin until the
+    reason was asserted (ASK-514)."""
+    r = subprocess.run([sys.executable, SCRIPT, *args], cwd=cwd,
+                       capture_output=True, text=True)
+    return r.returncode, r.stderr
+
+
 def main():
     failures = []
 
@@ -87,6 +96,73 @@ def main():
         base = subprocess.run(["git", "rev-parse", "HEAD"], cwd=tmp, capture_output=True, text=True).stdout.strip()
         write(os.path.join(tmp, "plugins/foo/cmd.md"), "v3\n")
         check("--against ref, changed no bump -> exit 2", run_script(tmp, "--against", base) == 2)
+
+    # --- ASK-514: --against must resolve to the MERGE BASE, not the moving tip ---
+    #
+    # The shipped check ran `git diff <ref>` and `version_at(<ref>)` against the
+    # TIP of origin/main, so anything landing on main after a PR branched was
+    # attributed to that PR. Reproduced live on PR #127, which touched only
+    # plugins/kipi-core and was failed for plugins/kipi-design.
+    #
+    # FOUR cases on purpose. A fix that simply stops the gate firing would pass
+    # case A alone, so B and C prove the gate still refuses a real violation and
+    # still clears a real bump. D is the half that is easy to miss: the moving
+    # tip can also HIDE a violation, because a bump on MAIN makes the PR's own
+    # unbumped plugin look bumped.
+    with tempfile.TemporaryDirectory() as tmp:
+        git(tmp, "init", "-q")
+        git(tmp, "config", "user.email", "t@t")
+        git(tmp, "config", "user.name", "t")
+        for name, ver in (("foo", "1.0.0"), ("bar", "2.0.0")):
+            write(os.path.join(tmp, f"plugins/{name}/.claude-plugin/plugin.json"),
+                  manifest(ver))
+            write(os.path.join(tmp, f"plugins/{name}/cmd.md"), "v1\n")
+        write(os.path.join(tmp, "README.md"), "root\n")
+        git(tmp, "add", "-A"); git(tmp, "commit", "-qm", "init")
+        git(tmp, "branch", "-M", "main")
+        git(tmp, "checkout", "-qb", "feature")
+
+        # main advances with an unbumped plugin change of its OWN (the c166cc96
+        # shape: kipi-design edited on main, version left at 1.2.8).
+        git(tmp, "checkout", "-q", "main")
+        write(os.path.join(tmp, "plugins/bar/cmd.md"), "v2\n")
+        git(tmp, "add", "-A"); git(tmp, "commit", "-qm", "main: bar, no bump")
+        git(tmp, "checkout", "-q", "feature")
+
+        # A. the PR touches no plugin at all -> main's sin is not the PR's
+        write(os.path.join(tmp, "README.md"), "feature edit\n")
+        git(tmp, "add", "-A"); git(tmp, "commit", "-qm", "feature: docs only")
+        check("A. main's unbumped plugin is NOT attributed to the PR -> exit 0",
+              run_script(tmp, "--against", "main") == 0)
+
+        # B. the PR's OWN unbumped plugin must still be refused
+        write(os.path.join(tmp, "plugins/foo/cmd.md"), "v2\n")
+        git(tmp, "add", "-A"); git(tmp, "commit", "-qm", "feature: foo, no bump")
+        check("B. the PR's own unbumped plugin STILL fails -> exit 2",
+              run_script(tmp, "--against", "main") == 2)
+
+        # C. and a real bump must still clear it, so B is not just 'always red'
+        write(os.path.join(tmp, "plugins/foo/.claude-plugin/plugin.json"),
+              manifest("1.1.0"))
+        git(tmp, "add", "-A"); git(tmp, "commit", "-qm", "feature: bump foo")
+        check("C. the PR's own plugin, bumped -> exit 0",
+              run_script(tmp, "--against", "main") == 0)
+
+        # D. the tip can HIDE a violation: main bumps foo, the PR does not, and
+        # comparing versions against the tip makes the PR look compliant.
+        git(tmp, "checkout", "-q", "main")
+        write(os.path.join(tmp, "plugins/foo/.claude-plugin/plugin.json"),
+              manifest("1.9.0"))
+        git(tmp, "add", "-A"); git(tmp, "commit", "-qm", "main: bump foo to 1.9.0")
+        git(tmp, "checkout", "-qb", "feature2", "feature~1")   # foo changed, NOT bumped
+        rc, err = run_script_full(tmp, "--against", "main")
+        # THE REASON, not just the code. Against the tip this exited 2 for `bar`
+        # -- main's own change -- while silently EXCUSING foo, because
+        # version_at(tip, foo)=1.9.0 differed from the PR's 1.0.0 and so read as
+        # a bump the PR never made. Asserting only the exit code passed on the
+        # wrong plugin and hid exactly the half this case exists to catch.
+        check("D. a bump on MAIN does not excuse the PR's unbumped plugin",
+              rc == 2 and "- foo" in err and "- bar" not in err)
 
     if failures:
         print(f"\nFAILED: {failures}")

--- a/q-system/.q-system/scripts/test_plugin_version_bump_check.py
+++ b/q-system/.q-system/scripts/test_plugin_version_bump_check.py
@@ -203,6 +203,31 @@ def main():
         check("G. ...and still clears on a real bump -> exit 0",
               run_script(tmp, "--against", base) == 0)
 
+    # --- ASK-514: CI must hand the gate an IMMUTABLE base, not a fetched ref ---
+    #
+    # The gate is only as correct as the base it is given, and a
+    # remote-tracking ref is not trustworthy: `git fetch origin main || true`
+    # swallows a failure, leaving origin/main STALE BUT RESOLVABLE. Fail-closed
+    # never fires (it resolves fine), and version_at(stale base) then reads a
+    # HISTORICAL bump that makes the PR's own unbumped plugin look bumped.
+    # Measured on a scratch repo:
+    #     --against HEAD        -> exit 2   (correctly refused)
+    #     --against stale-main  -> exit 0   (the violation was EXCUSED)
+    # github.event.pull_request.base.sha is the base GitHub itself computed for
+    # the PR. It needs no fetch, always resolves, and cannot go stale.
+    wf = os.path.join(HERE, "..", "..", "..", ".github", "workflows", "validate.yml")
+    if os.path.isfile(wf):
+        text = open(wf).read()
+        invocations = [l for l in text.splitlines()
+                       if "plugin-version-bump-check.py" in l or "--against" in l]
+        joined = "\n".join(invocations)
+        check("H. CI passes an immutable base sha, not a fetched ref",
+              "--against" in joined and "origin/main" not in joined)
+        check("I. CI does not swallow a failure on the line feeding the gate",
+              not any("|| true" in l and "fetch" in l for l in
+                      text.splitlines()[max(0, text.splitlines().index(invocations[0]) - 4):]
+                      ) if invocations else True)
+
     if failures:
         print(f"\nFAILED: {failures}")
         sys.exit(1)


### PR DESCRIPTION
`plugin-version-bump-check.py` is a **blocking** required check in fleet CI, and
it was wrong in both directions at once.

## Too loud

`git diff <ref>` and `version_at(<ref>)` both read the **tip** of `origin/main`,
so any plugin changed on main *after* a PR branched appeared in the diff — and
its version matched on both sides precisely because the PR never touched it,
which is the exact violation shape.

Reproduced live: **#127 touched only `plugins/kipi-core` and CI failed it for
`plugins/kipi-design`.** Merging main in, with no code change whatsoever, turned
it green.

## Too quiet (the half that is easy to miss)

A version bump landing on **main** makes the PR's own unbumped plugin look
bumped, because `version_at(tip)` then differs from `version_now()` for a change
the PR never made. The gate *excuses* a real violation.

Same root cause, opposite symptom. One resolution fixes both: the comparison
point is where the branch diverged.

## Why four cases

The dangerous fix here is one that quietly stops the gate firing, and case A
alone cannot tell that apart from a correct fix.

| case | scenario | required |
|---|---|---|
| A | main alone changed a plugin unbumped; PR untouched | exit 0 |
| B | the PR's own plugin changed, unbumped | exit 2 |
| C | the PR's own plugin changed and bumped | exit 0 |
| D | main bumps a plugin the PR changed unbumped | exit 2 **for that plugin** |

A mutant that disables the gate outright is killed by six checks.

**Case D passed for the wrong reason in its first cut** — it exited 2 because of
`bar`, main's own change, while silently excusing `foo`. An exit code cannot say
*which* plugin was flagged, so D now asserts the reason. Third time today a
check of mine could not fail for the thing it existed to catch, and the first
time I caught it before shipping rather than after.

## Also: kipi-design 1.2.8 → 1.2.9

`c166cc96` (ASK-511) changed `hooks/dogfood_gate.py` and
`hooks/test_dogfood_gate.py` and left the version alone, so that fix was inert
for anyone whose cache is keyed on 1.2.8 — the real problem the gate was
pointing at while blaming the wrong PR.

The guard step is labelled **PR only** and does not run on pushes to `main`, so
`validate=success` on `c166cc96` is the main-push run and says nothing about
whether the guard passed.

## Verification

```
RED before   A, C, D failed; B passed
             (the gate was still refusing real violations, so this was a
              false-positive bug, not a dead gate)
GREEN after  all checks passed
mutants      revert-to-tip                KILLED (A, C, D)
             merge_base always falls back KILLED (A, C, D)
             DISABLE the gate entirely    KILLED (6 red, incl. B and D)
real repo    --against origin/main exits 0 from this branch,
             resolving to merge-base 85eb96cf
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)