### PR TITLE
A guard is absent only if no skeleton path for it exists in the target (ASK-798)

### DIFF
--- a/q-system/.q-system/scripts/repo-preflight.sh
+++ b/q-system/.q-system/scripts/repo-preflight.sh
@@ -255,18 +255,53 @@ missing_scripts = sorted(scripts(skel) - scripts(repo))
 # green fixture in this test suite was itself that shape. Resolve each guard the
 # skeleton wires and require the file to actually be present in the target.
 import os
+# A GUARD IS ABSENT ONLY IF NO SKELETON PATH FOR IT EXISTS IN THE TARGET.
+#
+# The previous rule took hits[:1] -- the first os.walk hit anywhere under the
+# skeleton -- and demanded THAT exact relative path in the instance. The skeleton
+# root also holds PR review worktrees (.pr31rev/, .pr25rev/) and template-repo/,
+# none of which ship to any instance, so the first hit routinely resolved to a
+# path no instance could ever have.
+#
+# Measured 2026-08-14 against ktlyst and interview-coach by replicating this block
+# verbatim: 36 guards reported absent, 35 of them PHANTOM -- present in the
+# instance at a different skeleton path, e.g. audhd-lint.py resolved to
+# .pr31rev/r2/tree/q-system/.q-system/scripts/audhd-lint.py. Exactly ONE was real
+# (merge-bypass-gate.py). os.walk order is not stable across machines either, so
+# the same repo could pass or fail depending on directory iteration.
+#
+# This is NOT a loosening. The check still demands the guard file exist in the
+# target; it stops demanding it exist at a path that only ever existed inside a
+# scratch worktree. After this fix both repos still REFUSE -- on the one real
+# absence -- which is the proof it did not go soft.
+SKIP_DIRS = {'.git', 'node_modules', '__pycache__', '.venv', '.pytest_cache',
+             'template-repo', 'worktrees'}
+
+
+def _shipping(dirname):
+    """Directories that never reach an instance, so never define the guard path."""
+    if dirname in SKIP_DIRS:
+        return False
+    # Review/scratch worktrees this repo creates at its own root. `.q-system` is a
+    # real shipped directory, so dotted names are filtered by prefix, not wholesale.
+    for junk in ('.pr', '.wt-', '.fable-wt', '.sana-tmp'):
+        if dirname.startswith(junk):
+            return False
+    return True
+
+
 skel_root, repo_root = sys.argv[3], sys.argv[4]
 absent = []
 for rel in sorted(scripts(skel)):
     hits = []
-    for base, _dirs, files in os.walk(skel_root):
-        if '/.git' in base:
-            continue
+    for base, dirs, files in os.walk(skel_root):
+        dirs[:] = [d for d in dirs if _shipping(d)]
         if rel in files:
             hits.append(os.path.relpath(os.path.join(base, rel), skel_root))
-    for h in hits[:1]:
-        if not os.path.isfile(os.path.join(repo_root, h)):
-            absent.append(h)
+    # Sorted so the reported path is deterministic rather than walk-order dependent.
+    hits.sort()
+    if hits and not any(os.path.isfile(os.path.join(repo_root, h)) for h in hits):
+        absent.append(hits[0])
 parts = []
 if missing_events:
     parts.append("events=" + "/".join(missing_events))

--- a/q-system/.q-system/scripts/repo-preflight.sh
+++ b/q-system/.q-system/scripts/repo-preflight.sh
@@ -263,12 +263,18 @@ import os
 # none of which ship to any instance, so the first hit routinely resolved to a
 # path no instance could ever have.
 #
-# Measured 2026-08-14 against ktlyst and interview-coach by replicating this block
-# verbatim: 36 guards reported absent, 35 of them PHANTOM -- present in the
-# instance at a different skeleton path, e.g. audhd-lint.py resolved to
-# .pr31rev/r2/tree/q-system/.q-system/scripts/audhd-lint.py. Exactly ONE was real
-# (merge-bypass-gate.py). os.walk order is not stable across machines either, so
-# the same repo could pass or fail depending on directory iteration.
+# Measured 2026-08-14 against both dispatch-enabled repos by replicating this block
+# verbatim: each reported 36 guards absent, 35 of them PHANTOM -- present in the
+# instance at a different skeleton path, e.g. a lint script resolving to its copy
+# inside a PR review worktree instead of its shipped location. Exactly ONE was
+# real. os.walk order is not stable across machines either, so the same repo could
+# pass or fail depending on directory iteration.
+#
+# NO INSTANCE NAMES ABOVE, DELIBERATELY. This file ships to every instance, so
+# validate-separation Gate 1.2 sweeps it for live instance names and the first cut
+# of this comment named the two repos and turned CI red. The measurement is the
+# durable part; the names belong in the PR body. A text check cannot tell a rule
+# from a mention of one, which is why this warning names no repo either.
 #
 # This is NOT a loosening. The check still demands the guard file exist in the
 # target; it stops demanding it exist at a path that only ever existed inside a


### PR DESCRIPTION
## The finding

`repo-preflight.sh` is the gate that decides whether the dispatcher may enter a repo. Its hook-parity check resolved each wired guard by taking the **first `os.walk` hit** under the skeleton and demanding that exact relative path in the target.

The skeleton root also holds PR review worktrees (`.pr31rev/`, `.pr25rev/`) and `template-repo/`. None of those ship to any instance. So the first hit routinely resolved to a path **no instance could ever have**.

## Measured, not argued

Replicated this block verbatim against the live skeleton:

| repo | reported absent | phantom | real |
|---|---|---|---|
| ktlyst | 36 | **35** | 1 |
| interview-coach | 36 | **35** | 1 |

Phantom = the guard **is** present in the instance, at the real path. Example: `audhd-lint.py` resolved to `.pr31rev/r2/tree/q-system/.q-system/scripts/audhd-lint.py`.

**Consequence:** the hook gate could never be satisfied, and no fleet update could ever have fixed it. The phantom absences are a property of the skeleton's scratch directories, not of the instance. 18 ready `owner:sana` issues across 14 projects are skipped every cycle because dispatch cannot enter a repo.

`os.walk` order is not stable across machines either, so the same repo could pass or fail on directory iteration alone. Hits are now sorted for a deterministic reported path.

## This is not a loosening

The check still requires the guard file to exist in the target. It stops requiring it at a path that only ever existed inside a scratch worktree.

**Proven by running the real gate, with a negative control.** With a `.pr99rev/` fixture holding copies of four guards:

- OLD: `FAIL hooks: ... absent=headline-lint.py/merge-bypass-gate.py/open-loops.py/voice-lint.py` — all four present in the instance at the real path
- NEW: no hooks failure emitted

Remove the fixture and both agree. The fixture was built because a fresh clone has no `.pr*` directories, so testing there would have passed vacuously.

## End state

`repo-preflight.sh <ktlyst> <pinned-remote>` now passes hooks, remote, credentials and dirty. The only remaining refusal:

```
FAIL branch-protection: GitHub refused the protection query for
assafkip/ktlyst-saas-product@main: Branch not protected
```

That is a GitHub setting, deliberately untouched.

## Note on the other half

`merge-bypass-gate.py` was the single real absence. It is no longer missing: both repos were synced at 14:18/14:19 and now carry the file and wire it. That half closed without this PR; this PR is what stops the phantoms from refusing anyway.

Related: ASK-798, ASK-797, sp-3e201efb, sp-f17e584c.