### PR TITLE
One exclusion set, so a plugin .env stops shipping fleet-wide (ASK-772)

### DIFF
--- a/kipi-update.sh
+++ b/kipi-update.sh
@@ -198,6 +198,55 @@ is_managed_plugin_path() {
 # plugins/ tree an EARLIER update staged and never committed). The fleet updater
 # was blocked by itself, silently. This list is deliberately narrow and explicit:
 # anything not named here is treated as founder work and still refuses.
+# THE ONE plugin-copy exclusion set (ASK-772). Two consumers derive from it and
+# they answer halves of a single question:
+#
+#   the per-plugin rsync         -- "never copy this into an instance"
+#   the source-provenance preflight -- "never alarm about this, because it is
+#                                       never copied"
+#
+# Writing the set down twice is how a secret shipped. `.gitignore:3` is `*.env`
+# and kipi-design's cip/generate.py reads a plugin-root .env for API keys, so a
+# gitignored plugins/<name>/.env was invisible to `git status` and copied happily
+# by rsync into all 23 instances (Codex, PR #149 round 3).
+#
+# Adding it to ONE consumer swaps one failure for another: rsync-only leaves the
+# preflight aborting the whole fleet over a file that can no longer leak (a
+# denial of service on every update), preflight-only leaves the leak open and
+# silent. Hence one list.
+#
+# Each entry is "<rsync --exclude pattern>::<regex matching the same paths>".
+# Two representations, adjacent, because rsync globs and grep regexes are not
+# interconvertible in bash without a converter more fragile than the duplication
+# it removes. `::` is the delimiter, not `|`, because the regexes contain `|`.
+# test-kipi-update-plugin-excludes.sh drives BOTH consumers off this list and
+# fails if they disagree, so agreement is proven behaviourally rather than by
+# the two strings having been typed the same.
+PLUGIN_COPY_EXCLUDES=(
+  "/.git/::(^|/)\.git/"
+  "__pycache__/::(^|/)__pycache__/"
+  "*.pyc::\.pyc\$"
+  ".venv/::(^|/)\.venv/"
+  ".pytest_cache/::(^|/)\.pytest_cache/"
+  ".env::(^|/)\.env\$"
+  ".env.*::(^|/)\.env\."
+)
+
+plugin_copy_rsync_flags() {
+  local entry
+  for entry in "${PLUGIN_COPY_EXCLUDES[@]}"; do
+    printf -- '--exclude=%s\n' "${entry%%::*}"
+  done
+}
+
+plugin_copy_filter_regex() {
+  local entry out=""
+  for entry in "${PLUGIN_COPY_EXCLUDES[@]}"; do
+    out="${out:+$out|}${entry#*::}"
+  done
+  printf '%s\n' "$out"
+}
+
 SYSTEM_OWNED_PATHS=(
   "q-system/memory/.sycophancy-monthly-stamp"
   "q-system/.q-system/claude-integrity-baseline.json"
@@ -448,7 +497,7 @@ SYNC_SCOPE_DIRTY="$(
     git -C "$SCRIPT_DIR" status --porcelain --ignored=matching -- plugins \
       2>/dev/null || true
   } | sed 's/^...//' \
-    | grep -vE '(^|/)(\.git|__pycache__|\.venv|\.pytest_cache)/|\.pyc$' || true
+    | grep -vE "$(plugin_copy_filter_regex)" || true
 )"
 if [ -n "$SYNC_SCOPE_DIRTY" ]; then
   echo ""
@@ -895,14 +944,36 @@ stage_config_sync() {
     # syncer now walk the same list, so the stager can no longer name a path
     # the syncer will not write -- which is what the old post-hoc [ -d ] filter
     # was patching around. See managed_plugin_names for the scar.
+    # THE THIRD CONSUMER of PLUGIN_COPY_EXCLUDES, and the one that made the
+    # duplication expensive rather than merely untidy (ASK-772). This walk had
+    # its OWN hardcoded prune list -- .git, __pycache__, .pytest_cache, .venv,
+    # *.pyc -- a third copy of the same value. Excluding `.env` from the rsync
+    # without teaching the stager left it naming a path the syncer no longer
+    # writes, and `git add` on a missing path is fatal:
+    #
+    #     fatal: pathspec 'plugins/demo/.env.local' did not match any files
+    #     ERROR: config sync did not reach a complete committed state
+    #
+    # which is the exact class the comment above already warns about, arriving
+    # from the one direction it did not cover. The find still prunes cheaply so
+    # it never descends into a .venv; the shared regex is what decides.
+    plugin_excl_re="$(plugin_copy_filter_regex)"
     while IFS= read -r -d '' plugin_name; do
       while IFS= read -r -d '' source; do
-        plugin_paths+=("${source#"$SCRIPT_DIR/"}")
+        relative="${source#"$SCRIPT_DIR/"}"
+        # Matched on the path RELATIVE to the plugin dir, the same thing rsync
+        # matches its --exclude patterns against. Matching the repo-relative path
+        # would let a `.env` anywhere above the plugin root change the answer.
+        case "${source#"$SKELETON_PLUGIN_ROOT/$plugin_name/"}" in
+          *) printf '%s' "${source#"$SKELETON_PLUGIN_ROOT/$plugin_name/"}" \
+               | grep -qE "$plugin_excl_re" && continue ;;
+        esac
+        plugin_paths+=("$relative")
       done < <(
         find "$SKELETON_PLUGIN_ROOT/$plugin_name" \
           \( -type d -name .git -o -type d -name __pycache__ \
              -o -type d -name .pytest_cache -o -type d -name .venv \) -prune -o \
-          \( -type f ! -name '*.pyc' -o -type l \) -print0
+          \( -type f -o -type l \) -print0
       )
     done < <(managed_plugin_names)
     # A path the INSTANCE ignores cannot be staged, and `git add` treats that
@@ -1888,9 +1959,14 @@ print("\n".join(mod.EXTRA_WATCHED))
         # It was 107MB of the 112MB plugin tree, copied into 23 instances
         # where it could never work. --delete-excluded also clears the stale
         # copies already there. Pairs with test-kipi-update-build-artifacts.sh.
+        # Flags derived from PLUGIN_COPY_EXCLUDES, never hand-listed here: this
+        # site and the preflight filter are the two consumers that must agree,
+        # and a hand-listed copy is how a plugin-root .env shipped fleet-wide
+        # (ASK-772). Word-splitting the generator output is intended -- every
+        # pattern is a shell-safe token by construction.
+        # shellcheck disable=SC2046
         if ! rsync -a --delete --delete-excluded \
-            --exclude="/.git/" --exclude="__pycache__/" --exclude="*.pyc" \
-            --exclude=".venv/" --exclude=".pytest_cache/" \
+            $(plugin_copy_rsync_flags) \
             "$SKELETON_PLUGIN_ROOT/$plugin_name/" \
             "$path/plugins/$plugin_name/" 2>/dev/null; then
           CONFIG_FAILED=1

--- a/q-system/.q-system/capability-manifest.json
+++ b/q-system/.q-system/capability-manifest.json
@@ -151,6 +151,10 @@
       "timeout_s": 300
     },
     {
+      "path": "q-system/.q-system/scripts/test/test-kipi-update-plugin-excludes.sh",
+      "runner": "bash"
+    },
+    {
       "path": "q-system/.q-system/scripts/test/test-kipi-update-preservation-failure.sh",
       "runner": "bash"
     },
@@ -602,6 +606,7 @@
     "q-system/.q-system/scripts/test/test-kipi-update-dry-final-state.sh",
     "q-system/.q-system/scripts/test/test-kipi-update-hook-contract.sh",
     "q-system/.q-system/scripts/test/test-kipi-update-leak-preflight.sh",
+    "q-system/.q-system/scripts/test/test-kipi-update-plugin-excludes.sh",
     "q-system/.q-system/scripts/test/test-kipi-update-preservation-failure.sh",
     "q-system/.q-system/scripts/test/test-kipi-update-safety.sh",
     "q-system/.q-system/scripts/test/test-kipi-update-source-provenance.sh",
@@ -686,7 +691,7 @@
     },
     {
       "path": "q-system/.q-system/scripts/stat-verify.py",
-      "reason": "802-line stat verification engine; zero hook wiring and its stat-registry.json data file exists in exactly one instance — wiring it is a founder product decision",
+      "reason": "802-line stat verification engine; zero hook wiring and its stat-registry.json data file exists in exactly one instance \u2014 wiring it is a founder product decision",
       "spillover_id": "sp-72b60bff"
     },
     {
@@ -706,8 +711,8 @@
     }
   ],
   "uncovered_known": [
-    "plugins/*/tests — prd-os plugin suite, run by the plugin's own harness; outside v1 scan roots (finding-9 deferred)",
+    "plugins/*/tests \u2014 prd-os plugin suite, run by the plugin's own harness; outside v1 scan roots (finding-9 deferred)",
     "repo-root *.sh utilities are wiring surfaces, not test artifacts",
-    "stat-registry.json: NOT expressible as required_data in v1 — the one instance holding it keeps canonical under its own instance_q_dir (not q-system/) and its registry name differs from its dir basename, so a scoped entry could never fire (grounded 2026-07-23). Declared gap; owning decision + instance detail in spillover sp-72b60bff"
+    "stat-registry.json: NOT expressible as required_data in v1 \u2014 the one instance holding it keeps canonical under its own instance_q_dir (not q-system/) and its registry name differs from its dir basename, so a scoped entry could never fire (grounded 2026-07-23). Declared gap; owning decision + instance detail in spillover sp-72b60bff"
   ]
 }

--- a/q-system/.q-system/scripts/test/test-kipi-update-plugin-excludes.sh
+++ b/q-system/.q-system/scripts/test/test-kipi-update-plugin-excludes.sh
@@ -1,0 +1,161 @@
+#!/usr/bin/env bash
+# A plugin-root .env is copied into all 23 instances and committed there.
+#
+# The per-plugin rsync excludes exactly five classes -- .git/, __pycache__/,
+# *.pyc, .venv/, .pytest_cache/ -- and nothing else. `.gitignore:3` is `*.env`,
+# so a plugin .env is invisible to `git status` while rsync copies it happily.
+# It is not hypothetical: plugins/kipi-design/skills/design/scripts/cip/
+# generate.py reads a plugin-root .env for API keys.
+#
+# Found by Codex on PR #149 round 3, filed as ASK-772.
+#
+# THE DRIFT TRAP THIS FILE EXISTS TO CLOSE. The exclusion set was written down
+# TWICE: once as rsync --exclude flags (~L1892) and once as a grep filter in the
+# ASK-762 source-provenance preflight (~L451). The two must agree, because they
+# answer halves of one question:
+#
+#   rsync excludes  = "never copy this"
+#   preflight filter = "do not alarm about this, because it is never copied"
+#
+# Add `.env` to the rsync only and the preflight starts aborting the fleet over a
+# file that can no longer leak. Add it to the preflight only and the leak stays
+# open and silent. One value, two authorities, opposite failure modes.
+#
+# So this file does NOT compare the two lists as strings -- that only proves they
+# were typed the same. It drives BOTH behaviours from the shared set and asserts
+# each entry is excluded by the copy AND silent in the preflight. A new entry
+# added to one consumer and not the other fails here.
+set -euo pipefail
+ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/../../../.." && pwd)"
+fail() { echo "FAIL: $1" >&2; exit 1; }
+G() { git -c user.email=t@t.t -c user.name=test -c commit.gpgsign=false "$@"; }
+
+build() {
+  local work="$1" sk="$work/skel" inst="$work/inst"
+  mkdir -p "$sk/q-system/.q-system/scripts" "$sk/q-system/.q-system/state" \
+           "$sk/q-system/hooks" "$sk/plugins/demo" "$sk/.claude/rules"
+  for f in kipi-update.sh kipi-update-preserve-scan.py kipi-update-deletion-guard.py \
+           validate-separation.py; do
+    cp "$ROOT/$f" "$sk/$f"
+  done
+  cp "$ROOT/q-system/.q-system/scripts/propagation-leak-gate.py" \
+     "$sk/q-system/.q-system/scripts/propagation-leak-gate.py"
+  cp "$ROOT/q-system/.q-system/scripts/containment-targets.py" \
+     "$sk/q-system/.q-system/scripts/containment-targets.py"
+  cp "$ROOT/q-system/hooks/auto-commit.py" "$sk/q-system/hooks/auto-commit.py"
+  cat > "$sk/q-system/.q-system/state/propagation-leak-baseline.json" <<'JSON'
+{
+  "schema_version": 1,
+  "blocking_classes": ["case_proof_gap", "client_identity", "dated_interaction",
+                       "pricing", "relationship", "source_identity",
+                       "sourced_interaction"],
+  "classifier_sha256": null,
+  "entries": []
+}
+JSON
+  printf 'generic skeleton content\n' > "$sk/q-system/tracked.md"
+  printf 'plugin content\n' > "$sk/plugins/demo/content.txt"
+  printf '# demo rule\n' > "$sk/.claude/rules/demo.md"
+  # The skeleton ignores secrets and caches, exactly as the real repo does. That
+  # is the whole point: gitignored is not "absent", it is "invisible to git and
+  # fully visible to rsync".
+  printf '*.env\n.env\n__pycache__/\n*.pyc\n.venv/\n.pytest_cache/\n' > "$sk/.gitignore"
+  ( cd "$sk" && G init -q -b main && G add -A -f && G commit -qm skel )
+  printf '{"instances":[{"name":"testinst","path":"%s","subtree_prefix":"q-system","type":"subtree"}]}\n' \
+    "$inst" > "$sk/instance-registry.json"
+
+  mkdir -p "$inst/q-system" "$inst/plugins/demo" "$inst/.claude"
+  printf 'instance state\n' > "$inst/q-system/tracked.md"
+  ( cd "$inst" && G init -q -b main && G add -A -f && G commit -qm inst )
+}
+
+# The secret, plus one file per already-excluded class, so a regression in any
+# of the five shows up here too rather than only the new entry.
+plant_excludables() {
+  local sk="$1"
+  printf 'ANTHROPIC_API_KEY=sk-not-a-real-key\n' > "$sk/plugins/demo/.env"
+  printf 'OPENAI_API_KEY=sk-also-not-real\n' > "$sk/plugins/demo/.env.local"
+  mkdir -p "$sk/plugins/demo/__pycache__" "$sk/plugins/demo/.venv" \
+           "$sk/plugins/demo/.pytest_cache"
+  printf 'cache\n' > "$sk/plugins/demo/__pycache__/x.pyc"
+  printf 'venv\n' > "$sk/plugins/demo/.venv/pyvenv.cfg"
+  printf 'cache\n' > "$sk/plugins/demo/.pytest_cache/CACHEDIR.TAG"
+  printf 'compiled\n' > "$sk/plugins/demo/stale.pyc"
+}
+
+EXCLUDABLES=(
+  "plugins/demo/.env"
+  "plugins/demo/.env.local"
+  "plugins/demo/__pycache__/x.pyc"
+  "plugins/demo/.venv/pyvenv.cfg"
+  "plugins/demo/.pytest_cache/CACHEDIR.TAG"
+  "plugins/demo/stale.pyc"
+)
+
+# ------------------------------------------------------------------ property 1
+# Nothing in the excluded set reaches an instance. The .env entries are the
+# reason this file exists; the other four are regression cover.
+assert_excluded_files_never_reach_an_instance() {
+  local work sk inst; work="$(mktemp -d)"; sk="$work/skel"; inst="$work/inst"
+  build "$work"
+  plant_excludables "$sk"
+
+  bash "$sk/kipi-update.sh" >"$work/out" 2>&1 || true
+
+  local rel leaked=0
+  for rel in "${EXCLUDABLES[@]}"; do
+    if [ -e "$inst/$rel" ]; then
+      echo "  LEAKED: $rel" >&2
+      leaked=1
+    fi
+  done
+  [ "$leaked" -eq 0 ] || fail "excluded plugin files were copied into the instance"
+
+  # The sync must actually have RUN, or "nothing leaked" is vacuous -- a run that
+  # aborted early would satisfy the loop above while proving nothing.
+  [ -e "$inst/plugins/demo/content.txt" ] || \
+    fail "the plugin sync did not run at all, so the no-leak check proves nothing: $(cat "$work/out")"
+
+  echo "PASS: no excluded plugin file reaches an instance (.env, .env.local, caches, pyc)"
+}
+
+# ------------------------------------------------------------------ property 2
+# The other half of the same value. A file the copy can never carry must not
+# abort the fleet in the ASK-762 preflight -- otherwise adding an exclusion to
+# one consumer silently breaks the other.
+assert_excluded_files_do_not_abort_the_preflight() {
+  local work sk out; work="$(mktemp -d)"; sk="$work/skel"
+  build "$work"
+  plant_excludables "$sk"
+
+  out="$(bash "$sk/kipi-update.sh" 2>&1)" || true
+  if echo "$out" | grep -q "ABORT: the skeleton"; then
+    fail "the source-provenance preflight aborted over files that can never be copied:
+$(echo "$out" | grep -A8 'ABORT: the skeleton')"
+  fi
+
+  echo "PASS: excluded plugin files are silent in the source-provenance preflight"
+}
+
+# ------------------------------------------------------------------ property 3
+# The guard must still fire on an untracked plugin file that IS copied. Without
+# this, widening the exclusion set to silence the preflight would pass property 2
+# by disarming the guard entirely.
+assert_a_copied_untracked_plugin_file_still_aborts() {
+  local work sk inst; work="$(mktemp -d)"; sk="$work/skel"; inst="$work/inst"
+  build "$work"
+  printf 'unreviewed, and rsync WILL copy this\n' > "$sk/plugins/demo/scratch.md"
+
+  local out; out="$(bash "$sk/kipi-update.sh" 2>&1)" || true
+  echo "$out" | grep -q "ABORT: the skeleton" || \
+    fail "an untracked plugin file that IS copied did not abort the preflight: $out"
+  echo "$out" | grep -q "plugins/demo/scratch.md" || \
+    fail "the abort did not name the file: $out"
+
+  echo "PASS: an untracked plugin file that IS copied still aborts"
+}
+
+assert_excluded_files_never_reach_an_instance
+assert_excluded_files_do_not_abort_the_preflight
+assert_a_copied_untracked_plugin_file_still_aborts
+echo "PASS: one exclusion set, both consumers agree, and the guard stays armed"

--- a/q-system/.q-system/scripts/test/test-kipi-update-source-provenance.sh
+++ b/q-system/.q-system/scripts/test/test-kipi-update-source-provenance.sh
@@ -202,11 +202,35 @@ assert_ignored_plugin_files_abort_but_pruned_ones_do_not() {
     fail "the guard fired on classes the plugin rsync excludes: $out"
   fi
 
-  # The secret: ignored, and copied anyway.
+  # REVERSED 2026-08-14 BY ASK-772, deliberately, and the reversal is the point.
+  # This used to assert that an ignored plugins/<name>/.env ABORTS. That was
+  # correct while the rsync copied it: the guard's contract is "alarm on anything
+  # that reaches an instance", and a .env reached all 23.
+  #
+  # ASK-772 added `.env` / `.env.*` to PLUGIN_COPY_EXCLUDES, so the copy no
+  # longer carries it. The same contract now requires SILENCE -- alarming over a
+  # file that cannot leak would halt every fleet update forever, which is a
+  # denial of service dressed as security.
+  #
+  # This is not the guard being weakened. The leak moved from "detected" to
+  # "impossible", which is strictly better, and test-kipi-update-plugin-excludes.sh
+  # is what holds the impossibility. If that file ever goes green while a .env
+  # lands in an instance, THIS assertion is wrong again and must flip back.
   printf 'ANTHROPIC_API_KEY=sk-not-a-real-key\n' > "$sk/plugins/demo/.env"
-  assert_aborts_untouched "$sk" "$inst" "ignored plugin .env" "plugins/demo/.env"
+  printf 'OPENAI_API_KEY=sk-also-not-real\n' > "$sk/plugins/demo/.env.local"
+  out="$(bash "$sk/kipi-update.sh" 2>&1)" || true
+  if echo "$out" | grep -q "ABORT: the skeleton"; then
+    fail "the guard fired on a .env the plugin copy now excludes: $out"
+  fi
+  rm -f "$sk/plugins/demo/.env" "$sk/plugins/demo/.env.local"
 
-  echo "PASS: an ignored plugin .env aborts; rsync-excluded classes stay silent"
+  # An untracked plugin file that IS still copied must abort, or the assertion
+  # above would be satisfied by a guard that had simply stopped working.
+  printf 'unreviewed, and rsync WILL copy this\n' > "$sk/plugins/demo/scratch.md"
+  assert_aborts_untouched "$sk" "$inst" "copied untracked plugin file" "plugins/demo/scratch.md"
+  rm -f "$sk/plugins/demo/scratch.md"
+
+  echo "PASS: rsync-excluded classes stay silent; a file the copy DOES carry still aborts"
 }
 
 # ---------------------------------------------------------------- property 2


### PR DESCRIPTION
## A plugin-root `.env` was copied into all 23 instances and committed there

The per-plugin rsync excluded five classes and nothing else. `.gitignore:3` is `*.env`, and `plugins/kipi-design/skills/design/scripts/cip/generate.py` reads a plugin-root `.env` for API keys — so the file was invisible to `git status` and copied happily by rsync. Found by Codex on PR #149 round 3.

## Why fixing one place would have made it worse

The exclusion set was written down **twice** — rsync `--exclude` flags and the ASK-762 preflight's grep filter. They answer halves of one question:

- rsync excludes → *never copy this*
- preflight filter → *never alarm about this, because it is never copied*

Fix the rsync alone and the preflight aborts every fleet update over a file that can no longer leak — denial of service dressed as security. Fix the preflight alone and the leak stays open and silent.

`PLUGIN_COPY_EXCLUDES` is now the single source, with `.env` and `.env.*` added. Each entry carries the rsync glob and an equivalent regex adjacently; the two are not interconvertible in bash without a converter more fragile than the duplication it removes.

## There was a third consumer, and only a behavioural test could have found it

The stager's `find` had its own hardcoded prune list. Excluding `.env` from the copy without teaching the stager left it naming a path the syncer no longer writes:

```
fatal: pathspec 'plugins/demo/.env.local' did not match any files
ERROR: config sync did not reach a complete committed state
```

A test comparing the two lists as strings would have passed. This one drives **both behaviours** off the shared set and caught the third site.

## One assertion is deliberately reversed

`test-kipi-update-source-provenance.sh` asserted that an ignored `.env` **aborts**. That was correct while the copy carried it. Now it cannot, and the same contract requires **silence**.

This is not the guard weakening. The leak moved from *detected* to *impossible*, which is strictly better, and the new fixture is what holds the impossibility. If it ever goes green while a `.env` lands in an instance, that assertion is wrong again and must flip back. The comment says so in the file.

## Verification

- Reproducer is **RED** without this change — and not vacuously: it asserts the sync actually *ran*, which is what surfaced that today's "safety" is just the preflight halting the fleet.
- Property 3 keeps the guard armed: an untracked plugin file that **is** still copied must still abort, so property 2 can't be satisfied by disarming.
- All 13 updater/rollback fixtures pass. `validate-separation.py` 25/25. Declared in `capability-manifest.json`.

## Sequencing

Branched off main alongside #151, which also edits `kipi-update.sh` in a different region (the system-state carve-out). #151 is the root-cause fix for the blocked fleet; merge it first and I'll rebase this.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0151EYtGH6at3XTWqbBHAxEi