### PR TITLE
Rescue memory-lifecycle: three instances held the last copy (ASK-803)

### DIFF
--- a/rescued/README.md
+++ b/rescued/README.md
@@ -1,0 +1,54 @@
+# rescued/
+
+Code that survived only by accident and had nowhere else to live.
+
+**This directory does not ship.** `kipi update` syncs `q-system/`,
+`.claude/{agents,output-styles,rules}/*.md`, `.claude/settings.json` and
+`plugins/*/`. A top-level `rescued/` is in none of those sets, which is the
+whole reason it is here rather than in `plugins/`.
+
+That placement is deliberate and it is the point: rescuing code and
+distributing code are two decisions, and the second one has a 23-instance blast
+radius. Putting a rescue straight into `plugins/` would make the fleet-wide
+change a side effect of the save. Anything here is preserved, in history, and
+inert until someone decides otherwise on purpose.
+
+## memory-lifecycle
+
+Traced 2026-08-14 (sp-067fdd08).
+
+The skeleton once shipped `plugins/memory-lifecycle` as a SYMLINK to
+`/Users/assafkip/projects/memory-lifecycle` -- note `assafkip`, an old home
+directory, not the current `assafkipnis`. Commit `1be3dfd0` removed it as a
+"dead memory-lifecycle symlink", which it was: the target no longer exists, and
+there is no copy under the current home and no git repo for it anywhere under
+`~/projects`.
+
+But `rsync` had already dereferenced that symlink on the way out. So three
+instances -- interview-coach, fractional-cxo and negotiator -- each ended up
+holding 10 REAL files, byte-identical across all three (`f1c515ed71aa`). Those
+copies were the only ones left anywhere.
+
+They read as instance dirt. `repo-preflight.sh` refuses interview-coach over
+them, and `kipi-update.sh` already predicted the class in its own comment:
+
+> an ORPHANED plugin dir -- one an older skeleton shipped and a newer one
+> dropped, e.g. plugins/memory-lifecycle -- is no longer covered, so it still
+> blocks that instance. That is the right answer.
+
+Correct that it blocks. What nobody noticed is that the orphan was the last
+copy, so every obvious way to clear that refusal -- delete the untracked
+directory -- destroys a working plugin. Two of the three instances have it
+STAGED, which is what a half-finished rescue looks like.
+
+It is not dirt. It is 3 hooks (`session-start`, `compile-memories`,
+`detect-pitfalls`), 3 test files, a `rules/memory-freshness.md`, a
+`lefthook.yml` and a `plugin.json`. **Its own suite passes: 18 tests, 0
+failures**, run before this commit.
+
+### What is NOT decided here
+
+Whether it becomes a managed plugin again. That would ship it to 23 instances
+and its `lefthook.yml` could arm hooks nobody reviewed, so it earns its own
+issue and its own review. Until then the code is safe and the instances stay
+refusing, which is the honest state rather than a swept one.

--- a/rescued/memory-lifecycle/README.md
+++ b/rescued/memory-lifecycle/README.md
@@ -1,0 +1,155 @@
+# memory-lifecycle
+
+Every memory tool helps Claude remember things. This one tells Claude when to stop trusting what it remembers.
+
+## What this solves
+
+Claude Code remembers facts between sessions. That's useful. The problem is it treats every fact as equally true forever.
+
+You tell Claude "Josh is reviewing the demo this week, don't follow up until April 14." Claude saves that. April 20 rolls around. Claude still thinks Josh is mid-review and holds off on the follow-up. Six days of silence because Claude trusted a stale fact.
+
+This plugin adds an expiration layer to Claude's memory.
+
+## How it works
+
+You tag each memory with how fast it goes stale.
+
+**fast** - changes day to day. Active demos, deadlines, "wait until Thursday," relationship status.
+
+**medium** - drifts over weeks. Team roles, config IDs, integration settings.
+
+**slow** - stable. Your preferences, process rules, voice conventions. This is the default.
+
+The tagging looks like this in the memory file:
+
+```yaml
+---
+name: Josh demo engagement
+type: project
+decay: fast
+---
+Josh is reviewing the demo this week. No follow-up until Apr 14.
+```
+
+## What happens at every session start
+
+The plugin checks all your memories and does three things:
+
+**1. Warns about fast-decay memories.**
+
+Claude sees this before doing anything:
+
+```
+MEMORY FRESHNESS WARNING
+==================================================
+These memories are marked decay: fast.
+MUST verify before acting on their content.
+
+  [FAST] Josh demo engagement (project_josh-demo.md)
+  [FAST] Antler IC deadline (project_antler-deadline.md)
+==================================================
+```
+
+Claude now checks whether Josh is still reviewing before deciding to hold off on follow-up.
+
+**2. Archives stale memories automatically.**
+
+- Fast-decay memories go to archive after 14 days without being checked or updated
+- Medium-decay memories go after 60 days
+- Slow-decay memories stay forever
+
+Archived means moved to a subfolder. Not deleted. You can always pull them back.
+
+**3. Promotes verified memories.**
+
+When Claude checks a fast-decay memory and confirms it's still true, it records that check. After 3 verifications over 30+ days, the memory gets promoted to medium-decay. After 5 verifications over 60+ days, medium becomes slow.
+
+A fact that stayed true for a month and got checked three times is no longer volatile. The system recognizes that automatically.
+
+## Install
+
+```bash
+claude plugin add assafkip/memory-lifecycle
+```
+
+That's it. No config. No API keys. No database. The plugin hooks into Claude Code's session start and runs automatically.
+
+## What's inside
+
+Six files. ~550 lines of Python. Zero dependencies.
+
+- `hooks/session-start.py` - freshness warnings, auto-archive, promotion, pitfall integration
+- `hooks/detect-pitfalls.py` - transcript parsing for user corrections
+- `hooks/compile-memories.py` - cluster detection and compilation planning
+- `rules/memory-freshness.md` - instructions that tell Claude how to act on all of this
+- `plugin.json` - Claude Code plugin manifest
+- `tests/` - 86 tests across three test suites
+
+## Why it's built this way
+
+**No database.** The memory files themselves are the database. The decay tag lives in the file's header. Nothing to sync, nothing to corrupt.
+
+**No background process.** The biggest memory tool in the ecosystem (claude-mem, 48K stars) runs a persistent HTTP server. Its top bugs are zombie processes and 110-second hangs on session close. This plugin runs once at session start, prints output, exits. Done.
+
+**No AI in the loop.** Every decision is date math. "Is this memory older than 14 days with no verification? Archive it." No prompts, no token costs, no hallucinated decisions about what to keep.
+
+**Archive, don't delete.** Stale memories move to a subfolder. Nothing is lost. You can restore any archived memory by dragging the file back.
+
+## Verification tracking
+
+When Claude checks a fast-decay memory and confirms it's still accurate, it updates two fields:
+
+```yaml
+last_verified: 2026-04-11
+verify_count: 3
+```
+
+This resets the staleness clock (no archive for another 14 days) and counts toward promotion. Claude does this automatically when following the plugin's rules.
+
+## Pitfall detection
+
+This runs automatically at session start. The plugin reads the previous session's transcript and looks for moments where the user corrected a memory.
+
+Claude reads a memory that says "demo is active." You say "that's outdated, it ended last week." The plugin detects the correction pattern and creates a new fast-decay memory:
+
+```
+PITFALL DETECTION: 1 correction(s) from last session
+  -> pitfall_project_demo_2026-04-11.md
+(Auto-created fast-decay memories. Review and update the originals.)
+```
+
+Next session, Claude sees the pitfall warning, reads the original memory, and updates it. The stale fact gets corrected without you having to remember to fix it.
+
+The detection covers patterns like:
+- "that's changed / outdated / wrong / not true anymore"
+- "not anymore"
+- "we already moved past that"
+- "forget that"
+- "update: the meeting was cancelled"
+
+It only fires when Claude actually read a memory file before the correction. Random mentions of "that changed" in unrelated conversation don't trigger it.
+
+## Memory compilation
+
+When you accumulate several memories about the same topic (five separate "Josh demo status" updates over three weeks), you can compile them into one clean summary.
+
+Ask Claude to compile memories. The plugin identifies clusters of 3+ related memories (including archived ones), shows you the plan, and Claude merges them into a single slow-decay memory. The originals get archived.
+
+The compiled memory keeps the most recent facts and any decisions or lessons learned. Status updates and timestamps that are no longer relevant get dropped.
+
+This is the only part that uses Claude's intelligence. Everything else is date math.
+
+## What's inside
+
+Six files. ~550 lines of Python. Zero dependencies.
+
+- `hooks/session-start.py` - freshness warnings + auto-archive + promotion + pitfall integration
+- `hooks/detect-pitfalls.py` - transcript parsing for correction patterns
+- `hooks/compile-memories.py` - cluster detection and compilation planning
+- `rules/memory-freshness.md` - instructions that tell Claude how to act on all of this
+- `plugin.json` - Claude Code plugin manifest
+- `tests/` - 86 tests covering every capability
+
+## License
+
+MIT

--- a/rescued/memory-lifecycle/hooks/compile-memories.py
+++ b/rescued/memory-lifecycle/hooks/compile-memories.py
@@ -1,0 +1,234 @@
+#!/usr/bin/env python3
+"""
+Memory Compilation Candidate Finder.
+
+Scans archived and active memories for compilation opportunities:
+clusters of 3+ related memories that could be merged into a single
+slow-decay summary.
+
+This script is deterministic. It identifies candidates and prints
+a compilation plan. The actual merging is done by Claude following
+the rules in memory-freshness.md (requires LLM for summarization).
+
+Borrowed from: claude-memory-compiler's daily-log -> knowledge-article
+compilation pattern.
+
+Usage: python3 compile-memories.py [--dry-run]
+"""
+
+import json
+import os
+import re
+import sys
+from collections import defaultdict
+from pathlib import Path
+
+
+def get_memory_dir():
+    """Compute the auto-memory directory from project dir."""
+    project_dir = os.environ.get("CLAUDE_PROJECT_DIR", os.getcwd())
+    project_slug = project_dir.replace("/", "-")
+    return Path.home() / ".claude" / "projects" / project_slug / "memory"
+
+
+def parse_frontmatter(content):
+    """Extract frontmatter dict from markdown content."""
+    if not content.startswith("---"):
+        return {}
+
+    parts = content.split("---", 2)
+    if len(parts) < 3:
+        return {}
+
+    fm = {}
+    for line in parts[1].strip().split("\n"):
+        if ":" in line:
+            key, val = line.split(":", 1)
+            fm[key.strip()] = val.strip()
+    return fm
+
+
+def get_body(content):
+    """Extract body text after frontmatter."""
+    if not content.startswith("---"):
+        return content
+
+    parts = content.split("---", 2)
+    if len(parts) < 3:
+        return content
+    return parts[2].strip()
+
+
+def extract_cluster_key(filename, fm):
+    """Extract a cluster key from filename and frontmatter.
+
+    Groups memories by:
+    1. Type prefix (project_, feedback_, user_, reference_)
+    2. Subject extracted from name (first 2-3 meaningful words)
+    """
+    mem_type = fm.get("type", "unknown")
+    name = fm.get("name", filename)
+
+    # Extract subject words (skip common prefixes and version/status suffixes)
+    skip_words = {"pitfall", "update", "status", "note", "re", "the", "a", "an",
+                  "v1", "v2", "v3", "v4", "v5", "old", "new", "latest", "current",
+                  "corrected", "compiled"}
+    words = re.findall(r"[a-zA-Z]+", name.lower())
+    subject_words = [w for w in words if w not in skip_words][:2]
+
+    if not subject_words:
+        return f"{mem_type}/_ungrouped"
+
+    return f"{mem_type}/{'-'.join(subject_words)}"
+
+
+def find_clusters(memory_dir):
+    """Find groups of 3+ related memories that could be compiled.
+
+    Searches both active memories and archived ones.
+    """
+    all_memories = defaultdict(list)
+
+    # Scan active memories
+    for md_file in sorted(memory_dir.glob("*.md")):
+        if md_file.name == "MEMORY.md":
+            continue
+        try:
+            content = md_file.read_text()
+        except (IOError, OSError):
+            continue
+
+        fm = parse_frontmatter(content)
+        key = extract_cluster_key(md_file.stem, fm)
+        all_memories[key].append({
+            "path": md_file,
+            "filename": md_file.name,
+            "name": fm.get("name", md_file.stem),
+            "decay": fm.get("decay", "slow"),
+            "type": fm.get("type", "unknown"),
+            "location": "active",
+            "body_preview": get_body(content)[:100],
+        })
+
+    # Scan archived memories
+    archive_dir = memory_dir / "archived"
+    if archive_dir.exists():
+        for md_file in sorted(archive_dir.glob("*.md")):
+            try:
+                content = md_file.read_text()
+            except (IOError, OSError):
+                continue
+
+            fm = parse_frontmatter(content)
+            key = extract_cluster_key(md_file.stem, fm)
+            all_memories[key].append({
+                "path": md_file,
+                "filename": md_file.name,
+                "name": fm.get("name", md_file.stem),
+                "decay": fm.get("decay", "slow"),
+                "type": fm.get("type", "unknown"),
+                "location": "archived",
+                "body_preview": get_body(content)[:100],
+            })
+
+    # Filter to clusters of 3+
+    clusters = {k: v for k, v in all_memories.items() if len(v) >= 3}
+    return clusters
+
+
+def print_compilation_plan(clusters):
+    """Print a human-readable compilation plan."""
+    if not clusters:
+        print("No compilation candidates found.")
+        print("Clusters need 3+ related memories to qualify.")
+        return
+
+    print(f"MEMORY COMPILATION CANDIDATES: {len(clusters)} cluster(s)")
+    print("=" * 60)
+    print()
+
+    for key, memories in sorted(clusters.items()):
+        mem_type, subject = key.split("/", 1)
+        active_count = sum(1 for m in memories if m["location"] == "active")
+        archived_count = sum(1 for m in memories if m["location"] == "archived")
+
+        print(f"Cluster: {subject} ({mem_type})")
+        print(f"  {len(memories)} memories ({active_count} active, {archived_count} archived)")
+        print()
+
+        for mem in memories:
+            loc_tag = "[archived]" if mem["location"] == "archived" else f"[{mem['decay']}]"
+            print(f"    {loc_tag} {mem['filename']}")
+            print(f"           {mem['name']}")
+            if mem["body_preview"]:
+                preview = mem["body_preview"].replace("\n", " ")[:80]
+                print(f"           \"{preview}...\"")
+            print()
+
+        print(f"  Suggested compiled name: {mem_type}_{subject.replace('-', '_')}_compiled.md")
+        print(f"  Suggested decay: slow")
+        print()
+        print("-" * 60)
+        print()
+
+
+def generate_compilation_prompt(clusters):
+    """Generate a prompt Claude can use to compile the memories."""
+    if not clusters:
+        return ""
+
+    lines = []
+    lines.append("## Memory Compilation Instructions")
+    lines.append("")
+    lines.append("For each cluster below, create ONE new slow-decay memory that captures")
+    lines.append("the essential knowledge from all source memories. Then archive the sources.")
+    lines.append("")
+
+    for key, memories in sorted(clusters.items()):
+        mem_type, subject = key.split("/", 1)
+        lines.append(f"### Cluster: {subject}")
+        lines.append(f"Type: {mem_type}")
+        lines.append(f"Source files ({len(memories)}):")
+        for mem in memories:
+            lines.append(f"  - `{mem['path']}`")
+        lines.append("")
+        lines.append(f"Output file: `{mem_type}_{subject.replace('-', '_')}_compiled.md`")
+        lines.append("Decay: slow")
+        lines.append("")
+        lines.append("Compilation rules:")
+        lines.append("- Keep the most recent factual state, not the history")
+        lines.append("- Preserve any decisions or lessons learned")
+        lines.append("- Drop timestamps and status updates that are no longer relevant")
+        lines.append("- If facts conflict between memories, keep the most recent one")
+        lines.append("- Add `origin: compiled` to frontmatter")
+        lines.append("")
+
+    return "\n".join(lines)
+
+
+def main():
+    memory_dir = get_memory_dir()
+    if not memory_dir.exists():
+        print("No memory directory found.")
+        sys.exit(0)
+
+    dry_run = "--dry-run" in sys.argv
+
+    clusters = find_clusters(memory_dir)
+
+    if dry_run or not clusters:
+        print_compilation_plan(clusters)
+        sys.exit(0)
+
+    # Print plan and compilation prompt
+    print_compilation_plan(clusters)
+    print()
+    prompt = generate_compilation_prompt(clusters)
+    if prompt:
+        print(prompt)
+
+    sys.exit(0)
+
+
+if __name__ == "__main__":
+    main()

--- a/rescued/memory-lifecycle/hooks/detect-pitfalls.py
+++ b/rescued/memory-lifecycle/hooks/detect-pitfalls.py
@@ -1,0 +1,232 @@
+#!/usr/bin/env python3
+"""
+Pitfall Detection (SessionStart).
+
+Parses the most recent session transcript for patterns where:
+1. Claude read a memory file
+2. The user corrected the memory ("that changed", "that's outdated", etc.)
+
+When detected, creates a fast-decay memory recording the correction
+so future sessions know the fact was invalidated.
+
+Borrowed from: claude-memory-engine's transcript pitfall detection
+(retry loops, user corrections -> auto-recorded pitfalls).
+
+Exit 0 always. Prints summary of detected pitfalls.
+"""
+
+import json
+import os
+import re
+import sys
+from datetime import datetime
+from pathlib import Path
+
+
+# Correction patterns the user might say after Claude acts on stale memory
+CORRECTION_PATTERNS = [
+    r"that('s| is| has) (changed|outdated|stale|old|wrong|not true|no longer|not accurate)",
+    r"(no|nope),?\s+(that|it)('s| is| has) (changed|different|not right|wrong)",
+    r"that was (last week|before|earlier|old)",
+    r"(actually|update|correction|fyi|btw)[,:;]?\s+.*(changed|different|moved|cancelled|over|done|finished|ended)",
+    r"not anymore",
+    r"that('s| is) (done|over|finished|dead|killed|cancelled|postponed)",
+    r"we (already|no longer|stopped|moved past|dropped)",
+    r"forget (that|about|it)",
+    r"(ignore|disregard) (that|the) (memory|fact|note)",
+]
+
+CORRECTION_RE = re.compile("|".join(CORRECTION_PATTERNS), re.IGNORECASE)
+
+# Pattern to detect Claude reading a memory file
+MEMORY_READ_PATTERN = re.compile(
+    r"\.claude/projects/[^/]+/memory/([^\"'\s]+\.md)"
+)
+
+
+def get_memory_dir():
+    """Compute the auto-memory directory from project dir."""
+    project_dir = os.environ.get("CLAUDE_PROJECT_DIR", os.getcwd())
+    project_slug = project_dir.replace("/", "-")
+    return Path.home() / ".claude" / "projects" / project_slug / "memory"
+
+
+def get_project_dir():
+    """Get the project directory."""
+    return Path(os.environ.get("CLAUDE_PROJECT_DIR", os.getcwd()))
+
+
+def find_latest_transcript():
+    """Find the most recent session JSONL transcript."""
+    project_dir = os.environ.get("CLAUDE_PROJECT_DIR", os.getcwd())
+    project_slug = project_dir.replace("/", "-")
+    sessions_dir = Path.home() / ".claude" / "projects" / project_slug
+
+    if not sessions_dir.exists():
+        return None
+
+    jsonl_files = sorted(
+        sessions_dir.glob("*.jsonl"),
+        key=lambda f: f.stat().st_mtime,
+        reverse=True,
+    )
+
+    # Skip the current session (most recent), check the previous one
+    if len(jsonl_files) >= 2:
+        return jsonl_files[1]
+    return None
+
+
+def parse_transcript(transcript_path, max_lines=500):
+    """Parse a JSONL transcript for memory reads followed by corrections.
+
+    Returns list of (memory_filename, correction_text, user_message).
+    """
+    pitfalls = []
+
+    try:
+        lines = transcript_path.read_text().strip().split("\n")
+    except (IOError, OSError):
+        return []
+
+    # Only check the last N lines to bound processing time
+    lines = lines[-max_lines:]
+
+    recent_memory_reads = []
+    for line in lines:
+        try:
+            entry = json.loads(line)
+        except json.JSONDecodeError:
+            continue
+
+        # Track memory file reads
+        content_str = json.dumps(entry)
+        memory_matches = MEMORY_READ_PATTERN.findall(content_str)
+        for mem_file in memory_matches:
+            if mem_file != "MEMORY.md":
+                recent_memory_reads.append(mem_file)
+
+        # Check user messages for correction patterns
+        if entry.get("role") == "user":
+            user_text = ""
+            if isinstance(entry.get("content"), str):
+                user_text = entry["content"]
+            elif isinstance(entry.get("content"), list):
+                for block in entry["content"]:
+                    if isinstance(block, dict) and block.get("type") == "text":
+                        user_text += block.get("text", "")
+
+            if user_text and CORRECTION_RE.search(user_text) and recent_memory_reads:
+                # Found a correction after memory reads
+                for mem_file in recent_memory_reads:
+                    pitfalls.append((mem_file, user_text[:200]))
+                recent_memory_reads = []
+
+    return pitfalls
+
+
+def create_pitfall_memory(memory_dir, memory_filename, correction_text):
+    """Create a fast-decay memory recording that a fact was corrected."""
+    today = datetime.now().strftime("%Y-%m-%d")
+    slug = Path(memory_filename).stem
+    pitfall_filename = f"pitfall_{slug}_{today}.md"
+    pitfall_path = memory_dir / pitfall_filename
+
+    # Don't create duplicate pitfalls for the same memory on the same day
+    if pitfall_path.exists():
+        return None
+
+    content = f"""---
+name: Pitfall - {slug} corrected
+description: User corrected a fact from {memory_filename} on {today}
+type: feedback
+decay: fast
+origin: pitfall_detection
+---
+
+The user corrected information from `{memory_filename}` on {today}.
+
+User said: "{correction_text}"
+
+**Action:** Read `{memory_filename}` and update it with the corrected information.
+If the original memory is now fully outdated, archive it.
+"""
+
+    pitfall_path.write_text(content)
+    return pitfall_filename
+
+
+def update_memory_index(memory_dir):
+    """Add new pitfall memories to MEMORY.md index."""
+    index_path = memory_dir / "MEMORY.md"
+
+    existing = ""
+    if index_path.exists():
+        existing = index_path.read_text()
+
+    for md_file in sorted(memory_dir.glob("pitfall_*.md")):
+        if md_file.name not in existing:
+            # Parse frontmatter for description
+            content = md_file.read_text()
+            desc = ""
+            if content.startswith("---"):
+                parts = content.split("---", 2)
+                if len(parts) >= 3:
+                    for line in parts[1].split("\n"):
+                        if line.strip().startswith("description:"):
+                            desc = line.split(":", 1)[1].strip()
+
+            entry = f"- [fast] [Pitfall - {md_file.stem}]({md_file.name}) - {desc}\n"
+            existing += entry
+
+    index_path.write_text(existing)
+
+
+def run_pitfall_detection():
+    """Main entry point. Returns list of created pitfall filenames."""
+    memory_dir = get_memory_dir()
+    if not memory_dir.exists():
+        return []
+
+    transcript = find_latest_transcript()
+    if transcript is None:
+        return []
+
+    # Check if we already processed this transcript
+    state_file = memory_dir / ".memory-lifecycle-state.json"
+    state = {}
+    if state_file.exists():
+        try:
+            state = json.loads(state_file.read_text())
+        except (json.JSONDecodeError, IOError):
+            pass
+
+    last_processed = state.get("last_pitfall_transcript")
+    if last_processed == str(transcript):
+        return []
+
+    pitfalls = parse_transcript(transcript)
+    created = []
+
+    for memory_filename, correction_text in pitfalls:
+        result = create_pitfall_memory(memory_dir, memory_filename, correction_text)
+        if result:
+            created.append(result)
+
+    if created:
+        update_memory_index(memory_dir)
+
+    # Record that we processed this transcript
+    state["last_pitfall_transcript"] = str(transcript)
+    state_file.write_text(json.dumps(state, indent=2) + "\n")
+
+    return created
+
+
+if __name__ == "__main__":
+    created = run_pitfall_detection()
+    if created:
+        print(f"PITFALL DETECTION: {len(created)} correction(s) from last session")
+        for f in created:
+            print(f"  -> {f}")
+    sys.exit(0)

--- a/rescued/memory-lifecycle/hooks/session-start.py
+++ b/rescued/memory-lifecycle/hooks/session-start.py
@@ -1,0 +1,312 @@
+#!/usr/bin/env python3
+"""
+Memory Lifecycle Hook (SessionStart).
+
+Three jobs, all deterministic, no LLM:
+1. Freshness warnings - print [FAST] for fast-decay memories
+2. Auto-archive - move stale memories to archived/
+3. Decay promotion - promote verified memories to slower decay
+
+Runs on SessionStart. Exit 0 always (never blocks).
+"""
+
+import json
+import os
+import re
+import shutil
+import sys
+from datetime import datetime, timedelta
+from pathlib import Path
+
+
+# --- Staleness thresholds (days without verification or update) ---
+ARCHIVE_THRESHOLDS = {
+    "fast": 14,
+    "medium": 60,
+    "slow": None,  # never auto-archive
+}
+
+# --- Promotion rules ---
+# (current_decay, min_verify_count, min_age_days) -> new_decay
+PROMOTION_RULES = [
+    ("fast", 3, 30, "medium"),
+    ("medium", 5, 60, "slow"),
+]
+
+
+def get_memory_dir():
+    """Compute the auto-memory directory from project dir."""
+    project_dir = os.environ.get("CLAUDE_PROJECT_DIR", os.getcwd())
+    project_slug = project_dir.replace("/", "-")
+    return Path.home() / ".claude" / "projects" / project_slug / "memory"
+
+
+def parse_frontmatter(content):
+    """Extract frontmatter dict from markdown content."""
+    if not content.startswith("---"):
+        return {}
+
+    parts = content.split("---", 2)
+    if len(parts) < 3:
+        return {}
+
+    fm = {}
+    for line in parts[1].strip().split("\n"):
+        if ":" in line:
+            key, val = line.split(":", 1)
+            fm[key.strip()] = val.strip()
+    return fm
+
+
+def update_frontmatter(content, updates):
+    """Update frontmatter fields in markdown content. Returns new content."""
+    if not content.startswith("---"):
+        return content
+
+    parts = content.split("---", 2)
+    if len(parts) < 3:
+        return content
+
+    lines = parts[1].strip().split("\n")
+    updated_keys = set()
+
+    new_lines = []
+    for line in lines:
+        if ":" in line:
+            key = line.split(":", 1)[0].strip()
+            if key in updates:
+                new_lines.append(f"{key}: {updates[key]}")
+                updated_keys.add(key)
+                continue
+        new_lines.append(line)
+
+    for key, val in updates.items():
+        if key not in updated_keys:
+            new_lines.append(f"{key}: {val}")
+
+    return f"---\n{chr(10).join(new_lines)}\n---{parts[2]}"
+
+
+def get_file_age_days(file_path):
+    """Get file age in days from mtime."""
+    mtime = datetime.fromtimestamp(file_path.stat().st_mtime)
+    return (datetime.now() - mtime).days
+
+
+def get_last_activity_date(fm, file_path):
+    """Get the most recent activity date for a memory file."""
+    dates = []
+
+    if fm.get("last_verified"):
+        try:
+            dates.append(datetime.strptime(fm["last_verified"], "%Y-%m-%d"))
+        except ValueError:
+            pass
+
+    dates.append(datetime.fromtimestamp(file_path.stat().st_mtime))
+
+    return max(dates)
+
+
+def load_state(memory_dir):
+    """Load lifecycle state file."""
+    state_file = memory_dir / ".memory-lifecycle-state.json"
+    if state_file.exists():
+        try:
+            return json.loads(state_file.read_text())
+        except (json.JSONDecodeError, IOError):
+            pass
+    return {"last_archive_run": None, "last_promotion_run": None, "archived": []}
+
+
+def save_state(memory_dir, state):
+    """Save lifecycle state file."""
+    state_file = memory_dir / ".memory-lifecycle-state.json"
+    state_file.write_text(json.dumps(state, indent=2) + "\n")
+
+
+def update_memory_index(memory_dir):
+    """Rebuild MEMORY.md index from current memory files."""
+    index_path = memory_dir / "MEMORY.md"
+    entries = []
+
+    for md_file in sorted(memory_dir.glob("*.md")):
+        if md_file.name == "MEMORY.md":
+            continue
+
+        content = md_file.read_text()
+        fm = parse_frontmatter(content)
+        name = fm.get("name", md_file.stem)
+        desc = fm.get("description", "")
+        decay = fm.get("decay", "slow")
+
+        prefix = "[fast] " if decay == "fast" else ""
+        hook = f" - {desc}" if desc else ""
+        entries.append(f"- {prefix}[{name}]({md_file.name}){hook}")
+
+    index_path.write_text("\n".join(entries) + "\n")
+
+
+def check_freshness(memory_dir):
+    """Print [FAST] warnings for fast-decay memories. Returns list of (name, filename)."""
+    fast_memories = []
+
+    for md_file in sorted(memory_dir.glob("*.md")):
+        if md_file.name == "MEMORY.md":
+            continue
+
+        try:
+            content = md_file.read_text()
+        except (IOError, OSError):
+            continue
+
+        fm = parse_frontmatter(content)
+        if fm.get("decay") == "fast":
+            name = fm.get("name", md_file.stem)
+            fast_memories.append((name, md_file.name))
+
+    return fast_memories
+
+
+def run_archive(memory_dir, state):
+    """Archive stale memories. Returns list of archived filenames."""
+    archive_dir = memory_dir / "archived"
+    archived = []
+    today = datetime.now()
+
+    for md_file in sorted(memory_dir.glob("*.md")):
+        if md_file.name == "MEMORY.md":
+            continue
+
+        try:
+            content = md_file.read_text()
+        except (IOError, OSError):
+            continue
+
+        fm = parse_frontmatter(content)
+        decay = fm.get("decay", "slow")
+        threshold = ARCHIVE_THRESHOLDS.get(decay)
+
+        if threshold is None:
+            continue
+
+        last_activity = get_last_activity_date(fm, md_file)
+        days_stale = (today - last_activity).days
+
+        if days_stale >= threshold:
+            archive_dir.mkdir(exist_ok=True)
+            dest = archive_dir / md_file.name
+            shutil.move(str(md_file), str(dest))
+            archived.append(md_file.name)
+
+    if archived:
+        state["archived"] = state.get("archived", []) + archived
+        state["last_archive_run"] = today.strftime("%Y-%m-%d")
+
+    return archived
+
+
+def run_promotion(memory_dir):
+    """Promote verified memories to slower decay. Returns list of (filename, old, new)."""
+    promoted = []
+
+    for md_file in sorted(memory_dir.glob("*.md")):
+        if md_file.name == "MEMORY.md":
+            continue
+
+        try:
+            content = md_file.read_text()
+        except (IOError, OSError):
+            continue
+
+        fm = parse_frontmatter(content)
+        decay = fm.get("decay", "slow")
+        verify_count = int(fm.get("verify_count", "0"))
+        file_age = get_file_age_days(md_file)
+
+        for rule_decay, min_count, min_age, new_decay in PROMOTION_RULES:
+            if decay == rule_decay and verify_count >= min_count and file_age >= min_age:
+                new_content = update_frontmatter(content, {"decay": new_decay})
+                md_file.write_text(new_content)
+                promoted.append((md_file.name, decay, new_decay))
+                break
+
+    return promoted
+
+
+def main():
+    memory_dir = get_memory_dir()
+    if not memory_dir.exists():
+        sys.exit(0)
+
+    state = load_state(memory_dir)
+    output_lines = []
+
+    # 1. Freshness warnings
+    fast_memories = check_freshness(memory_dir)
+    if fast_memories:
+        output_lines.append("MEMORY FRESHNESS WARNING")
+        output_lines.append("=" * 50)
+        output_lines.append("These memories are marked decay: fast.")
+        output_lines.append("MUST verify before acting on their content.")
+        output_lines.append("Either tool-verify OR ask the user.")
+        output_lines.append("")
+        for name, filename in fast_memories:
+            output_lines.append(f"  [FAST] {name} ({filename})")
+        output_lines.append("")
+
+    # 2. Auto-archive stale memories
+    archived = run_archive(memory_dir, state)
+    if archived:
+        output_lines.append(f"ARCHIVED {len(archived)} stale memories:")
+        for filename in archived:
+            output_lines.append(f"  -> archived/{filename}")
+        output_lines.append("(Moved to memory/archived/. Reversible.)")
+        output_lines.append("")
+
+    # 3. Decay promotion
+    promoted = run_promotion(memory_dir)
+    if promoted:
+        output_lines.append(f"PROMOTED {len(promoted)} verified memories:")
+        for filename, old, new in promoted:
+            output_lines.append(f"  {filename}: {old} -> {new}")
+        output_lines.append("")
+
+    # 4. Pitfall detection from last session
+    try:
+        from detect_pitfalls import run_pitfall_detection
+        pitfalls = run_pitfall_detection()
+    except ImportError:
+        # detect-pitfalls.py not found (standalone run), try relative import
+        try:
+            hook_dir = os.path.dirname(os.path.abspath(__file__))
+            sys.path.insert(0, hook_dir)
+            from detect_pitfalls import run_pitfall_detection
+            pitfalls = run_pitfall_detection()
+        except ImportError:
+            pitfalls = []
+
+    if pitfalls:
+        output_lines.append(f"PITFALL DETECTION: {len(pitfalls)} correction(s) from last session")
+        for f in pitfalls:
+            output_lines.append(f"  -> {f}")
+        output_lines.append("(Auto-created fast-decay memories. Review and update the originals.)")
+        output_lines.append("")
+
+    # 5. Update index if anything changed
+    if archived or promoted or pitfalls:
+        update_memory_index(memory_dir)
+
+    # 6. Save state
+    save_state(memory_dir, state)
+
+    # 7. Print output
+    if output_lines:
+        output_lines.append("=" * 50)
+        print("\n".join(output_lines))
+
+    sys.exit(0)
+
+
+if __name__ == "__main__":
+    main()

--- a/rescued/memory-lifecycle/lefthook.yml
+++ b/rescued/memory-lifecycle/lefthook.yml
@@ -1,0 +1,35 @@
+# Lefthook template — copy into repo root as lefthook.yml, then `lefthook install`
+# Gate 1: secrets. Gate 2: huge files. Gate 3: gitignored files trying to sneak in.
+
+pre-commit:
+  parallel: true
+  commands:
+    gitleaks:
+      run: gitleaks protect --staged --redact --no-banner
+      fail_text: "Secret detected. Run 'gitleaks protect --staged -v' for details."
+
+    large-files:
+      run: |
+        staged=$(git diff --cached --name-only --diff-filter=A)
+        [ -z "$staged" ] && exit 0
+        for f in $staged; do
+          [ -f "$f" ] || continue
+          size=$(stat -f%z "$f" 2>/dev/null || stat -c%s "$f")
+          if [ "$size" -gt 10485760 ]; then
+            echo "BLOCK: $f is $((size / 1048576))MB (>10MB). Use git-lfs or exclude."
+            exit 1
+          fi
+        done
+
+    blocked-paths:
+      run: |
+        # Block .env, .envrc, .env.<env>, *.pem/*.key (incl. rotations like key.pem.old), *.jsonl,
+        # and known AI-tooling caches. Allow .env.example / .env.sample / .env.template.
+        # Gitleaks is the deeper safety-net for anything that slips through.
+        blocked=$(git diff --cached --name-only | grep -E '(^|/)(\.env$|\.envrc$|\.env\.local$|\.env\.(production|staging|development|test)($|\..+)|.*\.pem(\..*)?$|.*\.key(\..*)?$|.*\.jsonl$|\.claude/(plans|sessions|skills|MEMORY)/|__pycache__/)' || true)
+        if [ -n "$blocked" ]; then
+          echo "BLOCK: these paths should not be committed:"
+          echo "$blocked"
+          echo "Rename .env.example/.env.sample/.env.template if you meant to commit an example file."
+          exit 1
+        fi

--- a/rescued/memory-lifecycle/plugin.json
+++ b/rescued/memory-lifecycle/plugin.json
@@ -1,0 +1,22 @@
+{
+  "name": "memory-lifecycle",
+  "description": "Memory freshness, auto-archive, and decay promotion for Claude Code. Tags memories with temporal trust. Warns on stale facts. Archives dead memories. Promotes verified ones.",
+  "version": "1.0.0",
+  "hooks": {
+    "SessionStart": [
+      {
+        "matcher": "startup",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "python3 \"$PLUGIN_DIR/hooks/session-start.py\"",
+            "timeout": 10
+          }
+        ]
+      }
+    ]
+  },
+  "rules": [
+    "rules/memory-freshness.md"
+  ]
+}

--- a/rescued/memory-lifecycle/rules/memory-freshness.md
+++ b/rescued/memory-lifecycle/rules/memory-freshness.md
@@ -1,0 +1,147 @@
+# Memory Lifecycle Rules
+
+The auto-memory system at `~/.claude/projects/<project>/memory/` stores facts that persist across sessions. Some facts decay fast (project state, deadlines, demo status). Others are stable (voice rules, process conventions, user preferences). The `decay` frontmatter field controls how Claude treats each memory.
+
+## Decay field
+
+Every memory file frontmatter MAY include:
+
+`decay: fast | medium | slow`
+
+Default: `slow` (if missing).
+
+| Value | Meaning | Verification before acting |
+|---|---|---|
+| `fast` | Time-bound facts that flip day-to-day (active demos, deadlines, "wait until X", relationship stages) | MUST verify. Check current state via tool OR surface to user for confirmation. |
+| `medium` | Structural facts that drift over weeks (IDs, team roles, configs, integration settings) | SHOULD verify if the action depends on the fact being current. Skip if informational only. |
+| `slow` | Stable facts (voice rules, process conventions, architectural decisions, user preferences) | No verification needed. Trust unless contradicted by user in current session. |
+
+## Verification tracking
+
+After verifying a fast or medium-decay memory and confirming it is still true, update the memory file's frontmatter:
+
+```yaml
+last_verified: 2026-04-11
+verify_count: 3
+```
+
+- Set `last_verified` to today's date
+- Increment `verify_count` by 1
+- This resets the staleness clock and contributes to eventual promotion
+
+If verification fails (the fact is no longer true):
+- Update the memory body to reflect the new state
+- Update `last_verified` to today
+- Do NOT silently override. State what changed.
+
+## When this rule fires
+
+This rule fires when you are about to:
+- Recommend an action based on memory content
+- Draft messaging that asserts a fact from memory
+- Assert current state (where someone is, what's in flight, what the deadline is)
+- Make a decision whose correctness depends on memory being current
+
+This rule does NOT fire when you are:
+- Reading memory for context only
+- Citing memory in a discussion with the user (where they can correct you)
+- Loading the MEMORY.md index at session start
+
+## Acting on fast memories
+
+Required steps before acting:
+
+1. Read the memory file
+2. Identify the time-bound fact (e.g., "Josh said wait until Apr 14")
+3. Either verify via tool OR surface to user. Pick one. Do not skip.
+4. Only after verification (or user confirmation): act on the memory
+
+## MEMORY.md index markers
+
+Index lines for fast-decay memories get a `[fast]` prefix:
+
+`- [fast] [Demo status](project_demo-status.md) - Active demo, verified Apr 10`
+
+This makes freshness risk visible at session start without reading each file.
+
+## Auto-archive (deterministic, runs on SessionStart)
+
+The lifecycle hook automatically archives stale memories:
+- `fast` decay: archived after 14 days without verification or file update
+- `medium` decay: archived after 60 days without verification or file update
+- `slow` decay: never auto-archived
+
+Archived memories move to `memory/archived/`. They are removed from MEMORY.md but preserved on disk. Reversible by moving the file back.
+
+## Decay promotion (deterministic, runs on SessionStart)
+
+Memories that have been verified repeatedly get promoted to slower decay:
+- `fast` with 3+ verifications and 30+ days old -> promoted to `medium`
+- `medium` with 5+ verifications and 60+ days old -> promoted to `slow`
+
+Rationale: if a fact has been true for a month and verified three times, it is no longer fast-decay. It has become established knowledge.
+
+## Frontmatter schema
+
+```yaml
+---
+name: descriptive memory name
+description: one-line description for MEMORY.md index
+type: user | feedback | project | reference
+decay: fast | medium | slow
+last_verified: YYYY-MM-DD
+verify_count: N
+origin: manual | auto | pitfall_detection
+---
+```
+
+All fields except `name` and `type` are optional. `decay` defaults to `slow`. `verify_count` defaults to 0.
+
+## Conflict with age warnings
+
+Claude Code may inject age-based warnings ("This memory is X days old"). The `decay` field overrides these:
+- `slow` + age warning -> trust the memory (age warning is overcautious for stable rules)
+- `fast` + no age warning -> still verify (could be stale within a day)
+- `medium` + age warning -> verify if acting on it
+
+`decay` is content-based and authoritative. Age warnings are blanket and passive.
+
+## Failure modes this prevents
+
+1. Acting on "demo in progress, don't follow up" after the demo died
+2. Patching a config based on cached IDs that changed
+3. Drafting outreach based on a relationship stage that advanced in another session
+4. Asserting a deadline that already passed
+5. Recommending a tool integration based on credentials that expired
+
+## Pitfall detection (automatic)
+
+The SessionStart hook scans the previous session's transcript for correction patterns. When the user corrects a fact from memory ("that changed", "that's outdated", "not anymore"), the system auto-creates a fast-decay memory recording the correction.
+
+Pitfall memories are tagged `origin: pitfall_detection` and appear as `[FAST]` warnings at the next session start. They instruct you to update the original memory.
+
+When you see a pitfall memory:
+1. Read the pitfall to understand what was corrected
+2. Read the original memory it references
+3. Update the original with the corrected information
+4. If the original is fully outdated, archive it
+5. Archive the pitfall memory (it served its purpose)
+
+## Memory compilation (user-invoked)
+
+When the user asks to compile or consolidate memories, run `compile-memories.py` to identify clusters of 3+ related memories.
+
+Compilation rules:
+- Keep the most recent factual state, not the history of changes
+- Preserve decisions and lessons learned
+- Drop timestamps and status updates that are no longer relevant
+- If facts conflict between memories, keep the most recent one
+- Set `decay: slow` and `origin: compiled` on the compiled memory
+- Archive (don't delete) the source memories after compilation
+- Update MEMORY.md index
+
+Only compile when the user explicitly asks. Never auto-compile.
+
+## Deterministic enforcement
+
+The SessionStart hook reads memory frontmatter and prints `[FAST]` warnings to context. It also runs pitfall detection on the previous session's transcript. The model sees warnings whether it remembers this rule file or not. The hook is the enforcement; this file is the spec.

--- a/rescued/memory-lifecycle/tests/test_compile.py
+++ b/rescued/memory-lifecycle/tests/test_compile.py
@@ -1,0 +1,174 @@
+#!/usr/bin/env python3
+"""
+Tests for memory compilation candidate finder.
+
+Covers: cluster detection, frontmatter parsing, compilation plan generation.
+
+Run: python3 tests/test_compile.py
+"""
+
+import os
+import sys
+import tempfile
+from pathlib import Path
+
+# Import the module
+import importlib.util
+hook_path = os.path.join(os.path.dirname(__file__), "..", "hooks", "compile-memories.py")
+spec = importlib.util.spec_from_file_location("compile_memories", hook_path)
+compiler = importlib.util.module_from_spec(spec)
+spec.loader.exec_module(compiler)
+
+PASS = 0
+FAIL = 0
+
+
+def check(label, condition):
+    global PASS, FAIL
+    if condition:
+        PASS += 1
+        print(f"  PASS {label}")
+    else:
+        FAIL += 1
+        print(f"  FAIL {label}")
+
+
+def make_memory(directory, filename, frontmatter_dict, body="Content."):
+    lines = ["---"]
+    for k, v in frontmatter_dict.items():
+        lines.append(f"{k}: {v}")
+    lines.append("---")
+    lines.append("")
+    lines.append(body)
+    path = directory / filename
+    path.write_text("\n".join(lines))
+    return path
+
+
+# --- Test: Cluster key extraction ---
+
+def test_cluster_key():
+    print("\n--- Cluster key extraction ---")
+
+    key1 = compiler.extract_cluster_key("project_josh_demo", {"type": "project", "name": "Josh demo status"})
+    check("extracts type and subject", key1.startswith("project/"))
+    check("subject words present", "josh" in key1)
+
+    key2 = compiler.extract_cluster_key("feedback_testing", {"type": "feedback", "name": "Testing approach"})
+    check("feedback type", key2.startswith("feedback/"))
+
+    key3 = compiler.extract_cluster_key("pitfall_update", {"type": "feedback", "name": "Pitfall - update corrected"})
+    check("skips 'pitfall' and 'update' words", "pitfall" not in key3.split("/")[1])
+
+
+# --- Test: Cluster finding ---
+
+def test_find_clusters():
+    print("\n--- Cluster finding ---")
+
+    with tempfile.TemporaryDirectory() as tmp:
+        tmp_dir = Path(tmp)
+
+        # Create 3 related project memories about Josh
+        make_memory(tmp_dir, "project_josh_1.md", {"name": "Josh demo v1", "type": "project", "decay": "fast"})
+        make_memory(tmp_dir, "project_josh_2.md", {"name": "Josh demo v2", "type": "project", "decay": "fast"})
+        make_memory(tmp_dir, "project_josh_3.md", {"name": "Josh demo v3", "type": "project", "decay": "medium"})
+
+        # Create 2 unrelated feedback memories (not enough for cluster)
+        make_memory(tmp_dir, "feedback_voice.md", {"name": "Voice rules", "type": "feedback"})
+        make_memory(tmp_dir, "feedback_testing.md", {"name": "Testing approach", "type": "feedback"})
+
+        make_memory(tmp_dir, "MEMORY.md", {}, "Index")
+
+        clusters = compiler.find_clusters(tmp_dir)
+
+        check("finds 1 cluster", len(clusters) == 1)
+        cluster_key = list(clusters.keys())[0]
+        check("cluster has 3 memories", len(clusters[cluster_key]) == 3)
+
+
+def test_finds_archived():
+    print("\n--- Includes archived memories ---")
+
+    with tempfile.TemporaryDirectory() as tmp:
+        tmp_dir = Path(tmp)
+        archive_dir = tmp_dir / "archived"
+        archive_dir.mkdir()
+
+        # 2 active + 1 archived = cluster of 3
+        make_memory(tmp_dir, "project_josh_1.md", {"name": "Josh demo v1", "type": "project"})
+        make_memory(tmp_dir, "project_josh_2.md", {"name": "Josh demo v2", "type": "project"})
+        make_memory(archive_dir, "project_josh_old.md", {"name": "Josh demo old", "type": "project"})
+
+        make_memory(tmp_dir, "MEMORY.md", {}, "Index")
+
+        clusters = compiler.find_clusters(tmp_dir)
+        check("finds cluster across active + archived", len(clusters) >= 1)
+
+        if clusters:
+            cluster = list(clusters.values())[0]
+            locations = [m["location"] for m in cluster]
+            check("includes archived memory", "archived" in locations)
+            check("includes active memories", "active" in locations)
+
+
+def test_no_small_clusters():
+    print("\n--- No clusters under 3 ---")
+
+    with tempfile.TemporaryDirectory() as tmp:
+        tmp_dir = Path(tmp)
+
+        make_memory(tmp_dir, "project_alpha.md", {"name": "Alpha project", "type": "project"})
+        make_memory(tmp_dir, "project_beta.md", {"name": "Beta project", "type": "project"})
+        make_memory(tmp_dir, "MEMORY.md", {}, "Index")
+
+        clusters = compiler.find_clusters(tmp_dir)
+        check("no clusters from 2 memories", len(clusters) == 0)
+
+
+# --- Test: Compilation prompt ---
+
+def test_compilation_prompt():
+    print("\n--- Compilation prompt ---")
+
+    clusters = {
+        "project/josh-demo": [
+            {"path": Path("/tmp/a.md"), "filename": "a.md", "name": "Josh v1",
+             "decay": "fast", "type": "project", "location": "active", "body_preview": "Demo active"},
+            {"path": Path("/tmp/b.md"), "filename": "b.md", "name": "Josh v2",
+             "decay": "fast", "type": "project", "location": "active", "body_preview": "Demo reviewed"},
+            {"path": Path("/tmp/c.md"), "filename": "c.md", "name": "Josh v3",
+             "decay": "medium", "type": "project", "location": "archived", "body_preview": "Demo ended"},
+        ]
+    }
+
+    prompt = compiler.generate_compilation_prompt(clusters)
+    check("prompt includes cluster name", "josh-demo" in prompt)
+    check("prompt includes source files", "/tmp/a.md" in prompt)
+    check("prompt specifies slow decay", "slow" in prompt.lower())
+    check("prompt mentions keeping recent state", "most recent" in prompt.lower())
+
+    empty = compiler.generate_compilation_prompt({})
+    check("empty clusters produce empty prompt", empty == "")
+
+
+# --- Run all ---
+
+if __name__ == "__main__":
+    test_cluster_key()
+    test_find_clusters()
+    test_finds_archived()
+    test_no_small_clusters()
+    test_compilation_prompt()
+
+    print(f"\n{'=' * 50}")
+    print(f"  PASS: {PASS}")
+    print(f"  FAIL: {FAIL}")
+    print(f"{'=' * 50}")
+
+    if FAIL > 0:
+        print(f"\n{FAIL} test(s) failed.")
+        sys.exit(1)
+    else:
+        print("\nAll tests passed.")
+        sys.exit(0)

--- a/rescued/memory-lifecycle/tests/test_lifecycle.py
+++ b/rescued/memory-lifecycle/tests/test_lifecycle.py
@@ -1,0 +1,282 @@
+#!/usr/bin/env python3
+"""
+Tests for memory lifecycle hook.
+
+Covers: frontmatter parsing, freshness detection, auto-archive,
+decay promotion, MEMORY.md index updates.
+
+Run: python3 tests/test_lifecycle.py
+"""
+
+import json
+import os
+import sys
+import shutil
+import tempfile
+from datetime import datetime, timedelta
+from pathlib import Path
+
+# Add parent to path so we can import the hook
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), "..", "hooks"))
+
+from importlib import import_module
+
+# Import session-start.py (hyphenated filename)
+import importlib.util
+hook_path = os.path.join(os.path.dirname(__file__), "..", "hooks", "session-start.py")
+spec = importlib.util.spec_from_file_location("session_start", hook_path)
+hook = importlib.util.module_from_spec(spec)
+spec.loader.exec_module(hook)
+
+
+PASS = 0
+FAIL = 0
+
+
+def check(label, condition):
+    global PASS, FAIL
+    if condition:
+        PASS += 1
+        print(f"  PASS {label}")
+    else:
+        FAIL += 1
+        print(f"  FAIL {label}")
+
+
+def make_memory(tmp_dir, filename, frontmatter_dict, body="Memory content."):
+    """Create a memory file with frontmatter."""
+    lines = ["---"]
+    for k, v in frontmatter_dict.items():
+        lines.append(f"{k}: {v}")
+    lines.append("---")
+    lines.append("")
+    lines.append(body)
+
+    path = tmp_dir / filename
+    path.write_text("\n".join(lines))
+    return path
+
+
+def set_file_age(path, days):
+    """Set file mtime to N days ago."""
+    import time
+    old_time = time.time() - (days * 86400)
+    os.utime(path, (old_time, old_time))
+
+
+# --- Test: Frontmatter parsing ---
+
+def test_parse_frontmatter():
+    print("\n--- Frontmatter parsing ---")
+
+    content = "---\nname: test\ndecay: fast\nverify_count: 3\n---\nBody."
+    fm = hook.parse_frontmatter(content)
+    check("parses name", fm.get("name") == "test")
+    check("parses decay", fm.get("decay") == "fast")
+    check("parses verify_count", fm.get("verify_count") == "3")
+
+    fm_empty = hook.parse_frontmatter("No frontmatter here.")
+    check("returns empty dict for no frontmatter", fm_empty == {})
+
+    fm_partial = hook.parse_frontmatter("---\nname: only\n---\n")
+    check("handles partial frontmatter", fm_partial.get("name") == "only")
+
+
+# --- Test: Update frontmatter ---
+
+def test_update_frontmatter():
+    print("\n--- Frontmatter update ---")
+
+    content = "---\nname: test\ndecay: fast\n---\nBody text."
+    updated = hook.update_frontmatter(content, {"decay": "medium"})
+    fm = hook.parse_frontmatter(updated)
+    check("updates existing field", fm.get("decay") == "medium")
+    check("preserves other fields", fm.get("name") == "test")
+    check("preserves body", "Body text." in updated)
+
+    added = hook.update_frontmatter(content, {"last_verified": "2026-04-11"})
+    fm2 = hook.parse_frontmatter(added)
+    check("adds new field", fm2.get("last_verified") == "2026-04-11")
+
+
+# --- Test: Freshness detection ---
+
+def test_freshness():
+    print("\n--- Freshness detection ---")
+
+    with tempfile.TemporaryDirectory() as tmp:
+        tmp_dir = Path(tmp)
+        make_memory(tmp_dir, "fast_mem.md", {"name": "Fast thing", "decay": "fast"})
+        make_memory(tmp_dir, "slow_mem.md", {"name": "Slow thing", "decay": "slow"})
+        make_memory(tmp_dir, "no_decay.md", {"name": "No decay"})
+        make_memory(tmp_dir, "MEMORY.md", {}, "Index file")
+
+        fast = hook.check_freshness(tmp_dir)
+        check("finds fast-decay memory", len(fast) == 1)
+        check("correct name", fast[0][0] == "Fast thing")
+        check("correct filename", fast[0][1] == "fast_mem.md")
+
+
+# --- Test: Auto-archive ---
+
+def test_archive():
+    print("\n--- Auto-archive ---")
+
+    with tempfile.TemporaryDirectory() as tmp:
+        tmp_dir = Path(tmp)
+        state = {"archived": []}
+
+        # Fast-decay, 20 days old, no verification -> should archive
+        p1 = make_memory(tmp_dir, "stale_fast.md", {"name": "Stale", "decay": "fast"})
+        set_file_age(p1, 20)
+
+        # Fast-decay, 5 days old -> should NOT archive
+        p2 = make_memory(tmp_dir, "fresh_fast.md", {"name": "Fresh", "decay": "fast"})
+        set_file_age(p2, 5)
+
+        # Slow-decay, 100 days old -> should NOT archive (slow never archives)
+        p3 = make_memory(tmp_dir, "old_slow.md", {"name": "Old slow", "decay": "slow"})
+        set_file_age(p3, 100)
+
+        # Medium-decay, 70 days old -> should archive
+        p4 = make_memory(tmp_dir, "stale_medium.md", {"name": "Stale med", "decay": "medium"})
+        set_file_age(p4, 70)
+
+        # Fast-decay, 20 days old BUT recently verified -> should NOT archive
+        p5 = make_memory(tmp_dir, "verified_fast.md", {
+            "name": "Verified",
+            "decay": "fast",
+            "last_verified": datetime.now().strftime("%Y-%m-%d"),
+        })
+        set_file_age(p5, 20)
+
+        make_memory(tmp_dir, "MEMORY.md", {}, "Index")
+
+        archived = hook.run_archive(tmp_dir, state)
+
+        check("archives stale fast-decay", "stale_fast.md" in archived)
+        check("keeps fresh fast-decay", "fresh_fast.md" not in archived)
+        check("never archives slow-decay", "old_slow.md" not in archived)
+        check("archives stale medium-decay", "stale_medium.md" in archived)
+        check("keeps recently verified", "verified_fast.md" not in archived)
+        check("archived dir created", (tmp_dir / "archived").exists())
+        check("file moved to archived/", (tmp_dir / "archived" / "stale_fast.md").exists())
+        check("file removed from root", not (tmp_dir / "stale_fast.md").exists())
+
+
+# --- Test: Decay promotion ---
+
+def test_promotion():
+    print("\n--- Decay promotion ---")
+
+    with tempfile.TemporaryDirectory() as tmp:
+        tmp_dir = Path(tmp)
+
+        # Fast, verified 3x, 35 days old -> promote to medium
+        p1 = make_memory(tmp_dir, "promote_me.md", {
+            "name": "Promotable",
+            "decay": "fast",
+            "verify_count": "3",
+        })
+        set_file_age(p1, 35)
+
+        # Fast, verified 2x, 35 days old -> NOT enough verifications
+        p2 = make_memory(tmp_dir, "not_enough.md", {
+            "name": "Not enough",
+            "decay": "fast",
+            "verify_count": "2",
+        })
+        set_file_age(p2, 35)
+
+        # Fast, verified 3x, 10 days old -> NOT old enough
+        p3 = make_memory(tmp_dir, "too_new.md", {
+            "name": "Too new",
+            "decay": "fast",
+            "verify_count": "3",
+        })
+        set_file_age(p3, 10)
+
+        # Medium, verified 5x, 65 days old -> promote to slow
+        p4 = make_memory(tmp_dir, "medium_promote.md", {
+            "name": "Medium up",
+            "decay": "medium",
+            "verify_count": "5",
+        })
+        set_file_age(p4, 65)
+
+        make_memory(tmp_dir, "MEMORY.md", {}, "Index")
+
+        promoted = hook.run_promotion(tmp_dir)
+
+        check("promotes fast -> medium", ("promote_me.md", "fast", "medium") in promoted)
+        check("skips insufficient verifications", not any(p[0] == "not_enough.md" for p in promoted))
+        check("skips too-new memory", not any(p[0] == "too_new.md" for p in promoted))
+        check("promotes medium -> slow", ("medium_promote.md", "medium", "slow") in promoted)
+
+        # Verify frontmatter actually changed
+        content = (tmp_dir / "promote_me.md").read_text()
+        fm = hook.parse_frontmatter(content)
+        check("frontmatter updated to medium", fm.get("decay") == "medium")
+
+
+# --- Test: MEMORY.md index rebuild ---
+
+def test_index_rebuild():
+    print("\n--- MEMORY.md index rebuild ---")
+
+    with tempfile.TemporaryDirectory() as tmp:
+        tmp_dir = Path(tmp)
+        make_memory(tmp_dir, "fast_one.md", {"name": "Fast One", "decay": "fast", "description": "A fast thing"})
+        make_memory(tmp_dir, "slow_one.md", {"name": "Slow One", "decay": "slow", "description": "A slow thing"})
+        make_memory(tmp_dir, "MEMORY.md", {}, "Old index")
+
+        hook.update_memory_index(tmp_dir)
+
+        index = (tmp_dir / "MEMORY.md").read_text()
+        check("index contains fast prefix", "[fast]" in index)
+        check("index contains fast memory link", "[Fast One](fast_one.md)" in index)
+        check("index contains slow memory link", "[Slow One](slow_one.md)" in index)
+        check("slow has no [fast] prefix", "[fast] [Slow One]" not in index)
+
+
+# --- Test: State file ---
+
+def test_state():
+    print("\n--- State file ---")
+
+    with tempfile.TemporaryDirectory() as tmp:
+        tmp_dir = Path(tmp)
+        state = {"last_archive_run": "2026-04-11", "archived": ["old.md"]}
+
+        hook.save_state(tmp_dir, state)
+        loaded = hook.load_state(tmp_dir)
+
+        check("state round-trips", loaded["last_archive_run"] == "2026-04-11")
+        check("archived list preserved", "old.md" in loaded["archived"])
+
+        empty = hook.load_state(Path("/nonexistent"))
+        check("missing state returns default", empty == {"last_archive_run": None, "last_promotion_run": None, "archived": []})
+
+
+# --- Run all ---
+
+if __name__ == "__main__":
+    test_parse_frontmatter()
+    test_update_frontmatter()
+    test_freshness()
+    test_archive()
+    test_promotion()
+    test_index_rebuild()
+    test_state()
+
+    print(f"\n{'=' * 50}")
+    print(f"  PASS: {PASS}")
+    print(f"  FAIL: {FAIL}")
+    print(f"{'=' * 50}")
+
+    if FAIL > 0:
+        print(f"\n{FAIL} test(s) failed.")
+        sys.exit(1)
+    else:
+        print("\nAll tests passed.")
+        sys.exit(0)

--- a/rescued/memory-lifecycle/tests/test_pitfalls.py
+++ b/rescued/memory-lifecycle/tests/test_pitfalls.py
@@ -1,0 +1,211 @@
+#!/usr/bin/env python3
+"""
+Tests for pitfall detection.
+
+Covers: correction pattern matching, transcript parsing,
+pitfall memory creation, deduplication.
+
+Run: python3 tests/test_pitfalls.py
+"""
+
+import json
+import os
+import sys
+import tempfile
+from datetime import datetime
+from pathlib import Path
+
+# Import the module
+import importlib.util
+hook_path = os.path.join(os.path.dirname(__file__), "..", "hooks", "detect-pitfalls.py")
+spec = importlib.util.spec_from_file_location("detect_pitfalls", hook_path)
+pitfalls = importlib.util.module_from_spec(spec)
+spec.loader.exec_module(pitfalls)
+
+PASS = 0
+FAIL = 0
+
+
+def check(label, condition):
+    global PASS, FAIL
+    if condition:
+        PASS += 1
+        print(f"  PASS {label}")
+    else:
+        FAIL += 1
+        print(f"  FAIL {label}")
+
+
+# --- Test: Correction pattern matching ---
+
+def test_correction_patterns():
+    print("\n--- Correction pattern matching ---")
+
+    should_match = [
+        "that's changed since last week",
+        "that is outdated",
+        "that has changed",
+        "no, that's different now",
+        "nope, it's not right",
+        "that was last week",
+        "actually, the deadline moved",
+        "not anymore",
+        "that's done",
+        "that is over",
+        "that's finished",
+        "we already moved past that",
+        "we no longer do that",
+        "forget that",
+        "ignore the memory about Josh",
+        "update: the meeting was cancelled",
+        "correction, he's different now",
+        "we stopped doing that",
+        "we dropped that approach",
+    ]
+
+    should_not_match = [
+        "sounds good",
+        "thanks for the update",
+        "let's move forward",
+        "can you check the memory?",
+        "what does the memory say?",
+        "I like that approach",
+    ]
+
+    for text in should_match:
+        match = pitfalls.CORRECTION_RE.search(text)
+        check(f"matches: \"{text[:50]}\"", match is not None)
+
+    for text in should_not_match:
+        match = pitfalls.CORRECTION_RE.search(text)
+        check(f"no match: \"{text[:50]}\"", match is None)
+
+
+# --- Test: Transcript parsing ---
+
+def test_transcript_parsing():
+    print("\n--- Transcript parsing ---")
+
+    with tempfile.TemporaryDirectory() as tmp:
+        transcript_path = Path(tmp) / "session.jsonl"
+
+        # Simulate: Claude reads a memory file, then user corrects it
+        entries = [
+            {"role": "assistant", "content": [
+                {"type": "tool_use", "name": "Read",
+                 "input": {"file_path": "/home/user/.claude/projects/-home-user-myproject/memory/project_demo.md"}}
+            ]},
+            {"role": "tool", "content": "---\nname: demo status\ndecay: fast\n---\nDemo is active."},
+            {"role": "assistant", "content": "Based on the memory, the demo is still active."},
+            {"role": "user", "content": "that's outdated, the demo ended last week"},
+        ]
+
+        transcript_path.write_text("\n".join(json.dumps(e) for e in entries))
+
+        results = pitfalls.parse_transcript(transcript_path)
+        check("finds pitfall", len(results) >= 1)
+        if results:
+            check("correct memory file", "project_demo.md" in results[0][0])
+            check("captures correction text", "outdated" in results[0][1])
+
+
+def test_no_false_positives():
+    print("\n--- No false positives ---")
+
+    with tempfile.TemporaryDirectory() as tmp:
+        transcript_path = Path(tmp) / "session.jsonl"
+
+        # User says "sounds good" after memory read - should NOT trigger
+        entries = [
+            {"role": "assistant", "content": [
+                {"type": "tool_use", "name": "Read",
+                 "input": {"file_path": "/home/user/.claude/projects/-home-user-myproject/memory/project_demo.md"}}
+            ]},
+            {"role": "tool", "content": "---\nname: demo status\n---\nDemo is active."},
+            {"role": "user", "content": "sounds good, let's continue"},
+        ]
+
+        transcript_path.write_text("\n".join(json.dumps(e) for e in entries))
+        results = pitfalls.parse_transcript(transcript_path)
+        check("no false positive on 'sounds good'", len(results) == 0)
+
+
+def test_no_memory_read():
+    print("\n--- No memory read context ---")
+
+    with tempfile.TemporaryDirectory() as tmp:
+        transcript_path = Path(tmp) / "session.jsonl"
+
+        # User says "that's changed" but no memory was read - should NOT trigger
+        entries = [
+            {"role": "assistant", "content": "Let me check the code."},
+            {"role": "user", "content": "that's changed since last week"},
+        ]
+
+        transcript_path.write_text("\n".join(json.dumps(e) for e in entries))
+        results = pitfalls.parse_transcript(transcript_path)
+        check("no pitfall without memory read", len(results) == 0)
+
+
+# --- Test: Pitfall memory creation ---
+
+def test_create_pitfall():
+    print("\n--- Pitfall memory creation ---")
+
+    with tempfile.TemporaryDirectory() as tmp:
+        memory_dir = Path(tmp)
+        today = datetime.now().strftime("%Y-%m-%d")
+
+        result = pitfalls.create_pitfall_memory(
+            memory_dir,
+            "project_demo.md",
+            "that's outdated, the demo ended last week"
+        )
+
+        check("returns filename", result is not None)
+        check("filename has pitfall prefix", result.startswith("pitfall_"))
+
+        pitfall_path = memory_dir / result
+        check("file created", pitfall_path.exists())
+
+        content = pitfall_path.read_text()
+        check("has fast decay", "decay: fast" in content)
+        check("has pitfall_detection origin", "origin: pitfall_detection" in content)
+        check("references source memory", "project_demo.md" in content)
+        check("includes correction text", "outdated" in content)
+
+
+def test_no_duplicate_pitfall():
+    print("\n--- No duplicate pitfalls ---")
+
+    with tempfile.TemporaryDirectory() as tmp:
+        memory_dir = Path(tmp)
+
+        first = pitfalls.create_pitfall_memory(memory_dir, "project_demo.md", "changed")
+        second = pitfalls.create_pitfall_memory(memory_dir, "project_demo.md", "changed again")
+
+        check("first creation succeeds", first is not None)
+        check("duplicate returns None", second is None)
+
+
+# --- Run all ---
+
+if __name__ == "__main__":
+    test_correction_patterns()
+    test_transcript_parsing()
+    test_no_false_positives()
+    test_no_memory_read()
+    test_create_pitfall()
+    test_no_duplicate_pitfall()
+
+    print(f"\n{'=' * 50}")
+    print(f"  PASS: {PASS}")
+    print(f"  FAIL: {FAIL}")
+    print(f"{'=' * 50}")
+
+    if FAIL > 0:
+        print(f"\n{FAIL} test(s) failed.")
+        sys.exit(1)
+    else:
+        print("\nAll tests passed.")
+        sys.exit(0)


### PR DESCRIPTION
## Three instances held the only surviving copy of a working plugin

The skeleton once shipped `plugins/memory-lifecycle` as a **symlink** to `/Users/assafkip/projects/memory-lifecycle` — note `assafkip`, an old home directory. Commit `1be3dfd0` removed it as a "dead memory-lifecycle symlink", which it was.

But rsync had already dereferenced it. So `interview-coach`, `fractional-cxo` and `negotiator` each hold 10 real files, byte-identical (`f1c515ed71aa`) — and those were the only copies left anywhere. The symlink target is gone, nothing exists under the current home, and there is no repo for it under `~/projects`.

## Why this was urgent

Those files read as instance dirt. `repo-preflight.sh` refuses interview-coach over them, which is what blocks the second dispatch repo. **Every obvious way to clear that refusal — delete the untracked directory — destroys the plugin permanently.** Two of the three have it *staged*, which is what a half-finished rescue looks like.

`kipi-update.sh` predicted the class in its own comment: an orphaned plugin dir "is no longer covered, so it still blocks that instance. That is the right answer." Correct that it blocks. Nobody noticed the orphan was the last copy.

## It is working code

3 hooks (`session-start`, `compile-memories`, `detect-pitfalls`), 3 test files, `rules/memory-freshness.md`, `lefthook.yml`, `plugin.json`. **18 tests, 0 failures**, run before and after the move.

## Rescued to `rescued/`, not `plugins/` — the placement is the argument

The fleet sync copies `q-system/`, `.claude/{agents,output-styles,rules}/*.md`, `.claude/settings.json` and `plugins/*/`. A top-level `rescued/` is in none of them.

Putting it back in `plugins/` would make a 23-instance fan-out a side effect of saving a file, and its `lefthook.yml` could arm hooks nobody has reviewed. **Rescuing code and distributing code are two decisions; this PR makes only the first.**

## Not decided here

Whether it returns as a managed plugin. That earns its own issue. Until then the code is safe and the three instances stay refusing — the honest state rather than a swept one.

## Verification

- 18/18 tests pass from the new path
- `validate-separation.py 1` — Gate 1.2 and the full skeleton sweep clean (0 files). Phase 1, not the bare Phase 0 form that hid this gate earlier today.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0151EYtGH6at3XTWqbBHAxEi