### PR TITLE
Rescue the open-loops spillover-capture fix an auto-commit stranded (ASK-763)

### DIFF
--- a/q-system/.q-system/scripts/open-loops.py
+++ b/q-system/.q-system/scripts/open-loops.py
@@ -64,14 +64,72 @@ def registry_loops(qroot):
     return out
 
 
+def ledger_root(repo_root):
+    """Directory holding the ONE spillover ledger, shared by every worktree.
+
+    Mirrors prd_runner.py `_ledger_root`: `.gitignore` excludes `*.jsonl`, so the
+    ledger never travels through git and a per-worktree root gives each worktree a
+    private copy. Resolving it any other way here would make this script blind to
+    captures the gate can see -- the same load-path mistake as the marketplace clone.
+    Fails open to repo_root (a missed skip only over-surfaces; it never drops).
+    """
+    import subprocess
+    try:
+        out = subprocess.run(["git", "rev-parse", "--git-common-dir"],
+                             cwd=str(repo_root), capture_output=True, text=True, timeout=10)
+        if out.returncode == 0 and out.stdout.strip():
+            common = Path(out.stdout.strip())
+            if not common.is_absolute():
+                common = Path(repo_root) / common
+            parent = common.resolve().parent
+            if (parent / ".git").exists():
+                return parent
+    except Exception:
+        pass
+    return repo_root
+
+
+def captured_finding_ids(repo_root):
+    """Set of `defer-<prd-slug>-<finding-id>` ids the spillover ledger already holds.
+
+    A `deferred` disposition AUTO-creates a spillover item (no-orphan-findings.md),
+    and `gates run` stays RED until that item resolves. So a captured finding is
+    TRACKED, not in limbo, whether its item is still open or already resolved --
+    counting it in the catch-all below re-reported tracked work as untracked at
+    every SessionStart (2026-08-14: 3 deterministic-reading findings nagged for
+    weeks, 2 of them already RESOLVED). Reading is enough; this never writes.
+    """
+    ids = set()
+    path = ledger_root(repo_root) / ".prd-os" / "spillover.jsonl"
+    try:
+        lines = path.read_text().splitlines()
+    except Exception:
+        return ids  # no ledger -> nothing is captured -> count everything (fail open)
+    for line in lines:
+        line = line.strip()
+        if not line:
+            continue
+        try:
+            rec = json.loads(line)
+        except Exception:
+            continue
+        rid = str(rec.get("id") or "")
+        if rid.startswith("defer-"):
+            ids.add(rid)
+    return ids
+
+
 def deferred_findings(repo_root):
     """Returns (surfaced, unclassified). surfaced = genuine future-work deferrals.
-    unclassified = deferred + not closeout-bookkeeping + not keyword-matched: COUNTED
-    (never silently dropped) so a plainly-worded parked finding can't fall on the ground."""
+    unclassified = deferred + not closeout-bookkeeping + not keyword-matched + not
+    already captured in the spillover ledger: COUNTED (never silently dropped) so a
+    plainly-worded parked finding can't fall on the ground."""
     out = []
     seen = set()
     unclassified = 0
+    captured = captured_finding_ids(repo_root)
     for jf in sorted(glob.glob(str(repo_root / ".prd-os" / "findings" / "*.jsonl"))):
+        prd_slug = Path(jf).name[: -len("-findings.jsonl")] if jf.endswith("-findings.jsonl") else Path(jf).stem
         try:
             lines = Path(jf).read_text().splitlines()
         except Exception:
@@ -86,6 +144,8 @@ def deferred_findings(repo_root):
                 continue
             if str(d.get("disposition", "")).lower() != "deferred":
                 continue
+            if f"defer-{prd_slug}-{d.get('id')}" in captured:
+                continue  # the spillover ledger owns it; `gates run` is its enforcer
             rationale = (d.get("rationale") or "").strip()
             if not rationale or FOLDED_RE.search(rationale):
                 continue  # closeout bookkeeping -> genuinely closed

--- a/q-system/.q-system/scripts/test/test-open-loops.sh
+++ b/q-system/.q-system/scripts/test/test-open-loops.sh
@@ -1,5 +1,7 @@
 #!/usr/bin/env bash
 # AUDHD anti-drop: open-loops.py surfaces every parked item. Pairs with open-loops.json registry.
+# spillover-skip -- every "deferred" string in this file is a TEST FIXTURE fed to the
+# surfacer, not a real parked item. Capturing them would put fake work in the ledger.
 set -euo pipefail
 ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/../../../.." && pwd)"
 S="$ROOT/q-system/.q-system/scripts/open-loops.py"
@@ -62,4 +64,29 @@ printf '%s\n' \
 OUT6="$(CLAUDE_PROJECT_DIR="$T3" python3 "$S" --report 2>&1)"
 echo "$OUT6" | grep -qi "not auto-classified" || fail "plainly-worded deferred not caught by catch-all (silent fall): $OUT6"
 
-echo "PASS: surfaces registry loops (incl seeded OSS PRs) + genuine deferred findings, excludes closed + folded bookkeeping, catch-all guarantees zero silent-fall, valid SessionStart JSON, never blocks on empty"
+# 7. already-captured: a plainly-worded deferred finding that the spillover ledger
+#    ALREADY holds (auto-created id `defer-<prd>-<finding-id>`, no-orphan-findings)
+#    is not in limbo -- the gate keeps it RED until resolved. Counting it in the
+#    catch-all re-surfaced tracked work as untracked every session (2026-08-14:
+#    3 deterministic-reading findings, 2 of them already RESOLVED, nagged forever).
+T4="$(mktemp -d)"; mkdir -p "$T4/q-system/memory" "$T4/.prd-os/findings"
+echo '{"loops":[]}' > "$T4/q-system/memory/open-loops.json"
+printf '%s\n' \
+ '{"id":"finding-3","disposition":"deferred","body":"captured already","rationale":"park this for now, real and out of scope here"}' \
+ '{"id":"finding-9","disposition":"deferred","body":"not captured","rationale":"park this for now, real and out of scope here"}' \
+ > "$T4/.prd-os/findings/prd-demo-2026-08-14-findings.jsonl"
+printf '%s\n' \
+ '{"id":"defer-prd-demo-2026-08-14-finding-3","source":"prd-demo-2026-08-14","description":"captured already","status":"open"}' \
+ > "$T4/.prd-os/spillover.jsonl"
+OUT7="$(CLAUDE_PROJECT_DIR="$T4" python3 "$S" --report 2>&1)"
+echo "$OUT7" | grep -q "1 deferred prd-os finding(s) not auto-classified" \
+  || fail "expected exactly 1 uncaptured finding in the catch-all (spillover-captured one must be excluded): $OUT7"
+
+# 7b. mutation guard: with NO ledger the same fixture must count BOTH, so section 7
+#     can fail for the reason it claims (a ledger-blind counter says 2).
+rm "$T4/.prd-os/spillover.jsonl"
+OUT7B="$(CLAUDE_PROJECT_DIR="$T4" python3 "$S" --report 2>&1)"
+echo "$OUT7B" | grep -q "2 deferred prd-os finding(s) not auto-classified" \
+  || fail "ledger-absent case must count both findings (check is decorative otherwise): $OUT7B"
+
+echo "PASS: surfaces registry loops (incl seeded OSS PRs) + genuine deferred findings, excludes closed + folded bookkeeping + spillover-captured, catch-all guarantees zero silent-fall, valid SessionStart JSON, never blocks on empty"


### PR DESCRIPTION
## Why this is a rescue

An unattended auto-commit wrote `421d78ac` onto the **local** `sana/ask-728-plugin-parity` checkout during the 2026-08-14 session and never pushed it. That branch is **15 commits behind origin and 2 ahead**, so the work existed only on this machine.

It also carried no issue id — which the `linear-issue-ref` commit-msg hook exists to refuse. So the ledger had no record of it either.

The other stranded commit, `eb25f466` (ASK-746 digest plist), turned out **byte-identical** to what main already carries. Redundant, dropped. This one is not on main in any form.

## What it fixes

A `deferred` disposition auto-creates a spillover item (`no-orphan-findings.md`). The open-loops catch-all was not reading that ledger, so it counted already-tracked findings and reported them to the founder as untracked.

`ledger_root()` resolves the ONE shared ledger via `git rev-parse --git-common-dir`, mirroring `prd_runner.py`. A per-worktree path would make this script blind to captures the gate can see — the same load-path mistake as the marketplace clone. It fails open to `repo_root`, because a missed skip only over-surfaces and never drops.

## Verification

Run on **this** branch, off current main — not on the stale branch it was stranded on:

- `test-open-loops.sh` is **RED** without the `open-loops.py` half: `expected exactly 1 uncaptured finding in the catch-all (spillover-captured one must be excluded)`.
- Green with it.

## Note for triage

ASK-759, ASK-760, ASK-763, ASK-765 and ASK-767 all describe overlapping slices of this same open-loops/spillover behavior. This PR claims ASK-763, the exact match. The duplication is worth a pass but is not touched here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0151EYtGH6at3XTWqbBHAxEi