### PR TITLE
Get main green: three inherited failures, three different root causes (ASK-740, ASK-746)

### DIFF
--- a/kipi-update.sh
+++ b/kipi-update.sh
@@ -510,6 +510,8 @@ checkpoint_instance() {
 
 restore_instance() {
   local target="${CHECKPOINT_TARGET:-}" uf
+  local spec
+  local -a restore_specs=()
   [ -n "$target" ] || return 0
   [ -d "$CHECKPOINT_DIR" ] || return 0
   # An interrupted rebase, first, because aborting one restores HEAD and the
@@ -570,8 +572,32 @@ restore_instance() {
   # move together; the pathspec below is the same one the guard uses.
   git -C "$target" reset -q HEAD -- "$CHECKPOINT_PREFIX/" .claude/ plugins/ \
     $(pathspec_owned_excludes "$CHECKPOINT_PREFIX") 2>/dev/null || true
-  git -C "$target" checkout -q -- "$CHECKPOINT_PREFIX/" .claude/ plugins/ \
-    $(pathspec_owned_excludes "$CHECKPOINT_PREFIX") 2>/dev/null || true
+  # `git checkout -- A B C` is ALL-OR-NOTHING. If ANY pathspec matches nothing
+  # in the index it errors ("pathspec '.claude/' did not match any file(s)
+  # known to git") and restores NONE of them -- while `git reset` above accepts
+  # the same unmatched pathspec and returns 0. An instance that tracks no
+  # .claude/ or plugins/ (a subtree instance that has never had a config sync
+  # land is exactly that) therefore had its ENTIRE worktree restore silently
+  # no-op: `2>/dev/null || true` hid the message and the exit code both, so the
+  # index looked restored while the worktree kept the run's writes.
+  #
+  # That is what stranded instances: a failed run left `M q-system/tracked.md`
+  # behind and every later run refused at the dirty-tree guard, reading the
+  # updater's own debris as founder work. Measured 2026-08-13 (ASK-740): with
+  # the unmatched specs passed, checkout rc=1 and the file stays modified; with
+  # them dropped, rc=0 and the file is restored.
+  #
+  # Filtering by `ls-files` rather than by a directory test on purpose: what
+  # checkout requires is a match in the INDEX, not a directory on disk.
+  for spec in "$CHECKPOINT_PREFIX/" .claude/ plugins/; do
+    if [ -n "$(git -C "$target" ls-files -- "$spec" 2>/dev/null)" ]; then
+      restore_specs+=("$spec")
+    fi
+  done
+  if [ "${#restore_specs[@]}" -gt 0 ]; then
+    git -C "$target" checkout -q -- "${restore_specs[@]}" \
+      $(pathspec_owned_excludes "$CHECKPOINT_PREFIX") 2>/dev/null || true
+  fi
   # Finally, remove files this run created: untracked NOW, absent from the
   # checkpoint, and inside the sync's own scope. Never a recursive delete of a
   # directory this run was not observed to create.

--- a/q-system/.q-system/capability-manifest.json
+++ b/q-system/.q-system/capability-manifest.json
@@ -607,6 +607,11 @@
       "spillover_id": "sp-0f773063"
     },
     {
+      "path": "q-system/.q-system/scripts/lessons_recall.py",
+      "reason": "retrieval + de-duplication over the lessons corpus: exec bit, real __main__, four subcommands, and ZERO references anywhere in the repo outside its own usage docstring. A genuine true positive, not a gate defect. Built to fix a measured decay in q-system/hooks/lessons-index.py (122 lessons, only the 20 most recent ever surfaced, title-only, evicting), which is also the obvious wiring destination -- but arming a retrieval engine at SessionStart changes behaviour on every governed instance, so it is a deliberate decision and not a side effect of a CI-green fix. Declared inert rather than given fake wiring. Wire it or retire it.",
+      "spillover_id": "sp-067205d3"
+    },
+    {
       "path": "q-system/.q-system/scripts/linear-collapse-jobmigration.py",
       "reason": "one-shot family collapse: it absorbed the 32-member job-migration family into ASK-151 on 2026-07-28 and has no second family to run on. ASK-226 generalises it; retire this one when that lands",
       "spillover_id": "sp-fb332466"

--- a/q-system/.q-system/scripts/capability-gate.py
+++ b/q-system/.q-system/scripts/capability-gate.py
@@ -493,6 +493,50 @@ def references_engine(name, surface):
                      surface) is not None
 
 
+# A file the TEST RUNNER loads by name, with no import and no call site anywhere
+# by design. The textual-reference model this whole check rests on structurally
+# cannot express "the runner picks this up by convention", so such a file can
+# only ever be a false positive here -- and the only way to silence it with a
+# reference would be to write a fake one.
+RUNNER_LOADED_NAMES = frozenset({"conftest.py"})
+
+# The `__main__` guard as SYNTAX: start of a line, not anywhere in the bytes.
+_MAIN_GUARD_RE = re.compile(r"^\s*if\s+__name__\s*==\s*['\"]__main__['\"]\s*:",
+                            re.MULTILINE)
+
+
+def is_runnable_engine(path, text):
+    """True when this file RUNS, as opposed to being read or imported.
+
+    Scar (sp-7773af84's neighbour, measured 2026-08-14; main had been red on it
+    since 2026-08-10). The test used to be:
+
+        os.access(p, os.X_OK) or "__main__" in text
+
+    a bare substring over the whole file. `conftest.py` has no exec bit and no
+    guard -- the only `__main__` in it is one line of PROSE inside its module
+    docstring, advising future authors to guard their exits under
+    `if __name__ == "__main__":`. That sentence alone promoted it to a candidate,
+    and because pytest loads conftest by NAME it could never then prove itself
+    wired, so the gate reported it inert on every run forever.
+
+    Two separate defects, so both are closed: a substring cannot tell code from a
+    comment ABOUT code, hence the guard is now matched as syntax at the start of
+    a line; and a runner-loaded file is not an engine at all, hence
+    RUNNER_LOADED_NAMES. Fixing only the first would have hidden the second by
+    accident, because THIS conftest happens to lack an exec bit -- one that
+    carried the exec bit would still be flagged wrongly.
+
+    Deliberately NOT widened past that. The check keeps its own scar in view: it
+    exists because two dead engines citing each other stayed invisible for
+    months, so anything that makes it blind is a bigger cost than a false
+    positive, which is loud and resolved by a declared_inert entry.
+    """
+    if path.name in RUNNER_LOADED_NAMES:
+        return False
+    return os.access(path, os.X_OK) or _MAIN_GUARD_RE.search(text) is not None
+
+
 def check_inert_engines(root, manifest, errors, notes):
     """F2 class: a runnable .py with zero textual references across the wiring
     surfaces and no declared_inert entry is a silently-dead engine.
@@ -522,8 +566,7 @@ def check_inert_engines(root, manifest, errors, notes):
               + list(root.glob("plugins/*/skills/*/scripts/*.py"))):
         if p.is_file() and not p.name.startswith(("test_", "test-")) \
                 and not any(part in ("test", "tests") for part in p.parts):
-            text = p.read_text(errors="ignore")
-            if os.access(p, os.X_OK) or "__main__" in text:
+            if is_runnable_engine(p, p.read_text(errors="ignore")):
                 plugin_candidates.add(p)
     candidates = set()
     for p in list(base.glob("*.py")) + list((base / "scripts").rglob("*.py")):
@@ -532,9 +575,9 @@ def check_inert_engines(root, manifest, errors, notes):
         if any(part in ("test", "tests") for part in p.parts):
             continue
         # runnable contract: exec bit or a __main__ guard; a pure library
-        # module with neither is not an "engine" (standard-review minor)
-        text = p.read_text(errors="ignore")
-        if os.access(p, os.X_OK) or "__main__" in text:
+        # module with neither is not an "engine" (standard-review minor).
+        # One authority for that question -- see is_runnable_engine.
+        if is_runnable_engine(p, p.read_text(errors="ignore")):
             candidates.add(p)
     surface = gather_wiring_text(root, {p.name for p in candidates})
     wired = set()

--- a/q-system/.q-system/scripts/client-name-guard.py
+++ b/q-system/.q-system/scripts/client-name-guard.py
@@ -1,11 +1,20 @@
 #!/usr/bin/env python3
 """Block a client name from reaching a PUBLIC repo, in staged content or the message.
 
-Scar (2026-08-13): a pre-push scan of 15 commits found "[4_points_consulting]
-huntkit sync BLOCKED: /Users/assafkipnis/projects/huntkit" sitting in an alert
-test fixture, plus two commit subjects naming clients. This repo is public with
-102 stars and 23 forks. gitleaks passed all of it, because a client name is not
-a secret in the credential sense. Nothing else looked.
+Scar (2026-08-13): a pre-push scan of 15 commits found a captured production
+alert sitting in a test fixture that carried a CLIENT NAME and the founder's
+absolute home path, plus two commit subjects naming clients. This repo is public
+with 102 stars and 23 forks. gitleaks passed all of it, because a client name is
+not a secret in the credential sense. Nothing else looked.
+
+The offending strings are described by CLASS above and deliberately NOT quoted
+here. Quoting them would republish the exact data this file exists to keep out
+of a public repo -- and this file is on the guard's own exclusion list, so
+nothing would have stopped it. That is not hypothetical: for one commit this
+docstring did quote them verbatim, which put a client name and a real home path
+back into the public tree and tripped validate-separation.py's skeleton sweep
+(caught 2026-08-14, ASK-746). A privacy exclusion names the data class, never
+the data.
 
 Two of those were already public and could not be recalled: rewriting history
 does not remove objects that 23 forks already hold, and GitHub keeps dangling

--- a/q-system/.q-system/scripts/fable-escalate.py
+++ b/q-system/.q-system/scripts/fable-escalate.py
@@ -296,29 +296,59 @@ def log_row(row):
 
 
 def notify_channel_configured():
-    """True when a page could actually leave this machine.
-
-    slack-notify.sh resolves its webhook from $KIPI_SLACK_WEBHOOK then
-    ~/.config/kipi/slack-webhook, and its own header states: "No webhook
-    configured -> silent no-op (exit 0), so callers never break." So its exit
-    code cannot distinguish a delivered message from a swallowed one; the
-    webhook has to be checked separately or delivery is unknowable.
+    """True when an alert could actually leave this machine.
 
     An explicit KIPI_FABLE_NOTIFY_CMD means the caller supplied its own
     notifier and owns its delivery semantics, so its channel is not ours to
     judge.
+
+    Scar (sp-7773af84, measured 2026-08-14, the reason this reads Linear and not
+    a webhook): on 2026-08-10 slack-notify.sh's destination changed from Slack to
+    Linear -- it now shells alert-to-linear.py and never resolves a webhook at
+    all. This function was left behind still gating on $KIPI_SLACK_WEBHOOK and
+    ~/.config/kipi/slack-webhook, which by then decided NOTHING about whether an
+    alert could be filed. Two failures came out of that, in opposite directions:
+
+      1. Production: a machine holding a valid Linear key but no leftover webhook
+         file answered False here, so `send_ping` returned False WITHOUT EVER
+         RUNNING THE NOTIFIER. The watchdog's page was suppressed by a channel
+         that no longer exists.
+      2. CI: test_launchd_health_check.py set a webhook to a refused port and
+         asserted "not delivered". The webhook was inert, so the assertion was
+         really measuring whether the runner had a Linear key -- it failed on
+         `refuses -> NOT delivered` on a keyed machine and on the opposite
+         assertion, `accepts -> delivered`, in CI. It could not be green anywhere,
+         and on a keyed machine it filed REAL tickets (ASK-736 repeats, ASK-744,
+         ASK-745, all canceled).
+
+    So the channel is asked about the destination that exists. The key lookup is
+    borrowed from linear-sync.py -- the fleet's single writer for how it talks to
+    Linear, and the same module alert-to-linear.py loads -- rather than re-derived
+    here, because a copy is exactly what drifted above. KIPI_ALERT_CAPTURE is a
+    genuine configured destination too: the message is appended to that file and
+    nothing is dropped, which is what the bash and python suites redirect into.
+
+    A load failure or a missing key answers False -- "no channel" -- which the
+    callers read as NOT delivered. That costs a duplicate alert, never a missed
+    one. It is the same trade the rest of this path makes.
     """
     if os.environ.get("KIPI_FABLE_NOTIFY_CMD"):
         return True
-    if (os.environ.get("KIPI_SLACK_WEBHOOK") or "").strip():
+    if (os.environ.get("KIPI_ALERT_CAPTURE") or "").strip():
         return True
-    path = os.path.join(os.path.expanduser("~"), ".config", "kipi",
-                        "slack-webhook")
     try:
-        with open(path, encoding="utf-8") as fh:
-            return bool(fh.read().strip())
-    except OSError:
+        spec = importlib.util.spec_from_file_location(
+            "kipi_linear_sync_channel",
+            os.path.join(os.path.dirname(os.path.abspath(__file__)),
+                         "linear-sync.py"))
+        if spec is None or spec.loader is None:
+            return False
+        module = importlib.util.module_from_spec(spec)
+        spec.loader.exec_module(module)
+        module.linear_api_key()
+    except Exception:  # noqa: BLE001
         return False
+    return True
 
 
 # slack-notify.sh's EXIT CONTRACT (ASK-534), transcribed once. Read it as a

--- a/q-system/.q-system/scripts/launchd-health-check.py
+++ b/q-system/.q-system/scripts/launchd-health-check.py
@@ -218,11 +218,16 @@ def notify_channel_configured():
     """True when a page could actually leave this machine.
 
     Borrowed, not re-derived: `fable-escalate.py` already owns the Python read of
-    slack-notify.sh's webhook resolution order ($KIPI_SLACK_WEBHOOK, then
-    ~/.config/kipi/slack-webhook), and a second copy here is the drift
-    `fleet-homogeneity` exists to stop. Loaded through the same lazy-importlib
-    shape as `_fleet_health` / `_intent_module`, so its absence cannot stop the
-    watchdog.
+    whether slack-notify.sh has a destination to write to, and a second copy here
+    is the drift `fleet-homogeneity` exists to stop. Loaded through the same
+    lazy-importlib shape as `_fleet_health` / `_intent_module`, so its absence
+    cannot stop the watchdog.
+
+    That destination is LINEAR, not Slack, since 2026-08-10. This paragraph used
+    to name the webhook resolution order ($KIPI_SLACK_WEBHOOK, then
+    ~/.config/kipi/slack-webhook) and it outlived the channel by four days --
+    which is the same way sp-7773af84 stayed invisible. The resolution order is
+    deliberately NOT restated here; it belongs to the function being borrowed.
 
     A load failure answers False -- "delivery unknown". The caller reads that as
     NOT delivered, which costs a repeated ping and never costs a missed one. That

--- a/q-system/.q-system/scripts/test/test-kipi-update-hook-contract.sh
+++ b/q-system/.q-system/scripts/test/test-kipi-update-hook-contract.sh
@@ -232,10 +232,31 @@ git -C "$CONFIG_BLOCKED/instance" log -1 --format=%s |
 [ ! -e "$CONFIG_BLOCKED/capability.log" ] ||
   fail "capability phase ran after config hook rejection"
 
+# The dirt below sits on q-system/tracked.md -- a file the sync WRITES -- and not
+# on the instance-root unrelated.md it used to use. That is a fixture fix, not a
+# relaxed assertion: every check in this block is unchanged and now actually
+# exercises the guard instead of an empty set.
+#
+# WHY (ASK-609, 548919d4, 2026-08-10). The dirty-tree guard used to be repo-wide.
+# It was deliberately scoped that day to the paths the sync can reach, after
+# measuring 182 dirty files across four blocked instances with ZERO of them in a
+# path the sync writes -- four instances locked out of every fix, including the
+# one written to unblock them, by a guard protecting nothing. That commit shipped
+# its own two-direction test (test-kipi-update-dirty-guard-scope.sh) and did NOT
+# update this file, so from 2026-08-10 these five assertions asserted the
+# pre-ASK-609 repo-wide contract against post-ASK-609 code. Instrumented at
+# 11f0eb8a: the guard never fired, no refusal was printed, FAIL stayed 0 and the
+# run exited 0 -- so there was never a swallowed exit code here to fix. That is
+# what kept main's Skeleton Validation red for four days.
+#
+# Two tests encoding opposite contracts is a decision, not a bug, and it is made
+# here in favour of ASK-609: root-level dirt genuinely cannot be clobbered
+# (staging is pathspec-scoped throughout), so blocking on it protected an empty
+# set at the cost of stranding real instances.
 DIRTY="$WORK/dirty"
 make_fixture "$DIRTY"
 DIRTY_HEAD="$(git -C "$DIRTY/instance" rev-parse HEAD)"
-printf 'founder work in progress\n' > "$DIRTY/instance/unrelated.md"
+printf 'founder work in progress\n' > "$DIRTY/instance/q-system/tracked.md"
 set +e
 HOOK_LOG="$DIRTY/hook.log" CAPABILITY_LOG="$DIRTY/capability.log" \
   bash "$DIRTY/skeleton/kipi-update.sh" >"$DIRTY/output.log" 2>&1
@@ -244,7 +265,7 @@ set -e
 [ "$DIRTY_RC" -ne 0 ] || fail "dirty instance returned success"
 [ "$(git -C "$DIRTY/instance" rev-parse HEAD)" = "$DIRTY_HEAD" ] ||
   fail "updater committed unrelated work in progress"
-grep -q 'founder work in progress' "$DIRTY/instance/unrelated.md" ||
+grep -q 'founder work in progress' "$DIRTY/instance/q-system/tracked.md" ||
   fail "updater changed unrelated work in progress"
 [ ! -e "$DIRTY/hook.log" ] ||
   fail "updater reached a commit hook after dirty-tree refusal"
@@ -254,8 +275,8 @@ grep -q 'dirty working tree' "$DIRTY/output.log" ||
 STAGED="$WORK/staged"
 make_fixture "$STAGED"
 STAGED_HEAD="$(git -C "$STAGED/instance" rev-parse HEAD)"
-printf 'staged founder work\n' > "$STAGED/instance/unrelated.md"
-git -C "$STAGED/instance" add unrelated.md
+printf 'staged founder work\n' > "$STAGED/instance/q-system/tracked.md"
+git -C "$STAGED/instance" add q-system/tracked.md
 set +e
 HOOK_LOG="$STAGED/hook.log" CAPABILITY_LOG="$STAGED/capability.log" \
   bash "$STAGED/skeleton/kipi-update.sh" >"$STAGED/output.log" 2>&1

--- a/q-system/.q-system/scripts/test/verify-alert-wiring.sh
+++ b/q-system/.q-system/scripts/test/verify-alert-wiring.sh
@@ -8,6 +8,13 @@
 # webhook script, so they must never be confused for a live copy.
 set -uo pipefail
 
+# The fleet checkout root. A literal /Users/<founder> cannot live under
+# q-system/ in this PUBLIC repo -- validate-separation.py's full skeleton sweep
+# fails on one, and that failure sat invisible for days behind an earlier red
+# gate (ASK-746). Default keeps the behaviour identical on the founder's machine;
+# override for a differently-laid-out checkout.
+FLEET_ROOT="${KIPI_FLEET_ROOT:-$HOME/projects}"
+
 PASS=0; FAIL=0
 ok()  { PASS=$((PASS+1)); printf '  ok   %s\n' "$1"; }
 bad() { FAIL=$((FAIL+1)); printf '  FAIL %s\n       %s\n' "$1" "${2:-}"; }
@@ -30,7 +37,7 @@ while IFS= read -r f; do
   if is_scratch "$f"; then stale=$((stale+1)); continue; fi
   live=$((live+1))
   head -3 "$f" | grep -q "Linear ticket" || wrong="$wrong$f\n"
-done < <(find /Users/assafkipnis/projects -name "slack-notify.sh" -not -path "*/.git/*" 2>/dev/null)
+done < <(find "$FLEET_ROOT" -name "slack-notify.sh" -not -path "*/.git/*" 2>/dev/null)
 if [ -z "$wrong" ]; then
   ok "all $live live copies route to Linear ($stale scratch/worktree copies excluded)"
 else
@@ -43,13 +50,13 @@ bad_ac=""
 while IFS= read -r f; do
   is_scratch "$f" && continue
   grep -q "_notify_slack\|slack-notify" "$f" && bad_ac="$bad_ac$f\n"
-done < <(find /Users/assafkipnis/projects -name "auto-commit.py" -not -path "*/.git/*" 2>/dev/null)
+done < <(find "$FLEET_ROOT" -name "auto-commit.py" -not -path "*/.git/*" 2>/dev/null)
 [ -z "$bad_ac" ] && ok "no live auto-commit.py references the alert path" \
                  || bad "an auto-commit still alerts" "$(printf "$bad_ac")"
 
 # --- 3. the cole carve-out is throttled --------------------------------------
 echo "-- 3. cole carve-out speaks once per day"
-CP=/Users/assafkipnis/projects/cole-gtm/gtm/scripts/podcast/daily_social_publer.py
+CP=$FLEET_ROOT/cole-gtm/gtm/scripts/podcast/daily_social_publer.py
 grep -q "carve-out-said" "$CP" 2>/dev/null \
   && ok "carve-out throttle present" \
   || bad "carve-out throttle missing" "$CP"
@@ -69,9 +76,9 @@ done
 
 # --- 5. the pytest guard holds through the real chain ------------------------
 echo "-- 5. a test cannot file a ticket (full 2-hop chain, per live repo)"
-for repo in /Users/assafkipnis/projects/consulting \
-            /Users/assafkipnis/projects/cole-gtm \
-            /Users/assafkipnis/projects/kipi-system; do
+for repo in $FLEET_ROOT/consulting \
+            $FLEET_ROOT/cole-gtm \
+            $FLEET_ROOT/kipi-system; do
   n="$repo/q-system/.q-system/scripts/slack-notify.sh"
   [ -f "$n" ] || { bad "no notify script in $(basename "$repo")" "$n"; continue; }
   out=$(PYTEST_CURRENT_TEST="probe (call)" bash "$n" "wiring receipt probe" 2>&1)
@@ -133,7 +140,7 @@ for n in names:
 sys.exit(1)
 PY
   then posters="$posters$f\n"; fi
-done < <(grep -rl "config/kipi/slack-webhook" /Users/assafkipnis/projects \
+done < <(grep -rl "config/kipi/slack-webhook" "$FLEET_ROOT" \
           --include=*.py --include=*.sh 2>/dev/null | grep -v "/.git/")
 uniq_posters="$(printf "$posters" | sed '/^$/d' | sort -u)"
 count="$(printf '%s' "$uniq_posters" | grep -c . || true)"

--- a/q-system/.q-system/scripts/test_capability_gate.py
+++ b/q-system/.q-system/scripts/test_capability_gate.py
@@ -223,6 +223,46 @@ def sec_wiring():
         (root / "q-system/.q-system/capability-manifest.json").write_text(json.dumps(m))
         rc, out = run_gate(root, "--check-only")
         check("wiring: declared_inert passes with note", rc == 0 and "DECLARED-INERT" in out)
+    # ASK-746 neighbour: the candidate filter said `"__main__" in text`, a bare
+    # substring over the whole file. conftest.py has no exec bit and no guard --
+    # its only `__main__` is one line of PROSE in its docstring telling future
+    # authors to guard their exits. That sentence promoted it to a candidate, and
+    # since pytest loads conftest BY NAME it could never prove itself wired, so
+    # main's Skeleton Validation carried `inert-engine: conftest.py` from
+    # 2026-08-10 to 2026-08-14. The tempting "fix" is a fake reference on a
+    # wiring surface; the real one is that this was never an engine.
+    #
+    # The control for these lives above: "wiring: unwired engine RED". If a
+    # loosened filter ever stops seeing real dead engines, that case goes green
+    # and these three cannot tell you, so they are read together.
+    with tempfile.TemporaryDirectory() as tmp:
+        root = make_repo(tmp)
+        c = root / "q-system/.q-system/scripts/conftest.py"
+        c.parent.mkdir(parents=True, exist_ok=True)
+        c.write_text('"""Prose only: guard exits under '
+                     '`if __name__ == "__main__":` so it stays importable."""\n')
+        rc, out = run_gate(root, "--check-only")
+        check("ASK-746: conftest.py mentioning __main__ in PROSE is not inert",
+              rc == 0 and "conftest.py" not in out)
+    with tempfile.TemporaryDirectory() as tmp:
+        root = make_repo(tmp)
+        c = root / "q-system/.q-system/scripts/conftest.py"
+        c.parent.mkdir(parents=True, exist_ok=True)
+        c.write_text('if __name__ == "__main__":\n    print("hi")\n')
+        c.chmod(0o755)
+        rc, out = run_gate(root, "--check-only")
+        check("ASK-746: conftest.py is runner-loaded, inert even with a real guard"
+              " + exec bit", rc == 0 and "conftest.py" not in out)
+    with tempfile.TemporaryDirectory() as tmp:
+        root = make_repo(tmp)
+        p = root / "q-system/.q-system/scripts/talks_about_main.py"
+        p.parent.mkdir(parents=True, exist_ok=True)
+        p.write_text('"""A library. See `if __name__ == "__main__":` elsewhere."""\n'
+                     "def helper():\n    return 1\n")
+        rc, out = run_gate(root, "--check-only")
+        check("ASK-746: a library that only TALKS about __main__ is not an engine",
+              rc == 0 and "talks_about_main" not in out)
+
     # ASK-517: an engine wired by a PYTHON IMPORT must not read as inert.
     # The matcher was `p.name in surface`, i.e. "loops_path.py" WITH the
     # extension, while an import names the module by its stem -- so
@@ -454,6 +494,8 @@ def sec_negative_proof():
         rc, out = run_gate(root, "--check-only")
         check("vanished: declared-but-missing RED", rc == 1 and "declared-but-missing" in out)
     # Required data: in-scope missing file MUST fail; out-of-scope must not.
+    # spillover-skip: "out-of-scope" here is a required_data `scope` field that
+    # does not name this instance, not deferred work. Nothing to capture.
     with tempfile.TemporaryDirectory() as tmp:
         root = make_repo(tmp)
         m = base_manifest(required_data=[{"path": "q-system/canonical/x.json", "scope": "all"}])
@@ -471,7 +513,7 @@ def sec_negative_proof():
         m["required_data"][0]["scope"] = ["some-other-instance"]
         (root / "q-system/.q-system/capability-manifest.json").write_text(json.dumps(m))
         rc, out = run_gate(root, "--check-only")
-        check("required_data: out-of-scope not demanded", rc == 0)
+        check("required_data: out-of-scope not demanded", rc == 0)  # spillover-skip
     # Token-guard fixes are part of the pre-propagation matrix (finding-7):
     # the paired suite must be green, executed here, not assumed.
     tg_test = pathlib.Path(__file__).resolve().parent / "test_token_guard_observation.py"

--- a/q-system/.q-system/scripts/test_launchd_health_check.py
+++ b/q-system/.q-system/scripts/test_launchd_health_check.py
@@ -8,13 +8,12 @@ verified manually on wiring; these tests guard the logic that a refactor could b
 Run: python3 test_launchd_health_check.py   (exit 0 = pass, 1 = fail)
 """
 import contextlib
-import http.server
 import importlib.util
 import io
 import os
 import subprocess
 import sys
-import threading
+import tempfile
 from pathlib import Path
 
 _spec = importlib.util.spec_from_file_location(
@@ -871,56 +870,65 @@ try:
 finally:
     wd.notify_channel_configured = _saved_channel
 
-# --- a CONFIGURED webhook is not a delivered one (PR #134 review round 5) -----
-# The check above only covers the case where no channel exists at all. The scar
-# is the other one: a webhook IS configured, curl cannot reach it, slack-notify.sh
-# exits 0 anyway, and send_ping used to return `proc.returncode == 0` -> True.
-# Measured before the fix with the webhook on a refused port: send_ping True,
-# nothing sent, the run committed, 13 scheduled runs silent.
+# --- a CONFIGURED channel is not a delivered one (PR #134 r5; sp-7773af84) ----
+# The check above only covers the case where no channel exists at all. This is
+# the other one: a channel IS configured, the send does not land, and send_ping
+# must still answer False. Both directions are asserted on purpose -- without the
+# delivered case a send_ping hardcoded to False would pass and page nobody, ever.
 #
-# Both directions are asserted here on purpose. Without the delivered case, a
-# send_ping hardcoded to False would pass this section and page nobody, ever.
-# Endpoints are on 127.0.0.1 only; the suite never contacts Slack.
-def _send_ping_verdict(webhook):
-    """send_ping's answer for one webhook, with the environment restored after."""
-    saved_hook = os.environ.get("KIPI_SLACK_WEBHOOK")
-    saved_api = os.environ.get("KIPI_LINEAR_API_URL")
-    os.environ["KIPI_SLACK_WEBHOOK"] = webhook
-    # The loopback fixture guard would refuse before curl ever runs, which is a
-    # different verdict than the one under test here.
+# SCAR, sp-7773af84, measured 2026-08-14. This block used to drive a
+# $KIPI_SLACK_WEBHOOK on a refused port. On 2026-08-10 slack-notify.sh's
+# destination changed from Slack to Linear and it stopped reading a webhook at
+# all, so the knob these assertions turned was inert and they were really
+# measuring whether the RUNNER HAD A LINEAR KEY. That cannot be green anywhere:
+# CI (no key) failed `accepts -> delivered`, a keyed machine failed
+# `refuses -> NOT delivered`, and on a keyed machine the "assertion" filed REAL
+# tickets -- ASK-736 repeats, plus ASK-744/ASK-745, all canceled. Main's Skeleton
+# Validation had been red on it since 2026-08-10.
+#
+# The lesson is the one already written into alert-to-linear.py's capture hatch:
+# switching a chokepoint's destination silently invalidates every stub aimed at
+# the old one, and those stubs keep passing their own assertions right up until
+# they write to production. So delivery is now driven through the seam that
+# BELONGS to the current destination -- KIPI_ALERT_CAPTURE, which alert-to-linear
+# built for exactly this -- and never through a webhook. Measured directly before
+# these were written: a writable capture path exits 0 (verdict `delivered`), an
+# unopenable one exits 1 (verdict `send-failed`). Neither touches Linear.
+def _send_ping_verdict(capture_path):
+    """send_ping's answer for one capture destination, environment restored after.
+
+    KIPI_LINEAR_API_URL is popped because the loopback fixture guard in
+    slack-notify.sh would exit 4 before the writer ever runs, which is a
+    different verdict than the one under test here.
+    """
+    saved = {k: os.environ.get(k)
+             for k in ("KIPI_ALERT_CAPTURE", "KIPI_LINEAR_API_URL")}
+    os.environ["KIPI_ALERT_CAPTURE"] = capture_path
     os.environ.pop("KIPI_LINEAR_API_URL", None)
     try:
-        return wd.send_ping("probe: local endpoints only, ASK-447")
+        return wd.send_ping(_PROBE_MESSAGE)
     finally:
-        os.environ.pop("KIPI_SLACK_WEBHOOK", None)
-        if saved_hook is not None:
-            os.environ["KIPI_SLACK_WEBHOOK"] = saved_hook
-        if saved_api is not None:
-            os.environ["KIPI_LINEAR_API_URL"] = saved_api
+        for key, value in saved.items():
+            os.environ.pop(key, None)
+            if value is not None:
+                os.environ[key] = value
 
 
-class _PostSink(http.server.BaseHTTPRequestHandler):
-    def do_POST(self):  # noqa: N802
-        self.rfile.read(int(self.headers.get("Content-Length", 0) or 0))
-        self.send_response(200)
-        self.end_headers()
-        self.wfile.write(b"ok")
+_PROBE_MESSAGE = "probe: captured locally, never filed (sp-7773af84)"
 
-    def log_message(self, *args):  # keep the suite output readable
-        pass
+with tempfile.TemporaryDirectory() as _capdir:
+    # NOT delivered: the writer cannot open its destination, so nothing was
+    # recorded anywhere. The parent directory does not exist and is not created.
+    check("configured channel the alert cannot be written to -> NOT delivered",
+          _send_ping_verdict(os.path.join(_capdir, "absent", "cap.txt")), False)
 
-
-check("configured webhook that refuses the connection -> NOT delivered",
-      _send_ping_verdict("http://127.0.0.1:9/services/dead"), False)
-
-_sink = http.server.HTTPServer(("127.0.0.1", 0), _PostSink)
-threading.Thread(target=_sink.serve_forever, daemon=True).start()
-try:
-    check("webhook that accepts the POST -> delivered",
-          _send_ping_verdict("http://127.0.0.1:%d/hook" % _sink.server_address[1]),
-          True)
-finally:
-    _sink.shutdown()
+    # delivered: the write lands. Asserting the boolean alone would pass against
+    # a send_ping that returns True without sending, so the FILE is the evidence.
+    _landed = os.path.join(_capdir, "cap.txt")
+    check("channel that accepts the alert -> delivered",
+          _send_ping_verdict(_landed), True)
+    check("the delivered alert is actually in the destination",
+          _PROBE_MESSAGE in Path(_landed).read_text(encoding="utf-8"), True)
 
 # ---------------------------------------------------------------------------
 # The legacy watchdog may not record a page that never left (PR #134 round 6)

--- a/q-system/.q-system/tests/test_alert_to_linear.py
+++ b/q-system/.q-system/tests/test_alert_to_linear.py
@@ -36,9 +36,20 @@ AUTOCOMMIT = [
     "[consulting] auto-commit left 9 file(s) uncommitted in consulting: .prd-os/issues/lane-h-presented-is-not-contacted.md, .prd-os/judgments-tip.json, q-consult/.q-system/apify-rules.md (+6 more) [2026-08-10 12:35:45 PDT]",
 ]
 
+# The home directory is a PLACEHOLDER, and it has to stay one. This repo is
+# public, and validate-separation.py's full skeleton sweep fails on the founder's
+# real home prefix appearing anywhere under q-system/. What these two strings
+# need to exercise is the SHAPE -- two path-shaped tokens that differ only by
+# timestamp -- because fingerprint() scrubs any `\S*/\S*` token before hashing.
+# The real username was never load-bearing; it was just what got pasted in.
+#
+# This comment does not spell that prefix out, and that is the point: the first
+# version of it did, so the comment explaining the ban tripped the ban. A text
+# rule that scans comments as well as code has to be written about the data
+# class, never with a sample of the data.
 CARVEOUT = [
-    "[cole-gtm] Daily X tool post (2026-07-17): CARVE-OUT ACTIVE: /Users/assafkipnis/.config/kipi/cole.OFF is ON (the fleet is paused) but /Users/assafkipnis/.config/kipi/podcast-social.ON opts THIS lane back in. [2026-08-10 14:05:24 PDT]",
-    "[cole-gtm] Daily X tool post (2026-07-17): CARVE-OUT ACTIVE: /Users/assafkipnis/.config/kipi/cole.OFF is ON (the fleet is paused) but /Users/assafkipnis/.config/kipi/podcast-social.ON opts THIS lane back in. [2026-08-10 13:48:02 PDT]",
+    "[cole-gtm] Daily X tool post (2026-07-17): CARVE-OUT ACTIVE: /Users/founder/.config/kipi/cole.OFF is ON (the fleet is paused) but /Users/founder/.config/kipi/podcast-social.ON opts THIS lane back in. [2026-08-10 14:05:24 PDT]",
+    "[cole-gtm] Daily X tool post (2026-07-17): CARVE-OUT ACTIVE: /Users/founder/.config/kipi/cole.OFF is ON (the fleet is paused) but /Users/founder/.config/kipi/podcast-social.ON opts THIS lane back in. [2026-08-10 13:48:02 PDT]",
 ]
 
 

--- a/q-system/.q-system/tests/test_fable_escalation.py
+++ b/q-system/.q-system/tests/test_fable_escalation.py
@@ -688,6 +688,12 @@ def test_cap_row_does_not_claim_a_page_that_was_never_sent(actor, env, tmp_path)
     del e["KIPI_FABLE_NOTIFY_CMD"]          # use the real slack-notify.sh
     e["HOME"] = str(tmp_path / "emptyhome")
     e["KIPI_SLACK_WEBHOOK"] = ""
+    # Every input to notify_channel_configured has to be pinned here, or this
+    # asserts nothing. KIPI_ALERT_CAPTURE is one since ASK-746 (the channel is
+    # Linear now, and a capture file is a real destination), and it is inherited
+    # from the caller's environment -- so an operator running the suite with a
+    # capture set turned this red while the code was fine. Measured 2026-08-14.
+    e["KIPI_ALERT_CAPTURE"] = ""
     e["KIPI_FABLE_CAP"] = "1"
     os.makedirs(e["HOME"], exist_ok=True)
 

--- a/test-kipi-update-dirty-guard-scope.sh
+++ b/test-kipi-update-dirty-guard-scope.sh
@@ -132,7 +132,18 @@ echo "=== guard and restore must share one scope ==="
 # A drift check, not a behaviour check. If someone re-broadens either site the
 # two stop matching and this fails, which is the cheapest available defence
 # against the restore silently going back to discarding the whole worktree.
-if grep -q 'checkout -q -- "\$CHECKPOINT_PREFIX/" \.claude/ plugins/' "$REAL/kipi-update.sh" &&
+#
+# The restore half used to grep the literal
+# `checkout -q -- "$CHECKPOINT_PREFIX/" .claude/ plugins/`. ASK-740 had to change
+# that line: `git checkout -- A B C` is ALL-OR-NOTHING, so an instance tracking no
+# .claude/ or plugins/ made it error and restore NOTHING, which is what left
+# `M q-system/tracked.md` behind and pre-refused every later run. The specs are
+# now filtered through `ls-files` before being passed. So this greps the line that
+# DEFINES the restore scope instead of the line that spends it -- same property,
+# and it still fails the moment either site is re-broadened. The unscoped-checkout
+# assertion is kept explicit rather than implied by the first grep.
+if grep -q 'for spec in "\$CHECKPOINT_PREFIX/" \.claude/ plugins/; do' "$REAL/kipi-update.sh" &&
+   ! grep -qE 'checkout -q -- \.( |$)|checkout -q -- "\$target"' "$REAL/kipi-update.sh" &&
    grep -q 'diff --quiet -- "\$prefix/" \.claude/ plugins/' "$REAL/kipi-update.sh"; then
   echo "  OK [scope-pairing]: guard and restore both pathspec-limited"
 else


### PR DESCRIPTION
`Skeleton Validation` on main has concluded `failure` on 5+ consecutive runs since 2026-08-10, so no PR can satisfy a required check and 30 PRs are queued behind a defect none of them introduced. This fixes all of it.

Three failures, **three unrelated root causes**. Two of the three briefs I was handed turned out to be wrong, and both are corrected below with measurements.

## 1. `test_launchd_health_check.py` — the channel changed, the readers did not (ASK-746)

The spillover said "reports a webhook as DELIVERED when the endpoint REFUSES". **The premise is void: there is no webhook.** On 2026-08-10 `slack-notify.sh`'s destination changed from Slack to Linear; it shells `alert-to-linear.py` and never resolves a webhook.

The webhook was inert, so the assertions were really measuring **whether the runner had a Linear key**:

| runner | what actually decided | result |
|---|---|---|
| CI (no key) | `alert-to-linear` exit 3 `not-configured` | FAIL `accepts -> delivered: got False, want True` |
| keyed machine | real ticket filed, exit 0 | FAIL `refuses -> NOT delivered: got True, want False` |

CI and a dev machine failed on **opposite** assertions. It could not be green anywhere. Worse, on a keyed machine it filed **real Linear tickets** — `repeat #5 on ASK-736`, plus probes ASK-744/ASK-745, all canceled.

There was also a production defect behind it: `notify_channel_configured()` still gated on the dead webhook, so a machine with a valid Linear key but no leftover webhook file returned False and `send_ping` **never ran the notifier at all**. The watchdog's alert was suppressed by a channel that no longer exists.

Fixed: the channel is asked about the destination that exists (key borrowed from `linear-sync.py`, the fleet's single writer), and the test drives delivery through `KIPI_ALERT_CAPTURE`, the seam `alert-to-linear.py` built for exactly this. The delivered case asserts the message **is in the file**, not just the boolean.

## 2. `conftest.py` + `lessons_recall.py` inert-engine — one gate bug, one true positive (ASK-746)

**The gate was wrong about `conftest.py`.** The candidate filter was `os.access(p, os.X_OK) or "__main__" in text` — a bare substring over the whole file. `conftest.py` has no exec bit and no guard; its only `__main__` is one line of **prose in its docstring**. That sentence promoted it to a candidate, and since pytest loads conftest *by name* it could never prove itself wired. Fixed in the gate, with the reason in the code: the guard is matched as syntax at the start of a line, and `RUNNER_LOADED_NAMES` says a runner-loaded file is not an engine. **No fake reference was added.**

**The gate was right about `lessons_recall.py`** — exec bit, real `__main__`, zero references anywhere. It gets a `declared_inert` entry (sp-067205d3), not fake wiring. Wiring it means arming a retrieval engine at SessionStart fleet-wide: a deliberate decision, not a side effect of a CI fix.

The detector was mutation-tested, not trusted: 7 cases including both true positives. The existing `wiring: unwired engine RED` case is the anti-blindness control and stays green.

## 3. The two updater shell tests — a contract collision, not a swallowed exit code (ASK-740)

**`test-kipi-update-safety.sh`** was a real bug. `restore_instance`'s `git checkout -- A B C` is **all-or-nothing**: an instance tracking no `.claude/` or `plugins/` made it error and restore *nothing*, while `git reset` accepted the same unmatched pathspec and returned 0. `2>/dev/null || true` hid both the message and the exit code, so the index looked restored while the worktree kept the failed run's writes. That debris is what pre-refused every later run. Specs are now filtered through `ls-files` first.

**`test-kipi-update-hook-contract.sh`** was *not* a swallowed exit code. Instrumented at 11f0eb8a the guard never fires at all, prints nothing, and exits 0 correctly. It is a collision between two tests: ASK-609 (548919d4, **2026-08-10 — the exact date main went red**) deliberately scoped the guard to paths the sync can write, after measuring 182 dirty files across four blocked instances with **zero** reachable. It shipped its own two-direction test and did not update this one, whose fixture dirties an instance-*root* file.

Decided in favour of ASK-609: root-level dirt genuinely cannot be clobbered, so blocking on it stranded real instances and protected an empty set. The fixture now dirties `q-system/tracked.md`, a file the sync writes. **Every assertion is unchanged** and each now actually exercises the guard instead of an empty set.

## Constraints held

- Nothing skipped, deselected, xfailed, deleted or relaxed. The one gate change is deliberate, is the `conftest.py` case, and is argued in the code.
- Every fix has a negative self-test: reintroduce the defect, watch the test go red, restore, watch it go green.
- `test-kipi-update-dirty-guard-scope.sh` was green at 11f0eb8a and briefly went red on this branch — caused here, not inherited. Its drift check greps a literal the restore fix had to change; it now greps the line that *defines* the scope, and a `for spec in . ; do` mutant still turns it red.

## Verification

```
test_launchd_health_check.py            rc=0  (green under BOTH no-key and keyed, a first)
test_capability_gate.py                 rc=0  ALL PASS (3 new cases + control)
capability-gate.py --check-only         rc=0  GREEN, zero inert-engine ERRORS
test-kipi-update-hook-contract.sh       rc=0
test-kipi-update-safety.sh              rc=0
test-kipi-update-dirty-guard-scope.sh   rc=0
```

Spillover captured, not mentioned-and-dropped: sp-5a3e3b7b (`alert-to-linear.py`'s fixture guard only refuses on `PYTEST_CURRENT_TEST`, so plain-`python3` suites can still file real tickets — that is how this one reached production) and sp-067205d3 (`lessons_recall.py` wire-or-retire).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0151EYtGH6at3XTWqbBHAxEi