### PR TITLE
URGENT: the inert-engine check cannot see a Python import, and it has main red (ASK-517)

### DIFF
--- a/q-system/.q-system/scripts/capability-gate.py
+++ b/q-system/.q-system/scripts/capability-gate.py
@@ -20,6 +20,7 @@ import argparse
 import datetime
 import json
 import os
+import re
 import signal
 import subprocess
 import sys
@@ -465,6 +466,33 @@ def gather_wiring_text(root, exclude_names):
     return "\n".join(chunks)
 
 
+def references_engine(name, surface):
+    """True when `surface` references this engine by FILENAME or by Python import.
+
+    Scar (ASK-517): the matcher was `p.name in surface`, i.e. the filename WITH
+    its .py extension, while a Python import names the module by its STEM. So
+    q-system/.q-system/scripts/loops_path.py -- imported by
+    q-system/hooks/session-start.py, which is wired in both .claude/settings.json
+    and settings-template.json -- was reported as a dead engine. That reddened
+    origin/main and blocked every merge in the repo until this fix. An engine
+    wired by `import` was structurally invisible to the one check built to find
+    dead engines.
+
+    The import form is matched EXPLICITLY, never by bare stem. A bare stem would
+    make a script called utils.py read as wired anywhere the word "utils"
+    appears, which turns the check off without anyone noticing -- trading a
+    false positive for a silent false negative, in the check whose whole job is
+    catching things nobody noticed.
+    """
+    if name in surface:
+        return True
+    if not name.endswith(".py"):
+        return False
+    stem = re.escape(name[:-3])
+    return re.search(r"\bimport\s+%s\b|\bfrom\s+%s\s+import\b" % (stem, stem),
+                     surface) is not None
+
+
 def check_inert_engines(root, manifest, errors, notes):
     """F2 class: a runnable .py with zero textual references across the wiring
     surfaces and no declared_inert entry is a silently-dead engine.
@@ -514,7 +542,7 @@ def check_inert_engines(root, manifest, errors, notes):
     while changed:
         changed = False
         for p in sorted(candidates - wired):
-            if p.name in surface:
+            if references_engine(p.name, surface):
                 wired.add(p)
                 surface += "\n" + p.read_text(errors="ignore")
                 changed = True
@@ -533,7 +561,7 @@ def check_inert_engines(root, manifest, errors, notes):
     while changed:
         changed = False
         for p in sorted(plugin_candidates - p_wired):
-            if p.name in plugin_surface:
+            if references_engine(p.name, plugin_surface):
                 p_wired.add(p)
                 plugin_surface += "\n" + p.read_text(errors="ignore")
                 changed = True

--- a/q-system/.q-system/scripts/test_capability_gate.py
+++ b/q-system/.q-system/scripts/test_capability_gate.py
@@ -223,6 +223,45 @@ def sec_wiring():
         (root / "q-system/.q-system/capability-manifest.json").write_text(json.dumps(m))
         rc, out = run_gate(root, "--check-only")
         check("wiring: declared_inert passes with note", rc == 0 and "DECLARED-INERT" in out)
+    # ASK-517: an engine wired by a PYTHON IMPORT must not read as inert.
+    # The matcher was `p.name in surface`, i.e. "loops_path.py" WITH the
+    # extension, while an import names the module by its stem -- so
+    # q-system/.q-system/scripts/loops_path.py, imported by the wired hook
+    # q-system/hooks/session-start.py, reddened origin/main and blocked every
+    # merge in the repo. Three cases, because the dangerous fix is one that
+    # loosens the matcher until nothing is ever inert again.
+    with tempfile.TemporaryDirectory() as tmp:
+        root = make_repo(tmp)
+        engine(root, "q-system/.q-system/scripts/imported_engine.py")
+        hook = root / "q-system/hooks/session-start.py"
+        hook.parent.mkdir(parents=True, exist_ok=True)
+        hook.write_text("import imported_engine\nimported_engine.go()\n")
+        rc, out = run_gate(root, "--check-only")
+        check("ASK-517: engine wired by `import <stem>` is NOT inert",
+              rc == 0 and "imported_engine" not in out)
+    with tempfile.TemporaryDirectory() as tmp:
+        root = make_repo(tmp)
+        engine(root, "q-system/.q-system/scripts/from_imported.py")
+        hook = root / "q-system/hooks/session-start.py"
+        hook.parent.mkdir(parents=True, exist_ok=True)
+        hook.write_text("from from_imported import thing\n")
+        rc, out = run_gate(root, "--check-only")
+        check("ASK-517: `from <stem> import ...` also counts",
+              rc == 0 and "from_imported" not in out)
+    with tempfile.TemporaryDirectory() as tmp:
+        # PRECISION half: a bare mention of the stem in prose is NOT wiring.
+        # Matching a bare stem would make any script called utils.py read as
+        # wired anywhere the word "utils" appears, which turns the check off
+        # without anyone noticing.
+        root = make_repo(tmp)
+        engine(root, "q-system/.q-system/scripts/only_mentioned.py")
+        hook = root / "q-system/hooks/session-start.py"
+        hook.parent.mkdir(parents=True, exist_ok=True)
+        hook.write_text("# only_mentioned is a nice idea, nobody calls it\n")
+        rc, out = run_gate(root, "--check-only")
+        check("ASK-517: a prose mention is NOT wiring, still RED",
+              rc == 1 and "only_mentioned.py" in out)
+
     # plugins/ is scanned but REPORT-ONLY: it must surface as a note and must
     # NOT fail the gate, because the widening could not be validated from a
     # worktree (sp-1cb1a348). Both halves are asserted -- a note-only check


### PR DESCRIPTION
**`origin/main` is RED on the capability gate, so nothing can merge.** Verified
on a clean detached worktree at `origin/main`, untouched by anything of mine:

```
RED: inert-engine: q-system/.q-system/scripts/loops_path.py has no reference
     on any wiring surface and no declared_inert entry
capability-gate: RED (1)
```

## The engine is wired; the gate could not see the form

The matcher was `p.name in surface` — `"loops_path.py"`, **with the extension**
— while a Python import names the module by its **stem**.

`q-system/hooks/session-start.py` is wired in both `.claude/settings.json` and
`settings-template.json`, and does `import loops_path`. Replicating the gate's
own `gather_wiring_text` rather than grepping:

```
loops_path.py  (what the gate matched on) in surface: False
loops_path     (the import form)          in surface: True
   import loops_path
   loops, status = loops_path.open_loops(qroot)
   if status != loops_path.FOUND:
```

An engine wired by `import` was structurally invisible to the one check built to
find dead engines.

## Fixed the gate, not the manifest

`loops_path.py` **is** wired. A `declared_inert` entry would have written a
falsehood into the manifest and hidden a real engine from the check permanently;
deleting it would have broken `session-start.py`.

The import form is matched **explicitly** (`import <stem>`, `from <stem> import`),
never by bare stem. A bare stem would make a script called `utils.py` read as
wired anywhere the word "utils" appears — trading a false positive for a silent
false negative, in the check whose whole job is catching what nobody noticed.

## Verification

```
RED before   the two import cases failed; the prose-mention case already passed,
             so the fix could not be "match anything"
GREEN after  ALL PASS, and capability-gate --check-only on the real repo
             goes RED (1) -> GREEN
mutants      revert-to-filename-only      KILLED (both import cases)
             BARE-STEM match              KILLED (the prose-mention case)
             everything-counts-as-wired   KILLED (8 cases)
```

The bare-stem mutant dying on the precision case is the important one: it shows
this is a fix and not a loosening.

## Provenance

Arrived via `8ee795b4` (ASK-350), which added `loops_path.py` as a shared
resolver imported by the hook. Nothing was wrong with that change — the gate
could not see its wiring form.

🤖 Generated with [Claude Code](https://claude.com/claude-code)