### PR TITLE
Merge-bypass gate: deny --admin and direct-to-protected-branch push (ASK-791)

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -168,6 +168,11 @@
             "type": "command",
             "command": "test -f \"$CLAUDE_PROJECT_DIR/q-system/.q-system/scripts/claude-path-write-guard.py\" && python3 \"$CLAUDE_PROJECT_DIR/q-system/.q-system/scripts/claude-path-write-guard.py\"",
             "timeout": 10
+          },
+          {
+            "type": "command",
+            "command": "test -f \"$CLAUDE_PROJECT_DIR/q-system/.q-system/scripts/merge-bypass-gate.py\" && python3 \"$CLAUDE_PROJECT_DIR/q-system/.q-system/scripts/merge-bypass-gate.py\"",
+            "timeout": 5
           }
         ]
       }

--- a/q-system/.q-system/capability-manifest.json
+++ b/q-system/.q-system/capability-manifest.json
@@ -80,7 +80,15 @@
       "runner": "python3"
     },
     {
+      "path": "q-system/.q-system/scripts/test/test-control-file-propagate.sh",
+      "runner": "bash"
+    },
+    {
       "path": "q-system/.q-system/scripts/test/test-converge.sh",
+      "runner": "bash"
+    },
+    {
+      "path": "q-system/.q-system/scripts/test/test-dispatch-client-refusal-after-hold.sh",
       "runner": "bash"
     },
     {
@@ -108,6 +116,18 @@
     {
       "path": "q-system/.q-system/scripts/test/test-gate-13b-scope.py",
       "runner": "python3"
+    },
+    {
+      "path": "q-system/.q-system/scripts/test/test-gh-repo-scope-converge.sh",
+      "runner": "bash"
+    },
+    {
+      "path": "q-system/.q-system/scripts/test/test-gh-repo-scope-reviewer.sh",
+      "runner": "bash"
+    },
+    {
+      "path": "q-system/.q-system/scripts/test/test-gh-repo-scope-worker.sh",
+      "runner": "bash"
     },
     {
       "path": "q-system/.q-system/scripts/test/test-install-plist.sh",
@@ -301,6 +321,10 @@
       "timeout_s": 600
     },
     {
+      "path": "q-system/.q-system/scripts/test/test-review-artifact-repo-keyed.sh",
+      "runner": "bash"
+    },
+    {
       "path": "q-system/.q-system/scripts/test/test-review-comment-body.sh",
       "runner": "bash"
     },
@@ -446,6 +470,10 @@
       "runner": "python3"
     },
     {
+      "path": "q-system/.q-system/scripts/test_dispatch_reachability.py",
+      "runner": "python3"
+    },
+    {
       "path": "q-system/.q-system/scripts/test_evidence_ledger.py",
       "runner": "python3"
     },
@@ -491,6 +519,10 @@
     },
     {
       "path": "q-system/.q-system/scripts/test_memory_scores_surface.py",
+      "runner": "python3"
+    },
+    {
+      "path": "q-system/.q-system/scripts/test_merge_bypass_gate.py",
       "runner": "python3"
     },
     {
@@ -570,34 +602,6 @@
       "path": "q-system/.q-system/tests/test_token_guard_cache_race.py",
       "runner": "python3",
       "timeout_s": 120
-    },
-    {
-      "path": "q-system/.q-system/scripts/test/test-gh-repo-scope-worker.sh",
-      "runner": "bash"
-    },
-    {
-      "path": "q-system/.q-system/scripts/test/test-gh-repo-scope-converge.sh",
-      "runner": "bash"
-    },
-    {
-      "path": "q-system/.q-system/scripts/test/test-gh-repo-scope-reviewer.sh",
-      "runner": "bash"
-    },
-    {
-      "path": "q-system/.q-system/scripts/test/test-review-artifact-repo-keyed.sh",
-      "runner": "bash"
-    },
-    {
-      "path": "q-system/.q-system/scripts/test/test-dispatch-client-refusal-after-hold.sh",
-      "runner": "bash"
-    },
-    {
-      "path": "q-system/.q-system/scripts/test_dispatch_reachability.py",
-      "runner": "python3"
-    },
-    {
-      "path": "q-system/.q-system/scripts/test/test-control-file-propagate.sh",
-      "runner": "bash"
     }
   ],
   "required_data": [],

--- a/q-system/.q-system/capability-manifest.json
+++ b/q-system/.q-system/capability-manifest.json
@@ -526,6 +526,10 @@
       "runner": "python3"
     },
     {
+      "path": "q-system/.q-system/scripts/test_merge_bypass_gate_admin_forms.py",
+      "runner": "python3"
+    },
+    {
       "path": "q-system/.q-system/scripts/test_plugin_version_bump_check.py",
       "runner": "python3"
     },

--- a/q-system/.q-system/capability-manifest.json
+++ b/q-system/.q-system/capability-manifest.json
@@ -530,6 +530,10 @@
       "runner": "python3"
     },
     {
+      "path": "q-system/.q-system/scripts/test_merge_bypass_gate_global_flags.py",
+      "runner": "python3"
+    },
+    {
       "path": "q-system/.q-system/scripts/test_plugin_version_bump_check.py",
       "runner": "python3"
     },

--- a/q-system/.q-system/scripts/merge-bypass-gate.py
+++ b/q-system/.q-system/scripts/merge-bypass-gate.py
@@ -176,40 +176,99 @@ def _is_github(url: str | None) -> bool:
 # ParseBool's exact vocabulary, not a lowercase-and-compare: `T` and `t` are true
 # while `TrUe` is an ERROR to gh, so treating any case-fold of "true" as truthy
 # would be a different set than the one the tool implements.
-_PARSEBOOL_TRUE = {"1", "t", "T", "TRUE", "true", "True"}
-_PARSEBOOL_FALSE = {"0", "f", "F", "FALSE", "false", "False"}
+#
+# ROUND 3 CHANGED THE RULE, NOT THE PATTERN LIST. Two reviews found two evasions
+# of the denylist above, and the probe written to confirm the second found a third
+# that was never reported:
+#
+#   gh pr merge --admin                        DENY    round 1 shipped this
+#   gh pr merge --admin=true                   ALLOW   round 2, the = spelling
+#   gh -R owner/repo pr merge --admin          ALLOW   round 3, reported
+#   gh --repo owner/repo pr merge --admin      ALLOW   round 3, same class
+#   gh --hostname github.com pr merge --admin  ALLOW   found by the probe
+#
+# The last three are not more flags to add. ANY gh global flag taking a SEPARATE
+# value pushes that value into the positional stream and shifts the subcommand out
+# from under a positional check. That is gh's grammar: this repo neither owns it
+# nor can enumerate it. Three spellings in three rounds is the signal to stop
+# patching and invert the rule.
+#
+# A DENYLIST fails OPEN on the shape you did not think of. An ALLOWLIST fails
+# CLOSED. Anything that is not exactly the safe invocation is refused, so a
+# grammar feature nobody here has heard of is denied by construction rather than
+# by having been anticipated. Same principle as the capability token: authority
+# granted narrowly and explicitly, never inferred from the absence of a known-bad
+# marker.
+#
+# THE SAFE SHAPE:  gh pr merge --auto [method] [pr-ref]
+# No global flags, no env prefix. `--auto` is REQUIRED because it is the only
+# merge that defers to the required checks -- GitHub holds the PR until they pass.
+# It is also exactly what linear-worker.sh and converge.sh already run, so
+# requiring it breaks no measured caller.
+#
+# HONEST COST: a gh command carrying a bare `merge` token that is not this shape
+# is refused and must be rephrased. That is a real false positive. It is the right
+# direction for the most irreversible action in the fleet, and the deny message
+# names the shape to use.
+_GH_MERGE_ALLOWED_FLAGS = {
+    "--auto",                       # required: the deferral to required checks
+    "--squash", "-s", "--merge", "-m", "--rebase", "-r",
+    "--delete-branch", "-d",
+}
+# Used ONLY to keep non-merge pr commands out of the trigger. Listing one wrong or
+# missing one costs a false DENY, never a false ALLOW.
+_GH_PR_OTHER_SUBCOMMANDS = {
+    "create", "list", "view", "checkout", "close", "comment", "diff", "edit",
+    "ready", "reopen", "status", "lock", "unlock", "review", "update-branch",
+}
+_PR_REF = re.compile(r"^(?:\d+|https://github\.com/[^/]+/[^/]+/pull/\d+)$")
+
+_SAFE_SHAPE = ("the only merge this gate permits is:\n"
+               "    gh pr merge --auto [--squash] [<n>]\n"
+               "  no global flags (-R / --repo / --hostname), no env prefix, "
+               "no other flags.")
 
 
-def _admin_requested(args: list[str]) -> bool:
-    """True when these argv words ask gh to merge with admin privileges.
+def _merge_verdict(seg: list[str], had_env_prefix: bool = False) -> str | None:
+    """An unsafe `gh ... merge` invocation -> reason. Anything else -> None.
 
-    `--admin=false` is deliberately NOT a request: it explicitly declines admin,
-    and denying it would be a false positive on a correct command. A value outside
-    ParseBool IS refused -- gh would reject it anyway, so nothing legitimate is
-    lost, and "the command would have failed regardless" is not a reason for this
-    gate to hand it through.
+    The trigger is deliberately broad (a bare `merge` token anywhere in a gh
+    command) because over-triggering costs a rephrase while under-triggering costs
+    an unchecked merge into main.
     """
-    for tok in args:
-        if tok == "--admin":
-            return True
-        if tok.startswith("--admin="):
-            return tok.split("=", 1)[1] not in _PARSEBOOL_FALSE
-    return False
-
-
-def _merge_verdict(seg: list[str]) -> str | None:
-    """`gh pr merge ... --admin` -> reason. Anything else -> None."""
     if not seg or Path(seg[0]).name != "gh":
         return None
-    rest = [t for t in seg[1:] if not t.startswith("-")]
-    if rest[:2] != ["pr", "merge"]:
+    args = seg[1:]
+    if "merge" not in args:
         return None
-    if not _admin_requested(seg[1:]):
+    # `gh pr list --search merge` and friends: a different pr subcommand in the
+    # subcommand slot means this was never a merge. Recognised only in the
+    # no-global-flag form; with a global flag present it falls through to the
+    # shape check and is refused, which is the safe direction.
+    if len(args) >= 2 and args[0] == "pr" and args[1] in _GH_PR_OTHER_SUBCOMMANDS:
         return None
-    return ("`gh pr merge --admin` merges past the required checks on this repo. "
-            "Measured: branch protection requires ['validate', 'kipi/reviewer-approved'] "
-            "but enforce_admins is false and this credential is an admin, so --admin "
-            "defeats both.")
+
+    if had_env_prefix:
+        return ("an environment prefix on a gh merge can redirect it (GH_REPO, "
+                "GH_HOST) without changing a single argument.\n  " + _SAFE_SHAPE)
+    if args[:2] != ["pr", "merge"]:
+        return ("this is not the plain `gh pr merge` form. A global flag that "
+                "takes a value (-R, --repo, --hostname) shifts the subcommand, "
+                "which is how two earlier bypasses worked, so every form but the "
+                "plain one is refused.\n  " + _SAFE_SHAPE)
+
+    rest = args[2:]
+    unknown = [t for t in rest
+               if t not in _GH_MERGE_ALLOWED_FLAGS and not _PR_REF.match(t)]
+    if unknown:
+        return (f"unrecognised argument(s) on a merge: {unknown}. Refusing rather "
+                "than guessing what they do -- `--admin` in every spelling lands "
+                "here.\n  " + _SAFE_SHAPE)
+    if "--auto" not in rest:
+        return ("a merge without --auto does not defer to the required checks. "
+                "--auto lets GitHub hold the PR until 'validate' and "
+                "'kipi/reviewer-approved' pass.\n  " + _SAFE_SHAPE)
+    return None
 
 
 def _push_verdict(seg: list[str], cwd: str) -> str | None:
@@ -302,15 +361,19 @@ def classify(command: str, cwd: str) -> tuple[str, str]:
         parsed = False
 
     cur_dir = cwd
-    for seg in _split_segments(tokens):
-        seg = _strip_env_prefix(seg)
+    for raw_seg in _split_segments(tokens):
+        seg = _strip_env_prefix(raw_seg)
         if not seg:
             continue
+        # An env prefix is not cosmetic on a merge: GH_REPO / GH_HOST retarget gh
+        # without changing one argument, so the same argv can merge in a different
+        # repo. The prefix was previously stripped and forgotten.
+        had_env_prefix = len(seg) != len(raw_seg)
         if Path(seg[0]).name == "cd" and len(seg) > 1:
             resolved = _resolve_dir(seg[1], cur_dir)
             cur_dir = resolved if resolved else cur_dir
             continue
-        reason = _merge_verdict(seg)
+        reason = _merge_verdict(seg, had_env_prefix)
         if reason:
             return "deny", reason
         reason = _push_verdict(seg, cur_dir)

--- a/q-system/.q-system/scripts/merge-bypass-gate.py
+++ b/q-system/.q-system/scripts/merge-bypass-gate.py
@@ -1,0 +1,321 @@
+#!/usr/bin/env python3
+"""PreToolUse gate: refuse the two command shapes that BYPASS the merge machinery.
+
+Pairs with: no skill. This is the executable half of a rule that existed only as
+prose ("No `--admin`, ever") in four plan docs and nowhere in code.
+
+WHY THIS EXISTS (measured 2026-08-14, ASK-TBD / sp-6dc1b64c)
+
+    gh api repos/:owner/:repo/branches/main/protection
+      required checks : ['validate', 'kipi/reviewer-approved']
+      enforce_admins  : False
+    gh api repos/:owner/:repo --jq .permissions
+      {"admin": true, "push": true}      # the credential every agent holds
+
+`enforce_admins:false` exempts an IDENTITY, not a check. So `gh pr merge --admin`
+merged to main past BOTH required checks, and a probe of the only layer that could
+have refused it (destructive-op-deny.sh) returned ALLOW for every push and merge
+form while its own controls returned DENY. The rule against it was written down
+four times and enforced zero times.
+
+WHAT THIS DENIES, AND WHY IT IS ONLY THESE TWO
+
+The founder's hard constraint is "I do not want to be the merge step - ever."
+So this must not add an approval step to merging. It denies only the shapes that
+route AROUND machinery that already works without a human:
+
+    gh pr merge --auto ...   ALLOW  GitHub holds it until required checks pass.
+                                    This is the path linear-worker.sh already uses.
+    gh pr merge --admin ...  DENY   The only way to defeat kipi/reviewer-approved.
+    git push <protected>     DENY   Skips the PR, so skips both required checks.
+    everything else          ALLOW  not-applicable
+
+The effect is to make the autonomous path the ONLY path, which is what the founder
+asked for. A gate that denied every merge would stop the worker and get switched
+off (destructive-op-deny.sh states that principle in its own comments; the
+design-auto-invoke scar is a gate that was off protecting nothing).
+
+WHY ARGV AND NOT THE RAW STRING
+
+destructive-op-deny.sh deliberately matches raw command strings and accepts that it
+fires on prose that merely QUOTES a banned command, because any parser that decides
+"this string is only prose" is a new bypass surface on a hook guarding production
+deletes. That trade is right for THAT hook and wrong for this one: the blast radius
+here is a refused merge, not a deleted volume, and `--body "do not use --admin"` is
+an ordinary thing to type. Its own comment names the fix it wanted -- "a payload
+field carrying the parsed command WORDS rather than the raw string" -- so this gate
+does the parse with shlex and matches tokens. A parse FAILURE falls back to the raw
+string, so a malformed command cannot launder a bypass through a broken tokenizer.
+
+WHY UNRESOLVABLE MEANS ALLOW
+
+A deny is only correct when this can PROVE the target is a protected branch on a
+GitHub remote. When the repo directory cannot be determined (a `cd $WORK/seed` whose
+variable is script-local, a `-C` path that does not exist), it allows. Lesson
+`a-hook-that-fails-closed-on-a-missing-script-blocks-the-fix-too`: a PreToolUse gate
+whose failure mode is "block everything" also blocks the tools needed to repair it.
+The residual hole is named in section 6 of the plan rather than papered over.
+
+Contract: PreToolUse hook JSON on stdin. Deny = permissionDecision JSON on stdout,
+exit 0 (the same shape as destructive-op-deny.sh emit_deny). Allow = exit 0, silent.
+Self-test: python3 test_merge_bypass_gate.py
+"""
+
+from __future__ import annotations
+
+import json
+import os
+import re
+import shlex
+import subprocess
+import sys
+from pathlib import Path
+
+# Hardcoded, not queried. A PreToolUse hook runs on every Bash call under a 5s
+# timeout; a network round-trip to read branch protection would make every command
+# in the session wait on GitHub, and would fail open whenever the network is down.
+# These are the two names the fleet actually protects.
+PROTECTED_BRANCHES = {"main", "master"}
+
+# Shell separators that start a new command. `|` is included so `foo | git push ...`
+# is examined rather than swallowed as an argument of foo.
+_SEPARATORS = {";", "&&", "||", "|", "\n"}
+
+# git flags taking a separate value, so the value is never mistaken for a positional
+# (`git push --repo X origin main` must read origin as the remote, not X).
+_GIT_VALUE_FLAGS = {"-o", "--push-option", "--repo", "--receive-pack", "--exec",
+                    "--signed", "--force-with-lease", "-C", "--git-dir",
+                    "--work-tree", "--namespace"}
+
+
+def _split_segments(tokens: list[str]) -> list[list[str]]:
+    """Split a token list into separate commands on shell separators."""
+    segments: list[list[str]] = [[]]
+    for tok in tokens:
+        if tok in _SEPARATORS:
+            segments.append([])
+        else:
+            segments[-1].append(tok)
+    return [s for s in segments if s]
+
+
+def _strip_env_prefix(seg: list[str]) -> list[str]:
+    """Drop leading VAR=value assignments and `env`, so `FOO=1 git push` still reads."""
+    i = 0
+    while i < len(seg):
+        tok = seg[i]
+        if tok == "env":
+            i += 1
+        elif re.match(r"^[A-Za-z_][A-Za-z0-9_]*=", tok):
+            i += 1
+        else:
+            break
+    return seg[i:]
+
+
+def _resolve_dir(raw: str, base: str) -> str | None:
+    """Resolve a directory argument, or None when it cannot be known.
+
+    expandvars is what separates the two cases that matter. `cd $HOME/projects/x`
+    is knowable and must stay gated. `cd $WORK/seed` inside a test script is a
+    script-local variable this process never had, so it stays literal, and an
+    unresolved `$` means the answer is None -> allow. Guessing there would deny a
+    push to a throwaway local repo.
+    """
+    if not raw:
+        return None
+    expanded = os.path.expandvars(os.path.expanduser(raw))
+    if "$" in expanded:
+        return None
+    p = Path(expanded)
+    if not p.is_absolute():
+        p = Path(base) / p
+    try:
+        resolved = p.resolve()
+    except OSError:
+        return None
+    return str(resolved) if resolved.is_dir() else None
+
+
+def _remote_url(repo_dir: str, remote: str) -> str | None:
+    try:
+        r = subprocess.run(["git", "-C", repo_dir, "remote", "get-url", remote],
+                           capture_output=True, text=True, timeout=3)
+    except Exception:
+        return None
+    return r.stdout.strip() if r.returncode == 0 else None
+
+
+def _current_branch(repo_dir: str) -> str | None:
+    try:
+        r = subprocess.run(["git", "-C", repo_dir, "rev-parse", "--abbrev-ref", "HEAD"],
+                           capture_output=True, text=True, timeout=3)
+    except Exception:
+        return None
+    branch = r.stdout.strip()
+    return branch if r.returncode == 0 and branch and branch != "HEAD" else None
+
+
+def _is_github(url: str | None) -> bool:
+    return bool(url) and "github.com" in url
+
+
+def _merge_verdict(seg: list[str]) -> str | None:
+    """`gh pr merge ... --admin` -> reason. Anything else -> None."""
+    if not seg or Path(seg[0]).name != "gh":
+        return None
+    rest = [t for t in seg[1:] if not t.startswith("-")]
+    if rest[:2] != ["pr", "merge"]:
+        return None
+    if "--admin" not in seg[1:]:
+        return None
+    return ("`gh pr merge --admin` merges past the required checks on this repo. "
+            "Measured: branch protection requires ['validate', 'kipi/reviewer-approved'] "
+            "but enforce_admins is false and this credential is an admin, so --admin "
+            "defeats both.")
+
+
+def _push_verdict(seg: list[str], cwd: str) -> str | None:
+    """`git push` landing on a protected branch of a GitHub remote -> reason."""
+    if not seg or Path(seg[0]).name != "git":
+        return None
+
+    repo_dir = cwd
+    args: list[str] = []
+    i = 1
+    saw_push = False
+    while i < len(seg):
+        tok = seg[i]
+        if tok == "-C" and i + 1 < len(seg):
+            # `git -C <dir> push ...` targets ANOTHER repo. Resolving origin in the
+            # session cwd instead would deny a push to a temp repo while missing a
+            # push to the real one.
+            resolved = _resolve_dir(seg[i + 1], cwd)
+            if resolved is None:
+                return None
+            repo_dir = resolved
+            i += 2
+            continue
+        if not saw_push:
+            if tok == "push":
+                saw_push = True
+            i += 1
+            continue
+        args.append(tok)
+        i += 1
+
+    if not saw_push:
+        return None
+
+    # Positionals only: <remote> [<refspec>...]
+    positionals: list[str] = []
+    j = 0
+    while j < len(args):
+        tok = args[j]
+        if tok in _GIT_VALUE_FLAGS:
+            j += 2
+            continue
+        if tok.startswith("-"):
+            j += 1
+            continue
+        positionals.append(tok)
+        j += 1
+
+    remote = positionals[0] if positionals else "origin"
+    refspecs = positionals[1:]
+
+    # A URL typed straight on the command line never reaches `remote get-url`.
+    url = remote if re.match(r"^(https?://|git@|ssh://)", remote) else _remote_url(repo_dir, remote)
+    if not _is_github(url):
+        return None
+
+    if refspecs:
+        # `src:dst` lands on dst; a bare name lands on itself.
+        targets = [rs.split(":")[-1] for rs in refspecs]
+    else:
+        branch = _current_branch(repo_dir)
+        if branch is None:
+            return None
+        targets = [branch]
+
+    hit = [t for t in targets if t.lstrip("+").split("/")[-1] in PROTECTED_BRANCHES]
+    if not hit:
+        return None
+    return (f"pushing straight to {hit[0]!r} on a GitHub remote skips the pull "
+            "request, and both required checks live on the PR.")
+
+
+def classify(command: str, cwd: str) -> tuple[str, str]:
+    """THE decision. One constructor, so the property has one place to be wrong.
+
+    Lesson `a-safety-property-enforced-at-n-sites-is-not-a-chokepoint`: a rule
+    maintained by N cooperating checks is waiting for the round that finds the
+    N+1th seam. The hook body below only renders what this returns.
+    """
+    if not command or not command.strip():
+        return "allow", ""
+    try:
+        tokens = shlex.split(command, comments=False, posix=True)
+        parsed = True
+    except ValueError:
+        # An unbalanced quote must not launder a bypass. Fall back to the raw
+        # string, which over-matches (destructive-op-deny.sh's trade) but only for
+        # commands that were already unparseable.
+        tokens = command.split()
+        parsed = False
+
+    cur_dir = cwd
+    for seg in _split_segments(tokens):
+        seg = _strip_env_prefix(seg)
+        if not seg:
+            continue
+        if Path(seg[0]).name == "cd" and len(seg) > 1:
+            resolved = _resolve_dir(seg[1], cur_dir)
+            cur_dir = resolved if resolved else cur_dir
+            continue
+        reason = _merge_verdict(seg)
+        if reason:
+            return "deny", reason
+        reason = _push_verdict(seg, cur_dir)
+        if reason:
+            return "deny", reason
+
+    if not parsed and "--admin" in command and re.search(r"\bpr\s+merge\b", command):
+        return "deny", ("`gh pr merge --admin` appears in a command this gate could "
+                        "not tokenize (unbalanced quote). Refusing rather than "
+                        "guessing.")
+    return "allow", ""
+
+
+REMEDY = (
+    "  Let the machinery merge it:  gh pr merge --auto --squash <n>\n"
+    "  GitHub then merges it itself once 'validate' and 'kipi/reviewer-approved' "
+    "are green. No human in the loop, which is the point.\n"
+    "  If a check is wrong, fix the check. Do not route around it."
+)
+
+
+def main() -> int:
+    try:
+        payload = json.load(sys.stdin)
+    except Exception:
+        return 0
+    if payload.get("tool_name") != "Bash":
+        return 0
+    command = (payload.get("tool_input") or {}).get("command") or ""
+    cwd = payload.get("cwd") or os.getcwd()
+
+    decision, reason = classify(command, cwd)
+    if decision == "allow":
+        return 0
+
+    print(json.dumps({"hookSpecificOutput": {
+        "hookEventName": "PreToolUse",
+        "permissionDecision": "deny",
+        "permissionDecisionReason": f"merge-bypass-gate: {reason}\n{REMEDY}",
+    }}))
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/q-system/.q-system/scripts/merge-bypass-gate.py
+++ b/q-system/.q-system/scripts/merge-bypass-gate.py
@@ -160,6 +160,43 @@ def _is_github(url: str | None) -> bool:
     return bool(url) and "github.com" in url
 
 
+# gh is Go/cobra, so a bool flag accepts BOTH `--admin` and `--admin=<value>`, and
+# the value is read by strconv.ParseBool. Measured against the real binary before
+# fixing (Codex major, PR #155):
+#
+#   $ gh pr merge --admin=notabool 999999
+#   invalid argument "notabool" for "--admin" flag: strconv.ParseBool: ...
+#   $ gh pr merge --admin=true 999999 --squash
+#   GraphQL: Could not resolve to a PullRequest with the number of 999999.
+#
+# The first proves the `=` spelling is accepted; the second proves `--admin=true`
+# clears flag parsing and reaches the merge. Matching the bare token `--admin` let
+# every truthy spelling through the gate whose whole job is to refuse them.
+#
+# ParseBool's exact vocabulary, not a lowercase-and-compare: `T` and `t` are true
+# while `TrUe` is an ERROR to gh, so treating any case-fold of "true" as truthy
+# would be a different set than the one the tool implements.
+_PARSEBOOL_TRUE = {"1", "t", "T", "TRUE", "true", "True"}
+_PARSEBOOL_FALSE = {"0", "f", "F", "FALSE", "false", "False"}
+
+
+def _admin_requested(args: list[str]) -> bool:
+    """True when these argv words ask gh to merge with admin privileges.
+
+    `--admin=false` is deliberately NOT a request: it explicitly declines admin,
+    and denying it would be a false positive on a correct command. A value outside
+    ParseBool IS refused -- gh would reject it anyway, so nothing legitimate is
+    lost, and "the command would have failed regardless" is not a reason for this
+    gate to hand it through.
+    """
+    for tok in args:
+        if tok == "--admin":
+            return True
+        if tok.startswith("--admin="):
+            return tok.split("=", 1)[1] not in _PARSEBOOL_FALSE
+    return False
+
+
 def _merge_verdict(seg: list[str]) -> str | None:
     """`gh pr merge ... --admin` -> reason. Anything else -> None."""
     if not seg or Path(seg[0]).name != "gh":
@@ -167,7 +204,7 @@ def _merge_verdict(seg: list[str]) -> str | None:
     rest = [t for t in seg[1:] if not t.startswith("-")]
     if rest[:2] != ["pr", "merge"]:
         return None
-    if "--admin" not in seg[1:]:
+    if not _admin_requested(seg[1:]):
         return None
     return ("`gh pr merge --admin` merges past the required checks on this repo. "
             "Measured: branch protection requires ['validate', 'kipi/reviewer-approved'] "

--- a/q-system/.q-system/scripts/test_merge_bypass_gate.py
+++ b/q-system/.q-system/scripts/test_merge_bypass_gate.py
@@ -1,0 +1,139 @@
+#!/usr/bin/env python3
+"""Self-test for merge-bypass-gate.py.
+
+Every case asserts the SPECIFIC decision it expects, never merely "something
+happened". An assertion that accepts any refusal cannot tell the branch it means
+to test from an unrelated crash.
+
+Hermetic: builds real git repos in a temp dir and points their `origin` at a
+github.com URL that is never contacted (the gate only reads `remote get-url`).
+No live data path, no network.
+
+Run: python3 test_merge_bypass_gate.py
+"""
+
+from __future__ import annotations
+
+import importlib.util
+import subprocess
+import sys
+import tempfile
+from pathlib import Path
+
+# Same loader shape as test_blocked_claim_evidence_lint.py: the module under test
+# has a hyphenated filename, so it is loaded by path rather than imported.
+GATE = Path(__file__).resolve().parent / "merge-bypass-gate.py"
+_spec = importlib.util.spec_from_file_location("merge_bypass_gate", GATE)
+_mod = importlib.util.module_from_spec(_spec)
+_spec.loader.exec_module(_mod)
+classify = _mod.classify
+
+
+def _git(repo: Path, *args: str) -> None:
+    subprocess.run(["git", "-C", str(repo), *args],
+                   check=True, capture_output=True, text=True)
+
+
+def _make_repo(root: Path, name: str, origin: str, branch: str) -> Path:
+    repo = root / name
+    repo.mkdir(parents=True)
+    _git(repo, "init", "-q", "-b", branch)
+    _git(repo, "config", "user.email", "t@t.test")
+    _git(repo, "config", "user.name", "t")
+    (repo / "f.txt").write_text("x\n")
+    _git(repo, "add", "-A")
+    _git(repo, "commit", "-qm", "seed")
+    _git(repo, "remote", "add", "origin", origin)
+    return repo
+
+
+GH = "https://github.com/example/repo.git"
+
+FAILURES: list[str] = []
+CHECKS = 0
+
+
+def check(name: str, command: str, cwd: Path, want: str) -> None:
+    global CHECKS
+    CHECKS += 1
+    got, reason = classify(command, str(cwd))
+    if got != want:
+        FAILURES.append(
+            f"{name}\n    command : {command}\n    want    : {want}\n"
+            f"    got     : {got}\n    reason  : {reason}")
+
+
+def main() -> int:
+    with tempfile.TemporaryDirectory() as td:
+        root = Path(td)
+        # A repo that looks like ours: github origin, sitting on a feature branch.
+        gh_feature = _make_repo(root, "gh_feature", GH, "sana/feature")
+        # Same, but checked out ON main -- the bare `git push` case.
+        gh_main = _make_repo(root, "gh_main", GH, "main")
+        # The shape every test script in this repo uses: origin is a local path.
+        local_origin = _make_repo(root, "local", str(root / "bare.git"), "main")
+
+        # --- the bypass forms: must DENY ---
+        check("admin flag last", "gh pr merge 999 --squash --admin", gh_feature, "deny")
+        check("admin flag first", "gh pr merge --admin --squash 999", gh_feature, "deny")
+        check("admin flag middle", "gh pr merge 12 --admin -s", gh_feature, "deny")
+        check("push main", "git push origin main", gh_feature, "deny")
+        check("push -u main", "git push -u origin main", gh_feature, "deny")
+        check("push HEAD:main", "git push origin HEAD:main", gh_feature, "deny")
+        check("push master", "git push origin master", gh_feature, "deny")
+        check("push refspec main:main", "git push origin main:main", gh_feature, "deny")
+        check("bare push while on main", "git push", gh_main, "deny")
+        check("push by URL", f"git push {GH} main", gh_feature, "deny")
+        check("admin after a chained cd",
+              f"cd {gh_feature} && gh pr merge 3 --admin", root, "deny")
+        check("push main via git -C",
+              f"git -C {gh_feature} push origin main", root, "deny")
+        check("env prefix does not hide it",
+              "FOO=1 git push origin main", gh_feature, "deny")
+
+        # --- the autonomous path and not-applicable: must ALLOW ---
+        check("auto merge", "gh pr merge --auto --squash 999", gh_feature, "allow")
+        check("auto merge, no admin", "gh pr merge 999 --auto -s", gh_feature, "allow")
+        check("feature branch push",
+              "git push -u origin sana/some-branch", gh_feature, "allow")
+        check("bare push while on a feature branch", "git push", gh_feature, "allow")
+        check("local git merge", "git merge origin/main", gh_feature, "allow")
+        check("gh pr create", "gh pr create --title x --body y", gh_feature, "allow")
+        check("pr list", "gh pr list --state open", gh_feature, "allow")
+
+        # The false positive that would make this gate get switched off: the flag
+        # appears only inside a quoted argument, so argv never contains it.
+        check("admin quoted in a body string",
+              "gh pr create --title x --body 'never use --admin here'",
+              gh_feature, "allow")
+        check("admin quoted in a merge body",
+              "gh pr merge 9 --auto --body 'do not --admin this'",
+              gh_feature, "allow")
+
+        # THE carve-out that keeps this repo's own test scripts green: a local
+        # origin is not GitHub, so pushing main there is nobody's bypass.
+        check("push main to a local origin",
+              "git push origin main", local_origin, "allow")
+        check("push main to a local origin via -C",
+              f"git -C {local_origin} push origin main", root, "allow")
+        # A script-local variable this process never had: unresolvable, so allow
+        # rather than guess. This is the `cd "$WORK/seed" && git push` shape.
+        check("unresolvable cd target",
+              'cd "$WORK/seed" && git push origin HEAD:main', root, "allow")
+
+        # --- degenerate input ---
+        check("empty command", "", gh_feature, "allow")
+        check("unbalanced quote hiding admin",
+              "gh pr merge 9 --admin --body 'oops", gh_feature, "deny")
+
+    if FAILURES:
+        print(f"FAIL {len(FAILURES)}/{CHECKS}\n")
+        for f in FAILURES:
+            print("  " + f + "\n")
+        return 1
+    print(f"ok  {CHECKS}/{CHECKS} checks passed")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/q-system/.q-system/scripts/test_merge_bypass_gate.py
+++ b/q-system/.q-system/scripts/test_merge_bypass_gate.py
@@ -106,9 +106,13 @@ def main() -> int:
         check("admin quoted in a body string",
               "gh pr create --title x --body 'never use --admin here'",
               gh_feature, "allow")
-        check("admin quoted in a merge body",
+        # DENY under the allowlist. --body takes a value, and admitting
+        # value-taking flags is where grammar modelling creeps back in on the
+        # side that can produce a bypass. Keeping the permitted set minimal
+        # costs a rare rephrase; the deny message names the shape to use.
+        check("body flag on a merge is not in the permitted set",
               "gh pr merge 9 --auto --body 'do not --admin this'",
-              gh_feature, "allow")
+              gh_feature, "deny")
 
         # THE carve-out that keeps this repo's own test scripts green: a local
         # origin is not GitHub, so pushing main there is nobody's bypass.

--- a/q-system/.q-system/scripts/test_merge_bypass_gate_admin_forms.py
+++ b/q-system/.q-system/scripts/test_merge_bypass_gate_admin_forms.py
@@ -22,9 +22,13 @@ code and observed going red:
     MERGE_GATE_REF=9092c61e python3 test_merge_bypass_gate_admin_forms.py   # RED
     python3 test_merge_bypass_gate_admin_forms.py                          # GREEN
 
-`--admin=false` is asserted ALLOW on purpose. Denying it would be a false positive
-on a command that explicitly declines admin, and a gate that refuses correct
-commands is one somebody switches off.
+ROUND 3 FLIPPED THE FALSY CASES from ALLOW to DENY, and the flip is recorded here
+rather than quietly edited. Under the round-2 DENYLIST, `--admin=false` had to be
+allowed: it declines admin, so denying it would have been a false positive. Under
+the round-3 ALLOWLIST the question is different -- `--admin=false` is not in the
+permitted set and the command carries no `--auto`, so it is refused like any other
+shape that is not the safe one. That is not a regression; it is the inversion
+working. The safe shape is small on purpose.
 """
 
 from __future__ import annotations
@@ -78,15 +82,26 @@ CASES: list[tuple[str, str, str]] = [
 for v in TRUTHY:
     CASES.append((f"--admin={v} (truthy)", f"gh pr merge 999 --squash --admin={v}", "deny"))
 for v in FALSY:
-    CASES.append((f"--admin={v} (falsy, must NOT be a false positive)",
-                  f"gh pr merge 999 --squash --admin={v}", "allow"))
+    # Refused by the allowlist: not a permitted flag, and no --auto. See the
+    # docstring -- this expectation was ALLOW under the denylist and the change is
+    # deliberate.
+    CASES.append((f"--admin={v} (falsy, refused by the allowlist)",
+                  f"gh pr merge 999 --squash --admin={v}", "deny"))
 CASES += [
     ("--admin=garbage (gh would reject it; refuse anyway)",
      "gh pr merge 999 --admin=notabool", "deny"),
     ("--admin=true first, before the PR number",
      "gh pr merge --admin=true --squash 999", "deny"),
-    ("--admin=true quoted inside a body stays allowed",
-     "gh pr merge 9 --auto --body 'never --admin=true this'", "allow"),
+    # Same allowlist consequence as the falsy cases: --body is not permitted on a
+    # merge. What this case still pins is that the refusal comes from the ARGUMENT
+    # not matching the safe set, never from the string "--admin=true" appearing
+    # inside a quoted value -- the reason text names --body, not the quoted text.
+    ("--admin=true quoted in a body: refused for --body, not for the quoted text",
+     "gh pr merge 9 --auto --body 'never --admin=true this'", "deny"),
+    # The argv-not-raw-string property, kept alive on a command the allowlist
+    # never touches: a quoted --admin inside a pr CREATE must stay allowed.
+    ("--admin=true quoted in a pr create body stays allowed",
+     "gh pr create --title x --body 'never --admin=true this'", "allow"),
     ("--auto is still allowed", "gh pr merge --auto --squash 999", "allow"),
 ]
 

--- a/q-system/.q-system/scripts/test_merge_bypass_gate_admin_forms.py
+++ b/q-system/.q-system/scripts/test_merge_bypass_gate_admin_forms.py
@@ -1,0 +1,114 @@
+#!/usr/bin/env python3
+"""Reproducer: `gh pr merge --admin=true` must be refused, not only bare `--admin`.
+
+THE DEFECT (Codex major on PR #155, confirmed against gh before fixing):
+
+    $ gh pr merge --admin=notabool 999999
+    invalid argument "notabool" for "--admin" flag: strconv.ParseBool: ...
+    $ gh pr merge --admin=true 999999 --squash
+    GraphQL: Could not resolve to a PullRequest with the number of 999999.
+
+The first proves gh ACCEPTS the `--admin=<value>` spelling and parses it with Go's
+strconv.ParseBool. The second proves `--admin=true` clears flag parsing and reaches
+the merge call. The original gate matched the token `--admin` exactly, so every
+`--admin=<truthy>` form walked straight through the gate whose entire purpose is
+to refuse admin merges.
+
+WHY ITS OWN FILE. Folded into the main suite this would have been one more green
+line in a run that was already green, and a case added after its fix has never been
+watched fail. This file carries a REF HATCH so it can be pointed at the pre-fix
+code and observed going red:
+
+    MERGE_GATE_REF=9092c61e python3 test_merge_bypass_gate_admin_forms.py   # RED
+    python3 test_merge_bypass_gate_admin_forms.py                          # GREEN
+
+`--admin=false` is asserted ALLOW on purpose. Denying it would be a false positive
+on a command that explicitly declines admin, and a gate that refuses correct
+commands is one somebody switches off.
+"""
+
+from __future__ import annotations
+
+import importlib.util
+import os
+import subprocess
+import sys
+import tempfile
+from pathlib import Path
+
+REL = "q-system/.q-system/scripts/merge-bypass-gate.py"
+HERE = Path(__file__).resolve().parent
+REPO = HERE.parents[2]
+
+
+def _load_classify():
+    """Load classify() from the working tree, or from a git ref when asked.
+
+    The ref hatch is what lets this case be watched FAILING against the code that
+    shipped the bug. Without it the assertion below is unfalsifiable decoration.
+    """
+    ref = os.environ.get("MERGE_GATE_REF", "").strip()
+    if ref:
+        src = subprocess.run(["git", "-C", str(REPO), "show", f"{ref}:{REL}"],
+                             capture_output=True, text=True)
+        if src.returncode != 0:
+            print(f"FAIL: cannot read {REL} at ref {ref!r}: {src.stderr.strip()}")
+            sys.exit(2)
+        tmp = Path(tempfile.mkdtemp()) / "gate_at_ref.py"
+        tmp.write_text(src.stdout)
+        target, label = tmp, f"ref {ref}"
+    else:
+        target, label = REPO / REL, "working tree"
+
+    spec = importlib.util.spec_from_file_location("gate_under_test", target)
+    mod = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(mod)
+    return mod.classify, label
+
+
+# strconv.ParseBool truthy spellings. gh rejects anything outside ParseBool, so a
+# value that is neither truthy nor falsy can never merge -- but it is still refused,
+# because "the command would have failed anyway" is not a reason to hand it through.
+TRUTHY = ["true", "True", "TRUE", "1", "t", "T"]
+FALSY = ["false", "False", "FALSE", "0", "f", "F"]
+
+CASES: list[tuple[str, str, str]] = [
+    ("bare --admin", "gh pr merge 999 --squash --admin", "deny"),
+]
+for v in TRUTHY:
+    CASES.append((f"--admin={v} (truthy)", f"gh pr merge 999 --squash --admin={v}", "deny"))
+for v in FALSY:
+    CASES.append((f"--admin={v} (falsy, must NOT be a false positive)",
+                  f"gh pr merge 999 --squash --admin={v}", "allow"))
+CASES += [
+    ("--admin=garbage (gh would reject it; refuse anyway)",
+     "gh pr merge 999 --admin=notabool", "deny"),
+    ("--admin=true first, before the PR number",
+     "gh pr merge --admin=true --squash 999", "deny"),
+    ("--admin=true quoted inside a body stays allowed",
+     "gh pr merge 9 --auto --body 'never --admin=true this'", "allow"),
+    ("--auto is still allowed", "gh pr merge --auto --squash 999", "allow"),
+]
+
+
+def main() -> int:
+    classify, label = _load_classify()
+    cwd = str(REPO)
+    failures = []
+    for name, command, want in CASES:
+        got, reason = classify(command, cwd)
+        if got != want:
+            failures.append(f"{name}\n      command: {command}\n"
+                            f"      want {want}, got {got}  {reason[:70]}")
+    print(f"target: {label}")
+    if failures:
+        print(f"FAIL {len(failures)}/{len(CASES)}")
+        for f in failures:
+            print("    " + f)
+        return 1
+    print(f"ok  {len(CASES)}/{len(CASES)} admin-form checks passed")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/q-system/.q-system/scripts/test_merge_bypass_gate_global_flags.py
+++ b/q-system/.q-system/scripts/test_merge_bypass_gate_global_flags.py
@@ -1,0 +1,148 @@
+#!/usr/bin/env python3
+"""Reproducer: a gh GLOBAL FLAG must not be able to smuggle a merge past the gate.
+
+THE DEFECT (Codex major on PR #155 round 3, plus one this probe found itself):
+
+    gh -R owner/repo pr merge 155 --admin          ALLOW   reported
+    gh --repo owner/repo pr merge 155 --admin      ALLOW   same class
+    gh --hostname github.com pr merge 155 --admin  ALLOW   never reported
+    GH_REPO=other/repo gh pr merge --auto --squash ALLOW   never reported
+
+The round-2 gate located the subcommand by filtering non-dash tokens and reading
+the first two. Any global flag that takes a SEPARATE value leaves that value in
+the positional stream, so `pr merge` slid out of positions 0 and 1 and the merge
+check never fired. The `=` spellings happened to work, which is what made the hole
+look like one flag rather than a class.
+
+WHY THE FIX IS AN ALLOWLIST AND NOT THREE MORE PATTERNS. Three spellings in three
+review rounds against gh's argument grammar -- which this repo neither owns nor can
+enumerate -- is the signal to invert the rule instead of extending the list. A
+denylist fails OPEN on the shape nobody thought of; an allowlist fails CLOSED. The
+cases below therefore assert the PROPERTY (anything but the safe shape is refused)
+rather than a list of known-bad spellings, so a grammar feature invented next year
+is covered by construction.
+
+REF HATCH -- watch it fail against the code that shipped the hole:
+
+    MERGE_GATE_REF=09beb939 python3 test_merge_bypass_gate_global_flags.py   # RED
+    python3 test_merge_bypass_gate_global_flags.py                          # GREEN
+"""
+
+from __future__ import annotations
+
+import importlib.util
+import os
+import subprocess
+import sys
+import tempfile
+from pathlib import Path
+
+REL = "q-system/.q-system/scripts/merge-bypass-gate.py"
+HERE = Path(__file__).resolve().parent
+REPO = HERE.parents[2]
+
+
+def _load_classify():
+    ref = os.environ.get("MERGE_GATE_REF", "").strip()
+    if ref:
+        src = subprocess.run(["git", "-C", str(REPO), "show", f"{ref}:{REL}"],
+                             capture_output=True, text=True)
+        if src.returncode != 0:
+            print(f"FAIL: cannot read {REL} at ref {ref!r}: {src.stderr.strip()}")
+            sys.exit(2)
+        tmp = Path(tempfile.mkdtemp()) / "gate_at_ref.py"
+        tmp.write_text(src.stdout)
+        target, label = tmp, f"ref {ref}"
+    else:
+        target, label = REPO / REL, "working tree"
+    spec = importlib.util.spec_from_file_location("gate_under_test", target)
+    mod = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(mod)
+    return mod.classify, label
+
+
+# Every global-flag spelling, with and without the admin flag. The admin flag is
+# incidental here: the POINT is that a global flag must not make a merge
+# unrecognisable, so the no-admin rows matter just as much.
+CASES: list[tuple[str, str, str]] = [
+    ("-R shorthand", "gh -R owner/repo pr merge 155 --squash --admin", "deny"),
+    ("--repo separate value", "gh --repo owner/repo pr merge 155 --admin", "deny"),
+    ("--repo= joined value", "gh --repo=owner/repo pr merge 155 --admin", "deny"),
+    ("--hostname separate value", "gh --hostname github.com pr merge 155 --admin", "deny"),
+    ("-R with no admin flag at all is still not the safe shape",
+     "gh -R owner/repo pr merge 155 --auto --squash", "deny"),
+    ("env prefix can retarget the repo without changing one argument",
+     "GH_REPO=other/repo gh pr merge 155 --auto --squash", "deny"),
+    ("GH_HOST prefix, same class",
+     "GH_HOST=ghe.example.com gh pr merge 155 --auto --squash", "deny"),
+    ("a global flag this gate has never heard of is refused by construction",
+     "gh --some-future-global x pr merge 155 --auto --squash", "deny"),
+    # --auto is the whole reason the safe shape is safe: it is the only merge that
+    # lets GitHub hold the PR until the required checks pass.
+    ("merge without --auto", "gh pr merge 155 --squash", "deny"),
+
+    # The safe shape still works, in the orderings real callers use.
+    # linear-worker.sh runs `gh pr merge --auto --squash "$pr"`.
+    ("safe shape, worker ordering", "gh pr merge --auto --squash 155", "allow"),
+    ("safe shape, ref first", "gh pr merge 155 --auto --squash", "allow"),
+    ("safe shape, short method flag", "gh pr merge 155 --auto -s", "allow"),
+    ("safe shape with delete-branch", "gh pr merge --auto -d --squash 155", "allow"),
+    ("safe shape with a PR url",
+     "gh pr merge https://github.com/o/r/pull/155 --auto --squash", "allow"),
+
+    # Non-merge gh commands must stay out of the way entirely.
+    ("pr list mentioning merge", "gh pr list --search merge", "allow"),
+    ("pr view", "gh pr view 155", "allow"),
+    ("api call", "gh api repos/o/r/commits/abc/status", "allow"),
+]
+
+
+# The decision alone under-tests this gate. Several branches deny the SAME command
+# for different reasons -- a global-flag command is refused both by the subcommand
+# check and, one step later, by the unknown-argument check. Mutation showed that
+# removing the subcommand check changed no verdict, only the explanation. The
+# explanation is what teaches the operator which shape to use, so it is asserted
+# here and the branch becomes observable instead of silently redundant.
+REASON_CASES: list[tuple[str, str, str]] = [
+    ("-R is explained as a subcommand shift, not as an unknown argument",
+     "gh -R owner/repo pr merge 155 --auto --squash",
+     "not the plain `gh pr merge` form"),
+    ("an unknown flag is named in the refusal",
+     "gh pr merge 155 --auto --squash --admin",
+     "unrecognised argument"),
+    ("a missing --auto says so",
+     "gh pr merge 155 --squash",
+     "does not defer to the required checks"),
+    ("an env prefix is explained as a retarget",
+     "GH_REPO=other/repo gh pr merge 155 --auto --squash",
+     "can redirect it"),
+]
+
+
+def main() -> int:
+    classify, label = _load_classify()
+    cwd = str(REPO)
+    failures = []
+    for name, command, want_in_reason in REASON_CASES:
+        got, reason = classify(command, cwd)
+        if got != "deny" or want_in_reason not in reason:
+            failures.append(f"{name}\n      command: {command}\n"
+                            f"      want deny mentioning {want_in_reason!r}\n"
+                            f"      got {got}: {reason[:90]}")
+    for name, command, want in CASES:
+        got, reason = classify(command, cwd)
+        if got != want:
+            failures.append(f"{name}\n      command: {command}\n"
+                            f"      want {want}, got {got}  {reason[:70]}")
+    print(f"target: {label}")
+    if failures:
+        print(f"FAIL {len(failures)}/{len(CASES)}")
+        for f in failures:
+            print("    " + f)
+        return 1
+    print(f"ok  {len(CASES) + len(REASON_CASES)} global-flag checks passed")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/settings-template.json
+++ b/settings-template.json
@@ -180,6 +180,11 @@
             "type": "command",
             "command": "test -f \"$CLAUDE_PROJECT_DIR/q-system/.q-system/scripts/claude-path-write-guard.py\" && python3 \"$CLAUDE_PROJECT_DIR/q-system/.q-system/scripts/claude-path-write-guard.py\"",
             "timeout": 10
+          },
+          {
+            "type": "command",
+            "command": "test -f \"$CLAUDE_PROJECT_DIR/q-system/.q-system/scripts/merge-bypass-gate.py\" && python3 \"$CLAUDE_PROJECT_DIR/q-system/.q-system/scripts/merge-bypass-gate.py\"",
+            "timeout": 5
           }
         ]
       }


### PR DESCRIPTION
## Summary
- Adopts the trust-gate pattern from vercel-labs/eve-software-factory-template (`sp-6dc1b64c`) for prd-os/kipi-dsse's two real gaps: push and merge had zero enforcement. Closeout was checked first and found already stronger than eve's reference pattern (content-sealed receipts vs. eve's session-scoped trust class) — no closeout work in this PR.
- New PreToolUse hook on Bash (`merge-bypass-gate.py`) denies only the bypass forms: `gh pr merge ... --admin` (currently merges past both required checks live, since `enforce_admins:false` + agent credential is admin) and a direct `git push` to a protected branch on a GitHub remote. `--auto`, feature-branch pushes, and local `git merge` are unaffected — the autonomous merge path stays the only path, and the founder is never inserted into the merge step.
- Full plan at `q-system/output/plans/trust-gate-prd-os-2026-08-14.md`.

## Test plan
- [x] Red baseline: 5 bypass forms ALLOW pre-fix while destructive-op controls (`--force`, `reset --hard`) still DENY
- [x] Post-fix: all 5 bypass forms DENY, controls unchanged, `--auto` and feature-branch pushes still ALLOW
- [x] 27/27 unit tests, hermetic temp git repos
- [x] 5/5 mutants killed by their named case (mutant-apply-and-restore verified by grep both directions)
- [x] Load-path proof: a real live Bash call with `--admin` was refused by the wired hook in this session
- [x] `settings-template-sync-check.py` green (hook wired in both settings.json and settings-template.json)
- [x] Capability manifest declares the new test

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01JbfBBxYJW7MwaAvpYhvKzc