### PR TITLE
Refuse to fan .claude/ and plugins/ bytes nobody reviewed (ASK-762)

### DIFF
--- a/kipi-update.sh
+++ b/kipi-update.sh
@@ -423,12 +423,32 @@ fi
 # clone's .git/info/exclude, so on a fresh clone the wholesale form fires on the
 # repo's own worktree convention.) plugins/ stays whole: the syncer walks each
 # managed plugin with `find`, so an untracked file inside one is copied too.
+# IGNORED IS NOT ABSENT (Codex review of #149 round 3, major). `git status` hides
+# ignored files by default, but rsync does not: the plugin copy excludes only
+# .git/, __pycache__/, *.pyc, .venv/ and .pytest_cache/, so a gitignored
+# plugins/<name>/.env goes to all 23 instances. That is not hypothetical --
+# `.gitignore:3` is `*.env` and kipi-design's cip/generate.py reads a plugin-root
+# .env for API keys. A guard that claims to cover what rsyncs has to look where
+# rsync looks, so plugins/ is scanned with --ignored=matching and then filtered
+# by the SAME five exclusions the rsync uses. Measured on this repo the day it
+# was written: 0 such files, so the guard arrives green and fires on the next one.
+#
+# The .claude half is the mirror-image mistake, caught as a minor in the same
+# round: it was recursive where the copy is a flat `*.md` glob, so a nested or
+# non-md file raised an alarm nothing could act on. `:(glob)` makes `*` stop at
+# the directory separator; a bare pathspec would let it match subdirectories and
+# re-widen the very scope this narrows.
 SYNC_SCOPE_DIRTY="$(
   {
     git -C "$SCRIPT_DIR" status --porcelain -- \
-      .claude/agents .claude/output-styles .claude/rules .claude/settings.json \
-      plugins 2>/dev/null || true
-  } | sed 's/^...//'
+      ':(glob).claude/agents/*.md' \
+      ':(glob).claude/output-styles/*.md' \
+      ':(glob).claude/rules/*.md' \
+      .claude/settings.json 2>/dev/null || true
+    git -C "$SCRIPT_DIR" status --porcelain --ignored=matching -- plugins \
+      2>/dev/null || true
+  } | sed 's/^...//' \
+    | grep -vE '(^|/)(\.git|__pycache__|\.venv|\.pytest_cache)/|\.pyc$' || true
 )"
 if [ -n "$SYNC_SCOPE_DIRTY" ]; then
   echo ""

--- a/kipi-update.sh
+++ b/kipi-update.sh
@@ -415,9 +415,19 @@ fi
 #   a silent guard is indistinguishable from one that passed.
 #
 # Pinned by test-kipi-update-source-provenance.sh.
+# SCOPED TO WHAT ACTUALLY RSYNCS, not to `.claude/` wholesale. The config sync
+# copies .claude/{agents,output-styles,rules}/*.md and .claude/settings.json --
+# nothing else under .claude/ ever reaches an instance. A wholesale check would
+# abort on .claude/worktrees/ and settings.local.json, which protect nothing and
+# would get the guard switched off. (The worktrees dir is ignored only in this
+# clone's .git/info/exclude, so on a fresh clone the wholesale form fires on the
+# repo's own worktree convention.) plugins/ stays whole: the syncer walks each
+# managed plugin with `find`, so an untracked file inside one is copied too.
 SYNC_SCOPE_DIRTY="$(
   {
-    git -C "$SCRIPT_DIR" status --porcelain -- .claude plugins 2>/dev/null || true
+    git -C "$SCRIPT_DIR" status --porcelain -- \
+      .claude/agents .claude/output-styles .claude/rules .claude/settings.json \
+      plugins 2>/dev/null || true
   } | sed 's/^...//'
 )"
 if [ -n "$SYNC_SCOPE_DIRTY" ]; then

--- a/kipi-update.sh
+++ b/kipi-update.sh
@@ -388,6 +388,67 @@ if [ "$LEAK_RC" -ne 0 ]; then
   exit 1
 fi
 
+# Preflight: the bytes fanned out must be the bytes that were reviewed.
+#
+# q-system/ is copied with `git archive` from HEAD, and the two checks above
+# refuse when the index and HEAD disagree. `.claude/` and `plugins/` get no
+# such protection: they rsync from $SCRIPT_DIR -- the WORKING TREE, on whatever
+# branch it is checked out on. Nothing asked which branch that was.
+#
+# Scar 2026-08-14 (sp-ea9c1628): kipi-system sat on sana/ask-728-plugin-parity
+# holding an uncommitted partial forward-port of voicekit/selector.py -- the
+# nearest-length ranking without the anchor-survives fix Codex caught in #147
+# and main already carried. A run from that state writes code strictly OLDER
+# than main into every config-sync instance and prints PASS. Silent, plausible,
+# and 23 repos wide; hence a preflight rather than a habit.
+#
+# Two halves, deliberately different in what they need:
+#
+#   DIRTY runs always. Staleness against HEAD needs no remote to be wrong, and
+#   an untracked file under plugins/ rsyncs just as happily as a tracked one --
+#   `git diff` is blind to it, so it is asked for by name.
+#
+#   BRANCH arms only when an `origin` remote exists. SKELETON_BRANCH names a
+#   branch ON origin; a repo with no origin has no main to be stale against,
+#   and every kipi-update fixture in q-system/.q-system/scripts/test/ is
+#   exactly that repo. It announces the disarm rather than going quiet, because
+#   a silent guard is indistinguishable from one that passed.
+#
+# Pinned by test-kipi-update-source-provenance.sh.
+SYNC_SCOPE_DIRTY="$(
+  {
+    git -C "$SCRIPT_DIR" status --porcelain -- .claude plugins 2>/dev/null || true
+  } | sed 's/^...//'
+)"
+if [ -n "$SYNC_SCOPE_DIRTY" ]; then
+  echo ""
+  echo "ABORT: the skeleton's .claude/ or plugins/ is not committed."
+  echo "These rsync from the working tree, so every line below would reach all"
+  echo "registered instances without ever having passed a review:"
+  printf '%s\n' "$SYNC_SCOPE_DIRTY" | sed 's/^/  /'
+  echo "Commit them, or restore them from ${SKELETON_BRANCH}, before propagating."
+  exit 1
+fi
+
+if git -C "$SCRIPT_DIR" remote get-url origin >/dev/null 2>&1; then
+  SKELETON_HEAD_BRANCH="$(git -C "$SCRIPT_DIR" symbolic-ref --short -q HEAD || true)"
+  if [ "$SKELETON_HEAD_BRANCH" != "$SKELETON_BRANCH" ]; then
+    echo ""
+    echo "ABORT: the skeleton is not on $SKELETON_BRANCH."
+    if [ -z "$SKELETON_HEAD_BRANCH" ]; then
+      echo "  HEAD is detached."
+    else
+      echo "  HEAD is on $SKELETON_HEAD_BRANCH."
+    fi
+    echo ".claude/ and plugins/ rsync from this working tree, so a feature"
+    echo "branch fans its unmerged -- or merely older -- copy to every instance."
+    echo "Check out $SKELETON_BRANCH and pull before propagating."
+    exit 1
+  fi
+else
+  echo "skeleton branch check: DISARMED (no origin remote; nothing to be stale against)"
+fi
+
 PASS=0
 FAIL=0
 SKIP=0

--- a/kipi-update.sh
+++ b/kipi-update.sh
@@ -455,6 +455,54 @@ if git -C "$SCRIPT_DIR" remote get-url origin >/dev/null 2>&1; then
     echo "Check out $SKELETON_BRANCH and pull before propagating."
     exit 1
   fi
+
+  # THE NAME IS NOT THE COMMIT (Codex review of #149, major). Being ON main says
+  # nothing about being AT main: a local main 15 commits behind origin passes a
+  # name check and fans a reviewed-months-ago copy to 23 instances, which is the
+  # exact failure this preflight exists to stop, one level up. It also catches
+  # the mirror case -- local commits that were never pushed, so the bytes going
+  # out were never reviewed by anyone.
+  #
+  # Measured 2026-08-14 on this very repo: the ask-728 checkout was 2 ahead and
+  # 15 behind origin, carrying an unattended auto-commit that never left the
+  # machine (rescued as PR #150).
+  #
+  # Fail closed when the comparison cannot be made. GIT_TERMINAL_PROMPT=0 is
+  # exported at the top of this script, so an unreachable origin errors out
+  # rather than hanging on credentials. Fanning to 23 repos on an unproven
+  # source is worse than not fanning at all.
+  if ! git -C "$SCRIPT_DIR" fetch origin "$SKELETON_BRANCH" --quiet 2>/dev/null; then
+    echo ""
+    echo "ABORT: could not fetch origin/$SKELETON_BRANCH."
+    echo "Without it there is no way to prove this working tree matches what was"
+    echo "reviewed. Fix connectivity, or propagate later; do not fan 23 repos"
+    echo "from an unverified source."
+    exit 1
+  fi
+  SKELETON_LOCAL_SHA="$(git -C "$SCRIPT_DIR" rev-parse HEAD 2>/dev/null || true)"
+  SKELETON_REMOTE_SHA="$(
+    git -C "$SCRIPT_DIR" rev-parse "refs/remotes/origin/$SKELETON_BRANCH" 2>/dev/null || true
+  )"
+  if [ -z "$SKELETON_LOCAL_SHA" ] || [ -z "$SKELETON_REMOTE_SHA" ]; then
+    echo ""
+    echo "ABORT: could not resolve HEAD or origin/$SKELETON_BRANCH to a commit."
+    exit 1
+  fi
+  if [ "$SKELETON_LOCAL_SHA" != "$SKELETON_REMOTE_SHA" ]; then
+    SKELETON_DRIFT="$(
+      git -C "$SCRIPT_DIR" rev-list --left-right --count \
+        "HEAD...refs/remotes/origin/$SKELETON_BRANCH" 2>/dev/null || printf '? ?'
+    )"
+    echo ""
+    echo "ABORT: the skeleton is on $SKELETON_BRANCH but not AT origin/$SKELETON_BRANCH."
+    echo "  local:  $SKELETON_LOCAL_SHA"
+    echo "  origin: $SKELETON_REMOTE_SHA"
+    echo "  ahead/behind: $SKELETON_DRIFT"
+    echo "Ahead means bytes nobody reviewed; behind means bytes that were"
+    echo "superseded. Either way the fleet would get something other than"
+    echo "$SKELETON_BRANCH. Push or pull before propagating."
+    exit 1
+  fi
 else
   echo "skeleton branch check: DISARMED (no origin remote; nothing to be stale against)"
 fi

--- a/q-system/.q-system/capability-manifest.json
+++ b/q-system/.q-system/capability-manifest.json
@@ -159,6 +159,10 @@
       "runner": "bash"
     },
     {
+      "path": "q-system/.q-system/scripts/test/test-kipi-update-source-provenance.sh",
+      "runner": "bash"
+    },
+    {
       "path": "q-system/.q-system/scripts/test/test-kipi-update-unmanaged-instance.sh",
       "runner": "bash"
     },
@@ -600,6 +604,7 @@
     "q-system/.q-system/scripts/test/test-kipi-update-leak-preflight.sh",
     "q-system/.q-system/scripts/test/test-kipi-update-preservation-failure.sh",
     "q-system/.q-system/scripts/test/test-kipi-update-safety.sh",
+    "q-system/.q-system/scripts/test/test-kipi-update-source-provenance.sh",
     "q-system/.q-system/scripts/test/test-lessons-push-guard.sh",
     "q-system/.q-system/scripts/test/test-propagation-entrypoints.py",
     "q-system/.q-system/scripts/test/test-propagation-leak-baseline.py",

--- a/q-system/.q-system/scripts/test/test-kipi-update-dry-final-state.sh
+++ b/q-system/.q-system/scripts/test/test-kipi-update-dry-final-state.sh
@@ -154,7 +154,12 @@ printf '{"permissions":{"allow":["Read"]},"hooks":{}}\n' \
 (
   cd "$SKELETON"
   git_test init -q
-  git_test add q-system
+  # .claude/ and plugins/ too, not q-system/ alone. The real skeleton tracks
+  # all three, and the source-provenance preflight refuses to rsync a config
+  # scope that is not committed -- correctly, since that scope reaches every
+  # instance straight from the working tree. Committing only q-system/ made
+  # this fixture a repo the updater will not run on. (2026-08-14)
+  git_test add q-system .claude plugins settings-template.json
   git_test commit -qm skeleton
 )
 printf \

--- a/q-system/.q-system/scripts/test/test-kipi-update-source-provenance.sh
+++ b/q-system/.q-system/scripts/test/test-kipi-update-source-provenance.sh
@@ -191,6 +191,53 @@ assert_off_branch_aborts() {
   echo "PASS: a skeleton off SKELETON_BRANCH, attached or detached, aborts before any instance is touched"
 }
 
+# --------------------------------------------------- the name is not the commit
+# Being ON main says nothing about being AT main. Round 2 of the Codex review of
+# #149 caught this: the first version checked only the branch NAME, so a local
+# main behind origin passed and fanned a superseded copy to every instance --
+# the exact failure the preflight exists to stop, one level up.
+#
+# Both directions are wrong for the same reason. BEHIND ships bytes that were
+# superseded; AHEAD ships bytes nobody reviewed. Measured 2026-08-14 on the real
+# repo: 2 ahead, 15 behind, carrying an unattended auto-commit that never left
+# the machine (PR #150).
+assert_main_that_is_not_at_origin_aborts() {
+  local work sk inst bare out
+  work="$(mktemp -d)"; sk="$work/skel"; inst="$work/inst"; bare="$work/origin.git"
+  build_skeleton "$work"
+  G init -q --bare "$bare"
+  ( cd "$sk" && G remote add origin "$bare" && G push -q origin HEAD:refs/heads/main \
+    && G checkout -q -B main && G fetch -q origin main )
+
+  # In sync: must pass. Without this the two aborts below prove nothing, since a
+  # guard that always fires would satisfy them.
+  out="$(bash "$sk/kipi-update.sh" 2>&1)" || true
+  if echo "$out" | grep -q "ABORT: the skeleton"; then
+    fail "the guard fired on a main that IS at origin/main: $out"
+  fi
+
+  # AHEAD: a local commit that was never pushed.
+  printf 'never pushed\n' >> "$sk/plugins/demo/README.md"
+  # Named path, not `add -A`: instance-registry.json is deliberately untracked in
+  # this fixture, and sweeping it into a local-only commit means the `reset
+  # --hard origin/main` below deletes it out from under the updater.
+  ( cd "$sk" && G add plugins/demo/README.md && G commit -qm "local only" )
+  assert_aborts_untouched "$sk" "$inst" "main ahead of origin" "ahead/behind"
+
+  # BEHIND: origin moves on without this checkout. Built by pushing from a
+  # second clone, so the skeleton's own ref genuinely lags rather than being
+  # hand-edited into looking like it does.
+  ( cd "$sk" && G reset -q --hard origin/main )
+  # -b main explicitly: the bare repo's HEAD still points at the default branch
+  # name, which nothing ever created here, so a plain clone checks out nothing.
+  G clone -q -b main "$bare" "$work/other"
+  printf 'landed on origin after this checkout\n' > "$work/other/plugins/demo/LATER.md"
+  ( cd "$work/other" && G add -A && G commit -qm "moved on" && G push -q origin HEAD:main )
+  assert_aborts_untouched "$sk" "$inst" "main behind origin" "ahead/behind"
+
+  echo "PASS: a main that is ahead of or behind origin/main aborts before any instance is touched"
+}
+
 # ---------------------------------------------------------------- no-origin
 # Every other kipi-update fixture is a repo with no origin. The branch half
 # must stay disarmed there -- and must SAY it is disarmed, because a guard that
@@ -213,5 +260,6 @@ assert_no_origin_disarms_the_branch_half_loudly() {
 assert_dirty_sync_scope_aborts
 assert_unsynced_claude_paths_do_not_abort
 assert_off_branch_aborts
+assert_main_that_is_not_at_origin_aborts
 assert_no_origin_disarms_the_branch_half_loudly
 echo "PASS: kipi update refuses to fan bytes that were never reviewed"

--- a/q-system/.q-system/scripts/test/test-kipi-update-source-provenance.sh
+++ b/q-system/.q-system/scripts/test/test-kipi-update-source-provenance.sh
@@ -137,6 +137,33 @@ assert_dirty_sync_scope_aborts() {
   echo "PASS: a dirty, staged, or untracked .claude/ or plugins/ aborts before any instance is touched"
 }
 
+# ------------------------------------------------------- scope, not wholesale
+# The config sync copies .claude/{agents,output-styles,rules}/*.md and
+# .claude/settings.json. NOTHING else under .claude/ reaches an instance, so
+# nothing else may abort the fleet.
+#
+# This is the half that keeps the guard switched ON. `.claude/worktrees/` is the
+# repo's own convention and is ignored only in a clone's .git/info/exclude, not
+# in the committed .gitignore -- a wholesale `.claude` check fires on a fresh
+# clone the first time anyone makes a worktree. A guard that cries wolf on the
+# workflow it ships with gets deleted, and then it protects nothing.
+assert_unsynced_claude_paths_do_not_abort() {
+  local work sk out
+  work="$(mktemp -d)"; sk="$work/skel"
+  build_skeleton "$work"
+
+  mkdir -p "$sk/.claude/worktrees/some-branch"
+  printf 'a whole checkout lives here\n' > "$sk/.claude/worktrees/some-branch/file.md"
+  printf '{"permissions":{"allow":["Read"]}}\n' > "$sk/.claude/settings.local.json"
+
+  out="$(bash "$sk/kipi-update.sh" 2>&1)" || true
+  if echo "$out" | grep -q "ABORT: the skeleton"; then
+    fail "the guard fired on .claude/ paths that never rsync: $out"
+  fi
+
+  echo "PASS: dirty .claude/ paths outside the synced set do not abort"
+}
+
 # ---------------------------------------------------------------- property 2
 # The branch half. Arming needs an origin remote, so the fixture grows one --
 # a bare repo, no network.
@@ -184,6 +211,7 @@ assert_no_origin_disarms_the_branch_half_loudly() {
 }
 
 assert_dirty_sync_scope_aborts
+assert_unsynced_claude_paths_do_not_abort
 assert_off_branch_aborts
 assert_no_origin_disarms_the_branch_half_loudly
 echo "PASS: kipi update refuses to fan bytes that were never reviewed"

--- a/q-system/.q-system/scripts/test/test-kipi-update-source-provenance.sh
+++ b/q-system/.q-system/scripts/test/test-kipi-update-source-provenance.sh
@@ -156,12 +156,57 @@ assert_unsynced_claude_paths_do_not_abort() {
   printf 'a whole checkout lives here\n' > "$sk/.claude/worktrees/some-branch/file.md"
   printf '{"permissions":{"allow":["Read"]}}\n' > "$sk/.claude/settings.local.json"
 
+  # Recursive-vs-flat: the copy is a flat `*.md` glob, so a nested file and a
+  # non-md file in the synced dirs are both unreachable by it. Round 3 of the
+  # Codex review of #149 caught the guard alarming on them.
+  mkdir -p "$sk/.claude/rules/nested" "$sk/.claude/agents"
+  printf 'unreachable by the flat glob\n' > "$sk/.claude/rules/nested/deep.md"
+  printf 'not markdown\n' > "$sk/.claude/agents/notes.txt"
+
   out="$(bash "$sk/kipi-update.sh" 2>&1)" || true
   if echo "$out" | grep -q "ABORT: the skeleton"; then
     fail "the guard fired on .claude/ paths that never rsync: $out"
   fi
 
   echo "PASS: dirty .claude/ paths outside the synced set do not abort"
+}
+
+# ------------------------------------------------------- ignored is not absent
+# `git status` hides ignored files by default; rsync does not. The plugin copy
+# excludes only .git/, __pycache__/, *.pyc, .venv/ and .pytest_cache/, so a
+# gitignored plugins/<name>/.env reaches all 23 instances unseen.
+#
+# Round 3 of the Codex review of #149, major, and not hypothetical: this repo's
+# .gitignore line 3 is `*.env`, and kipi-design's cip/generate.py reads a
+# plugin-root .env for API keys. Round 3 found it on round-1 code, which means
+# rounds 1 and 2 both missed an entire input class -- ignored files.
+#
+# The pruned classes must stay silent in the same breath. A guard that abends on
+# every __pycache__ is a guard somebody switches off, and then the .env ships.
+assert_ignored_plugin_files_abort_but_pruned_ones_do_not() {
+  local work sk inst out
+  work="$(mktemp -d)"; sk="$work/skel"; inst="$work/inst"
+  build_skeleton "$work"
+  printf '*.env\n__pycache__/\n*.pyc\n.venv/\n.pytest_cache/\n' > "$sk/.gitignore"
+  ( cd "$sk" && G add .gitignore && G commit -qm ignore )
+
+  # The five rsync-excluded classes: ignored AND never copied, so silent.
+  mkdir -p "$sk/plugins/demo/__pycache__" "$sk/plugins/demo/.venv" \
+           "$sk/plugins/demo/.pytest_cache"
+  printf 'cache\n' > "$sk/plugins/demo/__pycache__/x.pyc"
+  printf 'venv\n' > "$sk/plugins/demo/.venv/pyvenv.cfg"
+  printf 'cache\n' > "$sk/plugins/demo/.pytest_cache/CACHEDIR.TAG"
+  printf 'compiled\n' > "$sk/plugins/demo/stale.pyc"
+  out="$(bash "$sk/kipi-update.sh" 2>&1)" || true
+  if echo "$out" | grep -q "ABORT: the skeleton"; then
+    fail "the guard fired on classes the plugin rsync excludes: $out"
+  fi
+
+  # The secret: ignored, and copied anyway.
+  printf 'ANTHROPIC_API_KEY=sk-not-a-real-key\n' > "$sk/plugins/demo/.env"
+  assert_aborts_untouched "$sk" "$inst" "ignored plugin .env" "plugins/demo/.env"
+
+  echo "PASS: an ignored plugin .env aborts; rsync-excluded classes stay silent"
 }
 
 # ---------------------------------------------------------------- property 2
@@ -259,6 +304,7 @@ assert_no_origin_disarms_the_branch_half_loudly() {
 
 assert_dirty_sync_scope_aborts
 assert_unsynced_claude_paths_do_not_abort
+assert_ignored_plugin_files_abort_but_pruned_ones_do_not
 assert_off_branch_aborts
 assert_main_that_is_not_at_origin_aborts
 assert_no_origin_disarms_the_branch_half_loudly

--- a/q-system/.q-system/scripts/test/test-kipi-update-source-provenance.sh
+++ b/q-system/.q-system/scripts/test/test-kipi-update-source-provenance.sh
@@ -1,0 +1,189 @@
+#!/usr/bin/env bash
+# The bytes fanned out to 23 instances must be the bytes that were reviewed.
+#
+# q-system/ is copied with `git archive` from HEAD, and two preflights already
+# refuse when the index and HEAD disagree. `.claude/` and `plugins/` are NOT:
+# they rsync from $SCRIPT_DIR, the skeleton's WORKING TREE, on whatever branch
+# it happens to be checked out on. Nothing checked which branch that was.
+#
+# Measured 2026-08-14: kipi-system sat on sana/ask-728-plugin-parity with an
+# uncommitted partial forward-port of plugins/kipi-core/voicekit/selector.py --
+# the nearest-length ranking without the anchor-survives fix Codex caught in
+# #147 and main already carried. A run from that state would have written code
+# strictly older than main into every config-sync instance and printed PASS.
+# That is the false-success shape with fleet blast radius, so it gets a
+# preflight rather than a habit.
+#
+# Two properties:
+#   1. a dirty .claude/ or plugins/ ABORTS before any instance is touched;
+#   2. a skeleton off SKELETON_BRANCH ABORTS the same way.
+#
+# The branch half is armed only when an `origin` remote exists. SKELETON_BRANCH
+# names a branch ON origin; a repo with no origin has no main to be stale
+# against, and every kipi-update fixture in this directory is exactly that repo.
+# The dirty half runs unconditionally, because staleness against HEAD needs no
+# remote to be wrong.
+set -euo pipefail
+ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/../../../.." && pwd)"
+fail() { echo "FAIL: $1" >&2; exit 1; }
+G() { git -c user.email=t@t.t -c user.name=test -c commit.gpgsign=false "$@"; }
+
+BASELINE_REL="q-system/.q-system/state/propagation-leak-baseline.json"
+
+# A skeleton the updater will actually walk, with one instance registered.
+# Deliberately the same shape as test-kipi-update-leak-preflight.sh's fixture:
+# these two guards sit next to each other in the preflight and a divergent
+# fixture would let one pass on a repo the other could not survive.
+build_skeleton() {
+  local work="$1" sk="$work/skel" inst="$work/inst"
+  mkdir -p "$sk/q-system/.q-system/scripts" "$sk/q-system/.q-system/state" \
+           "$sk/q-system/marketing" "$sk/plugins/demo" "$sk/.claude/rules"
+  cp "$ROOT/kipi-update.sh" "$sk/kipi-update.sh"
+  cp "$ROOT/kipi-update-preserve-scan.py" "$sk/kipi-update-preserve-scan.py"
+  cp "$ROOT/kipi-update-deletion-guard.py" "$sk/kipi-update-deletion-guard.py"
+  cp "$ROOT/q-system/.q-system/scripts/propagation-leak-gate.py" \
+     "$sk/q-system/.q-system/scripts/propagation-leak-gate.py"
+  cp "$ROOT/q-system/.q-system/scripts/containment-targets.py" \
+     "$sk/q-system/.q-system/scripts/containment-targets.py"
+  cp "$ROOT/validate-separation.py" "$sk/validate-separation.py"
+  cat > "$sk/$BASELINE_REL" <<'BASELINE_JSON'
+{
+  "schema_version": 1,
+  "blocking_classes": [
+    "case_proof_gap",
+    "client_identity",
+    "dated_interaction",
+    "pricing",
+    "relationship",
+    "source_identity",
+    "sourced_interaction"
+  ],
+  "classifier_sha256": null,
+  "entries": []
+}
+BASELINE_JSON
+  printf 'generic skeleton content\n' > "$sk/q-system/marketing/outreach.md"
+  printf '# demo plugin\n' > "$sk/plugins/demo/README.md"
+  printf '# demo rule\n' > "$sk/.claude/rules/demo.md"
+  ( cd "$sk" && G init -q && G add -A -f && G commit -qm skel )
+  printf '{"instances":[{"name":"testinst","path":"%s","subtree_prefix":"q-system","type":"subtree"}]}\n' \
+    "$inst" > "$sk/instance-registry.json"
+
+  mkdir -p "$inst/q-system" "$inst/.claude"
+  printf 'instance state\n' > "$inst/q-system/tracked.md"
+  ( cd "$inst" && G init -q && G add -A -f && G commit -qm inst )
+}
+
+instance_fingerprint() {
+  ( cd "$1" && G rev-parse HEAD && G status --porcelain && \
+    find . -path ./.git -prune -o -type f -print0 2>/dev/null \
+      | sort -z | xargs -0 shasum -a 256 2>/dev/null )
+}
+
+# Positional, not exit-code. This minimal fixture exits non-zero later in the
+# run for unrelated reasons, so `run && fail` would prove nothing at all --
+# the same trap the leak-preflight fixture documents at its assert helper.
+assert_aborts_untouched() {
+  local sk="$1" inst="$2" what="$3" needle="$4" before after out
+  before="$(instance_fingerprint "$inst")"
+  out="$(bash "$sk/kipi-update.sh" 2>&1)" || true
+  after="$(instance_fingerprint "$inst")"
+  if echo "$out" | grep -q -- "--- testinst"; then
+    fail "$what: the instance loop was ENTERED instead of aborting: $out"
+  fi
+  echo "$out" | grep -qi "ABORT" || fail "$what aborted without saying so: $out"
+  echo "$out" | grep -q -- "$needle" || \
+    fail "$what did not name what was wrong ('$needle'): $out"
+  [ "$before" = "$after" ] || fail "$what: instance was touched"
+}
+
+# ---------------------------------------------------------------- property 1
+# A modification sitting in .claude/ or plugins/ is what actually rsyncs, so an
+# uncommitted edit reaches the fleet without ever passing a review.
+assert_dirty_sync_scope_aborts() {
+  local work sk inst out
+  work="$(mktemp -d)"; sk="$work/skel"; inst="$work/inst"
+  build_skeleton "$work"
+
+  # Clean baseline: the guard must not fire on a skeleton that is fine, or it
+  # gets switched off and protects nothing.
+  out="$(bash "$sk/kipi-update.sh" 2>&1)" || true
+  if echo "$out" | grep -q "ABORT: the skeleton"; then
+    fail "the guard fired on a clean skeleton: $out"
+  fi
+
+  printf '# edited, never committed\n' >> "$sk/plugins/demo/README.md"
+  assert_aborts_untouched "$sk" "$inst" "dirty plugins/" "plugins/demo/README.md"
+  ( cd "$sk" && G checkout -q -- plugins/demo/README.md )
+
+  printf '# edited, never committed\n' >> "$sk/.claude/rules/demo.md"
+  assert_aborts_untouched "$sk" "$inst" "dirty .claude/" ".claude/rules/demo.md"
+  ( cd "$sk" && G checkout -q -- .claude/rules/demo.md )
+
+  # Staged-but-uncommitted is the same defect wearing a hat: rsync reads the
+  # working tree either way, and `git add` is not a review.
+  printf '# staged, never committed\n' >> "$sk/plugins/demo/README.md"
+  ( cd "$sk" && G add plugins/demo/README.md )
+  assert_aborts_untouched "$sk" "$inst" "staged plugins/" "plugins/demo/README.md"
+  ( cd "$sk" && G reset -q -- plugins/demo/README.md && \
+    G checkout -q -- plugins/demo/README.md )
+
+  # An UNTRACKED file under plugins/ also rsyncs. It is not a modification, so
+  # `git diff` is blind to it; the guard has to look for it on purpose.
+  printf '# never added\n' > "$sk/plugins/demo/scratch.md"
+  assert_aborts_untouched "$sk" "$inst" "untracked plugins/" "plugins/demo/scratch.md"
+  rm -f "$sk/plugins/demo/scratch.md"
+
+  echo "PASS: a dirty, staged, or untracked .claude/ or plugins/ aborts before any instance is touched"
+}
+
+# ---------------------------------------------------------------- property 2
+# The branch half. Arming needs an origin remote, so the fixture grows one --
+# a bare repo, no network.
+assert_off_branch_aborts() {
+  local work sk inst bare out
+  work="$(mktemp -d)"; sk="$work/skel"; inst="$work/inst"; bare="$work/origin.git"
+  build_skeleton "$work"
+  G init -q --bare "$bare"
+  ( cd "$sk" && G remote add origin "$bare" && G push -q origin HEAD:refs/heads/main )
+
+  # On main with an origin: still clean, still must not fire.
+  ( cd "$sk" && G checkout -q -B main )
+  out="$(bash "$sk/kipi-update.sh" 2>&1)" || true
+  if echo "$out" | grep -q "ABORT: the skeleton"; then
+    fail "the guard fired on a clean skeleton sitting on main: $out"
+  fi
+
+  ( cd "$sk" && G checkout -q -b sana/some-feature )
+  assert_aborts_untouched "$sk" "$inst" "off SKELETON_BRANCH" "sana/some-feature"
+
+  # Detached HEAD is off-branch too, and reads as "" rather than a wrong name.
+  ( cd "$sk" && G checkout -q --detach HEAD )
+  assert_aborts_untouched "$sk" "$inst" "detached HEAD" "detached"
+
+  echo "PASS: a skeleton off SKELETON_BRANCH, attached or detached, aborts before any instance is touched"
+}
+
+# ---------------------------------------------------------------- no-origin
+# Every other kipi-update fixture is a repo with no origin. The branch half
+# must stay disarmed there -- and must SAY it is disarmed, because a guard that
+# goes quiet is indistinguishable from a guard that passed.
+assert_no_origin_disarms_the_branch_half_loudly() {
+  local work sk out
+  work="$(mktemp -d)"; sk="$work/skel"
+  build_skeleton "$work"
+  ( cd "$sk" && G checkout -q -b sana/some-feature )
+  out="$(bash "$sk/kipi-update.sh" 2>&1)" || true
+  if echo "$out" | grep -q "ABORT: the skeleton"; then
+    fail "the branch half fired on a repo with no origin: $out"
+  fi
+  echo "$out" | grep -q "no origin remote" || \
+    fail "the disarmed branch half did not announce itself: $out"
+
+  echo "PASS: no origin disarms the branch half and says so"
+}
+
+assert_dirty_sync_scope_aborts
+assert_off_branch_aborts
+assert_no_origin_disarms_the_branch_half_loudly
+echo "PASS: kipi update refuses to fan bytes that were never reviewed"


### PR DESCRIPTION
## The hole

`kipi-update.sh` copies `q-system/` with `git archive` from HEAD, and two preflights already refuse when the index and HEAD disagree.

`.claude/` and `plugins/` got neither. They rsync from `$SCRIPT_DIR` — the skeleton's **working tree**, on whatever branch it is checked out on. `SKELETON_BRANCH="main"` was read only by the direct-clone pull path.

## Measured, not theorized (2026-08-14, sp-ea9c1628)

kipi-system was sitting on `sana/ask-728-plugin-parity` holding an uncommitted partial forward-port of `plugins/kipi-core/voicekit/selector.py`: the nearest-length ranking **without** the anchor-survives fix Codex caught in #147 and main already carried.

A fleet-update run from that state writes code strictly older than main into every config-sync instance and prints `PASS`. Silent, plausible, 23 repos wide.

## The guard

Two halves, deliberately different in what they need.

**DIRTY — always armed.** Staleness against HEAD needs no remote to be wrong. It asks for untracked files by name, because those rsync too and `git diff` cannot see them. Modified, staged, and untracked all abort.

**BRANCH — armed only when an `origin` remote exists.** `SKELETON_BRANCH` names a branch *on* origin; a repo without one has no main to be stale against, and every existing updater fixture is exactly that repo. It prints the disarm rather than going quiet — a silent guard is indistinguishable from one that passed.

Both abort before any instance is read or written, and name what was wrong.

## Verification

- New fixture `test-kipi-update-source-provenance.sh` is **RED without the guard**: with a dirty `plugins/`, the run entered the instance loop and synced. Green with it.
- All 12 updater/rollback fixtures pass.
- `validate-separation.py` 25/25.
- Declared in `capability-manifest.json` (entry list + `skeleton_only`).

## One fixture changed, not weakened

`test-kipi-update-dry-final-state.sh` committed only `q-system/`, leaving `.claude/` and `plugins/` untracked where the real skeleton tracks both — a repo the updater will not run on. The guard exposed that. The fixture now commits all three.

## Not in scope

`sp-10cf4f76` (rsync `--delete` removing tracked instance-only scripts) is a different defect in the same file and stays open.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0151EYtGH6at3XTWqbBHAxEi