### PR TITLE
feat(claude-changes): a route to a script that does not exist is a lie, not enforcement (ASK-290)

### DIFF
--- a/.prd-os/receipts.jsonl
+++ b/.prd-os/receipts.jsonl
@@ -124,3 +124,4 @@
 {"commit_sha": "4f4b0bf58e833da1d03b0b4f47df40b4476f6919", "issue_id": "ASK-447", "receipts": {"reviewed": "2026-08-09T11:28:24Z"}, "reviewed_at": "2026-08-09T11:28:24Z"}
 {"commit_sha": "20cbf72b9db116453c0ace4bd83a6d1f0c110bb6", "issue_id": "ASK-457", "receipts": {"reviewed": "2026-08-10T11:51:03Z"}, "reviewed_at": "2026-08-10T11:51:03Z"}
 {"commit_sha": "f590ed790ee23d5d076c6d943a75ebf63c4714b8", "issue_id": "ASK-291", "receipts": {"reviewed": "2026-08-10T16:24:51Z"}, "reviewed_at": "2026-08-10T16:24:51Z"}
+{"commit_sha": "6cd247a80f0688273ff6595d4e77d80c289a091f", "issue_id": "ASK-290", "receipts": {"reviewed": "2026-08-12T15:17:45Z"}, "reviewed_at": "2026-08-12T15:17:45Z"}

--- a/.prd-os/receipts.jsonl
+++ b/.prd-os/receipts.jsonl
@@ -125,3 +125,4 @@
 {"commit_sha": "20cbf72b9db116453c0ace4bd83a6d1f0c110bb6", "issue_id": "ASK-457", "receipts": {"reviewed": "2026-08-10T11:51:03Z"}, "reviewed_at": "2026-08-10T11:51:03Z"}
 {"commit_sha": "f590ed790ee23d5d076c6d943a75ebf63c4714b8", "issue_id": "ASK-291", "receipts": {"reviewed": "2026-08-10T16:24:51Z"}, "reviewed_at": "2026-08-10T16:24:51Z"}
 {"commit_sha": "6cd247a80f0688273ff6595d4e77d80c289a091f", "issue_id": "ASK-290", "receipts": {"reviewed": "2026-08-12T15:17:45Z"}, "reviewed_at": "2026-08-12T15:17:45Z"}
+{"commit_sha": "a3677935eea1e898e5db436788f26aee555ffb9b", "issue_id": "ASK-290", "receipts": {"reviewed": "2026-08-12T15:26:00Z"}, "reviewed_at": "2026-08-12T15:26:00Z"}

--- a/q-system/.q-system/scripts/apply_claude_changes.py
+++ b/q-system/.q-system/scripts/apply_claude_changes.py
@@ -74,6 +74,14 @@ its line count passes. Marker placement is checked at heading granularity only:
 moving it between two headings of the same file is invisible here. That is the
 deliberate trade: a ratchet that judged prose would refuse the honest
 corrections this op exists to enable.
+
+And one more, added deliberately by ASK-290: a route is a census member only
+when it RESOLVES to a real file, so a route this repo cannot see is not
+protected. Resolution is repo-only, which means a rule pointing at a hook
+outside the repo (~/.claude/hooks/destructive-op-deny.sh) is unprotected prose a
+replace could drop -- captured as sp-f4e9682b rather than silently accepted.
+The alternative was worse: counting unresolvable routes is what made correcting
+a FALSE enforcement claim impossible, which is the single job this op exists for.
 """
 import contextlib
 import importlib.util
@@ -101,8 +109,10 @@ ANCHOR_OPS = ("insert_after", "insert_before", "replace")
 
 RULES_DIR = os.path.join(".claude", "rules")
 
-# A rule's pointer to the thing that actually enforces it. Census member, so a
-# replace cannot quietly cut a reader's route to the enforcer.
+# A rule's pointer to the thing that actually enforces it. Census member WHEN IT
+# RESOLVES TO A REAL FILE (see _exec_ref_resolves), so a replace cannot quietly
+# cut a reader's route to the enforcer -- and can still correct a route to an
+# enforcer that was never there.
 #
 # The DIRECTORY PREFIX is part of the mark, not decoration. Matching the
 # basename alone let a replace keep `existing-lint.py` while moving its route to
@@ -624,8 +634,70 @@ def _frontmatter(text):
     return match.group(0) if match else ""
 
 
-def _rule_marks(rules_dir):
-    """Read every rule ONCE and return (token_marks, line_marks).
+# Directories the script index never walks. .git holds thousands of blobs and no
+# routable script; node_modules is the same shape. Every OTHER dot-directory is
+# walked on purpose -- see _script_index.
+_INDEX_PRUNE = frozenset({".git", "node_modules"})
+
+_SCRIPT_INDEX = {}
+
+
+def _script_index(root):
+    """Every .py/.sh under root, indexed by repo-relative path AND by basename.
+
+    os.walk, NOT glob("**"): glob's ** skips dot-directories, and every script
+    this repo's rules route a reader to lives under `q-system/.q-system/scripts/`
+    -- a dot-directory. A glob-based index would report all of them missing, and
+    since a missing script means "not a census member", that would silently empty
+    the named_executables census instead of merely narrowing it. The blinding
+    version of this check looks identical to the working one from the outside,
+    which is why the index is walked and not globbed.
+
+    Cached per root. Both censuses of one run resolve against the same real tree,
+    computed before any write, so the tree cannot move between them.
+    """
+    key = os.path.abspath(root)
+    if key in _SCRIPT_INDEX:
+        return _SCRIPT_INDEX[key]
+    rels, names = set(), set()
+    for dirpath, dirnames, filenames in os.walk(key):
+        dirnames[:] = [d for d in dirnames if d not in _INDEX_PRUNE]
+        for filename in filenames:
+            if not filename.endswith((".py", ".sh")):
+                continue
+            names.add(filename)
+            rels.add(os.path.relpath(os.path.join(dirpath, filename), key))
+    _SCRIPT_INDEX[key] = (rels, names)
+    return _SCRIPT_INDEX[key]
+
+
+def _exec_ref_resolves(ref, index):
+    """Does this written route point at a file that is actually there?
+
+    The existence qualifier is load-bearing in the PERMISSIVE direction, and that
+    is the whole of ASK-290: a rule naming a script that does not exist is a
+    LIE, not enforcement. Counting it as a census member made deleting the lie
+    look like deleting enforcement, so the engine refused the single edit
+    `replace` was built for. Measured on the fixture: correcting
+    `retired-lint.py` exited `REFUSED: enforcement ratchet: 1 rule_marks
+    entr(ies) would disappear`.
+
+    It cannot weaken anything, because BOTH censuses resolve against the same
+    real tree: rerouting a live enforcer to a dead path still drops the old
+    member and adds none, so the set difference refuses it exactly as before.
+
+    A route with a directory prefix must exist AT THAT PATH -- resolving it by
+    basename would undo PR #70 round 4, where moving `existing-lint.py` under
+    `q-system/retired/hooks/` kept the reader's route dead and the census happy.
+    """
+    rels, names = index
+    if os.sep in ref:
+        return os.path.normpath(ref) in rels
+    return ref in names
+
+
+def _rule_marks(rules_dir, script_index):
+    """Read every rule ONCE and return (enforced_marks, exec_marks, line_marks).
 
     One walk and one read per file on purpose. Two functions each opening the
     same rules is two readers free to drift -- the defect class round 2 found in
@@ -640,14 +712,17 @@ def _rule_marks(rules_dir):
     Two token classes are countable without judgement, which is the bar for a
     ratchet member:
 
-      enforced : the file claims (ENFORCED anywhere. Demoting a rule to advisory
-                 is enforcement-weakening whether or not the prose is honest. If
-                 the claim is genuinely false, the fix is to correct the SCOPE
-                 (which replace now allows) or to take the marker off through a
-                 different tool and a real conversation -- same standing as
-                 removing a hook.
-      exec     : a named .py/.sh the rule routes a reader to. A rule whose
-                 pointer to its enforcer vanishes is a rule nobody can act on.
+      enforced_claims   : the file claims (ENFORCED anywhere. Demoting a rule to
+                 advisory is enforcement-weakening whether or not the prose is
+                 honest. If the claim is genuinely false, the fix is to correct
+                 the SCOPE (which replace now allows) or to take the marker off
+                 through a different tool and a real conversation -- same
+                 standing as removing a hook.
+      named_executables : a named .py/.sh the rule routes a reader to, AND that
+                 resolves to a real file (_exec_ref_resolves). A rule whose
+                 pointer to its enforcer vanishes is a rule nobody can act on;
+                 a rule pointing at a file that was never there is prose, and
+                 correcting it is the one job `replace` exists to do.
 
     Deliberately NOT counted: prose meaning and tone. A ratchet that tried to
     judge those would refuse the honest corrections this op exists to enable.
@@ -669,10 +744,11 @@ def _rule_marks(rules_dir):
     residue is named in the module docstring rather than papered over: a rewrite
     that keeps the shape and hollows out the meaning still passes.
     """
-    token_marks = set()
+    enforced_marks = set()
+    exec_marks = set()
     line_marks = set()
     if not os.path.isdir(rules_dir):
-        return token_marks, line_marks
+        return enforced_marks, exec_marks, line_marks
     # os.walk, not os.listdir. rule_text_only permits a rule at any depth under
     # rules/, so a one-level census left a subdirectory rule inside replace's
     # reach and outside every content check at once (PR #70 round 4, minor). The
@@ -691,7 +767,9 @@ def _rule_marks(rules_dir):
             except (OSError, UnicodeDecodeError):
                 continue
             for ref in set(_EXEC_REF.findall(text)):
-                token_marks.add("%s|exec|%s" % (name, ref))
+                if not _exec_ref_resolves(ref, script_index):
+                    continue
+                exec_marks.add("%s|exec|%s" % (name, ref))
             # (ENFORCED is counted twice, and the second count is the one that
             # closes the hole. A whole-file presence boolean let a replace lift
             # the marker off the heading that DECLARES the rule enforced and park
@@ -705,20 +783,29 @@ def _rule_marks(rules_dir):
             # survives both. Same encode-a-count-as-a-set trick as line marks,
             # for the same reason -- ratchet_check compares sets.
             for index in range(text.count("(ENFORCED")):
-                token_marks.add("%s|enforced|%d" % (name, index))
+                enforced_marks.add("%s|enforced|%d" % (name, index))
             lines = text.splitlines()
             headings = sum(1 for line in lines
                            if _HEADING.match(line) and "(ENFORCED" in line)
             for index in range(headings):
-                token_marks.add("%s|enforced-heading|%d" % (name, index))
+                enforced_marks.add("%s|enforced-heading|%d" % (name, index))
             substantive = sum(1 for line in lines if line.strip())
             for index in range(substantive):
                 line_marks.add("%s|line|%d" % (name, index))
-    return token_marks, line_marks
+    return enforced_marks, exec_marks, line_marks
 
 
-def census(root):
-    """Count the live enforcement points. Enforcement may only grow."""
+def census(root, resolve_root=None):
+    """Count the live enforcement points. Enforcement may only grow.
+
+    resolve_root is where a rule's named script is looked for, and it is NOT
+    always `root`. The "after" census reads a copy tree that holds `.claude/`
+    and nothing else, so resolving there would find zero scripts and report the
+    whole named_executables census as gone -- turning the qualifier into a
+    blanket amnesty on exec routes. Both censuses of a run therefore resolve
+    against the REAL repo root, which is also what makes the comparison mean
+    anything: the two sides differ only in rule TEXT.
+    """
     c = {}
     settings_path = os.path.join(root, ".claude", "settings.json")
     settings = {}
@@ -732,7 +819,9 @@ def census(root):
     perms = settings.get("permissions") or {}
     c["deny"] = set(perms.get("deny") or [])
     c["rules"] = _dir_names(os.path.join(root, ".claude", "rules"))
-    c["rule_marks"], c["rule_lines"] = _rule_marks(os.path.join(root, ".claude", "rules"))
+    c["enforced_claims"], c["named_executables"], c["rule_lines"] = _rule_marks(
+        os.path.join(root, ".claude", "rules"),
+        _script_index(resolve_root if resolve_root is not None else root))
     c["agents"] = _dir_names(os.path.join(root, ".claude", "agents"))
     c["output_styles"] = _dir_names(os.path.join(root, ".claude", "output-styles"))
 
@@ -1048,13 +1137,17 @@ def main(argv):
                 fh.write(content)
 
         before_census = census(root)
-        after_census = census(copy_root)
+        # resolve_root=root, not copy_root: the copy holds only .claude/, so
+        # every named script would resolve to nothing there. See census().
+        after_census = census(copy_root, resolve_root=root)
         ratchet_check(before_census, after_census)
-        log.append("ratchet ok: hooks %d->%d, rules %d->%d, rule-marks %d->%d, deny %d->%d" % (
-            len(before_census["hooks"]), len(after_census["hooks"]),
-            len(before_census["rules"]), len(after_census["rules"]),
-            len(before_census["rule_marks"]), len(after_census["rule_marks"]),
-            len(before_census["deny"]), len(after_census["deny"])))
+        log.append("ratchet ok: hooks %d->%d, rules %d->%d, enforced %d->%d, "
+                   "execs %d->%d, deny %d->%d" % (
+                       len(before_census["hooks"]), len(after_census["hooks"]),
+                       len(before_census["rules"]), len(after_census["rules"]),
+                       len(before_census["enforced_claims"]), len(after_census["enforced_claims"]),
+                       len(before_census["named_executables"]), len(after_census["named_executables"]),
+                       len(before_census["deny"]), len(after_census["deny"])))
 
         if settings_key is not None:
             permission_surface_check(root, staged[settings_key])

--- a/q-system/.q-system/scripts/test/test-apply-claude-changes.sh
+++ b/q-system/.q-system/scripts/test/test-apply-claude-changes.sh
@@ -61,6 +61,18 @@ The deterministic half is `existing-lint.py`, wired PostToolUse on Edit|Write.
 This rule is enforced end to end and covers every path in the repo.
 MD
   echo "print('lint')" > "$r/q-system/.q-system/scripts/existing-lint.py"
+  # A rule whose named enforcer DOES NOT EXIST. This is the false-claim shape
+  # ASK-290 is about: the rule says a script enforces it, no such file is on
+  # disk, so the sentence is a lie and correcting it is exactly a `replace`.
+  # A census that counted the route regardless of existence made that
+  # correction look like enforcement being removed, and refused it.
+  cat > "$r/.claude/rules/false-claim-rule.md" <<'MD'
+# Stale Rule (ENFORCED)
+
+The deterministic half is `retired-lint.py`, wired PostToolUse on Edit|Write.
+
+Nothing on disk carries that name; the check moved and the sentence did not.
+MD
   # A rule carrying NEITHER token class the content census counts, plus the
   # frontmatter that decides whether it loads at all. 5 of this repo's 34 real
   # rules look exactly like this (security.md, content-output.md, ...), so it is
@@ -829,6 +841,68 @@ run_engine "$ENGINE" "$T/reword.json" "$T"
 check "same-length reword still succeeds" 0 "OK applied reword-advisory" "$RC" "$OUT"
 rm -r "$T"
 
+# ------------------------- 15j. a route to a script that does not exist (ASK-290)
+# The whole reason `replace` exists is to CORRECT a false enforcement claim, and
+# the commonest false claim is a rule naming an enforcer that is not there. A
+# census that counted every .py/.sh a rule mentions counted that lie as
+# enforcement, so removing it read as enforcement disappearing and the engine
+# refused the one edit it was built for. Existence is the qualifier: a route
+# that resolves to no file is not enforcement and is not a census member.
+T=$(mktemp -d); mk_fixture "$T"
+cat > "$T/fixstale.json" <<'JSON'
+{
+  "schema_version": 1, "slug": "fix-stale-route",
+  "reason": "the named enforcer does not exist; say so instead of naming it",
+  "edits": [ { "file": ".claude/rules/false-claim-rule.md", "op": "replace",
+               "anchor": "The deterministic half is `retired-lint.py`, wired PostToolUse on Edit|Write.",
+               "insert": "No script carries this today; it is advisory until one is wired.",
+               "reason": "retired-lint.py is not on disk, so the sentence is a lie" } ]
+}
+JSON
+run_engine "$ENGINE" "$T/fixstale.json" "$T"
+check "correcting a route to a NONEXISTENT script succeeds" 0 "OK applied fix-stale-route" "$RC" "$OUT"
+check_one_line "correcting a route to a nonexistent script" "$OUT"
+if grep -q "retired-lint.py" "$T/.claude/rules/false-claim-rule.md"; then
+  bad "the false route survived; the correction this op exists for is still blocked"
+else ok "the false route is gone"; fi
+if grep -q "(ENFORCED)" "$T/.claude/rules/false-claim-rule.md"; then
+  ok "correcting the route left the (ENFORCED) marker alone"
+else bad "correcting the route collaterally dropped the (ENFORCED) marker"; fi
+
+# The permissive half must not leak into the strict half. Same edit shape, on
+# the rule whose script IS on disk, stays refused -- that is 15c, restated here
+# so the two live side by side and the qualifier cannot be read as a blanket
+# amnesty for exec routes.
+cat > "$T/fixreal.json" <<'JSON'
+{
+  "schema_version": 1, "slug": "drop-real-route",
+  "reason": "same shape, but the named script exists",
+  "edits": [ { "file": ".claude/rules/enforced-rule.md", "op": "replace",
+               "anchor": "The deterministic half is `existing-lint.py`, wired PostToolUse on Edit|Write.",
+               "insert": "No script carries this today; it is advisory until one is wired.",
+               "reason": "r" } ]
+}
+JSON
+run_engine "$ENGINE" "$T/fixreal.json" "$T"
+check "dropping a route to an EXISTING script still refused" 2 "enforcement ratchet" "$RC" "$OUT"
+
+# Rerouting a live enforcer to a path that does not exist is the weakening this
+# qualifier could have opened: the old mark goes, and the new route is not a
+# member because it resolves to nothing. The set difference is what refuses it.
+cat > "$T/reroute.json" <<'JSON'
+{
+  "schema_version": 1, "slug": "reroute-to-nowhere",
+  "reason": "point the reader at a path that does not exist",
+  "edits": [ { "file": ".claude/rules/enforced-rule.md", "op": "replace",
+               "anchor": "The deterministic half is `existing-lint.py`, wired PostToolUse on Edit|Write.",
+               "insert": "The deterministic half is `q-system/retired/existing-lint.py`, still wired.",
+               "reason": "r" } ]
+}
+JSON
+run_engine "$ENGINE" "$T/reroute.json" "$T"
+check "rerouting a live enforcer to a dead path refused" 2 "enforcement ratchet" "$RC" "$OUT"
+rm -r "$T"
+
 # 15j. narrowing frontmatter so the rule never loads (PR #70 round 3, major).
 # Same body, same tokens, same line count -- every content check sees no change,
 # and the rule is dead because its paths: no longer match anything.
@@ -1434,7 +1508,7 @@ echo "--- mutation: stop counting which headings carry (ENFORCED ---"
 # the marker be lifted off the heading and parked in prose saying the opposite.
 T=$(mktemp -d); mk_fixture "$T"
 MUT="$T/mutant_head.py"
-mutate "$MUT" '                token_marks.add("%s|enforced-heading|%d" % (name, index))' \
+mutate "$MUT" '                enforced_marks.add("%s|enforced-heading|%d" % (name, index))' \
               '                pass'
 cat > "$T/park.json" <<'JSON'
 {
@@ -1491,8 +1565,8 @@ MUT="$T/mutant_marks.py"
 # Both (ENFORCED counters, because either one alone still refuses the demotion:
 # the occurrence count and the heading count each see this edit.
 mutate2 "$MUT" \
-  '                token_marks.add("%s|enforced|%d" % (name, index))' '                pass' \
-  '                token_marks.add("%s|enforced-heading|%d" % (name, index))' '                pass'
+  '                enforced_marks.add("%s|enforced|%d" % (name, index))' '                pass' \
+  '                enforced_marks.add("%s|enforced-heading|%d" % (name, index))' '                pass'
 cat > "$T/demote.json" <<'JSON'
 {
   "schema_version": 1, "slug": "demote-rule", "reason": "quietly downgrade a rule",
@@ -1544,6 +1618,65 @@ if grep -q 'Bash(:\*)' "$T/.claude/settings.json"; then
   ok "MUTATION spelling: collapse removed -> the unchecked spelling widened permissions.allow (rc=$MRC), test goes RED as required"
 else
   bad "MUTATION spelling: mutant did not widen permissions - case 15p is not load-bearing"
+fi
+rm -r "$T"
+
+echo
+echo "--- mutation: count exec routes that resolve to nothing (ASK-290) ---"
+# Without the existence qualifier, a rule's route to a script that is NOT ON
+# DISK counts as enforcement, so correcting that false claim reads as
+# enforcement disappearing and is refused. That refusal is the observed RED this
+# issue started from; the mutant has to reproduce it or case 15j proves nothing.
+T=$(mktemp -d); mk_fixture "$T"
+cat > "$T/fixstale.json" <<'JSON'
+{
+  "schema_version": 1, "slug": "fix-stale-route",
+  "reason": "the named enforcer does not exist; say so instead of naming it",
+  "edits": [ { "file": ".claude/rules/false-claim-rule.md", "op": "replace",
+               "anchor": "The deterministic half is `retired-lint.py`, wired PostToolUse on Edit|Write.",
+               "insert": "No script carries this today; it is advisory until one is wired.",
+               "reason": "r" } ]
+}
+JSON
+MUT="$T/mutant_exists.py"
+mutate "$MUT" '                if not _exec_ref_resolves(ref, script_index):' \
+              '                if False:'
+set +e
+MOUT=$(python3 "$MUT" "$T/fixstale.json" --root "$T" 2>&1); MRC=$?
+set -e
+if [ "$MRC" = "2" ]; then
+  ok "MUTATION exists: qualifier removed -> correcting a route to a missing script refused again (rc=$MRC), test goes RED as required"
+else
+  bad "MUTATION exists: mutant still applied - case 15j is not load-bearing :: $MOUT"
+fi
+rm -r "$T"
+
+echo "--- mutation: resolve the AFTER census against the copy tree (ASK-290) ---"
+# The copy holds .claude/ and nothing else. Resolving there finds zero scripts,
+# so every named_executables mark vanishes on the after side and EVERY replace
+# on a rule that names a live enforcer is refused -- the qualifier turned into
+# an outage on the safe route. Case 15's plain correction is what catches it.
+T=$(mktemp -d); mk_fixture "$T"
+cat > "$T/fixclaim.json" <<'JSON'
+{
+  "schema_version": 1, "slug": "fix-false-claim",
+  "reason": "correct an overbroad enforcement sentence",
+  "edits": [ { "file": ".claude/rules/enforced-rule.md", "op": "replace",
+               "anchor": "This rule is enforced end to end and covers every path in the repo.",
+               "insert": "This rule is enforced on Edit|Write only; other paths are advisory.",
+               "reason": "r" } ]
+}
+JSON
+MUT="$T/mutant_resolveroot.py"
+mutate "$MUT" '        after_census = census(copy_root, resolve_root=root)' \
+              '        after_census = census(copy_root)'
+set +e
+MOUT=$(python3 "$MUT" "$T/fixclaim.json" --root "$T" 2>&1); MRC=$?
+set -e
+if [ "$MRC" = "2" ]; then
+  ok "MUTATION resolve-root: resolved against the copy -> an honest correction refused (rc=$MRC), test goes RED as required"
+else
+  bad "MUTATION resolve-root: mutant still applied - the resolve-root choice is not load-bearing :: $MOUT"
 fi
 rm -r "$T"
 


### PR DESCRIPTION
## What ASK-290 actually left open

ASK-289 (PR #70) shipped the `replace` op and the rule-CONTENT census. ASK-290's
**Design** section names one piece that did not ship with it: `named_executables`
as `(rule, script)` pairs **where the script resolves to a real file**.

That gap is not cosmetic. The exec census counted every `.py`/`.sh` a rule
named, present or not. So a rule saying "the deterministic half is
`retired-lint.py`" with no such file on disk counted as enforcement, and
correcting that false claim read as enforcement being removed.

## Observed RED first

```
FAIL: correcting a route to a NONEXISTENT script succeeds (exit 2, wanted 0)
:: REFUSED: enforcement ratchet: 1 rule_marks entr(ies) would disappear,
   first: false-claim-rule.md|exec|retired-lint.py
```

The engine refused the single edit `replace` was built to make. Fixing a false
enforcement claim is exactly a replace (three PRs on 2026-08-01 each found a rule
carrying one), and the ratchet that was widened to make replace safe is what
blocked it.

## The change

- `_exec_ref_resolves` + `_script_index`: a written route is a census member only
  when it resolves to a real file.
- Both censuses resolve against the **real repo root**, never the `.claude/`-only
  copy tree. Resolving in the copy would find zero scripts and empty the census
  entirely, converting the qualifier into a blanket amnesty on exec routes.
- `os.walk`, not `glob("**")`: `**` skips dot-directories and every script this
  repo routes rules to lives under `q-system/.q-system/scripts/`. A glob index
  would report all of them missing, and the blinded version looks identical to
  the working one from outside.
- A prefixed route must exist **at that path**; resolving by basename would undo
  PR #70 round 4 (moving a script under `retired/` kept the reader's route dead
  and the census happy).
- Census keys split per the DoR Design so a refusal names what shrank:
  `enforced_claims` and `named_executables`.

## It stays strict where it must

The qualifier cannot weaken anything, because both sides resolve against the same
real tree. Three cases pin that, all passing:

- dropping a route to a script that **does** exist -> still refused
- rerouting a live enforcer to a dead path -> still refused (old member gone, new
  route is not a member)
- repointing to a dead directory (PR #70 round 4) -> still refused

## Check

`bash q-system/.q-system/scripts/test/test-apply-claude-changes.sh`

```
passed: 130   failed: 0
```

was 122 before. Two new mutants, both kill their case:

```
PASS: MUTATION exists: qualifier removed -> correcting a route to a missing
      script refused again (rc=2), test goes RED as required
PASS: MUTATION resolve-root: resolved against the copy -> an honest correction
      refused (rc=2), test goes RED as required
```

Real-repo census, read-only: `enforced_claims 63 | named_executables 98 | rule_lines 1600`.

## Blast radius

The `.claude/` write path only. No change to the harness guard (ASK-282), no
direct shell write path reopened. No `delete` op (the DoR's Not-doing line).

## Honest boundary, documented not hidden

Resolution is repo-only, so a rule naming a hook outside the repo
(`~/.claude/hooks/destructive-op-deny.sh`) is unprotected prose a replace could
drop. Already captured as **sp-f4e9682b**; named in the module docstring rather
than left implicit. The alternative was worse: counting unresolvable routes is
what made correcting a false claim impossible in the first place.

DO NOT MERGE - closeout runs through /issue-verify and /issue-closeout.