### PR TITLE
The founder-alert channel reports whether the message was sent (ASK-534)

### DIFF
--- a/q-system/.q-system/capability-manifest.json
+++ b/q-system/.q-system/capability-manifest.json
@@ -235,6 +235,10 @@
       "runner": "bash"
     },
     {
+      "path": "q-system/.q-system/scripts/test/test-notify-exit-contract.sh",
+      "runner": "bash"
+    },
+    {
       "path": "q-system/.q-system/scripts/test/test-notify-fixture-guard.sh",
       "runner": "bash"
     },

--- a/q-system/.q-system/scripts/slack-notify.sh
+++ b/q-system/.q-system/scripts/slack-notify.sh
@@ -6,7 +6,13 @@
 # Webhook URL is a SECRET -- never committed. Resolved from, in order:
 #   1. $KIPI_SLACK_WEBHOOK
 #   2. ~/.config/kipi/slack-webhook  (gitignored file, one line)
-# No webhook configured -> silent no-op (exit 0), so callers never break.
+# EXIT CONTRACT (ASK-534). Exit 0 means DELIVERED and nothing else:
+#   0  delivered (curl succeeded)
+#   1  send attempted and FAILED (curl status + stderr reported)
+#   3  no webhook configured -- nothing to send on (a setup state, not an error)
+#   4  refused: fixture run (see the guard below)
+# Callers that do not care still work unchanged (`|| true`); callers that need to
+# know whether a human was actually reached can finally ask.
 #
 # Usage: slack-notify.sh "message text"
 set -uo pipefail
@@ -90,7 +96,7 @@ if [ -n "${KIPI_LINEAR_API_URL:-}" ]; then
   if _kipi_loopback_host "$_KHOST"; then
     printf 'slack-notify: REFUSED to page a human -- fixture run (KIPI_LINEAR_API_URL host "%s" is loopback). Message NOT sent: %s\n' \
            "$_KHOST" "$MSG" >&2
-    exit 0
+    exit 4
   fi
 fi
 
@@ -98,9 +104,50 @@ HOOK="${KIPI_SLACK_WEBHOOK:-}"
 if [ -z "$HOOK" ] && [ -f "$HOME/.config/kipi/slack-webhook" ]; then
   HOOK="$(tr -d '\n\r' < "$HOME/.config/kipi/slack-webhook")"
 fi
-[ -n "$HOOK" ] || exit 0   # not configured yet -> silent
+if [ -z "$HOOK" ]; then
+  # NOT AN ERROR, and NOT a delivery either. Distinct from 1 so a caller can tell
+  # "nothing to send on" (a setup state, common on a fresh instance) from "the
+  # send failed" (an operational problem). Deliberately NOT 0: exit 0 is the
+  # promise that a human was reached, and this script must never make that
+  # promise on behalf of a webhook that does not exist.
+  exit 3
+fi
 
 PAYLOAD="$(python3 -c "import json,sys; print(json.dumps({'text': sys.argv[1]}))" "$MSG" 2>/dev/null)"
-[ -n "$PAYLOAD" ] || exit 0
-curl -fsS -X POST -H 'Content-type: application/json' --data "$PAYLOAD" "$HOOK" >/dev/null 2>&1 || true
+if [ -z "$PAYLOAD" ]; then
+  printf 'slack-notify: could not build the JSON payload; message NOT sent: %s\n' "$MSG" >&2
+  exit 1
+fi
+
+# THE SEND RESULT IS REPORTED, NOT SWALLOWED (ASK-534, sp-8f879dc5).
+#
+# This line used to end in `|| true` followed by an unconditional `exit 0`, so a
+# dead webhook, an HTTP 404, an expired URL and no-network were all
+# indistinguishable from a delivered message. This is the SINGLE sanctioned
+# founder-alert channel (founder-notifications.md bans osascript), so that one
+# `|| true` meant every autonomous-run alert in the fleet could stop arriving
+# with no symptom anywhere. Delivery was last confirmed BY HAND on 2026-07-29;
+# nothing in the system would have reported it otherwise.
+#
+# Callers were audited before this changed (ASK-534): every one either ignores
+# the status (`|| true`, or an unchecked subprocess.run) or already WANTS it.
+# kipi-dispatch.sh:197 is the latter -- its `else` branch says "page did NOT go
+# out; leaving the marker unset so the next heartbeat retries it" and was DEAD
+# CODE, unreachable while this script always exited 0. This arms it.
+#
+# fable-escalate.py built the same distinction at its own call site as a
+# workaround (notify_attempted / notify_channel_configured / notify_delivered).
+# That workaround stays correct and is left alone; it is now backed by a
+# chokepoint that tells the truth instead of a caller guessing around one.
+CURL_ERR="$(curl -fsS -X POST -H 'Content-type: application/json' \
+                 --data "$PAYLOAD" "$HOOK" 2>&1 >/dev/null)"
+CURL_RC=$?
+if [ "$CURL_RC" -ne 0 ]; then
+  # The message goes to stderr so an alert that failed to send is still readable
+  # in the job log. A silently swallowed alert is the exact failure mode
+  # founder-notifications.md exists to prevent.
+  printf 'slack-notify: send FAILED (curl exit %s: %s). Message NOT delivered: %s\n' \
+         "$CURL_RC" "${CURL_ERR:-no stderr}" "$MSG" >&2
+  exit 1
+fi
 exit 0

--- a/q-system/.q-system/scripts/test/test-notify-exit-contract.sh
+++ b/q-system/.q-system/scripts/test/test-notify-exit-contract.sh
@@ -1,0 +1,100 @@
+#!/bin/bash
+# ASK-534 / sp-8f879dc5: slack-notify.sh must report whether the message was sent.
+#
+# THE DEFECT. The send line ended in `|| true` followed by an unconditional
+# `exit 0`, so a dead webhook, an HTTP 404, an expired URL and no-network were
+# all indistinguishable from a delivered message. This is the SINGLE sanctioned
+# founder-alert channel (founder-notifications.md bans osascript), so that one
+# `|| true` meant every autonomous-run alert in the fleet could stop arriving
+# with no symptom anywhere. Delivery was last confirmed BY HAND on 2026-07-29.
+#
+# WHY A REAL LOCAL SERVER AND NOT A STUBBED curl. The whole defect is that the
+# script did not read curl's status. A test that replaces curl proves the test's
+# stub works, not that the script reads the status of the thing it actually
+# runs. So: a real HTTP server on loopback, one endpoint returning 200 and one
+# returning 404, and curl -f run for real against both. The 404 case is the one
+# that matters -- a webhook that Slack has revoked answers exactly that way, and
+# it is the shape the old code called success.
+#
+# NOTE the deliberate asymmetry: the webhook URL points at loopback here, which
+# is FINE. The fixture guard keys on KIPI_LINEAR_API_URL, a different variable.
+# Case 2 below pins that the guard still fires, so this test cannot accidentally
+# prove the guard away.
+set -uo pipefail
+
+HERE="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+NOTIFY="$HERE/../slack-notify.sh"
+[ -f "$NOTIFY" ] || { echo "FAIL: slack-notify.sh not found at $NOTIFY"; exit 1; }
+
+TMP="$(mktemp -d)"
+trap 'rm -rf "$TMP" 2>/dev/null; [ -n "${SRV_PID:-}" ] && kill "$SRV_PID" 2>/dev/null' EXIT
+
+PASS=0; FAIL=0
+ok()   { PASS=$((PASS+1)); echo "PASS: $1"; }
+bad()  { FAIL=$((FAIL+1)); echo "FAIL: $1"; }
+check_rc() { # want, got, label
+  if [ "$2" = "$1" ]; then ok "$3 (exit $2)"; else bad "$3 -- wanted exit $1, got $2"; fi
+}
+
+# A fake Slack: /ok returns 200, anything else 404. Bound to an ephemeral port so
+# two runs of this suite cannot collide.
+cat > "$TMP/srv.py" <<'PY'
+import http.server, socketserver, threading, sys
+class H(http.server.BaseHTTPRequestHandler):
+    def do_POST(self):
+        n = int(self.headers.get("Content-Length", 0)); self.rfile.read(n)
+        code = 200 if self.path == "/ok" else 404
+        self.send_response(code); self.end_headers(); self.wfile.write(b"x")
+    def log_message(self, *a): pass
+with socketserver.TCPServer(("127.0.0.1", 0), H) as s:
+    print(s.server_address[1], flush=True)
+    s.serve_forever()
+PY
+python3 "$TMP/srv.py" > "$TMP/port" 2>/dev/null &
+SRV_PID=$!
+for _ in $(seq 1 50); do [ -s "$TMP/port" ] && break; sleep 0.1; done
+PORT="$(tr -d '[:space:]' < "$TMP/port")"
+[ -n "$PORT" ] || { echo "FAIL: fixture server never reported a port"; exit 1; }
+
+# Every case runs with HOME pointed at an empty dir so the
+# ~/.config/kipi/slack-webhook fallback cannot resolve and leak a real webhook.
+mkdir -p "$TMP/home"
+run() { env -i PATH="$PATH" HOME="$TMP/home" "$@" bash "$NOTIFY" "test message" 2>"$TMP/err"; }
+
+# --- 1. no webhook configured -> 3, distinct from both delivered and failed ---
+run KIPI_SLACK_WEBHOOK=
+check_rc 3 "$?" "no webhook configured exits 3"
+
+# --- 2. fixture run -> 4, and the guard still fires with a webhook present ----
+run KIPI_SLACK_WEBHOOK="http://127.0.0.1:$PORT/ok" KIPI_LINEAR_API_URL="http://127.0.0.1:9/graphql"
+rc=$?
+check_rc 4 "$rc" "fixture run is refused"
+grep -q "REFUSED" "$TMP/err" || bad "fixture refusal did not say REFUSED on stderr"
+
+# --- 3. delivered -> 0 --------------------------------------------------------
+run KIPI_SLACK_WEBHOOK="http://127.0.0.1:$PORT/ok"
+check_rc 0 "$?" "a 200 from the webhook is a delivery"
+
+# --- 4. HTTP 404 -> 1. THE REGRESSION. A revoked Slack webhook answers 404 and
+#        the old code reported that as success.
+run KIPI_SLACK_WEBHOOK="http://127.0.0.1:$PORT/revoked"
+rc=$?
+check_rc 1 "$rc" "an HTTP 404 (revoked webhook) is a FAILURE, not a delivery"
+grep -q "send FAILED" "$TMP/err" || bad "404 did not report 'send FAILED' on stderr"
+
+# --- 5. unreachable host -> 1 -------------------------------------------------
+run KIPI_SLACK_WEBHOOK="http://127.0.0.1:1/definitely-dead"
+rc=$?
+check_rc 1 "$rc" "an unreachable webhook is a FAILURE"
+grep -q "Message NOT delivered" "$TMP/err" || bad "unreachable host did not name the undelivered message"
+
+# --- 6. the undelivered TEXT survives to stderr, so the alert is still readable
+run KIPI_SLACK_WEBHOOK="http://127.0.0.1:1/definitely-dead"
+grep -q "test message" "$TMP/err" \
+  && ok "the undelivered message text is still readable in the job log" \
+  || bad "the alert text was swallowed along with the failure"
+
+echo
+echo "passed=$PASS failed=$FAIL"
+[ "$FAIL" -eq 0 ] || exit 1
+exit 0


### PR DESCRIPTION
Closes ASK-534. Resolves `sp-8f879dc5`, open since 2026-07-29, raised minor -> major here after the blast radius was measured.

## The defect

`slack-notify.sh` ended its send in `|| true` followed by an unconditional `exit 0`. A revoked webhook, an HTTP 404, an expired URL and no-network were all indistinguishable from a delivered message.

This is the **single sanctioned founder-alert channel** (`founder-notifications.md` bans osascript). So that one `|| true` meant every autonomous-run alert in the fleet could stop arriving with no symptom anywhere. The last confirmation that delivery worked at all was done **by hand on 2026-07-29**.

## Exit contract

Exit 0 now means DELIVERED and nothing else.

| code | meaning |
|---|---|
| 0 | delivered |
| 1 | send attempted and FAILED (curl status + stderr reported) |
| 3 | no webhook configured — a setup state, not an error |
| 4 | refused: fixture run |

## Callers audited before changing a shared contract

Every caller either ignores the status (`|| true`, or an unchecked `subprocess.run`) or already wants it.

`kipi-dispatch.sh:197` is the latter — its `else` branch reads *"page did NOT go out; leaving the marker unset so the next heartbeat retries it"* and was **dead code**, unreachable while this script always exited 0. This arms it.

`fable-escalate.py` built the same distinction at its own call site as a workaround (`notify_attempted` / `notify_channel_configured` / `notify_delivered`). That stays correct and is left alone — it's now backed by a chokepoint that tells the truth instead of a caller guessing around one.

## Evidence

The test drives a **real loopback HTTP server** rather than stubbing curl. The defect was precisely that the script never read curl's status, so a stubbed curl would only prove the stub works. The 404 case is the one that matters: that is how Slack answers a revoked webhook, and the old code called it success.

- Negative self-test against main's script: **7 of 8 assertions fail**, including `an HTTP 404 (revoked webhook) is a FAILURE, not a delivery -- wanted exit 1, got 0`
- Against the fix: **6/6 pass**
- Existing `test-notify-fixture-guard.sh`: **25/25 still green** (the fixture guard keys on `KIPI_LINEAR_API_URL`, a different variable, and case 2 pins that it still fires)

🤖 Generated with [Claude Code](https://claude.com/claude-code)