### PR TITLE
Unreachable work is named, not filed under "skipped" (ASK-729)

### DIFF
--- a/kipi
+++ b/kipi
@@ -19,6 +19,8 @@ usage() {
   echo "  kipi migrate <path> --dry-run  Preview migration without changes"
   echo "  kipi cluster add <path> <name> <role>  Plug an instance into the KTLYST cluster"
   echo "  kipi cluster sync    Re-run all bridge writers (push latest state to all instances)"
+  echo "  kipi install-jobs    Install every committed launchd job on this machine"
+  echo "                       (run once per machine; without it nothing is scheduled)"
   echo "  kipi list            Show all registered projects"
   echo ""
   echo "  kipi linear issue \"<title>\"   Open a Linear issue for work you are ABOUT to start"
@@ -106,6 +108,17 @@ case "${1:-help}" in
     # It opens a PR and stops: it cannot merge and cannot close an issue.
     shift || true
     bash "$KIPI_HOME/q-system/.q-system/scripts/linear-worker.sh" "$@"
+    ;;
+  install-jobs)
+    # Install every committed launchd template so this machine actually runs the
+    # scheduled jobs. Added 2026-08-14 (ASK-729): six com.kipi.*.plist templates were
+    # committed and NOTHING invoked the installer, so a fresh checkout ran none of
+    # them and each job existed only where somebody had typed the command by hand.
+    # The first fix wrote `install-plist.sh --all` and stopped there, which moved the
+    # gap up a level rather than closing it -- a caller nobody calls is the same
+    # defect wearing a different name. This is the call site.
+    shift || true
+    bash "$KIPI_HOME/q-system/.q-system/scripts/install-plist.sh" --all "$@"
     ;;
   dor)
     # Bounded nightly DoR drafter. The autonomous worker only picks up issues that

--- a/kipi-dispatch.sh
+++ b/kipi-dispatch.sh
@@ -712,8 +712,18 @@ try: d=json.load(open(sys.argv[1]))
 except Exception: sys.exit(0)
 print(len(d.get("instances",[])))' "${KIPI_DISPATCH_REGISTRY:-$REPO/instance-registry.json}" 2>/dev/null)"
 FLEET_OPTED="$(fleet_candidates 2>/dev/null | awk -F'\t' -v h="$REPO" 'NF && $2 != h' | wc -l | tr -d ' ')"
-FLEET_HELD="$(printf '%s\n' "$PICKS" | awk -F'\t' -v h="$REPO" 'NF && $2 != h' | wc -l | tr -d ' ')"
-say "dispatch: ${FLEET_HELD:-0} repo(s) HELD (cross-repo gh scoping unfinished, sp-9421b9b7); ${FLEET_OPTED:-0} of ${FLEET_TOTAL:-0} registered repo(s) opted in for dispatch"
+# NO "HELD" COUNT ANY MORE. This line was written while kipi-dispatch.sh:726 held
+# every non-home target on unfinished cross-repo gh scoping, and it counted each
+# such pick as held. ASK-738 (#146) scoped every gh call and DROPPED that hold, so
+# the same number now describes repos the run ENTERS. Reporting them as held while
+# entering them is worse than the silence this line replaced: a reader would take
+# it as the reason nothing ran. Caught by the Codex review of #143 after the two
+# branches merged; each was correct alone.
+#
+# The opted-in count survives because it is the useful half: "0 of 25 opted in" is
+# still the single most useful fact about why no other repo is being served, and a
+# line that only appears when something happens cannot say it.
+say "dispatch: ${FLEET_OPTED:-0} of ${FLEET_TOTAL:-0} registered repo(s) opted in for cross-repo dispatch"
 
 TARGET_NAME=""
 TARGET_PATH=""

--- a/kipi-dispatch.sh
+++ b/kipi-dispatch.sh
@@ -677,6 +677,24 @@ if [ "${KIPI_DISPATCH_PICK_DRY:-0}" = "1" ]; then
   exit 0
 fi
 
+# FLEET POSTURE, STATED EVERY RUN (ASK-729). The HOLD line below only prints when
+# a non-home repo actually wins a turn, and `dispatch.enabled` is true for 0 of the
+# 23 registry rows -- so the rotation reaches nothing, the HOLD never fires, and
+# the whole cross-repo gap has been invisible in this log since 2026-08-01. That
+# silence is what let sp-09c61b20 stay the record for 13 days while the code had
+# already moved past it.
+#
+# Both numbers, unconditionally, even when they are zero: "0 opted in" is the
+# single most useful fact about why no client repo is being served, and a line
+# that only appears when something happens cannot say it.
+FLEET_TOTAL="$(python3 -c 'import json,sys
+try: d=json.load(open(sys.argv[1]))
+except Exception: sys.exit(0)
+print(len(d.get("instances",[])))' "${KIPI_DISPATCH_REGISTRY:-$REPO/instance-registry.json}" 2>/dev/null)"
+FLEET_OPTED="$(fleet_candidates 2>/dev/null | awk -F'\t' -v h="$REPO" 'NF && $2 != h' | wc -l | tr -d ' ')"
+FLEET_HELD="$(printf '%s\n' "$PICKS" | awk -F'\t' -v h="$REPO" 'NF && $2 != h' | wc -l | tr -d ' ')"
+say "dispatch: ${FLEET_HELD:-0} repo(s) HELD (cross-repo gh scoping unfinished, sp-9421b9b7); ${FLEET_OPTED:-0} of ${FLEET_TOTAL:-0} registered repo(s) opted in for dispatch"
+
 TARGET_NAME=""
 TARGET_PATH=""
 while IFS=$'\t' read -r PNAME PPATH; do

--- a/q-system/.q-system/capability-manifest.json
+++ b/q-system/.q-system/capability-manifest.json
@@ -558,6 +558,10 @@
       "path": "q-system/.q-system/tests/test_token_guard_cache_race.py",
       "runner": "python3",
       "timeout_s": 120
+    },
+    {
+      "path": "q-system/.q-system/scripts/test_dispatch_reachability.py",
+      "runner": "python3"
     }
   ],
   "required_data": [],
@@ -653,7 +657,7 @@
     },
     {
       "path": "q-system/.q-system/scripts/stat-verify.py",
-      "reason": "802-line stat verification engine; zero hook wiring and its stat-registry.json data file exists in exactly one instance \u2014 wiring it is a founder product decision",
+      "reason": "802-line stat verification engine; zero hook wiring and its stat-registry.json data file exists in exactly one instance — wiring it is a founder product decision",
       "spillover_id": "sp-72b60bff"
     },
     {
@@ -673,8 +677,8 @@
     }
   ],
   "uncovered_known": [
-    "plugins/*/tests \u2014 prd-os plugin suite, run by the plugin's own harness; outside v1 scan roots (finding-9 deferred)",
+    "plugins/*/tests — prd-os plugin suite, run by the plugin's own harness; outside v1 scan roots (finding-9 deferred)",
     "repo-root *.sh utilities are wiring surfaces, not test artifacts",
-    "stat-registry.json: NOT expressible as required_data in v1 \u2014 the one instance holding it keeps canonical under its own instance_q_dir (not q-system/) and its registry name differs from its dir basename, so a scoped entry could never fire (grounded 2026-07-23). Declared gap; owning decision + instance detail in spillover sp-72b60bff"
+    "stat-registry.json: NOT expressible as required_data in v1 — the one instance holding it keeps canonical under its own instance_q_dir (not q-system/) and its registry name differs from its dir basename, so a scoped entry could never fire (grounded 2026-07-23). Declared gap; owning decision + instance detail in spillover sp-72b60bff"
   ]
 }

--- a/q-system/.q-system/scripts/com.kipi.linear-daily-digest.plist
+++ b/q-system/.q-system/scripts/com.kipi.linear-daily-digest.plist
@@ -1,0 +1,36 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<!-- Daily Linear digest: what closed, what opened, what could not be worked.
+     Founder-directed 2026-08-13: one Slack message a day at 4pm, so the queue
+     stops being something he has to go and look at.
+
+     TEMPLATE, not a loadable plist: __KIPI_REPO__ and __HOME__ are materialized by
+     install-plist.sh. The first version of this job was written STRAIGHT into
+     ~/Library/LaunchAgents with the founder's home path hardcoded and was never
+     committed at all, which is the b2df00e / ASK-113 scar repeating: unusable on
+     any other machine, invisible to validate-separation, and it made
+     daily-linear-digest.py read as an inert engine to the capability gate because
+     nothing in the repo referenced it. A scheduled job that exists on one laptop
+     is not a mechanism, it is a habit.
+
+     Install: bash q-system/.q-system/scripts/install-plist.sh com.kipi.linear-daily-digest -->
+<plist version="1.0">
+<dict>
+  <key>Label</key><string>com.kipi.linear-daily-digest</string>
+  <key>ProgramArguments</key>
+  <array>
+    <string>/bin/bash</string><string>-lc</string>
+    <!-- Through a login shell so the Linear key and the Slack webhook resolve the
+         same way they do for a human. launchd does NOT inherit a login environment,
+         and a job that runs blind because its credentials are absent is exactly what
+         com.cole.delivery-watch did for 19 days before anyone noticed (ASK-718). -->
+    <string>python3 __KIPI_REPO__/q-system/.q-system/scripts/daily-linear-digest.py</string>
+  </array>
+  <!-- Local 16:00. launchd calendar intervals are LOCAL time, so this is 4pm
+       Pacific year-round without tracking PST/PDT. -->
+  <key>StartCalendarInterval</key><dict><key>Hour</key><integer>16</integer><key>Minute</key><integer>0</integer></dict>
+  <key>RunAtLoad</key><false/>
+  <key>StandardOutPath</key><string>__HOME__/.config/kipi/logs/linear-daily-digest.out.log</string>
+  <key>StandardErrorPath</key><string>__HOME__/.config/kipi/logs/linear-daily-digest.err.log</string>
+</dict>
+</plist>

--- a/q-system/.q-system/scripts/daily-linear-digest.py
+++ b/q-system/.q-system/scripts/daily-linear-digest.py
@@ -67,11 +67,15 @@ def _linear():
     return mod
 
 
+# PAGINATED. `first: 100` with no cursor silently dropped everything past the
+# hundredth updated issue, so a busy day reported a short list as if it were the
+# whole day -- a silent cap inside the tool whose job is saying what happened.
 ISSUES_Q = """
-query($after: DateTimeOrDuration!) {
-  issues(filter: {updatedAt: {gte: $after}}, first: 100) {
+query($after: DateTimeOrDuration!, $cursor: String) {
+  issues(filter: {updatedAt: {gte: $after}}, first: 100, after: $cursor) {
     nodes { identifier title url createdAt completedAt canceledAt
             state { name type } }
+    pageInfo { hasNextPage endCursor }
   }
 }
 """
@@ -84,12 +88,25 @@ def fetch(since_iso: str):
     that cannot tell "nothing happened" from "I could not look" will report the
     first when it means the second.
     """
+    nodes, cursor, pages = [], None, 0
     try:
         ls = _linear()
-        data = ls.graphql(ISSUES_Q, {"after": since_iso})
+        while True:
+            data = ls.graphql(ISSUES_Q, {"after": since_iso, "cursor": cursor})
+            block = (data or {}).get("issues") or {}
+            nodes.extend(block.get("nodes") or [])
+            info = block.get("pageInfo") or {}
+            pages += 1
+            # A bound, because an unbounded loop against a paging API is its own
+            # outage. 20 pages is 2000 issues; past that the digest says so rather
+            # than truncating quietly.
+            if not info.get("hasNextPage") or pages >= 20:
+                if info.get("hasNextPage"):
+                    return [], [], f"more than {len(nodes)} issues updated today; digest would be partial"
+                break
+            cursor = info.get("endCursor")
     except Exception as exc:  # noqa: BLE001
         return [], [], f"{type(exc).__name__}: {str(exc)[:180]}"
-    nodes = ((data or {}).get("issues") or {}).get("nodes") or []
     closed = [n for n in nodes if n.get("completedAt", "") and n["completedAt"] >= since_iso]
     opened = [n for n in nodes if n.get("createdAt", "") and n["createdAt"] >= since_iso]
     return closed, opened, None

--- a/q-system/.q-system/scripts/daily-linear-digest.py
+++ b/q-system/.q-system/scripts/daily-linear-digest.py
@@ -134,7 +134,7 @@ BLOCKED_PATTERNS = (
 BLOCKED_SOURCES = (WORKER_LOG, DISPATCH_LOG)
 
 
-def blocked_today(day: str):
+def blocked_today(window: tuple):
     """(lines, error). Reads the producers own logs; invents no state of its own."""
     # The WORKER log staying required is deliberate: it is the one that always
     # exists on a healthy machine, so its absence is a real fault worth shouting
@@ -156,7 +156,19 @@ def blocked_today(day: str):
     # and "45 skipped" as if they were two facts. They are one fact, measured twice.
     latest = {}
     for line in text.splitlines():
-        if not line.startswith(day):
+        # A TIME RANGE, not a date prefix. Two clocks were in play and neither was
+        # wrong alone: the logs stamp UTC, the reader lives in local time. Matching a
+        # UTC prefix while labelling the message with the local date reported a
+        # window spanning two local days under one local heading. Matching a local
+        # prefix found nothing at all, because the log never writes that string.
+        # One definition wins: the reader's own day, expressed as UTC bounds.
+        stamp = line[:20]
+        try:
+            ts = dt.datetime.strptime(stamp, "%Y-%m-%dT%H:%M:%SZ").replace(
+                tzinfo=dt.timezone.utc)
+        except ValueError:
+            continue
+        if not (window[0] <= ts <= window[1]):
             continue
         for i, pat in enumerate(BLOCKED_PATTERNS):
             m = pat.search(line)
@@ -183,13 +195,15 @@ def build(now: dt.datetime):
     # lines and printed "nothing" on a day full of them. A silent empty, inside the
     # tool built to stop silent empties. The header keeps the LOCAL date because that
     # is the day the reader is having.
-    day = now.astimezone(dt.timezone.utc).strftime("%Y-%m-%d")
     local_day = now.strftime("%Y-%m-%d")
     since = now.replace(hour=0, minute=0, second=0, microsecond=0)
+    # The reader's day, in UTC bounds, so the filter and the heading describe the
+    # same span of time.
+    window = (since.astimezone(dt.timezone.utc), now.astimezone(dt.timezone.utc))
     since_iso = since.astimezone(dt.timezone.utc).strftime("%Y-%m-%dT%H:%M:%S.000Z")
 
     closed, opened, api_err = fetch(since_iso)
-    blocked, log_err = blocked_today(day)
+    blocked, log_err = blocked_today(window)
 
     lines = [f"*Linear daily* {local_day} (as of {now.strftime('%H:%M %Z')})", ""]
     lines += _section("Closed today", closed, api_err,

--- a/q-system/.q-system/scripts/daily-linear-digest.py
+++ b/q-system/.q-system/scripts/daily-linear-digest.py
@@ -1,0 +1,257 @@
+#!/usr/bin/env python3
+"""One Slack message a day: what closed, what opened, what could not be worked.
+
+Founder-directed 2026-08-13: "I want to create a mechanism that pings me once a day
+on slack with which linear issues were closed today -- what they are about / New
+linear issues opened today -- what they are about / Linear issues that you tried and
+could not be worked - why. I want it every day at 4pm PST."
+
+## The three sections and where each comes from
+
+- CLOSED / OPENED: Linear itself, via `linear-sync.graphql`. One client, reused, not
+  a second one -- two readers of one API is the derivation split this fleet keeps
+  paying for.
+- COULD NOT BE WORKED: `~/.config/kipi/linear-worker.log`, which ALREADY records it:
+  "held at needs-scope (refused as unexecutable)", "held at blocked:capability",
+  "skipped as out-of-repo". That log existed before this digest; nothing was
+  invented to feed it.
+
+## Two rules this thing must never break
+
+**An empty section and a broken section are different facts.** If the Linear query
+fails, this says FAILED. It never prints "0 closed today", because a silent zero
+reading as a quiet day is the exact defect the 2026-07-21 silent-delivery RCA is
+about, and shipping it inside a status digest would be absurd.
+
+**The send is verified, not assumed.** `slack-notify.sh` is a silent no-op that
+still exits 0 when no webhook resolves. So delivery is recorded separately from the
+attempt, and a run that could not deliver says so on stdout where launchd logs it.
+
+## Its own deadman is the founder
+
+A daily message that stops arriving is visible to a human on day one, which is more
+than most of this fleet's watchdogs manage. It still stamps its own run in the
+message so a stale pin is obvious.
+
+    python3 daily-linear-digest.py            # send
+    python3 daily-linear-digest.py --dry-run  # print, send nothing
+"""
+from __future__ import annotations
+
+import argparse
+import datetime as dt
+import importlib.util
+import json
+import os
+import re
+import subprocess
+import sys
+from pathlib import Path
+
+HERE = Path(__file__).resolve().parent
+_STATE = Path(os.environ.get("KIPI_STATE_DIR", os.path.expanduser("~/.config/kipi")))
+WORKER_LOG = _STATE / "linear-worker.log"
+# ASK-729: the second producer. "Could not be worked" is written in two places --
+# the worker says what it refused to pick, the dispatcher says which repos it
+# refused to ENTER. Reading only the worker made the entire cross-repo hold
+# invisible for 13 days, which is the failure this section exists to prevent.
+DISPATCH_LOG = _STATE / "dispatch.log"
+NOTIFY = HERE / "slack-notify.sh"
+
+
+def _linear():
+    """The existing client. One reader of the Linear API, never a second."""
+    spec = importlib.util.spec_from_file_location("linear_sync", HERE / "linear-sync.py")
+    mod = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(mod)
+    return mod
+
+
+ISSUES_Q = """
+query($after: DateTimeOrDuration!) {
+  issues(filter: {updatedAt: {gte: $after}}, first: 100) {
+    nodes { identifier title url createdAt completedAt canceledAt
+            state { name type } }
+  }
+}
+"""
+
+
+def fetch(since_iso: str):
+    """(closed, opened, error). `error` is a string when the API could not answer.
+
+    Returning an error rather than an empty list is the whole contract: a caller
+    that cannot tell "nothing happened" from "I could not look" will report the
+    first when it means the second.
+    """
+    try:
+        ls = _linear()
+        data = ls.graphql(ISSUES_Q, {"after": since_iso})
+    except Exception as exc:  # noqa: BLE001
+        return [], [], f"{type(exc).__name__}: {str(exc)[:180]}"
+    nodes = ((data or {}).get("issues") or {}).get("nodes") or []
+    closed = [n for n in nodes if n.get("completedAt", "") and n["completedAt"] >= since_iso]
+    opened = [n for n in nodes if n.get("createdAt", "") and n["createdAt"] >= since_iso]
+    return closed, opened, None
+
+
+# Lines the worker writes when it looked at an issue and could not take it. Kept as
+# data so a change in the worker's wording shows up as a diff here rather than as a
+# silently empty section.
+# The COUNT is part of the fact. An earlier version matched from "held at" onward
+# and dropped the leading "2 issue(s)", which turned a number into a vibe.
+BLOCKED_PATTERNS = (
+    re.compile(r"\d+ issue\(s\) held at needs-scope[^\n]*"),
+    re.compile(r"\d+ issue\(s\) held at blocked:[^\n]*"),
+    re.compile(r"\d+ ready-shaped issue\(s\) skipped as out-of-repo[^\n]*"),
+    # ASK-729. These two are the "whether or not it is fully fixed" half: while
+    # cross-repo dispatch stays held, the digest still has to say how much work is
+    # stranded and why, every day, instead of the gap living in one log line
+    # nobody reads.
+    re.compile(r"\d+ ready-shaped issue\(s\) UNREACHABLE: no local checkout[^\n]*"),
+    re.compile(r"\d+ repo\(s\) HELD \(cross-repo gh scoping[^\n]*"),
+)
+
+# Which producer each pattern reads. Kept explicit so a pattern cannot silently
+# scan a log that never emits it and read as a healthy "nothing".
+BLOCKED_SOURCES = (WORKER_LOG, DISPATCH_LOG)
+
+
+def blocked_today(day: str):
+    """(lines, error). Reads the producers own logs; invents no state of its own."""
+    # The WORKER log staying required is deliberate: it is the one that always
+    # exists on a healthy machine, so its absence is a real fault worth shouting
+    # about. A missing dispatch.log only means the dispatcher has not run yet,
+    # which is not an error and must not blank the whole section.
+    if not WORKER_LOG.exists():
+        return [], f"no worker log at {WORKER_LOG}"
+    chunks = []
+    for src in BLOCKED_SOURCES:
+        if not src.exists():
+            continue
+        try:
+            chunks.append(src.read_text(encoding="utf-8", errors="replace"))
+        except Exception as exc:  # noqa: BLE001
+            return [], f"unreadable log {src}: {exc}"
+    text = "\n".join(chunks)
+    # LAST occurrence per pattern, not every one. The worker runs several times a
+    # day and each run logs its own counts, so listing them all showed "44 skipped"
+    # and "45 skipped" as if they were two facts. They are one fact, measured twice.
+    latest = {}
+    for line in text.splitlines():
+        if not line.startswith(day):
+            continue
+        for i, pat in enumerate(BLOCKED_PATTERNS):
+            m = pat.search(line)
+            if m:
+                latest[i] = m.group(0)
+    return [latest[i] for i in sorted(latest)], None
+
+
+def _section(title, rows, error, fmt):
+    if error:
+        # Loud, and never mistakable for a quiet day.
+        return [f"*{title}*", f"  COULD NOT READ: {error}"]
+    if not rows:
+        return [f"*{title}*", "  nothing"]
+    return [f"*{title}*"] + [f"  {fmt(r)}" for r in rows[:15]] + (
+        [f"  ...and {len(rows) - 15} more"] if len(rows) > 15 else [])
+
+
+def build(now: dt.datetime):
+    day = now.strftime("%Y-%m-%d")
+    since = now.replace(hour=0, minute=0, second=0, microsecond=0)
+    since_iso = since.astimezone(dt.timezone.utc).strftime("%Y-%m-%dT%H:%M:%S.000Z")
+
+    closed, opened, api_err = fetch(since_iso)
+    blocked, log_err = blocked_today(day)
+
+    lines = [f"*Linear daily* {day} (as of {now.strftime('%H:%M %Z')})", ""]
+    lines += _section("Closed today", closed, api_err,
+                      lambda n: f"{n['identifier']} {n['title'][:90]}")
+    lines.append("")
+    lines += _section("Opened today", opened, api_err,
+                      lambda n: f"{n['identifier']} {n['title'][:90]}")
+    lines.append("")
+    lines += _section("Tried, could not be worked", blocked, log_err, lambda s: s)
+    return "\n".join(lines), (api_err or log_err)
+
+
+def send(message: str):
+    """POST to the Slack webhook and read SLACK'S answer, not an exit code.
+
+    ## Why this does not use slack-notify.sh
+
+    That script does not send to Slack. It was repointed 2026-08-10 to file Linear
+    tickets ("I dont want to see any of these. Any of the ones that need attention
+    should go to Sana - not me") and its own header says so: "THE NAME IS NOW WRONG
+    ON PURPOSE... Nothing in this file sends to Slack."
+
+    The first version of this digest called it, got exit 0, and recorded
+    `delivered_claim: True`. It had filed ASK-724 -- a status digest as a Linear
+    ticket. Exit 0 meant "ticket opened", which is a true statement about a
+    different action than the one intended.
+
+    ## Why routing a DIGEST to Slack does not reopen the 2026-08-10 decision
+
+    That decision was about an alert FLOOD: #general carried 100 messages in four
+    and a half hours, 86 of them from two emitters, burying four security reverts
+    and a dead job. This is one curated message a day, founder-requested
+    2026-08-13, and it is not on the alert path -- alerts still go to Linear.
+    Do not "fix" this back by pointing it at slack-notify.sh.
+
+    Slack answers HTTP 200 with the literal body `ok` on success and 200 with an
+    error string on some failures, so the BODY is checked, not the status alone.
+    """
+    hook_path = Path(os.environ.get("KIPI_SLACK_WEBHOOK_FILE",
+                                    os.path.expanduser("~/.config/kipi/slack-webhook")))
+    hook = os.environ.get("KIPI_SLACK_WEBHOOK") or (
+        hook_path.read_text(encoding="utf-8").strip() if hook_path.is_file() else "")
+    if not hook:
+        return {"delivered": False, "reason": f"no webhook (env or {hook_path})"}
+    if not hook.startswith("https://hooks.slack.com/"):
+        return {"delivered": False, "reason": "webhook is not a Slack incoming-webhook URL"}
+
+    import urllib.error
+    import urllib.request
+    req = urllib.request.Request(
+        hook, data=json.dumps({"text": message}).encode(),
+        headers={"Content-Type": "application/json"}, method="POST")
+    try:
+        with urllib.request.urlopen(req, timeout=30) as resp:
+            body = resp.read().decode(errors="replace").strip()
+            code = resp.status
+    except urllib.error.HTTPError as exc:
+        return {"delivered": False, "http": exc.code,
+                "body": exc.read().decode(errors="replace")[:120]}
+    except Exception as exc:  # noqa: BLE001
+        return {"delivered": False, "reason": f"{type(exc).__name__}: {str(exc)[:120]}"}
+    # Slack's own word for success. Anything else is a failure however green the
+    # status line looks.
+    return {"delivered": body == "ok", "http": code, "body": body[:120]}
+
+
+def main() -> int:
+    ap = argparse.ArgumentParser()
+    ap.add_argument("--dry-run", action="store_true")
+    args = ap.parse_args()
+
+    now = dt.datetime.now().astimezone()
+    message, degraded = build(now)
+    print(message)
+    if args.dry_run:
+        print("\n[dry-run] nothing sent")
+        return 0
+    result = send(message)
+    print(f"\n[send] {result}")
+    if not result.get("delivered"):
+        # Never exit 0 on an undelivered digest. That is the whole defect this
+        # script was built in the middle of.
+        return 1
+    # Non-zero when a section could not be read, so launchd's log and any future
+    # watchdog can tell a degraded digest from a clean one.
+    return 1 if degraded else 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/q-system/.q-system/scripts/daily-linear-digest.py
+++ b/q-system/.q-system/scripts/daily-linear-digest.py
@@ -176,14 +176,22 @@ def _section(title, rows, error, fmt):
 
 
 def build(now: dt.datetime):
-    day = now.strftime("%Y-%m-%d")
+    # MATCH THE LOG'S OWN CLOCK. `linear-worker.log` and `dispatch.log` prefix every
+    # line with a UTC stamp (`date -u`), and this compared them against the LOCAL
+    # date. Measured 2026-08-13 21:5x PDT: local said 2026-08-13 while the logs were
+    # already writing 2026-08-14, so the "could not be worked" section matched zero
+    # lines and printed "nothing" on a day full of them. A silent empty, inside the
+    # tool built to stop silent empties. The header keeps the LOCAL date because that
+    # is the day the reader is having.
+    day = now.astimezone(dt.timezone.utc).strftime("%Y-%m-%d")
+    local_day = now.strftime("%Y-%m-%d")
     since = now.replace(hour=0, minute=0, second=0, microsecond=0)
     since_iso = since.astimezone(dt.timezone.utc).strftime("%Y-%m-%dT%H:%M:%S.000Z")
 
     closed, opened, api_err = fetch(since_iso)
     blocked, log_err = blocked_today(day)
 
-    lines = [f"*Linear daily* {day} (as of {now.strftime('%H:%M %Z')})", ""]
+    lines = [f"*Linear daily* {local_day} (as of {now.strftime('%H:%M %Z')})", ""]
     lines += _section("Closed today", closed, api_err,
                       lambda n: f"{n['identifier']} {n['title'][:90]}")
     lines.append("")

--- a/q-system/.q-system/scripts/install-plist.sh
+++ b/q-system/.q-system/scripts/install-plist.sh
@@ -36,6 +36,35 @@ if [ $# -lt 1 ]; then
   exit 2
 fi
 
+# --all: install EVERY committed template. Added 2026-08-14 (ASK-729, Codex review
+# of #147/#143 major). Six templates were committed and NOTHING called the
+# installer, so a merge taught no machine to run any of them -- every job ran only
+# where somebody had typed the command by hand. A scheduled job that exists on one
+# laptop is not a mechanism. This is the caller, so a fresh checkout can arm the
+# fleet's jobs in one step, and each install still reports its own result rather
+# than the loop reporting a single aggregate success.
+if [ "$1" = "--all" ]; then
+  # REFUSE FROM A WORKTREE. Measured the hard way 2026-08-14: running --all from a
+  # git worktree rewrote every live job to point at that worktree, including the
+  # dispatcher, seconds before the directory was to be deleted. One label is a
+  # deliberate act on one job; --all is a fleet-wide rewrite, and aiming that at a
+  # temporary checkout silently disarms every scheduled job on the machine.
+  if [ -f "$KIPI_REPO/.git" ] || [ ! -d "$KIPI_REPO/.git" ]; then
+    echo "REFUSED: --all only runs from the primary checkout, not a worktree." >&2
+    echo "  resolved KIPI_REPO=$KIPI_REPO" >&2
+    echo "  every installed job would point here and break when it is removed." >&2
+    echo "  install a single label instead: install-plist.sh <label>" >&2
+    exit 2
+  fi
+  rc=0
+  for _p in "$SCRIPT_DIR"/com.kipi.*.plist; do
+    [ -e "$_p" ] || continue
+    _label="$(basename "$_p" .plist)"
+    if bash "$0" "$_label"; then :; else rc=1; echo "  FAILED: $_label" >&2; fi
+  done
+  exit "$rc"
+fi
+
 LABEL="$1"
 shift
 TEMPLATE="$SCRIPT_DIR/$LABEL.plist"

--- a/q-system/.q-system/scripts/linear-worker.sh
+++ b/q-system/.q-system/scripts/linear-worker.sh
@@ -280,28 +280,56 @@ fi
 # guard below rather than as a silently empty queue, but still wrong.
 #
 # Order: explicit env override, then the registry, then basename.
-REPO_PROJECT="${KIPI_LINEAR_PROJECT:-}"
-if [ -z "$REPO_PROJECT" ]; then
-  # The path being looked UP is the target; the registry doing the looking up is
-  # always the skeleton's. An instance carries no instance-registry.json, so
-  # reading it from the target would fall through to basename for every repo and
-  # quietly re-break the filter for exactly the three instances named below.
-  REPO_PROJECT="$(SKEL_PATH="$TARGET_REPO" REG="$SKEL/instance-registry.json" python3 - <<'PY' 2>/dev/null
+# ONE REGISTRY READ, TWO FACTS (ASK-729). sp-421fa27d already records that the
+# project-name derivation is duplicated between this script and
+# spillover-promote.py. Reachability needs the SAME registry, so the fix was
+# either a second reader here or one read that answers both questions. This is
+# the second: it returns this repo identity AND the set of project names whose
+# checkout exists on this machine, from a single parse.
+#
+# The path being looked UP is the target; the registry doing the looking up is
+# always the skeleton. An instance carries no instance-registry.json, so
+# reading it from the target would fall through to basename for every repo and
+# quietly re-break the filter for exactly the three instances named below.
+#
+# registry_ok is carried explicitly and is NOT the same as an empty list. An
+# unreadable registry means reachability is UNKNOWN, and reporting unknown as
+# unreachable would fire a loud false alarm on every project at once -- the
+# failure mode this issue exists to remove, pointed the other way.
+REGISTRY_FACTS="$(SKEL_PATH="$TARGET_REPO" REG="$SKEL/instance-registry.json" python3 - <<'PY' 2>/dev/null
 import json, os
 skel = os.path.realpath(os.environ["SKEL_PATH"])
+ok = True
 try:
     reg = json.load(open(os.environ["REG"]))
 except Exception:
-    reg = []
+    reg, ok = [], False
 entries = reg.get("instances", reg) if isinstance(reg, dict) else reg
+name = ""
+local = []
 for e in entries if isinstance(entries, list) else []:
-    if isinstance(e, dict) and e.get("path") and os.path.realpath(e["path"]) == skel:
-        print(e.get("name", "")); break
+    if not isinstance(e, dict):
+        continue
+    p, n = e.get("path"), e.get("name") or ""
+    if not p:
+        continue
+    if not name and os.path.realpath(p) == skel:
+        name = n
+    if n and os.path.isdir(p):
+        local.append(n)
+print(json.dumps({"name": name, "local_projects": sorted(set(local)), "ok": ok}))
 PY
 )"
-fi
+_facts_get() { printf '%s' "$REGISTRY_FACTS" | python3 -c "import json,sys;d=json.load(sys.stdin);v=d.get('$1');print('\n'.join(v) if isinstance(v,list) else v)" 2>/dev/null; }
+
+REPO_PROJECT="${KIPI_LINEAR_PROJECT:-}"
+[ -n "$REPO_PROJECT" ] || REPO_PROJECT="$(_facts_get name)"
 [ -n "$REPO_PROJECT" ] || REPO_PROJECT="$(basename "$TARGET_REPO")"
 export REPO_PROJECT
+
+LOCAL_PROJECTS="$(_facts_get local_projects)"
+REGISTRY_OK="$(_facts_get ok)"
+export LOCAL_PROJECTS REGISTRY_OK
 
 # --- pick ready issues ------------------------------------------------------
 PICKED="$(python3 - "$ONLY_ISSUE" <<'PY'
@@ -327,6 +355,9 @@ while True:
     after = p["pageInfo"]["endCursor"]
 
 repo_project = os.environ["REPO_PROJECT"]
+# Reachability, from the SAME registry read that produced repo_project (ASK-729).
+local_projects = {p for p in os.environ.get("LOCAL_PROJECTS", "").splitlines() if p}
+registry_ok = os.environ.get("REGISTRY_OK", "") == "True"
 
 def project_of(i):
     return (i.get("project") or {}).get("name")
@@ -373,6 +404,32 @@ def ready_ignoring_project(i):
             and "Definition of Ready" in (i.get("description") or ""))
 
 dropped = [i for i in issues if ready_ignoring_project(i) and not in_this_repo(i)]
+
+# TWO POPULATIONS, NOT ONE (ASK-729). Every out-of-repo issue used to be reported
+# on a single "skipped as out-of-repo" line. On 2026-08-13 that line read 45 and
+# it hid the distinction that decides whether anyone can do anything:
+#
+#   SKIPPED     the project has a checkout on this machine, just not the one this
+#               run is in. The dispatcher rotation reaches it on a later turn.
+#   UNREACHABLE no checkout exists for it anywhere here. No rotation, no cursor
+#               and no amount of waiting reaches it. Someone must clone the repo
+#               or register it before any machine can pick that work up.
+#
+# Reporting the second as the first is why 45 issues read as a filter doing its
+# job for 13 days. An unset project is UNREACHABLE, not skipped: "target unknown"
+# is not "target is elsewhere", and it needs a human to set the project.
+def has_local_checkout(i):
+    name = project_of(i)
+    return bool(name) and name in local_projects
+
+# An unreadable registry means reachability is UNKNOWN. Calling every project
+# unreachable there would be a false alarm on the whole board at once, so the
+# classification collapses back to the old single bucket and the shell says why.
+if registry_ok:
+    skipped_local = [i for i in dropped if has_local_checkout(i)]
+    unreachable = [i for i in dropped if not has_local_checkout(i)]
+else:
+    skipped_local, unreachable = dropped, []
 def held_with(label):
     return [i for i in issues
             if label in {l["name"] for l in i["labels"]["nodes"]} and in_this_repo(i)]
@@ -398,6 +455,13 @@ print(json.dumps({
     "total_open": len(issues),
     "dropped_out_of_repo": len(dropped),
     "dropped_projects": sorted({project_of(i) or "(unset)" for i in dropped}),
+    # ASK-729: the same population, split by whether anyone here can act on it.
+    "skipped_local": len(skipped_local),
+    "skipped_local_projects": sorted({project_of(i) or "(unset)" for i in skipped_local}),
+    "unreachable": len(unreachable),
+    "unreachable_projects": sorted({project_of(i) or "(unset)" for i in unreachable}),
+    "unreachable_ids": [i["identifier"] for i in unreachable],
+    "registry_ok": registry_ok,
     "deferred_needs_scope": len(deferred),
     "blocked_capability": len(blocked_cap),
     "blocked_capability_ids": [i["identifier"] for i in blocked_cap],
@@ -436,14 +500,25 @@ if [ "$PROJECT_KNOWN" = "False" ]; then
   exit 9
 fi
 
-DROPPED="$(printf '%s' "$PICKED" | python3 -c 'import json,sys;print(json.load(sys.stdin).get("dropped_out_of_repo",0))' 2>/dev/null)"
-DROPPED_IN="$(printf '%s' "$PICKED" | python3 -c 'import json,sys;print(", ".join(json.load(sys.stdin).get("dropped_projects",[])))' 2>/dev/null)"
+DROPPED="$(printf '%s' "$PICKED" | python3 -c 'import json,sys;print(json.load(sys.stdin).get("skipped_local",0))' 2>/dev/null)"
+DROPPED_IN="$(printf '%s' "$PICKED" | python3 -c 'import json,sys;print(", ".join(json.load(sys.stdin).get("skipped_local_projects",[])))' 2>/dev/null)"
+UNREACH="$(printf '%s' "$PICKED" | python3 -c 'import json,sys;print(json.load(sys.stdin).get("unreachable",0))' 2>/dev/null)"
+UNREACH_IN="$(printf '%s' "$PICKED" | python3 -c 'import json,sys;print(", ".join(json.load(sys.stdin).get("unreachable_projects",[])))' 2>/dev/null)"
+REG_OK="$(printf '%s' "$PICKED" | python3 -c 'import json,sys;print(json.load(sys.stdin).get("registry_ok",True))' 2>/dev/null)"
 DEFERRED="$(printf '%s' "$PICKED" | python3 -c 'import json,sys;print(json.load(sys.stdin).get("deferred_needs_scope",0))' 2>/dev/null)"
 
 say "worker: $READY_COUNT ready issue(s) (owner:sana, has a DoR, not owner:assaf, project=$REPO_PROJECT)"
 # Accounted for, never silently dropped. These two lines are what let an operator
 # tell a working filter from a broken query without re-querying Linear by hand.
 [ "${DROPPED:-0}" != "0" ] && say "worker: $DROPPED ready-shaped issue(s) skipped as out-of-repo (other project: $DROPPED_IN) -- this checkout is $REPO_PROJECT and cannot check those out"
+# UNREACHABLE IS NOT A ROUTINE SKIP, AND NEVER SHARES ITS LINE (ASK-729). A skip
+# resolves itself on a later rotation turn; this does not resolve at all until a
+# human clones or registers the repo. It is stated separately, with the project
+# names and the count, on every run -- because the failure being fixed here is
+# 13 days of a real backlog reading as normal filter output.
+[ "${UNREACH:-0}" != "0" ] && say "worker: $UNREACH ready-shaped issue(s) UNREACHABLE: no local checkout for $UNREACH_IN -- no dispatcher on this machine can reach them until those repos are cloned and registered"
+# Fail loud rather than classify on a guess (see registry_ok in the picker).
+[ "$REG_OK" = "False" ] && say "worker: WARNING instance-registry.json could not be read, so reachability is UNKNOWN this run and every out-of-repo issue is reported as a routine skip"
 [ "${DEFERRED:-0}" != "0" ] && say "worker: $DEFERRED issue(s) held at needs-scope (refused as unexecutable; the DoR drafter re-scopes them)"
 
 BLOCKED_CAP="$(printf '%s' "$PICKED" | python3 -c 'import json,sys;print(json.load(sys.stdin).get("blocked_capability",0))' 2>/dev/null)"

--- a/q-system/.q-system/scripts/test/test-terminal-states.sh
+++ b/q-system/.q-system/scripts/test/test-terminal-states.sh
@@ -1,4 +1,20 @@
 #!/usr/bin/env bash
+# NEVER LET THIS TEST REACH THE FOUNDER PHONE (ASK-729).
+#
+# This file passes $SRC (linear-worker.sh) to validate.py and to python mutation
+# helpers as a FILE ARGUMENT; it never executes the worker, so today nothing here
+# can page. That is a property of the current code, not a guarantee about the next
+# edit: the worker is pager-capable, and the moment any assertion here decides to
+# RUN it, an unstubbed run rings the founder actual phone at whatever hour the
+# suite happens to fire.
+#
+# So the seam is stubbed once, up front, for the whole file rather than argued
+# about per call site. The fable-discipline lint also reads $SRC being handed to
+# python3 as "this test drives the runner" and blocks on it; this export answers
+# that honestly instead of bypassing the gate with a skip marker, which would
+# switch the check off for every future edit to this file too.
+export KIPI_NOTIFY=/usr/bin/true
+
 # test-terminal-states.sh -- the gate that stops a tenth dead end shipping.
 #
 # Pairs with q-system/.q-system/terminal-states.json (Piece B,

--- a/q-system/.q-system/scripts/test_dispatch_reachability.py
+++ b/q-system/.q-system/scripts/test_dispatch_reachability.py
@@ -1,0 +1,197 @@
+#!/usr/bin/env python3
+"""SKIPPED is routine, UNREACHABLE is a fact nobody can act on from here (ASK-729).
+
+why this shape: linear-worker.sh reported every out-of-repo issue on ONE line --
+"N ready-shaped issue(s) skipped as out-of-repo". Measured 2026-08-13 against the
+live board that line read 45, and it mixed two populations that call for opposite
+responses:
+
+  * a project whose checkout EXISTS on this machine, just not the one this run is
+    in. Routine. The dispatcher's rotation reaches it on a later turn.
+  * a project with NO local checkout at all. No dispatcher on this machine can
+    ever reach it, on any turn, however long you wait.
+
+Collapsing the second into the first is why 45 issues sat for 13 days looking like
+a filter doing its job. The count was never wrong; the CLASS was.
+
+This test runs the SHIPPED linear-worker.sh end to end against a throwaway
+skeleton, a throwaway target repo and a stubbed Linear. It asserts on the log the
+worker actually writes, because the defect was in what the run SAID, and a unit
+test over a predicate cannot see a reporting line.
+
+The negative self-test matters more than the positive one here: it is easy to
+write an UNREACHABLE line that fires on everything, which would be the same
+single-bucket defect with a louder word. So the test pins BOTH directions -- the
+reachable project must NOT appear in the unreachable line, and vice versa.
+"""
+import json
+import os
+import shutil
+import subprocess
+from pathlib import Path
+
+import pytest
+
+SCRIPTS = Path(__file__).resolve().parent
+WORKER = SCRIPTS / "linear-worker.sh"
+
+# Stands in for linear-sync.py: the ONE seam that reaches the network. Serves the
+# fixture board from a file so the test never invents a payload shape the real
+# query would not return.
+STUB_SYNC = '''
+import json, os
+def graphql(q, v):
+    if "teams(" in q:
+        return {"teams": {"nodes": [{"id": "TEAM"}]}}
+    issues = json.load(open(os.environ["FIXTURE_ISSUES"]))
+    return {"issues": {"nodes": issues,
+                       "pageInfo": {"hasNextPage": False, "endCursor": None}}}
+'''
+
+
+def _issue(ident, project, labels=("owner:sana",)):
+    return {
+        "id": ident,
+        "identifier": ident,
+        "title": "t " + ident,
+        # ready() requires this heading; without it the issue is not ready-shaped
+        # and would drop out for a reason that has nothing to do with reachability.
+        "description": "## Definition of Ready\nstuff",
+        "state": {"name": "Backlog", "type": "backlog"},
+        "project": {"name": project} if project else None,
+        "labels": {"nodes": [{"name": l} for l in labels]},
+    }
+
+
+@pytest.fixture()
+def harness(tmp_path):
+    """A skeleton, a target repo with a real origin, and a stubbed Linear."""
+    skel = tmp_path / "skel"
+    (skel / "q-system" / ".q-system").mkdir(parents=True)
+    shutil.copytree(SCRIPTS, skel / "q-system" / ".q-system" / "scripts")
+    (skel / "q-system" / ".q-system" / "scripts" / "linear-sync.py").write_text(STUB_SYNC)
+
+    # git fetch runs before any of the reporting under test, so origin has to be
+    # real or the run exits 9 and this test measures the guard instead.
+    subprocess.run(["git", "init", "-q", "--bare", str(tmp_path / "origin.git")], check=True)
+    target = tmp_path / "target"
+    subprocess.run(["git", "init", "-q", str(target)], check=True)
+    for k, v in (("user.email", "t@t"), ("user.name", "t")):
+        subprocess.run(["git", "-C", str(target), "config", k, v], check=True)
+    (target / "f.txt").write_text("x")
+    subprocess.run(["git", "-C", str(target), "add", "-A"], check=True)
+    subprocess.run(["git", "-C", str(target), "commit", "-qm", "init"], check=True)
+    subprocess.run(["git", "-C", str(target), "remote", "add", "origin",
+                    str(tmp_path / "origin.git")], check=True)
+    subprocess.run(["git", "-C", str(target), "push", "-q", "origin", "HEAD:main"], check=True)
+
+    # haslocal EXISTS on disk; nolocal deliberately does not.
+    (tmp_path / "haslocal").mkdir()
+    registry = {"instances": [
+        {"name": "targetproj", "path": str(target)},
+        {"name": "haslocal", "path": str(tmp_path / "haslocal")},
+        {"name": "nolocal", "path": str(tmp_path / "no-such-checkout")},
+    ]}
+    (skel / "instance-registry.json").write_text(json.dumps(registry))
+
+    board = [
+        # project_known guard: some issue must name this repo's project, or the
+        # run exits 9 before reporting anything.
+        _issue("ASK-900", "targetproj", ("owner:assaf",)),
+        _issue("ASK-901", "haslocal"),
+        _issue("ASK-902", "haslocal"),
+        _issue("ASK-903", "nolocal"),
+        _issue("ASK-904", "nolocal"),
+        _issue("ASK-905", "nolocal"),
+        # An issue with no project set is not merely "elsewhere", it is
+        # unaddressable. It belongs with UNREACHABLE, not with routine skips.
+        _issue("ASK-906", None),
+    ]
+    fixture = tmp_path / "fixture.json"
+    fixture.write_text(json.dumps(board))
+
+    state = tmp_path / "state"
+    state.mkdir()
+
+    def run():
+        env = dict(os.environ)
+        env.update({
+            "KIPI_SKEL": str(skel),
+            "KIPI_STATE_DIR": str(state),
+            "FIXTURE_ISSUES": str(fixture),
+            "KIPI_NOTIFY": "/bin/true",
+        })
+        p = subprocess.run(
+            ["bash", str(skel / "q-system" / ".q-system" / "scripts" / "linear-worker.sh"),
+             "--repo", str(target)],
+            capture_output=True, text=True, env=env, timeout=300)
+        return p.stdout + p.stderr
+
+    return run
+
+
+def _line(out, needle):
+    for ln in out.splitlines():
+        if needle in ln:
+            return ln
+    return ""
+
+
+def test_no_checkout_is_reported_unreachable_not_skipped(harness):
+    out = harness()
+
+    unreachable = _line(out, "UNREACHABLE")
+    assert unreachable, (
+        "no UNREACHABLE line. 4 of the 6 dropped issues (3 nolocal + 1 unset) have "
+        "no local checkout and no dispatcher can reach them, but the run reported "
+        f"them as a routine skip. Output was:\n{out}")
+
+    # The counts are the whole point: 2 reachable-but-elsewhere, 4 unreachable.
+    assert "4" in unreachable, f"expected 4 unreachable, got: {unreachable}"
+    assert "nolocal" in unreachable, f"expected nolocal named, got: {unreachable}"
+
+    # NEGATIVE SELF-TEST. An UNREACHABLE line that fires on everything is the same
+    # single-bucket defect wearing a louder word, and it would pass every
+    # assertion above. haslocal HAS a checkout, so it must not appear here.
+    assert "haslocal" not in unreachable, (
+        f"haslocal has a local checkout and is reachable on a later rotation turn; "
+        f"reporting it as unreachable is a false alarm: {unreachable}")
+
+
+def test_skipped_line_keeps_only_the_reachable_projects(harness):
+    out = harness()
+
+    skipped = _line(out, "skipped as out-of-repo")
+    assert skipped, f"the routine-skip line disappeared entirely:\n{out}"
+
+    assert "haslocal" in skipped, f"expected haslocal in the skip line: {skipped}"
+    # The other direction of the same negative test.
+    assert "nolocal" not in skipped, (
+        f"nolocal has no checkout anywhere; counting it as a routine skip is the "
+        f"exact defect ASK-729 fixes: {skipped}")
+    assert " 2 " in skipped, f"expected 2 routine skips, got: {skipped}"
+
+
+def test_digest_patterns_match_the_lines_the_worker_actually_writes(harness):
+    """The reporting is only fixed if the thing that surfaces it can see it.
+
+    A log line nobody parses is the state this issue started in, so the digest's
+    own patterns are asserted against real worker output rather than against a
+    hand-typed sample that could agree with my assumption instead of the code.
+    """
+    digest = SCRIPTS / "daily-linear-digest.py"
+    if not digest.exists():
+        pytest.skip("daily-linear-digest.py not present in this checkout")
+
+    import re
+    src = digest.read_text()
+    pats = re.findall(r're\.compile\(r"([^"]+)"\)', src)
+    assert pats, "no BLOCKED_PATTERNS found in daily-linear-digest.py"
+
+    out = harness()
+    for needle in ("UNREACHABLE", "skipped as out-of-repo"):
+        line = _line(out, needle)
+        assert line, f"worker wrote no {needle!r} line"
+        assert any(re.search(p, line) for p in pats), (
+            f"the digest recognises no pattern for the worker's {needle!r} line, so "
+            f"it stays invisible in the daily report:\n  {line}")


### PR DESCRIPTION
## What this is

ASK-729 rescoped to **B**: ship the visibility half, leave the gate shut.

The brief said the remaining job was to give `linear-worker.sh` a target-repo
argument. **It already has one.** `--repo` is parsed at `linear-worker.sh:153`,
`TARGET_REPO` resolves at `:181`, and `git -C "$TARGET_REPO"` drives fetch
(`:250`) and `git worktree add` (`:1092`). All of it shipped in `c39968b9`, the
same commit that shipped the rotation and preflight.

The note that said otherwise (`sp-09c61b20`, 20:44:06Z) was superseded 20 minutes
later by `sp-9421b9b7` (21:04:34Z). It has been voided with that evidence.

The real blocker is that `gh` resolves its repo from cwd and ignores
`TARGET_REPO`:

```
cwd = kipi-system, TARGET_REPO=<other>  ->  assafkip/kipi-system
cwd = <other>                           ->  assafkip/<other>
```

`kipi-dispatch.sh:205` cds to home and stays, so three paths bind to the wrong
repository. **The HOLD at `kipi-dispatch.sh:726` is untouched.** Deleting it
would aim an unattended self-merging loop at client repos. That work is ASK-738,
with its own reproducer and review.

## Red first

```
worker: 6 ready-shaped issue(s) skipped as out-of-repo (other project: (unset), haslocal, nolocal)
```

All six in one bucket. Four of them have no local checkout anywhere.

## Green

```
worker: 2 ready-shaped issue(s) skipped as out-of-repo (other project: haslocal) -- this checkout is targetproj and cannot check those out
worker: 4 ready-shaped issue(s) UNREACHABLE: no local checkout for (unset), nolocal -- no dispatcher on this machine can reach them until those repos are cloned and registered
```

Negative control, registry unreadable:

```
worker: 6 ready-shaped issue(s) skipped as out-of-repo (other project: (unset), haslocal, nolocal)
worker: WARNING instance-registry.json could not be read, so reachability is UNKNOWN this run
```

Unknown reports as unknown rather than false-alarming the whole board.

## Fleet posture, every run

```
dispatch: 0 repo(s) HELD (cross-repo gh scoping unfinished, sp-9421b9b7); 0 of 23 registered repo(s) opted in for dispatch
```

Measured against the real registry. `0 of 23` is why the HOLD has never fired
and why this gap was invisible for 13 days.

## Digest

`daily-linear-digest.py` was **untracked** while a loaded launchd job ran it
daily at 16:00. It is now under version control, reads `dispatch.log` as a second
producer, and has patterns for both new lines. All three patterns proven to fire
against real producer output, not hand-typed samples.

## Tests

`423 passed` on this branch. One pre-existing failure,
`test_launchd_health_check_logic`, reproduced on clean `origin/main` (11f0eb8a)
in a detached worktree. Not from this change; captured as `sp-7773af84`.

## Not done here, deliberately

- The HOLD stays. No repo opted in. `KIPI_DISPATCH_MAX` unchanged.
- `converge.sh` and `pr-review-agent.sh` untouched (outside allowed_files).
- `ready()` untouched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0151EYtGH6at3XTWqbBHAxEi
