### PR TITLE
Scope every gh call to the target repo, and let dispatch enter more than one (ASK-738)

### DIFF
--- a/kipi-dispatch.sh
+++ b/kipi-dispatch.sh
@@ -749,13 +749,20 @@ if [ "$TARGET_PATH" != "$REPO" ]; then
   # Setting one and not the other dispatches the work to the target and then
   # converges against home, which is the defect wearing the other hat.
   #
-  # WHITESPACE REFUSES. $WORK_ARGS is spliced unquoted into `bash ./kipi work`
-  # below (it must be, so that empty expands to nothing), so a path with a space
-  # would split into two wrong arguments and the worker would run against the
-  # home repo with a garbage --repo. Loud refusal beats a silent wrong target.
+  # WHITESPACE **AND GLOB CHARACTERS** REFUSE. $WORK_ARGS is spliced unquoted into
+  # `bash ./kipi work` below (it must be, so that empty expands to nothing), which
+  # means the shell does BOTH word-splitting and pathname expansion on it:
+  #   - a space splits the path into two wrong arguments, and the worker runs
+  #     against the home repo with a garbage --repo;
+  #   - a `*`, `?` or `[` is glob-expanded against the CWD, so --repo silently
+  #     becomes some unrelated matching path, or the literal path if nothing
+  #     matches. Either way the agent is aimed somewhere nobody chose.
+  # The glob half was missed on the first cut and caught by codex on PR #146
+  # (sp-b2f0627e). Loud refusal beats a silent wrong target: this decides which
+  # repository an unattended self-merging loop enters.
   case "$TARGET_PATH" in
-    *[[:space:]]*)
-      say "REFUSING $TARGET_NAME: its registry path contains whitespace ($TARGET_PATH), which cannot be passed safely as --repo; not entering"
+    *[[:space:]]*|*'*'*|*'?'*|*'['*|*']'*)
+      say "REFUSING $TARGET_NAME: its registry path contains whitespace or a glob character ($TARGET_PATH), which cannot be passed safely as an unquoted --repo; not entering"
       exit 0 ;;
   esac
   WORK_ARGS="--repo $TARGET_PATH"

--- a/kipi-dispatch.sh
+++ b/kipi-dispatch.sh
@@ -723,28 +723,44 @@ fi
 # which forwards only its own arguments to the worker.
 WORK_ARGS=""
 if [ "$TARGET_PATH" != "$REPO" ]; then
-  # HELD: cleared preflight, and STILL not entered (sp-9421b9b7).
+  # THE HOLD IS GONE (ASK-738). It was here from sp-9421b9b7 because `gh`
+  # resolves its repository from the process cwd and ignores every path variable
+  # this script carries -- and line 205 cd's into the home checkout and stays. So
+  # `git -C` worked in the target while `gh` answered about kipi-system. Three
+  # paths did that; the worst, pr-review-agent.sh, would review the wrong repo's
+  # code and post `kipi/reviewer-approved` on it, so the wrong-repo failure ran
+  # through the gate itself. All three are now scoped with -R from ONE derivation
+  # (repo-slug-lib.sh), and review artifacts are keyed by repo AND PR so two
+  # repos' PR #42 cannot consume each other's records.
   #
-  # The worker's --repo argument redirects `git -C`, and that part is built and
-  # tested. It does NOT redirect `gh`, and codex found three paths that silently
-  # bind to the home checkout anyway:
-  #   1. the worker's existing-PR lookup, merge-state/head queries and reviewer
-  #      invocation are unqualified `gh` calls;
-  #   2. converge.sh runs pr_for_branch / pr_head_sha from the home checkout, so
-  #      after the worker opens a PR in the target it finds none and stops;
-  #   3. pr-review-agent.sh derives its repo from its own location, so an external
-  #      PR number resolves against the HOME repo -- and if that number exists,
-  #      the wrong code is reviewed and gets the verdict.
-  # Review artifacts are also keyed pr-<number>.* in one shared state dir, so two
-  # repos with PR #42 consume each other's records.
+  # WHAT PROTECTS CLIENT REPOS IS NOT THIS LINE, AND NEVER WAS. Founder,
+  # 2026-08-13: "no. unattended agents should not reach a client repo." That is
+  # enforced by repo-preflight.sh check 0, which #144 landed and which pick_list
+  # above runs BEFORE any repo reaches this point -- a client-shaped path is
+  # refused there even when its registry row says dispatch.enabled: true. This
+  # HOLD was a blunt stand-in for a gate that did not exist yet. It exists now,
+  # upstream, and it fails closed. Removing a stand-in is only safe because the
+  # real thing landed first; if check 0 is ever weakened, that is the line that
+  # matters, not this one.
   #
-  # Any one of those is enough to act on the wrong repository, and two of the
-  # three files are outside this issue's contract. A gate that lets an agent into
-  # a client repo on that footing is worse than the gap it closes, so entry stays
-  # shut until the gh-scoping issue lands. The rotation still OFFERS the turn and
-  # advances past it, so nothing starves behind this.
-  say "HOLD $TARGET_NAME: cleared preflight, but cross-repo gh scoping is unfinished (sp-9421b9b7); not entering"
-  exit 0
+  # TWO CARRIERS FOR ONE FACT, as the comment above says: --repo is the explicit
+  # argument the worker parses, and KIPI_TARGET_REPO crosses the converge.sh
+  # boundary by inheritance because converge forwards only its own arguments.
+  # Setting one and not the other dispatches the work to the target and then
+  # converges against home, which is the defect wearing the other hat.
+  #
+  # WHITESPACE REFUSES. $WORK_ARGS is spliced unquoted into `bash ./kipi work`
+  # below (it must be, so that empty expands to nothing), so a path with a space
+  # would split into two wrong arguments and the worker would run against the
+  # home repo with a garbage --repo. Loud refusal beats a silent wrong target.
+  case "$TARGET_PATH" in
+    *[[:space:]]*)
+      say "REFUSING $TARGET_NAME: its registry path contains whitespace ($TARGET_PATH), which cannot be passed safely as --repo; not entering"
+      exit 0 ;;
+  esac
+  WORK_ARGS="--repo $TARGET_PATH"
+  export KIPI_TARGET_REPO="$TARGET_PATH"
+  say "entering $TARGET_NAME ($TARGET_PATH) -- cleared preflight, gh scoped to its own remote"
 fi
 # Consume the turn HERE, not after a successful dispatch. A repo that took its turn
 # and had nothing ready must still hand the next turn on, or an idle home repo

--- a/q-system/.q-system/capability-manifest.json
+++ b/q-system/.q-system/capability-manifest.json
@@ -558,6 +558,22 @@
       "path": "q-system/.q-system/tests/test_token_guard_cache_race.py",
       "runner": "python3",
       "timeout_s": 120
+    },
+    {
+      "path": "q-system/.q-system/scripts/test/test-gh-repo-scope-worker.sh",
+      "runner": "bash"
+    },
+    {
+      "path": "q-system/.q-system/scripts/test/test-gh-repo-scope-converge.sh",
+      "runner": "bash"
+    },
+    {
+      "path": "q-system/.q-system/scripts/test/test-gh-repo-scope-reviewer.sh",
+      "runner": "bash"
+    },
+    {
+      "path": "q-system/.q-system/scripts/test/test-review-artifact-repo-keyed.sh",
+      "runner": "bash"
     }
   ],
   "required_data": [],

--- a/q-system/.q-system/capability-manifest.json
+++ b/q-system/.q-system/capability-manifest.json
@@ -574,6 +574,10 @@
     {
       "path": "q-system/.q-system/scripts/test/test-review-artifact-repo-keyed.sh",
       "runner": "bash"
+    },
+    {
+      "path": "q-system/.q-system/scripts/test/test-dispatch-client-refusal-after-hold.sh",
+      "runner": "bash"
     }
   ],
   "required_data": [],

--- a/q-system/.q-system/scripts/converge.sh
+++ b/q-system/.q-system/scripts/converge.sh
@@ -41,6 +41,9 @@ STATE_DIR="${KIPI_STATE_DIR:-$HOME/.config/kipi}"
 REVIEWS_DIR="$STATE_DIR/pr-reviews"
 LOG="$STATE_DIR/linear-worker.log"
 . "$SCRIPT_DIR/pr-verdict-lib.sh"
+# THE ONE SLUG DERIVATION (ASK-738). gh binds to cwd and ignores every path
+# variable here, so every gh call below is scoped with -R from this lib.
+. "$SCRIPT_DIR/repo-slug-lib.sh"
 
 # The worker command is injectable ONLY so the test suite can drive this loop
 # against a fake that returns scripted verdicts. Testing convergence against the
@@ -65,7 +68,19 @@ TS() { date -u +%Y-%m-%dT%H:%M:%SZ; }
 say() { echo "$(TS) converge[$ISSUE] $*" | tee -a "$LOG"; }
 
 BRANCH="sana/$(echo "$ISSUE" | tr 'A-Z' 'a-z')"
-pr_for_branch() { gh pr list --head "$BRANCH" --json number -q '.[0].number' 2>/dev/null; }
+# SCOPED TO THE REPO THE WORK IS IN, not to cwd (ASK-738). This driver runs
+# from the dispatcher's cwd (the home checkout), so an unqualified `gh pr list`
+# asked the HOME repo whether the TARGET's branch had a PR: after the worker
+# opened one in the target, converge found none and stopped -- or worse, found
+# an unrelated PR of the same branch name at home and drove rounds against it.
+# KIPI_TARGET_REPO is the carrier kipi-dispatch.sh uses; it forwards only its
+# own arguments to the worker, so the target crosses that boundary by
+# inheritance. Derived ONCE, through the shared lib, same as the worker.
+TARGET_REPO="${KIPI_TARGET_REPO:-$SKEL}"
+KIPI_GH_REPO_ARGS="$(gh_repo_args "$(slug_for_repo "$TARGET_REPO" "${KIPI_SLUG_REGISTRY:-$SKEL/instance-registry.json}")")"
+export KIPI_GH_REPO_ARGS
+# shellcheck disable=SC2086
+pr_for_branch() { gh pr list $KIPI_GH_REPO_ARGS --head "$BRANCH" --json number -q '.[0].number' 2>/dev/null; }
 # The head sha comes from pr_head_sha in the shared lib, not a local copy of the
 # same `gh pr view`: this driver and linear-worker.sh now BOTH compare it against
 # the sha a review pinned, and two private readers of one input is how those two
@@ -73,7 +88,7 @@ pr_for_branch() { gh pr list --head "$BRANCH" --json number -q '.[0].number' 2>/
 
 if [ "$DRY" = "1" ]; then
   PR="$(pr_for_branch)"
-  V=""; [ -n "$PR" ] && V="$(verdict_from_record "$REVIEWS_DIR/pr-$PR.verdict.json")"
+  V=""; [ -n "$PR" ] && V="$(verdict_from_record "$(verdict_record_path "$REVIEWS_DIR" "$(slug_for_repo "$TARGET_REPO" "${KIPI_SLUG_REGISTRY:-$SKEL/instance-registry.json}")" "$PR")")"
   say "[dry] branch=$BRANCH pr=${PR:-none} verdict=${V:-none} would run up to $MAX_ROUNDS round(s)"
   exit 0
 fi

--- a/q-system/.q-system/scripts/converge.sh
+++ b/q-system/.q-system/scripts/converge.sh
@@ -77,7 +77,8 @@ BRANCH="sana/$(echo "$ISSUE" | tr 'A-Z' 'a-z')"
 # own arguments to the worker, so the target crosses that boundary by
 # inheritance. Derived ONCE, through the shared lib, same as the worker.
 TARGET_REPO="${KIPI_TARGET_REPO:-$SKEL}"
-KIPI_GH_REPO_ARGS="$(gh_repo_args "$(slug_for_repo "$TARGET_REPO" "${KIPI_SLUG_REGISTRY:-$SKEL/instance-registry.json}")")"
+TARGET_SLUG="$(slug_for_repo "$TARGET_REPO" "${KIPI_SLUG_REGISTRY:-$SKEL/instance-registry.json}")"
+KIPI_GH_REPO_ARGS="$(gh_repo_args "$TARGET_SLUG")"
 export KIPI_GH_REPO_ARGS
 # shellcheck disable=SC2086
 pr_for_branch() { gh pr list $KIPI_GH_REPO_ARGS --head "$BRANCH" --json number -q '.[0].number' 2>/dev/null; }
@@ -88,7 +89,7 @@ pr_for_branch() { gh pr list $KIPI_GH_REPO_ARGS --head "$BRANCH" --json number -
 
 if [ "$DRY" = "1" ]; then
   PR="$(pr_for_branch)"
-  V=""; [ -n "$PR" ] && V="$(verdict_from_record "$(verdict_record_path "$REVIEWS_DIR" "$(slug_for_repo "$TARGET_REPO" "${KIPI_SLUG_REGISTRY:-$SKEL/instance-registry.json}")" "$PR")")"
+  V=""; [ -n "$PR" ] && V="$(verdict_from_record "$(verdict_record_path "$REVIEWS_DIR" "$TARGET_SLUG" "$PR")")"
   say "[dry] branch=$BRANCH pr=${PR:-none} verdict=${V:-none} would run up to $MAX_ROUNDS round(s)"
   exit 0
 fi
@@ -744,9 +745,9 @@ while [ "$ROUND" -lt "$MAX_ROUNDS" ]; do
     exit 7
   fi
 
-  VERDICT="$(verdict_from_record "$REVIEWS_DIR/pr-$PR.verdict.json")"
+  VERDICT="$(verdict_from_record "$(verdict_record_path "$REVIEWS_DIR" "$TARGET_SLUG" "$PR")")"
   SHA="$(pr_head_sha "$PR")"
-  REVIEWED_SHA="$(head_sha_from_record "$REVIEWS_DIR/pr-$PR.verdict.json")"
+  REVIEWED_SHA="$(head_sha_from_record "$(verdict_record_path "$REVIEWS_DIR" "$TARGET_SLUG" "$PR")")"
 
   # ARGUMENT 2 IS THE MERGE STATE, and this driver still does not read it: ASK-212
   # scoped mergeability to the worker, which runs first inside every round here.
@@ -798,9 +799,9 @@ while [ "$ROUND" -lt "$MAX_ROUNDS" ]; do
     # It runs before the auto-merge report because auto-merge lands the PR the
     # moment `validate` goes green, and `validate` is the job that reads this
     # receipt.
-    receipt_ensure "$SHA" "$REVIEWS_DIR/pr-$PR.verdict.json" "$REVIEWED_SHA" "$PR"
+    receipt_ensure "$SHA" "$(verdict_record_path "$REVIEWS_DIR" "$TARGET_SLUG" "$PR")" "$REVIEWED_SHA" "$PR"
 
-    AUTOMERGE="$(automerge_from_record "$REVIEWS_DIR/pr-$PR.automerge")"
+    AUTOMERGE="$(automerge_from_record "$REVIEWS_DIR/$(artifact_key "$TARGET_SLUG" "$PR").automerge")"
     case "$AUTOMERGE" in
       armed)
         MERGE_LOG="Auto-merge is armed -- GitHub merges it once every required check is green. If it sits green: gh pr merge --auto --squash $PR"

--- a/q-system/.q-system/scripts/linear-worker.sh
+++ b/q-system/.q-system/scripts/linear-worker.sh
@@ -96,6 +96,9 @@ LOG="$STATE_DIR/linear-worker.log"
 REVIEWS_DIR="$STATE_DIR/pr-reviews"
 # Verdict semantics shared with pr-review-agent.sh -- one extractor, one gate.
 . "$SCRIPT_DIR/pr-verdict-lib.sh"
+# THE ONE SLUG DERIVATION (ASK-738). gh binds to cwd and ignores every path
+# variable here, so every gh call below is scoped with -R from this lib.
+. "$SCRIPT_DIR/repo-slug-lib.sh"
 
 MAX_ATTEMPTS=3
 # Conflict rounds are capped SEPARATELY from failed attempts (ASK-212).
@@ -184,6 +187,18 @@ if [ ! -d "$TARGET_REPO" ]; then
 fi
 TARGET_REPO="$(cd "$TARGET_REPO" && pwd)"
 export TARGET_REPO
+
+# --- WHICH REPO EVERY `gh` CALL ASKS ABOUT (ASK-738) ----------------------
+# `git -C "$TARGET_REPO"` redirects the git half of this script. It does NOT
+# redirect `gh`, which resolves its repo from the PROCESS CWD -- and
+# kipi-dispatch.sh:205 leaves that cwd in the HOME checkout. Measured: the
+# existing-PR lookup below answered about kipi-system while the work happened
+# in the target. Derived ONCE, here, and spliced into every gh call as -R.
+# Empty for a repo with no pinned remote and no origin: the calls then behave
+# exactly as they did before, which is correct only because that case is the
+# dispatcher's own checkout.
+KIPI_GH_REPO_ARGS="$(gh_repo_args "$(slug_for_repo "$TARGET_REPO" "${KIPI_SLUG_REGISTRY:-$SKEL/instance-registry.json}")")"
+export KIPI_GH_REPO_ARGS
 
 export SCRIPT_DIR
 mkdir -p "$STATE_DIR"
@@ -899,16 +914,17 @@ A DoR that cannot be met from the environment the worker actually runs in is a d
   # BEFORE the claim and the Linear progress note on purpose -- a "Picked up"
   # note on a permanent Linear object followed by an immediate skip is a false
   # alarm, and false alarms train the reader to ignore the real notes.
-  EXISTING_PR="$(gh pr list --head "$BRANCH" --json number -q '.[0].number' 2>/dev/null)"
+  # shellcheck disable=SC2086  # unquoted on purpose: empty must expand to nothing
+  EXISTING_PR="$(gh pr list $KIPI_GH_REPO_ARGS --head "$BRANCH" --json number -q '.[0].number' 2>/dev/null)"
   REWORK=""
   CONFLICT_ROUND=""
   DRIFT_ROUND=""
   if [ -n "$EXISTING_PR" ]; then
-    PR_VERDICT="$(verdict_from_record "$REVIEWS_DIR/pr-$EXISTING_PR.verdict.json")"
+    PR_VERDICT="$(verdict_from_record "$(verdict_record_path "$REVIEWS_DIR" "$(slug_for_repo "$TARGET_REPO" "${KIPI_SLUG_REGISTRY:-$SKEL/instance-registry.json}")" "$EXISTING_PR")")"
     if [ -z "$PR_VERDICT" ]; then
       # Fallback for PRs reviewed before the verdict record existed: extract
       # from the newest review .md with the SAME extractor the reviewer uses.
-      LATEST_REVIEW="$(ls -t "$REVIEWS_DIR/pr-$EXISTING_PR-"*.md 2>/dev/null | head -1)"
+      LATEST_REVIEW="$(ls -t "$REVIEWS_DIR/$(artifact_key "$(slug_for_repo "$TARGET_REPO" "${KIPI_SLUG_REGISTRY:-$SKEL/instance-registry.json}")" "$EXISTING_PR")-"*.md "$REVIEWS_DIR/pr-$EXISTING_PR-"*.md 2>/dev/null | head -1)"
       [ -n "$LATEST_REVIEW" ] && PR_VERDICT="$(extract_verdict "$LATEST_REVIEW")"
     fi
     # MERGEABILITY IS HALF THE GATE (ASK-212). Read once, through the shared lib,

--- a/q-system/.q-system/scripts/linear-worker.sh
+++ b/q-system/.q-system/scripts/linear-worker.sh
@@ -187,6 +187,9 @@ if [ ! -d "$TARGET_REPO" ]; then
 fi
 TARGET_REPO="$(cd "$TARGET_REPO" && pwd)"
 export TARGET_REPO
+# The target's slug, resolved ONCE. Every gh scope and every artifact path in
+# this script reads it from here (ASK-738).
+TARGET_SLUG="$(slug_for_repo "$TARGET_REPO" "${KIPI_SLUG_REGISTRY:-$SKEL/instance-registry.json}")"
 
 # --- WHICH REPO EVERY `gh` CALL ASKS ABOUT (ASK-738) ----------------------
 # `git -C "$TARGET_REPO"` redirects the git half of this script. It does NOT
@@ -197,7 +200,7 @@ export TARGET_REPO
 # Empty for a repo with no pinned remote and no origin: the calls then behave
 # exactly as they did before, which is correct only because that case is the
 # dispatcher's own checkout.
-KIPI_GH_REPO_ARGS="$(gh_repo_args "$(slug_for_repo "$TARGET_REPO" "${KIPI_SLUG_REGISTRY:-$SKEL/instance-registry.json}")")"
+KIPI_GH_REPO_ARGS="$(gh_repo_args "$TARGET_SLUG")"
 export KIPI_GH_REPO_ARGS
 
 export SCRIPT_DIR
@@ -784,7 +787,7 @@ arm_automerge() {
   # to tell the operator who merges this PR and cannot re-probe without becoming
   # a second reader of one input; asserting instead is what put "no human merge
   # needed" on PRs nothing had armed.
-  record_automerge "$REVIEWS_DIR/pr-$pr.automerge" "$AUTOMERGE"
+  record_automerge "$REVIEWS_DIR/$(artifact_key "$TARGET_SLUG" "$pr").automerge" "$AUTOMERGE"
   return 0
 }
 
@@ -920,11 +923,11 @@ A DoR that cannot be met from the environment the worker actually runs in is a d
   CONFLICT_ROUND=""
   DRIFT_ROUND=""
   if [ -n "$EXISTING_PR" ]; then
-    PR_VERDICT="$(verdict_from_record "$(verdict_record_path "$REVIEWS_DIR" "$(slug_for_repo "$TARGET_REPO" "${KIPI_SLUG_REGISTRY:-$SKEL/instance-registry.json}")" "$EXISTING_PR")")"
+    PR_VERDICT="$(verdict_from_record "$(verdict_record_path "$REVIEWS_DIR" "$TARGET_SLUG" "$EXISTING_PR")")"
     if [ -z "$PR_VERDICT" ]; then
       # Fallback for PRs reviewed before the verdict record existed: extract
       # from the newest review .md with the SAME extractor the reviewer uses.
-      LATEST_REVIEW="$(ls -t "$REVIEWS_DIR/$(artifact_key "$(slug_for_repo "$TARGET_REPO" "${KIPI_SLUG_REGISTRY:-$SKEL/instance-registry.json}")" "$EXISTING_PR")-"*.md "$REVIEWS_DIR/pr-$EXISTING_PR-"*.md 2>/dev/null | head -1)"
+      LATEST_REVIEW="$(ls -t "$REVIEWS_DIR/$(artifact_key "$TARGET_SLUG" "$EXISTING_PR")-"*.md "$REVIEWS_DIR/pr-$EXISTING_PR-"*.md 2>/dev/null | head -1)"
       [ -n "$LATEST_REVIEW" ] && PR_VERDICT="$(extract_verdict "$LATEST_REVIEW")"
     fi
     # MERGEABILITY IS HALF THE GATE (ASK-212). Read once, through the shared lib,
@@ -945,7 +948,7 @@ A DoR that cannot be met from the environment the worker actually runs in is a d
     #
     # APPENDED, NEVER INSERTED: $MERGE_STATE keeps argument 2. Reordering it would
     # silently stop ASK-212's rebase rounds from ever firing again.
-    REVIEWED_SHA="$(head_sha_from_record "$REVIEWS_DIR/pr-$EXISTING_PR.verdict.json")"
+    REVIEWED_SHA="$(head_sha_from_record "$(verdict_record_path "$REVIEWS_DIR" "$TARGET_SLUG" "$EXISTING_PR")")"
     CURRENT_SHA="$(pr_head_sha "$EXISTING_PR")"
     GATE_NOTE="$(rework_gate "$PR_VERDICT" "$MERGE_STATE" "$REVIEWED_SHA" "$CURRENT_SHA")"; GATE=$?
     [ -n "$GATE_NOTE" ] && say "$GATE_NOTE"
@@ -1812,7 +1815,7 @@ json.dump(d,open('$ATTEMPTS','w'),indent=2); print(e['rounds'])" 2>/dev/null || 
     # Read back the verdict RECORD the reviewer just wrote (never re-grep the
     # review prose) and state what happens next in plain terms. Rework itself
     # fires on the NEXT run, through the severity-floor gate above.
-    FINAL_VERDICT="$(verdict_from_record "$REVIEWS_DIR/pr-$PR_NUM.verdict.json")"
+    FINAL_VERDICT="$(verdict_from_record "$(verdict_record_path "$REVIEWS_DIR" "$TARGET_SLUG" "$PR_NUM")")"
     # RE-GATE THE RECORD BEFORE REPORTING ON IT (PR #30 review round 2, major 3).
     # The reviewer above can fail -- it is a `|| say WARN` line, not a hard stop --
     # and when it does, this read returns the SAME record the gate at the top of
@@ -1826,7 +1829,7 @@ json.dump(d,open('$ATTEMPTS','w'),indent=2); print(e['rounds'])" 2>/dev/null || 
     # so the values from the top of the loop describe a state that no longer
     # exists. The gate is the ONE reader of the comparison -- deriving it here
     # would be a second reader with drifting semantics.
-    FINAL_REVIEWED_SHA="$(head_sha_from_record "$REVIEWS_DIR/pr-$PR_NUM.verdict.json")"
+    FINAL_REVIEWED_SHA="$(head_sha_from_record "$(verdict_record_path "$REVIEWS_DIR" "$TARGET_SLUG" "$PR_NUM")")"
     FINAL_CURRENT_SHA="$(pr_head_sha "$PR_NUM")"
     # AND THE GATE'S NOTE IS SAID, NOT SWALLOWED (PR #30 review round 3, minor 2).
     # converge.sh's own call site states the rule this line broke: "Swallowing it

--- a/q-system/.q-system/scripts/pr-review-agent.sh
+++ b/q-system/.q-system/scripts/pr-review-agent.sh
@@ -125,15 +125,43 @@ CODEX_MODEL="${KIPI_REVIEW_CODEX_MODEL:-gpt-5.6-sol}"
 # grepping the review prose with their own regex is two readers with different
 # semantics -- the defect class review round 2 flagged on this very PR line.
 . "$SCRIPT_DIR/pr-verdict-lib.sh"
+# THE ONE SLUG DERIVATION (ASK-738).
+. "$SCRIPT_DIR/repo-slug-lib.sh"
+
+# REVIEW_REPO is the repo UNDER REVIEW. $SKEL stays what it always was: where the
+# control code lives. Every git read that asks "does this tree hold the PR"
+# targets REVIEW_REPO; every gh call is scoped to its slug. Defaults to $SKEL, so
+# every existing caller behaves exactly as before.
+REVIEW_REPO="${TARGET_REPO_ARG:-${KIPI_TARGET_REPO:-$SKEL}}"
+[ -d "$REVIEW_REPO" ] || { echo "--repo: no such directory: $REVIEW_REPO" >&2; exit 1; }
+REVIEW_REPO="$(cd "$REVIEW_REPO" && pwd)"
+REVIEW_SLUG="$(slug_for_repo "$REVIEW_REPO" "${KIPI_SLUG_REGISTRY:-$SKEL/instance-registry.json}")"
+KIPI_GH_REPO_ARGS="$(gh_repo_args "$REVIEW_SLUG")"
+export KIPI_GH_REPO_ARGS
+# The prompt below tells the MODEL to run `gh pr view` / `gh pr diff` itself. An
+# unscoped instruction there reads another repository's diff no matter what this
+# script does, so the scope has to travel INTO the prompt text too.
+GH_R_PROMPT=""
+[ -n "$REVIEW_SLUG" ] && GH_R_PROMPT="-R $REVIEW_SLUG "
+# `gh api` cannot take -R (see post_status). Empty slug keeps the placeholder
+# form, which is what every pre-ASK-738 caller and fixture already relies on.
+STATUS_REPO_PATH="{owner}/{repo}"
+[ -n "$REVIEW_SLUG" ] && STATUS_REPO_PATH="$REVIEW_SLUG"
 
 # CODEX BY DEFAULT. Env-overridable so a codex outage long enough to matter is a
 # config change (`KIPI_REVIEW_ENGINE=claude`), not an edit to the script that
 # gates every PR in the repo.
-PR=""; ISSUE=""; POST=0; ENGINE="${KIPI_REVIEW_ENGINE:-codex}"
+PR=""; ISSUE=""; POST=0; ENGINE="${KIPI_REVIEW_ENGINE:-codex}"; TARGET_REPO_ARG=""
 while [ $# -gt 0 ]; do
   case "$1" in
     --issue)  shift; ISSUE="${1:-}" ;;
     --engine) shift; ENGINE="${1:-}" ;;
+    # WHICH REPO THE WORK IS IN (ASK-738). $SKEL is where this CODE lives; it is
+    # not where the PR lives. Before this argument the two were the same
+    # variable, so a review of an external PR number resolved against the home
+    # repo -- and if that number existed there, the wrong repository's code was
+    # reviewed and got the verdict and the commit status.
+    --repo)   shift; TARGET_REPO_ARG="${1:-}" ;;
     --post)   POST=1 ;;
     -*) echo "unknown arg: $1" >&2; exit 1 ;;
     *) PR="$1" ;;
@@ -211,7 +239,7 @@ REVIEW_UNUSABLE=0
 
 mkdir -p "$ENGINE_DIR" "$VERDICT_DIR"
 TS() { date -u +%Y-%m-%dT%H:%M:%SZ; }
-REVIEW="$ENGINE_DIR/pr-$PR-$(date +%Y%m%d-%H%M%S).md"
+REVIEW="$ENGINE_DIR/$(artifact_key "$REVIEW_SLUG" "$PR")-$(date +%Y%m%d-%H%M%S).md"
 
 # Same bash wall clock as the worker: macOS ships no `timeout` without coreutils,
 # and a review that never returns is worse than one that fails.
@@ -231,7 +259,7 @@ command -v gh >/dev/null 2>&1 || { echo "gh CLI required" >&2; exit 1; }
 # the other way (a push between here and the reviewer's own `gh pr diff`) pins
 # the OLDER sha, which reads as drift and routes to a re-review. Safe direction.
 # The sha is first in the tuple so a tab inside a PR title cannot displace it.
-PR_META="$(gh pr view "$PR" --json headRefOid,title -q '.headRefOid + "\t" + .title' 2>/dev/null)" \
+PR_META="$(gh pr view "$PR" $KIPI_GH_REPO_ARGS --json headRefOid,title -q '.headRefOid + "\t" + .title' 2>/dev/null)" \
   || { echo "no PR #$PR" >&2; exit 1; }
 HEAD_SHA="${PR_META%%$'\t'*}"
 PR_TITLE="${PR_META#*$'\t'}"
@@ -257,7 +285,7 @@ PR_TITLE="${PR_META#*$'\t'}"
 # asked for the sha+title tuple, so the two strings never matched and the check
 # refused every review. Caught by test-review-tree-guard going 1/23.
 sleep 3
-PR_META_CONFIRM="$(gh pr view "$PR" --json headRefOid,title -q '.headRefOid + "\t" + .title' 2>/dev/null || true)"
+PR_META_CONFIRM="$(gh pr view "$PR" $KIPI_GH_REPO_ARGS --json headRefOid,title -q '.headRefOid + "\t" + .title' 2>/dev/null || true)"
 HEAD_SHA_CONFIRM="${PR_META_CONFIRM%%$'\t'*}"
 if [ -n "$HEAD_SHA_CONFIRM" ] && [ "$HEAD_SHA_CONFIRM" != "$HEAD_SHA" ]; then
   echo "REFUSING: PR #$PR's head moved between two reads (${HEAD_SHA:0:8} then ${HEAD_SHA_CONFIRM:0:8})." >&2
@@ -332,12 +360,15 @@ REVIEW_ROOT="$SKEL"
 # removal is a destructive op on a path this script does not own, and re-checkout
 # reaches the same state.
 review_worktree() {  # review_worktree <sha> -> prints path, or nothing
-  local sha="$1" wt="$HOME/.config/kipi/review-trees/pr-$PR"
+  # KEYED BY REPO AND PR (ASK-738). One shared review-trees/pr-<N> path meant
+  # two repos' PR #42 shared a single detached worktree, re-checked out to
+  # whichever repo asked last -- a review reading the wrong repository's files.
+  local sha="$1" wt; wt="$(review_tree_path "$HOME/.config/kipi" "$REVIEW_SLUG" "$PR")"
   mkdir -p "$(dirname "$wt")" 2>/dev/null || return 1
   if [ -d "$wt/.git" ] || [ -f "$wt/.git" ]; then
     git -C "$wt" checkout --detach --force "$sha" >/dev/null 2>&1 || return 1
   else
-    git -C "$SKEL" worktree add --detach "$wt" "$sha" >/dev/null 2>&1 || return 1
+    git -C "$REVIEW_REPO" worktree add --detach "$wt" "$sha" >/dev/null 2>&1 || return 1
   fi
   # Prove it landed where we asked. A worktree silently sitting at the wrong sha
   # is the same false-provenance bug in a new costume.
@@ -345,7 +376,7 @@ review_worktree() {  # review_worktree <sha> -> prints path, or nothing
   printf '%s' "$wt"
 }
 
-if [ -n "$HEAD_SHA" ] && git -C "$SKEL" cat-file -e "${HEAD_SHA}^{commit}" 2>/dev/null; then
+if [ -n "$HEAD_SHA" ] && git -C "$REVIEW_REPO" cat-file -e "${HEAD_SHA}^{commit}" 2>/dev/null; then
   ISOLATED="$(review_worktree "$HEAD_SHA" || true)"
   if [ -n "$ISOLATED" ]; then
     REVIEW_ROOT="$ISOLATED"
@@ -372,9 +403,9 @@ else
 fi
 
 if [ "$HEAD_SHA_ISOLATED" != "1" ] && [ -n "$HEAD_SHA" ]; then
-  if ! git -C "$SKEL" cat-file -e "${HEAD_SHA}^{commit}" 2>/dev/null; then
-    echo "  WARN: $SKEL does not have commit $HEAD_SHA, so the tree/PR match cannot be proven (stale or partial clone?). Proceeding; a review of the wrong tree would report findings absent from this diff." >&2
-  elif ! git -C "$SKEL" merge-base --is-ancestor "$HEAD_SHA" HEAD 2>/dev/null; then
+  if ! git -C "$REVIEW_REPO" cat-file -e "${HEAD_SHA}^{commit}" 2>/dev/null; then
+    echo "  WARN: $REVIEW_REPO does not have commit $HEAD_SHA, so the tree/PR match cannot be proven (stale or partial clone?). Proceeding; a review of the wrong tree would report findings absent from this diff." >&2
+  elif ! git -C "$REVIEW_REPO" merge-base --is-ancestor "$HEAD_SHA" HEAD 2>/dev/null; then
     # SKEL does not contain the PR. Find a worktree that does. `worktree list
     # --porcelain` emits a `worktree <path>` line per tree, SKEL included; testing
     # SKEL again is harmless and keeps the loop free of a special case.
@@ -385,13 +416,13 @@ if [ "$HEAD_SHA_ISOLATED" != "1" ] && [ -n "$HEAD_SHA" ]; then
       if git -C "$wt" merge-base --is-ancestor "$HEAD_SHA" HEAD 2>/dev/null; then
         FOUND_ROOT="$wt"; break
       fi
-    done < <(git -C "$SKEL" worktree list --porcelain 2>/dev/null | awk '/^worktree /{print substr($0,10)}')
+    done < <(git -C "$REVIEW_REPO" worktree list --porcelain 2>/dev/null | awk '/^worktree /{print substr($0,10)}')
 
     if [ -n "$FOUND_ROOT" ]; then
       REVIEW_ROOT="$FOUND_ROOT"
-      echo "  tree: $REVIEW_ROOT (holds PR #$PR at ${HEAD_SHA:0:8}; the script itself lives in $SKEL)"
+      echo "  tree: $REVIEW_ROOT (holds PR #$PR at ${HEAD_SHA:0:8}; the script itself lives in $SKEL, the code under review in $REVIEW_REPO)"
     else
-      echo "REFUSING: PR #$PR is at $HEAD_SHA, which is not in the history of $SKEL (HEAD $(git -C "$SKEL" rev-parse --short HEAD 2>/dev/null)) or of any worktree it lists." >&2
+      echo "REFUSING: PR #$PR is at $HEAD_SHA, which is not in the history of $REVIEW_REPO (HEAD $(git -C "$REVIEW_REPO" rev-parse --short HEAD 2>/dev/null)) or of any worktree it lists." >&2
       echo "  The reviewer reads FILES from a tree and the DIFF from the PR. With no tree holding this commit, every finding would cite code that is not in this PR, stamped with this PR's sha." >&2
       echo "  Fetch the PR's head, or run it from a tree that has it. No review was dispatched and NO status was posted -- absent is not approved." >&2
       exit 1
@@ -415,7 +446,7 @@ if [ "$ROUND" -gt 1 ]; then
 
 ## THIS IS REVIEW ROUND $ROUND OF THIS PR
 
-Earlier rounds are in the PR comments (\`gh pr view $PR --comments\`). Read them
+Earlier rounds are in the PR comments (\`gh ${GH_R_PROMPT}pr view $PR --comments\`). Read them
 AFTER you have formed your own read of the code, never before -- your value is
 that you did not inherit anyone's frame.
 
@@ -460,8 +491,8 @@ fail safe for the author -- it just burns a round.
 
 ## Read the change
 
-  gh pr view $PR
-  gh pr diff $PR
+  gh ${GH_R_PROMPT}pr view $PR
+  gh ${GH_R_PROMPT}pr diff $PR
 
 ## What your fresh eyes are FOR
 
@@ -819,11 +850,14 @@ REVIEWED_BY="$CODEX_MODEL"
 # no record would be written, and the suite would report a break in the test
 # rather than the defect. Keep the derivation adjacent to the python3 call.
 
-python3 - "$PR" "$ISSUE" "$VERDICT" "$REVIEW" "$(TS)" "$STATED_VERDICT" "$DERIVED_VERDICT" "$ROUND" "$HEAD_SHA" "$VERDICT_DIR" "$ENGINE" "$INVOKER" "$REVIEW_USABLE" "$REVIEWED_BY" "$DEGRADED" <<'PY'
+# The record path comes from the ONE resolver (repo-slug-lib.sh), passed in as
+# argv 16 rather than rebuilt in python -- a second place that knows the naming
+# rule is a second writer, which is the defect class this repo keeps finding.
+python3 - "$PR" "$ISSUE" "$VERDICT" "$REVIEW" "$(TS)" "$STATED_VERDICT" "$DERIVED_VERDICT" "$ROUND" "$HEAD_SHA" "$VERDICT_DIR" "$ENGINE" "$INVOKER" "$REVIEW_USABLE" "$REVIEWED_BY" "$DEGRADED" "$(verdict_record_write_path "$VERDICT_DIR" "$REVIEW_SLUG" "$PR")" <<'PY'
 import json, sys
 (pr, issue, verdict, review, ts, stated, derived, rnd, head_sha, verdict_dir,
  engine, invoker, usable, reviewed_by, degraded) = sys.argv[1:16]
-out = f"{verdict_dir}/pr-{pr}.verdict.json"
+out = sys.argv[16]
 json.dump({"pr": int(pr), "issue": issue, "verdict": verdict,
            "stated": stated, "derived": derived,
            "source": "findings" if derived else "prose",
@@ -902,7 +936,10 @@ post_reviewer_status() {
   # second opinion, and the whole point of this engine is that it is not Claude.
   [ "$DEGRADED" = "1" ] && desc="DEGRADED (codex down, Opus fallback): $desc"
   desc="$(printf '%.140s' "$desc")"
-  local args=(api -X POST "repos/{owner}/{repo}/statuses/$sha"
+  # STATUS_REPO_PATH, not {owner}/{repo}: `gh api` resolves those placeholders
+  # from the CWD repo and accepts no -R, so an unattended run posted
+  # kipi/reviewer-approved onto the home repo for a review of another one.
+  local args=(api -X POST "repos/$STATUS_REPO_PATH/statuses/$sha"
               -f "state=$state" -f "context=$context" -f "description=$desc")
   # Link only a real URL. The PR comment just above is what --post creates; when
   # that failed there is nothing to link, and a local file path is not a URL.
@@ -960,7 +997,7 @@ if [ "$POST" = "1" ]; then
   # between a size rejection, an auth failure and a closed PR -- the same
   # discard-the-reason defect PR #46 fixed one call lower down.
   COMMENT_ERR="$(mktemp "${TMPDIR:-/tmp}/pr-review-comment-err.XXXXXX" 2>/dev/null)" || COMMENT_ERR=/dev/null
-  if COMMENT_URL="$(gh pr comment "$PR" --body-file "$POST_FILE" 2>"$COMMENT_ERR")"; then
+  if COMMENT_URL="$(gh pr comment "$PR" $KIPI_GH_REPO_ARGS --body-file "$POST_FILE" 2>"$COMMENT_ERR")"; then
     echo "  posted to PR #$PR ($(wc -c <"$POST_FILE" | tr -d ' ') bytes rendered from $(wc -c <"$REVIEW" | tr -d ' '))"
   else
     COMMENT_URL=""

--- a/q-system/.q-system/scripts/pr-review-agent.sh
+++ b/q-system/.q-system/scripts/pr-review-agent.sh
@@ -128,25 +128,7 @@ CODEX_MODEL="${KIPI_REVIEW_CODEX_MODEL:-gpt-5.6-sol}"
 # THE ONE SLUG DERIVATION (ASK-738).
 . "$SCRIPT_DIR/repo-slug-lib.sh"
 
-# REVIEW_REPO is the repo UNDER REVIEW. $SKEL stays what it always was: where the
-# control code lives. Every git read that asks "does this tree hold the PR"
-# targets REVIEW_REPO; every gh call is scoped to its slug. Defaults to $SKEL, so
-# every existing caller behaves exactly as before.
-REVIEW_REPO="${TARGET_REPO_ARG:-${KIPI_TARGET_REPO:-$SKEL}}"
-[ -d "$REVIEW_REPO" ] || { echo "--repo: no such directory: $REVIEW_REPO" >&2; exit 1; }
-REVIEW_REPO="$(cd "$REVIEW_REPO" && pwd)"
-REVIEW_SLUG="$(slug_for_repo "$REVIEW_REPO" "${KIPI_SLUG_REGISTRY:-$SKEL/instance-registry.json}")"
-KIPI_GH_REPO_ARGS="$(gh_repo_args "$REVIEW_SLUG")"
-export KIPI_GH_REPO_ARGS
-# The prompt below tells the MODEL to run `gh pr view` / `gh pr diff` itself. An
-# unscoped instruction there reads another repository's diff no matter what this
-# script does, so the scope has to travel INTO the prompt text too.
-GH_R_PROMPT=""
-[ -n "$REVIEW_SLUG" ] && GH_R_PROMPT="-R $REVIEW_SLUG "
-# `gh api` cannot take -R (see post_status). Empty slug keeps the placeholder
-# form, which is what every pre-ASK-738 caller and fixture already relies on.
-STATUS_REPO_PATH="{owner}/{repo}"
-[ -n "$REVIEW_SLUG" ] && STATUS_REPO_PATH="$REVIEW_SLUG"
+
 
 # CODEX BY DEFAULT. Env-overridable so a codex outage long enough to matter is a
 # config change (`KIPI_REVIEW_ENGINE=claude`), not an edit to the script that
@@ -168,6 +150,33 @@ while [ $# -gt 0 ]; do
   esac
   shift || true
 done
+
+# RESOLVED AFTER THE ARGUMENT LOOP, and that placement is the whole point.
+# This block first sat above the loop, so it read TARGET_REPO_ARG before the
+# loop had parsed it AND before line "PR=\"\"; ISSUE=..." reset it to empty --
+# `--repo` was a DEAD FLAG that silently fell through to $SKEL. Caught by codex
+# on PR #146; my own test missed it because it drove the env form
+# (KIPI_TARGET_REPO), which resolves the same either way. A flag with no test
+# that exercises the FLAG is an untested flag.
+# REVIEW_REPO is the repo UNDER REVIEW. $SKEL stays what it always was: where the
+# control code lives. Every git read that asks "does this tree hold the PR"
+# targets REVIEW_REPO; every gh call is scoped to its slug. Defaults to $SKEL, so
+# every existing caller behaves exactly as before.
+REVIEW_REPO="${TARGET_REPO_ARG:-${KIPI_TARGET_REPO:-$SKEL}}"
+[ -d "$REVIEW_REPO" ] || { echo "--repo: no such directory: $REVIEW_REPO" >&2; exit 1; }
+REVIEW_REPO="$(cd "$REVIEW_REPO" && pwd)"
+REVIEW_SLUG="$(slug_for_repo "$REVIEW_REPO" "${KIPI_SLUG_REGISTRY:-$SKEL/instance-registry.json}")"
+KIPI_GH_REPO_ARGS="$(gh_repo_args "$REVIEW_SLUG")"
+export KIPI_GH_REPO_ARGS
+# The prompt below tells the MODEL to run `gh pr view` / `gh pr diff` itself. An
+# unscoped instruction there reads another repository's diff no matter what this
+# script does, so the scope has to travel INTO the prompt text too.
+GH_R_PROMPT=""
+[ -n "$REVIEW_SLUG" ] && GH_R_PROMPT="-R $REVIEW_SLUG "
+# `gh api` cannot take -R (see post_status). Empty slug keeps the placeholder
+# form, which is what every pre-ASK-738 caller and fixture already relies on.
+STATUS_REPO_PATH="{owner}/{repo}"
+[ -n "$REVIEW_SLUG" ] && STATUS_REPO_PATH="$REVIEW_SLUG"
 [ -n "$PR" ] || { echo "usage: pr-review-agent.sh <pr-number> [--issue ASK-nnn] [--post] [--engine claude|codex]" >&2; exit 1; }
 
 # WHAT THE ENGINE CHANGES. Everything else below this block is shared, which is

--- a/q-system/.q-system/scripts/pr-verdict-lib.sh
+++ b/q-system/.q-system/scripts/pr-verdict-lib.sh
@@ -369,7 +369,8 @@ resolve_verdict() {   # resolve_verdict <stated> <derived>
 # `gh pr view` is two readers of one input with drifting semantics. Empty on any
 # failure, which the gate treats as "still merges" -- see rework_gate.
 pr_merge_state() {
-  gh pr view "$1" --json mergeStateStatus -q .mergeStateStatus 2>/dev/null | tr -d '[:space:]'
+  # shellcheck disable=SC2086  # scoped by the ONE derivation (ASK-738)
+  gh pr view "$1" ${KIPI_GH_REPO_ARGS:-} --json mergeStateStatus -q .mergeStateStatus 2>/dev/null | tr -d '[:space:]'
 }
 
 # pr_head_sha <pr-number>
@@ -381,7 +382,11 @@ pr_merge_state() {
 # defect class this file exists to close. Empty on any failure, which rework_gate
 # reads as "unknown, fall back and say so", never as drift.
 pr_head_sha() {
-  gh pr view "$1" --json headRefOid -q .headRefOid 2>/dev/null | tr -d '[:space:]'
+  # $KIPI_GH_REPO_ARGS is set ONCE by whichever script sourced this lib, from
+  # repo-slug-lib.sh (ASK-738). Unquoted so an empty value expands to nothing;
+  # it is never anything but "-R owner/repo" by construction.
+  # shellcheck disable=SC2086
+  gh pr view "$1" ${KIPI_GH_REPO_ARGS:-} --json headRefOid -q .headRefOid 2>/dev/null | tr -d '[:space:]'
 }
 
 # --- the arm-state record (ASK-222, PR #33 review round 3, finding 1) --------

--- a/q-system/.q-system/scripts/repo-slug-lib.sh
+++ b/q-system/.q-system/scripts/repo-slug-lib.sh
@@ -1,0 +1,183 @@
+#!/usr/bin/env bash
+# THE ONE PLACE a GitHub owner/repo slug is derived, and the one place a review
+# artifact path is built (ASK-738).
+#
+# WHY THIS FILE EXISTS
+# --------------------
+# `gh` resolves its repository from the PROCESS WORKING DIRECTORY and ignores
+# every path variable this fleet carries. Measured 2026-08-13:
+#
+#   cwd = kipi-system checkout, TARGET_REPO=<other>  ->  assafkip/kipi-system
+#   cwd = <other>                                    ->  assafkip/<other>
+#
+# kipi-dispatch.sh:205 does `cd "$REPO"` and never leaves, so an unqualified `gh`
+# anywhere in the dispatched chain answers about the HOME repo while `git -C`
+# does the work in the target. Three call sites did exactly that, and the worst
+# of them (pr-review-agent.sh) would review the wrong repository's code and post
+# a verdict and a commit status on it.
+#
+# The fix is `-R <owner>/<repo>` on every call. The reason it lives in a lib
+# rather than at each call site: sp-421fa27d already records ONE duplicated
+# derivation in this codebase (project-name, split between linear-worker.sh and
+# spillover-promote.py). A second copy of a rule about which repository an
+# unattended self-merging agent may act on is not a style problem. Every caller
+# reads the answer from here.
+#
+# ORDER OF AUTHORITY, and why it is this order:
+#   1. the registry row's dispatch.expected_remote -- the PIN. repo-preflight.sh
+#      already refuses to enter any repo whose row does not carry it, so for
+#      every cross-repo target this is always the answer. Deriving from the pin
+#      rather than from the repo's own origin means a re-pointed or spoofed local
+#      origin cannot aim an agent at a repository the registry never named.
+#   2. the repo's own configured origin -- the FALLBACK, and it exists for
+#      exactly one case: the dispatcher's OWN checkout, which fleet_candidates
+#      emits with an empty expected_remote and which carries no registry row.
+#      Refusing there would break the only repo this loop runs in today.
+#      It is still derived from the TARGET PATH, never from cwd, so it does not
+#      reintroduce the defect.
+#
+# `git config --get remote.origin.url`, NOT `git remote get-url origin`:
+# get-url APPLIES url.<base>.insteadOf rewriting, so on a box that rewrites
+# github.com to a mirror it returns the mirror path and no slug forms. Measured
+# in this repo's own test fixture, which uses insteadOf for local transport.
+
+# slug_from_remote <remote-url> -> owner/repo, or empty
+# Handles the two forms git remotes actually take here. Empty output means "no
+# slug", and every caller must treat that as "do not scope", never as a default.
+slug_from_remote() {
+  local u="${1:-}" s=""
+  case "$u" in
+    git@*:*)            s="${u#*:}" ;;
+    ssh://*|https://*|http://*)
+                        s="${u#*://}"; s="${s#*@}"; s="${s#*/}" ;;
+    *)                  s="" ;;
+  esac
+  s="${s%.git}"
+  s="${s%/}"
+  # An owner/repo has exactly one slash. Anything else is a path or a malformed
+  # URL, and guessing at it is how a query lands on the wrong repository.
+  case "$s" in
+    */*/*) s="" ;;
+    */*)   : ;;
+    *)     s="" ;;
+  esac
+  printf '%s' "$s"
+}
+
+# _registry_remote_for <repo-path> <registry-path> -> the pinned expected_remote
+# Quoted heredoc + argv, never `python3 -c "..."` inside $( ): the inline form
+# broke bash parsing at RUNTIME ONLY elsewhere in this tree (repo-preflight.sh
+# carries the same scar), and a path with an apostrophe in it is enough to do it.
+_registry_remote_for() {
+  [ -f "${2:-}" ] || return 0
+  python3 - "$1" "$2" <<'PY' 2>/dev/null
+import json, os, sys
+want = os.path.realpath(sys.argv[1])
+try:
+    data = json.load(open(sys.argv[2]))
+except Exception:
+    raise SystemExit(0)          # unreadable registry means "no pin", never a guess
+entries = data.get("instances", data) if isinstance(data, dict) else data
+for e in entries if isinstance(entries, list) else []:
+    if not isinstance(e, dict):
+        continue
+    p = e.get("path")
+    if not p:
+        continue
+    try:
+        if os.path.realpath(p) != want:
+            continue
+    except Exception:
+        continue
+    d = e.get("dispatch")
+    if isinstance(d, dict) and d.get("expected_remote"):
+        print(d["expected_remote"])
+    break
+PY
+}
+
+# slug_for_repo <repo-path> [registry-path] -> owner/repo, or empty
+slug_for_repo() {
+  local repo="${1:-}" reg="${2:-${KIPI_SLUG_REGISTRY:-}}" remote="" slug=""
+  [ -n "$repo" ] || return 0
+  [ -d "$repo" ] || return 0
+  remote="$(_registry_remote_for "$repo" "$reg")"
+  slug="$(slug_from_remote "$remote")"
+  # FALL BACK ON A PIN THAT YIELDS NO SLUG, not merely on an absent pin. A row
+  # whose expected_remote is malformed -- or a registry read that returned
+  # something that is not a remote at all -- would otherwise leave the slug empty,
+  # and an empty slug means every gh call silently reverts to cwd binding. That
+  # is the exact defect this lib exists to close, reappearing as a quiet
+  # degradation instead of a loud one. Caught by this repo's own worker
+  # reproducer, where a stubbed python3 made the registry read return JSON.
+  if [ -z "$slug" ]; then
+    remote="$(git -C "$repo" config --get remote.origin.url 2>/dev/null)"
+    slug="$(slug_from_remote "$remote")"
+  fi
+  printf '%s' "$slug"
+}
+
+# gh_repo_args <slug> -> the argv fragment to splice into a gh call
+#
+# UNQUOTED WORD-SPLITTING IS THE POINT and it is why this returns a string rather
+# than an array: bash 3.2 (what /bin/bash is on macOS) treats an EMPTY array's
+# "${a[@]}" as unbound under `set -u`, so an array-based helper dies on exactly
+# the no-slug path. Callers splice $(gh_repo_args "$SLUG") unquoted. A slug is
+# [-.\w]+/[-.\w]+ by construction above, so it can never contain whitespace or a
+# glob character.
+gh_repo_args() {
+  [ -n "${1:-}" ] || return 0
+  printf -- '-R %s' "$1"
+}
+
+# --- artifact keying --------------------------------------------------------
+# Review artifacts used to be keyed `pr-<number>` in ONE shared state dir, so
+# PR #42 in kipi-system and PR #42 in a client repo were the same three paths:
+# the verdict record the gates read, the review prose the round counter globs,
+# and the detached worktree the reviewer reads files from. The second review
+# overwrote the first, and a gate could read an APPROVE earned by a different
+# repository's code.
+#
+# `/` -> `__` because these are path SEGMENTS. Keeping the slash would make the
+# owner a directory level, which silently changes what every `find` and glob in
+# the suite matches.
+
+# artifact_key <slug> <pr> -> the basename stem for this repo's PR
+artifact_key() {
+  local slug="${1:-}" pr="${2:-}"
+  if [ -z "$slug" ]; then
+    printf 'pr-%s' "$pr"          # no slug: legacy shape, and it is the home repo
+    return 0
+  fi
+  printf '%s__pr-%s' "$(printf '%s' "$slug" | tr '/' '_' | tr -c 'A-Za-z0-9._-' '_')" "$pr"
+}
+
+# verdict_record_path <dir> <slug> <pr> -> the path to READ
+#
+# WRITES ALWAYS USE THE REPO-KEYED PATH (verdict_record_write_path). Reads fall
+# back to the legacy `pr-<N>.verdict.json` when the repo-keyed file does not
+# exist, for one bounded reason: ~90 records under ~/.config/kipi/pr-reviews/
+# predate this change and all belong to the home repo. Dropping them would make
+# every open PR look unreviewed and trigger a re-review round on each. The
+# fallback is read-only and lives HERE, in the single resolver, so there is still
+# exactly one writer and one reader of this path shape.
+verdict_record_path() {
+  local dir="${1:-}" slug="${2:-}" pr="${3:-}" keyed=""
+  keyed="$dir/$(artifact_key "$slug" "$pr").verdict.json"
+  if [ -f "$keyed" ]; then printf '%s' "$keyed"; return 0; fi
+  local legacy="$dir/pr-$pr.verdict.json"
+  if [ -f "$legacy" ]; then printf '%s' "$legacy"; return 0; fi
+  printf '%s' "$keyed"
+}
+
+verdict_record_write_path() {
+  printf '%s/%s.verdict.json' "${1:-}" "$(artifact_key "${2:-}" "${3:-}")"
+}
+
+# review_tree_path <state-dir> <slug> <pr>
+# One detached worktree per (repo, PR). Sharing one path across repos meant a
+# tree re-checked out to whichever repo asked last, which is a review reading the
+# wrong repository's files with the right-looking provenance.
+review_tree_path() {
+  printf '%s/review-trees/%s' "${1:-}" "$(artifact_key "${2:-}" "${3:-}")"
+}

--- a/q-system/.q-system/scripts/test/test-dispatch-client-refusal-after-hold.sh
+++ b/q-system/.q-system/scripts/test/test-dispatch-client-refusal-after-hold.sh
@@ -1,0 +1,218 @@
+#!/usr/bin/env bash
+# THE GUARD THAT REPLACES THE HOLD (ASK-738 + ASK-741).
+#
+# kipi-dispatch.sh used to refuse EVERY non-home repo unconditionally
+# ("HOLD ...: cross-repo gh scoping is unfinished", sp-9421b9b7). ASK-738 fixed
+# the gh scoping and removed that line. The HOLD was also, incidentally, the
+# thing standing between an unattended self-merging loop and twelve client
+# engagement repos -- so removing it moves that job onto repo-preflight.sh
+# check 0 alone (ASK-741, PR #144).
+#
+# Founder decision 2026-08-13, verbatim: "no. unattended agents should not reach
+# a client repo."
+#
+# So this test asserts BOTH directions through the REAL dispatcher, because
+# either one alone is worthless:
+#
+#   1. a client-shaped repo, OPTED IN with dispatch.enabled: true, is refused and
+#      never reaches `kipi work`;
+#   2. an ordinary opted-in repo IS entered, with --repo pointing at it.
+#
+# Without (2) this suite would pass on a dispatcher that refuses everything --
+# which is exactly what the HOLD did, and it would report "client repos are
+# protected" while the whole feature was dead. Without (1) the founder's
+# constraint is unenforced. The pair is the test.
+#
+# THE ASSERTION IS ON WHAT `kipi work` WAS CALLED WITH, not on a log line. A log
+# line is what the dispatcher SAYS; argv is what it DID. The fixture's `kipi` is a
+# recorder, so "did the client path ever reach the worker" is answered by a file.
+set -uo pipefail
+
+ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/../../../.." && pwd)"
+DISPATCH="$ROOT/kipi-dispatch.sh"
+
+PASS=0
+fail() { echo "FAIL: $1" >&2; exit 1; }
+ok()   { PASS=$((PASS + 1)); echo "  ok: $1"; }
+
+[ -f "$DISPATCH" ] || fail "kipi-dispatch.sh not found at $DISPATCH"
+REAL_GIT="$(command -v git)" || fail "git not on PATH"
+
+WORK="$(mktemp -d)"
+trap 'rm -rf "$WORK"' EXIT
+G() { git -c user.email=t@t.t -c user.name=t "$@"; }
+
+# --- the three repos --------------------------------------------------------
+# CLIENT path shape is what check 0 keys on: <root>/consulting/projects/<thing>.
+# Derived from shape, never from a list of client names, so this fixture is the
+# same fact the shipping check reads.
+HOMEREPO="$WORK/kipi-system"
+CLIENT="$WORK/consulting/projects/alice"
+PLAIN="$WORK/otherorg/projects/plainrepo"
+
+# EVERY ORIGIN IS A LOCAL BARE REPO reached through insteadOf. The first cut gave
+# the fixture a real https://github.com/... origin; the dispatcher's stale-checkout
+# refusal then compared it against the REAL kipi-system main and reported "origin
+# /main holds 1030 commit(s) this checkout lacks", so the run refused before
+# pick_list and the suite proved nothing. The URL still has to READ as github.com
+# because repo-preflight.sh derives its slug from it.
+# ONLY THE HOME REPO GETS insteadOf. It needs a reachable origin/main or the
+# dispatcher's stale-checkout refusal fires before pick_list ever runs. The two
+# TARGETS must NOT have it: repo-preflight.sh check 4 compares
+# `git remote get-url origin` against the registry's pin, and get-url APPLIES
+# insteadOf rewriting -- so the rewrite made check 4 report
+# "origin is <local path> but the registry pins https://github.com/...".
+# That is not a fixture quirk, it is a live defect in preflight on any box that
+# rewrites github.com to a mirror (captured as sp-72ee0308). Here the targets
+# simply keep an unrewritten github URL; nothing fetches them.
+mkrepo() {  # mkrepo <dir> <name> <rewrite:0|1>
+  mkdir -p "$1"
+  git init -q "$1"
+  echo x > "$1/f.txt"
+  G -C "$1" add -A; G -C "$1" commit -q -m c1
+  git -C "$1" branch -M main
+  git -C "$1" remote add origin "https://github.com/assafkip/$2.git"
+  if [ "$3" = "1" ]; then
+    git init -q --bare "$WORK/origin-$2.git"
+    git -C "$WORK/origin-$2.git" symbolic-ref HEAD refs/heads/main
+    git -C "$1" config "url.$WORK/origin-.insteadOf" "https://github.com/assafkip/"
+    git -C "$1" push -q -u origin main
+  fi
+}
+mkrepo "$HOMEREPO" kipi-system 1
+mkrepo "$CLIENT"   alice        0
+mkrepo "$PLAIN"    plainrepo    0
+
+# The dispatcher runs `bash ./kipi work $WORK_ARGS` from $REPO. This recorder IS
+# the assertion surface: argv is what it DID.
+cat > "$HOMEREPO/kipi" <<EOF
+#!/usr/bin/env bash
+printf '%s\n' "\$*" >> "$WORK/kipi-calls.txt"
+echo "no ready issues"
+exit 0
+EOF
+chmod +x "$HOMEREPO/kipi"
+: > "$WORK/kipi-calls.txt"
+
+# The dispatcher resolves the preflight off $REPO, so the fixture home repo has
+# to carry the REAL one -- a stub here would test nothing. PLAIN must then CLEAR
+# all seven checks, which means it needs byte-identical control code and the same
+# wired hook scripts. Copying the same tree into both is the only way to satisfy
+# a check whose whole point is byte equality.
+seed_control_code() {  # seed_control_code <repo>
+  mkdir -p "$1/q-system/.q-system/scripts" "$1/.claude"
+  cp "$ROOT/q-system/.q-system/scripts/repo-preflight.sh" \
+     "$ROOT/q-system/.q-system/scripts/linear-worker.sh" "$1/q-system/.q-system/scripts/"
+  printf '{"hooks":{}}\n' > "$1/.claude/settings.json"
+  G -C "$1" add -A; G -C "$1" commit -q -m "control code"
+  # Only the home repo has a reachable origin; the targets are never fetched.
+  git -C "$1" push -q origin main 2>/dev/null || true
+}
+seed_control_code "$HOMEREPO"
+seed_control_code "$PLAIN"
+seed_control_code "$CLIENT"
+
+# --- gh, stubbed so checks 6 and 7 can be answered offline -------------------
+# NOT a blanket exit 0: check 7 is the one that matters most for a client repo,
+# and a stub that made everything pass would let this suite go green against a
+# dispatcher with no branch-protection check at all. It answers only the two
+# questions preflight asks, and answers them truthfully for the fixture.
+STUB="$WORK/bin"; mkdir -p "$STUB"
+cat > "$STUB/gh" <<'GHEOF'
+#!/usr/bin/env bash
+case "$*" in
+  "auth status"*)            exit 0 ;;
+  "repo view"*)              echo "ok"; exit 0 ;;
+  *"/branches/"*"/protection") echo '{"required_pull_request_reviews":{},"required_status_checks":{"contexts":["kipi/reviewer-approved"]}}'; exit 0 ;;
+  "api repos/"*)             echo "main"; exit 0 ;;
+esac
+exit 0
+GHEOF
+chmod +x "$STUB/gh"
+export PATH="$STUB:$PATH"
+
+# --- both non-home rows OPTED IN. That is the point: enabled is not consent. ---
+REG="$WORK/registry.json"
+cat > "$REG" <<JSON
+{"instances":[
+  {"name":"alice","path":"$CLIENT","has_git":true,
+   "dispatch":{"enabled":true,"expected_remote":"https://github.com/assafkip/alice.git"}},
+  {"name":"plainrepo","path":"$PLAIN","has_git":true,
+   "dispatch":{"enabled":true,"expected_remote":"https://github.com/assafkip/plainrepo.git"}}
+]}
+JSON
+
+# --- CASE 0, NEGATIVE SELF-TEST: check 0 fires on the fixture's own shape -----
+# If the client path does not trip the preflight directly, nothing below means
+# anything -- the dispatcher would be refusing it for some unrelated reason.
+PF_OUT="$(bash "$ROOT/q-system/.q-system/scripts/repo-preflight.sh" "$CLIENT" "https://github.com/assafkip/alice.git" 2>&1)"
+PF_RC=$?
+printf '%s' "$PF_OUT" | grep -q '^FAIL client-repo:' \
+  || fail "negative self-test: repo-preflight.sh did not refuse the client-shaped fixture $CLIENT as a client repo (rc=$PF_RC). It said:
+$(printf '%s' "$PF_OUT" | sed 's/^/        /')"
+[ "$PF_RC" -ne 0 ] || fail "negative self-test: the client refusal printed but exited 0"
+ok "negative self-test: check 0 refuses $CLIENT by path shape (rc=$PF_RC)"
+
+# --- CASE 0b: and it does NOT refuse the ordinary repo as a client -----------
+# A check that refused everything would satisfy case 1 while being useless.
+PF_PLAIN="$(bash "$ROOT/q-system/.q-system/scripts/repo-preflight.sh" "$PLAIN" "https://github.com/assafkip/plainrepo.git" 2>&1)"
+printf '%s' "$PF_PLAIN" | grep -q '^FAIL client-repo:' \
+  && fail "check 0 called the ORDINARY repo $PLAIN a client engagement repo; the shape rule is over-broad"
+ok "negative self-test: check 0 does not fire on the ordinary repo"
+
+# --- the dispatcher run -----------------------------------------------------
+# HOME, registry, cursor and turn lock all redirected into the temp dir so this
+# cannot touch the founder's live dispatch state.
+run_dispatch() {
+  ( cd "$HOMEREPO" \
+    && HOME="$WORK/home" KIPI_REPO="$HOMEREPO" \
+       KIPI_DISPATCH_REGISTRY="$REG" \
+       KIPI_DISPATCH_CURSOR="$WORK/cursor" \
+       KIPI_DISPATCH_TURNLOCK="$WORK/turn.lock" \
+       KIPI_NOTIFY="/usr/bin/true" \
+       bash "$DISPATCH" ) >>"$WORK/stdout.txt" 2>&1
+}
+mkdir -p "$WORK/home/.config/kipi"
+DLOG="$WORK/home/.config/kipi/dispatch.log"
+: > "$WORK/stdout.txt"
+# Several cycles: the rotation hands the turn on each time, so every row gets a
+# turn rather than the first one pinning the loop.
+for _ in 1 2 3 4; do run_dispatch; done
+
+echo "  [ctx] kipi work was called with:"
+sed 's/^/        /' "$WORK/kipi-calls.txt" 2>/dev/null | head -10
+echo "  [ctx] dispatcher said:"
+grep -E 'REFUSED|entering|HOLD|client engagement' "$DLOG" 2>/dev/null | sed 's/^/        /' | head -8
+
+# --- 1. THE CLIENT REPO NEVER REACHED THE WORKER ----------------------------
+if grep -q -- "$CLIENT" "$WORK/kipi-calls.txt" 2>/dev/null; then
+  fail "CLIENT REPO ENTERED: \`kipi work\` was invoked with the client engagement repo $CLIENT.
+      Founder decision 2026-08-13: unattended agents must not reach a client repo.
+      calls: $(tr '\n' ' ' < "$WORK/kipi-calls.txt")"
+fi
+ok "the opted-in CLIENT repo never reached kipi work"
+
+# --- 2. and the dispatcher said why, in the digest's shape ------------------
+# A silent refusal is indistinguishable from an empty queue (ASK-741).
+grep -q 'client engagement repos' "$DLOG" \
+  || fail "the dispatcher refused the client repo without saying so; the daily digest scrapes this line, so the refusal is invisible to the founder.
+$(tail -15 "$DLOG" | sed 's/^/        /')"
+ok "the refusal is stated in the log in the digest's own shape"
+
+# --- 3. THE ORDINARY REPO IS ACTUALLY ENTERED -------------------------------
+# Without this the suite would pass on a dispatcher that refuses everything --
+# which is precisely what the HOLD did while reporting healthy.
+grep -q -- "--repo $PLAIN" "$WORK/kipi-calls.txt" 2>/dev/null \
+  || fail "THE HOLD IS EFFECTIVELY STILL THERE: the ordinary opted-in repo $PLAIN was never dispatched with --repo.
+      Cross-repo dispatch is the whole point of ASK-738; a suite green on refusal alone would hide that it does nothing.
+      calls: $(tr '\n' ' ' < "$WORK/kipi-calls.txt")
+      log:
+$(tail -20 "$DLOG" | sed 's/^/        /')"
+ok "the ordinary opted-in repo IS entered, with --repo pointing at it"
+
+# --- 4. no HOLD line survives anywhere --------------------------------------
+grep -q 'cross-repo gh scoping is unfinished' "$DLOG" \
+  && fail "the dispatcher still emits the sp-9421b9b7 HOLD; ASK-738 was supposed to remove it"
+ok "the sp-9421b9b7 HOLD no longer fires"
+
+echo "PASS ($PASS checks) test-dispatch-client-refusal-after-hold.sh"

--- a/q-system/.q-system/scripts/test/test-gh-repo-scope-converge.sh
+++ b/q-system/.q-system/scripts/test/test-gh-repo-scope-converge.sh
@@ -1,0 +1,150 @@
+#!/usr/bin/env bash
+# Reproducer + acceptance for call site 2 of ASK-738: converge.sh resolves the
+# PR from the CWD's repo, not from the repo the work is in.
+#
+# THE DEFECT: converge.sh:68
+#   pr_for_branch() { gh pr list --head "$BRANCH" --json number -q '.[0].number'; }
+# runs with no `cd` and no `-R`, so it inherits kipi-dispatch.sh's cwd (the home
+# checkout, kipi-dispatch.sh:205). After linear-worker.sh opens a PR in the
+# TARGET repo, converge asks the HOME repo whether that branch has a PR, gets
+# nothing, and stops -- the convergence loop never runs a second round on any
+# repo but its own. `pr_head_sha` (pr-verdict-lib.sh) has the same shape.
+#
+# WHY --dry IS THE DRIVER. --dry is the shortest path that calls pr_for_branch
+# for real, with no agent spend and no network. The subject is which repository
+# the call resolves to, and --dry resolves it exactly the way a live round does
+# because it is the same function.
+#
+# NEGATIVE SELF-TEST (case 0) proves the fake gh reports the HOME slug from the
+# home checkout before any assertion below is trusted.
+set -uo pipefail
+
+ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/../../../.." && pwd)"
+CONVERGE="$ROOT/q-system/.q-system/scripts/converge.sh"
+
+PASS=0
+fail() { echo "FAIL: $1" >&2; exit 1; }
+ok()   { PASS=$((PASS + 1)); echo "  ok: $1"; }
+
+[ -f "$CONVERGE" ] || fail "converge.sh does not exist at $CONVERGE"
+REAL_GIT="$(command -v git)" || fail "git not on PATH"
+
+WORK="$(mktemp -d)"
+trap 'rm -rf "$WORK"' EXIT
+unset KIPI_TARGET_REPO KIPI_LINEAR_CLAIMS 2>/dev/null || true
+
+G() { git -c user.email=t@t.t -c user.name=t "$@"; }
+STUB="$WORK/bin"; mkdir -p "$STUB" "$WORK/home"
+
+HOME_SLUG="assafkip/homerepo"
+TARGET_SLUG="assafkip/targetrepo"
+
+mkrepo() {  # mkrepo <dir> <name>  -- github-shaped origin, local transport
+  git init -q --bare "$WORK/origin-$2.git"
+  git -C "$WORK/origin-$2.git" symbolic-ref HEAD refs/heads/main
+  git init -q "$1"
+  git -C "$1" config "url.$WORK/origin-.insteadOf" "https://github.com/assafkip/"
+  G -C "$1" commit -q --allow-empty -m c1
+  git -C "$1" branch -M main
+  git -C "$1" remote add origin "https://github.com/assafkip/$2.git"
+  git -C "$1" push -q -u origin main
+}
+mkrepo "$WORK/skel"   homerepo
+mkrepo "$WORK/target" targetrepo
+
+GH_LOG="$WORK/gh-resolved.txt"; : > "$GH_LOG"
+cat > "$STUB/gh" <<EOF
+#!/usr/bin/env bash
+R=""; prev=""
+for a in "\$@"; do
+  case "\$prev" in -R|--repo) R="\$a" ;; esac
+  prev="\$a"
+done
+if [ -z "\$R" ]; then
+  # config --get, not \`remote get-url\`: get-url applies insteadOf rewriting.
+  url="\$("$REAL_GIT" config --get remote.origin.url 2>/dev/null)"
+  R="\${url#https://github.com/}"; R="\${R%.git}"
+  [ "\$R" = "\$url" ] && R="UNRESOLVED"
+fi
+printf '%s\t%s\n' "\$R" "\$*" >> "$GH_LOG"
+# A PR exists in whichever repo is asked, so a leak is visible as a WRONG
+# SUBJECT rather than as an empty answer that could have many causes.
+case "\$*" in
+  *"pr list"*)  echo 42 ;;
+  *"pr view"*)  echo deadbeefdeadbeefdeadbeefdeadbeefdeadbeef ;;
+esac
+exit 0
+EOF
+chmod +x "$STUB/gh"
+export PATH="$STUB:$PATH"
+[ "$(command -v git)" = "$REAL_GIT" ] || fail "git was shadowed by a stub"
+
+cat > "$WORK/skel/instance-registry.json" <<JSON
+{"instances":[
+  {"name":"targetproj","path":"$WORK/target","has_git":true,
+   "dispatch":{"enabled":true,"expected_remote":"https://github.com/assafkip/targetrepo.git"}}
+]}
+JSON
+
+# ===========================================================================
+# CASE 0 -- NEGATIVE SELF-TEST
+# ===========================================================================
+( cd "$WORK/skel" && gh pr list --head probe --json number >/dev/null 2>&1 )
+SELF="$(awk -F'\t' '$2 ~ /--head probe/ {print $1}' "$GH_LOG" | head -1)"
+[ "$SELF" = "$HOME_SLUG" ] \
+  || fail "negative self-test: unqualified gh from the home checkout resolved to '${SELF:-<nothing logged>}', expected $HOME_SLUG. The fake is not reproducing gh's cwd binding."
+ok "negative self-test: unqualified gh from the home checkout resolves to $HOME_SLUG"
+: > "$GH_LOG"
+
+# ===========================================================================
+# CASE 1 -- pr_for_branch, run from HOME with the work in the TARGET
+# ===========================================================================
+# KIPI_TARGET_REPO is the carrier kipi-dispatch.sh uses to reach converge: it
+# forwards only its own arguments to the worker, so the target crosses that
+# boundary by inheritance.
+( cd "$WORK/skel" \
+  && HOME="$WORK/home" KIPI_SKEL="$WORK/skel" KIPI_STATE_DIR="$WORK/state" \
+     KIPI_NOTIFY="/usr/bin/true" KIPI_TARGET_REPO="$WORK/target" \
+     bash "$CONVERGE" --issue ASK-AAA --dry ) >"$WORK/run.out" 2>&1
+RC=$?
+
+echo "  [ctx] cwd during the run: $WORK/skel (slug $HOME_SLUG)"
+echo "  [ctx] KIPI_TARGET_REPO:   $WORK/target (slug $TARGET_SLUG)"
+echo "  [ctx] converge rc: $RC"
+echo "  [ctx] converge said: $(tail -1 "$WORK/run.out")"
+
+SLUGS="$(awk -F'\t' '$2 ~ /pr list/ {print $1}' "$GH_LOG" | sort -u)"
+[ -n "$SLUGS" ] \
+  || fail "converge made NO 'gh pr list' call (rc=$RC). The reproducer never reached pr_for_branch. Output:
+$(tail -15 "$WORK/run.out")"
+
+if printf '%s\n' "$SLUGS" | grep -qx "$HOME_SLUG"; then
+  fail "CROSS-REPO LEAK at converge.sh:68 -- pr_for_branch resolved to the HOME repo ($HOME_SLUG) while the work is in $TARGET_SLUG.
+      This is why converge finds no PR after the worker opens one in the target.
+      gh calls:
+$(sed 's/^/        /' "$GH_LOG")"
+fi
+[ "$SLUGS" = "$TARGET_SLUG" ] \
+  || fail "pr_for_branch resolved to '$SLUGS', expected exactly $TARGET_SLUG"
+ok "pr_for_branch is scoped to the target repo ($TARGET_SLUG)"
+
+# --- 2. no call in the run falls back to cwd --------------------------------
+LEAKED="$(awk -F'\t' -v h="$HOME_SLUG" '$1 == h' "$GH_LOG")"
+[ -z "$LEAKED" ] \
+  || fail "some gh call in converge still resolves to the HOME repo:
+$(printf '%s\n' "$LEAKED" | sed 's/^/        /')"
+ok "no gh call in the converge run fell back to cwd"
+
+# --- 3. no --repo / no KIPI_TARGET_REPO still resolves home -----------------
+: > "$GH_LOG"
+( cd "$WORK/skel" \
+  && HOME="$WORK/home" KIPI_SKEL="$WORK/skel" KIPI_STATE_DIR="$WORK/state2" \
+     KIPI_NOTIFY="/usr/bin/true" \
+     bash "$CONVERGE" --issue ASK-BBB --dry ) >"$WORK/run2.out" 2>&1
+HOME_SLUGS="$(awk -F'\t' '$2 ~ /pr list/ {print $1}' "$GH_LOG" | sort -u)"
+[ "$HOME_SLUGS" = "$HOME_SLUG" ] \
+  || fail "an unscoped converge run resolved to '${HOME_SLUGS:-<nothing>}', expected the home slug $HOME_SLUG:
+$(tail -10 "$WORK/run2.out")"
+ok "an unscoped run still resolves to the home repo ($HOME_SLUG)"
+
+echo "PASS ($PASS checks) test-gh-repo-scope-converge.sh"

--- a/q-system/.q-system/scripts/test/test-gh-repo-scope-reviewer.sh
+++ b/q-system/.q-system/scripts/test/test-gh-repo-scope-reviewer.sh
@@ -1,0 +1,198 @@
+#!/usr/bin/env bash
+# Reproducer + acceptance for call site 3 of ASK-738, the one that can approve
+# the WRONG CODE: pr-review-agent.sh reviews the repo the SCRIPT lives in, not
+# the repo the WORK is in.
+#
+# THE DEFECT: pr-review-agent.sh:66-67 derives
+#   SKEL="$(cd "$SCRIPT_DIR/../../.." && pwd)"
+# from BASH_SOURCE, so the review root follows the CODE. Every `gh` call is
+# additionally unqualified, so the PR metadata comes from whatever repo the cwd
+# points at. Dispatch a review of PR #42 in a target repo and both halves answer
+# about the home repo instead. If #42 EXISTS at home -- and on a busy repo it
+# does -- the reviewer reads home's tree, pins home's head sha, and posts a
+# verdict and a `kipi/reviewer-approved` commit status. The wrong repo's code is
+# reviewed and gets the verdict, with provenance that looks authoritative.
+#
+# THIS TEST MAKES THAT COLLISION CONCRETE rather than asserting an argv shape:
+# PR #42 exists in BOTH repos at DIFFERENT head shas. The question the assertion
+# asks is "whose commit did the reviewer pin?", which has exactly one right
+# answer and is not satisfiable by accident.
+#
+# WHY A COPIED SKELETON. SKEL comes from the script's own location, so the only
+# way to observe the derivation is to run a copy that lives in a fixture repo.
+# The copy is byte-identical (cp of the shipping file), so this is the real
+# script, not a rewrite of it.
+set -uo pipefail
+
+ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/../../../.." && pwd)"
+SRC_DIR="$ROOT/q-system/.q-system/scripts"
+
+PASS=0
+fail() { echo "FAIL: $1" >&2; exit 1; }
+ok()   { PASS=$((PASS + 1)); echo "  ok: $1"; }
+
+[ -f "$SRC_DIR/pr-review-agent.sh" ] || fail "pr-review-agent.sh missing at $SRC_DIR"
+REAL_GIT="$(command -v git)" || fail "git not on PATH"
+
+WORK="$(mktemp -d)"
+trap 'rm -rf "$WORK"' EXIT
+unset KIPI_TARGET_REPO KIPI_REVIEW_ENGINE 2>/dev/null || true
+
+G() { git -c user.email=t@t.t -c user.name=t "$@"; }
+STUB="$WORK/bin"; mkdir -p "$STUB" "$WORK/home"
+
+HOME_SLUG="assafkip/homerepo"
+TARGET_SLUG="assafkip/targetrepo"
+
+# --- two repos, each with a DISTINCT commit that could be "PR #42" ----------
+mkrepo() {  # mkrepo <dir> <name> <marker-file>
+  git init -q --bare "$WORK/origin-$2.git"
+  git -C "$WORK/origin-$2.git" symbolic-ref HEAD refs/heads/main
+  git init -q "$1"
+  git -C "$1" config "url.$WORK/origin-.insteadOf" "https://github.com/assafkip/"
+  echo "$3" > "$1/WHOSE_CODE.txt"
+  G -C "$1" add -A; G -C "$1" commit -q -m "c1 in $2"
+  git -C "$1" branch -M main
+  git -C "$1" remote add origin "https://github.com/assafkip/$2.git"
+  git -C "$1" push -q -u origin main
+}
+# The skeleton must carry the control code 3 levels down, or the script's own
+# repo-root guard refuses before anything under test runs.
+mkdir -p "$WORK/skel/q-system/.q-system/scripts"
+mkrepo "$WORK/skel"   homerepo   HOME_REPO_CODE
+mkrepo "$WORK/target" targetrepo TARGET_REPO_CODE
+cp "$SRC_DIR/pr-review-agent.sh" "$SRC_DIR/pr-verdict-lib.sh" "$WORK/skel/q-system/.q-system/scripts/"
+# The new shared derivation, if it exists yet, must travel with the copy.
+[ -f "$SRC_DIR/repo-slug-lib.sh" ] && cp "$SRC_DIR/repo-slug-lib.sh" "$WORK/skel/q-system/.q-system/scripts/"
+G -C "$WORK/skel" add -A; G -C "$WORK/skel" commit -q -m "control code"
+git -C "$WORK/skel" push -q origin main
+AGENT="$WORK/skel/q-system/.q-system/scripts/pr-review-agent.sh"
+
+cat > "$WORK/skel/instance-registry.json" <<JSON
+{"instances":[
+  {"name":"targetproj","path":"$WORK/target","has_git":true,
+   "dispatch":{"enabled":true,"expected_remote":"https://github.com/assafkip/targetrepo.git"}}
+]}
+JSON
+
+SHA_HOME="$(git -C "$WORK/skel" rev-parse HEAD)"
+SHA_TARGET="$(git -C "$WORK/target" rev-parse HEAD)"
+[ "$SHA_HOME" != "$SHA_TARGET" ] || fail "fixture: both repos landed on the same sha, the collision is not observable"
+
+# --- fake gh: cwd-bound like the real one, answers PER RESOLVED REPO --------
+GH_LOG="$WORK/gh-resolved.txt"; : > "$GH_LOG"
+cat > "$STUB/gh" <<EOF
+#!/usr/bin/env bash
+R=""; prev=""
+for a in "\$@"; do
+  case "\$prev" in -R|--repo) R="\$a" ;; esac
+  prev="\$a"
+done
+if [ -z "\$R" ]; then
+  url="\$("$REAL_GIT" config --get remote.origin.url 2>/dev/null)"
+  R="\${url#https://github.com/}"; R="\${R%.git}"
+  [ "\$R" = "\$url" ] && R="UNRESOLVED"
+fi
+printf '%s\t%s\n' "\$R" "\$*" >> "$GH_LOG"
+# PR #42 EXISTS IN BOTH REPOS, at different heads. This is the collision.
+case "\$R" in
+  "$HOME_SLUG")   SHA="$SHA_HOME";   T="PR 42 in the HOME repo" ;;
+  "$TARGET_SLUG") SHA="$SHA_TARGET"; T="PR 42 in the TARGET repo (ASK-AAA)" ;;
+  *)              exit 1 ;;
+esac
+case "\$*" in
+  *"pr view"*"headRefOid"*) printf '%s\t%s\n' "\$SHA" "\$T" ;;
+  *"pr diff"*)              echo "diff --git a/WHOSE_CODE.txt b/WHOSE_CODE.txt" ;;
+  *"api"*)                  echo '{}' ;;
+esac
+exit 0
+EOF
+chmod +x "$STUB/gh"
+
+# No model may run. Both engines are stubbed; a real one would be spend + network.
+for e in codex claude; do
+  printf '#!/usr/bin/env bash\necho "STUB %s ran"\nexit 0\n' "$e" > "$STUB/$e"
+  chmod +x "$STUB/$e"
+done
+export PATH="$STUB:$PATH"
+[ "$(command -v git)" = "$REAL_GIT" ] || fail "git was shadowed by a stub"
+
+# ===========================================================================
+# CASE 0 -- NEGATIVE SELF-TEST: the fake really does bind to cwd, and really
+# does hand back a DIFFERENT sha per repo.
+# ===========================================================================
+P_HOME="$( cd "$WORK/skel"   && gh pr view 42 --json headRefOid,title -q '.headRefOid' 2>/dev/null | cut -f1 )"
+P_TGT="$(  cd "$WORK/target" && gh pr view 42 --json headRefOid,title -q '.headRefOid' 2>/dev/null | cut -f1 )"
+[ "$P_HOME" = "$SHA_HOME" ] \
+  || fail "negative self-test: gh from the home checkout returned '${P_HOME:-<nothing>}', expected $SHA_HOME"
+[ "$P_TGT" = "$SHA_TARGET" ] \
+  || fail "negative self-test: gh from the target checkout returned '${P_TGT:-<nothing>}', expected $SHA_TARGET"
+ok "negative self-test: PR #42 resolves to two different heads in the two repos"
+: > "$GH_LOG"
+
+# ===========================================================================
+# CASE 1 -- review PR #42 of the TARGET, dispatched from the HOME cwd
+# ===========================================================================
+( cd "$WORK/skel" \
+  && HOME="$WORK/home" KIPI_STATE_DIR="$WORK/state" KIPI_NOTIFY="/usr/bin/true" \
+     KIPI_TARGET_REPO="$WORK/target" \
+     bash "$AGENT" 42 --issue ASK-AAA --engine codex ) >"$WORK/run.out" 2>&1
+RC=$?
+
+echo "  [ctx] cwd during the run: $WORK/skel (slug $HOME_SLUG, head ${SHA_HOME:0:8})"
+echo "  [ctx] repo under review:  $WORK/target (slug $TARGET_SLUG, head ${SHA_TARGET:0:8})"
+echo "  [ctx] reviewer rc: $RC"
+
+VIEW_SLUGS="$(awk -F'\t' '$2 ~ /pr view/ {print $1}' "$GH_LOG" | sort -u)"
+[ -n "$VIEW_SLUGS" ] \
+  || fail "the reviewer made NO 'gh pr view' call (rc=$RC). It never reached the metadata read. Output:
+$(tail -20 "$WORK/run.out")"
+
+if printf '%s\n' "$VIEW_SLUGS" | grep -qx "$HOME_SLUG"; then
+  fail "WRONG-REPO REVIEW at pr-review-agent.sh -- the PR metadata read resolved to the HOME repo ($HOME_SLUG) while the work is in $TARGET_SLUG.
+      PR #42 exists in BOTH. The reviewer is about to read home's code and stamp a verdict on it as if it were the target's PR.
+      gh calls:
+$(sed 's/^/        /' "$GH_LOG")"
+fi
+[ "$VIEW_SLUGS" = "$TARGET_SLUG" ] \
+  || fail "the PR metadata read resolved to '$VIEW_SLUGS', expected exactly $TARGET_SLUG"
+ok "the PR metadata read is scoped to the repo under review ($TARGET_SLUG)"
+
+# --- 2. THE SHA THE VERDICT WILL CARRY --------------------------------------
+# The slug assertion above proves which repo was ASKED. This proves which repo's
+# COMMIT the run adopted -- the thing the verdict record and the commit status
+# are stamped with.
+PINNED="$(grep -o 'head sha under review: [0-9a-f]*' "$WORK/run.out" | awk '{print $5}' | head -1)"
+[ -n "$PINNED" ] || fail "the run never printed a head sha under review:
+$(tail -20 "$WORK/run.out")"
+if [ "$PINNED" = "$SHA_HOME" ]; then
+  fail "FALSE PROVENANCE: the reviewer pinned the HOME repo's commit ($SHA_HOME) for a review of $TARGET_SLUG PR #42 (whose head is $SHA_TARGET).
+      A verdict written against this sha names a commit in a repository nobody asked about."
+fi
+[ "$PINNED" = "$SHA_TARGET" ] \
+  || fail "the reviewer pinned '$PINNED', which is neither repo's head (home $SHA_HOME, target $SHA_TARGET)"
+ok "the verdict is pinned to the TARGET repo's commit (${SHA_TARGET:0:8})"
+
+# --- 3. the tree it read from belongs to the target -------------------------
+# The review root follows the WORK, not the script. WHOSE_CODE.txt differs
+# between the repos, so the tree's own content answers this.
+TREE="$(grep -oE 'tree: [^ ]+' "$WORK/run.out" | head -1 | awk '{print $2}')"
+if [ -n "$TREE" ] && [ -f "$TREE/WHOSE_CODE.txt" ]; then
+  WHOSE="$(cat "$TREE/WHOSE_CODE.txt")"
+  [ "$WHOSE" = "TARGET_REPO_CODE" ] \
+    || fail "the reviewer read files from a tree containing '$WHOSE'; a review of $TARGET_SLUG must read TARGET_REPO_CODE. tree=$TREE"
+  ok "the review tree holds the TARGET repo's code ($TREE)"
+else
+  # Not a silent pass: say which branch ran, so a green line always names what
+  # it actually checked.
+  echo "  note: no isolated tree line in the output (reviewer took the fallback path); tree content not asserted this run"
+fi
+
+# --- 4. nothing in the run fell back to cwd ---------------------------------
+LEAKED="$(awk -F'\t' -v h="$HOME_SLUG" '$1 == h' "$GH_LOG")"
+[ -z "$LEAKED" ] \
+  || fail "some gh call in the reviewer still resolves to the HOME repo:
+$(printf '%s\n' "$LEAKED" | sed 's/^/        /')"
+ok "no gh call in the reviewer fell back to cwd"
+
+echo "PASS ($PASS checks) test-gh-repo-scope-reviewer.sh"

--- a/q-system/.q-system/scripts/test/test-gh-repo-scope-reviewer.sh
+++ b/q-system/.q-system/scripts/test/test-gh-repo-scope-reviewer.sh
@@ -195,4 +195,43 @@ LEAKED="$(awk -F'\t' -v h="$HOME_SLUG" '$1 == h' "$GH_LOG")"
 $(printf '%s\n' "$LEAKED" | sed 's/^/        /')"
 ok "no gh call in the reviewer fell back to cwd"
 
+# ===========================================================================
+# CASE 2 -- THE --repo FLAG, not the env var (PR #146 review, codex minor)
+# ===========================================================================
+# Case 1 drives KIPI_TARGET_REPO. Both forms feed one expression, so a bug that
+# breaks only the FLAG is invisible to it -- and there was one: the resolution
+# block sat ABOVE the argument loop, so it read TARGET_REPO_ARG before the loop
+# parsed it and before the initialiser reset it to empty. `--repo` fell through
+# to $SKEL silently. A flag with no test that exercises the flag is untested.
+#
+# The env var is explicitly UNSET here. Left set, this case would pass on the
+# broken order for exactly the reason case 1 did.
+: > "$GH_LOG"
+( cd "$WORK/skel" \
+  && env -u KIPI_TARGET_REPO \
+     HOME="$WORK/home2" KIPI_STATE_DIR="$WORK/state2" KIPI_NOTIFY="/usr/bin/true" \
+     bash "$AGENT" 42 --issue ASK-AAA --engine codex --repo "$WORK/target" \
+) >"$WORK/run-flag.out" 2>&1
+RC2=$?
+echo "  [ctx] --repo flag run (KIPI_TARGET_REPO unset), rc=$RC2"
+
+FLAG_SLUGS="$(awk -F'\t' '$2 ~ /pr view/ {print $1}' "$GH_LOG" | sort -u)"
+[ -n "$FLAG_SLUGS" ] \
+  || fail "the --repo run made no 'gh pr view' call (rc=$RC2):
+$(tail -20 "$WORK/run-flag.out")"
+if printf '%s\n' "$FLAG_SLUGS" | grep -qx "$HOME_SLUG"; then
+  fail "DEAD FLAG: --repo $WORK/target was accepted and IGNORED -- the run resolved to the HOME repo ($HOME_SLUG).
+      The resolution reads TARGET_REPO_ARG before the argument loop assigns it.
+      gh calls:
+$(sed 's/^/        /' "$GH_LOG")"
+fi
+[ "$FLAG_SLUGS" = "$TARGET_SLUG" ] \
+  || fail "the --repo run resolved to '$FLAG_SLUGS', expected $TARGET_SLUG"
+ok "the --repo FLAG scopes the review to the target ($TARGET_SLUG)"
+
+PINNED2="$(grep -o 'head sha under review: [0-9a-f]*' "$WORK/run-flag.out" | awk '{print $5}' | head -1)"
+[ "$PINNED2" = "$SHA_TARGET" ] \
+  || fail "the --repo run pinned '$PINNED2', expected the target's head $SHA_TARGET"
+ok "the --repo run pins the TARGET repo's commit"
+
 echo "PASS ($PASS checks) test-gh-repo-scope-reviewer.sh"

--- a/q-system/.q-system/scripts/test/test-gh-repo-scope-worker.sh
+++ b/q-system/.q-system/scripts/test/test-gh-repo-scope-worker.sh
@@ -1,0 +1,214 @@
+#!/usr/bin/env bash
+# Reproducer + acceptance for call site 1 of ASK-738: linear-worker.sh's
+# existing-PR lookup binds to the CWD's repo, not to --repo's target.
+#
+# THE DEFECT, measured 2026-08-13 before the fix:
+#   cwd = kipi-system checkout, TARGET_REPO=<other>  ->  gh answers about kipi-system
+#   cwd = <other>                                    ->  gh answers about <other>
+# `gh` resolves its repository from the process working directory and ignores
+# TARGET_REPO entirely. kipi-dispatch.sh:205 does `cd "$REPO"` and never leaves,
+# so `gh pr list --head "$BRANCH"` at linear-worker.sh:902 asks the HOME repo
+# whether the target's branch already has a PR. It answers about the wrong
+# repository, and every gate downstream of that answer (the severity floor, the
+# rework round, the reviewer invocation) inherits the wrong subject.
+#
+# WHY A FAKE gh AND NOT A REAL ONE. The subject is *which repository the call
+# resolves to*, which is a property of the argv and the cwd -- not of GitHub. A
+# fake that reproduces gh's own cwd-binding rule (read origin from cwd when no
+# -R is given) makes that property observable and keeps the test off the network.
+# The fake is deliberately FAITHFUL to the bug: with no -R it binds to cwd, so a
+# fix that merely moves the call inside a `cd` would also pass -- and that is a
+# real fix. What it cannot do is pass while the call stays unqualified from home.
+#
+# NEGATIVE SELF-TEST (case 0): the harness first proves the fake gh actually
+# reports the HOME slug when run unqualified from the home checkout. Without that,
+# a fake that silently failed to log anything would make every assertion below
+# vacuously true.
+#
+# Isolation: HOME / KIPI_SKEL / KIPI_STATE_DIR all inside a temp dir; python3,
+# gh, claude and the reviewer are stubbed. `git` stays REAL -- real remotes are
+# the subject.
+set -uo pipefail
+
+ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/../../../.." && pwd)"
+WORKER="$ROOT/q-system/.q-system/scripts/linear-worker.sh"
+
+PASS=0
+fail() { echo "FAIL: $1" >&2; exit 1; }
+ok()   { PASS=$((PASS + 1)); echo "  ok: $1"; }
+
+[ -f "$WORKER" ] || fail "linear-worker.sh does not exist at $WORKER"
+REAL_PY="$(command -v python3)" || fail "python3 not on PATH"
+REAL_GIT="$(command -v git)"    || fail "git not on PATH"
+
+WORK="$(mktemp -d)"
+trap 'rm -rf "$WORK"' EXIT
+unset KIPI_LINEAR_CLAIMS KIPI_SESSION_ID CLAUDE_SESSION_ID KIPI_TARGET_REPO 2>/dev/null || true
+
+G() { git -c user.email=t@t.t -c user.name=t "$@"; }
+STUB="$WORK/bin"; mkdir -p "$STUB" "$WORK/home"
+
+HOME_SLUG="assafkip/homerepo"
+TARGET_SLUG="assafkip/targetrepo"
+
+# --- two real repos with two DIFFERENT origins ------------------------------
+#
+# THE ORIGIN URL MUST BE GITHUB-SHAPED *AND* FETCHABLE. The first cut pointed
+# origin at a real https://github.com/... URL, so the worker's own `git fetch`
+# guard exited 9 before the run ever reached the call site under test -- the
+# reproducer reported "no gh pr list call at all" instead of the leak. Pointing
+# origin at a local path instead would have made the slug a filesystem path and
+# tested a shape the shipping code never sees. `insteadOf` gets both: the
+# configured URL (what slug derivation reads) stays github.com, while the
+# transport is redirected to a bare repo on disk.
+mkrepo() {  # mkrepo <dir> <name>
+  git init -q --bare "$WORK/origin-$2.git"
+  git -C "$WORK/origin-$2.git" symbolic-ref HEAD refs/heads/main
+  git init -q "$1"
+  git -C "$1" config "url.$WORK/origin-.insteadOf" "https://github.com/assafkip/"
+  G -C "$1" commit -q --allow-empty -m c1
+  git -C "$1" branch -M main
+  git -C "$1" remote add origin "https://github.com/assafkip/$2.git"
+  git -C "$1" push -q -u origin main
+}
+mkrepo "$WORK/skel"   homerepo
+mkrepo "$WORK/target" targetrepo
+
+# --- the fake gh: reproduces gh's cwd binding, records what it resolved ------
+GH_LOG="$WORK/gh-resolved.txt"; : > "$GH_LOG"
+cat > "$STUB/gh" <<EOF
+#!/usr/bin/env bash
+# Faithful to real gh: -R/--repo wins; otherwise the repo comes from CWD.
+R=""
+prev=""
+for a in "\$@"; do
+  case "\$prev" in -R|--repo) R="\$a" ;; esac
+  prev="\$a"
+done
+if [ -z "\$R" ]; then
+  # config --get, not \`remote get-url\`: get-url APPLIES insteadOf rewriting, so
+  # under this fixture it returns the local bare path and the slug never forms.
+  # Measured here on first run. The raw configured value is what gh reports on.
+  url="\$("$REAL_GIT" config --get remote.origin.url 2>/dev/null)"
+  R="\${url#https://github.com/}"; R="\${R%.git}"
+  [ "\$R" = "\$url" ] && R="UNRESOLVED"
+fi
+printf '%s\t%s\n' "\$R" "\$*" >> "$GH_LOG"
+# No PR exists anywhere: the lookup returns empty and the worker moves on.
+exit 0
+EOF
+chmod +x "$STUB/gh"
+
+# Never let this suite reach the real reviewer (sp-cb48c3c0).
+cat > "$STUB/reviewer-noop" <<'NOOP'
+#!/usr/bin/env bash
+echo "  [stub reviewer] would review PR $1 ($*)"
+exit 0
+NOOP
+chmod +x "$STUB/reviewer-noop"
+printf '#!/usr/bin/env bash\nexit 0\n' > "$STUB/claude"; chmod +x "$STUB/claude"
+
+picker_stub() {
+  cat > "$STUB/python3" <<EOF
+#!/usr/bin/env bash
+case "\${1:-}" in
+  -)  cat >/dev/null
+      printf '%s\n' '$1'
+      exit 0 ;;
+  *linear-sync.py) exit 0 ;;
+esac
+exec "$REAL_PY" "\$@"
+EOF
+  chmod +x "$STUB/python3"
+}
+
+export PATH="$STUB:$PATH"
+[ "$(command -v git)" = "$REAL_GIT" ] || fail "git was shadowed by a stub; real remotes are the subject"
+
+# --- the registry that pins the target's remote -----------------------------
+# expected_remote is the ONE authority for the target slug (ASK-738 acceptance 2).
+cat > "$WORK/skel/instance-registry.json" <<JSON
+{"instances":[
+  {"name":"targetproj","path":"$WORK/target","has_git":true,
+   "dispatch":{"enabled":true,"expected_remote":"https://github.com/assafkip/targetrepo.git"}}
+]}
+JSON
+
+# ===========================================================================
+# CASE 0 -- NEGATIVE SELF-TEST: the fake gh really does bind to cwd
+# ===========================================================================
+# If this does not report the HOME slug, the fake is not reproducing the bug and
+# every assertion below would pass for the wrong reason.
+( cd "$WORK/skel" && gh pr list --head probe --json number >/dev/null 2>&1 )
+SELF="$(awk -F'\t' '$2 ~ /--head probe/ {print $1}' "$GH_LOG" | head -1)"
+[ "$SELF" = "$HOME_SLUG" ] \
+  || fail "negative self-test: an unqualified gh run from the home checkout resolved to '${SELF:-<nothing logged>}', expected $HOME_SLUG. The fake gh is not reproducing gh's cwd binding, so this suite proves nothing."
+ok "negative self-test: unqualified gh from the home checkout resolves to $HOME_SLUG"
+: > "$GH_LOG"
+
+# ===========================================================================
+# CASE 1 -- the existing-PR lookup, run from HOME against a --repo TARGET
+# ===========================================================================
+picker_stub '{"ready":[{"id":"ASK-AAA","title":"t","project":"targetproj"}],"total_open":1}'
+
+# cwd is the HOME checkout, which is exactly where kipi-dispatch.sh:205 leaves it.
+( cd "$WORK/skel" \
+  && HOME="$WORK/home" KIPI_SKEL="$WORK/skel" KIPI_STATE_DIR="$WORK/state" \
+     KIPI_NOTIFY="/usr/bin/true" KIPI_PR_REVIEWER="$STUB/reviewer-noop" \
+     KIPI_LINEAR_PROJECT="targetproj" \
+     bash "$WORKER" --apply --repo "$WORK/target" --issue ASK-AAA --limit 1 \
+) >"$WORK/run.out" 2>&1
+RC=$?
+
+# STATE THE TARGET'S IDENTITY WITH THE RESULT (a failed setup that relocates the
+# test is otherwise indistinguishable from a pass).
+echo "  [ctx] cwd during the run: $WORK/skel (slug $HOME_SLUG)"
+echo "  [ctx] --repo target:      $WORK/target (slug $TARGET_SLUG)"
+echo "  [ctx] worker rc: $RC"
+
+PRLIST_SLUGS="$(awk -F'\t' '$2 ~ /pr list/ {print $1}' "$GH_LOG" | sort -u)"
+[ -n "$PRLIST_SLUGS" ] \
+  || fail "the worker made NO 'gh pr list' call at all (rc=$RC). The reproducer never reached the call site it is about. Last output:
+$(tail -15 "$WORK/run.out")"
+
+if printf '%s\n' "$PRLIST_SLUGS" | grep -qx "$HOME_SLUG"; then
+  fail "CROSS-REPO LEAK at linear-worker.sh:902 -- the existing-PR lookup resolved to the HOME repo ($HOME_SLUG) while the work targets $TARGET_SLUG.
+      resolved slugs seen: $(printf '%s' "$PRLIST_SLUGS" | tr '\n' ' ')
+      gh calls:
+$(sed 's/^/        /' "$GH_LOG")"
+fi
+[ "$PRLIST_SLUGS" = "$TARGET_SLUG" ] \
+  || fail "the existing-PR lookup resolved to '$PRLIST_SLUGS', expected exactly $TARGET_SLUG"
+ok "the existing-PR lookup is scoped to the target repo ($TARGET_SLUG)"
+
+# --- 2. NO gh call in the whole run may fall back to cwd --------------------
+# The negative half of acceptance criterion 5: not just the one line, the chain.
+LEAKED="$(awk -F'\t' -v h="$HOME_SLUG" '$1 == h' "$GH_LOG")"
+[ -z "$LEAKED" ] \
+  || fail "some gh call in the dispatched chain still resolves to the HOME repo:
+$(printf '%s\n' "$LEAKED" | sed 's/^/        /')"
+UNRES="$(awk -F'\t' '$1 == "UNRESOLVED"' "$GH_LOG")"
+[ -z "$UNRES" ] \
+  || fail "a gh call resolved against no known origin (ran from a non-repo cwd):
+$(printf '%s\n' "$UNRES" | sed 's/^/        /')"
+ok "every gh call in the dispatched chain resolved to the target, none to cwd"
+
+# --- 3. the home repo still works when it IS the target ---------------------
+# A fix that hard-codes a slug, or that refuses when no registry row exists,
+# would break the only repo this loop runs in today. The home checkout carries no
+# registry row of its own, so this is the fallback path, asserted explicitly.
+: > "$GH_LOG"
+picker_stub '{"ready":[{"id":"ASK-BBB","title":"t","project":"homerepo"}],"total_open":1}'
+( cd "$WORK/skel" \
+  && HOME="$WORK/home" KIPI_SKEL="$WORK/skel" KIPI_STATE_DIR="$WORK/state3" \
+     KIPI_NOTIFY="/usr/bin/true" KIPI_PR_REVIEWER="$STUB/reviewer-noop" \
+     KIPI_LINEAR_PROJECT="homerepo" \
+     bash "$WORKER" --apply --issue ASK-BBB --limit 1 ) >"$WORK/run3.out" 2>&1
+
+HOME_PRLIST="$(awk -F'\t' '$2 ~ /pr list/ {print $1}' "$GH_LOG" | sort -u)"
+[ "$HOME_PRLIST" = "$HOME_SLUG" ] \
+  || fail "a no---repo run resolved to '${HOME_PRLIST:-<nothing>}', expected the home slug $HOME_SLUG. The fix must not break the repo the loop runs in today.
+$(tail -15 "$WORK/run3.out")"
+ok "a run with no --repo still resolves to the home repo ($HOME_SLUG)"
+
+echo "PASS ($PASS checks) test-gh-repo-scope-worker.sh"

--- a/q-system/.q-system/scripts/test/test-repo-preflight.sh
+++ b/q-system/.q-system/scripts/test/test-repo-preflight.sh
@@ -755,19 +755,43 @@ printf '%s' "$GOUT" | grep -q 'absent=' \
   || bad "the refusal does not distinguish absent files from unwired ones: $GOUT"
 
 echo
-echo "== 18. a non-home repo is NOT entered while gh scoping is unfinished =="
-# The rotation still offers it a turn, and the dispatcher still refuses to run an
-# agent in it. Selection being correct is not the same as execution being safe.
-grep -q 'sp-9421b9b7' "$DISPATCH" \
-  && ok "cross-repo entry is held against a captured spillover item" \
-  || bad "cross-repo entry has no captured blocker reference"
-HOLD_LINE="$(grep -n 'HOLD \$TARGET_NAME' "$DISPATCH" | head -1 | cut -d: -f1)"
-WORKLINE="$(grep -n 'bash ./kipi work' "$DISPATCH" | head -1 | cut -d: -f1)"
-{ [ -n "$HOLD_LINE" ] && [ -n "$WORKLINE" ] && [ "$HOLD_LINE" -lt "$WORKLINE" ]; } \
-  && ok "the hold is reached BEFORE any worker is invoked" \
-  || bad "the hold does not precede the worker call, so an agent could still start"
+echo "== 18. a non-home repo IS entered, and only downstream of preflight (ASK-738) =="
+# THIS CASE WAS INVERTED BY ASK-738, DELIBERATELY. It used to assert the presence of
+# the sp-9421b9b7 HOLD ("cross-repo gh scoping is unfinished"), which refused every
+# non-home repo unconditionally. That hold existed because `gh` binds to the process
+# cwd and ignored the target repo, so three call sites acted on kipi-system while
+# `git -C` worked in the target. That is fixed, so the hold is gone -- and a test
+# still asserting it would pin the defect the issue was chartered to remove.
+#
+# What replaces it is not "nothing". Entry is now gated by pick_list running the REAL
+# preflight (every check in this file) before any repo reaches the worker, and the
+# behavioural proof that a client repo is still refused with the hold gone lives in
+# test-dispatch-client-refusal-after-hold.sh, which drives the dispatcher for real and
+# asserts on argv. This case holds the SOURCE-SHAPE half: the wiring exists, and
+# nothing reaches the worker ahead of the gate.
+grep -q 'HOLD \$TARGET_NAME' "$DISPATCH" \
+  && bad "the sp-9421b9b7 HOLD is still in kipi-dispatch.sh; ASK-738 removed it" \
+  || ok "the sp-9421b9b7 blanket hold is gone"
 
-echo
+# THE HOLD WAS ALSO CARRYING WIRING THAT WAS NEVER POPULATED. WORK_ARGS was declared
+# empty and the hold exited above it, so deleting the hold alone would have dispatched
+# the TARGET's turn against the HOME repo -- consuming a client's rotation slot to run
+# kipi-system's queue. Both carriers are required: --repo is what the worker parses,
+# KIPI_TARGET_REPO is what crosses converge.sh (which forwards only its own args).
+grep -q 'WORK_ARGS="--repo' "$DISPATCH" \
+  && ok "cross-repo entry passes --repo to the worker" \
+  || bad "the hold is gone but WORK_ARGS is never populated, so a target's turn would run the HOME repo's queue"
+grep -q 'export KIPI_TARGET_REPO=' "$DISPATCH" \
+  && ok "cross-repo entry exports KIPI_TARGET_REPO for converge" \
+  || bad "KIPI_TARGET_REPO is not exported, so the worker targets the repo and converge does not"
+
+# ORDER IS THE SAFETY PROPERTY, and it is the one thing the old case got right.
+PFLINE="$(grep -n 'bash "\$PREFLIGHT"' "$DISPATCH" | head -1 | cut -d: -f1)"
+WORKLINE="$(grep -n 'bash ./kipi work' "$DISPATCH" | head -1 | cut -d: -f1)"
+{ [ -n "$PFLINE" ] && [ -n "$WORKLINE" ] && [ "$PFLINE" -lt "$WORKLINE" ]; } \
+  && ok "the preflight is reached BEFORE any worker is invoked" \
+  || bad "the preflight does not precede the worker call, so an agent could start in an unvetted repo"
+
 echo "== 19. a CLIENT ENGAGEMENT repo is refused even when opted in (ASK-741) =="
 # Founder decision 2026-08-13: "no. unattended agents should not reach a client repo."
 #

--- a/q-system/.q-system/scripts/test/test-review-artifact-repo-keyed.sh
+++ b/q-system/.q-system/scripts/test/test-review-artifact-repo-keyed.sh
@@ -1,0 +1,165 @@
+#!/usr/bin/env bash
+# Reproducer + acceptance for ASK-738 criterion 3: review artifacts are keyed by
+# pr-<number> alone, so two repos with the same PR number consume each other's
+# records.
+#
+# THE DEFECT: pr-review-agent.sh writes
+#   $VERDICT_DIR/pr-<N>.verdict.json          (the record the gates read)
+#   $ENGINE_DIR/pr-<N>-<timestamp>.md         (the review prose + round counter)
+#   $HOME/.config/kipi/review-trees/pr-<N>    (the isolated tree)
+# and converge.sh:41 / linear-worker.sh:96 read $STATE_DIR/pr-reviews/pr-<N>.verdict.json.
+# Every one of those paths is keyed by PR NUMBER ONLY, in one shared state dir.
+# PR #42 in kipi-system and PR #42 in a client repo are the same three paths.
+#
+# WHAT THAT COSTS: the second review overwrites the first, so the worker's
+# severity-floor gate can read an APPROVE earned by a different repository's code
+# and skip the rework round -- or arm auto-merge on the strength of it. The
+# review-trees collision is worse still: one detached worktree path, re-checked
+# out to a sha from whichever repo asked last.
+#
+# THIS TEST DRIVES THE REAL WRITER twice, once per repo, same PR number, and
+# asks whether both records survive AND whether each one carries its own repo's
+# commit. Asserting file COUNT alone would pass on a writer that kept two files
+# with the wrong contents, so the sha is asserted per record.
+set -uo pipefail
+
+ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/../../../.." && pwd)"
+SRC_DIR="$ROOT/q-system/.q-system/scripts"
+
+PASS=0
+fail() { echo "FAIL: $1" >&2; exit 1; }
+ok()   { PASS=$((PASS + 1)); echo "  ok: $1"; }
+
+REAL_GIT="$(command -v git)" || fail "git not on PATH"
+WORK="$(mktemp -d)"
+trap 'rm -rf "$WORK"' EXIT
+unset KIPI_TARGET_REPO KIPI_REVIEW_ENGINE 2>/dev/null || true
+
+G() { git -c user.email=t@t.t -c user.name=t "$@"; }
+STUB="$WORK/bin"; mkdir -p "$STUB" "$WORK/home"
+
+SLUG_A="assafkip/repo-alpha"
+SLUG_B="assafkip/repo-beta"
+
+mkrepo() {  # mkrepo <dir> <name> <marker>
+  git init -q --bare "$WORK/origin-$2.git"
+  git -C "$WORK/origin-$2.git" symbolic-ref HEAD refs/heads/main
+  git init -q "$1"
+  git -C "$1" config "url.$WORK/origin-.insteadOf" "https://github.com/assafkip/"
+  echo "$3" > "$1/WHOSE_CODE.txt"
+  G -C "$1" add -A; G -C "$1" commit -q -m "c1 $2"
+  git -C "$1" branch -M main
+  git -C "$1" remote add origin "https://github.com/assafkip/$2.git"
+  git -C "$1" push -q -u origin main
+}
+mkdir -p "$WORK/skel/q-system/.q-system/scripts"
+mkrepo "$WORK/skel"  repo-alpha ALPHA_CODE
+mkrepo "$WORK/beta"  repo-beta  BETA_CODE
+cp "$SRC_DIR/pr-review-agent.sh" "$SRC_DIR/pr-verdict-lib.sh" "$WORK/skel/q-system/.q-system/scripts/"
+[ -f "$SRC_DIR/repo-slug-lib.sh" ] && cp "$SRC_DIR/repo-slug-lib.sh" "$WORK/skel/q-system/.q-system/scripts/"
+G -C "$WORK/skel" add -A; G -C "$WORK/skel" commit -q -m "control code"
+git -C "$WORK/skel" push -q origin main
+AGENT="$WORK/skel/q-system/.q-system/scripts/pr-review-agent.sh"
+
+cat > "$WORK/skel/instance-registry.json" <<JSON
+{"instances":[
+  {"name":"beta","path":"$WORK/beta","has_git":true,
+   "dispatch":{"enabled":true,"expected_remote":"https://github.com/assafkip/repo-beta.git"}}
+]}
+JSON
+
+SHA_A="$(git -C "$WORK/skel" rev-parse HEAD)"
+SHA_B="$(git -C "$WORK/beta" rev-parse HEAD)"
+[ "$SHA_A" != "$SHA_B" ] || fail "fixture: both repos share a sha, the collision is not observable"
+
+GH_LOG="$WORK/gh.txt"; : > "$GH_LOG"
+cat > "$STUB/gh" <<EOF
+#!/usr/bin/env bash
+R=""; prev=""
+for a in "\$@"; do
+  case "\$prev" in -R|--repo) R="\$a" ;; esac
+  prev="\$a"
+done
+if [ -z "\$R" ]; then
+  url="\$("$REAL_GIT" config --get remote.origin.url 2>/dev/null)"
+  R="\${url#https://github.com/}"; R="\${R%.git}"
+  [ "\$R" = "\$url" ] && R="UNRESOLVED"
+fi
+printf '%s\t%s\n' "\$R" "\$*" >> "$GH_LOG"
+case "\$R" in
+  "$SLUG_A") SHA="$SHA_A"; T="PR 42 alpha" ;;
+  "$SLUG_B") SHA="$SHA_B"; T="PR 42 beta"  ;;
+  *) exit 1 ;;
+esac
+case "\$*" in
+  *"pr view"*"headRefOid"*) printf '%s\t%s\n' "\$SHA" "\$T" ;;
+  *"pr diff"*)              echo "diff --git a/WHOSE_CODE.txt b/WHOSE_CODE.txt" ;;
+  *"api"*)                  echo '{}' ;;
+esac
+exit 0
+EOF
+chmod +x "$STUB/gh"
+for e in codex claude; do
+  printf '#!/usr/bin/env bash\necho "STUB %s"\nexit 0\n' "$e" > "$STUB/$e"; chmod +x "$STUB/$e"
+done
+export PATH="$STUB:$PATH"
+
+run_review() {  # run_review <repo-path> <outfile>
+  ( cd "$WORK/skel" \
+    && HOME="$WORK/home" KIPI_STATE_DIR="$WORK/state" KIPI_NOTIFY="/usr/bin/true" \
+       KIPI_TARGET_REPO="$1" \
+       bash "$AGENT" 42 --issue ASK-AAA --engine codex ) >"$2" 2>&1
+}
+
+# ===========================================================================
+# The two runs: SAME PR NUMBER, two different repositories.
+# ===========================================================================
+run_review "$WORK/skel" "$WORK/run-a.out"; RC_A=$?
+run_review "$WORK/beta" "$WORK/run-b.out"; RC_B=$?
+echo "  [ctx] run A: repo $WORK/skel (slug $SLUG_A, head ${SHA_A:0:8}) rc=$RC_A"
+echo "  [ctx] run B: repo $WORK/beta (slug $SLUG_B, head ${SHA_B:0:8}) rc=$RC_B"
+
+RECORDS="$(find "$WORK/home/.config/kipi/pr-reviews" -name '*.verdict.json' 2>/dev/null | sort)"
+echo "  [ctx] verdict records on disk:"
+printf '%s\n' "${RECORDS:-  <none>}" | sed 's/^/        /'
+
+[ -n "$RECORDS" ] \
+  || fail "neither run wrote a verdict record; the collision cannot be judged.
+      run A tail: $(tail -5 "$WORK/run-a.out")
+      run B tail: $(tail -5 "$WORK/run-b.out")"
+
+# --- 1. both repos' records survive ----------------------------------------
+COUNT="$(printf '%s\n' "$RECORDS" | grep -c .)"
+[ "$COUNT" -ge 2 ] \
+  || fail "ARTIFACT COLLISION: two reviews of PR #42 in two different repositories left $COUNT verdict record(s).
+      The second overwrote the first. A gate reading this record cannot tell whose code earned the verdict.
+      records: $(printf '%s' "$RECORDS" | tr '\n' ' ')"
+ok "two repos' PR #42 records both survive ($COUNT records)"
+
+# --- 2. each record carries ITS OWN repo's commit ---------------------------
+# Count alone would pass on a writer that kept two files with swapped contents.
+FOUND_A=0; FOUND_B=0
+while IFS= read -r rec; do
+  [ -n "$rec" ] || continue
+  S="$(python3 -c 'import json,sys; print(json.load(open(sys.argv[1])).get("head_sha",""))' "$rec" 2>/dev/null)"
+  [ "$S" = "$SHA_A" ] && FOUND_A=1
+  [ "$S" = "$SHA_B" ] && FOUND_B=1
+done <<< "$RECORDS"
+[ "$FOUND_A" = "1" ] || fail "no verdict record carries repo-alpha's head $SHA_A"
+[ "$FOUND_B" = "1" ] || fail "no verdict record carries repo-beta's head $SHA_B"
+ok "each record carries its own repo's head sha"
+
+# --- 3. the isolated review trees do not share one path ---------------------
+TREES="$(find "$WORK/home/.config/kipi/review-trees" -maxdepth 2 -name '.git' 2>/dev/null | wc -l | tr -d ' ')"
+TREE_A="$(grep -oE 'tree: [^ ]+' "$WORK/run-a.out" | head -1 | awk '{print $2}')"
+TREE_B="$(grep -oE 'tree: [^ ]+' "$WORK/run-b.out" | head -1 | awk '{print $2}')"
+if [ -n "$TREE_A" ] && [ -n "$TREE_B" ]; then
+  [ "$TREE_A" != "$TREE_B" ] \
+    || fail "TREE COLLISION: both repos' PR #42 reviews used the same worktree path $TREE_A.
+      One detached tree re-checked out to whichever repo asked last is a review reading the wrong repository's files."
+  ok "the two repos' review trees are distinct paths"
+else
+  echo "  note: one or both runs took the non-isolated fallback (A='${TREE_A:-none}' B='${TREE_B:-none}'); tree paths not asserted"
+fi
+
+echo "PASS ($PASS checks) test-review-artifact-repo-keyed.sh"

--- a/q-system/.q-system/scripts/test/test-review-degraded-provenance.sh
+++ b/q-system/.q-system/scripts/test/test-review-degraded-provenance.sh
@@ -25,6 +25,10 @@
 # assertion and it is the one a careless consumer would break.
 set -uo pipefail
 
+# _SD locates the scripts dir for the lib the extracted writer block needs.
+_SD="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+
+
 HERE="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 SCRIPTS="$(cd "$HERE/.." && pwd)"
 WORK="$(mktemp -d)"
@@ -86,6 +90,12 @@ run_writer() {  # run_writer <engine> <degraded> <verdict-dir> [writer-file]
     # silently record `usable: false` for every case and nobody would notice the
     # test had stopped matching the shipped arg list.
     REVIEW_USABLE=1
+    # The shipped script sources this before the writer block runs; the extracted
+    # copy needs it too or verdict_record_write_path is undefined and the record
+    # is never written (ASK-738). REVIEW_SLUG stays empty here, which is the
+    # legacy pr-<N> key -- repo keying has its own suite.
+    REVIEW_SLUG=""
+    . "$_SD/repo-slug-lib.sh"
     . "$writer"
   ) >/dev/null 2>&1
 }

--- a/q-system/.q-system/scripts/test/test-review-tree-guard.sh
+++ b/q-system/.q-system/scripts/test/test-review-tree-guard.sh
@@ -52,10 +52,15 @@ mkdir -p "$S/test" "$W/bin" "$W/home"
 # The two scripts under test, from the working tree or from a ref. Both come from
 # the SAME source: the reviewer sources the lib, and mixing an old reviewer with a
 # new lib would test a combination that never shipped.
-for f in pr-review-agent.sh pr-verdict-lib.sh; do
+for f in pr-review-agent.sh pr-verdict-lib.sh repo-slug-lib.sh; do
   if [ -n "$REF" ]; then
-    git -C "$ROOT" show "$REF:q-system/.q-system/scripts/$f" > "$S/$f" \
-      || fail "cannot read $f at ref $REF"
+    # repo-slug-lib.sh did not exist before ASK-738, so a ref older than it has
+    # nothing to show. Fall back to the working-tree copy rather than failing:
+    # the hatch exists to run an OLD reviewer, and an old reviewer never sources
+    # this file, so the extra copy is inert there.
+    git -C "$ROOT" show "$REF:q-system/.q-system/scripts/$f" > "$S/$f" 2>/dev/null \
+      || cp "$SRC_SCRIPTS/$f" "$S/$f" \
+      || fail "cannot read $f at ref $REF or from the working tree"
   else
     cp "$SRC_SCRIPTS/$f" "$S/$f" || fail "cannot copy $f from the working tree"
   fi

--- a/q-system/.q-system/scripts/test/test-severity-floor.sh
+++ b/q-system/.q-system/scripts/test/test-severity-floor.sh
@@ -30,6 +30,9 @@
 set -uo pipefail
 ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/../../../.." && pwd)"
 LIB="$ROOT/q-system/.q-system/scripts/pr-verdict-lib.sh"
+. "$ROOT/q-system/.q-system/scripts/repo-slug-lib.sh"
+# The basename the reviewer will write for PR 901 in THIS repo.
+REC901="$(artifact_key "$(slug_for_repo "$ROOT")" 901).verdict.json"
 WORKER="$ROOT/q-system/.q-system/scripts/linear-worker.sh"
 REVIEWER="$ROOT/q-system/.q-system/scripts/pr-review-agent.sh"
 
@@ -862,7 +865,7 @@ EOF
 cat > "$SW/gh" <<EOF
 #!/usr/bin/env bash
 case "\$*" in
-  "pr view 901 --json"*) printf '$SHA_A\tpin the sha the review actually read\n' ;;
+  "pr view 901"*) printf '$SHA_A\tpin the sha the review actually read\n' ;;
   *) exit 1 ;;
 esac
 exit 0
@@ -880,7 +883,7 @@ chmod +x "$SW/python3" "$SW/gh" "$SW/claude"
 # "codex is not producing an independent review (PR #901)" to a capture endpoint.
 ( PATH="$SW:$PATH" HOME="$W2/home-writer" KIPI_NOTIFY="/usr/bin/true" \
   bash "$REVIEWER" 901 ) >"$W2/writer.out" 2>&1
-REC="$W2/home-writer/.config/kipi/pr-reviews/pr-901.verdict.json"
+REC="$W2/home-writer/.config/kipi/pr-reviews/$REC901"
 [ -s "$REC" ] \
   || fail "the reviewer wrote no verdict record at all. It said:
 $(sed 's/^/        /' "$W2/writer.out")"
@@ -1055,7 +1058,7 @@ run_status_reviewer "$N4" --post
 [ "$RC" = "0" ] \
   || fail "a failed status POST took the whole review down (exit $RC). The verdict record is the
       loop's hand-off; losing it to a transient GitHub error costs a full re-review."
-[ -s "$N4/home/.config/kipi/pr-reviews/pr-901.verdict.json" ] \
+[ -s "$N4/home/.config/kipi/pr-reviews/$REC901" ] \
   || fail "a failed status POST cost the verdict record, which converge.sh and linear-worker.sh
       both read"
 grep -q "$SHA_A" "$N4/err.txt" \
@@ -2108,7 +2111,7 @@ ok "an unusable codex answer is not laundered through the fallback"
 # Q1's fixture is the noisy one on purpose; this reads back what the parser
 # actually extracted from it, because a status assertion alone cannot tell
 # "the noise was ignored" from "the noise happened to be harmless".
-Q1_REVIEW="$(ls -t "$Q1/home/.config/kipi/pr-reviews/codex/pr-901-"*.md 2>/dev/null | head -1)"
+Q1_REVIEW="$(ls -t "$Q1/home/.config/kipi/pr-reviews/codex/${REC901%.verdict.json}-"*.md 2>/dev/null | head -1)"
 [ -n "$Q1_REVIEW" ] \
   || fail "the codex engine wrote no review file under pr-reviews/codex/, so nothing can be
       re-parsed. Tree was: $(find "$Q1/home/.config/kipi/pr-reviews" -type f 2>/dev/null | tr '\n' ' ')"
@@ -2237,10 +2240,10 @@ ok "an unknown PR sha warns and proceeds (a partial clone does not wedge the loo
 # globs pr-<N>-*.md -- count the EXISTING claude rounds as codex's own, arming the
 # anti-re-litigation rule a round early on every PR with review history. So the
 # round counters do not move even though the gate did.
-[ -n "$(ls "$Q7/home/.config/kipi/pr-reviews/pr-901-"*.md 2>/dev/null)" ] \
+[ -n "$(ls "$Q7/home/.config/kipi/pr-reviews/${REC901%.verdict.json}-"*.md 2>/dev/null)" ] \
   || fail "the claude engine stopped writing its review to pr-reviews/ ; the worker's
       \`ls pr-reviews/pr-<N>-*.md\` read would find nothing"
-[ -z "$(ls "$Q1/home/.config/kipi/pr-reviews/pr-901-"*.md 2>/dev/null)" ] \
+[ -z "$(ls "$Q1/home/.config/kipi/pr-reviews/${REC901%.verdict.json}-"*.md 2>/dev/null)" ] \
   || fail "a codex review landed in the CLAUDE review directory. review_round globs
       pr-901-*.md, so every codex run would advance the claude reviewer's round counter."
 ok "the engines keep separate review directories (round counters do not cross-count)"
@@ -2249,15 +2252,15 @@ ok "the engines keep separate review directories (round counters do not cross-co
 # linear-worker.sh:76 both read pr-<N>.verdict.json at the pr-reviews ROOT. Codex
 # is the engine that checks Sana's work, so codex writes THAT file -- and the
 # advisory claude engine must not, or two writers would answer for one gate.
-[ -s "$Q1/home/.config/kipi/pr-reviews/pr-901.verdict.json" ] \
+[ -s "$Q1/home/.config/kipi/pr-reviews/$REC901" ] \
   || fail "THE DEFECT: the codex engine wrote no verdict record at the pr-reviews ROOT, so the
       file converge.sh:36 and linear-worker.sh:76 gate the loop on is never written by the
       engine that actually reviewed. The loop would read a stale or absent verdict."
-[ ! -f "$Q7/home/.config/kipi/pr-reviews/pr-901.verdict.json" ] \
+[ ! -f "$Q7/home/.config/kipi/pr-reviews/$REC901" ] \
   || fail "the ADVISORY claude engine wrote the loop's verdict record (pr-901.verdict.json).
       Two engines answering for one gate is the single-writer defect this repo keeps finding;
       a Claude verdict would drive the loop that exists to be checked by another lab."
-[ -s "$Q7/home/.config/kipi/pr-reviews/claude/pr-901.verdict.json" ] \
+[ -s "$Q7/home/.config/kipi/pr-reviews/claude/$REC901" ] \
   || fail "the claude engine wrote no verdict record of its own, so its advisory opinion is not
       recorded anywhere a later run can read"
 ok "codex writes the loop's verdict record; claude records its advisory one beside its reviews"

--- a/q-system/.q-system/scripts/test/test-verdict-usability.sh
+++ b/q-system/.q-system/scripts/test/test-verdict-usability.sh
@@ -72,6 +72,11 @@ mkdir -p "$REPO_FIXTURE/q-system/.q-system/scripts"
 git -C "$REPO_FIXTURE" init -q 2>/dev/null || { echo "FATAL: could not git-init the fixture repo" >&2; exit 1; }
 cp "$AGENT" "$REPO_FIXTURE/q-system/.q-system/scripts/pr-review-agent.sh"
 cp "$LIB" "$REPO_FIXTURE/q-system/.q-system/scripts/pr-verdict-lib.sh"
+# The reviewer sources this too (ASK-738); without it every case refuses before
+# writing a record and the usable key reads as a constant rather than a bug here.
+# From the SCRIPTS DIR, not from $(dirname "$LIB"): $LIB is already a copy in a
+# temp dir, so deriving the sibling from it looks right and resolves to nothing.
+cp "$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)/repo-slug-lib.sh" "$REPO_FIXTURE/q-system/.q-system/scripts/repo-slug-lib.sh"
 AGENT="$REPO_FIXTURE/q-system/.q-system/scripts/pr-review-agent.sh"
 
 # --- stubs: the engine and gh are the seams, and both are stubbed ------------


### PR DESCRIPTION
## The defect, measured

`gh` resolves its repository from the **process working directory** and ignores every path variable this fleet carries. Measured 2026-08-13:

```
cwd = kipi-system checkout, TARGET_REPO=<other>  ->  assafkip/kipi-system
cwd = <other>                                    ->  assafkip/<other>
```

`kipi-dispatch.sh:205` does `cd "$REPO"` and never leaves. So `git -C` did the work in the target while `gh` answered about the home repo.

## The sharpest one: the wrong-repo failure ran through the gate itself

`gh api` **takes no `-R`**. It expands `{owner}/{repo}` from the cwd-resolved repo, and there is no flag to redirect it.

That is the call at `pr-review-agent.sh` `post_status()` which posts `kipi/reviewer-approved` — the **required check**. So the failure was not "a review looked at the wrong diff". It was: review the home repo's code, then post a green required check naming the home repo, for a PR in a different repository. The gate that exists to catch wrong code was itself the thing acting on the wrong repo, and every log line read normally.

Fixed by substituting the slug into the path (`repos/$STATUS_REPO_PATH/statuses/$sha`) rather than by a flag that does not exist.

## Three red-then-green reproducers, one per call site

Each drives the real script and asserts **which repository the call resolved to** — not an argv shape. Each carries a negative self-test proving the fake `gh` reproduces gh's own cwd binding first; without it, a fake that logged nothing would make every assertion vacuously true.

| Call site | Red output at `621a5b43` |
|---|---|
| `linear-worker.sh:902` | `pr list --head sana/ask-aaa` resolved to `assafkip/homerepo` while `--repo` pointed at `assafkip/targetrepo` |
| `converge.sh:68` | reported `pr=42` — the **home** repo's PR, for work in the target |
| `pr-review-agent.sh` | pinned the home repo's head for a review of the target's PR #42 (#42 exists in both, at different shas) |
| artifacts | two reviews of PR #42 in two repos left **one** record, `pr-42.verdict.json` |

## One derivation, one place

`repo-slug-lib.sh`. `sp-421fa27d` already records a duplicated project-name derivation here; a second copy of "which repository may an unattended self-merging agent act on" is not a style problem.

Authority order: the registry row's `dispatch.expected_remote` (the pin `repo-preflight.sh` already requires), then the **target path's** own origin — never cwd. The fallback exists for one case: the dispatcher's own checkout, which carries no registry row.

A pin that yields **no slug** also falls back, because an empty slug silently reverts every call to cwd binding — the defect returning as a quiet degradation instead of a loud one.

## Artifacts keyed by repo AND PR

`pr-<N>.verdict.json`, the review-prose stem and the detached worktree were one shared path per PR number. Two repos' PR #42 shared all three; the second review overwrote the first and a gate could read an `APPROVE` earned by another repository's code.

Reads keep a legacy `pr-<N>` fallback **inside the single resolver**, so the ~90 existing home-repo records do not read as unreviewed.

## The HOLD is gone, and it needed wiring

`WORK_ARGS` was declared empty and never populated — the HOLD exited above it. **Removing the HOLD alone would have dispatched the target's turn against the home repo**: the rotation consumes a client's turn and runs kipi-system's queue. Both carriers are set now (`--repo` for the worker, `KIPI_TARGET_REPO` for converge, which forwards only its own arguments).

**What protects client repos is not this line and never was.** Founder, 2026-08-13: *"no. unattended agents should not reach a client repo."* That is `repo-preflight.sh` check 0 (#144), which `pick_list` runs **before** any repo reaches the removed block. The HOLD was a blunt stand-in for a gate that did not exist yet.

`test-dispatch-client-refusal-after-hold.sh` drives the real dispatcher and asserts **both** directions, because either alone is worthless:

- a client-shaped repo with `dispatch.enabled: true` is refused and never reaches `kipi work` (asserted on **argv**, not a log line)
- an ordinary opted-in repo **is** entered, with `--repo` pointing at it

Without the second, the suite would pass on a dispatcher that refuses everything — which is exactly what the HOLD did while reporting healthy.

## Scope

- **No repo is opted in.** `dispatch.enabled` is still false on all 23 rows.
- **`KIPI_DISPATCH_MAX` untouched.** Per-repo concurrency follows from this work; changing that constant is a separate decision with its own evidence.
- 11 rows are client engagement repos and are refused regardless of opt-in. 12 would be reachable once the founder switches them on.

## Found by grepping, not by a failing test

The first cut patched **one** verdict-record read per script and left five others on the legacy path. That is worse than not keying at all: the resolver's legacy fallback means a **new** repo-keyed record is invisible to those readers, so a reviewed PR reads as unreviewed forever. The suites all passed because their fixtures happen to write legacy records.

## Flag position is load-bearing

`-R` first displaces `$1` in every positional `gh` stub in this suite; `-R` after the PR number breaks an exact-prefix glob. There is no position that satisfies all of them, so the stubs that assert argv were updated to the real shape rather than the fix bent around them.

## Spillover captured

- `sp-0ec964bb` — `repo-preflight.sh` keeps a private `slug_of()` while `repo-slug-lib.sh` is now the one derivation. Two parsers, and the preflight copy guards entry into client repos.
- `sp-72ee0308` — preflight check 4 uses `git remote get-url origin`, which **applies `insteadOf` rewriting**. On a box that mirrors github.com it would refuse every repo. Measured: it bit this PR's own fixture.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0151EYtGH6at3XTWqbBHAxEi
