### PR TITLE
The carve-out that prevents the dirty-tree refusal was causing it (ASK-775)

### DIFF
--- a/kipi-update.sh
+++ b/kipi-update.sh
@@ -232,6 +232,37 @@ PLUGIN_COPY_EXCLUDES=(
   ".env.*::(^|/)\.env\."
 )
 
+# Was this exact content EVER shipped by the skeleton for this path? (Codex
+# review of #151 round 6, major.)
+#
+# Comparing only against the CURRENT skeleton attributes nothing on the real
+# fleet. Instances hold what an earlier fanout wrote -- ASK-728 pushed prd-os
+# 0.27.1 -- while the skeleton has since moved to 0.27.3. Measured on a live
+# blocked instance 2026-08-14: both plugins/prd-os/.claude-plugin/plugin.json and
+# plugins/prd-os/tests/test_judgment_compiler.py DIFFER from the current
+# skeleton, so a current-only test calls both founder work and the instance stays
+# blocked on every unattended update. The fix would have unblocked zero
+# instances, which is the same trap that killed ASK-775's first theory.
+#
+# The honest question is not "is this the newest skeleton content" but "did this
+# content come from the fleet at all". A blob the skeleton ever committed at this
+# path did. A founder edit essentially never collides with a historical skeleton
+# blob, because it would have to reproduce a shipped revision byte for byte.
+#
+# Bounded on purpose: only paths already known dirty reach here (a handful per
+# instance), and the walk is limited to commits touching that one path.
+fleet_authored_blob() {
+  local rel="$1" file="$2" blob candidate commit
+  blob="$(git -C "$SCRIPT_DIR" hash-object -- "$file" 2>/dev/null || true)"
+  [ -n "$blob" ] || return 1
+  while IFS= read -r commit; do
+    [ -n "$commit" ] || continue
+    candidate="$(git -C "$SCRIPT_DIR" rev-parse "$commit:$rel" 2>/dev/null || true)"
+    [ "$candidate" = "$blob" ] && return 0
+  done < <(git -C "$SCRIPT_DIR" rev-list --all -- "$rel" 2>/dev/null || true)
+  return 1
+}
+
 plugin_copy_rsync_flags() {
   local entry
   for entry in "${PLUGIN_COPY_EXCLUDES[@]}"; do
@@ -1687,8 +1718,13 @@ PY
               say "  keeping STAGED local edit, not the fleet's to commit: $dirty_rel"
             elif [ ! -e "$SCRIPT_DIR/$dirty_rel" ] && [ ! -e "$path/$dirty_rel" ]; then
               sys_add_paths+=("$dirty_rel")
-            elif [ -f "$SCRIPT_DIR/$dirty_rel" ] && [ -f "$path/$dirty_rel" ] &&
-                cmp -s "$SCRIPT_DIR/$dirty_rel" "$path/$dirty_rel"; then
+            elif [ -f "$path/$dirty_rel" ] &&
+                { { [ -f "$SCRIPT_DIR/$dirty_rel" ] &&
+                    cmp -s "$SCRIPT_DIR/$dirty_rel" "$path/$dirty_rel"; } ||
+                  fleet_authored_blob "$dirty_rel" "$path/$dirty_rel"; }; then
+              # Current-skeleton equality first as the cheap path; the history
+              # walk only runs when that fails, which on the real fleet is the
+              # common case (instances hold an older fanout's bytes).
               sys_add_paths+=("$dirty_rel")
             else
               say "  keeping local edit, not the fleet's to commit: $dirty_rel"

--- a/kipi-update.sh
+++ b/kipi-update.sh
@@ -1641,8 +1641,35 @@ PY
             # deletion is the fleet's to record. A file the skeleton still ships
             # is NOT this case -- someone local deleted it, and the sync will put
             # it back, so it stays a local edit.
+            # THE INDEX IS A THIRD VERSION, AND `git add` DESTROYS IT (Codex
+            # review of #151 round 4, major). Comparing only worktree-to-skeleton
+            # misses this sequence: a founder STAGES an edit, a later fanout
+            # overwrites the working tree with the skeleton's copy, the equality
+            # test then says "fleet-written", and `git add` replaces the staged
+            # blob with the skeleton content. The founder's staged work is gone,
+            # with no diff left to show it ever existed.
+            #
+            # Every path here therefore has to clear the index before content is
+            # even considered. NOT "index == skeleton", which would break the
+            # whole fix: in the ordinary fanout case the index equals HEAD, the
+            # instance is behind, so index != skeleton and every legitimate path
+            # would be refused. The question is narrower -- is there a staged
+            # CHANGE, and if so is that staged content itself the skeleton's?
+            #
+            #   no staged change          -> index is just HEAD, nothing to lose
+            #   staged change == skeleton -> the fleet staged its own write
+            #   staged change != skeleton -> founder work in the index. Leave it.
+            # Deletion is tested FIRST, before the index. Gone from both sides is
+            # unambiguous, and the staged-blob test cannot express it: `git show
+            # :path` fails for a staged deletion, so the comparison below would
+            # read "differs from the skeleton" and refuse a deletion the fleet
+            # itself made -- re-blocking the instance for the case round 3 fixed.
             if [ ! -e "$SCRIPT_DIR/$dirty_rel" ] && [ ! -e "$path/$dirty_rel" ]; then
               sys_add_paths+=("$dirty_rel")
+            elif ! git diff --cached --quiet -- "$dirty_rel" 2>/dev/null &&
+                ! git show ":$dirty_rel" 2>/dev/null \
+                    | cmp -s - "$SCRIPT_DIR/$dirty_rel" 2>/dev/null; then
+              say "  keeping STAGED local edit, not the fleet's to commit: $dirty_rel"
             elif [ -f "$SCRIPT_DIR/$dirty_rel" ] && [ -f "$path/$dirty_rel" ] &&
                 cmp -s "$SCRIPT_DIR/$dirty_rel" "$path/$dirty_rel"; then
               sys_add_paths+=("$dirty_rel")

--- a/kipi-update.sh
+++ b/kipi-update.sh
@@ -1529,14 +1529,49 @@ PY
       # Without the classifier present we add nothing new -- the tracked entries
       # still stage, which is what unblocks the sync, and unclassifiable
       # untracked content is left for the guard below to refuse honestly.
+      # TRACKED EDITS NEED A DIFFERENT TEST THAN UNTRACKED ONES (Codex review of
+      # #151 round 2, major). `git add -u -- plugins/<name>` stages every tracked
+      # modification under the directory, so a founder editing a .py inside a
+      # managed plugin had it committed under a chore message.
+      #
+      # But the obvious fix -- run tracked files through auto-commit.py too --
+      # breaks the thing this PR exists to fix. That classifier refuses source by
+      # extension, and the file blocking 7 of the 11 instances is
+      # plugins/prd-os/tests/test_judgment_compiler.py. Classify it and it is
+      # refused, never committed, and the instance stays blocked forever.
+      #
+      # The distinguisher is not the extension, it is AUTHORSHIP, and the skeleton
+      # can answer that directly: if the instance's working-tree content for a
+      # managed-plugin file is byte-identical to the SKELETON's current content,
+      # that content came from the fleet -- an earlier fanout wrote it and failed
+      # to commit (ASK-728 did exactly this). Committing it records what is
+      # already there. If it differs from the skeleton, someone local wrote it,
+      # and it is not ours to take at any extension; it is left dirty so the guard
+      # below refuses this instance and protects it.
+      #
+      # Fail-closed both ways: a file we cannot read on either side is treated as
+      # founder work and left alone.
       sys_add_paths=()
       for sys_path in "${sys_owned_dirty[@]}"; do
         if [ -d "$path/$sys_path" ]; then
+          # Tracked modifications: skeleton-content equality decides.
+          while IFS= read -r dirty_rel; do
+            [ -n "$dirty_rel" ] || continue
+            if [ -f "$SCRIPT_DIR/$dirty_rel" ] && [ -f "$path/$dirty_rel" ] &&
+                cmp -s "$SCRIPT_DIR/$dirty_rel" "$path/$dirty_rel"; then
+              sys_add_paths+=("$dirty_rel")
+            else
+              say "  keeping local edit, not the fleet's to commit: $dirty_rel"
+            fi
+          done < <(git diff --name-only -- "$sys_path" 2>/dev/null
+                   git diff --cached --name-only -- "$sys_path" 2>/dev/null)
+          # Untracked content: the classifier decides, as before.
           while IFS= read -r dirty_rel; do
             [ -n "$dirty_rel" ] || continue
             sys_add_paths+=("$dirty_rel")
           done < <(
-            git status --porcelain -uall -- "$sys_path" 2>/dev/null | cut -c4- \
+            git status --porcelain -uall -- "$sys_path" 2>/dev/null \
+              | grep '^??' | cut -c4- \
               | { if [ -f "$sys_classifier" ]; then
                     python3 "$sys_classifier" --system-state 2>/dev/null
                   else
@@ -1545,9 +1580,12 @@ PY
                     true
                   fi; }
           )
-          # The directory itself still goes to the COMMIT pathspec: tracked
-          # modifications under it need no staging and must not be dropped.
-          sys_add_paths+=()
+          # The directory is deliberately NOT added to sys_add_paths. It was, in
+          # round 2, "so tracked modifications are not dropped" -- and that single
+          # line put the directory back into the commit pathspec, which is how the
+          # founder-edit path survived the first fix. The expansion above is now
+          # the ONLY way a path under a managed plugin reaches the commit.
+          :
         else
           sys_add_paths+=("$sys_path")
         fi
@@ -1555,9 +1593,12 @@ PY
       if [ "${#sys_add_paths[@]}" -gt 0 ]; then
         git add -- "${sys_add_paths[@]}" 2>/dev/null || true
       fi
-      # Tracked-but-unstaged content under the directory entries, staged with
-      # `-u` so no untracked file can ride along.
-      git add -u -- "${sys_owned_dirty[@]}" 2>/dev/null || true
+      # NO `git add -u -- "${sys_owned_dirty[@]}"` here. Round 2 had one, to catch
+      # tracked-but-unstaged content, and `-u` scoped to a DIRECTORY stages every
+      # tracked modification under it -- founder edits to a managed plugin
+      # included. sys_add_paths already carries the tracked files that passed the
+      # skeleton-equality test, and `git add` stages them whether or not they were
+      # staged before, so nothing is lost by dropping this line.
       # `[no-issue: ...]` rather than --no-verify: the instance's commit-msg
       # gate wants a Linear id, and this is the sanctioned hatch that gets
       # LOGGED to linear-bypass.jsonl. Bypassing an instance's hooks wholesale
@@ -1567,12 +1608,20 @@ PY
       # for months: a carve-out that cannot fail loudly cannot be noticed when it
       # does. The run still continues on failure -- the guard below is the real
       # decision and it fails closed -- but it says what happened first.
-      if ! sys_commit_err="$(git commit -q -m "chore: commit system-written state before skeleton sync [no-issue: fleet updater system-state commit]
+      #
+      # GUARDED ON NON-EMPTY, and this is not defensive padding. `git commit --`
+      # with an EMPTY pathspec is not a no-op: it commits everything already
+      # staged, which is precisely the founder-sweeping behaviour the PR #98 rule
+      # exists to stop. sys_add_paths is empty exactly when every dirty path was
+      # judged a local edit, i.e. the case where sweeping would be worst.
+      if [ "${#sys_add_paths[@]}" -eq 0 ]; then
+        say "  nothing to commit: every dirty system-owned path is a local edit"
+      elif ! sys_commit_err="$(git commit -q -m "chore: commit system-written state before skeleton sync [no-issue: fleet updater system-state commit]
 
 These files are written by the fleet itself (sycophancy stamp, integrity
 baseline, hook state, skeleton-shipped plugins). Committing them here keeps the
 updater from being blocked by its own exhaust; founder work is never included
-because this commit is pathspec-limited." -- "${sys_owned_dirty[@]}" 2>&1)"; then
+because this commit is pathspec-limited." -- "${sys_add_paths[@]}" 2>&1)"; then
         echo "  WARNING: the system-state commit FAILED; this instance will very"
         echo "  likely be refused below over dirt that is not founder work:"
         printf '%s\n' "$sys_commit_err" | sed 's/^/    /'

--- a/kipi-update.sh
+++ b/kipi-update.sh
@@ -1659,17 +1659,34 @@ PY
             #   no staged change          -> index is just HEAD, nothing to lose
             #   staged change == skeleton -> the fleet staged its own write
             #   staged change != skeleton -> founder work in the index. Leave it.
-            # Deletion is tested FIRST, before the index. Gone from both sides is
-            # unambiguous, and the staged-blob test cannot express it: `git show
-            # :path` fails for a staged deletion, so the comparison below would
-            # read "differs from the skeleton" and refuse a deletion the fleet
-            # itself made -- re-blocking the instance for the case round 3 fixed.
-            if [ ! -e "$SCRIPT_DIR/$dirty_rel" ] && [ ! -e "$path/$dirty_rel" ]; then
-              sys_add_paths+=("$dirty_rel")
-            elif ! git diff --cached --quiet -- "$dirty_rel" 2>/dev/null &&
-                ! git show ":$dirty_rel" 2>/dev/null \
-                    | cmp -s - "$SCRIPT_DIR/$dirty_rel" 2>/dev/null; then
+            # ONE index question, asked BEFORE any content or deletion reasoning
+            # (Codex review of #151 round 5, blocker). Round 5 put the deletion
+            # test first so a staged deletion by the fleet would not be misread --
+            # and that ordering made deletion skip the index check entirely. A
+            # founder stages an edit, the skeleton drops the file, the copy
+            # removes it, and "absent from both" committed a deletion straight
+            # over the staged blob. I introduced that hole while fixing round 4's.
+            #
+            # Ordering cannot resolve this, because the two cases need different
+            # index facts. So the index is consulted once, up front, and the
+            # question is precise:
+            #
+            #   no staged change            -> index is HEAD, nothing to lose
+            #   staged change, NO index entry -> the fleet staged its own deletion
+            #   staged change, entry == skeleton -> the fleet staged its own write
+            #   staged change, entry != skeleton -> founder work. Stop here.
+            staged_is_founders=0
+            if ! git diff --cached --quiet -- "$dirty_rel" 2>/dev/null; then
+              if git show ":$dirty_rel" >/dev/null 2>&1 &&
+                  ! git show ":$dirty_rel" 2>/dev/null \
+                      | cmp -s - "$SCRIPT_DIR/$dirty_rel" 2>/dev/null; then
+                staged_is_founders=1
+              fi
+            fi
+            if [ "$staged_is_founders" = "1" ]; then
               say "  keeping STAGED local edit, not the fleet's to commit: $dirty_rel"
+            elif [ ! -e "$SCRIPT_DIR/$dirty_rel" ] && [ ! -e "$path/$dirty_rel" ]; then
+              sys_add_paths+=("$dirty_rel")
             elif [ -f "$SCRIPT_DIR/$dirty_rel" ] && [ -f "$path/$dirty_rel" ] &&
                 cmp -s "$SCRIPT_DIR/$dirty_rel" "$path/$dirty_rel"; then
               sys_add_paths+=("$dirty_rel")

--- a/kipi-update.sh
+++ b/kipi-update.sh
@@ -1506,8 +1506,11 @@ PY
       # "Committing N system-written file(s)" line printed either way.
       #
       # Measured 2026-08-14, full dry sweep of 23 instances: 11 refusals, 10 of
-      # them preceded by that announcement. ktlyst-website named 3 files, 2 of
-      # them untracked, and refused with all 3 still dirty.
+      # them preceded by that announcement. One instance named 3 files, 2 of
+      # them untracked, and refused with all 3 still dirty. (Instance NAMED in
+      # the sweep log, not here: the skeleton ships to every instance, so an
+      # instance name in a skeleton script is a propagation leak, which Gate 1
+      # refuses. Learned the hard way on this very commit.)
       #
       # FILES, NEVER DIRECTORIES (Codex review of #151, major). "Pathspec-limited"
       # was not the safety I claimed it was: sys_owned_dirty carries DIRECTORY

--- a/kipi-update.sh
+++ b/kipi-update.sh
@@ -1509,11 +1509,55 @@ PY
       # them preceded by that announcement. ktlyst-website named 3 files, 2 of
       # them untracked, and refused with all 3 still dirty.
       #
-      # The add is pathspec-limited to sys_owned_dirty, the same list the commit
-      # uses, so it cannot reach founder work -- it stages exactly what was
-      # already going to be committed and nothing else. The PR #98 rule was
-      # protecting against a BARE add; this is not one.
-      git add -- "${sys_owned_dirty[@]}" 2>/dev/null || true
+      # FILES, NEVER DIRECTORIES (Codex review of #151, major). "Pathspec-limited"
+      # was not the safety I claimed it was: sys_owned_dirty carries DIRECTORY
+      # entries -- `plugins/<name>` for every managed plugin, from
+      # system_owned_paths_for_run -- and `git add <dir>` recursively stages every
+      # untracked file beneath it. That includes untracked SOURCE a founder is
+      # mid-edit on inside a managed plugin. Measured on this repo: 91 such paths
+      # under plugins/kipi-core, 47 under plugins/prd-os.
+      #
+      # auto-commit.py:170 refuses source by extension precisely so the fleet
+      # never commits founder code (ASK-712). Handing `git add` a directory walks
+      # straight past that file-level decision. The fix for a silent commit
+      # failure must not become a silent commit of the wrong thing.
+      #
+      # So each entry is expanded to the paths that are ACTUALLY dirty under it,
+      # and every one of those is re-classified by the same auto-commit.py the
+      # untracked loop above uses. A path the classifier will not call system
+      # state is dropped here even though its parent directory is system-owned.
+      # Without the classifier present we add nothing new -- the tracked entries
+      # still stage, which is what unblocks the sync, and unclassifiable
+      # untracked content is left for the guard below to refuse honestly.
+      sys_add_paths=()
+      for sys_path in "${sys_owned_dirty[@]}"; do
+        if [ -d "$path/$sys_path" ]; then
+          while IFS= read -r dirty_rel; do
+            [ -n "$dirty_rel" ] || continue
+            sys_add_paths+=("$dirty_rel")
+          done < <(
+            git status --porcelain -uall -- "$sys_path" 2>/dev/null | cut -c4- \
+              | { if [ -f "$sys_classifier" ]; then
+                    python3 "$sys_classifier" --system-state 2>/dev/null
+                  else
+                    # No classifier, no new untracked staging. `true` consumes
+                    # stdin and emits nothing, which is the fail-closed answer.
+                    true
+                  fi; }
+          )
+          # The directory itself still goes to the COMMIT pathspec: tracked
+          # modifications under it need no staging and must not be dropped.
+          sys_add_paths+=()
+        else
+          sys_add_paths+=("$sys_path")
+        fi
+      done
+      if [ "${#sys_add_paths[@]}" -gt 0 ]; then
+        git add -- "${sys_add_paths[@]}" 2>/dev/null || true
+      fi
+      # Tracked-but-unstaged content under the directory entries, staged with
+      # `-u` so no untracked file can ride along.
+      git add -u -- "${sys_owned_dirty[@]}" 2>/dev/null || true
       # `[no-issue: ...]` rather than --no-verify: the instance's commit-msg
       # gate wants a Linear id, and this is the sanctioned hatch that gets
       # LOGGED to linear-bypass.jsonl. Bypassing an instance's hooks wholesale

--- a/kipi-update.sh
+++ b/kipi-update.sh
@@ -251,15 +251,39 @@ PLUGIN_COPY_EXCLUDES=(
 #
 # Bounded on purpose: only paths already known dirty reach here (a handful per
 # instance), and the walk is limited to commits touching that one path.
+# "SHIPPED" IS THE FAN-OUT BRANCH, NOT EVERY REF IN THE CLONE (Codex review of
+# #151 round 7, major). The first version walked `rev-list --all`, which includes
+# unmerged feature branches, other people's work, and anything else this clone
+# happens to hold. A blob that only ever existed on a branch was never shipped to
+# any instance, so accepting it lets an unattended update commit over founder
+# work that merely resembles someone's WIP. The fleet fans out from
+# $SKELETON_BRANCH and only from there, so that is the boundary.
+#
+# origin/<branch> is preferred over the local branch deliberately: the ASK-762
+# preflight already refuses to run unless HEAD equals origin/$SKELETON_BRANCH, so
+# the remote ref is the one with a proven meaning. The local fallbacks exist for
+# fixtures and clones with no origin, where there is no remote to disagree with.
+fleet_ship_ref() {
+  local ref
+  for ref in "refs/remotes/origin/$SKELETON_BRANCH" "refs/heads/$SKELETON_BRANCH" HEAD; do
+    if git -C "$SCRIPT_DIR" rev-parse --verify --quiet "$ref" >/dev/null 2>&1; then
+      printf '%s\n' "$ref"
+      return 0
+    fi
+  done
+  return 1
+}
+
 fleet_authored_blob() {
-  local rel="$1" file="$2" blob candidate commit
+  local rel="$1" file="$2" blob candidate commit ship_ref
+  ship_ref="$(fleet_ship_ref)" || return 1
   blob="$(git -C "$SCRIPT_DIR" hash-object -- "$file" 2>/dev/null || true)"
   [ -n "$blob" ] || return 1
   while IFS= read -r commit; do
     [ -n "$commit" ] || continue
     candidate="$(git -C "$SCRIPT_DIR" rev-parse "$commit:$rel" 2>/dev/null || true)"
     [ "$candidate" = "$blob" ] && return 0
-  done < <(git -C "$SCRIPT_DIR" rev-list --all -- "$rel" 2>/dev/null || true)
+  done < <(git -C "$SCRIPT_DIR" rev-list "$ship_ref" -- "$rel" 2>/dev/null || true)
   return 1
 }
 

--- a/kipi-update.sh
+++ b/kipi-update.sh
@@ -1485,23 +1485,54 @@ PY
         { [ "$DRY_RUN" != "--dry-run" ] || [ "$MODEL_RUN" = "1" ]; }; then
       say "  Committing ${#sys_owned_dirty[@]} system-written file(s) so they do not block the sync:"
       printf '    %s\n' "${sys_owned_dirty[@]}"
-      # PATHSPEC-limited commit, and NO `git add`. Both matter: `git commit`
-      # with no pathspec commits everything ALREADY STAGED, so a founder with
-      # staged work would have had it swept into this infra commit -- the exact
-      # thing the guard below exists to prevent, reintroduced by the fix for it
-      # (Codex review, PR #98). With a pathspec, only these paths are committed
-      # no matter what else sits in the index.
+      # PATHSPEC-limited commit. `git commit` with no pathspec commits everything
+      # ALREADY STAGED, so a founder with staged work would have had it swept into
+      # this infra commit -- the exact thing the guard below exists to prevent,
+      # reintroduced by the fix for it (Codex review, PR #98). With a pathspec,
+      # only these paths are committed no matter what else sits in the index.
       #
+      # THE ADD IS REQUIRED, AND IT IS SAFE (ASK-775). This block used to carry
+      # "NO `git add`" as a rule, which quietly broke the whole carve-out: the
+      # list MIXES tracked and untracked paths -- the classifier above pulls in
+      # untracked machine exhaust on purpose -- and
+      #
+      #     git commit -- <tracked> <untracked>
+      #     error: pathspec '<untracked>' did not match any file(s) known to git
+      #
+      # commits NOTHING. One untracked artifact therefore left the TRACKED
+      # skeleton-owned dirt uncommitted too, and the guard below then refused the
+      # instance over the very files this block had just announced it handled.
+      # With `2>/dev/null || true` the failure was invisible while the
+      # "Committing N system-written file(s)" line printed either way.
+      #
+      # Measured 2026-08-14, full dry sweep of 23 instances: 11 refusals, 10 of
+      # them preceded by that announcement. ktlyst-website named 3 files, 2 of
+      # them untracked, and refused with all 3 still dirty.
+      #
+      # The add is pathspec-limited to sys_owned_dirty, the same list the commit
+      # uses, so it cannot reach founder work -- it stages exactly what was
+      # already going to be committed and nothing else. The PR #98 rule was
+      # protecting against a BARE add; this is not one.
+      git add -- "${sys_owned_dirty[@]}" 2>/dev/null || true
       # `[no-issue: ...]` rather than --no-verify: the instance's commit-msg
       # gate wants a Linear id, and this is the sanctioned hatch that gets
       # LOGGED to linear-bypass.jsonl. Bypassing an instance's hooks wholesale
       # to land a commit in their repo is not ours to do.
-      git commit -q -m "chore: commit system-written state before skeleton sync [no-issue: fleet updater system-state commit]
+      #
+      # NOT SILENT ANY MORE. The old `2>/dev/null || true` is what let this run
+      # for months: a carve-out that cannot fail loudly cannot be noticed when it
+      # does. The run still continues on failure -- the guard below is the real
+      # decision and it fails closed -- but it says what happened first.
+      if ! sys_commit_err="$(git commit -q -m "chore: commit system-written state before skeleton sync [no-issue: fleet updater system-state commit]
 
 These files are written by the fleet itself (sycophancy stamp, integrity
 baseline, hook state, skeleton-shipped plugins). Committing them here keeps the
 updater from being blocked by its own exhaust; founder work is never included
-because this commit is pathspec-limited." -- "${sys_owned_dirty[@]}" 2>/dev/null || true
+because this commit is pathspec-limited." -- "${sys_owned_dirty[@]}" 2>&1)"; then
+        echo "  WARNING: the system-state commit FAILED; this instance will very"
+        echo "  likely be refused below over dirt that is not founder work:"
+        printf '%s\n' "$sys_commit_err" | sed 's/^/    /'
+      fi
     fi
 
     # Refuse tracked work in progress. The updater owns only its scoped sync

--- a/kipi-update.sh
+++ b/kipi-update.sh
@@ -1557,7 +1557,19 @@ PY
           # Tracked modifications: skeleton-content equality decides.
           while IFS= read -r dirty_rel; do
             [ -n "$dirty_rel" ] || continue
-            if [ -f "$SCRIPT_DIR/$dirty_rel" ] && [ -f "$path/$dirty_rel" ] &&
+            # DELETIONS ARE AUTHORED TOO (Codex review of #151 round 3, major).
+            # `cmp` needs both sides to exist, so a file the fleet DELETED read as
+            # a local edit and blocked the instance permanently -- the very
+            # deadlock this PR exists to break, reintroduced for the one case the
+            # equality test could not express. The skeleton answers deletion the
+            # same way it answers content: if the skeleton no longer ships the
+            # file AND the instance no longer has it, the copy removed it and the
+            # deletion is the fleet's to record. A file the skeleton still ships
+            # is NOT this case -- someone local deleted it, and the sync will put
+            # it back, so it stays a local edit.
+            if [ ! -e "$SCRIPT_DIR/$dirty_rel" ] && [ ! -e "$path/$dirty_rel" ]; then
+              sys_add_paths+=("$dirty_rel")
+            elif [ -f "$SCRIPT_DIR/$dirty_rel" ] && [ -f "$path/$dirty_rel" ] &&
                 cmp -s "$SCRIPT_DIR/$dirty_rel" "$path/$dirty_rel"; then
               sys_add_paths+=("$dirty_rel")
             else

--- a/q-system/.q-system/capability-manifest.json
+++ b/q-system/.q-system/capability-manifest.json
@@ -163,6 +163,10 @@
       "runner": "bash"
     },
     {
+      "path": "q-system/.q-system/scripts/test/test-kipi-update-system-state-commit.sh",
+      "runner": "bash"
+    },
+    {
       "path": "q-system/.q-system/scripts/test/test-kipi-update-unmanaged-instance.sh",
       "runner": "bash"
     },
@@ -605,6 +609,7 @@
     "q-system/.q-system/scripts/test/test-kipi-update-preservation-failure.sh",
     "q-system/.q-system/scripts/test/test-kipi-update-safety.sh",
     "q-system/.q-system/scripts/test/test-kipi-update-source-provenance.sh",
+    "q-system/.q-system/scripts/test/test-kipi-update-system-state-commit.sh",
     "q-system/.q-system/scripts/test/test-lessons-push-guard.sh",
     "q-system/.q-system/scripts/test/test-propagation-entrypoints.py",
     "q-system/.q-system/scripts/test/test-propagation-leak-baseline.py",
@@ -686,7 +691,7 @@
     },
     {
       "path": "q-system/.q-system/scripts/stat-verify.py",
-      "reason": "802-line stat verification engine; zero hook wiring and its stat-registry.json data file exists in exactly one instance — wiring it is a founder product decision",
+      "reason": "802-line stat verification engine; zero hook wiring and its stat-registry.json data file exists in exactly one instance \u2014 wiring it is a founder product decision",
       "spillover_id": "sp-72b60bff"
     },
     {
@@ -706,8 +711,8 @@
     }
   ],
   "uncovered_known": [
-    "plugins/*/tests — prd-os plugin suite, run by the plugin's own harness; outside v1 scan roots (finding-9 deferred)",
+    "plugins/*/tests \u2014 prd-os plugin suite, run by the plugin's own harness; outside v1 scan roots (finding-9 deferred)",
     "repo-root *.sh utilities are wiring surfaces, not test artifacts",
-    "stat-registry.json: NOT expressible as required_data in v1 — the one instance holding it keeps canonical under its own instance_q_dir (not q-system/) and its registry name differs from its dir basename, so a scoped entry could never fire (grounded 2026-07-23). Declared gap; owning decision + instance detail in spillover sp-72b60bff"
+    "stat-registry.json: NOT expressible as required_data in v1 \u2014 the one instance holding it keeps canonical under its own instance_q_dir (not q-system/) and its registry name differs from its dir basename, so a scoped entry could never fire (grounded 2026-07-23). Declared gap; owning decision + instance detail in spillover sp-72b60bff"
   ]
 }

--- a/q-system/.q-system/scripts/test/test-kipi-update-system-state-commit.sh
+++ b/q-system/.q-system/scripts/test/test-kipi-update-system-state-commit.sh
@@ -413,7 +413,62 @@ assert_a_staged_edit_survives_deletion_from_both_sides() {
   echo "PASS: a staged founder edit survives deletion from both the skeleton and the working tree"
 }
 
+# ------------------------------------------------------------------ property 8
+# Content from an OLDER skeleton version is still the fleet's.
+#
+# Codex review of #151 round 6, major, and it was the difference between this PR
+# working and doing nothing. Instances hold what an earlier fanout wrote while
+# the skeleton has moved on, so a current-skeleton-only equality test attributes
+# real fleet content to the founder and leaves the instance blocked forever.
+# Measured on a live blocked instance: both prd-os files DIFFER from the current
+# skeleton, so the current-only rule would have unblocked zero of them.
+#
+# The founder half is in the same run, because "accept anything that was ever
+# shipped" must not become "accept anything".
+assert_older_fleet_content_is_attributed_to_the_fleet() {
+  local work sk inst carve; work="$(mktemp -d)"; sk="$work/skel"; inst="$work/inst"
+  build "$work"
+
+  # v1 of a plugin file, shipped and committed by the skeleton.
+  printf 'def api():\n    return "v1"\n' > "$sk/plugins/demo/api.py"
+  printf 'def api():\n    return "v1"\n' > "$inst/plugins/demo/api.py"
+  ( cd "$sk" && G add -A -f && G commit -qm "skeleton ships v1" )
+  ( cd "$inst" && G add -A -f && G commit -qm "instance commits v1" )
+
+  # An earlier fanout wrote v2 into the instance and failed to commit...
+  printf 'def api():\n    return "v2"\n' > "$sk/plugins/demo/api.py"
+  ( cd "$sk" && G add -A && G commit -qm "skeleton ships v2" )
+  cp "$sk/plugins/demo/api.py" "$inst/plugins/demo/api.py"
+  # ...and the skeleton has since MOVED ON to v3. The instance's dirty content
+  # now matches no current skeleton file -- only a historical one.
+  printf 'def api():\n    return "v3"\n' > "$sk/plugins/demo/api.py"
+  ( cd "$sk" && G add -A && G commit -qm "skeleton ships v3" )
+
+  # A founder edit that was never any skeleton revision, in the same directory.
+  printf 'def local():\n    return "never shipped"\n' > "$inst/plugins/demo/local.py"
+  ( cd "$inst" && G add plugins/demo/local.py && G commit -qm "instance adds its own" )
+  printf 'def local():\n    return "founder changed it"\n' > "$inst/plugins/demo/local.py"
+
+  bash "$sk/kipi-update.sh" >"$work/out" 2>&1 || true
+
+  carve="$(G -C "$inst" log --format='%H %s' 2>/dev/null \
+             | grep -F 'commit system-written state' | head -1 | cut -d' ' -f1 || true)"
+  [ -n "$carve" ] || fail "no system-state commit: older fleet content stayed blocked: $(cat "$work/out")"
+
+  G -C "$inst" show --name-only --format= "$carve" 2>/dev/null \
+    | grep -qx "plugins/demo/api.py" || \
+    fail "content from an OLDER skeleton version was not attributed to the fleet"
+
+  if G -C "$inst" show --name-only --format= "$carve" 2>/dev/null \
+       | grep -qx "plugins/demo/local.py"; then
+    fail "a founder edit that was never a skeleton revision was committed"
+  fi
+
+  echo "PASS: content from any shipped skeleton revision is the fleet's; never-shipped content is not"
+}
+
 assert_a_mixed_pathspec_commit_commits_nothing
+assert_older_fleet_content_is_attributed_to_the_fleet
 assert_a_staged_founder_edit_is_never_overwritten
 assert_a_staged_edit_survives_deletion_from_both_sides
 assert_deletions_split_by_authorship

--- a/q-system/.q-system/scripts/test/test-kipi-update-system-state-commit.sh
+++ b/q-system/.q-system/scripts/test/test-kipi-update-system-state-commit.sh
@@ -162,8 +162,15 @@ assert_founder_work_is_never_swept() {
   # over a flat log guesses at which commit a filename belongs to and was
   # reporting a false positive on the sync commit two entries away.
   local carve
+  # `|| true` inside the substitution is load-bearing. Under `set -e` a FAILING
+  # command substitution kills the script AT the assignment, printing nothing --
+  # so when no carve-out commit exists (exactly the case an assertion below wants
+  # to report) this file exited silently mid-run and looked like a pass with
+  # fewer lines. Caught 2026-08-14 while running this very test against a
+  # deliberately broken updater. Same silent-failure class the code under test
+  # has; a test that dies quietly cannot police one.
   carve="$(G -C "$inst" log --format='%H %s' 2>/dev/null \
-             | grep -F 'commit system-written state' | head -1 | cut -d' ' -f1)"
+             | grep -F 'commit system-written state' | head -1 | cut -d' ' -f1 || true)"
   if [ -n "$carve" ]; then
     if G -C "$inst" show --name-only --format= "$carve" 2>/dev/null \
          | grep -qx "q-system/tracked.md"; then
@@ -196,7 +203,7 @@ assert_untracked_source_in_a_managed_plugin_is_never_staged() {
   bash "$sk/kipi-update.sh" >"$work/out" 2>&1 || true
 
   carve="$(G -C "$inst" log --format='%H %s' 2>/dev/null \
-             | grep -F 'commit system-written state' | head -1 | cut -d' ' -f1)"
+             | grep -F 'commit system-written state' | head -1 | cut -d' ' -f1 || true)"
   if [ -n "$carve" ]; then
     if G -C "$inst" show --name-only --format= "$carve" 2>/dev/null \
          | grep -qx "plugins/demo/scratch_wip.py"; then
@@ -256,7 +263,7 @@ assert_tracked_plugin_edits_split_by_authorship() {
   bash "$sk/kipi-update.sh" >"$work/out" 2>&1 || true
 
   carve="$(G -C "$inst" log --format='%H %s' 2>/dev/null \
-             | grep -F 'commit system-written state' | head -1 | cut -d' ' -f1)"
+             | grep -F 'commit system-written state' | head -1 | cut -d' ' -f1 || true)"
   [ -n "$carve" ] || fail "no system-state commit was made at all: $(cat "$work/out")"
 
   G -C "$inst" show --name-only --format= "$carve" 2>/dev/null \
@@ -277,7 +284,55 @@ assert_tracked_plugin_edits_split_by_authorship() {
   echo "PASS: fleet-written plugin files commit; tracked founder edits in the same dir do not"
 }
 
+# ------------------------------------------------------------------ property 5
+# Deletions are authored too. Codex review of #151 round 3: the equality test
+# needs both sides to exist, so a file the FLEET deleted read as a local edit and
+# blocked the instance permanently -- the same deadlock this file exists to
+# break, reintroduced for the one case `cmp` could not express.
+#
+# Both halves again, because "commit every deletion" is as wrong as "commit none":
+#   FLEET DELETION  skeleton no longer ships it, instance no longer has it.
+#                   Record it.
+#   LOCAL DELETION  skeleton still ships it. Someone local removed it and the sync
+#                   will put it back. Not ours to record.
+assert_deletions_split_by_authorship() {
+  local work sk inst carve; work="$(mktemp -d)"; sk="$work/skel"; inst="$work/inst"
+  build "$work"
+
+  # Two files tracked in BOTH, so each can be deleted independently.
+  printf 'dropped by a later skeleton\n' > "$sk/plugins/demo/retired.txt"
+  printf 'dropped by a later skeleton\n' > "$inst/plugins/demo/retired.txt"
+  printf 'still shipped\n' > "$sk/plugins/demo/kept.txt"
+  printf 'still shipped\n' > "$inst/plugins/demo/kept.txt"
+  ( cd "$sk" && G add -A -f && G commit -qm "skeleton ships both" )
+  ( cd "$inst" && G add -A -f && G commit -qm "instance has both" )
+
+  # FLEET DELETION: the skeleton dropped it and the copy removed it.
+  rm -f "$sk/plugins/demo/retired.txt" "$inst/plugins/demo/retired.txt"
+  ( cd "$sk" && G add -A && G commit -qm "skeleton retires the file" )
+  # LOCAL DELETION: the skeleton still ships kept.txt; someone local removed it.
+  rm -f "$inst/plugins/demo/kept.txt"
+
+  bash "$sk/kipi-update.sh" >"$work/out" 2>&1 || true
+
+  carve="$(G -C "$inst" log --format='%H %s' 2>/dev/null \
+             | grep -F 'commit system-written state' | head -1 | cut -d' ' -f1 || true)"
+  [ -n "$carve" ] || fail "no system-state commit was made: $(cat "$work/out")"
+
+  G -C "$inst" show --name-only --format= "$carve" 2>/dev/null \
+    | grep -qx "plugins/demo/retired.txt" || \
+    fail "the FLEET's deletion was not recorded, so the instance stays blocked"
+
+  if G -C "$inst" show --name-only --format= "$carve" 2>/dev/null \
+       | grep -qx "plugins/demo/kept.txt"; then
+    fail "a local deletion of a still-shipped file was recorded as the fleet's"
+  fi
+
+  echo "PASS: a fleet deletion is recorded; a local deletion of a shipped file is not"
+}
+
 assert_a_mixed_pathspec_commit_commits_nothing
+assert_deletions_split_by_authorship
 assert_the_carve_out_clears_tracked_system_dirt
 assert_founder_work_is_never_swept
 assert_untracked_source_in_a_managed_plugin_is_never_staged

--- a/q-system/.q-system/scripts/test/test-kipi-update-system-state-commit.sh
+++ b/q-system/.q-system/scripts/test/test-kipi-update-system-state-commit.sh
@@ -369,8 +369,53 @@ assert_a_staged_founder_edit_is_never_overwritten() {
   echo "PASS: a staged founder edit survives a working tree overwritten with skeleton content"
 }
 
+# ------------------------------------------------------------------ property 7
+# A staged founder edit must survive even when the file is DELETED from both the
+# skeleton and the working tree.
+#
+# Codex review of #151 round 5, BLOCKER, and the hole was created by round 5's
+# own fix: putting the deletion test before the index check meant "absent from
+# both" never consulted the index at all, so a committed deletion landed straight
+# on top of a staged founder blob. Two fixes in a row each opened the other's
+# case, which is why the index is now asked once, up front.
+assert_a_staged_edit_survives_deletion_from_both_sides() {
+  local work sk inst staged carve; work="$(mktemp -d)"; sk="$work/skel"; inst="$work/inst"
+  build "$work"
+
+  printf 'def doomed():\n    return 1\n' > "$sk/plugins/demo/doomed.py"
+  printf 'def doomed():\n    return 1\n' > "$inst/plugins/demo/doomed.py"
+  ( cd "$sk" && G add -A -f && G commit -qm "skeleton ships it" )
+  ( cd "$inst" && G add -A -f && G commit -qm "instance has it" )
+
+  # Founder stages an edit.
+  printf 'def doomed():\n    return "founder staged this"\n' > "$inst/plugins/demo/doomed.py"
+  ( cd "$inst" && G add plugins/demo/doomed.py )
+  # The skeleton retires the file and the copy removes it from the working tree.
+  rm -f "$sk/plugins/demo/doomed.py"
+  ( cd "$sk" && G add -A && G commit -qm "skeleton retires it" )
+  rm -f "$inst/plugins/demo/doomed.py"
+
+  bash "$sk/kipi-update.sh" >"$work/out" 2>&1 || true
+
+  staged="$(G -C "$inst" show ":plugins/demo/doomed.py" 2>/dev/null || true)"
+  case "$staged" in
+    *"founder staged this"*) : ;;
+    *) fail "the founder's STAGED blob was destroyed by the deletion path; index holds: '$staged'" ;;
+  esac
+
+  carve="$(G -C "$inst" log --format='%H %s' 2>/dev/null \
+             | grep -F 'commit system-written state' | head -1 | cut -d' ' -f1 || true)"
+  if [ -n "$carve" ] && G -C "$inst" show --name-only --format= "$carve" 2>/dev/null \
+       | grep -qx "plugins/demo/doomed.py"; then
+    fail "a deletion was committed over a staged founder edit"
+  fi
+
+  echo "PASS: a staged founder edit survives deletion from both the skeleton and the working tree"
+}
+
 assert_a_mixed_pathspec_commit_commits_nothing
 assert_a_staged_founder_edit_is_never_overwritten
+assert_a_staged_edit_survives_deletion_from_both_sides
 assert_deletions_split_by_authorship
 assert_the_carve_out_clears_tracked_system_dirt
 assert_founder_work_is_never_swept

--- a/q-system/.q-system/scripts/test/test-kipi-update-system-state-commit.sh
+++ b/q-system/.q-system/scripts/test/test-kipi-update-system-state-commit.sh
@@ -1,0 +1,175 @@
+#!/usr/bin/env bash
+# The carve-out that exists to PREVENT the dirty-tree refusal is what causes it.
+#
+# Before the guard at kipi-update.sh:~1534 judges an instance, a block above it
+# commits the fleet's own exhaust -- the sycophancy stamp, the integrity
+# baseline, hook state, and every skeleton-managed plugin dir -- so that
+# machine-written files are never mistaken for founder work. It builds a list
+# and runs ONE pathspec-limited commit over it.
+#
+# That list mixes TRACKED and UNTRACKED paths, and `git commit -- <pathspec>`
+# fails outright on a path git does not know:
+#
+#   error: pathspec 'untracked.txt' did not match any file(s) known to git
+#
+# git commits NOTHING when that happens, so the tracked half of the list stays
+# dirty too. The call ends in `2>/dev/null || true`, so the failure is invisible,
+# and the "Committing N system-written file(s)" line prints either way. The guard
+# then refuses the instance over the very files the carve-out just announced it
+# had handled.
+#
+# Measured 2026-08-14, full dry sweep of 23 instances: 11 refusals, 10 of them
+# preceded by that announcement. ktlyst-website announced 3 files (plugins/prd-os,
+# .claude-integrity-armed, claude-integrity-baseline.json) and then refused with
+# all 3 still dirty. Two of the three were untracked, which is what poisoned the
+# commit that would have cleared the third.
+#
+# This is why ASK-775's original theory looked right: the untracked integrity
+# artifacts ARE implicated. Not because the guard sees them -- it only reads
+# `git diff`, which is blind to untracked files -- but because their presence in
+# the pathspec kills the commit that would have cleared the tracked dirt.
+set -euo pipefail
+ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/../../../.." && pwd)"
+fail() { echo "FAIL: $1" >&2; exit 1; }
+G() { git -c user.email=t@t.t -c user.name=test -c commit.gpgsign=false "$@"; }
+
+# ------------------------------------------------------------------ property 0
+# The git behaviour the whole bug rests on. Pinned separately so that if a future
+# git ever changes it, this file says which assumption moved rather than leaving
+# the integration test failing for an unexplained reason.
+assert_a_mixed_pathspec_commit_commits_nothing() {
+  local work; work="$(mktemp -d)"
+  ( cd "$work" && G init -q
+    printf 'v1\n' > tracked.txt && G add -A && G commit -qm init
+    printf 'v2\n' > tracked.txt
+    printf 'new\n' > untracked.txt
+    if G commit -q -m mixed -- tracked.txt untracked.txt 2>/dev/null; then
+      echo "MIXED_COMMIT_SUCCEEDED"
+    fi
+    G status --porcelain )> "$work/out" 2>&1
+
+  if grep -q "MIXED_COMMIT_SUCCEEDED" "$work/out"; then
+    fail "git accepted a mixed tracked/untracked pathspec commit; the premise moved"
+  fi
+  grep -q "^ M tracked.txt" "$work/out" || \
+    fail "the TRACKED half should still be dirty after the failed commit: $(cat "$work/out")"
+
+  echo "PASS: one untracked path makes git commit -- <pathspec> commit nothing at all"
+}
+
+# ------------------------------------------------------------------ the fixture
+# A skeleton plus one instance that reproduces the live shape: a tracked,
+# skeleton-owned plugin file modified (what the guard actually trips on) AND
+# untracked integrity artifacts (what poisons the carve-out's commit).
+build() {
+  local work="$1" sk="$work/skel" inst="$work/inst"
+  mkdir -p "$sk/q-system/.q-system/scripts" "$sk/q-system/.q-system/state" \
+           "$sk/q-system/hooks" "$sk/plugins/demo" "$sk/.claude/rules"
+  for f in kipi-update.sh kipi-update-preserve-scan.py kipi-update-deletion-guard.py \
+           validate-separation.py; do
+    cp "$ROOT/$f" "$sk/$f"
+  done
+  cp "$ROOT/q-system/.q-system/scripts/propagation-leak-gate.py" \
+     "$sk/q-system/.q-system/scripts/propagation-leak-gate.py"
+  cp "$ROOT/q-system/.q-system/scripts/containment-targets.py" \
+     "$sk/q-system/.q-system/scripts/containment-targets.py"
+  # THE CLASSIFIER IS LOAD-BEARING FOR THIS FIXTURE. Without it the
+  # `[ -f "$sys_classifier" ]` branch is skipped, no UNTRACKED path ever enters
+  # sys_owned_dirty, the carve-out commits a single tracked path and succeeds --
+  # and the bug does not reproduce at all. Omitting it is how this test passed
+  # while the live fleet was failing (caught 2026-08-14 by instrumenting the
+  # fixture rather than trusting the green).
+  cp "$ROOT/q-system/hooks/auto-commit.py" "$sk/q-system/hooks/auto-commit.py"
+  cat > "$sk/q-system/.q-system/state/propagation-leak-baseline.json" <<'JSON'
+{
+  "schema_version": 1,
+  "blocking_classes": ["case_proof_gap", "client_identity", "dated_interaction",
+                       "pricing", "relationship", "source_identity",
+                       "sourced_interaction"],
+  "classifier_sha256": null,
+  "entries": []
+}
+JSON
+  printf 'generic skeleton content\n' > "$sk/q-system/tracked.md"
+  # v2 of the managed plugin: the sync will want to write this into the instance.
+  printf 'plugin v2\n' > "$sk/plugins/demo/content.txt"
+  printf '# demo rule\n' > "$sk/.claude/rules/demo.md"
+  ( cd "$sk" && G init -q -b main && G add -A -f && G commit -qm skel )
+  printf '{"instances":[{"name":"testinst","path":"%s","subtree_prefix":"q-system","type":"subtree"}]}\n' \
+    "$inst" > "$sk/instance-registry.json"
+
+  # The instance: v1 of the managed plugin, TRACKED and about to be modified.
+  mkdir -p "$inst/q-system/.q-system" "$inst/plugins/demo" "$inst/.claude"
+  printf 'instance state\n' > "$inst/q-system/tracked.md"
+  printf 'plugin v1\n' > "$inst/plugins/demo/content.txt"
+  ( cd "$inst" && G init -q -b main && G add -A -f && G commit -qm inst )
+
+  # The live shape, both halves:
+  #   TRACKED and modified -- a skeleton-owned plugin file. This is what the
+  #   guard reads, and what the carve-out is supposed to clear.
+  printf 'plugin v1-locally-rewritten\n' > "$inst/plugins/demo/content.txt"
+  #   UNTRACKED -- the integrity artifacts the tripwire writes into the synced
+  #   tree. Invisible to the guard, fatal to the carve-out's pathspec.
+  printf 'armed\n' > "$inst/q-system/.q-system/.claude-integrity-armed"
+  printf '{}\n' > "$inst/q-system/.q-system/claude-integrity-baseline.json"
+}
+
+# ------------------------------------------------------------------ property 1
+# The integration case. The carve-out must actually clear the tracked
+# skeleton-owned dirt so the instance syncs, and it must not be defeated by an
+# untracked path sharing its list.
+assert_the_carve_out_clears_tracked_system_dirt() {
+  local work sk inst out; work="$(mktemp -d)"; sk="$work/skel"; inst="$work/inst"
+  build "$work"
+
+  out="$(bash "$sk/kipi-update.sh" 2>&1)" || true
+
+  if echo "$out" | grep -q "refusing to commit unrelated work"; then
+    fail "the instance was refused over dirt the carve-out announced it handled:
+$(echo "$out" | grep -A12 -- '--- testinst')"
+  fi
+
+  # Positive, not merely the absence of the error: prove the tracked file is no
+  # longer dirty. "Did not print the failure" is how a skipped carve-out passes.
+  if ! G -C "$inst" diff --quiet -- plugins/demo/content.txt; then
+    fail "plugins/demo/content.txt is STILL dirty after the carve-out ran"
+  fi
+
+  echo "PASS: the carve-out commits tracked system-owned dirt even when untracked paths share its list"
+}
+
+# ------------------------------------------------------------------ property 2
+# The carve-out must never become a founder-work sweeper while being taught to
+# handle untracked paths. This is the rule the original `NO git add` comment was
+# protecting (Codex review, PR #98), and widening the add is exactly how it would
+# be lost.
+assert_founder_work_is_never_swept() {
+  local work sk inst out; work="$(mktemp -d)"; sk="$work/skel"; inst="$work/inst"
+  build "$work"
+
+  # Founder work, tracked and STAGED, in a path the sync is permitted to write.
+  printf 'founder edit, not the updater to take\n' > "$inst/q-system/tracked.md"
+  ( cd "$inst" && G add q-system/tracked.md )
+
+  out="$(bash "$sk/kipi-update.sh" 2>&1)" || true
+
+  # Ask the carve-out commit itself what it contains, by subject. `grep -B5`
+  # over a flat log guesses at which commit a filename belongs to and was
+  # reporting a false positive on the sync commit two entries away.
+  local carve
+  carve="$(G -C "$inst" log --format='%H %s' 2>/dev/null \
+             | grep -F 'commit system-written state' | head -1 | cut -d' ' -f1)"
+  if [ -n "$carve" ]; then
+    if G -C "$inst" show --name-only --format= "$carve" 2>/dev/null \
+         | grep -qx "q-system/tracked.md"; then
+      fail "founder work was swept into the system-state commit $carve"
+    fi
+  fi
+
+  echo "PASS: founder work is not swept into the system-state commit"
+}
+
+assert_a_mixed_pathspec_commit_commits_nothing
+assert_the_carve_out_clears_tracked_system_dirt
+assert_founder_work_is_never_swept
+echo "PASS: the system-state carve-out cannot be defeated by an untracked path"

--- a/q-system/.q-system/scripts/test/test-kipi-update-system-state-commit.sh
+++ b/q-system/.q-system/scripts/test/test-kipi-update-system-state-commit.sh
@@ -19,7 +19,7 @@
 # had handled.
 #
 # Measured 2026-08-14, full dry sweep of 23 instances: 11 refusals, 10 of them
-# preceded by that announcement. ktlyst-website announced 3 files (plugins/prd-os,
+# preceded by that announcement. One instance announced 3 files (plugins/prd-os,
 # .claude-integrity-armed, claude-integrity-baseline.json) and then refused with
 # all 3 still dirty. Two of the three were untracked, which is what poisoned the
 # commit that would have cleared the third.

--- a/q-system/.q-system/scripts/test/test-kipi-update-system-state-commit.sh
+++ b/q-system/.q-system/scripts/test/test-kipi-update-system-state-commit.sh
@@ -331,7 +331,46 @@ assert_deletions_split_by_authorship() {
   echo "PASS: a fleet deletion is recorded; a local deletion of a shipped file is not"
 }
 
+# ------------------------------------------------------------------ property 6
+# A STAGED founder edit must survive, even when the working tree has since been
+# overwritten with the skeleton's copy.
+#
+# Codex review of #151 round 4, major. The sequence is nastier than the unstaged
+# case because it leaves no trace: founder stages an edit; a later fanout writes
+# the skeleton's version over the working tree; the worktree-to-skeleton equality
+# test says "fleet-written"; `git add` replaces the staged blob with the skeleton
+# content. The staged work is gone and there is no diff left to show it existed.
+assert_a_staged_founder_edit_is_never_overwritten() {
+  local work sk inst staged; work="$(mktemp -d)"; sk="$work/skel"; inst="$work/inst"
+  build "$work"
+
+  printf 'def shipped():\n    return 1\n' > "$sk/plugins/demo/shipped.py"
+  printf 'def shipped():\n    return 0\n' > "$inst/plugins/demo/shipped.py"
+  ( cd "$sk" && G add -A -f && G commit -qm "skeleton ships it" )
+  ( cd "$inst" && G add -A -f && G commit -qm "instance has it" )
+
+  # Founder stages an edit...
+  printf 'def shipped():\n    return "founder staged this"\n' > "$inst/plugins/demo/shipped.py"
+  ( cd "$inst" && G add plugins/demo/shipped.py )
+  # ...then a fanout overwrites the WORKING TREE with the skeleton's copy. The
+  # index still holds the founder's blob; only the file on disk was replaced.
+  cp "$sk/plugins/demo/shipped.py" "$inst/plugins/demo/shipped.py"
+
+  bash "$sk/kipi-update.sh" >"$work/out" 2>&1 || true
+
+  # The staged blob must still be the founder's. This is the whole assertion:
+  # a passing run leaves the index untouched, a failing one silently rewrites it.
+  staged="$(G -C "$inst" show ":plugins/demo/shipped.py" 2>/dev/null || true)"
+  case "$staged" in
+    *"founder staged this"*) : ;;
+    *) fail "the founder's STAGED blob was overwritten by the carve-out; index now holds: $staged" ;;
+  esac
+
+  echo "PASS: a staged founder edit survives a working tree overwritten with skeleton content"
+}
+
 assert_a_mixed_pathspec_commit_commits_nothing
+assert_a_staged_founder_edit_is_never_overwritten
 assert_deletions_split_by_authorship
 assert_the_carve_out_clears_tracked_system_dirt
 assert_founder_work_is_never_swept

--- a/q-system/.q-system/scripts/test/test-kipi-update-system-state-commit.sh
+++ b/q-system/.q-system/scripts/test/test-kipi-update-system-state-commit.sh
@@ -169,7 +169,50 @@ assert_founder_work_is_never_swept() {
   echo "PASS: founder work is not swept into the system-state commit"
 }
 
+# ------------------------------------------------------------------ property 3
+# The add must never reach untracked SOURCE inside a managed plugin.
+#
+# Codex review of #151, major. sys_owned_dirty carries DIRECTORY entries --
+# `plugins/<name>` for every managed plugin -- and `git add <dir>` recursively
+# stages everything untracked beneath it, walking straight past the
+# source-by-extension refusal at auto-commit.py:170 (ASK-712). On this repo that
+# is 91 candidate paths under plugins/kipi-core alone.
+#
+# The shape that matters: a plugin that IS dirty for a legitimate system reason,
+# with a founder's untracked .py sitting next to the dirt. The carve-out must
+# take the first and leave the second.
+assert_untracked_source_in_a_managed_plugin_is_never_staged() {
+  local work sk inst carve; work="$(mktemp -d)"; sk="$work/skel"; inst="$work/inst"
+  build "$work"
+
+  # Founder's work in progress, untracked, inside the managed plugin dir.
+  printf 'def half_written():\n    pass\n' > "$inst/plugins/demo/scratch_wip.py"
+
+  bash "$sk/kipi-update.sh" >"$work/out" 2>&1 || true
+
+  carve="$(G -C "$inst" log --format='%H %s' 2>/dev/null \
+             | grep -F 'commit system-written state' | head -1 | cut -d' ' -f1)"
+  if [ -n "$carve" ]; then
+    if G -C "$inst" show --name-only --format= "$carve" 2>/dev/null \
+         | grep -qx "plugins/demo/scratch_wip.py"; then
+      fail "untracked founder source was staged and committed by the carve-out"
+    fi
+  fi
+  # Committed is the headline, but STAGED is the real line: a staged file would
+  # be swept by the next commit in that repo, by us or by anyone.
+  if G -C "$inst" diff --cached --name-only 2>/dev/null \
+       | grep -qx "plugins/demo/scratch_wip.py"; then
+    fail "untracked founder source was left STAGED by the carve-out"
+  fi
+  # And it must still be there, untouched.
+  [ -f "$inst/plugins/demo/scratch_wip.py" ] || \
+    fail "the founder's untracked source file was destroyed"
+
+  echo "PASS: untracked source inside a managed plugin is neither staged nor committed"
+}
+
 assert_a_mixed_pathspec_commit_commits_nothing
 assert_the_carve_out_clears_tracked_system_dirt
 assert_founder_work_is_never_swept
+assert_untracked_source_in_a_managed_plugin_is_never_staged
 echo "PASS: the system-state carve-out cannot be defeated by an untracked path"

--- a/q-system/.q-system/scripts/test/test-kipi-update-system-state-commit.sh
+++ b/q-system/.q-system/scripts/test/test-kipi-update-system-state-commit.sh
@@ -467,8 +467,47 @@ assert_older_fleet_content_is_attributed_to_the_fleet() {
   echo "PASS: content from any shipped skeleton revision is the fleet's; never-shipped content is not"
 }
 
+# ------------------------------------------------------------------ property 9
+# "Shipped" means the fan-out branch, not every ref in the clone.
+#
+# Codex review of #151 round 7, major. The first attribution walked `rev-list
+# --all`, which includes unmerged feature branches. A blob that only ever lived
+# on a branch was never sent to any instance, so accepting it would let an
+# unattended update commit over founder work that merely matches someone's WIP.
+assert_a_blob_only_on_an_unmerged_branch_is_not_shipped() {
+  local work sk inst carve; work="$(mktemp -d)"; sk="$work/skel"; inst="$work/inst"
+  build "$work"
+
+  printf 'def api():\n    return "main"\n' > "$sk/plugins/demo/api.py"
+  printf 'def api():\n    return "main"\n' > "$inst/plugins/demo/api.py"
+  ( cd "$sk" && G add -A -f && G commit -qm "skeleton ships main version" )
+  ( cd "$inst" && G add -A -f && G commit -qm "instance commits it" )
+
+  # A version that exists ONLY on an unmerged branch. Never fanned out.
+  ( cd "$sk" && G checkout -q -b someones/wip
+    printf 'def api():\n    return "never merged"\n' > plugins/demo/api.py
+    G add -A && G commit -qm "wip, never merged"
+    G checkout -q main )
+
+  # The instance's working tree happens to hold exactly that content. Under
+  # `rev-list --all` this reads as fleet-shipped and gets committed over.
+  printf 'def api():\n    return "never merged"\n' > "$inst/plugins/demo/api.py"
+
+  bash "$sk/kipi-update.sh" >"$work/out" 2>&1 || true
+
+  carve="$(G -C "$inst" log --format='%H %s' 2>/dev/null \
+             | grep -F 'commit system-written state' | head -1 | cut -d' ' -f1 || true)"
+  if [ -n "$carve" ] && G -C "$inst" show --name-only --format= "$carve" 2>/dev/null \
+       | grep -qx "plugins/demo/api.py"; then
+    fail "content that exists only on an unmerged branch was treated as fleet-shipped"
+  fi
+
+  echo "PASS: a blob that only exists on an unmerged branch is not treated as shipped"
+}
+
 assert_a_mixed_pathspec_commit_commits_nothing
 assert_older_fleet_content_is_attributed_to_the_fleet
+assert_a_blob_only_on_an_unmerged_branch_is_not_shipped
 assert_a_staged_founder_edit_is_never_overwritten
 assert_a_staged_edit_survives_deletion_from_both_sides
 assert_deletions_split_by_authorship

--- a/q-system/.q-system/scripts/test/test-kipi-update-system-state-commit.sh
+++ b/q-system/.q-system/scripts/test/test-kipi-update-system-state-commit.sh
@@ -105,9 +105,14 @@ JSON
   ( cd "$inst" && G init -q -b main && G add -A -f && G commit -qm inst )
 
   # The live shape, both halves:
-  #   TRACKED and modified -- a skeleton-owned plugin file. This is what the
-  #   guard reads, and what the carve-out is supposed to clear.
-  printf 'plugin v1-locally-rewritten\n' > "$inst/plugins/demo/content.txt"
+  #   TRACKED and modified -- a skeleton-owned plugin file, dirty because an
+  #   EARLIER FANOUT WROTE IT AND FAILED TO COMMIT. That is the real shape on the
+  #   fleet (ASK-728 did exactly this to plugins/prd-os), and the signature is
+  #   that the working-tree content equals the SKELETON's, not that it is some
+  #   arbitrary local rewrite. Corrected 2026-08-14: the first version of this
+  #   fixture used a local rewrite, which the authorship rule added in round 3
+  #   correctly refuses -- so it was testing a case the code is right to block.
+  cp "$sk/plugins/demo/content.txt" "$inst/plugins/demo/content.txt"
   #   UNTRACKED -- the integrity artifacts the tripwire writes into the synced
   #   tree. Invisible to the guard, fatal to the carve-out's pathspec.
   printf 'armed\n' > "$inst/q-system/.q-system/.claude-integrity-armed"
@@ -211,8 +216,70 @@ assert_untracked_source_in_a_managed_plugin_is_never_staged() {
   echo "PASS: untracked source inside a managed plugin is neither staged nor committed"
 }
 
+# ------------------------------------------------------------------ property 4
+# TRACKED founder edits inside a managed plugin, the mirror of property 3.
+# Codex review of #151 round 2: `git add -u -- plugins/<name>` stages every
+# tracked modification under the directory, so a founder editing a .py in a
+# managed plugin had it committed under a chore message. Property 3 could not
+# catch it (untracked only) and the founder-work fixture put its edit at
+# q-system/tracked.md, outside the plugin dir.
+#
+# Both halves in ONE run, because they are the same decision made twice and a
+# fix that gets one right by breaking the other is not a fix:
+#
+#   FLEET-WRITTEN  content byte-identical to the skeleton's, i.e. an earlier
+#                  fanout wrote it and failed to commit. MUST be committed --
+#                  this is what unblocks the instances, and on the real fleet it
+#                  is plugins/prd-os/tests/test_judgment_compiler.py, a .py the
+#                  extension classifier would refuse.
+#   LOCAL EDIT     content differs from the skeleton's. MUST be left alone at any
+#                  extension, so the guard below refuses and protects it.
+assert_tracked_plugin_edits_split_by_authorship() {
+  local work sk inst carve; work="$(mktemp -d)"; sk="$work/skel"; inst="$work/inst"
+  build "$work"
+
+  # A second managed-plugin file, tracked on both sides, so the run has one of
+  # each to sort.
+  printf 'def fleet_written():\n    return 1\n' > "$sk/plugins/demo/shipped.py"
+  printf 'def fleet_written():\n    return 0\n' > "$inst/plugins/demo/shipped.py"
+  printf 'def local():\n    return 0\n' > "$sk/plugins/demo/edited.py"
+  printf 'def local():\n    return 0\n' > "$inst/plugins/demo/edited.py"
+  ( cd "$sk" && G add -A -f && G commit -qm "skeleton ships two plugin files" )
+  ( cd "$inst" && G add -A -f && G commit -qm "instance has both" )
+
+  # FLEET-WRITTEN: instance working tree now matches the SKELETON exactly, the
+  # signature of a fanout that wrote and never committed.
+  cp "$sk/plugins/demo/shipped.py" "$inst/plugins/demo/shipped.py"
+  # LOCAL EDIT: differs from the skeleton. Founder work, .py, same directory.
+  printf 'def local():\n    return "founder was here"\n' > "$inst/plugins/demo/edited.py"
+
+  bash "$sk/kipi-update.sh" >"$work/out" 2>&1 || true
+
+  carve="$(G -C "$inst" log --format='%H %s' 2>/dev/null \
+             | grep -F 'commit system-written state' | head -1 | cut -d' ' -f1)"
+  [ -n "$carve" ] || fail "no system-state commit was made at all: $(cat "$work/out")"
+
+  G -C "$inst" show --name-only --format= "$carve" 2>/dev/null \
+    | grep -qx "plugins/demo/shipped.py" || \
+    fail "the FLEET-WRITTEN plugin file was not committed, so the instance stays blocked"
+
+  if G -C "$inst" show --name-only --format= "$carve" 2>/dev/null \
+       | grep -qx "plugins/demo/edited.py"; then
+    fail "a tracked founder edit inside a managed plugin was committed by the carve-out"
+  fi
+  if G -C "$inst" diff --cached --name-only 2>/dev/null \
+       | grep -qx "plugins/demo/edited.py"; then
+    fail "a tracked founder edit inside a managed plugin was left STAGED"
+  fi
+  grep -q 'founder was here' "$inst/plugins/demo/edited.py" || \
+    fail "the founder's edit was destroyed"
+
+  echo "PASS: fleet-written plugin files commit; tracked founder edits in the same dir do not"
+}
+
 assert_a_mixed_pathspec_commit_commits_nothing
 assert_the_carve_out_clears_tracked_system_dirt
 assert_founder_work_is_never_swept
 assert_untracked_source_in_a_managed_plugin_is_never_staged
+assert_tracked_plugin_edits_split_by_authorship
 echo "PASS: the system-state carve-out cannot be defeated by an untracked path"


### PR DESCRIPTION
## 10 of 11 blocked instances were refused over dirt the updater announced it had handled

Before the dirty-tree guard judges an instance, a block above it commits the fleet's own exhaust — sycophancy stamp, integrity baseline, hook state, every skeleton-managed plugin dir — so machine-written files are never mistaken for founder work. It builds **one** list and runs **one** pathspec-limited commit over it.

That list mixes tracked and untracked paths by design: the `auto-commit.py` classifier pulls untracked machine exhaust in on purpose. And:

```
git commit -- <tracked> <untracked>
error: pathspec '<untracked>' did not match any file(s) known to git
```

git commits **nothing**. One untracked integrity artifact therefore left the *tracked* skeleton-owned dirt uncommitted too, and the guard below then refused the whole instance.

`2>/dev/null || true` made that failure invisible, while the `Committing N system-written file(s)` line printed either way.

## Evidence

Full dry sweep, 2026-08-14, 23 instances: 11 refusals, **10 preceded by that announcement**. `ktlyst-website`:

```
DRY |   Committing 3 system-written file(s) so they do not block the sync:
    plugins/prd-os
    q-system/.q-system/.claude-integrity-armed
    q-system/.q-system/claude-integrity-baseline.json
  Changes vs skeleton: blocked by dirty working tree
     M plugins/prd-os/.claude-plugin/plugin.json
    ?? q-system/.q-system/.claude-integrity-armed
  ERROR: dirty working tree; refusing to commit unrelated work
```

Two of the three named files are untracked. That is what killed the commit that would have cleared the third.

## The fix

- `git add -- "${sys_owned_dirty[@]}"` before the commit, **pathspec-limited to the same list**. It stages exactly what was already going to be committed and cannot reach founder work. The PR #98 "NO `git add`" rule was protecting against a *bare* add; this is not one, and property 2 pins that.
- The commit reports failure instead of swallowing it. The run still continues — the guard below is the real decision and fails closed — but it says what happened.

## This corrects ASK-775's own theory

The issue claimed the untracked artifacts caused the refusal directly, fix = ship a `q-system/.gitignore`. They don't: the guard reads `git diff`, which is blind to untracked files. Measured: **11 refusals, 0 with zero tracked dirt.** A `.gitignore` would have unblocked zero instances while closing an Urgent issue. Correction posted on the issue.

They *are* implicated — just one step removed, by poisoning the pathspec.

## Verification

- Fixture reproduces the live shape exactly: same 3-file announcement, same refusal over those same files. **RED** without this change, green with it.
- Property 0 pins the git behaviour itself, so if a future git changes it this file says which assumption moved.
- Property 2 pins that founder work is still never swept.
- All 13 updater/rollback fixtures pass. `validate-separation.py` 25/25. Declared in `capability-manifest.json`.

## One trap worth naming

The fixture **must** copy `q-system/hooks/auto-commit.py`. Without the classifier, no untracked path enters the list, the carve-out commits a single tracked path and succeeds — and the bug does not reproduce. My first run passed green for exactly that reason while the fleet was broken. Caught by instrumenting the fixture instead of trusting the green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0151EYtGH6at3XTWqbBHAxEi