### PR TITLE
fix(update): stop the fleet updater deleting each instance's integrity baseline (ASK-792)

### DIFF
--- a/kipi-update.sh
+++ b/kipi-update.sh
@@ -307,6 +307,39 @@ SYSTEM_OWNED_PATHS=(
   "q-system/.q-system/claude-integrity-baseline.json"
   ".claude/state/stop-gate-firings.json"
 )
+
+# INSTANCE-LOCAL, AND COMMITTING IT IS WHAT DESTROYS IT (measured 2026-08-14, 6 instances).
+#
+# Measured 2026-08-14: 6 instances lost their integrity baseline to `kipi update`
+# and the tripwire then refused EVERY tool call on them
+# (claude-integrity-tripwire.py: "BASELINE MISSING on an armed tree", exit 2).
+# The chain is a loop this file closes on itself:
+#
+#   1. the block below COMMITS the baseline, so it becomes tracked;
+#   2. the skeleton's `git archive HEAD` does not contain it (.gitignore:116 --
+#      it is instance-local by ASK-282, and a shared baseline can never match a
+#      per-instance .claude/settings.json);
+#   3. kipi-update-preserve-scan.py rule 3 protects only paths the skeleton NEVER
+#      tracked. The skeleton DID track this one (e25734cb / 629d01b2) and then
+#      deleted it, so the scan reads a deliberate skeleton deletion and correctly
+#      lets `rsync --delete` propagate it.
+#
+# Step 3 is not the bug and must not be "fixed": a never-delete exemption there
+# would make preserve-scan lie about its own rule, which exists so real skeleton
+# deletions reach the fleet. The two instances that escaped did so only because
+# their baseline was still untracked, which is the state this list restores.
+#
+# It is a SEPARATE list applied AFTER both feeders, not an edit to the array
+# above, and that is the whole point. Two independent things append to
+# sys_owned_dirty: this hand list, and auto-commit.py --system-state, which
+# classifies the entire tree. Removing the path from the array alone leaves the
+# classifier free to re-add it -- and the classifier demonstrably does exactly
+# that, having committed .claude-integrity-armed (a path this array never named)
+# during the same 2026-08-14 sweep. One filter, past both, or it is not a fix.
+SYSTEM_NEVER_COMMIT=(
+  "q-system/.q-system/claude-integrity-baseline.json"
+  "q-system/.q-system/claude-integrity-baseline.json.lock"
+)
 # Skeleton-managed plugin dirs are appended at run time from the SAME
 # enumeration the sync itself uses (managed_plugin_names), never as a blanket
 # "plugins" entry. The blanket version classified the WHOLE tree as system-owned
@@ -1554,6 +1587,61 @@ PY
       git merge --abort 2>/dev/null || true
     fi
 
+    # ONE-TIME MIGRATION, and it must run BEFORE the block below (measured 2026-08-14, 6 instances).
+    #
+    # The chokepoint stops the baseline from BECOMING tracked. It does nothing for
+    # the 6 instances where it already is: on those, preserve-scan rule 3 still
+    # hands the committed copy to `rsync --delete` on the very next run. Untracking
+    # is the only thing that moves them into the state the two healthy instances
+    # are already in.
+    #
+    # Idempotent by construction: `ls-files --error-unmatch` is the test, so once
+    # the path is untracked every later run skips it and this costs one git call.
+    #
+    # NEVER a working-tree delete. `git rm --cached` unstages the file and leaves
+    # the instance's real baseline on disk, which is the whole point -- deleting it
+    # would cause by hand the exact outage this is repairing.
+    #
+    # THE PATHSPEC TRAP, and it is the reason for the assert. `git commit -- <path>`
+    # commits WORKTREE content and disregards the index, so the obvious
+    #
+    #     git rm --cached X && git commit -- X
+    #
+    # silently RE-ADDS X and undoes the untrack. The commit here therefore takes no
+    # pathspec -- which is only safe because the index was proved to hold nothing
+    # else, first by refusing outright when the founder has staged work (not ours to
+    # package, same rule as the dirty guard below), then by asserting the staged set
+    # is exactly this one path before committing.
+    for sys_path in "${SYSTEM_NEVER_COMMIT[@]}"; do
+      git ls-files --error-unmatch -- "$sys_path" >/dev/null 2>&1 || continue
+      if [ -n "$(git diff --cached --name-only 2>/dev/null)" ]; then
+        say "  WARNING: $sys_path is tracked, but the index already holds staged work."
+        say "           Leaving it. It will be deleted by this sync until it is untracked."
+        continue
+      fi
+      if ! git rm --cached --quiet -- "$sys_path" 2>/dev/null; then
+        say "  WARNING: could not untrack $sys_path"
+        continue
+      fi
+      sys_staged="$(git diff --cached --name-only 2>/dev/null)"
+      if [ "$sys_staged" != "$sys_path" ]; then
+        say "  WARNING: staging $sys_path produced an unexpected index; backing out"
+        git reset --quiet -q -- "$sys_path" >/dev/null 2>&1 || true
+        continue
+      fi
+      if git commit -q -m "chore: untrack instance-local $sys_path [no-issue: fleet updater instance-local untrack]
+
+This file is instance-local (ASK-282) and gitignored by policy. While it was
+tracked, the skeleton sync deleted it -- the skeleton once tracked the path and
+then removed it, so preserve-scan correctly treats it as a propagating deletion.
+The file itself is untouched on disk." 2>/dev/null; then
+        say "  untracking instance-local file: $sys_path"
+      else
+        say "  WARNING: could not commit the untrack of $sys_path; backing out"
+        git reset --quiet -q -- "$sys_path" >/dev/null 2>&1 || true
+      fi
+    done
+
     # Clear the system's OWN artifacts first, so the guard below judges founder
     # work only. Each path is committed individually and only if it is actually
     # dirty; nothing outside SYSTEM_OWNED_PATHS is ever touched here.
@@ -1598,6 +1686,33 @@ PY
       # against a scratch repo rather than by reading it.
       done < <(git status --porcelain -uall 2>/dev/null | cut -c4- \
                  | python3 "$sys_classifier" --system-state 2>/dev/null)
+    fi
+
+    # THE CHOKEPOINT (measured 2026-08-14, 6 instances). Both feeders have now run; this is the only place
+    # that can see everything either of them produced. See SYSTEM_NEVER_COMMIT for
+    # why committing these paths is what gets them deleted.
+    #
+    # `${arr[@]+"${arr[@]}"}` and the explicit empty branch are not style. This is
+    # /bin/bash 3.2 on macOS under `set -u`, where expanding an EMPTY array errors
+    # out (ASK-607 aborted a sync exactly this way), and where
+    # `arr=("${maybe_empty[@]:-}")` silently builds a ONE-element array holding the
+    # empty string -- which would then be printed as a committed file and handed to
+    # `git add ""`.
+    if [ "${#sys_owned_dirty[@]}" -gt 0 ]; then
+      sys_kept=()
+      for sys_path in ${sys_owned_dirty[@]+"${sys_owned_dirty[@]}"}; do
+        case " ${SYSTEM_NEVER_COMMIT[*]} " in
+          *" $sys_path "*)
+            say "  Leaving instance-local file uncommitted: $sys_path"
+            ;;
+          *) sys_kept+=("$sys_path") ;;
+        esac
+      done
+      if [ "${#sys_kept[@]}" -eq 0 ]; then
+        sys_owned_dirty=()
+      else
+        sys_owned_dirty=("${sys_kept[@]}")
+      fi
     fi
 
     # sp-46c73c76. This read `[ "$DRY_RUN" != "1" ]`, and DRY_RUN is only ever ""

--- a/test-kipi-update-preserve-integration.sh
+++ b/test-kipi-update-preserve-integration.sh
@@ -122,5 +122,240 @@ else
   fi
 fi
 
+BASELINE_REL="q-system/.q-system/claude-integrity-baseline.json"
+ARMED_REL="q-system/.q-system/.claude-integrity-armed"
+TRIPWIRE="$REAL/q-system/.q-system/scripts/claude-integrity-tripwire.py"
+
+# A recorder, never the real sink. notify() resolves
+# $root/q-system/.q-system/scripts/slack-notify.sh unless KIPI_NOTIFY overrides
+# it, and this box HAS ~/.config/kipi/slack-webhook -- so an unstubbed run pages
+# the founder with a SECURITY alarm from a test. Relying on "the temp tree has no
+# slack-notify.sh" would be an accidental shield, not isolation: it goes away the
+# day the fixture copies more of the skeleton. Stub the seam explicitly, then
+# ASSERT on the recorder, because the page IS the harm and exit 2 alone would
+# pass on a tree that refused for some unrelated reason.
+NOTIFY_LOG="$T/notify.log"
+cat > "$T/fake-notify.sh" <<'STUB'
+#!/bin/bash
+printf '%s\n' "$1" >> "$NOTIFY_LOG"
+STUB
+chmod +x "$T/fake-notify.sh"
+
+echo ""
+echo "=== RED: a baseline the skeleton ONCE TRACKED is deleted, and the tripwire refuses ==="
+# THE SHAPE THIS FILE COULD NOT SEE (measured 2026-08-14, 6 instances). Both cases above use a
+# NEVER-TRACKED instance-only file, which preserve-scan rule 3 protects. The
+# baseline is the opposite shape: the skeleton DID track
+# q-system/.q-system/claude-integrity-baseline.json (e25734cb / 629d01b2,
+# ASK-282) and then deleted it, so rule 3 reads a deliberate skeleton deletion
+# and correctly lets it propagate. Every guard in this file was green while
+# 6 instances lost their baseline.
+#
+# Reproducer, so it reimplements the sequence on purpose (see the header): the
+# point is to show the raw defect. What it does NOT reimplement is the two
+# programs whose verdicts decide the outcome -- the REAL preserve-scan and the
+# REAL tripwire both run here. This case stays red-capable forever: it is the
+# harm, not the fix. The fix is proved by the two cases below.
+R2="$T/red2"
+mkdir -p "$R2/skeleton/q-system/.q-system/scripts" "$R2/instance/q-system/.q-system/scripts"
+( cd "$R2/skeleton" && g init -q . &&
+  echo skel > q-system/.q-system/scripts/skel.py &&
+  echo '{"files":{}}' > "$BASELINE_REL" &&
+  g add -A && g commit -qm "ASK-282: skeleton once tracked the baseline" &&
+  rm "$BASELINE_REL" && g add -A && g commit -qm "ASK-282 round 2: instance-local, untrack it"
+) >/dev/null 2>&1
+
+# The instance committed its own baseline -- which is exactly what
+# kipi-update.sh's system-state commit does to it.
+( cd "$R2/instance" && g init -q . &&
+  echo skel > q-system/.q-system/scripts/skel.py &&
+  echo '{"files":{"x":"sha"}}' > "$BASELINE_REL" &&
+  : > "$ARMED_REL" &&
+  g add -A -f && g commit -qm "instance state" ) >/dev/null 2>&1
+
+if ! git -C "$R2/instance" ls-files --error-unmatch -- "$BASELINE_REL" >/dev/null 2>&1; then
+  echo "  FAIL: fixture never tracked the baseline, so this case measures nothing"
+  FAILURES=$((FAILURES + 1))
+else
+  A2="$T/red2-archive"; mkdir -p "$A2"
+  git -C "$R2/skeleton" archive --format=tar HEAD -- q-system/ | tar -x -C "$A2"
+
+  # The REAL scanner decides. Not a stand-in for it.
+  PRESERVED="$(python3 "$REAL/kipi-update-preserve-scan.py" \
+                 --skeleton-archive "$A2" --instance "$R2/instance" \
+                 --prefix q-system --skeleton-git "$R2/skeleton" 2>/dev/null)"
+  # The two files sit in the SAME directory and go through the SAME scan, and
+  # the scan must answer them differently. That pairing is the control: if the
+  # armed marker were not preserved here, a deleted baseline would prove nothing
+  # about rule 3 -- it would just mean --delete removed everything.
+  if ! printf '%s\n' "$PRESERVED" | grep -qx -- "$ARMED_REL"; then
+    echo "  FAIL: preserve-scan did not protect the armed marker either; no discrimination to show"
+    FAILURES=$((FAILURES + 1))
+  elif printf '%s\n' "$PRESERVED" | grep -qx -- "$BASELINE_REL"; then
+    echo "  FAIL: preserve-scan protected the baseline, so the reproducer is wrong"
+    FAILURES=$((FAILURES + 1))
+  else
+    echo "  OK: preserve-scan preserved the armed marker and NOT the baseline (rule 3)"
+    # Snapshot + restore the preserved set, because that is what the updater does
+    # around its rsync. Skipping it would delete the armed marker too and the
+    # tripwire would then refuse for the wrong reason.
+    SNAP2="$T/red2-snap"; mkdir -p "$SNAP2"
+    while IFS= read -r rel; do
+      [ -n "$rel" ] || continue
+      mkdir -p "$SNAP2/$(dirname "$rel")" && cp -a "$R2/instance/$rel" "$SNAP2/$rel"
+    done <<< "$PRESERVED"
+    rsync -a --delete "$A2/q-system/" "$R2/instance/q-system/" 2>/dev/null
+    while IFS= read -r rel; do
+      [ -n "$rel" ] || continue
+      mkdir -p "$R2/instance/$(dirname "$rel")" && cp -a "$SNAP2/$rel" "$R2/instance/$rel"
+    done <<< "$PRESERVED"
+    if [ -f "$R2/instance/$BASELINE_REL" ]; then
+      echo "  FAIL: the baseline survived --delete; no harm to demonstrate"
+      FAILURES=$((FAILURES + 1))
+    elif [ ! -f "$R2/instance/$ARMED_REL" ]; then
+      echo "  FAIL: the armed marker also went; the refusal would not be this defect"
+      FAILURES=$((FAILURES + 1))
+    else
+      # THE ASSERTION THAT MATTERS. The missing file is the symptom; the tripwire
+      # refusing every tool call on an armed tree is the harm the founder feels.
+      : > "$NOTIFY_LOG"
+      KIPI_NOTIFY="$T/fake-notify.sh" NOTIFY_LOG="$NOTIFY_LOG" \
+        python3 "$TRIPWIRE" --check --root "$R2/instance" >/dev/null 2>&1
+      rc=$?
+      if [ "$rc" = "2" ] && grep -q "baseline is MISSING" "$NOTIFY_LOG" 2>/dev/null; then
+        echo "  OK: reproduced -- tripwire exit 2 and a SECURITY page on an armed tree"
+      else
+        echo "  FAIL: expected exit 2 + a SECURITY page, got rc=$rc, page=$(cat "$NOTIFY_LOG" 2>/dev/null | head -1)"
+        FAILURES=$((FAILURES + 1))
+      fi
+    fi
+  fi
+fi
+
+# --- The fix, driven through the REAL kipi-update.sh -------------------------
+# The case above is the harm and stays red-capable forever. These two are the
+# fix, and they assert on lines the RUNNING program prints, never on a file the
+# test placed itself.
+#
+# The fixture skeleton must TRACK-THEN-DELETE the baseline, the way the real one
+# does (e25734cb / 629d01b2). A fresh `git init` skeleton has never tracked it,
+# preserve-scan rule 3 would protect it, and both cases would pass against
+# unpatched code -- a fixture built wrong is a gate that cannot fire.
+build_skel() {
+  local S="$1"
+  mkdir -p "$S"
+  cp -R "$REAL/q-system" "$S/q-system"
+  cp "$REAL"/*.py "$REAL"/*.sh "$S/" 2>/dev/null
+  cp "$REAL"/*.json "$REAL"/*.yml "$S/" 2>/dev/null
+  cp -R "$REAL/plugins" "$S/plugins" 2>/dev/null
+  chmod +x "$S/kipi-update.sh"
+  rm -f "$S/$BASELINE_REL" "$S/$ARMED_REL"
+  ( cd "$S" && g init -q . &&
+    echo '{"files":{}}' > "$BASELINE_REL" && g add -A -f >/dev/null 2>&1 &&
+    g commit -qm "skeleton once tracked the baseline (ASK-282)" &&
+    rm "$BASELINE_REL" && g add -A >/dev/null 2>&1 &&
+    g commit -qm "skeleton untracked it: instance-local" ) >/dev/null 2>&1
+}
+
+reg() {  # $1=skeleton $2=instance path
+  cat > "$1/instance-registry.json" <<JSON
+{
+  "skeleton": "$1",
+  "instances": [
+    { "name": "fake", "path": "$2", "subtree_prefix": "q-system",
+      "instance_q_dir": "q-fake", "type": "subtree", "has_git": true }
+  ],
+  "standalone": [],
+  "eliminated": []
+}
+JSON
+}
+
+run_case() {  # $1=label $2=track-the-baseline? $3=logfile
+  local S="$T/$1/skeleton" I="$T/$1/instance"
+  build_skel "$S"
+  reg "$S" "$I"
+  mkdir -p "$I/q-system/.q-system/scripts"
+  echo "seed" > "$I/q-system/.q-system/scripts/seed.py"
+  ( cd "$I" && g init -q . && g add -A >/dev/null 2>&1 && g commit -qm inst ) >/dev/null 2>&1
+  echo '{"files":{"x":"sha"}}' > "$I/$BASELINE_REL"
+  : > "$I/$ARMED_REL"
+  if [ "$2" = "tracked" ]; then
+    ( cd "$I" && g add -A -f >/dev/null 2>&1 && g commit -qm "instance committed its baseline" ) >/dev/null 2>&1
+  fi
+  /bin/bash "$S/kipi-update.sh" --dry-run --only fake > "$3" 2>&1
+}
+
+echo ""
+echo "=== FIX 1: the updater must never COMMIT the baseline (chokepoint) ==="
+# Two feeders reach sys_owned_dirty: the SYSTEM_OWNED_PATHS hand list and
+# auto-commit.py --system-state, which classifies the whole tree. Committing the
+# baseline is what makes it tracked, which is what hands it to rule 3.
+L1="$T/fix1.log"
+run_case fix1 untracked "$L1"
+if ! grep -q -- "--- fake (subtree) ---" "$L1"; then
+  echo "  FAIL: the run never reached the instance, so nothing was measured"
+  tail -4 "$L1" | sed 's/^/      /'
+  FAILURES=$((FAILURES + 1))
+else
+  # A BARE indented path is the committed list and nothing else: the block prints
+  # its members with `printf '    %s\n'`. Matching the path anywhere in the log
+  # instead is what the first draft of this assertion did, and it swallowed the
+  # later "restored untracked: <path>" line -- reporting the defect while the
+  # chokepoint was in fact holding.
+  if grep -qE '^[[:space:]]*q-system/\.q-system/claude-integrity-baseline\.json[[:space:]]*$' "$L1"; then
+    echo "  FAIL: the updater committed the baseline (this is the defect)"
+    sed -n '/Committing .* system-written file/,+4p' "$L1" | sed 's/^/      | /'
+    FAILURES=$((FAILURES + 1))
+  else
+    echo "  OK: the baseline was not in the system-state commit"
+  fi
+  # Positive: the chokepoint FIRED. Absence alone would also pass on a run that
+  # never classified the baseline at all.
+  if grep -q "Leaving instance-local file uncommitted: $BASELINE_REL" "$L1"; then
+    echo "  OK: the chokepoint named it and declined to commit it"
+  else
+    echo "  FAIL: the chokepoint never fired on the baseline"
+    FAILURES=$((FAILURES + 1))
+  fi
+  # Positive signal: untracked means the ordinary snapshot catches it.
+  if grep -q "restored untracked: $BASELINE_REL" "$L1"; then
+    echo "  OK: it stayed untracked and was restored across the sync"
+  else
+    echo "  FAIL: the baseline was not restored as untracked after the sync"
+    grep -i "baseline" "$L1" | head -3 | sed 's/^/      /'
+    FAILURES=$((FAILURES + 1))
+  fi
+fi
+
+echo ""
+echo "=== FIX 2: an ALREADY-TRACKED baseline is untracked, not deleted (migration) ==="
+# The 6 instances already broken on 2026-08-14 have it committed. The chokepoint
+# alone does nothing for them: the file is already tracked, so rule 3 still hands
+# it to --delete on the very next run.
+L2="$T/fix2.log"
+run_case fix2 tracked "$L2"
+if ! grep -q -- "--- fake (subtree) ---" "$L2"; then
+  echo "  FAIL: the run never reached the instance, so nothing was measured"
+  tail -4 "$L2" | sed 's/^/      /'
+  FAILURES=$((FAILURES + 1))
+else
+  if grep -q "untracking instance-local file: $BASELINE_REL" "$L2"; then
+    echo "  OK: the updater announced the untrack"
+  else
+    echo "  FAIL: no untrack announcement for an already-tracked baseline"
+    FAILURES=$((FAILURES + 1))
+  fi
+  # The behavioural proof, printed by pre-existing updater code: a file only
+  # reaches "restored untracked" when it is genuinely untracked by then.
+  if grep -q "restored untracked: $BASELINE_REL" "$L2"; then
+    echo "  OK: it survived the sync as an untracked file"
+  else
+    echo "  FAIL: the baseline did not survive the sync"
+    grep -i "baseline" "$L2" | head -3 | sed 's/^/      /'
+    FAILURES=$((FAILURES + 1))
+  fi
+fi
+
 echo ""
 if [ "$FAILURES" = "0" ]; then echo "PASS"; exit 0; else echo "FAIL ($FAILURES)"; exit 1; fi


### PR DESCRIPTION
## What

Rescues commit `b95a7e1b`, which was sitting **unpushed on a local branch** and existed on no remote. Found while working sp-7fc21245.

- `kipi-update.sh` (+115): stop the updater deleting each instance's integrity baseline (instance-local state).
- `test-kipi-update-preserve-integration.sh` (+235, new): its test.

## Why this is a PR and not a direct commit

The commit was authored directly with a `[no-issue:]` marker and never pushed. That is the exact ASK-773 pattern: work committed to whatever branch is checked out, never reviewed, one disk failure from gone. 350 lines against the fleet's most dangerous script earns a review like everything else tonight.

I did not write this commit and did not modify it. It is pushed verbatim so its author keeps authorship and the work stops being at risk. Disposition of the content is the reviewer's call.

## Verified

- `b95a7e1b` was contained in no remote branch before this push (`git branch -r --contains` returned empty).
- Pushed unchanged; no rebase, no amend, no force.

Related: ASK-773 (unpushed-work class), ASK-791/#155.