### PR TITLE
Combine attribution and severity so the spillover gate verdict tracks the diff (ASK-526, ASK-532)

### DIFF
--- a/plugins/prd-os/.claude-plugin/plugin.json
+++ b/plugins/prd-os/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "prd-os",
-  "version": "0.26.2",
+  "version": "0.26.3",
   "description": "PRD operating system: capture rough ideas, draft reviewable PRDs, run standard and adversarial review (Codex or a Claude senior-staff-engineer subagent, recorded truthfully), triage findings, decompose approved PRDs into atomic issue specs, and execute those issues with scope enforcement, stop-gate receipts, and reviewer-attributed findings.",
   "author": {
     "name": "Assaf Kipnis"

--- a/plugins/prd-os/.claude-plugin/plugin.json
+++ b/plugins/prd-os/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "prd-os",
-  "version": "0.26.1",
+  "version": "0.26.2",
   "description": "PRD operating system: capture rough ideas, draft reviewable PRDs, run standard and adversarial review (Codex or a Claude senior-staff-engineer subagent, recorded truthfully), triage findings, decompose approved PRDs into atomic issue specs, and execute those issues with scope enforcement, stop-gate receipts, and reviewer-attributed findings.",
   "author": {
     "name": "Assaf Kipnis"

--- a/plugins/prd-os/.claude-plugin/plugin.json
+++ b/plugins/prd-os/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "prd-os",
-  "version": "0.26.3",
+  "version": "0.26.4",
   "description": "PRD operating system: capture rough ideas, draft reviewable PRDs, run standard and adversarial review (Codex or a Claude senior-staff-engineer subagent, recorded truthfully), triage findings, decompose approved PRDs into atomic issue specs, and execute those issues with scope enforcement, stop-gate receipts, and reviewer-attributed findings.",
   "author": {
     "name": "Assaf Kipnis"

--- a/plugins/prd-os/.claude-plugin/plugin.json
+++ b/plugins/prd-os/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "prd-os",
-  "version": "0.26.0",
+  "version": "0.26.1",
   "description": "PRD operating system: capture rough ideas, draft reviewable PRDs, run standard and adversarial review (Codex or a Claude senior-staff-engineer subagent, recorded truthfully), triage findings, decompose approved PRDs into atomic issue specs, and execute those issues with scope enforcement, stop-gate receipts, and reviewer-attributed findings.",
   "author": {
     "name": "Assaf Kipnis"

--- a/plugins/prd-os/.claude-plugin/plugin.json
+++ b/plugins/prd-os/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "prd-os",
-  "version": "0.25.1",
+  "version": "0.26.0",
   "description": "PRD operating system: capture rough ideas, draft reviewable PRDs, run standard and adversarial review (Codex or a Claude senior-staff-engineer subagent, recorded truthfully), triage findings, decompose approved PRDs into atomic issue specs, and execute those issues with scope enforcement, stop-gate receipts, and reviewer-attributed findings.",
   "author": {
     "name": "Assaf Kipnis"

--- a/plugins/prd-os/scripts/prd_runner.py
+++ b/plugins/prd-os/scripts/prd_runner.py
@@ -1832,6 +1832,41 @@ SPILLOVER_KNOWN_SEVERITIES = (
     SPILLOVER_BLOCKING_SEVERITIES + SPILLOVER_NONBLOCKING_SEVERITIES)
 
 
+def _spillover_blocks(record: dict, scope: str | None) -> bool:
+    """Does this open item turn `gates run` red?
+
+    THE COMBINED RULE. Attribution narrows WHICH items count; severity still sets
+    the bar; a `blocker` anywhere is the floor.
+
+        no live scope        -> severity decides (ASK-363's rule, unchanged)
+        item source == scope -> severity decides (your own item, normal bar)
+        inherited item       -> only `blocker` blocks
+
+    WHY BOTH AXES. ASK-363 shipped severity alone; ASK-526/527 shipped attribution
+    alone; neither is sufficient and each deletes the other's contract if landed
+    naively. Measured on kipi-system 2026-08-09: 636 open items, severity blocks 18,
+    and all 18 are inherited from other work -- attributable to no change under
+    review. A verdict RED with probability 1 regardless of the diff carries no
+    information about the diff. Attribution alone, though, blocks on a MINOR item
+    your own work opened, which collapses the deliberate two-bar split (`gates run`
+    is the day-to-day light, `archive` is the closeout bar that refuses on ANY open
+    item this work touched) -- see test_archive_still_refuses_on_a_minor_item.
+
+    THE KNOWN COST, named here rather than discovered later: one inherited `blocker`
+    wedges EVERY scope in the repo until somebody acts on it. That is the intended
+    blast radius of the word, but it makes severity a loaded gun -- mislabel one item
+    and all work halts. The escapes are auditable and there are exactly three, each
+    of which records a decision: `spillover reclassify --reason`, `resolve` against a
+    closed issue, or `void` with a reason. There is deliberately NO
+    --ignore-inherited flag; that would be the hand-clear no-orphan-findings.md
+    refuses everywhere else.
+    """
+    severity = (record.get("severity") or "").strip().lower()
+    if scope is None or record.get("source") == scope:
+        return _is_blocking_severity(severity)
+    return severity == "blocker"
+
+
 def _is_blocking_severity(value: str) -> bool:
     """Unknown severities block. See SPILLOVER_NONBLOCKING_SEVERITIES."""
     sev = (value or "").strip().lower()
@@ -1941,29 +1976,35 @@ def cmd_gates(cfg: Config, args) -> int:
     # record-a-void.
     openv = _spillover_open(cfg)
     scope = getattr(args, "scope", None) or _active_scope(cfg)
-    if scope:
-        attributable = [r for r in openv if r.get("source") == scope]
-        inherited = [r for r in openv if r.get("source") != scope]
-    else:
-        # Fail-closed. No active issue means no excuse: the bare `gates run`
-        # that wiring-check.md tells you to run still answers for the WHOLE
-        # ledger, so the scoping can never hide the tail from an audit.
-        attributable, inherited = openv, []
-        # Say WHY there is no scope. A silent fall-through to fail-closed reads
-        # as "the gate is just always red"; the note names the dead/missing/
-        # terminal spec that refused to grant amnesty, which is the actionable
-        # half (ASK-527).
+    if not scope:
+        # Say WHY there is no scope. A silent fall-through reads as "the gate is
+        # just always red"; the note names the dead/missing/terminal spec that
+        # refused to grant amnesty, which is the actionable half (ASK-527).
         note = _scope_refusal_note(cfg)
         if note:
             print(f"[scope] {note}")
-    if attributable:
-        names = ", ".join(r["id"] for r in attributable)
+    blocking = [r for r in openv if _spillover_blocks(r, scope)]
+    reported = [r for r in openv if r not in blocking]
+    inherited = [r for r in openv if scope and r.get("source") != scope]
+    if blocking:
+        names = ", ".join(r["id"] for r in blocking)
         detail = "\n".join(f"  {r['id']} [{r.get('severity')}]: {r.get('description', '')[:90]} (src {r.get('source')})"
-                           for r in attributable)
+                           for r in blocking)
         label = f"spillover[{scope}]" if scope else "spillover"
-        print(f"[RED] {label}: {len(attributable)} open item(s) this work must answer for: {names}")
-        failures.append((label, f"{len(attributable)} open spillover item(s):\n{detail}\n"
+        print(f"[RED] {label}: {len(blocking)} open item(s) this work must answer for: {names}")
+        failures.append((label, f"{len(blocking)} open spillover item(s):\n{detail}\n"
                                 f"Resolve via `prd_runner.py spillover resolve <id> --resolution-ref <closed-issue>`."))
+    if reported:
+        # Reported, never silent. `--severity` DEFAULTS to minor, so a defaulted
+        # item is indistinguishable from one assessed as minor -- the label says
+        # "untriaged" rather than laundering "nobody looked" as "we judged it
+        # small". This is how 533 of them accumulated unnoticed.
+        ids = ", ".join(r["id"] for r in reported[:10])
+        more = f" (+{len(reported) - 10} more)" if len(reported) > 10 else ""
+        print(f"[REPORT] spillover: {len(reported)} open minor-or-untriaged "
+              f"item(s), not blocking: {ids}{more}")
+        print("  Triage with `prd_runner.py spillover triage`; raise one with "
+              "`spillover add --severity major|blocker`.")
     # The census prints on EVERY run, red or green, passing or failing. An
     # inherited backlog that stops being PRINTED is functionally deleted for an
     # operator with ADHD, so the number leaving the blocking set must never mean
@@ -1972,16 +2013,20 @@ def cmd_gates(cfg: Config, args) -> int:
     if inherited:
         sev = [r for r in inherited if _is_blocking_severity(r.get("severity"))]
         census += (f"; {len(inherited)} inherited from other work (not attributable "
-                   f"to {scope}), reported not blocking")
+                   f"to {scope})")
         if sev:
-            census += f", of which {len(sev)} at blocking severity"
+            # The number that must never go quiet. These stopped BLOCKING; they
+            # did not stop existing, and a green run that omits them is the
+            # silent drop ASK-526 refused to trade away.
+            census += (f", of which {len(sev)} at blocking severity still open "
+                       f"and now non-blocking here")
     print(census)
     if failures:
         for gid, tail in failures:
             sys.stderr.write(f"GATE RED: {gid}\n{tail}\n")
         return 1
     print(f"all {len(records)} regression gates green; "
-          f"{len(attributable)} attributable spillover item(s)")
+          f"{len(blocking)} blocking spillover item(s)")
     return 0
 
 

--- a/plugins/prd-os/scripts/prd_runner.py
+++ b/plugins/prd-os/scripts/prd_runner.py
@@ -1933,6 +1933,46 @@ def cmd_gates(cfg: Config, args) -> int:
         record for record in records
         if record["lifecycle"] == "regression"
     ]
+    # SCOPE IS RESOLVED AND FROZEN BEFORE ANY GATE COMMAND RUNS (Codex round 3,
+    # PR #131, MAJOR). It used to be read AFTER the regression loop, so a gate
+    # command -- or a concurrent `gates run` in another worktree -- could switch
+    # .claude/state/active-issue.json mid-run and the verdict would be computed
+    # against a DIFFERENT scope than the one the run started under. Reproduced:
+    # scope ASK-A at gate start, ASK-B by verdict time, and the run's own open
+    # major was reclassified as 'inherited' and stopped blocking -- exit 0 over a
+    # major that run had left behind. Read once, hold it immutable for the run.
+    # An EXPLICIT --scope clears the same liveness bar as an inferred one.
+    #
+    # THE SCAR (Codex round 1, PR #131, reproduced against the real 638-record
+    # ledger): --scope used to be honoured unverified, on the rationale that the
+    # flag is "a caller ASSERTING accountability, which is a decision by
+    # somebody". Measured, that assertion bought:
+    #     blocking_unscoped=19  blocking_fake_scope=1  fake_scope_live=False
+    # A scope id naming nothing at all suppressed 18 inherited majors. The caller
+    # here is usually an unattended agent, so "somebody decided" is precisely what
+    # nobody can audit at 3am; an unverifiable assertion is not a decision, it is a
+    # hand-clear, and no-orphan-findings.md refuses hand-clears everywhere else.
+    # The flag is not removed (that would make it a lie) -- it is verified.
+    explicit = getattr(args, "scope", None)
+    if explicit:
+        live = (_scope_is_live(cfg, explicit, cfg.issues_dir)
+                or _scope_is_live(cfg, explicit, cfg.prds_dir))
+        if live:
+            scope = explicit
+        else:
+            scope = None
+            print(f"[scope] --scope '{explicit}' refused: it names no tracked, live "
+                  f"issue or PRD spec. Falling through to fail-closed; every open "
+                  f"item answers.")
+    else:
+        scope = _active_scope(cfg)
+    if not scope:
+        # Say WHY there is no scope. A silent fall-through reads as "the gate is
+        # just always red"; the note names the dead/missing/terminal spec that
+        # refused to grant amnesty, which is the actionable half (ASK-527).
+        note = _scope_refusal_note(cfg)
+        if note:
+            print(f"[scope] {note}")
     failures = []
     skipped_self_ref = 0
     for rec in records:
@@ -1984,38 +2024,6 @@ def cmd_gates(cfg: Config, args) -> int:
     # ways out of the ledger are still exactly resolve-against-a-closed-issue and
     # record-a-void.
     openv = _spillover_open(cfg)
-    # An EXPLICIT --scope clears the same liveness bar as an inferred one.
-    #
-    # THE SCAR (Codex round 1, PR #131, reproduced against the real 638-record
-    # ledger): --scope used to be honoured unverified, on the rationale that the
-    # flag is "a caller ASSERTING accountability, which is a decision by
-    # somebody". Measured, that assertion bought:
-    #     blocking_unscoped=19  blocking_fake_scope=1  fake_scope_live=False
-    # A scope id naming nothing at all suppressed 18 inherited majors. The caller
-    # here is usually an unattended agent, so "somebody decided" is precisely what
-    # nobody can audit at 3am; an unverifiable assertion is not a decision, it is a
-    # hand-clear, and no-orphan-findings.md refuses hand-clears everywhere else.
-    # The flag is not removed (that would make it a lie) -- it is verified.
-    explicit = getattr(args, "scope", None)
-    if explicit:
-        live = (_scope_is_live(cfg, explicit, cfg.issues_dir)
-                or _scope_is_live(cfg, explicit, cfg.prds_dir))
-        if live:
-            scope = explicit
-        else:
-            scope = None
-            print(f"[scope] --scope '{explicit}' refused: it names no tracked, live "
-                  f"issue or PRD spec. Falling through to fail-closed; every open "
-                  f"item answers.")
-    else:
-        scope = _active_scope(cfg)
-    if not scope:
-        # Say WHY there is no scope. A silent fall-through reads as "the gate is
-        # just always red"; the note names the dead/missing/terminal spec that
-        # refused to grant amnesty, which is the actionable half (ASK-527).
-        note = _scope_refusal_note(cfg)
-        if note:
-            print(f"[scope] {note}")
     blocking = [r for r in openv if _spillover_blocks(r, scope)]
     reported = [r for r in openv if r not in blocking]
     inherited = [r for r in openv if scope and r.get("source") != scope]

--- a/plugins/prd-os/scripts/prd_runner.py
+++ b/plugins/prd-os/scripts/prd_runner.py
@@ -1975,7 +1975,31 @@ def cmd_gates(cfg: Config, args) -> int:
     # ways out of the ledger are still exactly resolve-against-a-closed-issue and
     # record-a-void.
     openv = _spillover_open(cfg)
-    scope = getattr(args, "scope", None) or _active_scope(cfg)
+    # An EXPLICIT --scope clears the same liveness bar as an inferred one.
+    #
+    # THE SCAR (Codex round 1, PR #131, reproduced against the real 638-record
+    # ledger): --scope used to be honoured unverified, on the rationale that the
+    # flag is "a caller ASSERTING accountability, which is a decision by
+    # somebody". Measured, that assertion bought:
+    #     blocking_unscoped=19  blocking_fake_scope=1  fake_scope_live=False
+    # A scope id naming nothing at all suppressed 18 inherited majors. The caller
+    # here is usually an unattended agent, so "somebody decided" is precisely what
+    # nobody can audit at 3am; an unverifiable assertion is not a decision, it is a
+    # hand-clear, and no-orphan-findings.md refuses hand-clears everywhere else.
+    # The flag is not removed (that would make it a lie) -- it is verified.
+    explicit = getattr(args, "scope", None)
+    if explicit:
+        live = (_scope_is_live(cfg, explicit, cfg.issues_dir)
+                or _scope_is_live(cfg, explicit, cfg.prds_dir))
+        if live:
+            scope = explicit
+        else:
+            scope = None
+            print(f"[scope] --scope '{explicit}' refused: it names no tracked, live "
+                  f"issue or PRD spec. Falling through to fail-closed; every open "
+                  f"item answers.")
+    else:
+        scope = _active_scope(cfg)
     if not scope:
         # Say WHY there is no scope. A silent fall-through reads as "the gate is
         # just always red"; the note names the dead/missing/terminal spec that

--- a/plugins/prd-os/scripts/prd_runner.py
+++ b/plugins/prd-os/scripts/prd_runner.py
@@ -1169,6 +1169,15 @@ def gate_register(
 
 # ---------------------------------------------------------------------------
 # Spillover ledger (prd-os-spine-native): out-of-scope findings, durable + gated
+#
+# spillover-skip -- file-level ack for the fable-discipline deferral lint.
+# That lint flags the phrase "out-of-scope" in code as an UNCAPTURED deferral.
+# This file is the capture MECHANISM, so its own docstrings and --help text
+# necessarily name the thing it captures; every hit here is the vocabulary of
+# the ledger, not a finding being written down and walked away from. Acked at
+# file level (the lint's own convention, one marker per file) rather than by
+# rewording the API help, which would make the command harder to understand in
+# order to satisfy a detector aimed at a different shape of line.
 # ---------------------------------------------------------------------------
 # The scar: a finding marked `deferred`, or an adjacent issue "mentioned" in
 # prose, used to be terminal — it vanished and nobody (least of all an operator
@@ -1448,6 +1457,155 @@ def _verify_resolution_ref(cfg: Config, ref: str) -> dict:
     }
 
 
+_TERMINAL_SPEC_STATES = frozenset({
+    "archived", "closed", "cancelled", "canceled", "done", "abandoned",
+})
+
+
+def _spec_status(spec: Path) -> str | None:
+    """The `status:` frontmatter value, lowercased, or None if it has none."""
+    try:
+        lines = spec.read_text().splitlines()
+    except OSError:
+        return None
+    for line in lines:
+        s = line.strip()
+        if s.startswith("status:"):
+            return s.split(":", 1)[1].strip().strip("\"'").lower()
+    return None
+
+
+def _is_git_tracked(repo_root, spec: Path) -> bool:
+    """Whether git has this path committed. False for every unprovable case.
+
+    Durability, not tidiness: a spec that exists only in one working tree
+    vanishes on a fresh checkout. `_enforce_wiring_contract` (issue_runner)
+    already blocks issue close on exactly this test, after a created-but-unstaged
+    file passed every gate and then disappeared. A unit of work that can narrow a
+    fleet safety gate is held to the same bar.
+    """
+    import subprocess as _subprocess
+    try:
+        out = _subprocess.run(
+            ["git", "ls-files", "--error-unmatch", "--", str(spec)],
+            cwd=str(repo_root), capture_output=True, text=True, timeout=10,
+        )
+    except Exception:
+        # git missing, not a repo, timeout: unprovable. Refusing here costs a
+        # red gate; guessing True would hand out the amnesty this exists to stop.
+        return False
+    return out.returncode == 0
+
+
+def _scope_is_live(cfg: Config, scope_id: str, spec_dir: Path) -> bool:
+    """Whether `scope_id` is PROVABLY a live, durable unit of work (ASK-527).
+
+    Three independent proofs, all deterministic and none of them a clock: the
+    spec exists, git has it tracked, and its status is not terminal. Any one
+    failing -- or being unanswerable -- means no scope, which falls through to
+    the fail-closed path in cmd_gates where every open item blocks.
+    """
+    spec = spec_dir / f"{scope_id}.md"
+    # No separate existence check: `git ls-files --error-unmatch` already answers
+    # False for a path that is not there, and a redundant branch here would be a
+    # line no mutation test can kill. The distinction between "missing" and
+    # "untracked" is preserved where it earns its keep -- the operator-facing
+    # message in _scope_refusal_note.
+    if not _is_git_tracked(cfg.repo_root, spec):
+        return False
+    status = _spec_status(spec)
+    # A spec with no status frontmatter is unprovable, not permissive.
+    return status is not None and status not in _TERMINAL_SPEC_STATES
+
+
+def _active_scope(cfg: Config) -> str | None:
+    """The id `gates run` holds THIS run accountable for, or None.
+
+    The active issue wins over the active PRD: an issue is the narrower unit of
+    work and both state files exist at once during closeout. A DEAD active issue
+    does not fall back to the PRD -- that state is inconsistent, and resolving an
+    inconsistency in the direction of less enforcement is how amnesties happen.
+
+    Returning None is not a failure, it is the fail-closed signal -- see
+    cmd_gates, where no scope means every open item blocks.
+
+    WHY LIVENESS IS PROVEN AND NOT ASSUMED (ASK-527). This used to return the id
+    the state file named, full stop. Measured on kipi-system 2026-08-09: the file
+    named `prd-judgment-compiler-not-deployed-2026-08-05`, still at status "idea"
+    three days after it was loaded, whose spec was present on disk but never
+    committed. `gates run` exited 0 over 635 open items. A forgotten draft in one
+    working tree was silently granting a standing amnesty over the whole ledger --
+    the same lapse the age-cutoff design was rejected for in ASK-526, through a
+    different door.
+
+    An mtime age cap was rejected: it re-introduces a clock deciding what nobody
+    decided, and mtime does not survive checkout, rsync or `kipi update`, so the
+    gate would flap for reasons unrelated to the work. "Last ledger write by this
+    scope" was rejected as perverse -- a scope would stay alive by producing MORE
+    spillover.
+    """
+    for path, key, spec_dir in (
+        (cfg.active_issue_state_path, "issue_id", cfg.issues_dir),
+        (cfg.active_prd_state_path, "prd_id", cfg.prds_dir),
+    ):
+        if not path.is_file():
+            continue
+        try:
+            value = json.loads(path.read_text()).get(key)
+        except (json.JSONDecodeError, OSError):
+            continue
+        # `_empty_state()` writes the key with a None value on clear, so a
+        # cleared state file must read as "no scope", not as scope "None".
+        if isinstance(value, str) and value.strip():
+            scope_id = value.strip()
+            return scope_id if _scope_is_live(cfg, scope_id, spec_dir) else None
+    return None
+
+
+def _scope_refusal_note(cfg: Config) -> str | None:
+    """Display-only: WHY a named active scope was refused, or None.
+
+    A fail-closed run over a large ledger must be red for a NAMEABLE, one-command
+    reason ("this spec was never committed"), not just red. A red gate whose cause
+    the operator cannot see is the uninformative-roll-up defect from ASK-526
+    reappearing as the cure for ASK-527.
+
+    Deliberately separate from `_scope_is_live`: the predicate answers one
+    question and is what the gate depends on, while this only builds a sentence.
+    A single function returning both would make the message a load-bearing part
+    of the security decision.
+    """
+    for path, key, spec_dir, kind in (
+        (cfg.active_issue_state_path, "issue_id", cfg.issues_dir, "issue"),
+        (cfg.active_prd_state_path, "prd_id", cfg.prds_dir, "PRD"),
+    ):
+        if not path.is_file():
+            continue
+        try:
+            value = json.loads(path.read_text()).get(key)
+        except (json.JSONDecodeError, OSError):
+            continue
+        if not (isinstance(value, str) and value.strip()):
+            continue
+        sid = value.strip()
+        spec = spec_dir / f"{sid}.md"
+        where = _relpath(cfg, spec)
+        if not spec.is_file():
+            return f"active {kind} '{sid}' refused: spec {where} does not exist"
+        if not _is_git_tracked(cfg.repo_root, spec):
+            return (f"active {kind} '{sid}' refused: spec {where} is not git-tracked, "
+                    f"so it is not a durable unit of work. Commit it, or clear the "
+                    f"active state, then re-run")
+        status = _spec_status(spec)
+        if status is None:
+            return f"active {kind} '{sid}' refused: spec {where} has no status frontmatter"
+        if status in _TERMINAL_SPEC_STATES:
+            return (f"active {kind} '{sid}' refused: spec status is '{status}' "
+                    f"(terminal). Finished work carries no amnesty")
+        return None
+    return None
+
+
 def _spillover_group_counts(items: list, field: str) -> list:
     """(value, count) pairs for one field, biggest group first, ties by name.
 
@@ -1685,9 +1843,14 @@ def _is_blocking_severity(value: str) -> bool:
 def cmd_gates(cfg: Config, args) -> int:
     """gates list prints the registry; gates run executes regression gates from
     the repo root (operator-authored shell commands, the same trust boundary
-    as required_checks), per-gate green/RED, non-zero exit on any RED. `run`
-    ALSO fails while any spillover item is open (out-of-scope findings are part
-    of the standing no-bypass re-proof, so they can never be silently dropped)."""
+    as required_checks), per-gate green/RED, non-zero exit on any RED.
+
+    `run` ALSO fails on open spillover items ATTRIBUTABLE to the run's scope --
+    the active issue/PRD, or everything when there is no active scope. Items
+    inherited from other work are printed in the census on every run but do not
+    block, so the red light means "this work left something behind" instead of
+    "a backlog exists". See the block above the census for the measurement that
+    forced the split and for the age-cutoff design that was rejected."""
     import subprocess as _subprocess
     import re as _re
     path = _gates_path(cfg)
@@ -1748,35 +1911,77 @@ def cmd_gates(cfg: Config, args) -> int:
         if result.returncode != 0:
             tail = (result.stdout + result.stderr).strip().splitlines()[-5:]
             failures.append((rec["gate_id"], "\n".join(tail)))
-    # Out-of-scope findings are part of the standing re-proof: an open spillover
-    # item turns the gate RED until it is resolved against a closed issue.
+    # Spillover verdict, scoped by ATTRIBUTION and never by the clock (ASK-526).
+    #
+    # WHY ATTRIBUTION AND NOT SEVERITY ALONE. The severity filter that shipped
+    # in ASK-363 was a real improvement over the original boolean-over-the-whole
+    # -ledger, but it is the same defect one order of magnitude smaller, and
+    # measurement says so. Run against kipi-system 2026-08-09: 636 open items,
+    # of which the severity filter blocks 18 -- and all 18 are inherited from
+    # other work (prd-silent-absence, scs-validated-event-fold, ASK-402, PR-123).
+    # None is attributable to any change under review. A verdict that is RED with
+    # probability 1 no matter what you did carries no information about your
+    # diff, so a genuine new regression is invisible inside it. Severity answers
+    # "how bad is this?"; only attribution answers "did THIS work cause it?", and
+    # the gate's job is the second question.
+    #
+    # SEVERITY IS NOT DISCARDED, it is demoted to reporting: the census ranks the
+    # inherited tail by blocking-severity so the 18 stay visible and countable
+    # without holding every future PR hostage. Both signals survive; only the
+    # exit code changed hands.
+    #
+    # WHAT WAS REJECTED. An age cutoff ("only items newer than N days block").
+    # It would let this function print "no open spillover" while 636 items sat
+    # open -- a gate that states something false is strictly worse than one that
+    # is uninformative, and items would leave enforcement with nobody deciding,
+    # which is the silent drop no-orphan-findings.md exists to prevent.
+    #
+    # Nothing here removes an item, changes its status, or expires it. The two
+    # ways out of the ledger are still exactly resolve-against-a-closed-issue and
+    # record-a-void.
     openv = _spillover_open(cfg)
-    blocking = [r for r in openv if _is_blocking_severity(r.get("severity"))]
-    reported = [r for r in openv if r not in blocking]
-    if blocking:
-        names = ", ".join(r["id"] for r in blocking)
-        detail = "\n".join(f"  {r['id']} [{r.get('severity')}]: {r.get('description', '')[:90]} (src {r.get('source')})" for r in blocking)
-        print(f"[RED] spillover: {len(blocking)} open blocking-severity item(s): {names}")
-        failures.append(("spillover", f"{len(blocking)} open blocking-severity spillover item(s):\n{detail}\n"
-                                      f"Resolve via `prd_runner.py spillover resolve <id> --resolution-ref <closed-issue>`."))
-    if reported:
-        # Reported, never silent. These do not block, but a bucket nobody can
-        # see is how 533 of them accumulated. `--severity` DEFAULTS to minor, so
-        # a defaulted item is indistinguishable from one assessed as minor --
-        # the label says "untriaged" rather than laundering "nobody looked" as
-        # "we judged it small".
-        ids = ", ".join(r["id"] for r in reported[:10])
-        more = f" (+{len(reported) - 10} more)" if len(reported) > 10 else ""
-        print(f"[REPORT] spillover: {len(reported)} open minor-or-untriaged "
-              f"item(s), not blocking: {ids}{more}")
-        print("  Triage with `prd_runner.py spillover triage`; raise one with "
-              "`spillover add --severity major|blocker`.")
+    scope = getattr(args, "scope", None) or _active_scope(cfg)
+    if scope:
+        attributable = [r for r in openv if r.get("source") == scope]
+        inherited = [r for r in openv if r.get("source") != scope]
+    else:
+        # Fail-closed. No active issue means no excuse: the bare `gates run`
+        # that wiring-check.md tells you to run still answers for the WHOLE
+        # ledger, so the scoping can never hide the tail from an audit.
+        attributable, inherited = openv, []
+        # Say WHY there is no scope. A silent fall-through to fail-closed reads
+        # as "the gate is just always red"; the note names the dead/missing/
+        # terminal spec that refused to grant amnesty, which is the actionable
+        # half (ASK-527).
+        note = _scope_refusal_note(cfg)
+        if note:
+            print(f"[scope] {note}")
+    if attributable:
+        names = ", ".join(r["id"] for r in attributable)
+        detail = "\n".join(f"  {r['id']} [{r.get('severity')}]: {r.get('description', '')[:90]} (src {r.get('source')})"
+                           for r in attributable)
+        label = f"spillover[{scope}]" if scope else "spillover"
+        print(f"[RED] {label}: {len(attributable)} open item(s) this work must answer for: {names}")
+        failures.append((label, f"{len(attributable)} open spillover item(s):\n{detail}\n"
+                                f"Resolve via `prd_runner.py spillover resolve <id> --resolution-ref <closed-issue>`."))
+    # The census prints on EVERY run, red or green, passing or failing. An
+    # inherited backlog that stops being PRINTED is functionally deleted for an
+    # operator with ADHD, so the number leaving the blocking set must never mean
+    # the number leaving the screen. `spillover triage` is the lens on it.
+    census = f"[census] spillover: {len(openv)} open total"
+    if inherited:
+        sev = [r for r in inherited if _is_blocking_severity(r.get("severity"))]
+        census += (f"; {len(inherited)} inherited from other work (not attributable "
+                   f"to {scope}), reported not blocking")
+        if sev:
+            census += f", of which {len(sev)} at blocking severity"
+    print(census)
     if failures:
         for gid, tail in failures:
             sys.stderr.write(f"GATE RED: {gid}\n{tail}\n")
         return 1
     print(f"all {len(records)} regression gates green; "
-          f"no blocking-severity spillover")
+          f"{len(attributable)} attributable spillover item(s)")
     return 0
 
 
@@ -1806,6 +2011,12 @@ def main(argv: list[str] | None = None) -> int:
     p_gates = sub.add_parser("gates")
     p_gates.add_argument("gates_cmd", choices=("list", "run"))
     p_gates.add_argument("--lifecycle", choices=GATE_LIFECYCLES)
+    p_gates.add_argument(
+        "--scope",
+        help="issue/PRD id whose spillover items block this run. Default: the "
+             "active issue, then the active PRD. With NO scope the run is "
+             "fail-closed and every open item blocks. Items outside the scope "
+             "are always printed in the census, never expired")
     p_gates.set_defaults(func=cmd_gates)
 
     p_spill = sub.add_parser("spillover")

--- a/plugins/prd-os/scripts/prd_runner.py
+++ b/plugins/prd-os/scripts/prd_runner.py
@@ -1553,7 +1553,16 @@ def _active_scope(cfg: Config) -> str | None:
         try:
             value = json.loads(path.read_text()).get(key)
         except (json.JSONDecodeError, OSError):
-            continue
+            # PRESENT BUT UNREADABLE IS A REFUSAL, NOT A MISS (Codex round 2,
+            # PR #131, MAJOR). This used to `continue`, which walked on to the
+            # broader PRD scope and let a half-written active-issue.json widen
+            # the amnesty from one issue to a whole PRD. The producer writes this
+            # file NON-ATOMICALLY, so a partial write is a real failure mode, not
+            # a constructed one; reproduced with `{partial-json` yielding
+            # active_scope=prd-live. An absent file means "no issue is active",
+            # which is information; a corrupt file means "we cannot tell", which
+            # is not. Refuse outright and let the caller fail closed.
+            return None
         # `_empty_state()` writes the key with a None value on clear, so a
         # cleared state file must read as "no scope", not as scope "None".
         if isinstance(value, str) and value.strip():

--- a/plugins/prd-os/tests/test_active_scope_liveness.py
+++ b/plugins/prd-os/tests/test_active_scope_liveness.py
@@ -99,8 +99,9 @@ def _active_prd(repo: Path, prd_id: str) -> None:
     }))
 
 
-def _write_spec(repo: Path, prd_id: str, status: str, *, tracked: bool) -> None:
-    d = repo / ".prd-os" / "prds"
+def _write_spec(repo: Path, prd_id: str, status: str, *, tracked: bool,
+                kind: str = "prds") -> None:
+    d = repo / ".prd-os" / kind
     d.mkdir(parents=True, exist_ok=True)
     p = d / f"{prd_id}.md"
     p.write_text(f"---\nid: {prd_id}\nstatus: {status}\n---\n\n# {prd_id}\n")
@@ -217,11 +218,40 @@ def test_tracked_live_spec_still_scopes(repo):
     assert "600 inherited" in out, f"the census stopped naming the backlog.\nout={out}"
 
 
-def test_explicit_scope_flag_is_honoured_without_a_spec(repo):
-    """`--scope` is a caller ASSERTING accountability, which is a decision by
-    somebody. The defect was amnesty INFERRED from a file nobody looked at, so
-    the explicit flag stays honoured and is not required to name a spec."""
+def test_explicit_scope_without_a_live_spec_cannot_grant_amnesty(repo):
+    """`--scope` must clear the SAME liveness bar as an inferred scope.
+
+    THIS TEST USED TO ASSERT THE OPPOSITE, and that was the defect. The old
+    rationale was "`--scope` is a caller ASSERTING accountability, which is a
+    decision by somebody", so the flag was honoured without naming a live spec.
+    Codex round 1 on PR #131 reproduced what that actually buys, against the real
+    638-record ledger:
+
+        blocking_unscoped=19   blocking_fake_scope=1   fake_scope_live=False
+
+    A scope id that names nothing suppressed 18 inherited majors. That is a
+    hand-clear with extra steps, and no-orphan-findings.md refuses hand-clears
+    everywhere else. Caller intent is not durable proof: the caller is usually an
+    unattended agent, and "somebody decided" is exactly what nobody can audit at
+    3am. An unverifiable assertion is not a decision, it is a bypass."""
     _seed_backlog(repo, 600)
+    run(repo, "spillover", "add", "--source", "ASK-9", "--desc", "mine", "--id", "sp-mine",
+        "--severity", "major")
+    g = run(repo, "gates", "run", "--scope", "ASK-9")
+    out = g.stdout + g.stderr
+    assert g.returncode != 0, f"a scope naming no live spec granted amnesty.\nout={out}"
+    # Fail-closed means the WHOLE backlog answers, not just the caller's own item.
+    assert "600 inherited" not in out, (
+        f"the bogus scope still scoped the run; 600 items were filed as "
+        f"'inherited' and stopped blocking.\nout={out}")
+
+
+def test_explicit_scope_with_a_live_spec_still_scopes(repo):
+    """The flag is not deleted, it is verified. A `--scope` naming a tracked, live
+    spec still scopes -- otherwise the fix is 'remove the feature', which is not
+    the ask and would make the flag a lie."""
+    _seed_backlog(repo, 600)
+    _write_spec(repo, "ASK-9", "in-progress", tracked=True, kind="issues")
     run(repo, "spillover", "add", "--source", "ASK-9", "--desc", "mine", "--id", "sp-mine",
         "--severity", "major")
     g = run(repo, "gates", "run", "--scope", "ASK-9")

--- a/plugins/prd-os/tests/test_active_scope_liveness.py
+++ b/plugins/prd-os/tests/test_active_scope_liveness.py
@@ -309,3 +309,42 @@ def test_corrupt_active_issue_state_does_not_widen_to_the_prd(repo):
         f"the run was scoped to prd-live despite unreadable issue state; the "
         f"corrupt file widened the amnesty instead of refusing.\nout={out}"
     )
+
+
+def test_scope_is_frozen_before_gates_run_so_a_concurrent_switch_cannot_excuse(repo):
+    """The run's verdict must use the scope it STARTED under.
+
+    Codex round 3 on PR #131, MAJOR. Scope was resolved AFTER the regression loop,
+    so a gate command -- or a concurrent `gates run` in another worktree, which is
+    routine on this fleet -- could rewrite .claude/state/active-issue.json mid-run.
+    The verdict was then computed against a DIFFERENT scope than the one the work
+    was done under, and the run's OWN open major was reclassified as 'inherited',
+    stopped blocking, and the gate exited 0 over it.
+
+    This test drives the switch through the gate command itself, which is the same
+    seam a concurrent process reaches through and is deterministic to trigger.
+    """
+    _write_spec(repo, "ASK-A", "in-progress", tracked=True, kind="issues")
+    _write_spec(repo, "ASK-B", "in-progress", tracked=True, kind="issues")
+    d = repo / ".claude" / "state"
+    d.mkdir(parents=True, exist_ok=True)
+    (d / "active-issue.json").write_text(json.dumps({"issue_id": "ASK-A"}))
+    # A major left behind by ASK-A: it must block ASK-A's own run.
+    run(repo, "spillover", "add", "--source", "ASK-A", "--desc", "mine", "--id",
+        "sp-A", "--severity", "major")
+    # A passing gate whose side effect flips the active scope to ASK-B mid-run.
+    state = (d / "active-issue.json").as_posix()
+    (repo / ".prd-os" / "gates.jsonl").write_text(json.dumps({
+        "gate_id": "flips-the-scope", "issue_id": "ASK-A", "lifecycle": "regression",
+        "command": f"printf '%s' '{{\"issue_id\": \"ASK-B\"}}' > {state}",
+    }) + "\n")
+
+    g = run(repo, "gates", "run")
+    out = g.stdout + g.stderr
+    assert (d / "active-issue.json").read_text().strip().endswith("}"), "fixture did not run"
+    assert "ASK-B" in (d / "active-issue.json").read_text(), (
+        "the gate command did not actually flip the scope; the test proves nothing")
+    assert g.returncode != 0, (
+        f"a mid-run scope switch excused ASK-A's own open major and the gate "
+        f"exited 0.\nout={out}")
+    assert "sp-A" in out, f"ASK-A's own major was not named as blocking.\nout={out}"

--- a/plugins/prd-os/tests/test_active_scope_liveness.py
+++ b/plugins/prd-os/tests/test_active_scope_liveness.py
@@ -114,7 +114,8 @@ def _seed_backlog(repo: Path, n: int) -> None:
     shape; the rest are appended in that shape and then read back through the
     runner's own reader, so the fixture is validated by production code."""
     assert run(repo, "spillover", "add", "--source", "old-work",
-               "--desc", "seed item 0", "--id", "sp-seed0").returncode == 0
+               "--desc", "seed item 0", "--id", "sp-seed0",
+               "--severity", "major").returncode == 0
     ledger = repo / ".prd-os" / "spillover.jsonl"
     shape = json.loads(ledger.read_text().splitlines()[0])
     with ledger.open("a") as fh:
@@ -221,7 +222,8 @@ def test_explicit_scope_flag_is_honoured_without_a_spec(repo):
     somebody. The defect was amnesty INFERRED from a file nobody looked at, so
     the explicit flag stays honoured and is not required to name a spec."""
     _seed_backlog(repo, 600)
-    run(repo, "spillover", "add", "--source", "ASK-9", "--desc", "mine", "--id", "sp-mine")
+    run(repo, "spillover", "add", "--source", "ASK-9", "--desc", "mine", "--id", "sp-mine",
+        "--severity", "major")
     g = run(repo, "gates", "run", "--scope", "ASK-9")
     out = g.stdout + g.stderr
     assert g.returncode == 1 and "sp-mine" in out, out

--- a/plugins/prd-os/tests/test_active_scope_liveness.py
+++ b/plugins/prd-os/tests/test_active_scope_liveness.py
@@ -1,0 +1,247 @@
+"""ASK-527 reproducer: a stale or abandoned active scope must not grant amnesty.
+
+THE DEFECT (live on kipi-system when this was written, not hypothetical).
+ASK-526 made `gates run` fail-closed when there is no active scope. But the
+scope is INFERRED from `.claude/state/active-prd.json`, and nothing proved the
+thing it names is a real, live unit of work. Measured 2026-08-09:
+
+    active-prd.json -> prd-judgment-compiler-not-deployed-2026-08-05
+    status in the state file: "idea"   (never advanced past the first state)
+    loaded_at:                2026-08-05T17:48:04Z  (3 days earlier)
+    the spec file:            present on disk, NOT git-tracked
+    result:                   gates run exited 0 over 635 open items
+
+So a forgotten draft lying in one working tree silently narrowed the gate to
+itself and granted a standing amnesty over the entire ledger. That is the same
+hole the age-cutoff design was rejected for in ASK-526, arriving through a
+different door: enforcement lapsed and nobody decided anything.
+
+THE PROPERTY UNDER TEST. A scope may narrow the gate only if it is PROVABLY a
+live, durable unit of work. Every unprovable case -- spec missing, spec not
+tracked in git, spec in a terminal state, git unable to answer -- collapses to
+"no scope", which falls through to the fail-closed path where every open item
+blocks. Unprovable is never a reason to relax; it is the reason to refuse.
+
+WHY GIT-TRACKED IS THE DURABILITY TEST. Precedent in this same codebase:
+`_enforce_wiring_contract` (issue_runner) blocks close until every allowed_file
+is git-tracked, born from the scar that a created-but-unstaged file passed every
+gate and vanished on a fresh checkout. A PRD that governs a fleet safety gate but
+exists only in one working tree is not a durable unit of work either.
+
+WHAT WAS REJECTED, and why the clock is not welcome here:
+  - An mtime age cap re-introduces exactly the ASK-526 defect one layer up: the
+    scope would change state because time passed, with nobody deciding. Worse,
+    mtime is not a durable property -- git checkout, rsync and `kipi update` all
+    rewrite it, so the gate would flap for reasons unrelated to the work.
+  - "Last ledger write attributable to the scope" is perverse: a scope would keep
+    itself alive by PRODUCING MORE SPILLOVER. That rewards the behaviour the
+    ledger exists to bound.
+  - "Require an explicit active-state file instead of inferring" changes nothing.
+    The file already exists and is explicit. The file IS the problem, not its
+    absence.
+"""
+
+from __future__ import annotations
+
+import json
+import os
+import subprocess
+import sys
+from pathlib import Path
+
+import pytest
+
+PLUGIN_ROOT = Path(__file__).resolve().parents[1]
+PRD_RUNNER = PLUGIN_ROOT / "scripts" / "prd_runner.py"
+
+
+def run(repo: Path, *args: str, env: dict | None = None) -> subprocess.CompletedProcess:
+    return subprocess.run(
+        [sys.executable, str(PRD_RUNNER), "--repo-root", str(repo), *args],
+        capture_output=True, text=True, env=env,
+    )
+
+
+def _git(repo: Path, *args: str) -> None:
+    subprocess.run(["git", *args], cwd=str(repo), check=True,
+                   capture_output=True, text=True)
+
+
+@pytest.fixture
+def repo(tmp_path: Path) -> Path:
+    """A REAL git repo. The guard asks git whether a spec is tracked, so a
+    fixture that only mkdir'd `.git` would make every tracked-ness answer
+    unprovable and the tests would pass for the wrong reason."""
+    r = tmp_path / "repo"
+    (r / ".prd-os").mkdir(parents=True)
+    (r / ".prd-os" / "config.json").write_text(json.dumps({
+        "config_schema_version": 1,
+        "prds_dir": ".prd-os/prds",
+        "issues_dir": ".prd-os/issues",
+        "findings_dir": ".prd-os/findings",
+        "state_dir": ".claude/state",
+    }))
+    _git(r, "init", "-q")
+    _git(r, "config", "user.email", "t@example.com")
+    _git(r, "config", "user.name", "t")
+    (r / "README.md").write_text("fixture\n")
+    _git(r, "add", "README.md")
+    _git(r, "commit", "-q", "-m", "init")
+    return r
+
+
+def _active_prd(repo: Path, prd_id: str) -> None:
+    d = repo / ".claude" / "state"
+    d.mkdir(parents=True, exist_ok=True)
+    (d / "active-prd.json").write_text(json.dumps({
+        "prd_id": prd_id, "loaded_at": "2026-08-05T17:48:04Z",
+        "spec_path": f".prd-os/prds/{prd_id}.md", "status": "idea",
+    }))
+
+
+def _write_spec(repo: Path, prd_id: str, status: str, *, tracked: bool) -> None:
+    d = repo / ".prd-os" / "prds"
+    d.mkdir(parents=True, exist_ok=True)
+    p = d / f"{prd_id}.md"
+    p.write_text(f"---\nid: {prd_id}\nstatus: {status}\n---\n\n# {prd_id}\n")
+    if tracked:
+        _git(repo, "add", "-f", str(p.relative_to(repo)))
+        _git(repo, "commit", "-q", "-m", f"add {prd_id}")
+
+
+def _seed_backlog(repo: Path, n: int) -> None:
+    """Reproduce the real scale. One CLI call establishes the producer's record
+    shape; the rest are appended in that shape and then read back through the
+    runner's own reader, so the fixture is validated by production code."""
+    assert run(repo, "spillover", "add", "--source", "old-work",
+               "--desc", "seed item 0", "--id", "sp-seed0").returncode == 0
+    ledger = repo / ".prd-os" / "spillover.jsonl"
+    shape = json.loads(ledger.read_text().splitlines()[0])
+    with ledger.open("a") as fh:
+        for i in range(1, n):
+            rec = dict(shape, id=f"sp-seed{i}", description=f"seed item {i}")
+            fh.write(json.dumps(rec) + "\n")
+    check = run(repo, "spillover", "check")
+    assert check.returncode == 1, "the runner did not read the seeded backlog"
+    assert f"{n} open spillover item(s)" in check.stderr, check.stderr[-300:]
+
+
+# --- the defect: this is kipi-system's exact live state ----------------------
+
+def test_untracked_stale_spec_cannot_grant_amnesty(repo):
+    """RED before the fix: exits 0 over 600+ open items because a forgotten,
+    never-committed draft narrowed the gate to itself."""
+    _seed_backlog(repo, 600)
+    _active_prd(repo, "prd-abandoned")
+    _write_spec(repo, "prd-abandoned", "idea", tracked=False)
+    g = run(repo, "gates", "run")
+    out = g.stdout + g.stderr
+    assert g.returncode != 0, (
+        "an UNTRACKED spec granted a standing amnesty over 600 open items; "
+        f"the fail-closed path was never reached.\nout={out}"
+    )
+    assert "600" in out, f"the backlog it refused to excuse was not named.\nout={out}"
+    assert "not git-tracked" in out, (
+        f"refusal did not name a fixable reason, so the red gate is as "
+        f"uninformative as the one ASK-526 replaced.\nout={out}"
+    )
+
+
+def test_missing_spec_cannot_grant_amnesty(repo):
+    _seed_backlog(repo, 600)
+    _active_prd(repo, "prd-vanished")  # no spec written at all
+    g = run(repo, "gates", "run")
+    assert g.returncode != 0, (
+        "an active-state file naming a spec that does not exist still scoped "
+        f"the gate.\nout={g.stdout + g.stderr}"
+    )
+    assert "does not exist" in (g.stdout + g.stderr)
+
+
+def test_terminal_spec_cannot_grant_amnesty(repo):
+    _seed_backlog(repo, 600)
+    _active_prd(repo, "prd-done")
+    _write_spec(repo, "prd-done", "archived", tracked=True)
+    g = run(repo, "gates", "run")
+    assert g.returncode != 0, (
+        "an ARCHIVED PRD still scoped the gate; finished work must not carry a "
+        f"live amnesty.\nout={g.stdout + g.stderr}"
+    )
+
+
+def test_spec_without_status_frontmatter_cannot_grant_amnesty(repo):
+    """Unprovable is a refusal, not a pass. A spec whose status cannot be read
+    says nothing about whether the work is live."""
+    _seed_backlog(repo, 600)
+    _active_prd(repo, "prd-nostatus")
+    d = repo / ".prd-os" / "prds"
+    d.mkdir(parents=True, exist_ok=True)
+    (d / "prd-nostatus.md").write_text("---\nid: prd-nostatus\n---\n\n# no status\n")
+    _git(repo, "add", "-f", ".prd-os/prds/prd-nostatus.md")
+    _git(repo, "commit", "-q", "-m", "add prd-nostatus")
+    g = run(repo, "gates", "run")
+    assert g.returncode != 0, (
+        f"a spec with no status frontmatter scoped the gate.\nout={g.stdout + g.stderr}"
+    )
+
+
+def test_git_unable_to_answer_is_a_refusal_not_a_pass(repo):
+    """The fail-OPEN direction. If the tracked-ness lookup cannot run at all
+    (git missing from PATH), the scope is unprovable and must be refused. A
+    lookup that guessed True on failure would hand out amnesty precisely when
+    the system knows least."""
+    _seed_backlog(repo, 600)
+    _active_prd(repo, "prd-live")
+    _write_spec(repo, "prd-live", "draft", tracked=True)
+    assert run(repo, "gates", "run").returncode == 0, "precondition: scope is live"
+    blind = dict(os.environ, PATH="/nonexistent-so-git-cannot-be-found")
+    g = run(repo, "gates", "run", env=blind)
+    assert g.returncode != 0, (
+        "with git unavailable the guard assumed the spec was tracked and "
+        f"scoped the gate anyway.\nout={g.stdout + g.stderr}"
+    )
+
+
+# --- the invariants the guard must NOT break ---------------------------------
+
+def test_tracked_live_spec_still_scopes(repo):
+    """The guard must refuse abandoned scopes, not all scopes. If this ever goes
+    red the fix has become 'delete the feature', which is not the ask."""
+    _seed_backlog(repo, 600)
+    _active_prd(repo, "prd-live")
+    _write_spec(repo, "prd-live", "draft", tracked=True)
+    g = run(repo, "gates", "run")
+    out = g.stdout + g.stderr
+    assert g.returncode == 0, f"a live, tracked, in-flight PRD failed to scope.\nout={out}"
+    assert "600 inherited" in out, f"the census stopped naming the backlog.\nout={out}"
+
+
+def test_explicit_scope_flag_is_honoured_without_a_spec(repo):
+    """`--scope` is a caller ASSERTING accountability, which is a decision by
+    somebody. The defect was amnesty INFERRED from a file nobody looked at, so
+    the explicit flag stays honoured and is not required to name a spec."""
+    _seed_backlog(repo, 600)
+    run(repo, "spillover", "add", "--source", "ASK-9", "--desc", "mine", "--id", "sp-mine")
+    g = run(repo, "gates", "run", "--scope", "ASK-9")
+    out = g.stdout + g.stderr
+    assert g.returncode == 1 and "sp-mine" in out, out
+    assert "600 inherited" in out, f"census lost under an explicit scope.\nout={out}"
+
+
+def test_dead_issue_does_not_fall_back_to_a_live_prd(repo):
+    """The issue is the narrower unit and wins, but only while IT is live."""
+    _seed_backlog(repo, 600)
+    _active_prd(repo, "prd-live")
+    _write_spec(repo, "prd-live", "draft", tracked=True)
+    d = repo / ".claude" / "state"
+    (d / "active-issue.json").write_text(json.dumps({"issue_id": "iss-dead"}))
+    idir = repo / ".prd-os" / "issues"
+    idir.mkdir(parents=True, exist_ok=True)
+    (idir / "iss-dead.md").write_text("---\nid: iss-dead\nstatus: closed\n---\n")
+    _git(repo, "add", "-f", ".prd-os/issues/iss-dead.md")
+    _git(repo, "commit", "-q", "-m", "add iss-dead")
+    g = run(repo, "gates", "run")
+    assert g.returncode != 0, (
+        "a CLOSED active issue scoped the gate instead of falling through to "
+        f"fail-closed.\nout={g.stdout + g.stderr}"
+    )

--- a/plugins/prd-os/tests/test_active_scope_liveness.py
+++ b/plugins/prd-os/tests/test_active_scope_liveness.py
@@ -277,3 +277,35 @@ def test_dead_issue_does_not_fall_back_to_a_live_prd(repo):
         "a CLOSED active issue scoped the gate instead of falling through to "
         f"fail-closed.\nout={g.stdout + g.stderr}"
     )
+
+
+def test_corrupt_active_issue_state_does_not_widen_to_the_prd(repo):
+    """A half-written active-issue.json must REFUSE, not walk on to the PRD.
+
+    Codex round 2 on PR #131, MAJOR. `_active_scope` used to `continue` on a
+    JSONDecodeError, which fell through to the active PRD and silently WIDENED the
+    amnesty from one issue to a whole PRD. The producer writes this state file
+    non-atomically, so a torn write is a real failure mode, not a constructed one.
+
+    The doctrine this restores is already stated at the top of this file: an absent
+    file means "no issue is active", which is information; a corrupt file means "we
+    cannot tell", which is not. Unprovable is the reason to refuse, never to relax.
+    """
+    _seed_backlog(repo, 600)
+    # A live PRD that WOULD scope the run if the corrupt issue state were skipped.
+    _active_prd(repo, "prd-live")
+    _write_spec(repo, "prd-live", "in-progress", tracked=True)
+    d = repo / ".claude" / "state"
+    d.mkdir(parents=True, exist_ok=True)
+    (d / "active-issue.json").write_text("{partial-json")
+
+    g = run(repo, "gates", "run")
+    out = g.stdout + g.stderr
+    assert g.returncode != 0, (
+        f"a CORRUPT active-issue state fell through to the PRD scope and granted "
+        f"amnesty over 600 open items.\nout={out}"
+    )
+    assert "600 inherited" not in out, (
+        f"the run was scoped to prd-live despite unreadable issue state; the "
+        f"corrupt file widened the amnesty instead of refusing.\nout={out}"
+    )

--- a/plugins/prd-os/tests/test_spillover_combined_rule.py
+++ b/plugins/prd-os/tests/test_spillover_combined_rule.py
@@ -1,0 +1,166 @@
+"""The combined blocking contract: attribution narrows WHICH items count, severity
+still sets the bar, and a `blocker` anywhere is the floor.
+
+WHY THIS FILE EXISTS. Two fixes for one defect were written without seeing each
+other. ASK-363 shipped a SEVERITY filter (blocker/major/high block, minor is
+reported). ASK-526/527 shipped ATTRIBUTION scoping (only items your active scope
+opened block). Landed naively, each deletes the other's contract: pure attribution
+turns six severity tests red, and pure severity leaves the measured defect in place.
+
+THE MEASURED DEFECT, so a later reader does not "simplify" this back. Run against
+kipi-system 2026-08-09: 636 open items, of which the severity filter blocks 18, and
+all 18 are inherited from other work (prd-silent-absence, scs-validated-event-fold,
+ASK-402, PR-123). Not one is attributable to any change under review. A verdict that
+is RED with probability 1 regardless of the diff carries no information about the
+diff, and wiring-check.md still mandates `gates run` exits 0 as definition-of-done,
+so the repo's own done-check was decoration.
+
+THE RULE (see _spillover_blocks in prd_runner.py):
+
+    no live scope        -> severity decides (ASK-363's rule, unchanged)
+    item source == scope -> severity decides (your own item, normal bar)
+    inherited item       -> only `blocker` blocks
+
+The middle line is what keeps `archive` meaningful: `gates run` stays green day to
+day on a minor item YOUR work opened, and `archive` is the stricter bar that refuses
+on any open item at closeout. Collapsing those two bars is the "fix" this file
+exists to make fail loudly.
+"""
+
+from __future__ import annotations
+
+import json
+import subprocess
+import sys
+from pathlib import Path
+
+import pytest
+
+PLUGIN_ROOT = Path(__file__).resolve().parents[1]
+PRD_RUNNER = PLUGIN_ROOT / "scripts" / "prd_runner.py"
+
+
+def run(repo: Path, *args: str) -> subprocess.CompletedProcess:
+    return subprocess.run(
+        [sys.executable, str(PRD_RUNNER), "--repo-root", str(repo), *args],
+        capture_output=True, text=True,
+    )
+
+
+def _git(repo: Path, *args: str) -> None:
+    subprocess.run(["git", "-C", str(repo), *args], check=True,
+                   capture_output=True, text=True)
+
+
+@pytest.fixture
+def repo(tmp_path: Path) -> Path:
+    r = tmp_path / "repo"
+    (r / ".prd-os").mkdir(parents=True)
+    (r / ".prd-os" / "config.json").write_text(json.dumps({
+        "config_schema_version": 1,
+        "prds_dir": ".prd-os/prds",
+        "issues_dir": ".prd-os/issues",
+        "findings_dir": ".prd-os/findings",
+        "state_dir": ".claude/state",
+    }))
+    # A REAL git repo. ASK-527's liveness guard asks git whether the active spec
+    # is tracked; a mkdir'd .git makes that query fail, which the guard correctly
+    # reads as "cannot confirm -> no amnesty".
+    subprocess.run(["git", "init", "-q", str(r)], check=True)
+    _git(r, "config", "user.email", "t@t")
+    _git(r, "config", "user.name", "t")
+    (r / "README.md").write_text("x\n")
+    _git(r, "add", "README.md")
+    _git(r, "commit", "-q", "-m", "init")
+    return r
+
+
+def _scope(repo: Path, issue_id: str) -> None:
+    """Establish a LIVE, TRACKED active issue -- the ASK-527 precondition for a
+    scope to grant any amnesty at all."""
+    d = repo / ".claude" / "state"
+    d.mkdir(parents=True, exist_ok=True)
+    (d / "active-issue.json").write_text(json.dumps({"issue_id": issue_id}))
+    p = repo / ".prd-os" / "issues" / f"{issue_id}.md"
+    p.parent.mkdir(parents=True, exist_ok=True)
+    p.write_text(f"---\nid: {issue_id}\nstatus: in-progress\n---\n\nbody\n")
+    _git(repo, "add", "-f", str(p.relative_to(repo)))
+    _git(repo, "commit", "-q", "-m", f"add {issue_id}")
+
+
+def _add(repo: Path, sid: str, source: str, severity: str = "minor") -> None:
+    r = run(repo, "spillover", "add", "--source", source, "--desc",
+            f"item {sid}", "--id", sid, "--severity", severity)
+    assert r.returncode == 0, r.stderr
+
+
+# --- the defect the combination has to fix ----------------------------------
+
+def test_inherited_major_does_not_block_a_scoped_run(repo):
+    """THE MEASURED DEFECT. 17 inherited majors sat open; every one of them made
+    every scope red forever. RED before the combined rule: fail-closed attribution
+    blocked it, and pure severity blocked it too."""
+    _scope(repo, "ASK-1")
+    _add(repo, "sp-inherited", "some-old-issue", "major")
+    g = run(repo, "gates", "run")
+    assert g.returncode == 0, (
+        "an inherited MAJOR from other work blocked a clean scope; the red light "
+        f"is still uninformative.\nout={g.stdout + g.stderr}"
+    )
+
+
+def test_inherited_blocker_still_wedges_every_scope(repo):
+    """The deliberate floor, and the known cost. A `blocker` from ANY source stops
+    the world even though nobody in this scope can fix it.
+
+    THE FAILURE MODE, NAMED ON PURPOSE (do not discover this at 2am): one inherited
+    blocker wedges every scope in the repo until somebody acts on it. That is the
+    intended blast radius -- `blocker` is defined as "stop the world" -- but it means
+    the severity is a loaded gun and mislabelling one item halts all work. The escape
+    hatches are auditable and there are exactly three, all of which RECORD a decision:
+    `spillover reclassify` it with a --reason, `resolve` it against a closed issue, or
+    `void` it with a reason. There is deliberately no --ignore-inherited flag, because
+    that would be the hand-clear no-orphan-findings.md refuses everywhere else."""
+    _scope(repo, "ASK-1")
+    _add(repo, "sp-boom", "some-old-issue", "blocker")
+    g = run(repo, "gates", "run")
+    assert g.returncode != 0, (
+        f"an inherited BLOCKER did not stop the world.\nout={g.stdout + g.stderr}")
+    assert "sp-boom" in (g.stdout + g.stderr), "the blocker was not even named"
+
+
+def test_your_own_minor_does_not_block_gates_but_archive_still_refuses(repo):
+    """The two-bar split ASK-363 pinned, which pure attribution deleted. `gates run`
+    is the day-to-day light; `archive` is the closeout bar that reports everything
+    this work touched."""
+    _scope(repo, "ASK-1")
+    _add(repo, "sp-mine", "ASK-1", "minor")
+    g = run(repo, "gates", "run")
+    assert g.returncode == 0, (
+        f"a MINOR item this work opened blocked the daily gate.\nout={g.stdout}{g.stderr}")
+
+
+def test_your_own_major_still_blocks_your_scope(repo):
+    """Attribution narrows which items count; it does not lower the bar on yours."""
+    _scope(repo, "ASK-1")
+    _add(repo, "sp-mine", "ASK-1", "major")
+    g = run(repo, "gates", "run")
+    assert g.returncode != 0, (
+        f"a MAJOR this work opened did not block.\nout={g.stdout + g.stderr}")
+    assert "sp-mine" in (g.stdout + g.stderr)
+
+
+def test_census_still_prints_the_inherited_backlog_on_a_green_run(repo):
+    """The thing ASK-526 refused to trade away. A gate that goes green over a large
+    inherited backlog and says NOTHING is the silent drop, and for an operator with
+    ADHD a number that stops being printed is functionally deleted."""
+    _scope(repo, "ASK-1")
+    for i in range(17):
+        _add(repo, f"sp-maj{i}", "some-old-issue", "major")
+    _add(repo, "sp-min", "some-old-issue", "minor")
+    g = run(repo, "gates", "run")
+    assert g.returncode == 0, f"inherited majors blocked: {g.stdout}{g.stderr}"
+    out = g.stdout + g.stderr
+    assert "18 open total" in out, f"census did not state the total.\nout={out}"
+    assert "17" in out and "blocking severity" in out, (
+        f"census went green without naming the 17 inherited majors.\nout={out}")

--- a/plugins/prd-os/tests/test_spillover_gate_scope.py
+++ b/plugins/prd-os/tests/test_spillover_gate_scope.py
@@ -1,0 +1,201 @@
+"""ASK-526 reproducer: `gates run` must say WHICH thing is red.
+
+THE DEFECT. `cmd_gates` collapsed two unrelated verdicts into one exit code:
+"a regression gate failed" (you broke something) and "the spillover ledger is
+non-empty" (there is a backlog). Measured on kipi-system 2026-08-08: 640 open
+items, arriving ~50/day from 141 distinct sources against ~4/day resolved. A
+boolean over a queue whose arrival rate is 12x its service rate is RED with
+probability 1, permanently -- so every issue closeout inherited a red light
+that carried no information, and a genuine NEW regression is invisible inside
+it. That is the roll-up-status failure: BLOCKED tells you nothing about which
+thing is blocked.
+
+THE FIX UNDER TEST. Blocking is scoped by ATTRIBUTION, never by the clock.
+Items whose `source` is the active scope block; items inherited from other
+work are reported in a census that prints on EVERY run. Nothing ages out,
+nothing leaves the ledger, and an unscoped run stays fail-closed on the whole
+set -- so the bare `gates run` named by wiring-check.md still tells the truth
+about all 640.
+
+WHY NOT AN AGE CUTOFF (the rejected design). An age cutoff would let
+`gates run` print "no open spillover" while 640 items sat open. A gate that
+prints a false statement is strictly worse than one that is red: red is
+uninformative, a lying green is misleading. `test_census_*` below is what
+pins that -- a passing scoped run must still say the number out loud.
+"""
+
+from __future__ import annotations
+
+import json
+import subprocess
+import sys
+from pathlib import Path
+
+import pytest
+
+PLUGIN_ROOT = Path(__file__).resolve().parents[1]
+PRD_RUNNER = PLUGIN_ROOT / "scripts" / "prd_runner.py"
+
+
+def run(repo: Path, *args: str) -> subprocess.CompletedProcess:
+    return subprocess.run(
+        [sys.executable, str(PRD_RUNNER), "--repo-root", str(repo), *args],
+        capture_output=True, text=True,
+    )
+
+
+@pytest.fixture
+def repo(tmp_path: Path) -> Path:
+    r = tmp_path / "repo"
+    (r / ".prd-os").mkdir(parents=True)
+    # A REAL git repo, not a mkdir'd .git. ASK-527 asks git whether the active
+    # spec is tracked, and a fake .git makes that query fail, which the liveness
+    # guard correctly reads as "cannot confirm -> no amnesty". The fake passed
+    # only while nothing interrogated it.
+    subprocess.run(["git", "init", "-q", str(r)], check=True)
+    subprocess.run(["git", "-C", str(r), "config", "user.email", "t@t"], check=True)
+    subprocess.run(["git", "-C", str(r), "config", "user.name", "t"], check=True)
+    (r / "README.md").write_text("x\n")
+    subprocess.run(["git", "-C", str(r), "add", "README.md"], check=True)
+    subprocess.run(["git", "-C", str(r), "commit", "-q", "-m", "init"], check=True)
+    (r / ".prd-os" / "config.json").write_text(json.dumps({
+        "config_schema_version": 1,
+        "prds_dir": ".prd-os/prds",
+        "issues_dir": ".prd-os/issues",
+        "findings_dir": ".prd-os/findings",
+        "state_dir": ".claude/state",
+    }))
+    return r
+
+
+def _set_active_issue(repo: Path, issue_id: str) -> None:
+    d = repo / ".claude" / "state"
+    d.mkdir(parents=True, exist_ok=True)
+    (d / "active-issue.json").write_text(json.dumps({"issue_id": issue_id}))
+    _live_spec(repo, issue_id, "issues")
+
+
+def _set_active_prd(repo: Path, prd_id: str) -> None:
+    d = repo / ".claude" / "state"
+    d.mkdir(parents=True, exist_ok=True)
+    (d / "active-prd.json").write_text(json.dumps({"prd_id": prd_id}))
+    _live_spec(repo, prd_id, "prds")
+
+
+
+def _live_spec(repo: Path, sid: str, kind: str = "issues") -> None:
+    """A tracked spec in a non-terminal state -- the ASK-527 precondition for a
+    scope to grant amnesty at all. These tests predate that guard: they set the
+    active-scope pointer and nothing else, which ASK-527 now refuses. The
+    assertion below is unchanged; only the setup gained the precondition."""
+    d = repo / ".prd-os" / kind
+    d.mkdir(parents=True, exist_ok=True)
+    p = d / f"{sid}.md"
+    p.write_text(f"---\nid: {sid}\nstatus: in-progress\n---\n\nbody\n")
+    rel = str(p.relative_to(repo))
+    subprocess.run(["git", "-C", str(repo), "add", "-f", rel], check=True)
+    subprocess.run(["git", "-C", str(repo), "commit", "-q", "-m", f"add {sid}"], check=True)
+
+def _add(repo: Path, sid: str, source: str, desc: str = "a real finding") -> None:
+    assert run(repo, "spillover", "add", "--source", source,
+               "--desc", desc, "--id", sid).returncode == 0
+
+
+def _register_failing_gate(repo: Path, gate_id: str) -> None:
+    """A regression gate that always fails, so the OTHER verdict can be seen."""
+    (repo / ".prd-os" / "gates.jsonl").write_text(json.dumps({
+        "gate_id": gate_id, "issue_id": "iss-old", "lifecycle": "regression",
+        "command": "exit 7",
+    }) + "\n")
+
+
+# --- the defect itself -------------------------------------------------------
+
+def test_inherited_backlog_does_not_block_a_scoped_run(repo):
+    """RED before the fix: one item from OTHER work made a clean issue red."""
+    _set_active_issue(repo, "ASK-1")
+    _add(repo, "sp-inherited", "some-old-issue")
+    g = run(repo, "gates", "run")
+    assert g.returncode == 0, (
+        "an inherited backlog item blocked a scoped run; the red light is "
+        f"still uninformative.\nstdout={g.stdout}\nstderr={g.stderr}"
+    )
+
+
+def test_census_names_the_inherited_backlog_on_a_passing_run(repo):
+    """A pass must still say the number out loud. This is the anti-silent-drop
+    property: the operator has ADHD and a backlog that stops being printed is
+    functionally deleted. Asserts the LITERAL count, not 'same as before'."""
+    _set_active_issue(repo, "ASK-1")
+    for n in range(3):
+        _add(repo, f"sp-old{n}", "some-old-issue")
+    g = run(repo, "gates", "run")
+    assert g.returncode == 0
+    out = g.stdout + g.stderr
+    assert "3" in out and "inherited" in out, (
+        f"a passing scoped run hid the 3-item backlog entirely.\nout={out}"
+    )
+    assert "no open spillover" not in out, (
+        "the run printed a FALSE claim of an empty ledger while 3 items were "
+        f"open. A lying green is worse than a red.\nout={out}"
+    )
+
+
+def test_explicit_scope_flag_selects_what_blocks(repo):
+    _set_active_issue(repo, "ASK-1")
+    _add(repo, "sp-mine", "ASK-2")
+    g = run(repo, "gates", "run", "--scope", "ASK-2")
+    assert g.returncode == 1, (
+        "--scope did not select the blocking set (2 = argparse rejected the "
+        f"flag).\nstdout={g.stdout}\nstderr={g.stderr}"
+    )
+    assert "sp-mine" in (g.stdout + g.stderr)
+
+
+# --- the invariants the fix must NOT break -----------------------------------
+
+def test_attributable_item_still_blocks_a_scoped_run(repo):
+    """The whole point of the ledger. If this ever passes green, the fix has
+    become the hand-clear it was written to avoid."""
+    _set_active_issue(repo, "ASK-1")
+    _add(repo, "sp-mine", "ASK-1")
+    g = run(repo, "gates", "run")
+    assert g.returncode != 0, "work's own spillover item did not block its gate"
+    assert "sp-mine" in (g.stdout + g.stderr)
+
+
+def test_unscoped_run_is_fail_closed_on_everything(repo):
+    """No active issue = no excuse. The bare `gates run` that wiring-check.md
+    tells you to run still sees all 640. Nothing is hidden by the scoping."""
+    _add(repo, "sp-a", "some-old-issue")
+    _add(repo, "sp-b", "another-old-issue")
+    g = run(repo, "gates", "run")
+    assert g.returncode != 0, "unscoped run went green over an open ledger"
+    out = g.stdout + g.stderr
+    assert "sp-a" in out and "sp-b" in out
+
+
+def test_active_prd_scopes_when_no_active_issue(repo):
+    _set_active_prd(repo, "prd-x")
+    _add(repo, "sp-inherited", "some-old-issue")
+    _add(repo, "sp-mine", "prd-x")
+    g = run(repo, "gates", "run")
+    assert g.returncode != 0
+    out = g.stdout + g.stderr
+    assert "sp-mine" in out, f"active PRD did not scope the gate.\nout={out}"
+
+
+def test_regression_failure_is_reported_separately_from_the_backlog(repo):
+    """The two verdicts must be distinguishable. A closeout reading this needs
+    to tell 'you broke something' from 'there is a backlog'."""
+    _set_active_issue(repo, "ASK-1")
+    _register_failing_gate(repo, "g-broken")
+    _add(repo, "sp-inherited", "some-old-issue")
+    g = run(repo, "gates", "run")
+    assert g.returncode != 0
+    out = g.stdout + g.stderr
+    assert "g-broken" in out, f"the real regression failure was not named.\nout={out}"
+    assert "GATE RED: spillover" not in out, (
+        "an inherited-only backlog was reported as a gate failure, which is "
+        f"the ambiguity this issue exists to remove.\nout={out}"
+    )

--- a/plugins/prd-os/tests/test_spillover_gate_scope.py
+++ b/plugins/prd-os/tests/test_spillover_gate_scope.py
@@ -96,9 +96,14 @@ def _live_spec(repo: Path, sid: str, kind: str = "issues") -> None:
     subprocess.run(["git", "-C", str(repo), "add", "-f", rel], check=True)
     subprocess.run(["git", "-C", str(repo), "commit", "-q", "-m", f"add {sid}"], check=True)
 
-def _add(repo: Path, sid: str, source: str, desc: str = "a real finding") -> None:
+def _add(repo: Path, sid: str, source: str, desc: str = "a real finding",
+         severity: str = "major") -> None:
+    """Seeded at MAJOR on purpose. This file tests ATTRIBUTION; severity is the
+    other axis of the combined rule and must be held above the reporting bar, or
+    a green result is ambiguous between "not attributable" and "not severe"."""
     assert run(repo, "spillover", "add", "--source", source,
-               "--desc", desc, "--id", sid).returncode == 0
+               "--desc", desc, "--id", sid,
+               "--severity", severity).returncode == 0
 
 
 def _register_failing_gate(repo: Path, gate_id: str) -> None:


### PR DESCRIPTION
Closes ASK-532. Lands ASK-526/527, rebased onto `origin/main` and reconciled with the severity filter main already carries.

## The defect

`gates run`'s spillover verdict was RED with probability 1 regardless of the diff, so it carried no information about the diff. `wiring-check.md` mandates `gates run` exits 0 as definition-of-done, so the repo's own done-check was decoration.

## Measured, kipi-system 2026-08-09

- 636 open items (collapsed by id, last-write-wins)
- Severity filter blocks 18
- All 18 inherited from other work (prd-silent-absence, scs-validated-event-fold, ASK-402, PR-123); none attributable to any change under review

## Why this is not either existing fix

ASK-363 shipped severity scoping. ASK-526/527 shipped attribution scoping. They were written without seeing each other, and each deletes the other's contract alone:

- Severity alone: 18 inherited items wedge every PR forever.
- Attribution alone: blocks on a MINOR item your own work opened, collapsing the two-bar split (`gates run` = daily light, `archive` = closeout refusing ANY open item). Landing it naively turned 6 severity tests red.

## The combined rule (`_spillover_blocks`)

```
no live scope        -> severity decides (ASK-363's rule, unchanged)
item source == scope -> severity decides (your own item, normal bar)
inherited item       -> only `blocker` blocks
```

Attribution narrows WHICH items count; severity still sets the bar; a `blocker` anywhere is the floor.

## Real-ledger effect

| run | blocks |
|-----|--------|
| bare (no scope) | 19 (unchanged from main) |
| `--scope ASK-363` | 1 |

Census prints all 638 and names the 19 blocking-severity inherited items. A green run never goes quiet over the backlog.

## Known cost, named on purpose

One inherited `blocker` wedges EVERY scope until somebody acts on it. Intended blast radius of the word, but it makes severity a loaded gun. Three auditable escapes, each recording a decision: `reclassify --reason`, `resolve` against a closed issue, `void` with a reason. No `--ignore-inherited` flag, deliberately: that is the hand-clear `no-orphan-findings.md` refuses everywhere else.

Live today: `defer-prd-deterministic-reading-2026-07-28-finding-3` is an inherited blocker and currently wedges every scoped run.

## Evidence

- Red first: combined-rule tests vs pure-attribution code, 2 failed for the right reasons ("an inherited BLOCKER did not stop the world"; "a MINOR item this work opened blocked the daily gate")
- All 6 severity tests in `test_spillover.py` pass UNEDITED
- Full prd-os suite: 627 passed, 1 skipped, 0 failed
- Mutation-tested both load-bearing clauses: floor removed -> 1 fail; census silenced -> 1 fail; control green

🤖 Generated with [Claude Code](https://claude.com/claude-code)