### PR TITLE
Detect and alert on instance files holding bytes origin/main never shipped (ASK-795)

### DIFF
--- a/fleet-drift-baseline.json
+++ b/fleet-drift-baseline.json
@@ -1,0 +1,53 @@
+{
+  "_why": "Accepted drift, subtracted by exact (instance, path, blob). Never mute an instance by name -- that hides the next unreviewed blob to land in it.",
+  "accepted": [
+    {
+      "instance": "gtm-partner",
+      "path": "plugins/kipi-core/voicekit/selector.py",
+      "blob": "5888ffa5",
+      "reason": "Founder accepted these three instances as-is on 2026-08-14 (\"THAT IS FINE - they dont need it\"). Each refuses to sync on real local work: gtm-partner on unrelated dirt, fractional-cxo and negotiator on instance-authored plugins/memory-lifecycle. Keyed on the exact blob, so if any of these files CHANGES the entry stops matching and the drift is reported again. Tracked as sp-c9bbb589."
+    },
+    {
+      "instance": "gtm-partner",
+      "path": "plugins/prd-os/.claude-plugin/plugin.json",
+      "blob": "f9cf2110",
+      "reason": "Founder accepted these three instances as-is on 2026-08-14 (\"THAT IS FINE - they dont need it\"). Each refuses to sync on real local work: gtm-partner on unrelated dirt, fractional-cxo and negotiator on instance-authored plugins/memory-lifecycle. Keyed on the exact blob, so if any of these files CHANGES the entry stops matching and the drift is reported again. Tracked as sp-c9bbb589."
+    },
+    {
+      "instance": "gtm-partner",
+      "path": "plugins/prd-os/scripts/prd_runner.py",
+      "blob": "079e6b74",
+      "reason": "Founder accepted these three instances as-is on 2026-08-14 (\"THAT IS FINE - they dont need it\"). Each refuses to sync on real local work: gtm-partner on unrelated dirt, fractional-cxo and negotiator on instance-authored plugins/memory-lifecycle. Keyed on the exact blob, so if any of these files CHANGES the entry stops matching and the drift is reported again. Tracked as sp-c9bbb589."
+    },
+    {
+      "instance": "gtm-partner",
+      "path": "plugins/prd-os/tests/test_judgment_compiler.py",
+      "blob": "7f42be38",
+      "reason": "Founder accepted these three instances as-is on 2026-08-14 (\"THAT IS FINE - they dont need it\"). Each refuses to sync on real local work: gtm-partner on unrelated dirt, fractional-cxo and negotiator on instance-authored plugins/memory-lifecycle. Keyed on the exact blob, so if any of these files CHANGES the entry stops matching and the drift is reported again. Tracked as sp-c9bbb589."
+    },
+    {
+      "instance": "fractional-cxo",
+      "path": "plugins/prd-os/.claude-plugin/plugin.json",
+      "blob": "2c84ea60",
+      "reason": "Founder accepted these three instances as-is on 2026-08-14 (\"THAT IS FINE - they dont need it\"). Each refuses to sync on real local work: gtm-partner on unrelated dirt, fractional-cxo and negotiator on instance-authored plugins/memory-lifecycle. Keyed on the exact blob, so if any of these files CHANGES the entry stops matching and the drift is reported again. Tracked as sp-c9bbb589."
+    },
+    {
+      "instance": "fractional-cxo",
+      "path": "plugins/prd-os/scripts/prd_runner.py",
+      "blob": "079e6b74",
+      "reason": "Founder accepted these three instances as-is on 2026-08-14 (\"THAT IS FINE - they dont need it\"). Each refuses to sync on real local work: gtm-partner on unrelated dirt, fractional-cxo and negotiator on instance-authored plugins/memory-lifecycle. Keyed on the exact blob, so if any of these files CHANGES the entry stops matching and the drift is reported again. Tracked as sp-c9bbb589."
+    },
+    {
+      "instance": "negotiator",
+      "path": "plugins/prd-os/.claude-plugin/plugin.json",
+      "blob": "2c84ea60",
+      "reason": "Founder accepted these three instances as-is on 2026-08-14 (\"THAT IS FINE - they dont need it\"). Each refuses to sync on real local work: gtm-partner on unrelated dirt, fractional-cxo and negotiator on instance-authored plugins/memory-lifecycle. Keyed on the exact blob, so if any of these files CHANGES the entry stops matching and the drift is reported again. Tracked as sp-c9bbb589."
+    },
+    {
+      "instance": "negotiator",
+      "path": "plugins/prd-os/scripts/prd_runner.py",
+      "blob": "079e6b74",
+      "reason": "Founder accepted these three instances as-is on 2026-08-14 (\"THAT IS FINE - they dont need it\"). Each refuses to sync on real local work: gtm-partner on unrelated dirt, fractional-cxo and negotiator on instance-authored plugins/memory-lifecycle. Keyed on the exact blob, so if any of these files CHANGES the entry stops matching and the drift is reported again. Tracked as sp-c9bbb589."
+    }
+  ]
+}

--- a/fleet-drift-scan.py
+++ b/fleet-drift-scan.py
@@ -1,0 +1,227 @@
+#!/usr/bin/env python3
+"""Assert every instance's skeleton-owned files hold bytes origin/main actually shipped.
+
+WHY THIS EXISTS (scar, 2026-08-14, ASK-795 / sp-786f1c4b):
+PR #142 fanned prd-os 0.27.1 to the fleet from an UNMERGED feature branch. Eleven
+instances were left dirty and refused to sync, which is how anyone noticed. But ten
+others had the same unreviewed blob (7f42be38) sitting AT HEAD -- already committed,
+so `git status` read clean and not one gate ever complained. The visible half got a
+week of attention; the silent half was the more dangerous state and was found only by
+hand-diffing blobs across all 23 instances.
+
+The missing control was never "detect a dirty tree". It was: CLEAN IS NOT EVIDENCE OF
+CORRECT. Nothing anywhere asserted that an instance's skeleton-owned bytes came from
+the skeleton's reviewed history. PR #149's preflight stops the recurrence -- it refuses
+to fan from a non-main checkout -- but it is blind to drift already on disk.
+
+THE TEST, and why it is not "does this match current main":
+Comparing against the CURRENT skeleton blob attributes nothing on a real fleet.
+Instances legitimately lag; a lagging file would flag on every scan and the scan would
+be switched off. kipi-update.sh's own `fleet_authored_blob` already settled the honest
+question -- "was this content EVER shipped at this path" -- by walking `git rev-list
+<ship-ref> -- <path>`. This scanner applies that same rule, but proactively across
+every instance instead of only to files a sync happened to find dirty.
+
+Deliberately scoped to origin/main. A blob reachable only from an unmerged branch is
+exactly the defect, so searching all refs would have called 7f42be38 legitimate and
+reported the whole fleet green. That boundary is the entire point.
+
+READ-ONLY. It opens no instance for writing and never stages, commits, or checks out.
+Exit 1 on drift so it can later be wired to an alert; today it is a scan you run.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import os
+import re
+import subprocess
+import sys
+
+# Kept byte-identical in meaning to kipi-update.sh's PLUGIN_COPY_EXCLUDES. A file the
+# rsync never copies is not skeleton-owned, so flagging it would be a false positive.
+PLUGIN_COPY_EXCLUDE_RE = re.compile(
+    r"(^|/)\.git/|(^|/)__pycache__/|\.pyc$|(^|/)\.venv/|(^|/)\.pytest_cache/"
+    r"|(^|/)\.env$|(^|/)\.env\."
+)
+
+# The flat globs the config sync actually copies. NOT recursive, and not `.claude/`
+# wholesale -- widening it here would manufacture alarms about files that never ship
+# (settings.local.json, worktrees/), which is how a scan earns its own suppression.
+CLAUDE_FLAT_DIRS = ("agents", "output-styles", "rules")
+
+
+def git(repo: str, *args: str) -> str | None:
+    r = subprocess.run(
+        ["git", "-C", repo, *args], capture_output=True, text=True
+    )
+    return r.stdout.strip() if r.returncode == 0 else None
+
+
+def skeleton_owned_paths(skeleton: str, ship_ref: str) -> list[str]:
+    """Every path the fan-out writes, read from the ship ref rather than from disk.
+
+    Reading the working tree would let an uncommitted local file define the audit
+    scope, which is the same class of mistake the preflight exists to stop.
+    """
+    listing = git(skeleton, "ls-tree", "-r", "--name-only", ship_ref) or ""
+    paths = []
+    for rel in listing.splitlines():
+        if rel.startswith("plugins/"):
+            parts = rel.split("/", 2)
+            if len(parts) < 3:
+                continue
+            if PLUGIN_COPY_EXCLUDE_RE.search(parts[2]):
+                continue
+            paths.append(rel)
+        elif rel == ".claude/settings.json":
+            # DELIBERATELY NOT AUDITED. kipi-update.sh does not copy this file, it
+            # MERGES it (kipi-settings-merge.py: "preserves instance customizations",
+            # instance-added hooks survive). So an instance's settings.json is a
+            # per-instance product that by design equals no skeleton blob -- auditing
+            # it flags all 23 instances, forever, on the first run.
+            #
+            # Measured 2026-08-14 while calibrating this scanner against hand-verified
+            # truth: it fired on accountant, an instance remediated and confirmed
+            # correct minutes earlier. A detector whose first run cries wolf on every
+            # healthy instance gets muted, and then the real drift it exists to catch
+            # goes unread too. Drift in the MERGED result needs its own check against
+            # the template, which is a different question from provenance.
+            continue
+        else:
+            for scope in CLAUDE_FLAT_DIRS:
+                prefix = ".claude/" + scope + "/"
+                # Flat glob: the copy is `*.md` at depth 1, so a nested file is not
+                # shipped and must not be audited as if it were.
+                if rel.startswith(prefix) and "/" not in rel[len(prefix):] \
+                        and rel.endswith(".md"):
+                    paths.append(rel)
+    return paths
+
+
+class ShippedIndex:
+    """Blobs the ship ref ever held at a path. Built lazily; rev-list is the cost."""
+
+    def __init__(self, skeleton: str, ship_ref: str) -> None:
+        self.skeleton = skeleton
+        self.ship_ref = ship_ref
+        self._cache: dict[str, set[str]] = {}
+
+    def ever_shipped(self, rel: str, blob: str) -> bool:
+        if rel not in self._cache:
+            blobs: set[str] = set()
+            commits = git(self.skeleton, "rev-list", self.ship_ref, "--", rel) or ""
+            for commit in commits.splitlines():
+                b = git(self.skeleton, "rev-parse", f"{commit}:{rel}")
+                if b:
+                    blobs.add(b)
+            self._cache[rel] = blobs
+        return blob in self._cache[rel]
+
+
+def scan_instance(inst: dict, skeleton: str, ship_ref: str, paths: list[str],
+                  head_blobs: dict[str, str], index: ShippedIndex) -> list[dict]:
+    path = inst["path"]
+    findings: list[dict] = []
+    if not os.path.isdir(path):
+        return [{"instance": inst["name"], "path": "-", "kind": "instance-missing",
+                 "detail": path}]
+
+    for rel in paths:
+        current = head_blobs.get(rel)
+        # The instance's COMMITTED content. Worktree dirt is the dirty-tree guard's
+        # job; the silent-ten were clean at worktree AND wrong at HEAD, so HEAD is
+        # the half nothing was watching.
+        actual = git(path, "rev-parse", f"HEAD:{rel}")
+        if actual is None:
+            continue  # absent in this instance; the sync will add it
+        if actual == current:
+            continue  # matches main exactly, the common case, cheap
+        if index.ever_shipped(rel, actual):
+            findings.append({"instance": inst["name"], "path": rel, "kind": "lag",
+                             "detail": actual[:8]})
+        else:
+            findings.append({"instance": inst["name"], "path": rel, "kind": "DRIFT",
+                             "detail": actual[:8]})
+    return findings
+
+
+def main() -> int:
+    ap = argparse.ArgumentParser(description=__doc__)
+    ap.add_argument("--skeleton", default=os.path.dirname(os.path.abspath(__file__)))
+    ap.add_argument("--ship-ref", default="origin/main")
+    ap.add_argument("--only", action="append", help="instance name (repeatable)")
+    ap.add_argument("--show-lag", action="store_true",
+                    help="also list files that are merely behind main")
+    ap.add_argument("--json", action="store_true")
+    ap.add_argument("--no-fetch", action="store_true")
+    args = ap.parse_args()
+
+    skeleton = args.skeleton
+    registry = os.path.join(skeleton, "instance-registry.json")
+    if not os.path.exists(registry):
+        print(f"ABORT: no instance-registry.json at {skeleton}", file=sys.stderr)
+        return 2
+
+    if not args.no_fetch:
+        # Fail closed. An unproven ship ref cannot answer "was this ever shipped",
+        # and guessing green is worse than refusing.
+        if git(skeleton, "fetch", "origin", "main", "--quiet") is None:
+            print("ABORT: could not fetch origin/main; cannot prove provenance",
+                  file=sys.stderr)
+            return 2
+
+    if git(skeleton, "rev-parse", "--verify", args.ship_ref) is None:
+        print(f"ABORT: ship ref {args.ship_ref} does not resolve", file=sys.stderr)
+        return 2
+
+    paths = skeleton_owned_paths(skeleton, args.ship_ref)
+    head_blobs: dict[str, str] = {}
+    listing = git(skeleton, "ls-tree", "-r", args.ship_ref) or ""
+    for line in listing.splitlines():
+        meta, _, rel = line.partition("\t")
+        bits = meta.split()
+        if len(bits) >= 3:
+            head_blobs[rel] = bits[2]
+
+    with open(registry) as fh:
+        instances = json.load(fh)["instances"]
+    if args.only:
+        instances = [i for i in instances if i["name"] in set(args.only)]
+
+    index = ShippedIndex(skeleton, args.ship_ref)
+    findings: list[dict] = []
+    for inst in instances:
+        findings.extend(
+            scan_instance(inst, skeleton, args.ship_ref, paths, head_blobs, index)
+        )
+
+    drift = [f for f in findings if f["kind"] == "DRIFT"]
+    missing = [f for f in findings if f["kind"] == "instance-missing"]
+    lag = [f for f in findings if f["kind"] == "lag"]
+
+    if args.json:
+        print(json.dumps({"drift": drift, "lag": lag, "missing": missing}, indent=2))
+    else:
+        print(f"fleet-drift-scan: {len(instances)} instance(s), "
+              f"{len(paths)} skeleton-owned path(s), ship ref {args.ship_ref}")
+        for f in missing:
+            print(f"  MISSING  {f['instance']}: {f['detail']}")
+        if args.show_lag:
+            for f in lag:
+                print(f"  lag      {f['instance']:22} {f['path']} ({f['detail']})")
+        for f in drift:
+            print(f"  DRIFT    {f['instance']:22} {f['path']} (blob {f['detail']} "
+                  f"was never shipped at this path)")
+        print(f"  summary: {len(drift)} drift, {len(lag)} lag, {len(missing)} missing")
+        if drift:
+            print("\nDRIFT means the instance committed bytes origin/main never "
+                  "shipped at that path.\nThat is unreviewed content living in a "
+                  "repo that reports clean.")
+
+    return 1 if drift else 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/fleet-drift-scan.py
+++ b/fleet-drift-scan.py
@@ -156,6 +156,8 @@ def main() -> int:
                     help="also list files that are merely behind main")
     ap.add_argument("--json", action="store_true")
     ap.add_argument("--no-fetch", action="store_true")
+    ap.add_argument("--baseline", default=None,
+                    help="JSON file of accepted drift; matches are not reported")
     args = ap.parse_args()
 
     skeleton = args.skeleton
@@ -197,6 +199,26 @@ def main() -> int:
             scan_instance(inst, skeleton, args.ship_ref, paths, head_blobs, index)
         )
 
+    # ACCEPTED DRIFT IS SUBTRACTED BY EXACT (instance, path, blob), never by
+    # instance name. Muting a whole instance would hide the NEXT unreviewed blob to
+    # land in it, which is the only thing this scan exists to catch. Keyed on the
+    # blob, an accepted entry stops matching the moment the content changes.
+    #
+    # Why a baseline exists at all: on arrival this scan reports 8 drift, all in the
+    # three instances the founder has accepted as-is. An alerting detector that is
+    # RED on day one gets muted, and then it is worth nothing -- the same lesson the
+    # settings.json false positive taught while this script was being calibrated.
+    accepted_keys = set()
+    if args.baseline:
+        with open(args.baseline) as fh:
+            for row in json.load(fh).get("accepted", []):
+                accepted_keys.add((row["instance"], row["path"], row["blob"]))
+
+    accepted = [f for f in findings
+                if (f["instance"], f["path"], f["detail"]) in accepted_keys]
+    findings = [f for f in findings
+                if (f["instance"], f["path"], f["detail"]) not in accepted_keys]
+
     drift = [f for f in findings if f["kind"] == "DRIFT"]
     missing = [f for f in findings if f["kind"] == "instance-missing"]
     lag = [f for f in findings if f["kind"] == "lag"]
@@ -214,7 +236,8 @@ def main() -> int:
         for f in drift:
             print(f"  DRIFT    {f['instance']:22} {f['path']} (blob {f['detail']} "
                   f"was never shipped at this path)")
-        print(f"  summary: {len(drift)} drift, {len(lag)} lag, {len(missing)} missing")
+        print(f"  summary: {len(drift)} drift, {len(lag)} lag, "
+              f"{len(missing)} missing, {len(accepted)} accepted")
         if drift:
             print("\nDRIFT means the instance committed bytes origin/main never "
                   "shipped at that path.\nThat is unreviewed content living in a "

--- a/q-system/.q-system/capability-manifest.json
+++ b/q-system/.q-system/capability-manifest.json
@@ -610,6 +610,11 @@
       "path": "q-system/.q-system/tests/test_token_guard_cache_race.py",
       "runner": "python3",
       "timeout_s": 120
+    },
+    {
+      "path": "q-system/.q-system/tests/test_fleet_drift_no_answer.py",
+      "runner": "python3",
+      "timeout_s": 60
     }
   ],
   "required_data": [],

--- a/q-system/.q-system/scripts/fleet-health-daily.py
+++ b/q-system/.q-system/scripts/fleet-health-daily.py
@@ -1225,7 +1225,75 @@ def detect_stale_runtime_plugins(_ctx) -> list:
     }]
 
 
+def detect_fleet_drift(_ctx) -> list:
+    """An instance COMMITTED skeleton-owned bytes origin/main never shipped.
+
+    The dirty-tree guard watches worktrees, so it only ever sees the loud half.
+    Scar (ASK-795, 2026-08-14): PR #142 fanned prd-os 0.27.1 from an unmerged
+    branch; 11 instances went dirty and refused to sync, and TEN more had the same
+    blob already at HEAD -- committed, clean `git status`, no gate complaining.
+    The silent ten were found by hand-diffing blobs across all 23 instances.
+
+    Report-only by construction: this files an issue, it blocks nothing. The scan
+    itself opens no instance for writing.
+    """
+    scan = REPO_ROOT / "fleet-drift-scan.py"
+    baseline = REPO_ROOT / "fleet-drift-baseline.json"
+    if not scan.exists():
+        return []
+    cmd = [sys.executable, str(scan), "--json", "--skeleton", str(REPO_ROOT)]
+    if baseline.exists():
+        cmd += ["--baseline", str(baseline)]
+    try:
+        res = subprocess.run(cmd, capture_output=True, text=True, timeout=900)
+    except (subprocess.TimeoutExpired, OSError):
+        return []
+    # Exit 1 means drift FOUND, which is a normal result here, not an error. Only a
+    # verdict we cannot parse is treated as no-answer -- guessing green would make
+    # this detector's silence meaningless, which is the failure mode it exists for.
+    try:
+        payload = json.loads(res.stdout)
+    except json.JSONDecodeError:
+        return []
+
+    findings = []
+    for row in payload.get("drift", []):
+        inst, path, blob = row["instance"], row["path"], row["detail"]
+        findings.append({
+            "subject": f"{inst}:{path}",
+            "title": f"unreviewed bytes committed in {inst}: {path}",
+            "body": (
+                f"`{inst}` has `{path}` committed at blob `{blob}`, which "
+                "`origin/main` **never shipped at that path**.\n\n"
+                "The instance reports clean, so no dirty-tree guard will ever "
+                "mention it. That is the ASK-795 shape: content fanned from an "
+                "unmerged branch and then committed locally.\n\n"
+                "## Action\n"
+                "- Confirm with `python3 fleet-drift-scan.py --only "
+                f"{inst}` from the skeleton.\n"
+                "- If the bytes are fleet residue, let a normal `kipi update` "
+                "overwrite them (the syncer rewrites managed plugin paths).\n"
+                "- If they are deliberate local work, record them in "
+                "`fleet-drift-baseline.json` with a reason. Baseline entries are "
+                "keyed on the exact blob, so an accepted file that later CHANGES "
+                "is reported again rather than staying muted."
+            ),
+        })
+    return findings
+
+
 DETECTORS = [
+    {
+        "id": "fleet-drift",
+        "description": "an instance committed skeleton-owned bytes origin/main never shipped",
+        "detect": detect_fleet_drift,
+        "action": "file_issue",
+        "lesson_waived": (
+            "The lesson corpus has no entry for this class yet because nothing "
+            "detected it until now -- it was found by hand. The detector plus its "
+            "baseline IS the durable answer; a lesson would only restate it."
+        ),
+    },
     {
         "id": "runtime-plugin-stale",
         "description": "the RUNNING plugin copy is older than the merged one, or hand-edited",

--- a/q-system/.q-system/scripts/fleet-health-daily.py
+++ b/q-system/.q-system/scripts/fleet-health-daily.py
@@ -1244,17 +1244,56 @@ def detect_fleet_drift(_ctx) -> list:
     cmd = [sys.executable, str(scan), "--json", "--skeleton", str(REPO_ROOT)]
     if baseline.exists():
         cmd += ["--baseline", str(baseline)]
+
+    # A SCAN THAT DID NOT RUN IS NOT A CLEAN FLEET (codex major, PR #158 r1).
+    #
+    # Both failure paths below used to `return []`, which is byte-identical to
+    # the answer "I looked at 23 instances and every one is clean". The docstring
+    # above already said that guessing green makes this detector's silence
+    # meaningless -- the code did the opposite of its own comment. Worse, an empty
+    # list reads to the caller as a detector that RAN, so the blind-detector
+    # notification that exists to catch a detector producing nothing stays quiet
+    # too. A crashed scanner was therefore invisible twice over.
+    #
+    # So a no-answer becomes a LOUD finding instead of a silent green. This
+    # detector is report-only by construction and blocks nothing, so the cost of
+    # a false alarm is one issue a human closes; the cost of a false green is the
+    # ASK-795 shape going unseen for another cycle, which is what it exists for.
+    def _no_answer(reason: str) -> list:
+        return [{
+            "subject": "fleet-drift-scan:no-answer",
+            "title": "the fleet drift scan did not produce a verdict",
+            "body": (
+                f"`fleet-drift-scan.py` did not return a readable verdict: {reason}\n\n"
+                "**This is not a clean fleet.** No instance was cleared. The scan "
+                "failed to run or its output could not be parsed, so the ASK-795 "
+                "class (skeleton-owned bytes committed in an instance that "
+                "`origin/main` never shipped) is currently UNCHECKED.\n\n"
+                "## Action\n"
+                "- Run `python3 fleet-drift-scan.py --json --skeleton .` from the "
+                "skeleton and read the error.\n"
+                "- This detector reports only; nothing is blocked by it. The issue "
+                "closes when the scan produces a verdict again.\n"
+            ),
+        }]
+
     try:
         res = subprocess.run(cmd, capture_output=True, text=True, timeout=900)
-    except (subprocess.TimeoutExpired, OSError):
-        return []
+    except subprocess.TimeoutExpired:
+        return _no_answer("the scan exceeded its 900s timeout")
+    except OSError as e:
+        return _no_answer(f"the scan could not be executed ({e})")
     # Exit 1 means drift FOUND, which is a normal result here, not an error. Only a
     # verdict we cannot parse is treated as no-answer -- guessing green would make
     # this detector's silence meaningless, which is the failure mode it exists for.
     try:
         payload = json.loads(res.stdout)
-    except json.JSONDecodeError:
-        return []
+    except json.JSONDecodeError as e:
+        tail = (res.stderr or "").strip()[-400:]
+        return _no_answer(
+            f"its stdout was not JSON ({e})"
+            + (f"; stderr tail: `{tail}`" if tail else "")
+        )
 
     findings = []
     for row in payload.get("drift", []):

--- a/q-system/.q-system/tests/test_fleet_drift_no_answer.py
+++ b/q-system/.q-system/tests/test_fleet_drift_no_answer.py
@@ -1,0 +1,100 @@
+#!/usr/bin/env python3
+"""A drift scan that did not run must not read as a clean fleet (codex major, PR #158 r1).
+
+Both failure paths in detect_fleet_drift used to `return []`, which is
+byte-identical to "I checked 23 instances and every one is clean". An empty list
+also reads to the caller as a detector that RAN, so the blind-detector
+notification meant to catch a detector producing nothing stayed quiet as well.
+A crashed scanner was invisible twice over.
+
+These are the reproducers for that. Each one drives the REAL detector against a
+deliberately broken fleet-drift-scan.py and asserts the result is a loud
+no-answer, not silence.
+"""
+import importlib.util
+import pathlib
+import sys
+import tempfile
+import unittest
+
+HERE = pathlib.Path(__file__).resolve()
+SCRIPT = HERE.parents[1] / "scripts" / "fleet-health-daily.py"
+
+
+def load_module():
+    """Import fleet-health-daily.py by path; its name is not a valid identifier."""
+    spec = importlib.util.spec_from_file_location("fleet_health_daily", SCRIPT)
+    mod = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(mod)
+    return mod
+
+
+class NoAnswerIsNotGreen(unittest.TestCase):
+    def setUp(self):
+        if not SCRIPT.exists():
+            self.skipTest(f"no fleet-health-daily.py at {SCRIPT}")
+        self.mod = load_module()
+        self.tmp = tempfile.TemporaryDirectory()
+        self.addCleanup(self.tmp.cleanup)
+        self.root = pathlib.Path(self.tmp.name)
+        # REPO_ROOT is where the detector looks for the scanner. Pointing it at a
+        # temp dir is what keeps this test off the real fleet -- it never opens an
+        # instance, and the scanner it finds is one this test wrote.
+        self.mod.REPO_ROOT = self.root
+
+    def _write_scanner(self, body: str):
+        (self.root / "fleet-drift-scan.py").write_text(body)
+
+    def test_unparseable_stdout_is_a_finding_not_silence(self):
+        self._write_scanner("print('this is not json')\n")
+        out = self.mod.detect_fleet_drift(None)
+        self.assertTrue(
+            out, "unparseable scanner output returned [] -- a crash read as a clean fleet"
+        )
+        self.assertEqual(out[0]["subject"], "fleet-drift-scan:no-answer")
+        self.assertIn("not a clean fleet", out[0]["body"].lower())
+
+    def test_scanner_that_crashes_is_a_finding(self):
+        self._write_scanner("import sys\nsys.stderr.write('boom\\n')\nsys.exit(3)\n")
+        out = self.mod.detect_fleet_drift(None)
+        self.assertTrue(out, "a crashing scanner returned [] -- silence indistinguishable from green")
+        self.assertEqual(out[0]["subject"], "fleet-drift-scan:no-answer")
+
+    def test_stderr_tail_is_carried_so_the_issue_is_actionable(self):
+        self._write_scanner(
+            "import sys\nsys.stderr.write('ModuleNotFoundError: no such module\\n')\n"
+            "sys.exit(1)\n"
+        )
+        out = self.mod.detect_fleet_drift(None)
+        self.assertIn("ModuleNotFoundError", out[0]["body"],
+                      "the no-answer issue does not say WHY, so nobody can act on it")
+
+    def test_a_real_verdict_still_reports_drift(self):
+        # The guard must not have replaced the detector's actual job.
+        self._write_scanner(
+            "import json\n"
+            "print(json.dumps({'drift': [{'instance': 'inst-a', 'path': 'p/x.py',"
+            " 'detail': 'deadbeef'}]}))\n"
+        )
+        out = self.mod.detect_fleet_drift(None)
+        self.assertEqual(len(out), 1)
+        self.assertEqual(out[0]["subject"], "inst-a:p/x.py")
+
+    def test_a_clean_verdict_is_still_silent(self):
+        # THE NEGATIVE SELF-TEST. Without this, every assertion above would pass
+        # on a detector that returned a finding unconditionally -- which would be
+        # a different bug wearing the same green.
+        self._write_scanner("import json\nprint(json.dumps({'drift': []}))\n")
+        out = self.mod.detect_fleet_drift(None)
+        self.assertEqual(out, [], "a genuinely clean fleet must produce no finding")
+
+    def test_absent_scanner_is_still_a_no_op(self):
+        # No scanner file at all is "this feature is not installed here", which is
+        # different from "it ran and broke". Unchanged behaviour, asserted so the
+        # distinction does not quietly collapse into the no-answer path.
+        out = self.mod.detect_fleet_drift(None)
+        self.assertEqual(out, [])
+
+
+if __name__ == "__main__":
+    unittest.main(verbosity=2)

--- a/test-fleet-drift-scan.sh
+++ b/test-fleet-drift-scan.sh
@@ -1,0 +1,113 @@
+#!/bin/bash
+# Pairs with fleet-drift-scan.py (ASK-795 / sp-786f1c4b).
+#
+# The scan's whole value is telling LAG from DRIFT. A detector that flags every
+# instance behind main gets switched off within a day; one that flags nothing is
+# indistinguishable from one that works. So the two controls below are the test:
+# an old-but-shipped blob must stay QUIET, and a never-shipped blob must FIRE.
+#
+# Scar this encodes: the ten instances that committed PR #142's unmerged bytes were
+# found only by hand. Every automated check called them clean.
+set -u
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+SCAN="$SCRIPT_DIR/fleet-drift-scan.py"
+TMP="$(mktemp -d)"
+trap 'rm -r -- "$TMP" 2>/dev/null || true' EXIT
+
+FAILED=0
+ok()   { printf '  ok   %s\n' "$1"; }
+bad()  { printf '  FAIL %s\n' "$1"; FAILED=1; }
+
+q() { git -C "$1" "${@:2}" >/dev/null 2>&1; }
+
+# ---- build a fake skeleton with a real 3-revision history for one managed file ----
+SKEL="$TMP/skeleton"
+mkdir -p "$SKEL/plugins/demo/scripts"
+q "$SKEL" init -q -b main || git -C "$SKEL" init -q
+git -C "$SKEL" config user.email t@t; git -C "$SKEL" config user.name t
+
+write_rev() { printf 'revision %s\n' "$1" > "$SKEL/plugins/demo/scripts/tool.py"; }
+
+write_rev v1; q "$SKEL" add -A; q "$SKEL" commit -m v1
+BLOB_V1="$(git -C "$SKEL" rev-parse HEAD:plugins/demo/scripts/tool.py)"
+write_rev v2; q "$SKEL" add -A; q "$SKEL" commit -m v2
+write_rev v3; q "$SKEL" add -A; q "$SKEL" commit -m v3
+BLOB_V3="$(git -C "$SKEL" rev-parse HEAD:plugins/demo/scripts/tool.py)"
+
+# A blob that exists ONLY on a feature branch -- the exact shape of 7f42be38.
+q "$SKEL" checkout -q -b feature
+printf 'revision from-an-unmerged-branch\n' > "$SKEL/plugins/demo/scripts/tool.py"
+q "$SKEL" add -A; q "$SKEL" commit -m branch-only
+BLOB_BRANCH="$(git -C "$SKEL" rev-parse HEAD:plugins/demo/scripts/tool.py)"
+q "$SKEL" checkout -q main
+
+# The scan reads origin/main. No network here: point that ref at local main.
+git -C "$SKEL" update-ref refs/remotes/origin/main refs/heads/main
+
+[ "$BLOB_V1" != "$BLOB_V3" ] && [ "$BLOB_BRANCH" != "$BLOB_V3" ] \
+  && ok "fixture built distinct blobs" || bad "fixture blobs collided"
+
+# ---- three instances, one per case ----
+mk_instance() {  # name, content
+  local dir="$TMP/$1"
+  mkdir -p "$dir/plugins/demo/scripts"
+  q "$dir" init -q -b main || git -C "$dir" init -q
+  git -C "$dir" config user.email t@t; git -C "$dir" config user.name t
+  printf '%s\n' "$2" > "$dir/plugins/demo/scripts/tool.py"
+  q "$dir" add -A; q "$dir" commit -m seed
+}
+mk_instance current "revision v3"
+mk_instance lagging "revision v1"
+mk_instance drifted "revision from-an-unmerged-branch"
+
+cat > "$SKEL/instance-registry.json" <<EOF
+{"skeleton":{"path":"$SKEL"},"instances":[
+ {"name":"current","path":"$TMP/current"},
+ {"name":"lagging","path":"$TMP/lagging"},
+ {"name":"drifted","path":"$TMP/drifted"}]}
+EOF
+
+run_scan() { python3 "$SCAN" --skeleton "$SKEL" --no-fetch "$@" 2>&1; }
+
+OUT="$(run_scan)"; RC=$?
+
+# CONTROL 1: the instance matching main exactly must not appear at all.
+echo "$OUT" | grep -q 'current' \
+  && bad "an up-to-date instance was reported" \
+  || ok "up-to-date instance is silent"
+
+# CONTROL 2 (the false-positive killer): an OLD blob main really shipped is LAG,
+# never DRIFT. Get this wrong and the scan flags the whole fleet.
+echo "$OUT" | grep -q 'DRIFT .*lagging' \
+  && bad "a legitimately lagging instance was called DRIFT" \
+  || ok "lagging instance is not DRIFT"
+
+# CONTROL 3 (the true positive we must actually catch): branch-only bytes.
+echo "$OUT" | grep -q 'DRIFT .*drifted' \
+  && ok "branch-only blob is reported as DRIFT" \
+  || bad "branch-only blob was NOT detected -- the detector is inert"
+
+[ "$RC" -eq 1 ] && ok "exit 1 when drift exists" || bad "expected exit 1, got $RC"
+
+# CONTROL 4: with the drifted instance excluded, the scan must go green. Proves the
+# exit code tracks the finding rather than being hardcoded.
+run_scan --only current --only lagging >/dev/null 2>&1
+[ $? -eq 0 ] && ok "exit 0 when no drift in scope" || bad "expected exit 0"
+
+# CONTROL 5: an unmerged branch must NOT launder a blob. If the scan ever searched
+# all refs, the drifted instance would read clean -- that is the ASK-775 round-7
+# boundary, and it is the single assumption this whole file defends.
+echo "$OUT" | grep -q 'DRIFT .*drifted' \
+  && ok "ship-ref scope excludes feature branches" \
+  || bad "feature-branch blob was laundered as legitimate"
+
+# CONTROL 6: excluded paths are not audited (a .pyc must never be a finding).
+: > "$TMP/drifted/plugins/demo/scripts/junk.pyc"
+q "$TMP/drifted" add -A -f; q "$TMP/drifted" commit -m pyc
+run_scan | grep -q 'junk.pyc' \
+  && bad "an excluded .pyc was audited" || ok "excluded paths are skipped"
+
+echo ""
+[ "$FAILED" -eq 0 ] && echo "test-fleet-drift-scan: PASS" || echo "test-fleet-drift-scan: FAIL"
+exit "$FAILED"


### PR DESCRIPTION
## The gap

Tonight's remediation (ASK-795, sp-7fc21245) turned up something worse than the reported problem. PR #142 fanned prd-os 0.27.1 from an **unmerged** branch. 11 instances went dirty and refused to sync, which is the only reason anyone noticed. **Ten more had the same blob `7f42be38` already at HEAD** -- committed, so `git status` read clean and not one gate complained. They were found by hand-diffing blobs across all 23 instances.

**Clean is not evidence of correct.** PR #149 stops the recurrence; nothing detected drift already on disk.

## The rule, and why not "matches current main"

Comparing to the current skeleton blob flags every instance that legitimately lags, so the scan gets muted in a day. The honest question is the one `kipi-update.sh`'s own `fleet_authored_blob` already asks -- *was this blob ever shipped at this path* (`git rev-list <ship-ref> -- <path>`). This applies that rule proactively to **committed** content, the half nothing was watching.

Scoped to `origin/main` deliberately. A blob reachable only from an unmerged branch **is** the defect; searching all refs would call `7f42be38` legitimate and report the fleet green. That is the ASK-775 round-7 boundary.

## Armed, report-only

Wired into the existing daily `fleet-health-daily.py` run (08:15) as detector `fleet-drift`, `action: file_issue`. It files an issue. **It blocks nothing and writes to no instance.**

Armed **with a baseline**, because a detector that is RED on arrival gets muted and then protects nothing -- the same lesson the `settings.json` false positive taught while this was being calibrated. The 8 current findings all sit in the three instances the founder accepted as-is (gtm-partner, fractional-cxo, negotiator; sp-c9bbb589). They are recorded in `fleet-drift-baseline.json` **with reasons**, so the detector arrives green and fires on the next unreviewed blob.

The baseline subtracts by exact `(instance, path, blob)` -- **never by instance name**. Muting an instance would hide the next bad blob to land in it, which is the only thing this exists to catch.

## Verified by running it, not reading it

- `detect_fleet_drift` registered in `DETECTORS` as `fleet-drift`.
- baseline present → **0 findings**; baseline removed → **8 findings**, correctly titled; restored → **0** again.
- baseline blob tampered to a wrong value → that entry **reappears as DRIFT**, proving an accepted file that later changes is not silently muted.
- **Mutation-tested:** forcing `ever_shipped` to return `True` turns the suite RED (2 controls die, exit code flips); restoring makes it PASS. A detector that never fires reads exactly like one that works.

**Calibrated against hand-verified truth:** accountant (remediated, confirmed correct) → 0 drift. gtm-partner (measured to hold `7f42be38` at HEAD) → flags it plus the paired `plugin.json`, `prd_runner.py` and `voicekit/selector.py`.

**One false positive found and fixed:** `.claude/settings.json` is MERGED per instance by `kipi-settings-merge.py`, so it equals no skeleton blob by design. It fired on a known-good instance. Excluded, with the measurement in a why-comment.

## Note

A full scan takes several minutes (23 instances x 501 paths). Fine for a daily job; the subprocess carries a 900s timeout. A non-zero exit means drift **found**, a normal result; only an unparseable verdict is treated as no-answer.

Does not touch #149's preflight or #151's authorship rule.

Related: ASK-795, sp-786f1c4b, sp-c9bbb589, PR #142 (open), #149, #151.