### PR TITLE
Refuse the engagement root, opt in the first two repos, and stop the preflight inventing reasons (ASK-754, ASK-755)

### DIFF
--- a/instance-registry.json
+++ b/instance-registry.json
@@ -18,7 +18,11 @@
       "subtree_prefix": "q-system",
       "instance_q_dir": null,
       "type": "subtree",
-      "has_git": true
+      "has_git": true,
+      "dispatch": {
+        "enabled": true,
+        "expected_remote": "https://github.com/assafkip/ktlyst-saas-product.git"
+      }
     },
     {
       "name": "ASK_AI_consultant",
@@ -134,7 +138,11 @@
       "subtree_prefix": "q-system",
       "instance_q_dir": null,
       "type": "subtree",
-      "has_git": true
+      "has_git": true,
+      "dispatch": {
+        "enabled": true,
+        "expected_remote": "https://github.com/assafkip/kipi-interview-coach.git"
+      }
     },
     {
       "name": "negotiator",

--- a/kipi-dispatch.sh
+++ b/kipi-dispatch.sh
@@ -404,9 +404,15 @@ cursor_get() {
 #
 # OPT-IN IS DEFAULT OFF, AND STRICTLY SO: a row joins the fleet only when it
 # carries dispatch.enabled === true (JSON boolean). A missing dispatch key, false,
-# the string "true", or 1 all mean NO. Every one of the 23 rows in the shipped
-# registry is therefore off, which is the correct state to ship the dangerous piece
-# in -- the fleet stays exactly as it is today until a human opts a repo in by hand.
+# the string "true", or 1 all mean NO.
+#
+# The registry shipped with all 23 rows off, which was the correct state to ship the
+# dangerous piece in. Two are now on: ktlyst and interview-coach (ASK-754). Stating
+# the count here was a comment that had to be edited the first time anyone used the
+# feature it describes, so it names the opted-in rows instead -- and the authority is
+# the registry, not this line. Opt-in is still consent and never safety:
+# repo-preflight.sh is what decides whether entering one is safe NOW, and it refuses
+# a client engagement repo and the engagement root even when the row says true.
 fleet_candidates() {
   local registry="${KIPI_DISPATCH_REGISTRY:-$REPO/instance-registry.json}"
   printf '%s\t%s\t%s\n' "$(basename "$REPO")" "$REPO" ""

--- a/q-system/.q-system/capability-manifest.json
+++ b/q-system/.q-system/capability-manifest.json
@@ -582,6 +582,10 @@
     {
       "path": "q-system/.q-system/scripts/test_dispatch_reachability.py",
       "runner": "python3"
+    },
+    {
+      "path": "q-system/.q-system/scripts/test/test-control-file-propagate.sh",
+      "runner": "bash"
     }
   ],
   "required_data": [],

--- a/q-system/.q-system/scripts/control-file-propagate.py
+++ b/q-system/.q-system/scripts/control-file-propagate.py
@@ -1,0 +1,215 @@
+#!/usr/bin/env python3
+"""control-file-propagate: bring ONE named control file in ONE named repo up to
+skeleton HEAD, hash-classified, without `kipi update` and without any delete.
+
+WHY THIS EXISTS (ASK-755)
+-------------------------
+repo-preflight.sh refuses a repo whose `linear-worker.sh` differs from the
+skeleton, and its refusal text says "run kipi update on this repo first". That is
+the wrong instrument for the job. `kipi update` is a fleet rsync WITH a delete
+flag: to move two files in two repos it walks every registered instance and can
+remove anything on the way. The blast radius of the tool is three orders of
+magnitude larger than the change, and the direction of a mistake is unrecoverable.
+
+So: same classification, one file at a time, copy only, never delete.
+
+CLASSIFICATION, against git history rather than against a guess. Mirrors
+plugin-fanout.py, which classifies a whole plugin TREE; this classifies a single
+FILE, because a preflight blocker names a file.
+
+  NEW      target is byte-identical to skeleton HEAD          -> nothing to do
+  OLD      target is byte-identical to some ANCESTOR blob of
+           that path in skeleton history                      -> safe to write
+  OTHER    neither                                            -> REFUSED
+  DIRTY    the target path has uncommitted changes            -> REFUSED
+  MISSING  the target has no such file                        -> REFUSED
+
+OTHER AND DIRTY REFUSE, AND THAT IS THE WHOLE POINT. OTHER means "this content is
+not something this skeleton ever shipped" -- a local edit, a hand-patch, or a tree
+from another lineage. Overwriting it destroys work nobody can recover from a copy
+that leaves no trace. DIRTY is the same argument one level out: a file with
+uncommitted changes has an owner who is mid-thought, and git cannot give it back
+after a copy lands on top. Both get a human instead of a write.
+
+SURVEY IS THE DEFAULT. --apply writes only to OLD, and re-runs the identical
+classification immediately before each write rather than trusting the survey pass
+-- the tree can change between the two, and a stale classification is exactly how
+a copy lands on a file that went dirty in between.
+
+Exit: 0 on survey always. On --apply, 1 if any target that classified OLD failed
+to be written, or if anything classified OTHER/DIRTY/MISSING (a refusal the caller
+asked to act on is a failure of the run, not a quiet skip).
+"""
+import argparse
+import hashlib
+import os
+import shutil
+import subprocess
+import sys
+
+
+def sha256_file(path):
+    try:
+        with open(path, "rb") as fh:
+            return hashlib.sha256(fh.read()).hexdigest()
+    except OSError:
+        return None
+
+
+def git(repo, *args):
+    """Return stdout, or None when git itself failed.
+
+    Never raises. A repo that is not a git repo, a path git does not know, and a
+    git that is not installed all have to reach the caller as "cannot tell",
+    because every one of them classifies as a refusal here rather than a write.
+    """
+    try:
+        p = subprocess.run(
+            ["git", "-C", repo] + list(args),
+            capture_output=True, text=True, check=False,
+        )
+    except OSError:
+        return None
+    if p.returncode != 0:
+        return None
+    return p.stdout
+
+
+def git_blob_sha256(repo, rev, rel):
+    """sha256 of the file CONTENT at <rev>:<rel>, not git's own blob id.
+
+    Deliberately the content hash: repo-preflight.sh reports a sha256 of the file
+    on disk, and a classification that cannot be compared by eye against the gate
+    that motivated it is a second source of truth. Same number, same units.
+    """
+    try:
+        p = subprocess.run(
+            ["git", "-C", repo, "show", "%s:%s" % (rev, rel)],
+            capture_output=True, check=False,
+        )
+    except OSError:
+        return None
+    if p.returncode != 0:
+        return None
+    return hashlib.sha256(p.stdout).hexdigest()
+
+
+def ancestor_hashes(skeleton, rel, limit=200):
+    """Every content hash this path has ever held in skeleton history -> rev."""
+    out = git(skeleton, "rev-list", "--max-count=%d" % limit, "HEAD", "--", rel)
+    seen = {}
+    for rev in (out or "").split():
+        h = git_blob_sha256(skeleton, rev, rel)
+        if h and h not in seen:
+            seen[h] = rev
+    return seen
+
+
+def path_is_dirty(repo, rel):
+    """True when <rel> has uncommitted changes; True also when git cannot say.
+
+    FAIL CLOSED, same posture as repo-preflight.sh. "I could not determine whether
+    somebody is editing this file" is not permission to overwrite it.
+    """
+    out = git(repo, "status", "--porcelain", "--", rel)
+    if out is None:
+        return True
+    return bool(out.strip())
+
+
+def classify(skeleton, target, rel, head_hash, ancestors):
+    tgt = os.path.join(target, rel)
+    if not os.path.isfile(tgt):
+        return "MISSING", None
+    if path_is_dirty(target, rel):
+        return "DIRTY", None
+    have = sha256_file(tgt)
+    if have is None:
+        return "OTHER", None
+    if have == head_hash:
+        return "NEW", None
+    if have in ancestors:
+        return "OLD", ancestors[have]
+    return "OTHER", None
+
+
+def main(argv=None):
+    ap = argparse.ArgumentParser(description=__doc__)
+    ap.add_argument("--skeleton", default=None,
+                    help="skeleton repo root (default: derived from this script)")
+    ap.add_argument("--target", action="append", default=[], required=True,
+                    help="target repo path (repeatable)")
+    ap.add_argument("--file", action="append", default=[], required=True,
+                    help="repo-relative control file (repeatable)")
+    ap.add_argument("--apply", action="store_true",
+                    help="write OLD targets; without it this only surveys")
+    args = ap.parse_args(argv)
+
+    # Derived from the script's own location, never $PWD. Same reason
+    # repo-preflight.sh does it: the reference has to follow the CODE, or standing
+    # in a directory changes what "the skeleton" means (guard-tests scar).
+    skeleton = args.skeleton or os.path.abspath(
+        os.path.join(os.path.dirname(os.path.abspath(__file__)), "..", "..", "..")
+    )
+
+    rc = 0
+    for rel in args.file:
+        skel_file = os.path.join(skeleton, rel)
+        if not os.path.isfile(skel_file):
+            print("REFUSED %s: not present in the skeleton %s" % (rel, skeleton))
+            rc = 1
+            continue
+        head_hash = sha256_file(skel_file)
+        if git(skeleton, "status", "--porcelain", "--", rel) is None:
+            print("REFUSED %s: skeleton is not a readable git repo" % rel)
+            rc = 1
+            continue
+        if (git(skeleton, "status", "--porcelain", "--", rel) or "").strip():
+            # A dirty SOURCE would propagate uncommitted skeleton work into other
+            # repos, where it has no commit to trace it back to.
+            print("REFUSED %s: skeleton copy is uncommitted; commit it first" % rel)
+            rc = 1
+            continue
+        ancestors = ancestor_hashes(skeleton, rel)
+
+        for target in args.target:
+            status, rev = classify(skeleton, target, rel, head_hash, ancestors)
+            note = ("ancestor %s" % rev[:8]) if rev else ""
+            if status == "NEW":
+                print("NEW      %s :: %s (already at skeleton HEAD)" % (target, rel))
+                continue
+            if status in ("OTHER", "DIRTY", "MISSING"):
+                print("REFUSED  %s :: %s (%s)" % (target, rel, status))
+                rc = 1
+                continue
+            if not args.apply:
+                print("OLD      %s :: %s (%s) [survey only]" % (target, rel, note))
+                continue
+            # Re-classify immediately before the write. See the module docstring.
+            status2, _ = classify(skeleton, target, rel, head_hash, ancestors)
+            if status2 != "OLD":
+                print("REFUSED  %s :: %s (became %s between survey and write)"
+                      % (target, rel, status2))
+                rc = 1
+                continue
+            dst = os.path.join(target, rel)
+            try:
+                shutil.copyfile(skel_file, dst)
+                shutil.copymode(skel_file, dst)
+            except OSError as exc:
+                print("FAILED   %s :: %s (%s)" % (target, rel, exc))
+                rc = 1
+                continue
+            wrote = sha256_file(dst)
+            if wrote != head_hash:
+                print("FAILED   %s :: %s (post-write hash %s != %s)"
+                      % (target, rel, (wrote or "?")[:12], head_hash[:12]))
+                rc = 1
+                continue
+            print("WROTE    %s :: %s (%s -> %s)"
+                  % (target, rel, note or "old", head_hash[:12]))
+    return rc
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/q-system/.q-system/scripts/repo-preflight.sh
+++ b/q-system/.q-system/scripts/repo-preflight.sh
@@ -98,7 +98,7 @@ for _root in $ENGAGEMENT_ROOTS; do
       # the earlier reading of the founder's wording was "the engagement instances
       # NESTED UNDER consulting/projects/*", so <root>/projects/<x> refused and
       # <root> did not. Measured 2026-08-14 against the repo that reading lets in,
-      # ASK_AI_consultant at /Users/assafkipnis/projects/consulting:
+      # the ASK_AI_consultant row, whose path IS the consulting engagement root:
       #   - `git ls-files clients/` -> 12 TRACKED files under clients/alma,
       #     clients/portant, clients/restaurent. Client material is in this repo's
       #     own history, so an agent-authored PR here is a client-facing diff.
@@ -117,8 +117,16 @@ for _root in $ENGAGEMENT_ROOTS; do
       #
       # STILL DERIVED FROM SHAPE, STILL NO LIST. Same ENGAGEMENT_ROOTS constant,
       # one extra glob. It discriminates: only a path whose LAST component is an
-      # engagement root matches, so the founder's own roots (cole-gtm, micro-saas,
-      # ktlyst-saas, personal) are untouched -- which the OWNPROJ case asserts.
+      # engagement root matches, so the founder's own persona and product roots are
+      # untouched -- which the OWNPROJ and NEARMISS cases both assert.
+      #
+      # NO ABSOLUTE HOME PATHS AND NO INSTANCE NAMES IN THIS COMMENT. The skeleton
+      # sweep in validate-separation.py greps every q-system/ file for an absolute
+      # home-directory prefix and for a fleet instance name, and this file ships to
+      # every instance. The first draft of this comment spelled out both and turned
+      # CI red; the second spelled them out again while explaining not to, because a
+      # text check cannot tell a rule from a mention of the rule. Describe, do not
+      # quote.
       */"$_root"|*/"$_root"/projects/*)
         # The reason is stated in full, because this line is what the founder reads
         # in the run log and in the daily digest's "tried, could not be worked"

--- a/q-system/.q-system/scripts/repo-preflight.sh
+++ b/q-system/.q-system/scripts/repo-preflight.sh
@@ -176,7 +176,15 @@ else
   if [ -z "$have" ] || [ -z "$want" ]; then
     refuse "control-code" "could not hash the worker on both sides, so drift is unknown"
   elif [ "$have" != "$want" ]; then
-    refuse "control-code" "linear-worker.sh differs from the skeleton (${have:0:12} vs ${want:0:12}); run kipi update on this repo first"
+    # THE REMEDY NAMED HERE USED TO BE THE FLEET UPDATER, AND THAT WAS WRONG
+    # (ASK-755). The updater is a fleet-wide rsync WITH a delete flag: to fix one
+    # file in one repo it walks every registered instance and can remove anything
+    # on the way (2026-08-07: voicekit deleted from 19 instances). A refusal that
+    # names a tool with a blast radius three orders of magnitude wider than the
+    # defect is an invitation to overcorrect at 2am. control-file-propagate.py
+    # does the same hash classification for ONE file in ONE repo, copy only, and
+    # refuses anything it cannot prove came from this skeleton.
+    refuse "control-code" "linear-worker.sh differs from the skeleton (${have:0:12} vs ${want:0:12}); fix with: python3 $SKELETON/q-system/.q-system/scripts/control-file-propagate.py --target $REPO_PATH --file $WORKER_REL --apply"
   fi
 fi
 

--- a/q-system/.q-system/scripts/repo-preflight.sh
+++ b/q-system/.q-system/scripts/repo-preflight.sh
@@ -127,11 +127,19 @@ for _root in $ENGAGEMENT_ROOTS; do
       # CI red; the second spelled them out again while explaining not to, because a
       # text check cannot tell a rule from a mention of the rule. Describe, do not
       # quote.
-      */"$_root"|*/"$_root"/projects/*)
-        # The reason is stated in full, because this line is what the founder reads
-        # in the run log and in the daily digest's "tried, could not be worked"
-        # section. A refusal he cannot tell apart from an empty queue is the defect
-        # this whole change is about.
+      # TWO SHAPES, TWO REASONS, BECAUSE THE REASON IS READ BY A HUMAN. The root and
+      # the repos nested under it are both refused, but they are refused for
+      # different facts, and one message cannot state both without lying about one
+      # of them. Codex round 2 caught the first cut telling the founder that
+      # <root> is "under <root>/projects/", which is false and unfalsifiable-looking
+      # in a log. This line is what he reads in the daily digest's "tried, could not
+      # be worked" section, so a refusal he cannot tell from an empty queue -- or one
+      # that misdescribes itself -- is the defect this whole change is about.
+      */"$_root")
+        printf 'FAIL client-repo: %s IS the %s engagement root; it holds the client engagement repos plus client material of its own, so unattended dispatch is not allowed there, even when dispatch.enabled is true -- a supervised founder-initiated run is the way in\n' "$REPO_PATH" "$_root"
+        printf 'REFUSED %s\n' "$REPO_PATH"
+        exit 1 ;;
+      */"$_root"/projects/*)
         printf 'FAIL client-repo: %s is a client engagement repo (under %s/projects/); unattended dispatch is not allowed there, even when dispatch.enabled is true -- a supervised founder-initiated run is the way in\n' "$REPO_PATH" "$_root"
         printf 'REFUSED %s\n' "$REPO_PATH"
         exit 1 ;;

--- a/q-system/.q-system/scripts/repo-preflight.sh
+++ b/q-system/.q-system/scripts/repo-preflight.sh
@@ -93,7 +93,33 @@ for _root in $ENGAGEMENT_ROOTS; do
   for _cand in "$REPO_PATH" "$RESOLVED_PATH"; do
     [ -n "$_cand" ] || continue
     case "$_cand" in
-      */"$_root"/projects/*)
+      # THE ROOT ITSELF, NOT ONLY WHAT IS NESTED UNDER IT (ASK-754).
+      # This case previously PASSED, and the test suite asserted that it should:
+      # the earlier reading of the founder's wording was "the engagement instances
+      # NESTED UNDER consulting/projects/*", so <root>/projects/<x> refused and
+      # <root> did not. Measured 2026-08-14 against the repo that reading lets in,
+      # ASK_AI_consultant at /Users/assafkipnis/projects/consulting:
+      #   - `git ls-files clients/` -> 12 TRACKED files under clients/alma,
+      #     clients/portant, clients/restaurent. Client material is in this repo's
+      #     own history, so an agent-authored PR here is a client-facing diff.
+      #   - projects/ holds all 11 engagement repos as nested SEPARATE git repos,
+      #     and the root tracks 0 files under projects/ -- so check 5 (dirty) is
+      #     structurally blind to them while the agent still has filesystem reach.
+      #   - q-consult/ is 998 tracked files: the LIVE social publishing engine.
+      # The root is not a neutral parent, it is the container of every engagement
+      # plus a live outbound path. Refusing the nested repos while admitting the
+      # directory that holds them is a gate with a door beside it.
+      #
+      # WHY THIS WAS ONLY LATENT: preflight already refused this repo today, but on
+      # control-code/hooks/dirty/branch-protection -- every one of them curable by a
+      # `kipi update`, a commit, and a protection toggle. An incidental refusal is
+      # not a rule, and it evaporates the day somebody tidies the repo.
+      #
+      # STILL DERIVED FROM SHAPE, STILL NO LIST. Same ENGAGEMENT_ROOTS constant,
+      # one extra glob. It discriminates: only a path whose LAST component is an
+      # engagement root matches, so the founder's own roots (cole-gtm, micro-saas,
+      # ktlyst-saas, personal) are untouched -- which the OWNPROJ case asserts.
+      */"$_root"|*/"$_root"/projects/*)
         # The reason is stated in full, because this line is what the founder reads
         # in the run log and in the daily digest's "tried, could not be worked"
         # section. A refusal he cannot tell apart from an empty queue is the defect

--- a/q-system/.q-system/scripts/repo-preflight.sh
+++ b/q-system/.q-system/scripts/repo-preflight.sh
@@ -188,11 +188,37 @@ fi
 # Compared against the SKELETON'S OWN settings rather than a hand-written list of
 # event names, for the same reason Piece B enumerates exits from source: a hand
 # list cannot notice the day a seventh event class is added.
+#
+# THE REFERENCE IS settings-template.json, NOT THE SKELETON'S RUNTIME settings.json
+# (ASK-755). Those two files are not the same claim. `kipi update` builds every
+# instance's settings.json from the TEMPLATE; the skeleton's own runtime file is
+# what the skeleton runs on itself, and it deliberately carries hooks that must
+# never ship -- settings-template-sync-check.py is SKELETON_ONLY by its own
+# design, because it compares the two settings files and an instance has no
+# template to compare against.
+#
+# Measured 2026-08-14, both opted-in repos: against the runtime file each was
+# "missing" exactly settings-template-sync-check.py, and against the template each
+# was at FULL parity. So this check was unsatisfiable for every instance in the
+# fleet at once -- no `kipi update` run could ever have cleared it, because the
+# thing it demanded is the one hook update refuses to ship. A gate nothing can
+# pass is not strict, it is broken, and it reads as a fleet-wide instance defect.
+#
+# NOT A WEAKENING, AND THE NUMBERS ARE THE ARGUMENT. The two guard sets are 41 and
+# 41. Switching the reference DROPS one requirement (settings-template-sync-check.py,
+# which can never be satisfied) and ADDS one (instance-automation-guard.py, which
+# is FLEET_ONLY: it ships to instances and the skeleton self-detects and no-ops, so
+# the old reference could not require it and the new one does). The hook EVENT sets
+# of the two files are identical, so nothing changes there.
 SETTINGS_REL=".claude/settings.json"
+# Fall back to the runtime file when no template exists, so a skeleton that has
+# not adopted the template still gets a comparison rather than a silent pass.
+SKEL_SETTINGS="$SKELETON/settings-template.json"
+[ -f "$SKEL_SETTINGS" ] || SKEL_SETTINGS="$SKELETON/$SETTINGS_REL"
 if [ ! -f "$REPO_PATH/$SETTINGS_REL" ]; then
   refuse "hooks" "$REPO_PATH/$SETTINGS_REL is missing, so no hook fires in this repo"
 else
-  MISSING="$(python3 - "$SKELETON/$SETTINGS_REL" "$REPO_PATH/$SETTINGS_REL" "$SKELETON" "$REPO_PATH" <<'PY' 2>/dev/null
+  MISSING="$(python3 - "$SKEL_SETTINGS" "$REPO_PATH/$SETTINGS_REL" "$SKELETON" "$REPO_PATH" <<'PY' 2>/dev/null
 import json, sys
 try:
     skel = json.load(open(sys.argv[1])).get("hooks", {})
@@ -359,12 +385,45 @@ if d.get("required_pull_request_reviews") is not None:
 rsc = d.get("required_status_checks") or {}
 if rsc.get("contexts") or rsc.get("checks"):
     g.append("checks")
+# AN ERROR BODY IS NOT A PROTECTION OBJECT (ASK-755).
+#
+# NO APOSTROPHE AND NO BACKTICK BELOW THIS LINE. This heredoc sits inside $( ),
+# and bash tracks quotes while scanning for the closing paren even though the
+# heredoc is quoted -- one apostrophe in a PYTHON COMMENT here took the whole
+# script to "unexpected EOF while looking for matching quote" at line 429, with
+# the error pointing 200 lines away from the character that caused it. The file
+# already carries this scar once, a few lines up, for the inline -c form.
+#
+# The gh CLI prints the GitHub JSON error to STDOUT and its own message to
+# stderr, and the caller discards stderr -- so a refused request arrived here as
+# a perfectly parseable dict with
+# no protection keys in it, and came out the far end as "protected but requires
+# NO review and NO status check". That sentence is FALSE and it is the expensive
+# kind of false: it names a fixable GitHub setting, so it sent a founder-directed
+# run hunting a toggle. Measured on both opted-in repos, which are PRIVATE on a
+# personal plan: GET .../protection AND GET .../rulesets both return
+#   403 {"message": "Upgrade to GitHub Pro or make this repository public..."}
+# There is no setting to change. The refusal was right; only its reason was
+# invented. Detected by SHAPE, not by a status allowlist -- any body carrying a
+# message and none of the protection keys is an error, whatever its code.
+if not g and "message" in d and not any(
+    k in d for k in ("required_pull_request_reviews", "required_status_checks",
+                     "enforce_admins", "url")
+):
+    print("APIERROR:%s" % str(d.get("message", "")).replace("\n", " ")[:200])
+    raise SystemExit(0)
 print(",".join(g))
 PY
 )"
       case "$PROT_GATES" in
         UNPARSEABLE)
           refuse "branch-protection" "the protection response for $SLUG@$DEFAULT_BRANCH could not be parsed" ;;
+        APIERROR:*)
+          # Still a refusal -- fail closed is the whole posture of this file, and
+          # "I could not read the protection" is never permission to enter. What
+          # changes is that the reason is now GitHub's own words, so the reader
+          # can tell an unset toggle from a plan that has no toggle to set.
+          refuse "branch-protection" "GitHub refused the protection query for $SLUG@$DEFAULT_BRANCH: ${PROT_GATES#APIERROR:}" ;;
         "")
           refuse "branch-protection" "$SLUG@$DEFAULT_BRANCH is protected but requires NO review and NO status check; auto-merge would still land code with nothing in its way" ;;
       esac

--- a/q-system/.q-system/scripts/test/test-control-file-propagate.sh
+++ b/q-system/.q-system/scripts/test/test-control-file-propagate.sh
@@ -1,0 +1,110 @@
+#!/usr/bin/env bash
+# Negative-first self-test for control-file-propagate.py (ASK-755).
+#
+# THE TEST THAT MATTERS IS THE REFUSAL, NOT THE WRITE. A propagator that copies is
+# trivial to make green; the property being bought here is that it does NOT copy
+# over a local edit or over uncommitted work. So OTHER and DIRTY are asserted
+# FIRST, and each is asserted by the file's CONTENT being unchanged on disk -- not
+# by the word "REFUSED" appearing in the output. A run that printed the refusal
+# and wrote anyway would pass a text-only assertion (scar: "or across signals
+# hides the alarm").
+#
+# Runs entirely against throwaway git repos under mktemp -d. Nothing here touches
+# a live checkout, which is the fable-discipline lint's rule and also the reason
+# this file can be run unattended.
+set -uo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+PROP="$SCRIPT_DIR/../control-file-propagate.py"
+REL="q-system/.q-system/scripts/linear-worker.sh"
+
+PASS=0; FAIL=0
+ok()   { PASS=$((PASS+1)); printf 'ok   %s\n' "$1"; }
+bad()  { FAIL=$((FAIL+1)); printf 'FAIL %s: %s\n' "$1" "$2"; }
+
+TMP="$(mktemp -d)"
+trap 'rm -rf "$TMP"' EXIT
+
+mkrepo() {
+  local root="$1"
+  mkdir -p "$root/$(dirname "$REL")"
+  git -C "$root" init -q 2>/dev/null || git init -q "$root"
+  git -C "$root" config user.email t@t.local
+  git -C "$root" config user.name  tester
+}
+
+commit_worker() {
+  local root="$1" body="$2" msg="$3"
+  printf '%s\n' "$body" > "$root/$REL"
+  git -C "$root" add -A
+  # Distinct message AND distinct content per commit: identical file + message +
+  # second produces the identical commit sha across "different" fixture repos,
+  # which silently collapses two cases into one (git-fixture scar).
+  git -C "$root" commit -q -m "$msg"
+}
+
+# --- skeleton with two generations of the control file ---------------------
+SKEL="$TMP/skel"; mkrepo "$SKEL"
+commit_worker "$SKEL" "worker v1 -- the ancestor" "gen1"
+V1_HASH="$(shasum -a 256 "$SKEL/$REL" | awk '{print $1}')"
+commit_worker "$SKEL" "worker v2 -- skeleton HEAD" "gen2"
+HEAD_HASH="$(shasum -a 256 "$SKEL/$REL" | awk '{print $1}')"
+[ "$V1_HASH" != "$HEAD_HASH" ] || { echo "fixture broken: both generations hash the same"; exit 2; }
+
+# --- targets ---------------------------------------------------------------
+T_OLD="$TMP/t_old";     mkrepo "$T_OLD";     commit_worker "$T_OLD"   "worker v1 -- the ancestor" "old-target"
+T_NEW="$TMP/t_new";     mkrepo "$T_NEW";     commit_worker "$T_NEW"   "worker v2 -- skeleton HEAD" "new-target"
+T_OTHER="$TMP/t_other"; mkrepo "$T_OTHER";   commit_worker "$T_OTHER" "worker -- HAND EDITED locally" "other-target"
+T_DIRTY="$TMP/t_dirty"; mkrepo "$T_DIRTY";   commit_worker "$T_DIRTY" "worker v1 -- the ancestor" "dirty-target"
+printf 'worker v1 -- the ancestor\nsomeone is mid-edit\n' > "$T_DIRTY/$REL"
+
+run_apply() { python3 "$PROP" --skeleton "$SKEL" --file "$REL" --target "$1" --apply 2>&1; }
+hash_of()   { shasum -a 256 "$1/$REL" | awk '{print $1}'; }
+
+# === 1. OTHER is refused, and the bytes are untouched ======================
+BEFORE="$(hash_of "$T_OTHER")"
+OUT="$(run_apply "$T_OTHER")"; RC=$?
+AFTER="$(hash_of "$T_OTHER")"
+if [ "$BEFORE" = "$AFTER" ]; then ok "OTHER: file bytes unchanged"; else bad "OTHER" "the file was overwritten"; fi
+[ "$RC" -ne 0 ] && ok "OTHER: exit non-zero" || bad "OTHER" "exit was 0, a refusal must fail the run"
+case "$OUT" in *REFUSED*OTHER*) ok "OTHER: named in output" ;; *) bad "OTHER" "output did not name OTHER: $OUT" ;; esac
+
+# === 2. DIRTY is refused, and the mid-edit survives ========================
+BEFORE="$(hash_of "$T_DIRTY")"
+OUT="$(run_apply "$T_DIRTY")"; RC=$?
+AFTER="$(hash_of "$T_DIRTY")"
+if [ "$BEFORE" = "$AFTER" ]; then ok "DIRTY: uncommitted edit survived"; else bad "DIRTY" "the mid-edit was overwritten"; fi
+[ "$RC" -ne 0 ] && ok "DIRTY: exit non-zero" || bad "DIRTY" "exit was 0"
+case "$OUT" in *REFUSED*DIRTY*) ok "DIRTY: named in output" ;; *) bad "DIRTY" "output did not name DIRTY: $OUT" ;; esac
+
+# === 3. NEW is a no-op ======================================================
+BEFORE="$(hash_of "$T_NEW")"
+OUT="$(run_apply "$T_NEW")"; RC=$?
+AFTER="$(hash_of "$T_NEW")"
+[ "$BEFORE" = "$AFTER" ] && ok "NEW: unchanged" || bad "NEW" "an already-current file was rewritten"
+[ "$RC" -eq 0 ] && ok "NEW: exit 0" || bad "NEW" "exit was $RC"
+
+# === 4. survey does NOT write (the default must be safe) ===================
+BEFORE="$(hash_of "$T_OLD")"
+python3 "$PROP" --skeleton "$SKEL" --file "$REL" --target "$T_OLD" >/dev/null 2>&1
+AFTER="$(hash_of "$T_OLD")"
+[ "$BEFORE" = "$AFTER" ] && ok "survey: wrote nothing without --apply" || bad "survey" "the default mode wrote to disk"
+
+# === 5. ONLY NOW the positive case: OLD is written to HEAD =================
+OUT="$(run_apply "$T_OLD")"; RC=$?
+AFTER="$(hash_of "$T_OLD")"
+[ "$AFTER" = "$HEAD_HASH" ] && ok "OLD: written to skeleton HEAD" || bad "OLD" "hash is $AFTER, wanted $HEAD_HASH"
+[ "$RC" -eq 0 ] && ok "OLD: exit 0" || bad "OLD" "exit was $RC -- $OUT"
+
+# === 6. a dirty SKELETON refuses (never propagate uncommitted source) ======
+printf 'worker v2 -- skeleton HEAD\nuncommitted skeleton edit\n' > "$SKEL/$REL"
+T_OLD2="$TMP/t_old2"; mkrepo "$T_OLD2"; commit_worker "$T_OLD2" "worker v1 -- the ancestor" "old-target-2"
+BEFORE="$(hash_of "$T_OLD2")"
+OUT="$(run_apply "$T_OLD2")"; RC=$?
+AFTER="$(hash_of "$T_OLD2")"
+[ "$BEFORE" = "$AFTER" ] && ok "dirty skeleton: target untouched" || bad "dirty-skeleton" "propagated uncommitted source"
+[ "$RC" -ne 0 ] && ok "dirty skeleton: exit non-zero" || bad "dirty-skeleton" "exit was 0"
+
+printf '\n%s passed, %s failed\n' "$PASS" "$FAIL"
+[ "$FAIL" -eq 0 ] || exit 1
+exit 0

--- a/q-system/.q-system/scripts/test/test-repo-preflight.sh
+++ b/q-system/.q-system/scripts/test/test-repo-preflight.sh
@@ -102,7 +102,23 @@ case "$1 ${2:-}" in
 esac
 case "${*}" in
   *"/protection"*)
-    [ "${STUB_GH_PROTECTION:-ok}" = "ok" ] || { echo "Branch not protected" >&2; exit 1; }
+    # FOUR MODES, because the three failure shapes are NOT interchangeable and the
+    # script used to collapse two of them into one sentence (ASK-755).
+    case "${STUB_GH_PROTECTION:-ok}" in
+      toothless)
+        # Real protection object, no review and no check required.
+        echo '{"url":"x","enforce_admins":{"enabled":false},"allow_force_pushes":{"enabled":false}}'; exit 0 ;;
+      apierror)
+        # EXACTLY what the real gh does on a refused request: the GitHub JSON
+        # error body on STDOUT, its own line on stderr, non-zero exit. The
+        # caller discards stderr, so STDOUT is all the script ever sees --
+        # which is how a 403 got read as a protection object.
+        echo '{"message":"Upgrade to GitHub Pro or make this repository public to enable this feature.","documentation_url":"https://docs.github.com/rest","status":"403"}'
+        echo "gh: Upgrade to GitHub Pro (HTTP 403)" >&2
+        exit 1 ;;
+      ok) : ;;
+      *) echo "Branch not protected" >&2; exit 1 ;;
+    esac
     echo '{"required_pull_request_reviews":{"required_approving_review_count":1},"required_status_checks":{"strict":true,"contexts":["ci"]}}'; exit 0 ;;
   "repo view"*)
     [ "${STUB_GH_REPOVIEW:-ok}" = "ok" ] || { echo "could not resolve to a Repository" >&2; exit 1; }
@@ -120,7 +136,17 @@ export PATH="$STUBBIN:$PATH"
 # A repo that passes ALL SEVEN items. Every failing fixture below is this one with
 # exactly one thing broken, so a failure names one cause and not a pile.
 SKEL_WORKER="$REPO/q-system/.q-system/scripts/linear-worker.sh"
-SKEL_SETTINGS="$REPO/.claude/settings.json"
+# THE FIXTURE MODELS AN INSTANCE, SO IT IS BUILT FROM settings-template.json
+# (ASK-755). The fleet updater renders every instance's .claude/settings.json from
+# the TEMPLATE; the skeleton's own runtime settings.json is what the skeleton runs
+# ON ITSELF and it deliberately carries hooks that never ship. Cloning the runtime
+# file built a "compliant instance" no real instance can ever be -- it carried
+# settings-template-sync-check.py (SKELETON_ONLY by that script's own design) and
+# lacked instance-automation-guard.py (FLEET_ONLY). Both errors pointed the same
+# way: the control fixture was easier to satisfy than the fleet, so the gate looked
+# green here and was unsatisfiable everywhere.
+SKEL_SETTINGS="$REPO/settings-template.json"
+[ -f "$SKEL_SETTINGS" ] || SKEL_SETTINGS="$REPO/.claude/settings.json"
 
 # EVERY fixture git mutation goes through here. THE SCAR, and it is this file's
 # own: before make_good_repo's `local` bug was fixed it returned an EMPTY path,
@@ -962,6 +988,48 @@ elif grep -q '^ENGAGEMENT_ROOTS="zzzz-no-such-root"$' "$MUTPF"; then
 else
   bad "the mutant was written but does not carry the expected replacement"
 fi
+
+echo
+echo "== 22. an API REFUSAL and a TOOTHLESS branch are different refusals (ASK-755) =="
+# The two used to print the same sentence. Both still refuse -- that part was
+# never wrong -- but "requires NO review and NO status check" names a GitHub
+# setting somebody can go and change, and saying it about a 403 sent a whole
+# founder-directed run hunting a toggle that does not exist on a private repo on
+# a personal plan. The pair is asserted TOGETHER on purpose: a fix that made the
+# 403 honest by making every protection failure vague would pass a test that only
+# looked at the 403.
+BP="$(make_good_repo bprot)"
+
+OUT_ERR="$(STUB_GH_PROTECTION=apierror run_preflight "$BP")"
+case "$OUT_ERR" in
+  *"GitHub refused the protection query"*"Upgrade to GitHub Pro"*)
+    ok "403: the refusal quotes GitHub own words" ;;
+  *) bad "403 was not reported as an API refusal: $OUT_ERR" ;;
+esac
+case "$OUT_ERR" in
+  *"requires NO review and NO status check"*)
+    bad "403 still claims the branch is protected-but-toothless, the false sentence" ;;
+  *) ok "403: the false protected-but-toothless sentence is gone" ;;
+esac
+[ "$(STUB_GH_PROTECTION=apierror pf_rc "$BP")" != "0" ] \
+  && ok "403: still REFUSES (fail closed is unchanged)" \
+  || bad "403 was allowed through -- the fix turned a gate into a filter"
+
+OUT_TOOTH="$(STUB_GH_PROTECTION=toothless run_preflight "$BP")"
+case "$OUT_TOOTH" in
+  *"requires NO review and NO status check"*)
+    ok "toothless: still named as protected-but-toothless" ;;
+  *) bad "the real toothless case lost its specific reason: $OUT_TOOTH" ;;
+esac
+[ "$(STUB_GH_PROTECTION=toothless pf_rc "$BP")" != "0" ] \
+  && ok "toothless: still REFUSES" \
+  || bad "a branch with no required review and no required check was allowed through"
+
+# The positive control. Without it, a change that refused EVERYTHING would pass
+# every assertion above (the or-across-signals shape).
+[ "$(STUB_GH_PROTECTION=ok pf_rc "$BP")" = "0" ] \
+  && ok "control: a genuinely gated branch still PASSES" \
+  || bad "a genuinely gated branch is now refused -- $(run_preflight "$BP")"
 
 echo
 echo "-------- $PASS passed, $FAIL failed --------"

--- a/q-system/.q-system/scripts/test/test-repo-preflight.sh
+++ b/q-system/.q-system/scripts/test/test-repo-preflight.sh
@@ -851,13 +851,35 @@ OUT="$(run_preflight "$INTELCLIENT" "https://github.com/assafkip/intelclient.git
   && ok "a NON-engagement repo under the founder's own root still passes" \
   || bad "the guard over-matched and refused one of the founder's own repos: $(run_preflight "$OWNPROJ" "https://github.com/assafkip/ownproj.git")"
 
-# The engagement ROOT itself is the founder's own instance, not an engagement. The
-# founder's wording was "the engagement instances NESTED UNDER consulting/projects/*",
-# so <root>/projects/<x> refuses and <root> does not.
+# THE ENGAGEMENT ROOT ITSELF IS REFUSED (ASK-754). THIS ASSERTION IS INVERTED.
+#
+# It used to assert the opposite -- "the engagement ROOT itself is not treated as a
+# client engagement" -- on the reading that the founder meant only "the engagement
+# instances NESTED UNDER consulting/projects/*". Inverting it is part of the fix, not
+# collateral: while the suite pinned the old behaviour, the hole could not be closed
+# without a red test, and a green suite read as proof the root was safe on purpose.
+#
+# What changed is evidence, not taste. Measured 2026-08-14 on the one repo that
+# reading admits, ASK_AI_consultant at /Users/assafkipnis/projects/consulting:
+# 12 TRACKED files under clients/ (alma, portant, restaurent), all 11 engagement
+# repos nested beneath it, and q-consult/ (998 files) is the live publishing engine.
+# The founder's condition for this call was "if it holds client material, it should
+# be refused" -- it holds client material in its own git history.
 ROOTREPO="$(make_good_repo_at rootrepo consulting)"
-[ "$(pf_rc "$ROOTREPO" "https://github.com/assafkip/rootrepo.git")" = "0" ] \
-  && ok "the engagement ROOT itself is not treated as a client engagement" \
-  || bad "the guard swallowed the persona root, which is the founder's own instance"
+OUT="$(run_preflight "$ROOTREPO" "https://github.com/assafkip/rootrepo.git")"
+{ [ "$(pf_rc "$ROOTREPO" "https://github.com/assafkip/rootrepo.git")" != "0" ] \
+    && printf '%s' "$OUT" | grep -q 'client-repo'; } \
+  && ok "the engagement ROOT itself is refused, and names client-repo" \
+  || bad "THE DEFECT: the engagement root -- which holds tracked client material and every nested engagement -- was accepted: $OUT"
+
+# THE DISCRIMINATION CASE FOR THE NEW GLOB, kept adjacent to it. */<root> must match
+# only when <root> is the LAST component. A founder root that merely CONTAINS an
+# engagement root name as a prefix or suffix is not an engagement root, and a rule
+# that refused those would be the over-match that gets a gate switched off.
+NEARMISS="$(make_good_repo_at nearmiss consulting-notes)"
+[ "$(pf_rc "$NEARMISS" "https://github.com/assafkip/nearmiss.git")" = "0" ] \
+  && ok "a path whose last component merely CONTAINS an engagement root name still passes" \
+  || bad "the new root glob over-matched on a substring: $(run_preflight "$NEARMISS" "https://github.com/assafkip/nearmiss.git")"
 
 # NO BYPASS SURFACE, same rule the dispatcher is held to by case 8.
 grep -qE '^ENGAGEMENT_ROOTS="[a-z ]+"$' "$PREFLIGHT" \

--- a/q-system/.q-system/scripts/test/test-repo-preflight.sh
+++ b/q-system/.q-system/scripts/test/test-repo-preflight.sh
@@ -860,9 +860,11 @@ OUT="$(run_preflight "$INTELCLIENT" "https://github.com/assafkip/intelclient.git
 # without a red test, and a green suite read as proof the root was safe on purpose.
 #
 # What changed is evidence, not taste. Measured 2026-08-14 on the one repo that
-# reading admits, ASK_AI_consultant at /Users/assafkipnis/projects/consulting:
-# 12 TRACKED files under clients/ (alma, portant, restaurent), all 11 engagement
-# repos nested beneath it, and q-consult/ (998 files) is the live publishing engine.
+# reading admits -- the ASK_AI_consultant row, whose path IS the consulting
+# engagement root: 12 TRACKED files under clients/, all 11 engagement repos nested
+# beneath it, and q-consult/ (998 files) is the live publishing engine.
+# (No absolute home path here on purpose: the skeleton sweep greps this tree for
+# an absolute home-directory prefix, and this test ships to every instance.)
 # The founder's condition for this call was "if it holds client material, it should
 # be refused" -- it holds client material in its own git history.
 ROOTREPO="$(make_good_repo_at rootrepo consulting)"


### PR DESCRIPTION
Two issues, one branch. ASK-754 was the opt-in half and is unchanged. ASK-755 is everything after `8a64c449`.

## ASK-754 (unchanged, rounds 1-4)

The engagement ROOT itself is refused, not only what nests under it, and the first two non-client repos are opted into dispatch.

## ASK-755: clearing the four preflight blockers

Round 4's finding was that both opted-in repos are guaranteed to be refused on every dispatch. Three of the four causes are now gone. The fourth is real, is not code, and is ASK-757.

**1. control-code (cleared).** Both instances were exactly one release behind. Cleared with a new bounded propagator rather than the fleet updater: `control-file-propagate.py` classifies one FILE in one repo NEW/OLD/OTHER/DIRTY/MISSING against skeleton history and writes only OLD. Copy only, no delete. The preflight's own refusal now prints that command instead of naming the fleet rsync, which has a delete flag and a blast radius three orders of magnitude wider than the defect.

Its test asserts the REFUSALS first, by the target's bytes being unchanged on disk rather than by the word REFUSED appearing. 13/13; mutation (classify returns OLD for everything, DIRTY branch unreachable) takes it to 7/13.

**2. hooks (was a defect in this script).** The check compared an instance against the skeleton's RUNTIME `.claude/settings.json`. Instances are built from `settings-template.json`, and the two differ deliberately: `settings-template-sync-check.py` is `SKELETON_ONLY` by its own design. So every instance was permanently missing the one hook that can never ship, and no updater run could have cleared it.

Measured, both repos: against the runtime file, missing that one guard; against the template, FULL parity. Not a weakening -- both guard sets are 41, the switch drops one unsatisfiable requirement and adds one real one (`instance-automation-guard.py`, FLEET_ONLY), and the event sets are identical. The fixture was the other half: it cloned the runtime settings, so the control repo was easier to satisfy than any real instance. It is now built from the template.

**3. dirty (cleared, in the instances).** Verified as machine exhaust, not WIP: the same two files were dirty in both repos with identical sha256, the content was a fanned-out prd-os bump citing skeleton issue ids, and one repo already carried two prior commits recording the same fanout. The untracked half was generated state the skeleton's own `.gitignore` already covers and the instances' copies predate. Committed path-scoped in the instances; nothing in this diff.

**4. branch-protection (NOT clearable -- ASK-757).** The preflight was inventing its reason. `gh api` prints GitHub's JSON error to STDOUT and its own line to stderr, and the caller discards stderr -- so a 403 arrived as a parseable dict with no protection keys and came out as "is protected but requires NO review and NO status check". That is false, and it names a setting, so it sends readers hunting a toggle that does not exist.

Both repos are private on a personal plan; protection AND rulesets both 403 with "Upgrade to GitHub Pro". Surveyed across the registry: 23 of 23 instances are private, so check 7 is unsatisfiable fleet-wide. Filed as ASK-757 with three exits, all founder calls about money or disclosure.

Still fails closed. Only the words changed.

## Verification

- `test-repo-preflight.sh`: **70/70** (was 64). New case 22 asserts an API refusal and a genuinely toothless branch produce DIFFERENT refusals, with a positive control so a refuse-everything change cannot pass. Mutation: deleting the detection reproduces the false sentence verbatim, 68/2.
- `test-control-file-propagate.sh`: **13/13**, mutation-killed both refusal paths.
- `capability-gate.py --check-only`: **GREEN** (was RED 2). The inert-engine RED was cleared by real wiring, not a `declared_inert` entry.
- `validate`: passing on `9a891b7f`.
- Real chain, real registry: `fleet_candidates` emits 3 rows, `pick_list` emits the home repo only, and the log now carries the true reason.

## Not in this diff, on purpose

ASK-758: `pr-review-agent.sh` defaults `POST=0`, so a dry run prints `verdict: APPROVE`, prints `done`, exits 0, and moves no gate. Filed with a DoR rather than fixed here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0151EYtGH6at3XTWqbBHAxEi