### PR TITLE
Unattended dispatch refuses a client engagement repo, even when opted in (ASK-741)

### DIFF
--- a/kipi-dispatch.sh
+++ b/kipi-dispatch.sh
@@ -464,19 +464,39 @@ rotation() {
 # carries on past it; a repo that is permanently unsafe must not stall the repos
 # behind it forever.
 pick_list() {
-  local name path remote
+  local name path remote out client_n=0 client_names=""
   while IFS=$'\t' read -r name path remote; do
     [ -n "$name" ] || continue
     if [ "$path" = "$REPO" ]; then
       printf '%s\t%s\n' "$name" "$path"
       continue
     fi
-    if bash "$PREFLIGHT" "$path" "$remote" >/dev/null 2>&1; then
+    # STDOUT IS CAPTURED, NOT DISCARDED (ASK-741). This used to be
+    # `>/dev/null 2>&1`, so the preflight named every failed check on stdout and
+    # the dispatcher threw all of it away, logging only "REFUSED". A founder
+    # reading that line cannot tell a client-repo refusal from an expired token
+    # from an empty queue -- and "silent refusal is indistinguishable from nothing
+    # to do" is the exact failure this issue exists to remove. The reason the gate
+    # gives is the only thing that makes the gate legible.
+    if out="$(bash "$PREFLIGHT" "$path" "$remote" 2>&1)"; then
       printf '%s\t%s\n' "$name" "$path"
     else
-      say "preflight REFUSED $name ($path); not entering it"
+      say "preflight REFUSED $name ($path); not entering it -- $(printf '%s' "$out" | grep '^FAIL' | tr '\n' ';' | sed 's/;$//')"
+      case "$out" in
+        *"FAIL client-repo:"*)
+          client_n=$((client_n + 1))
+          client_names="${client_names:+$client_names, }$name" ;;
+      esac
     fi
   done < <(rotation)
+  # COUNTED, AND IN THE DIGEST'S OWN SHAPE. daily-linear-digest.py's third section
+  # ("tried, could not be worked") scrapes this log for `N thing(s) <what>` lines,
+  # so a refusal phrased any other way is invisible in the one surface the founder
+  # actually reads once a day. Emitted only when it happened: a client repo being
+  # refused is a real event, and a "0 refused" line every 15 minutes is the
+  # cry-wolf noise that gets a channel muted.
+  [ "$client_n" -gt 0 ] && say "$client_n repo(s) REFUSED as client engagement repos (unattended dispatch is not allowed there, even when opted in): $client_names"
+  return 0
 }
 
 # --- LIVENESS BEACON: page when the heartbeat COMES BACK ------------------

--- a/q-system/.q-system/scripts/repo-preflight.sh
+++ b/q-system/.q-system/scripts/repo-preflight.sh
@@ -52,6 +52,59 @@ refuse() { FAILED=1; printf 'FAIL %s: %s\n' "$1" "$2"; }
 [ -n "$REPO_PATH" ] || { printf 'FAIL usage: repo-preflight.sh <repo-path> <expected-remote>\n'; exit 2; }
 [ -d "$REPO_PATH" ] || { printf 'FAIL repo-path: %s is not a directory\n' "$REPO_PATH"; exit 1; }
 
+# --- 0. client engagement repo -------------------------------------------
+# Founder decision 2026-08-13, verbatim: "no. unattended agents should not reach
+# a client repo."
+#
+# THIS REFUSES EVEN WHEN THE ROW IS OPTED IN, WHICH IS THE WHOLE POINT.
+# `dispatch.enabled` defaulting to absent is a DEFAULT, and a default is not a
+# refusal: it records that nobody has switched a repo on yet, and it evaporates
+# the moment anyone -- a person editing the registry, or some later script that
+# opts rows in automatically -- writes `true`. What is on the other side of that
+# edit is a self-merging loop (converge, code, PR, review rounds, auto-merge) with
+# no human in the path, pointed at work the founder is accountable to a CLIENT
+# for, where there is a person on the other end and no undo. So this is checked
+# ahead of the kill-switch and ahead of every network call: it is the one refusal
+# that no state of the target repo, and no registry field, can argue with.
+#
+# DERIVED FROM PATH SHAPE, NEVER FROM A LIST OF CLIENTS. Measured 2026-08-13
+# against instance-registry.json: 12 of 25 rows sit under an engagement root.
+# Naming those twelve here would be a list that goes stale the day the thirteenth
+# client is onboarded -- and the failure mode of a stale allowlist is that the new
+# client is the one that gets dispatched into. The shape is the fact: the founder's
+# own systems live at <root>/projects/<thing> under roots he owns, and client
+# engagements live under exactly these two. A repo added under one of them next
+# month is refused with no code change, which is the only property that makes this
+# hold over time.
+#
+# NOT AN ENV VAR, NOT A REGISTRY FIELD. Same reason `gh` is taken from PATH and the
+# dispatcher hardcodes $PREFLIGHT off $REPO: a knob here would be a documented way
+# to aim the client-repo gate at nothing while every log line still read normally.
+ENGAGEMENT_ROOTS="consulting intel"
+
+# BOTH THE REGISTRY'S PATH AND ITS RESOLVED TARGET ARE TESTED, AND EITHER ONE
+# MATCHING REFUSES. A symlink is the obvious way this check gets walked around by
+# accident: a row pointing at an innocent-looking path that resolves into an
+# engagement dir, or an engagement-shaped path that resolves elsewhere. Refusing on
+# either side means the answer does not depend on which of the two a later reader
+# happens to think is "the" path. Fail closed, like every other item in this file.
+RESOLVED_PATH="$(cd "$REPO_PATH" 2>/dev/null && pwd -P)" || RESOLVED_PATH=""
+for _root in $ENGAGEMENT_ROOTS; do
+  for _cand in "$REPO_PATH" "$RESOLVED_PATH"; do
+    [ -n "$_cand" ] || continue
+    case "$_cand" in
+      */"$_root"/projects/*)
+        # The reason is stated in full, because this line is what the founder reads
+        # in the run log and in the daily digest's "tried, could not be worked"
+        # section. A refusal he cannot tell apart from an empty queue is the defect
+        # this whole change is about.
+        printf 'FAIL client-repo: %s is a client engagement repo (under %s/projects/); unattended dispatch is not allowed there, even when dispatch.enabled is true -- a supervised founder-initiated run is the way in\n' "$REPO_PATH" "$_root"
+        printf 'REFUSED %s\n' "$REPO_PATH"
+        exit 1 ;;
+    esac
+  done
+done
+
 # --- 1. kill-switch -------------------------------------------------------
 # Checked FIRST and short-circuits everything, including the network calls. A
 # founder or a client dropping this file is saying "stay out of here", and the

--- a/q-system/.q-system/scripts/test/test-repo-preflight.sh
+++ b/q-system/.q-system/scripts/test/test-repo-preflight.sh
@@ -768,6 +768,154 @@ WORKLINE="$(grep -n 'bash ./kipi work' "$DISPATCH" | head -1 | cut -d: -f1)"
   || bad "the hold does not precede the worker call, so an agent could still start"
 
 echo
+echo "== 19. a CLIENT ENGAGEMENT repo is refused even when opted in (ASK-741) =="
+# Founder decision 2026-08-13: "no. unattended agents should not reach a client repo."
+#
+# The property under test is NOT "client repos are off by default" -- case 5 already
+# covers default-off, and a default is not a refusal. It is that an engagement repo
+# carrying dispatch.enabled: true, and passing all seven other items, is STILL
+# absent from the pick list. Opt-in is what this has to survive.
+#
+# EVERY NAME HERE IS INVENTED. This repo is public (102 stars, 23 forks) and
+# client-name-guard.py blocks client names reaching it; a fixture named after a real
+# engagement would be the leak the guard exists to stop. The test is about the PATH
+# SHAPE, so invented names test it exactly as well as real ones would -- which is
+# itself the evidence that the derivation is not a name list.
+
+# make_good_repo builds at $WORK/$name and pins origin to that same name, so it
+# cannot build a NESTED path whose registry row name differs. Engagement-ness is a
+# property of the path and nothing else, so the two have to be separable here.
+make_good_repo_at() {
+  local rowname="$1"
+  local sub="$2"
+  local dir
+  dir="$(make_good_repo "$sub")"
+  fixture_git "$dir" remote set-url origin "https://github.com/assafkip/$rowname.git" >/dev/null 2>&1
+  printf '%s' "$dir"
+}
+
+# A client that DOES NOT EXIST TODAY. If this is refused, the refusal cannot be
+# coming from a list of the twelve engagements currently in the registry -- which is
+# the only durable proof that onboarding client thirteen needs no code change.
+NEWCLIENT="$(make_good_repo_at newclient consulting/projects/zzz-new-client)"
+# The negative control, built by the SAME builder, differing ONLY in path shape.
+# Without this the section could pass by refusing everything.
+OWNPROJ="$(make_good_repo_at ownproj cole-gtm/projects/own-thing)"
+INTELCLIENT="$(make_good_repo_at intelclient intel/projects/zzz-other-client)"
+
+OUT="$(run_preflight "$NEWCLIENT" "https://github.com/assafkip/newclient.git")"
+{ [ "$(pf_rc "$NEWCLIENT" "https://github.com/assafkip/newclient.git")" != "0" ] \
+    && printf '%s' "$OUT" | grep -q 'client-repo'; } \
+  && ok "an engagement repo that does not exist today is refused, and names client-repo" \
+  || bad "THE DEFECT: a not-yet-existing client repo was accepted: $OUT"
+
+printf '%s' "$OUT" | grep -q 'even when dispatch.enabled is true' \
+  && ok "the refusal states WHY, naming opt-in explicitly" \
+  || bad "the refusal does not say why, so it reads like any other skip: $OUT"
+
+OUT="$(run_preflight "$INTELCLIENT" "https://github.com/assafkip/intelclient.git")"
+{ [ "$(pf_rc "$INTELCLIENT" "https://github.com/assafkip/intelclient.git")" != "0" ] \
+    && printf '%s' "$OUT" | grep -q 'client-repo'; } \
+  && ok "the second engagement root is refused too, not just the first" \
+  || bad "an engagement root was not covered: $OUT"
+
+# THE OTHER DIRECTION. A check that refuses everything is not a check, and the
+# founder's own projects/ dirs are the same SHAPE one level up -- so this is the
+# case that proves the derivation discriminates rather than pattern-matching
+# "/projects/".
+[ "$(pf_rc "$OWNPROJ" "https://github.com/assafkip/ownproj.git")" = "0" ] \
+  && ok "a NON-engagement repo under the founder's own root still passes" \
+  || bad "the guard over-matched and refused one of the founder's own repos: $(run_preflight "$OWNPROJ" "https://github.com/assafkip/ownproj.git")"
+
+# The engagement ROOT itself is the founder's own instance, not an engagement. The
+# founder's wording was "the engagement instances NESTED UNDER consulting/projects/*",
+# so <root>/projects/<x> refuses and <root> does not.
+ROOTREPO="$(make_good_repo_at rootrepo consulting)"
+[ "$(pf_rc "$ROOTREPO" "https://github.com/assafkip/rootrepo.git")" = "0" ] \
+  && ok "the engagement ROOT itself is not treated as a client engagement" \
+  || bad "the guard swallowed the persona root, which is the founder's own instance"
+
+# NO BYPASS SURFACE, same rule the dispatcher is held to by case 8.
+grep -qE '^ENGAGEMENT_ROOTS="[a-z ]+"$' "$PREFLIGHT" \
+  && ok "the engagement roots are a literal in the script, not an override" \
+  || bad "the engagement roots are not a plain literal, so they may be overridable"
+grep -nE 'ENGAGEMENT_ROOTS="?\$\{|KIPI_[A-Z_]*ENGAGEMENT|KIPI_[A-Z_]*CLIENT' "$PREFLIGHT" \
+  && bad "an env var can redefine what counts as a client repo" \
+  || ok "no env var can redefine what counts as a client repo"
+
+echo
+echo "== 20. the client-repo refusal is ABSENT from the pick list, and SAID (ASK-741) =="
+# End to end through the dispatcher's own selection, not the preflight in isolation.
+# Both rows are opted in; only the shape differs.
+REG5="$WORK/reg5.json"
+mk_registry "$REG5" "newclient|$NEWCLIENT|true" "ownproj|$OWNPROJ|true"
+# stdout is the SELECTION; stderr carries say(). Merging them makes `grep newclient`
+# match the refusal REASON, which reports a correctly-refused repo as selected.
+PICKS5="$(KIPI_DISPATCH_REGISTRY="$REG5" KIPI_DISPATCH_CURSOR="$WORK/cursor5" bash "$HARNESS" 2>"$WORK/say5.log")"
+printf '%s' "$PICKS5" | grep -q 'ownproj' \
+  && ok "the opted-in NON-client repo IS selected (so the absence below means something)" \
+  || bad "the non-client control never reached the pick list, so this section proves nothing"
+printf '%s' "$PICKS5" | grep -q 'newclient' \
+  && bad "THE DEFECT: an opted-in client engagement repo is SELECTED for unattended dispatch" \
+  || ok "an opted-in client engagement repo is ABSENT from the pick list"
+
+# A SILENT REFUSAL IS THE DEFECT, NOT THE FIX. The founder has to be able to tell a
+# refusal from an empty queue, so the reason is asserted, not just the absence.
+grep -q 'FAIL client-repo' "$WORK/say5.log" \
+  && ok "the run output states WHY the repo was refused" \
+  || bad "the refusal is silent in the run output: $(cat "$WORK/say5.log")"
+# The counted shape daily-linear-digest.py's third section scrapes.
+grep -qE '[0-9]+ repo\(s\) REFUSED as client engagement repos' "$WORK/say5.log" \
+  && ok "the run output carries the counted line the daily digest reads" \
+  || bad "no counted line, so the digest's third section cannot show this: $(cat "$WORK/say5.log")"
+
+echo
+echo "== 21. MUTATION: break the derivation and case 20 must go RED (ASK-741) =="
+# A guard whose test stays green with the guard removed is decoration.
+# THE MUTANT MUST SIT AT THE SAME DEPTH AS THE REAL SCRIPT. repo-preflight.sh
+# derives SKELETON from its own ${BASH_SOURCE[0]} as "../../.." -- deliberately, so
+# the control-code reference follows the code rather than $PWD. A mutant dropped at
+# $WORK/mutant-preflight.sh therefore resolves SKELETON to a directory three levels
+# above mktemp, finds no linear-worker.sh there, and refuses on CONTROL-CODE. It was
+# measured doing exactly that: the mutant "still refused the client repo" and the
+# case read SURVIVED, when in truth the derivation under test had never run. A false
+# SURVIVED is worse than a false KILL -- it reports a load-bearing guard as
+# decorative. So the mutant gets a skeleton of its own, at the right depth.
+MUTSKEL="$WORK/mutskel"
+mkdir -p "$MUTSKEL/q-system/.q-system/scripts" "$MUTSKEL/.claude"
+cp "$SKEL_WORKER" "$MUTSKEL/q-system/.q-system/scripts/linear-worker.sh"
+cp "$SKEL_SETTINGS" "$MUTSKEL/.claude/settings.json"
+copy_guards "$MUTSKEL"
+MUTPF="$MUTSKEL/q-system/.q-system/scripts/repo-preflight.sh"
+sed 's|^ENGAGEMENT_ROOTS=.*|ENGAGEMENT_ROOTS="zzzz-no-such-root"|' "$PREFLIGHT" > "$MUTPF"
+# VALIDATE THE MUTANT APPLIED. A sed that matched nothing produces a byte-identical
+# file and a "SURVIVED" that means the edit never happened, not that the guard is weak.
+if cmp -s "$MUTPF" "$PREFLIGHT"; then
+  bad "the mutation changed nothing -- the mutant is not a mutant, so this proves nothing"
+elif grep -q '^ENGAGEMENT_ROOTS="zzzz-no-such-root"$' "$MUTPF"; then
+  ok "the mutant applied (the engagement roots were replaced with a root nothing is under)"
+  MUTH2="$WORK/select-mutant-pf.sh"
+  {
+    echo 'set -uo pipefail'
+    echo 'say() { printf "SAY %s\n" "$*" >&2; }'
+    echo "REPO=\"$REPO\""
+    echo "PREFLIGHT=\"$MUTPF\""
+    awk '/^cursor_get\(\) \{/,/^\}/'       "$DISPATCH"
+    awk '/^cursor_set\(\) \{/,/^\}/'       "$DISPATCH"
+    awk '/^fleet_candidates\(\) \{/,/^\}/' "$DISPATCH"
+    awk '/^rotation\(\) \{/,/^\}/'         "$DISPATCH"
+    awk '/^pick_list\(\) \{/,/^\}/'        "$DISPATCH"
+    echo 'pick_list'
+  } > "$MUTH2"
+  MP="$(KIPI_DISPATCH_REGISTRY="$REG5" KIPI_DISPATCH_CURSOR="$WORK/cursorM2" bash "$MUTH2" 2>/dev/null)"
+  printf '%s' "$MP" | grep -q 'newclient' \
+    && ok "with the derivation broken the client repo REAPPEARS -- case 20 is load-bearing" \
+    || bad "the mutant still refused the client repo, so case 20 is not driven by the derivation"
+else
+  bad "the mutant was written but does not carry the expected replacement"
+fi
+
+echo
 echo "-------- $PASS passed, $FAIL failed --------"
 [ "$FAIL" -eq 0 ] || exit 1
 echo "PASS: no repo is entered until seven named preflight checks pass, and selection rotates"


### PR DESCRIPTION
Founder decision 2026-08-13, verbatim: **"no. unattended agents should not reach a client repo."**

`com.kipi.dispatch` is a self-merging loop: pick a ready issue, converge a branch, code, open a PR, run review rounds, arm auto-merge, no human in the path. Fine on the founder's own systems. Not fine on work he is accountable to a client for.

The only thing keeping it out of an engagement repo was `dispatch.enabled` being absent on every registry row. **A default is not a refusal.** It records that nobody has switched a repo on yet, and it evaporates the moment anyone writes `true`.

## Red first

A fixture row under an engagement path, `dispatch.enabled: true`, passing all seven other preflight items:

```
== the dispatcher's pick, both rows opted in ==
.wt-ask741	/Users/assafkipnis/projects/kipi-system/.wt-ask741
zzznewclient	/var/.../consulting/projects/zzz-new-client
ownrepo	/var/.../cole-gtm/projects/own-thing

  PASS: negative control: a NON-client repo that is opted in is still selected
  FAIL: THE DEFECT: an opted-in CLIENT engagement repo is SELECTED for unattended dispatch
```

The control passing is what makes the failure mean something: the fixture was provably capable of being selected.

Green after:

```
SAY preflight REFUSED zzznewclient (...); not entering it -- FAIL client-repo: ... is a
client engagement repo (under consulting/projects/); unattended dispatch is not allowed
there, even when dispatch.enabled is true -- a supervised founder-initiated run is the way in
SAY 1 repo(s) REFUSED as client engagement repos (unattended dispatch is not allowed
there, even when opted in): zzznewclient
```

## Where the chokepoint went, and why

`repo-preflight.sh`, as **check 0**. It already *is* the single gate on unattended repo entry: one call site, no bypass surface by construction, fails closed, and it receives the registry path as its argument.

That last part is the reason it wins over the alternatives. Client-ness is derived from the **path**, and the preflight is already handed the path, so this adds **no new reader of registry structure**. `sp-421fa27d` records that the project-name derivation is already duplicated between `linear-worker.sh` and `spillover-promote.py`; putting the check in `fleet_candidates()` would have added a third, and would also have made the refusal *invisible* by dropping the row before anything could report it.

Checked ahead of the kill-switch and ahead of every network call: it is the one refusal no state of the target repo and no registry field can argue with.

## Derived from shape, never a name list

```sh
ENGAGEMENT_ROOTS="consulting intel"
case "$_cand" in */"$_root"/projects/*) ... refuse ;; esac
```

Proven by a fixture for an engagement that **does not exist today** (`consulting/projects/zzz-new-client`) being refused with no code edit. If the refusal came from a list of the twelve current engagements, that case would pass through.

Both the registry path and its resolved target are tested, and either one matching refuses, so a symlink cannot walk around it in either direction.

## The refusal is not silent

`pick_list()` was discarding the preflight's stdout (`>/dev/null 2>&1`), so it logged `REFUSED` and threw away every reason. A founder reading that cannot tell a client-repo refusal from an expired token from an empty queue. It now captures the output and names the failed check, plus a counted line in the shape `daily-linear-digest.py`'s "tried, could not be worked" section scrapes.

## Both directions

| fixture | opted in | result |
|---|---|---|
| `consulting/projects/zzz-new-client` | yes | REFUSED |
| `intel/projects/zzz-other-client` | yes | REFUSED |
| `cole-gtm/projects/own-thing` | yes | **SELECTED** |
| `consulting` (the root itself) | yes | **ACCEPTED** |

The engagement root is the founder's own instance, not an engagement, matching his wording ("the engagement instances *nested under* `consulting/projects/*`").

## Supervised runs, unaffected by construction

Not by intention. The preflight is referenced only in `kipi-dispatch.sh`, at one call site. `linear-worker.sh` and the `kipi` CLI have **zero** references, so `kipi work --issue X --repo <client path>` never reaches the guard.

## Mutation, including a false SURVIVED I had to fix

First run reported SURVIVED. The mutant sat at `$WORK/mutant-preflight.sh`, but `repo-preflight.sh` derives `SKELETON` from its own `${BASH_SOURCE[0]}` as `../../..` -- so the mutant resolved a skeleton three levels above mktemp, found no worker there, and refused on **control-code**. It "still refused the client repo" while the derivation under test had never run. A false SURVIVED reports a load-bearing guard as decorative. Gave the mutant its own skeleton at the right depth; it now genuinely kills.

## Verification

- `test-repo-preflight.sh`: **61 passed, 0 failed** (was 48)
- `pytest plugins/prd-os/tests/`: 630 passed, 1 skipped
- `pytest q-system/.q-system/tests/test_auto_commit.py`: 28 passed
- `validate-separation.py 1` (includes capability-gate full suite): see checks

## Coordination with #143

Branched off `origin/main` in an isolated worktree. **No file #143 owns was touched** except `kipi-dispatch.sh`, and in a different function: mine is `pick_list()` (~line 470), #143's hunk is the fleet-posture block (~line 677). No textual overlap.

`daily-linear-digest.py` is deliberately **not** created here. It does not exist on `main` (#143 creates it), so adding it would guarantee a hard conflict. Its `BLOCKED_SOURCES` already includes `dispatch.log`, so the surface is correct today; it needs one more regex in `BLOCKED_PATTERNS` to render my line. Captured as **sp-8cca6547** (major) to land after #143 merges.

[ASK-741]

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0151EYtGH6at3XTWqbBHAxEi
