### PR TITLE
Unblock the last 5 instances: reach 17/22 -> 22/22 (sp-ed9513cd, sp-3d5a247e)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -109,6 +109,16 @@ q-system/output/.update-check-*
 q-system/output/capability-maps/
 .runs/
 
+# Lock files beside the prd-os ledgers. flock targets, recreated on every
+# resolve/reclassify, and they were standing untracked-and-unignored inside a
+# TRACKED directory. sp-a21cb27c predicted an unattended auto-commit would sweep
+# them in; measured 2026-08-14 that is false -- auto-commit.py's NEVER list
+# already refuses any .lock, so system_state_paths returns [] for both. What was
+# left was permanent noise in `git status`, which is its own cost: a status that
+# is never clean is a status nobody reads.
+.prd-os/*.lock
+.prd-os/.judgments.lock
+
 # THE STANZA BETWEEN THESE MARKERS IS SHIPPED TO EVERY INSTANCE (sp-097d2e23).
 # kipi-update-gitignore-block.py parses it out of this file and writes it into
 # each instance's root .gitignore as a managed block. Root .gitignore is not in

--- a/.gitignore
+++ b/.gitignore
@@ -109,6 +109,17 @@ q-system/output/.update-check-*
 q-system/output/capability-maps/
 .runs/
 
+# THE STANZA BETWEEN THESE MARKERS IS SHIPPED TO EVERY INSTANCE (sp-097d2e23).
+# kipi-update-gitignore-block.py parses it out of this file and writes it into
+# each instance's root .gitignore as a managed block. Root .gitignore is not in
+# the updater's sync set, so until 2026-08-14 these rules existed only here --
+# and an instance that does not ignore these paths has git report them, which
+# hands them straight to auto-commit.py (q-system/.q-system/ classifies as
+# "chore", which the fleet sync commits unattended). Five of 22 instances had
+# already committed their own baseline or armed marker, the most recent that
+# same day. Add a path here and every instance gets it on the next update; the
+# writer refuses rather than guessing if these markers ever go missing.
+# >>> kipi-instance-local-stanza >>>
 # .claude/ integrity baseline is INSTANCE-LOCAL (ASK-282). Never commit it:
 # kipi update propagates the skeleton, but each instance regenerates
 # .claude/settings.json from settings-template.json, so a shared baseline can
@@ -121,6 +132,11 @@ q-system/output/claude-integrity/
 # update, so every fresh instance would claim prior arming, refuse to arm, and
 # Slack-page SECURITY on its first run -- the round-2 outage exactly.
 q-system/.q-system/.claude-integrity-armed
+# Daily update stamps. Pure updater exhaust, and the reason this line moved
+# into the shipped stanza: instances carry hundreds of them, many already
+# committed by the pre-ASK-498 generic-fallback sweep.
+q-system/output/.update-check-*
+# <<< kipi-instance-local-stanza <<<
 
 # PR-review scratch trees. 537 of these files were swept into the repo by an
 # unattended `chore: update project files` auto-commit (ec5efddf). Removing them

--- a/fleet-reach-audit.py
+++ b/fleet-reach-audit.py
@@ -133,7 +133,26 @@ class SkeletonBlobs:
     def shas_for(self, path):
         if path not in self._cache:
             shas = set()
-            commits = git(self.skeleton, "rev-list", "--all", "--", path).split()
+            # HEAD, NOT --all (PR #165 review round 5, major).
+            #
+            # `--all` is EVERY local ref: unmerged feature branches, remote-
+            # tracking refs, tags, the review worktrees. This repo carries dozens
+            # of in-flight sana/* branches at any moment. So a blob that never
+            # shipped -- one living only on somebody's experiment -- counted as
+            # "the skeleton wrote this", and fleet-unblock would commit it over
+            # founder content in an instance. The next real sync then overwrites
+            # it with what the shipped line actually says, so the founder's bytes
+            # are gone and the thing that replaced them was never skeleton
+            # content either.
+            #
+            # HEAD is the line the updater actually syncs from (`git archive
+            # HEAD`), and its ancestry is every version this skeleton could
+            # legitimately have written into an instance. An unrelated branch is
+            # not in that ancestry and now proves nothing.
+            #
+            # Reproducer: test_a_blob_that_only_exists_on_an_unmerged_branch_is_not_fleet_authored
+            # Control:    test_a_blob_on_the_shipped_line_is_still_fleet_authored
+            commits = git(self.skeleton, "rev-list", "HEAD", "--", path).split()
             for commit in commits:
                 sha = git(self.skeleton, "rev-parse", "-q", "--verify",
                           f"{commit}:{path}").strip()

--- a/fleet-unblock.py
+++ b/fleet-unblock.py
@@ -232,6 +232,56 @@ def decide(repo, row, audit, rescued):
     return "refuse", f"kind={row['kind']}; not attributable to the fleet"
 
 
+def plan_for_instance(repo, rows, audit, rescued):
+    """One verdict per PATH, strictest wins. Returns [(action, path, reason)].
+
+    THE STRUCTURAL FIX the PR #165 round-1 reviewer asked for, done after round 6
+    rather than after round 1 -- and rounds 1 and 4 are both what not doing it
+    cost. Those two findings were the SAME defect seen from opposite sides:
+    round 1 was an unattributable worktree under an attributable index, round 4
+    the mirror. Each got its own guard inside decide(). A third asymmetry would
+    have needed a third.
+
+    The cause is that a single path can produce SEVERAL rows -- audit_instance
+    reports the staged state and the worktree state separately -- and decide()
+    only ever saw one row at a time. So each row was judged on its own half of
+    the truth, and whichever half looked attributable won. Reproduced in the
+    round-4 fixture: one file, two rows, "acted on 2 path(s)" for a single path
+    (sp-511e994a).
+
+    Judging the PATH instead of the ROW makes the asymmetry unrepresentable:
+
+      any row refuses            -> the path refuses, carrying every reason
+      rows disagree on an action -> refuse; the tool cannot be sure, and this
+                                    writes to 22 repos
+      all rows agree             -> that action, ONCE
+
+    The per-side guards inside decide() stay. They are now belt and braces
+    rather than the only thing standing between a founder's staged edit and a
+    commit, and each still has its own reproducer from the round it came from.
+    """
+    by_path = {}
+    for row in rows:
+        by_path.setdefault(row["path"], []).append(row)
+
+    plan = []
+    for path, path_rows in by_path.items():
+        verdicts = [decide(repo, row, audit, rescued) for row in path_rows]
+        refusals = [reason for action, reason in verdicts if action == "refuse"]
+        if refusals:
+            plan.append(("refuse", path, "; ".join(dict.fromkeys(refusals))))
+            continue
+        actions = {action for action, _ in verdicts}
+        if len(actions) > 1:
+            plan.append(("refuse", path, (
+                "this path produced conflicting verdicts across its staged and "
+                f"worktree rows ({', '.join(sorted(actions))}); refusing rather "
+                "than picking one")))
+            continue
+        plan.append((verdicts[0][0], path, verdicts[0][1]))
+    return plan
+
+
 def audit_wrote(audit, path, sha):
     return audit.SKEL_BLOBS.wrote(path, sha) if sha else False
 
@@ -389,10 +439,7 @@ def main():
         if result["verdict"] not in ("BLOCKED-FLEET", "BLOCKED-FOUNDER"):
             continue
         repo = pathlib.Path(entry["path"])
-        plan = []
-        for row in result["blocked_by"]:
-            action, reason = decide(repo, row, audit, rescued)
-            plan.append((action, row["path"], reason))
+        plan = plan_for_instance(repo, result["blocked_by"], audit, rescued)
 
         print(f"{entry['name']}  [{result['verdict']}]")
         for action, path, reason in plan:

--- a/fleet-unblock.py
+++ b/fleet-unblock.py
@@ -234,9 +234,17 @@ def main():
     parser.add_argument("--skeleton", default=str(SKELETON))
     parser.add_argument("--only", action="append", default=[],
                         help="limit to these instance names (repeatable)")
+    # The [no-issue:] token is NOT a bypass added to get past a gate. One client
+    # engagement's instance requires every commit to name a Linear issue in THAT
+    # instance's project, and this commit is fleet exhaust: it has no issue there
+    # and should not be given a fake one, which is the failure mode that gate's
+    # own presence-check invites. Its script carries a first-class hatch
+    # (BYPASS_RE, reason required), and the updater's own system-state commits
+    # already use it. Instances without the gate ignore the token.
     parser.add_argument("--message", default=(
-        "chore(fleet): commit updater exhaust its writer never committed\n\n"
-        "Written by kipi update, never committed, so the dirty-tree guard "
+        "chore(fleet): commit updater exhaust its writer never committed "
+        "[no-issue: fleet updater exhaust, no issue in this instance]\n\n"
+        "Written by the fleet updater, never committed, so the dirty-tree guard "
         "refused every later sync. Attributed by fleet-unblock.py: each blob "
         "here is one the skeleton itself held at this exact path."))
     args = parser.parse_args()

--- a/fleet-unblock.py
+++ b/fleet-unblock.py
@@ -136,6 +136,31 @@ def decide(repo, row, audit, rescued):
         )
 
     if row["kind"] == "fleet-written":
+        # BOTH SIDES OF THE PATH, NOT ONE (PR #165 review, major).
+        #
+        # The index can hold a blob the skeleton really did ship while the
+        # WORKTREE holds bytes it never had -- a founder edit on top of a staged
+        # skeleton write. This branch used to match on the index alone and
+        # schedule a commit. `git commit` takes the INDEX, so the run would clear
+        # the dirty-tree guard, report the path repaired, and leave the founder's
+        # edit uncommitted for the next sync to overwrite. Founder work destroyed
+        # by the tool whose entire job is avoiding exactly that.
+        #
+        # One side matching the skeleton is not attribution, it is half of one.
+        # Reproducer: test_a_staged_skeleton_blob_with_a_founder_worktree_edit_is_refused.
+        #
+        # Scoped to the WORKTREE differing from the index, deliberately. In the
+        # ordinary case nothing is staged, so the index still holds the HEAD blob
+        # -- which the skeleton never wrote and never should have -- and
+        # demanding both sides be skeleton blobs would refuse every real repair.
+        # What matters is what is LEFT BEHIND after committing the index.
+        if work_sha and work_sha != index_sha and not audit_wrote(audit, path, work_sha):
+            return "refuse", (
+                f"index holds skeleton blob {index_sha[:12]} but the worktree "
+                f"holds {work_sha[:12]}, which the skeleton never wrote; "
+                "committing the index would leave that edit for the next sync "
+                "to overwrite"
+            )
         which = index_sha if audit_wrote(audit, path, index_sha) else work_sha
         return "commit", (
             f"blob {which[:12]} is one the skeleton itself held at {path}"
@@ -265,6 +290,7 @@ def main():
 
     print(f"MODE: {'APPLY' if args.apply else 'dry run'}\n")
     refused = 0
+    failed = 0
     acted = 0
     for entry in entries:
         result = audit.audit_instance(entry, owned, audit.SKEL_BLOBS)
@@ -285,12 +311,30 @@ def main():
         for action, path, reason in actionable:
             print(f"    {action:12s} {path}\n              {reason}")
         for action, path, outcome in apply_instance(repo, actionable, args.apply, args.message):
-            acted += 1
+            # A REFUSED outcome is not an action (PR #165 review, major).
+            # Counting it toward `acted` made "acted on 3 path(s)" the printed
+            # result of a run that repaired nothing.
+            if outcome.startswith("REFUSED"):
+                failed += 1
+            else:
+                acted += 1
             print(f"    -> {action:12s} {path}: {outcome}")
         print()
 
-    print(f"acted on {acted} path(s); refused {refused} path(s)")
-    return 0
+    print(f"acted on {acted} path(s); refused {refused} path(s)"
+          + (f"; {failed} action(s) FAILED" if failed else ""))
+    # NON-ZERO WHEN AN ACTION WE ACCEPTED THEN FAILED (PR #165 review, major).
+    #
+    # `refused` is a decision and is a SUCCESSFUL outcome: the script looked,
+    # could not attribute the change, and correctly left it alone. `failed` is
+    # different -- the script accepted the path, tried, and the repair did not
+    # happen (a pre-commit hook rejected it). Exiting 0 there tells an unattended
+    # fleet job the run succeeded while every instance stays blocked, which is
+    # the silent-success class this whole effort exists to end.
+    #
+    # Reproducers: test_a_refused_commit_does_not_report_success, and its
+    # negative control test_a_clean_successful_run_still_exits_zero.
+    return 1 if failed else 0
 
 
 if __name__ == "__main__":

--- a/fleet-unblock.py
+++ b/fleet-unblock.py
@@ -1,0 +1,289 @@
+#!/usr/bin/env python3
+"""Clear updater exhaust out of instances, and ONLY what it can attribute.
+
+`fleet-reach-audit.py` says WHY each instance refuses an update. This acts on
+that answer. It is the write half; the audit stays read-only so it can still be
+trusted as the before/after measurement of this script's own work.
+
+THE CLASSIFIER IS IMPORTED, NEVER TRANSCRIBED. guard_pathspec / classify /
+blob_sha come out of fleet-reach-audit.py at run time. A second copy of the
+guard's pathspec is exactly how a clearing tool starts touching a path the real
+guard never blocked on -- and this one writes, so that mistake costs founder
+work rather than a wrong number.
+
+Three actions, each with its own proof, and a refusal for everything else:
+
+  restore-mode  index and worktree hold the SAME blob and differ only in file
+                mode. The fix is chmod back to the index's mode, never a commit:
+                committing would make the broken mode the new truth. Found on
+                KTLYST_strategy 2026-08-14, where rsync had dropped +x (and
+                group/other read) from skill-trigger-eval.py -- a script that
+                had silently stopped being executable. The blocked update was
+                the only symptom anybody could see.
+
+  commit        the blob is one the SKELETON itself once held at this exact
+                path (fleet-reach-audit.SkeletonBlobs). A founder hand-edit does
+                not collide with skeleton bytes, so this is updater exhaust
+                whose writer never committed it. Committing is non-destructive:
+                the bytes are kept, not discarded, and the next sync writes the
+                newer skeleton copy over it.
+
+  unstage       a staged ADD whose worktree copy agrees with the index, AND
+                whose blob is present in the skeleton's committed rescued/ tree.
+                `git restore --staged` drops the index entry and leaves the file
+                on disk byte-for-byte, so nothing is destroyed even before the
+                rescued/ copy is counted. Both proofs are required because the
+                one time this class showed up (memory-lifecycle, ASK-803) the
+                orphan directory everybody read as dirt was the LAST COPY of
+                working code, and the obvious clear -- delete it -- destroyed it.
+
+Anything else is `refuse`: reported by name so a remaining refusal is legible
+rather than mysterious. Never a delete, never a discard of worktree content,
+never --no-verify.
+
+Dry run is the default. --apply writes.
+"""
+
+import argparse
+import importlib.util
+import json
+import pathlib
+import subprocess
+import sys
+
+SKELETON = pathlib.Path(__file__).resolve().parent
+
+
+def load_audit(skeleton):
+    """Import fleet-reach-audit.py as a module (its name has a hyphen)."""
+    path = pathlib.Path(skeleton) / "fleet-reach-audit.py"
+    if not path.is_file():
+        raise RuntimeError(
+            f"{path} is missing; fleet-unblock refuses to re-derive the "
+            "updater guard's pathspec from a second copy"
+        )
+    spec = importlib.util.spec_from_file_location("fleet_reach_audit", path)
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module
+
+
+def git(repo, *args):
+    """Returns (returncode, stdout, stderr). No exceptions, no shell."""
+    proc = subprocess.run(
+        ["git", "-C", str(repo), *args], capture_output=True, text=True
+    )
+    return proc.returncode, proc.stdout, proc.stderr
+
+
+def entry_mode(repo, path, where):
+    """File mode git sees, as a 6-digit string. "" when the path is absent."""
+    if where == "index":
+        out = git(repo, "ls-files", "-s", "--", path)[1].split()
+        return out[0] if out else ""
+    full = pathlib.Path(repo) / path
+    if not full.is_file():
+        return ""
+    # git only records the executable bit, so ask git rather than os.stat:
+    # a 100644-vs-100755 answer derived from st_mode would disagree with the
+    # guard on any filesystem git treats as mode-less.
+    for line in git(repo, "diff", "--raw", "--", path)[1].splitlines():
+        fields = line.split("\t")[0].lstrip(":").split()
+        if len(fields) >= 2:
+            return fields[1]
+    return entry_mode(repo, path, "index")
+
+
+def in_head(repo, path):
+    return git(repo, "cat-file", "-e", f"HEAD:{path}")[0] == 0
+
+
+class RescuedBlobs:
+    """Blobs the skeleton has COMMITTED under rescued/, by sha.
+
+    The preservation half of the `unstage` proof. Reads the skeleton's HEAD
+    tree, not the worktree: an uncommitted rescue is not a rescue, and this
+    script's whole job is not to trust an uncommitted copy of anything.
+    """
+
+    def __init__(self, skeleton):
+        self.shas = set()
+        out = git(skeleton, "ls-tree", "-r", "HEAD", "--", "rescued/")[1]
+        for line in out.splitlines():
+            fields = line.split()
+            if len(fields) >= 3:
+                self.shas.add(fields[2])
+
+    def holds(self, sha):
+        return bool(sha) and sha in self.shas
+
+
+def decide(repo, row, audit, rescued):
+    """One blocking row -> (action, reason). Refuses by default."""
+    path = row["path"]
+    index_sha = audit.blob_sha(repo, path, "index")
+    work_sha = audit.blob_sha(repo, path, "worktree")
+    index_mode = entry_mode(repo, path, "index")
+    work_mode = entry_mode(repo, path, "worktree")
+
+    # Mode first. A mode-only row also classifies as fleet-written (the blob IS
+    # a skeleton blob), and committing it would bake the broken mode in. Order
+    # matters here; this is not an arbitrary sequence.
+    if index_sha and index_sha == work_sha and index_mode != work_mode:
+        return "restore-mode", (
+            f"same blob {index_sha[:12]}, mode {work_mode or '?'} on disk vs "
+            f"{index_mode} in index; chmod back, never commit the broken mode"
+        )
+
+    if row["kind"] == "fleet-written":
+        which = index_sha if audit_wrote(audit, path, index_sha) else work_sha
+        return "commit", (
+            f"blob {which[:12]} is one the skeleton itself held at {path}"
+        )
+
+    if row["kind"] == "staged-only" and row["staged"] and not in_head(repo, path):
+        if rescued.holds(index_sha):
+            return "unstage", (
+                f"staged ADD, worktree agrees, and blob {index_sha[:12]} is "
+                "committed in the skeleton under rescued/"
+            )
+        return "refuse", (
+            f"staged ADD but blob {index_sha[:12]} is NOT in the skeleton's "
+            "committed rescued/ tree; unstaging leaves the only copy untracked"
+        )
+
+    return "refuse", f"kind={row['kind']}; not attributable to the fleet"
+
+
+def audit_wrote(audit, path, sha):
+    return audit.SKEL_BLOBS.wrote(path, sha) if sha else False
+
+
+def apply_instance(repo, plan, apply, message):
+    """Run one instance's plan. Returns a list of (action, path, outcome)."""
+    done = []
+    to_commit = [p for a, p, _ in plan if a == "commit"]
+    to_unstage = [p for a, p, _ in plan if a == "unstage"]
+    to_chmod = [(p, r) for a, p, r in plan if a == "restore-mode"]
+
+    for path, _reason in to_chmod:
+        mode = entry_mode(repo, path, "index")
+        if not apply:
+            done.append(("restore-mode", path, f"would chmod to {mode}"))
+            continue
+        bits = 0o755 if mode == "100755" else 0o644
+        (pathlib.Path(repo) / path).chmod(bits)
+        still = entry_mode(repo, path, "worktree")
+        done.append(("restore-mode", path,
+                     "clean" if still == mode else f"STILL {still}"))
+
+    for path in to_unstage:
+        if not apply:
+            done.append(("unstage", path, "would restore --staged"))
+            continue
+        rc, _, err = git(repo, "restore", "--staged", "--", path)
+        done.append(("unstage", path, "clean" if rc == 0 else f"FAILED {err.strip()}"))
+
+    if to_commit:
+        if not apply:
+            for path in to_commit:
+                done.append(("commit", path, "would stage + commit"))
+        else:
+            done += commit_with_unwind(repo, to_commit, message)
+    return done
+
+
+def commit_with_unwind(repo, paths, message):
+    """Stage and commit `paths`, restoring the prior index if the commit fails.
+
+    A commit here runs the INSTANCE's pre-commit hooks, and two of the five
+    instances have them. A hook exiting non-zero must not leave the index in a
+    state nobody chose: the founder would come back to paths staged by a script
+    that then reported failure. So the pre-run staged set is recorded first and
+    restored on any failure.
+
+    Never --no-verify. A hook that refuses this commit is a hook doing its job,
+    and the correct outcome is a refusal that says so.
+    """
+    was_staged = set()
+    for path in paths:
+        if git(repo, "diff", "--cached", "--quiet", "--", path)[0] != 0:
+            was_staged.add(path)
+
+    def unwind():
+        for path in paths:
+            if path not in was_staged:
+                git(repo, "restore", "--staged", "--", path)
+
+    rc, _, err = git(repo, "add", "--", *paths)
+    if rc != 0:
+        unwind()
+        return [("commit", p, f"FAILED add: {err.strip()}") for p in paths]
+
+    rc, _, err = git(repo, "commit", "-m", message, "--", *paths)
+    if rc != 0:
+        unwind()
+        detail = (err.strip() or "hook or commit refused").splitlines()[-1:]
+        return [("commit", p, f"REFUSED (index unwound): {detail}") for p in paths]
+    return [("commit", p, "committed") for p in paths]
+
+
+def main():
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--apply", action="store_true", help="write (default: dry run)")
+    parser.add_argument("--skeleton", default=str(SKELETON))
+    parser.add_argument("--only", action="append", default=[],
+                        help="limit to these instance names (repeatable)")
+    parser.add_argument("--message", default=(
+        "chore(fleet): commit updater exhaust its writer never committed\n\n"
+        "Written by kipi update, never committed, so the dirty-tree guard "
+        "refused every later sync. Attributed by fleet-unblock.py: each blob "
+        "here is one the skeleton itself held at this exact path."))
+    args = parser.parse_args()
+
+    skeleton = pathlib.Path(args.skeleton).resolve()
+    audit = load_audit(skeleton)
+    owned = audit.instance_owned_subtrees(skeleton / "kipi-update.sh")
+    audit.SKEL_BLOBS = audit.SkeletonBlobs(skeleton)
+    rescued = RescuedBlobs(skeleton)
+
+    registry = json.loads((skeleton / "instance-registry.json").read_text())
+    entries = [
+        i for i in registry["instances"]
+        if not str(i.get("status", "")).startswith("merged")
+        and i.get("skeleton_managed") is not False
+        and (not args.only or i["name"] in args.only)
+    ]
+
+    print(f"MODE: {'APPLY' if args.apply else 'dry run'}\n")
+    refused = 0
+    acted = 0
+    for entry in entries:
+        result = audit.audit_instance(entry, owned, audit.SKEL_BLOBS)
+        if result["verdict"] not in ("BLOCKED-FLEET", "BLOCKED-FOUNDER"):
+            continue
+        repo = pathlib.Path(entry["path"])
+        plan = []
+        for row in result["blocked_by"]:
+            action, reason = decide(repo, row, audit, rescued)
+            plan.append((action, row["path"], reason))
+
+        print(f"{entry['name']}  [{result['verdict']}]")
+        for action, path, reason in plan:
+            if action == "refuse":
+                refused += 1
+                print(f"    REFUSE  {path}\n              {reason}")
+        actionable = [p for p in plan if p[0] != "refuse"]
+        for action, path, reason in actionable:
+            print(f"    {action:12s} {path}\n              {reason}")
+        for action, path, outcome in apply_instance(repo, actionable, args.apply, args.message):
+            acted += 1
+            print(f"    -> {action:12s} {path}: {outcome}")
+        print()
+
+    print(f"acted on {acted} path(s); refused {refused} path(s)")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/fleet-unblock.py
+++ b/fleet-unblock.py
@@ -218,6 +218,26 @@ def apply_instance(repo, plan, apply, message):
     return done
 
 
+# SUCCESS IS AN ALLOWLIST (PR #165 review round 2, major).
+#
+# Round 1 made a REFUSED commit exit non-zero by testing
+# `outcome.startswith("REFUSED")`. The other producers emit "FAILED add: ",
+# "FAILED <err>" and "STILL <mode>" -- none of which start with REFUSED -- so
+# every one of them still counted as a successful action and still exited 0.
+#
+# A denylist of failure strings is the wrong shape for the thing an unattended
+# job reads as its exit code: the next outcome string anyone adds lands on the
+# success side by default. Fail closed instead. An outcome counts as success
+# only if it says so, and "would ..." is the dry run, which succeeds by writing
+# nothing.
+#
+# Pinned by test_a_failed_add_or_restore_is_not_counted_as_success and
+# test_every_outcome_the_code_emits_is_classified, the second of which derives
+# the outcome literals from this file so a new one cannot arrive unclassified.
+def succeeded(outcome):
+    return outcome in ("clean", "committed") or outcome.startswith("would ")
+
+
 def commit_with_unwind(repo, paths, message):
     """Stage and commit `paths`, restoring the prior index if the commit fails.
 
@@ -230,15 +250,35 @@ def commit_with_unwind(repo, paths, message):
     Never --no-verify. A hook that refuses this commit is a hook doing its job,
     and the correct outcome is a refusal that says so.
     """
-    was_staged = set()
+    # RECORD THE ENTRY, NOT JUST THE FACT (PR #165 review round 2, major).
+    #
+    # This used to be a set of "was already staged" paths, and unwind() SKIPPED
+    # them: the tool did not stage it, so the tool should not unstage it. By the
+    # time unwind runs, `git add` has already overwritten that index entry with
+    # the worktree content -- so a founder who had staged their own version of
+    # the path lost it, and the run printed "index unwound" while saying so.
+    #
+    # Skipping a path is not restoring it. Keep the exact index entry (mode and
+    # blob) and put it back.
+    # Reproducer: test_the_unwind_restores_content_the_founder_had_already_staged.
+    was_staged = {}
     for path in paths:
         if git(repo, "diff", "--cached", "--quiet", "--", path)[0] != 0:
-            was_staged.add(path)
+            rc, out, _ = git(repo, "ls-files", "--stage", "--", path)
+            entry = out.strip().splitlines()
+            if rc == 0 and entry:
+                meta = entry[0].split("\t", 1)[0].split()
+                if len(meta) >= 2:
+                    was_staged[path] = (meta[0], meta[1])   # (mode, blob sha)
 
     def unwind():
         for path in paths:
-            if path not in was_staged:
+            entry = was_staged.get(path)
+            if entry is None:
                 git(repo, "restore", "--staged", "--", path)
+            else:
+                mode, sha = entry
+                git(repo, "update-index", "--cacheinfo", f"{mode},{sha},{path}")
 
     rc, _, err = git(repo, "add", "--", *paths)
     if rc != 0:
@@ -311,13 +351,10 @@ def main():
         for action, path, reason in actionable:
             print(f"    {action:12s} {path}\n              {reason}")
         for action, path, outcome in apply_instance(repo, actionable, args.apply, args.message):
-            # A REFUSED outcome is not an action (PR #165 review, major).
-            # Counting it toward `acted` made "acted on 3 path(s)" the printed
-            # result of a run that repaired nothing.
-            if outcome.startswith("REFUSED"):
-                failed += 1
-            else:
+            if succeeded(outcome):
                 acted += 1
+            else:
+                failed += 1
             print(f"    -> {action:12s} {path}: {outcome}")
         print()
 

--- a/fleet-unblock.py
+++ b/fleet-unblock.py
@@ -98,6 +98,16 @@ def in_head(repo, path):
     return git(repo, "cat-file", "-e", f"HEAD:{path}")[0] == 0
 
 
+def head_blob(repo, path):
+    """Blob sha at HEAD for `path`, or "" when the path is not in HEAD.
+
+    Needed to tell "nothing is staged, so the index still mirrors HEAD" from
+    "somebody deliberately staged something". The index alone cannot say which.
+    """
+    rc, out, _ = git(repo, "rev-parse", f"HEAD:{path}")
+    return out.strip() if rc == 0 else ""
+
+
 class RescuedBlobs:
     """Blobs the skeleton has COMMITTED under rescued/, by sha.
 
@@ -176,6 +186,32 @@ def decide(repo, row, audit, rescued):
                 f"holds {work_sha[:12]}, which the skeleton never wrote; "
                 "committing the index would leave that edit for the next sync "
                 "to overwrite"
+            )
+        # THE MIRROR OF THE GUARD ABOVE (PR #165 review round 4, major).
+        #
+        # That one asks whether the WORKTREE is attributable. This asks the same
+        # of the INDEX, and the case it catches is the reverse: the founder
+        # STAGED their own version and the worktree happens to hold a skeleton
+        # blob. The guard above passes, `git add` then replaces the founder's
+        # staged entry with the worktree blob, and the commit SUCCEEDS -- so the
+        # unwind added in round 2 never runs, because nothing failed. The
+        # founder's staged version is committed away and gone.
+        #
+        # "Attributable" for the index means the skeleton wrote it, or nothing
+        # was staged at all -- an unstaged path still has the HEAD blob in its
+        # index, which is why this compares against HEAD rather than just
+        # checking for skeleton authorship.
+        #
+        # Scoped inside the fleet-written branch on purpose: a staged ADD is not
+        # in HEAD at all, and that case has its own rescued/ proof further down.
+        # Reproducer: test_founder_staged_content_under_a_skeleton_worktree_blob_is_refused.
+        if (in_head(repo, path) and index_sha
+                and index_sha != head_blob(repo, path)
+                and not audit_wrote(audit, path, index_sha)):
+            return "refuse", (
+                f"the index holds {index_sha[:12]}, which the skeleton never "
+                "wrote and which differs from HEAD, so the founder staged it "
+                "deliberately; committing would replace it with the worktree copy"
             )
         which = index_sha if audit_wrote(audit, path, index_sha) else work_sha
         return "commit", (

--- a/fleet-unblock.py
+++ b/fleet-unblock.py
@@ -129,7 +129,23 @@ def decide(repo, row, audit, rescued):
     # Mode first. A mode-only row also classifies as fleet-written (the blob IS
     # a skeleton blob), and committing it would bake the broken mode in. Order
     # matters here; this is not an arbitrary sequence.
-    if index_sha and index_sha == work_sha and index_mode != work_mode:
+    #
+    # BUT MODE-FIRST IS NOT ATTRIBUTION-FREE (PR #165 review round 3, major).
+    # Running before the kind check meant this branch also swallowed the FOUNDER
+    # case: a script the founder wrote and deliberately made executable has an
+    # unchanged blob and a changed mode, which is precisely the shape matched
+    # here. The tool chmod'ed it back and reported the instance repaired --
+    # silently undoing a deliberate change, on a file the skeleton has never
+    # heard of.
+    #
+    # The scar this branch exists for (KTLYST_strategy, skill-trigger-eval.py)
+    # was a SKELETON file whose +x rsync had dropped. Requiring the blob to be
+    # one the skeleton actually wrote keeps that case and drops the founder's.
+    # A non-skeleton blob falls through to the kind checks and is refused.
+    # Reproducer: test_a_founder_chmod_on_a_file_the_skeleton_never_shipped_is_refused
+    # Control:    test_the_skeleton_owned_mode_fix_still_fires
+    if (index_sha and index_sha == work_sha and index_mode != work_mode
+            and audit_wrote(audit, path, index_sha)):
         return "restore-mode", (
             f"same blob {index_sha[:12]}, mode {work_mode or '?'} on disk vs "
             f"{index_mode} in index; chmod back, never commit the broken mode"

--- a/kipi-update-gitignore-block.py
+++ b/kipi-update-gitignore-block.py
@@ -1,0 +1,186 @@
+#!/usr/bin/env python3
+"""Ship the skeleton's instance-local-never-commit stanza into an instance's
+root .gitignore, as a managed block.
+
+WHY (sp-097d2e23, sp-bd9bae14, measured 2026-08-14). The skeleton's root
+.gitignore says three things must never be committed, and says why:
+
+  * claude-integrity-baseline.json  -- instance-local (ASK-282); a shared
+    baseline can never match and Slack-pages every instance daily.
+  * .claude-integrity-armed         -- a committed marker makes a fresh
+    instance claim prior arming, refuse to arm, and page SECURITY on its
+    first run (the ASK-291 round-2 outage).
+  * q-system/output/.update-check-* -- daily update stamps, pure exhaust.
+
+Root .gitignore is NOT in the updater's sync set (the set is q-system/,
+.claude/{agents,output-styles,rules}/*.md, .claude/settings.json, plugins/),
+so no instance has ever received those rules. In the skeleton the gitignore
+makes those paths invisible to `git status`; in an instance it does not, so
+auto-commit.py sees them, classifies `q-system/.q-system/` as ("chore",
+"update system infrastructure"), and commits them unattended.
+
+That is not hypothetical. Measured across the 22 skeleton-managed instances:
+five had already committed the baseline and/or the armed marker, the most
+recent at 2026-08-14 14:22 under exactly that subject line. The two spillover
+notes were filed as separate minor defects; they are one defect, and the
+gitignore gap is the cause rather than a cosmetic side effect.
+
+DERIVED, NOT TRANSCRIBED. The stanza is parsed out of the skeleton's own root
+.gitignore between the two markers, so adding a fourth never-commit path there
+cannot leave this script behind. Same discipline the preserve scan adopted for
+INSTANCE_OWNED_PATHS in sp-3d5a247e, and for the same reason: a hand-kept
+second copy of a list drifts the moment anyone adds an entry.
+
+Refuses loudly rather than falling back to a literal. A silent fallback would
+write a block that does not match what the skeleton actually declares, and the
+failure mode -- an instance quietly committing its own tripwire state again --
+is invisible until something pages.
+
+Idempotent: rewrites the managed block in place, leaving every other line of
+the instance's .gitignore untouched. An instance that already ignores one of
+these paths on its own keeps that line; the block is additive.
+
+Usage:
+  kipi-update-gitignore-block.py --skeleton DIR --instance DIR [--check]
+
+  --check  report whether the block is current, write nothing. Exit 0 when
+           the instance block already matches the skeleton stanza, 1 when it
+           would change.
+"""
+import argparse
+import os
+import re
+import sys
+
+BEGIN = "# >>> kipi-managed: instance-local, never commit >>>"
+END = "# <<< kipi-managed: instance-local, never commit <<<"
+
+# The markers as they appear in the SKELETON's .gitignore. Kept distinct from
+# the block markers written into an instance so that the skeleton's own copy is
+# never mistaken for a managed block and rewritten by a stray --instance run
+# pointed at the skeleton.
+SKELETON_BEGIN = "# >>> kipi-instance-local-stanza >>>"
+SKELETON_END = "# <<< kipi-instance-local-stanza <<<"
+
+
+def skeleton_stanza(skeleton_dir):
+    """The never-commit path lines declared by the skeleton's root .gitignore."""
+    path = os.path.join(skeleton_dir, ".gitignore")
+    try:
+        with open(path, encoding="utf-8") as handle:
+            text = handle.read()
+    except OSError as exc:
+        raise RuntimeError(f"cannot read skeleton .gitignore at {path}: {exc}")
+    match = re.search(
+        re.escape(SKELETON_BEGIN) + r"\n(.*?)^" + re.escape(SKELETON_END),
+        text,
+        re.S | re.M,
+    )
+    if not match:
+        raise RuntimeError(
+            f"{SKELETON_BEGIN} markers not found in {path}; the gitignore block "
+            "writer cannot mirror the skeleton's never-commit stanza and refuses "
+            "to guess it"
+        )
+    lines = [line.rstrip() for line in match.group(1).splitlines()]
+    # Comments inside the stanza are the WHY, and an instance reading its own
+    # .gitignore deserves them as much as the skeleton does. Blank lines are
+    # dropped so the emitted block is stable regardless of skeleton spacing.
+    lines = [line for line in lines if line.strip()]
+    if not any(line and not line.startswith("#") for line in lines):
+        raise RuntimeError(
+            f"the stanza between the markers in {path} declares no paths; "
+            "refusing to write an empty managed block"
+        )
+    return lines
+
+
+def render_block(stanza):
+    return "\n".join([BEGIN] + stanza + [END]) + "\n"
+
+
+def existing_block(text):
+    """(before, block, after) for the managed block, or None when absent."""
+    match = re.search(
+        re.escape(BEGIN) + r"\n.*?^" + re.escape(END) + r"\n?",
+        text,
+        re.S | re.M,
+    )
+    if not match:
+        return None
+    return text[: match.start()], match.group(0), text[match.end():]
+
+
+def apply_block(instance_dir, stanza, check_only=False):
+    """Write/refresh the managed block. Returns (changed, action)."""
+    path = os.path.join(instance_dir, ".gitignore")
+    try:
+        with open(path, encoding="utf-8") as handle:
+            text = handle.read()
+    except FileNotFoundError:
+        text = ""
+    except OSError as exc:
+        raise RuntimeError(f"cannot read {path}: {exc}")
+
+    block = render_block(stanza)
+    found = existing_block(text)
+    if found is None:
+        # Append. A leading newline only when the file has content and does not
+        # already end in one, so repeated runs cannot grow blank lines.
+        prefix = text
+        if prefix and not prefix.endswith("\n"):
+            prefix += "\n"
+        if prefix:
+            prefix += "\n"
+        new_text = prefix + block
+        action = "added"
+    else:
+        before, current, after = found
+        if current.rstrip("\n") == block.rstrip("\n"):
+            return False, "current"
+        new_text = before + block + after
+        action = "refreshed"
+
+    if check_only:
+        return True, action
+
+    tmp = path + ".kipi-tmp"
+    with open(tmp, "w", encoding="utf-8") as handle:
+        handle.write(new_text)
+    os.replace(tmp, path)
+    return True, action
+
+
+def main(argv=None):
+    ap = argparse.ArgumentParser(description=__doc__)
+    ap.add_argument("--skeleton", required=True)
+    ap.add_argument("--instance", required=True)
+    ap.add_argument("--check", action="store_true")
+    args = ap.parse_args(argv)
+
+    if os.path.abspath(args.skeleton) == os.path.abspath(args.instance):
+        print("refusing to write a managed block into the skeleton itself",
+              file=sys.stderr)
+        return 2
+
+    try:
+        stanza = skeleton_stanza(args.skeleton)
+        changed, action = apply_block(args.instance, stanza, args.check)
+    except RuntimeError as exc:
+        print(f"ERROR: {exc}", file=sys.stderr)
+        return 2
+
+    if args.check:
+        if changed:
+            print(f"  .gitignore managed block would be {action}")
+            return 1
+        return 0
+
+    if changed:
+        print(f"  .gitignore managed block {action} "
+              f"({sum(1 for l in stanza if not l.startswith('#'))} path(s))")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/kipi-update-preserve-scan.py
+++ b/kipi-update-preserve-scan.py
@@ -35,14 +35,43 @@ import sys
 # stale skeleton copy from the old `git subtree add` creation path). Listing it
 # here stops this scanner from flagging shadow-tree files as preserve-candidates,
 # so the updater's rsync --delete can actually remove them (fleet cleanup 2026-07-01).
-EXCLUDED_PREFIXES = (
-    "my-project/",
-    "canonical/",
-    "memory/",
-    "output/",
-    ".q-system/agent-pipeline/bus/",
-    "q-system/",
-)
+def _owned_subtrees():
+    """INSTANCE_OWNED_SUBTREES, parsed out of kipi-update.sh.
+
+    DERIVED, NOT TRANSCRIBED (sp-3d5a247e). The comment above has always claimed
+    this list mirrors the updater's excludes "exactly"; measured 2026-08-14 it
+    was missing `research` and `.q-system/data`, so the claim had been false for
+    as long as those two entries had existed. A hand-kept second copy of a list
+    that lives somewhere else drifts the moment anyone adds an entry, and a
+    comment asserting the mirror is worse than no comment: it is read as
+    coverage, so nobody goes looking.
+
+    Refuses loudly rather than falling back to a literal. A silent fallback here
+    would preserve a file the updater is about to delete, or skip one it is not
+    permitted to touch, with nothing on screen either way.
+    """
+    import re
+    updater = os.path.join(os.path.dirname(os.path.abspath(__file__)),
+                           "kipi-update.sh")
+    with open(updater, encoding="utf-8") as handle:
+        text = handle.read()
+    match = re.search(r"^INSTANCE_OWNED_SUBTREES=\(\n(.*?)^\)", text, re.S | re.M)
+    if not match:
+        raise RuntimeError(
+            f"INSTANCE_OWNED_SUBTREES not found in {updater}; the preserve scan "
+            "cannot mirror the updater's excludes and refuses to guess them"
+        )
+    subs = [line.strip() for line in match.group(1).splitlines() if line.strip()]
+    if not subs:
+        raise RuntimeError(f"INSTANCE_OWNED_SUBTREES parsed empty from {updater}")
+    return tuple(f"{sub}/" for sub in subs)
+
+
+# The updater's own instance-owned subtrees, plus one entry that is NOT an rsync
+# exclude: "q-system/" is the forbidden nested shadow tree described above, and
+# it is excluded here for a different reason. Kept separate so the derived half
+# stays a faithful mirror.
+EXCLUDED_PREFIXES = _owned_subtrees() + ("q-system/",)
 
 
 def is_excluded(rel):

--- a/kipi-update.sh
+++ b/kipi-update.sh
@@ -1634,14 +1634,34 @@ PY
     # own .gitignore, so adding a fourth never-commit path there reaches all 22
     # instances without touching this file.
     #
-    # Advisory: an instance that cannot take the block is not a reason to
-    # abandon an otherwise good update, and the untrack below still runs.
+    # ADVISORY FOR THE UPDATE, A HARD PRECONDITION FOR THE UNTRACK
+    # (PR #165 review round 6, major -- a defect in this block's first version).
+    #
+    # That version said: "an instance that cannot take the block is not a reason
+    # to abandon an otherwise good update, and the untrack below still runs."
+    # The first half is right and the second half is the bug. `git rm --cached`
+    # leaves the marker on disk UNTRACKED; if the ignore rules are not in place
+    # at that moment, git reports it and the next ordinary session's auto-commit
+    # puts it straight back. So a failed block turned the untrack from a repair
+    # into the exact regression the ordering exists to prevent -- and it would do
+    # it again on every run, because the marker's one line is a timestamp the
+    # tripwire rewrites on every arm.
+    #
+    # Leaving the marker TRACKED is the stable state. It is where 5 instances
+    # already sit, the sync still works, and the next run can retry. Untracking
+    # without ignoring is strictly worse than not untracking at all.
+    #
+    # So: the sync continues (advisory), the untrack does not (gated).
     GITIGNORE_BLOCK="$SCRIPT_DIR/kipi-update-gitignore-block.py"
+    GITIGNORE_BLOCK_OK=0
     if [ -f "$GITIGNORE_BLOCK" ]; then
-      python3 "$GITIGNORE_BLOCK" --skeleton "$SCRIPT_DIR" --instance "$path" ||
-        echo "    WARN: could not write the .gitignore managed block; never-commit paths stay visible to auto-commit here"
+      if python3 "$GITIGNORE_BLOCK" --skeleton "$SCRIPT_DIR" --instance "$path"; then
+        GITIGNORE_BLOCK_OK=1
+      else
+        echo "    WARN: could not write the .gitignore managed block; skipping the never-commit untrack so the marker is not left untracked AND unignored"
+      fi
     else
-      echo "    WARN: .gitignore block writer missing; never-commit paths stay visible to auto-commit here"
+      echo "    WARN: .gitignore block writer missing; skipping the never-commit untrack so the marker is not left untracked AND unignored"
     fi
 
     # ONE-TIME MIGRATION, and it must run BEFORE the block below (measured 2026-08-14, 6 instances).
@@ -1670,6 +1690,11 @@ PY
     # package, same rule as the dirty guard below), then by asserting the staged set
     # is exactly this one path before committing.
     for sys_path in "${SYSTEM_NEVER_COMMIT[@]}"; do
+      # Gated on the managed block being in place -- see the WARN above. A first
+      # attempt at this guard used ${GITIGNORE_BLOCK_OK:+...} on the array, which
+      # is wrong: the flag is 0 or 1 and "0" is non-empty, so it expanded on
+      # failure exactly as before. Plain and readable beats clever here.
+      [ "$GITIGNORE_BLOCK_OK" = "1" ] || continue
       git ls-files --error-unmatch -- "$sys_path" >/dev/null 2>&1 || continue
       if [ -n "$(git diff --cached --name-only 2>/dev/null)" ]; then
         say "  WARNING: $sys_path is tracked, but the index already holds staged work."

--- a/kipi-update.sh
+++ b/kipi-update.sh
@@ -1610,6 +1610,40 @@ PY
       git merge --abort 2>/dev/null || true
     fi
 
+    # THE OTHER HALF OF THE UNTRACK BELOW, and it must run FIRST (sp-097d2e23).
+    #
+    # `git rm --cached` leaves the file on disk, UNTRACKED. In the skeleton that
+    # is invisible, because root .gitignore has covered these paths since
+    # .gitignore:123. No instance has ever had those lines: root .gitignore is
+    # not in this script's sync set (q-system/, .claude/{agents,output-styles,
+    # rules}/*.md, .claude/settings.json, plugins/). So on an instance the
+    # untracked marker is REPORTED by git status, auto-commit.py classifies
+    # q-system/.q-system/ as `chore` exhaust, and the next ordinary session
+    # commits it straight back. The migration below would then have to run
+    # again, and again, forever.
+    #
+    # That is not a prediction. SYSTEM_NEVER_COMMIT closes this script's own
+    # commit path; the commit that re-added the marker to an instance at
+    # 2026-08-14 14:22 carried auto-commit.py's subject ("chore: update system
+    # infrastructure"), not this script's ("...before skeleton sync"). Two
+    # writers, and the array only ever guarded one of them.
+    #
+    # Ignoring the path guards every writer at once -- this script, the Stop
+    # hook, a stray `git add -A`, the founder's own commit -- because it works
+    # at the layer all of them read. The stanza is PARSED from the skeleton's
+    # own .gitignore, so adding a fourth never-commit path there reaches all 22
+    # instances without touching this file.
+    #
+    # Advisory: an instance that cannot take the block is not a reason to
+    # abandon an otherwise good update, and the untrack below still runs.
+    GITIGNORE_BLOCK="$SCRIPT_DIR/kipi-update-gitignore-block.py"
+    if [ -f "$GITIGNORE_BLOCK" ]; then
+      python3 "$GITIGNORE_BLOCK" --skeleton "$SCRIPT_DIR" --instance "$path" ||
+        echo "    WARN: could not write the .gitignore managed block; never-commit paths stay visible to auto-commit here"
+    else
+      echo "    WARN: .gitignore block writer missing; never-commit paths stay visible to auto-commit here"
+    fi
+
     # ONE-TIME MIGRATION, and it must run BEFORE the block below (measured 2026-08-14, 6 instances).
     #
     # The chokepoint stops the baseline from BECOMING tracked. It does nothing for

--- a/q-system/.q-system/tests/separation/test_update_propagation.py
+++ b/q-system/.q-system/tests/separation/test_update_propagation.py
@@ -44,6 +44,7 @@ UPDATER_HELPERS = (
     "kipi-update-preserve-scan.py",
     "kipi-update-deletion-guard.py",
     "kipi-settings-merge.py",
+    "kipi-update-gitignore-block.py",
     "settings-template.json",
 )
 

--- a/q-system/.q-system/tests/test_gitignore_block.py
+++ b/q-system/.q-system/tests/test_gitignore_block.py
@@ -264,6 +264,46 @@ class TestTheWiringIntoTheUpdater:
         assert r.returncode == 0, r.stderr
 
 
+class TestTheFileTheWriterCreatesCanActuallyBeCommitted:
+    """A defect in THIS fix, found by running it against real instances.
+
+    Dry-checked on three live instances 2026-08-14: none of them has a root
+    .gitignore AT ALL, so the writer does not edit a file, it CREATES one. Git
+    honours an untracked .gitignore, so the ignore rules work either way -- but
+    an untracked file is one nobody committed, in a repo nobody looks at, and
+    auto-commit.py classified `.gitignore` as `unclassified`.
+
+    Unclassified means REPORTED, never committed (ASK-498). So the fix would
+    have left every one of the 22 instances printing the same unclassifiable
+    path on every single run, forever, and the file itself unversioned -- not in
+    the instance's history, not recoverable if something removed it.
+
+    That is the exact shape this whole PR is about: state the system writes for
+    itself that nothing is allowed to commit, sitting dirty until it becomes
+    background noise. Fixing it in the same breath rather than filing it.
+    """
+
+    def test_a_created_gitignore_is_offered_to_the_fleet_sync(self, tmp_path):
+        root = make_instance(tmp_path)
+        assert not (root / ".gitignore").exists()
+        blockmod.main(["--skeleton", REPO, "--instance", str(root)])
+
+        assert ".gitignore" in untracked(root), "precondition: it is untracked"
+        assert auto_commit.system_state_paths([".gitignore"]) == [".gitignore"], (
+            "the writer creates a file the fleet sync is not allowed to commit, "
+            "so it stays untracked and unclassified on every instance forever")
+
+    def test_it_is_chore_not_founder_content(self):
+        """It must be `chore`. system_state_paths narrows to chore precisely so
+        an unattended fleet-wide sweep never takes founder-authored content."""
+        assert auto_commit.classify(".gitignore")[0] == "chore"
+
+    def test_an_instance_gitignore_is_not_swept_as_unclassified(self):
+        """The negative half: `unclassified` is what REPORTS a path instead of
+        committing it. If this regresses, the noise comes straight back."""
+        assert auto_commit.classify(".gitignore") != auto_commit.SKIP_UNCLASSIFIED
+
+
 class TestUntrackingWithoutIgnoringRegresses:
     """The behavioural half of the ordering argument, run for real."""
 
@@ -303,7 +343,14 @@ class TestUntrackingWithoutIgnoringRegresses:
 
         assert (root / rel).exists(), "the untrack must never delete the file"
         assert rel not in untracked(root)
-        assert auto_commit.system_state_paths(untracked(root)) == []
+        # Names the MARKER rather than asserting the offered list is empty.
+        # The broad version was written before .gitignore itself became
+        # committable, and it then failed for the right reason: the writer
+        # creates a root .gitignore, which IS now offered to the fleet sync on
+        # purpose (see TestTheFileTheWriterCreatesCanActuallyBeCommitted). An
+        # assertion that breaks when an unrelated path is correctly added was
+        # testing the wrong thing.
+        assert rel not in auto_commit.system_state_paths(untracked(root))
 
 
 if __name__ == "__main__":

--- a/q-system/.q-system/tests/test_gitignore_block.py
+++ b/q-system/.q-system/tests/test_gitignore_block.py
@@ -238,6 +238,26 @@ class TestTheWiringIntoTheUpdater:
             "the .gitignore block is written AFTER the untrack migration, so "
             "every untracked marker is visible to auto-commit until the next run")
 
+    def test_it_also_runs_before_the_updater_scans_for_system_state(self):
+        """Belt and braces, and worth pinning.
+
+        SYSTEM_NEVER_COMMIT already stops the updater committing the three
+        integrity paths, so this ordering is not what protects them today. It is
+        what protects the NEXT path added to the stanza: a path that is ignored
+        before `git status` runs is never offered to the classifier at all, so it
+        needs no second entry in a hand-kept array to be safe. Ignoring is the
+        layer every writer reads; the array is one writer's opt-out list."""
+        text = self.text()
+        block_at = text.index("kipi-update-gitignore-block.py")
+        # The INVOCATION, not the first mention. `--system-state` appears in a
+        # comment ~1300 lines above the call site, and anchoring on that made
+        # this test pass for the wrong reason on its first run.
+        scan_at = text.index('"$sys_classifier" --system-state')
+        assert block_at < scan_at, (
+            "the .gitignore block is written after the updater scans for "
+            "system state, so a newly-stanza'd path is still offered to the "
+            "classifier on the run that introduces it")
+
     def test_the_updater_still_parses(self):
         r = subprocess.run(["bash", "-n", self.UPDATER],
                            capture_output=True, text=True)

--- a/q-system/.q-system/tests/test_gitignore_block.py
+++ b/q-system/.q-system/tests/test_gitignore_block.py
@@ -1,0 +1,290 @@
+#!/usr/bin/env python3
+"""The skeleton's never-commit stanza must reach every instance (sp-097d2e23).
+
+RED FIRST. The reproducer that opens this file is
+TestTheDefectThatWasMeasured::test_an_instance_without_the_stanza_commits_its_own_tripwire_state
+-- it drives the REAL auto-commit classifier against a REAL git repo laid out
+like an instance, and asserts the integrity paths are not offered to the fleet
+sync. Before the managed block existed that test failed, because git reported
+the paths as untracked and auto-commit classified them ("chore", "update system
+infrastructure"). That is not a hypothetical: five of the 22 skeleton-managed
+instances had already committed them, most recently 2026-08-14 14:22.
+
+Nothing here touches a live instance. Every test builds its own tree under
+tmp_path, which is the whole point -- a test that reads the real fleet would
+pass or fail on whatever state the fleet happened to be in that morning.
+"""
+import importlib.util
+import os
+import subprocess
+import sys
+
+import pytest
+
+REPO = os.path.dirname(os.path.dirname(os.path.dirname(os.path.dirname(
+    os.path.abspath(__file__)))))
+SCRIPT = os.path.join(REPO, "kipi-update-gitignore-block.py")
+HOOK = os.path.join(REPO, "q-system", "hooks", "auto-commit.py")
+
+
+def load(name, path):
+    spec = importlib.util.spec_from_file_location(name, path)
+    mod = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(mod)
+    return mod
+
+
+blockmod = load("gitignore_block", SCRIPT)
+auto_commit = load("auto_commit", HOOK)
+
+
+# The paths the skeleton's .gitignore says are instance-local. Named here so a
+# test can fail on a path SILENTLY LEAVING the stanza, which a test that only
+# read the stanza back could never notice.
+INSTANCE_LOCAL = (
+    "q-system/.q-system/claude-integrity-baseline.json",
+    "q-system/.q-system/claude-integrity-baseline.json.lock",
+    "q-system/.q-system/.claude-integrity-armed",
+)
+
+
+def git(repo, *args):
+    return subprocess.run(["git", "-C", repo, *args],
+                          capture_output=True, text=True, check=False)
+
+
+def make_instance(tmp_path, name="instance"):
+    """A git repo laid out the way a kipi instance is."""
+    root = tmp_path / name
+    (root / "q-system" / ".q-system").mkdir(parents=True)
+    (root / "q-system" / "output").mkdir(parents=True)
+    git(str(root), "init", "-q")
+    git(str(root), "config", "user.email", "t@t")
+    git(str(root), "config", "user.name", "t")
+    (root / "README.md").write_text("instance\n")
+    git(str(root), "add", "-A")
+    git(str(root), "commit", "-qm", "init")
+    return root
+
+
+def write_tripwire_state(root):
+    """Exactly what the tripwire and the update-check write into an instance."""
+    (root / "q-system" / ".q-system" / "claude-integrity-baseline.json").write_text(
+        '{"entries": {}}\n')
+    (root / "q-system" / ".q-system" / "claude-integrity-baseline.json.lock").write_text("")
+    (root / "q-system" / ".q-system" / ".claude-integrity-armed").write_text("armed\n")
+    (root / "q-system" / "output" / ".update-check-2026-08-14").write_text("")
+
+
+def untracked(root):
+    out = git(str(root), "status", "--porcelain", "--untracked-files=all").stdout
+    return [line[3:] for line in out.splitlines() if line.startswith("??")]
+
+
+class TestTheDefectThatWasMeasured:
+    """The reproducer. It fails with no managed block and passes with one."""
+
+    def test_an_instance_without_the_stanza_commits_its_own_tripwire_state(self, tmp_path):
+        """THE red test. Drives the real classifier, not a restatement of it."""
+        root = make_instance(tmp_path)
+        write_tripwire_state(root)
+
+        # Before: git reports the tripwire state, so the fleet sync takes it.
+        offered_before = auto_commit.system_state_paths(untracked(root))
+        assert any(p in offered_before for p in INSTANCE_LOCAL), (
+            "precondition: without the managed block the classifier must offer "
+            "the integrity paths -- if this fails the defect changed shape")
+
+        rc = blockmod.main(["--skeleton", REPO, "--instance", str(root)])
+        assert rc == 0
+
+        offered_after = auto_commit.system_state_paths(untracked(root))
+        for path in INSTANCE_LOCAL:
+            assert path not in offered_after, (
+                f"{path} is still offered to the fleet sync after the block")
+
+    def test_the_update_check_stamp_is_ignored_too(self, tmp_path):
+        root = make_instance(tmp_path)
+        write_tripwire_state(root)
+        blockmod.main(["--skeleton", REPO, "--instance", str(root)])
+        assert "q-system/output/.update-check-2026-08-14" not in untracked(root)
+
+
+class TestTheStanzaIsDerivedNotTranscribed:
+    """sp-3d5a247e's lesson, applied before it can happen again here."""
+
+    def test_every_instance_local_path_comes_from_the_skeleton_gitignore(self):
+        stanza = blockmod.skeleton_stanza(REPO)
+        paths = [l for l in stanza if not l.startswith("#")]
+        for path in INSTANCE_LOCAL:
+            assert path in paths, (
+                f"{path} left the skeleton stanza; either it is genuinely no "
+                "longer instance-local (update this test and say why) or the "
+                "stanza lost a line")
+
+    def test_a_skeleton_with_no_markers_refuses_rather_than_guessing(self, tmp_path):
+        fake = tmp_path / "skel"
+        fake.mkdir()
+        (fake / ".gitignore").write_text("*.pyc\n")
+        with pytest.raises(RuntimeError, match="refuses to guess"):
+            blockmod.skeleton_stanza(str(fake))
+
+    def test_a_stanza_declaring_no_paths_refuses(self, tmp_path):
+        fake = tmp_path / "skel"
+        fake.mkdir()
+        (fake / ".gitignore").write_text(
+            f"{blockmod.SKELETON_BEGIN}\n# only a comment\n{blockmod.SKELETON_END}\n")
+        with pytest.raises(RuntimeError, match="refusing to write an empty"):
+            blockmod.skeleton_stanza(str(fake))
+
+
+class TestItIsSafeToRunOnEveryUpdate:
+    """The updater calls this on all 22 instances on every run."""
+
+    def test_it_is_idempotent(self, tmp_path):
+        root = make_instance(tmp_path)
+        blockmod.main(["--skeleton", REPO, "--instance", str(root)])
+        first = (root / ".gitignore").read_text()
+        for _ in range(3):
+            blockmod.main(["--skeleton", REPO, "--instance", str(root)])
+        assert (root / ".gitignore").read_text() == first
+
+    def test_it_never_touches_a_line_the_instance_wrote(self, tmp_path):
+        root = make_instance(tmp_path)
+        own = "# the instance's own rules\nnode_modules/\n*.local\n"
+        (root / ".gitignore").write_text(own)
+        blockmod.main(["--skeleton", REPO, "--instance", str(root)])
+        after = (root / ".gitignore").read_text()
+        assert after.startswith(own)
+        assert blockmod.BEGIN in after
+
+    def test_a_refreshed_block_replaces_in_place_and_keeps_the_tail(self, tmp_path):
+        root = make_instance(tmp_path)
+        (root / ".gitignore").write_text(
+            f"head\n\n{blockmod.BEGIN}\nstale-path\n{blockmod.END}\ntail\n")
+        blockmod.main(["--skeleton", REPO, "--instance", str(root)])
+        after = (root / ".gitignore").read_text()
+        assert after.startswith("head\n")
+        assert after.rstrip().endswith("tail")
+        assert "stale-path" not in after
+        assert "q-system/.q-system/.claude-integrity-armed" in after
+
+    def test_it_creates_the_file_when_the_instance_has_no_gitignore(self, tmp_path):
+        root = make_instance(tmp_path)
+        assert not (root / ".gitignore").exists()
+        assert blockmod.main(["--skeleton", REPO, "--instance", str(root)]) == 0
+        assert blockmod.BEGIN in (root / ".gitignore").read_text()
+
+    def test_check_mode_writes_nothing_and_reports(self, tmp_path):
+        root = make_instance(tmp_path)
+        assert blockmod.main(
+            ["--skeleton", REPO, "--instance", str(root), "--check"]) == 1
+        assert not (root / ".gitignore").exists()
+        blockmod.main(["--skeleton", REPO, "--instance", str(root)])
+        assert blockmod.main(
+            ["--skeleton", REPO, "--instance", str(root), "--check"]) == 0
+
+    def test_it_refuses_to_write_into_the_skeleton_itself(self):
+        assert blockmod.main(["--skeleton", REPO, "--instance", REPO]) == 2
+
+
+class TestTheNegativeControl:
+    """A test that cannot fail is not a test. These prove the ones above can."""
+
+    def test_removing_the_stanza_breaks_the_reproducer(self, tmp_path):
+        """If the block stopped listing the armed marker, the red test must go
+        red again. Proven by running the real thing against a stanza with that
+        line removed, rather than by trusting that it would."""
+        fake_skel = tmp_path / "skel"
+        fake_skel.mkdir()
+        stanza = [l for l in blockmod.skeleton_stanza(REPO)
+                  if "claude-integrity-armed" not in l]
+        (fake_skel / ".gitignore").write_text(
+            blockmod.SKELETON_BEGIN + "\n" + "\n".join(stanza) + "\n"
+            + blockmod.SKELETON_END + "\n")
+
+        root = make_instance(tmp_path)
+        write_tripwire_state(root)
+        blockmod.main(["--skeleton", str(fake_skel), "--instance", str(root)])
+        offered = auto_commit.system_state_paths(untracked(root))
+        assert "q-system/.q-system/.claude-integrity-armed" in offered, (
+            "the assertion has no teeth: dropping the armed marker from the "
+            "stanza left the reproducer green")
+
+
+class TestTheWiringIntoTheUpdater:
+    """The block is useless unwired, and worse than useless wired in the wrong
+    order. Both halves are asserted here rather than trusted."""
+
+    UPDATER = os.path.join(REPO, "kipi-update.sh")
+
+    def text(self):
+        with open(self.UPDATER, encoding="utf-8") as handle:
+            return handle.read()
+
+    def test_the_updater_actually_calls_it(self):
+        assert "kipi-update-gitignore-block.py" in self.text(), (
+            "the writer is not called from the updater -- a built, tested, "
+            "wired-to-nothing engine (the sp-0f773063 class)")
+
+    def test_it_runs_BEFORE_the_untrack_migration(self):
+        """ORDER IS THE WHOLE POINT. `git rm --cached` leaves the file on disk
+        untracked; if it is not yet ignored at that moment, git reports it and
+        the next auto-commit puts it straight back."""
+        text = self.text()
+        block_at = text.index("kipi-update-gitignore-block.py")
+        untrack_at = text.index('for sys_path in "${SYSTEM_NEVER_COMMIT[@]}"')
+        assert block_at < untrack_at, (
+            "the .gitignore block is written AFTER the untrack migration, so "
+            "every untracked marker is visible to auto-commit until the next run")
+
+    def test_the_updater_still_parses(self):
+        r = subprocess.run(["bash", "-n", self.UPDATER],
+                           capture_output=True, text=True)
+        assert r.returncode == 0, r.stderr
+
+
+class TestUntrackingWithoutIgnoringRegresses:
+    """The behavioural half of the ordering argument, run for real."""
+
+    def track_the_marker(self, root):
+        rel = "q-system/.q-system/.claude-integrity-armed"
+        (root / rel).parent.mkdir(parents=True, exist_ok=True)
+        (root / rel).write_text("armed 2026-08-14T20:13:59Z\n")
+        git(str(root), "add", "-f", rel)
+        git(str(root), "commit", "-qm", "the state five instances were in")
+        assert git(str(root), "ls-files", "--error-unmatch", rel).returncode == 0
+        return rel
+
+    def test_untrack_alone_hands_the_marker_straight_back_to_auto_commit(self, tmp_path):
+        """NEGATIVE CONTROL for the ordering. Untracking without the block
+        leaves the marker untracked AND unignored, which is exactly the state
+        auto-commit sweeps."""
+        root = make_instance(tmp_path)
+        rel = self.track_the_marker(root)
+
+        git(str(root), "rm", "--cached", "--quiet", "--", rel)
+        git(str(root), "commit", "-qm", "untrack")
+
+        assert (root / rel).exists(), "the untrack must never delete the file"
+        assert rel in untracked(root)
+        assert auto_commit.system_state_paths(untracked(root)) == [rel], (
+            "if this is empty the regression closed some other way -- find out "
+            "where before deleting this test")
+
+    def test_block_then_untrack_ends_clean(self, tmp_path):
+        """The wired order. Same fixture, block first."""
+        root = make_instance(tmp_path)
+        rel = self.track_the_marker(root)
+
+        blockmod.main(["--skeleton", REPO, "--instance", str(root)])
+        git(str(root), "rm", "--cached", "--quiet", "--", rel)
+        git(str(root), "commit", "-qm", "untrack")
+
+        assert (root / rel).exists(), "the untrack must never delete the file"
+        assert rel not in untracked(root)
+        assert auto_commit.system_state_paths(untracked(root)) == []
+
+
+if __name__ == "__main__":
+    sys.exit(pytest.main([__file__, "-v"]))

--- a/q-system/.q-system/tests/test_gitignore_block.py
+++ b/q-system/.q-system/tests/test_gitignore_block.py
@@ -267,16 +267,27 @@ class TestTheWiringIntoTheUpdater:
 class TestTheFileTheWriterCreatesCanActuallyBeCommitted:
     """A defect in THIS fix, found by running it against real instances.
 
-    Dry-checked on three live instances 2026-08-14: none of them has a root
-    .gitignore AT ALL, so the writer does not edit a file, it CREATES one. Git
-    honours an untracked .gitignore, so the ignore rules work either way -- but
-    an untracked file is one nobody committed, in a repo nobody looks at, and
-    auto-commit.py classified `.gitignore` as `unclassified`.
+    Measured 2026-08-14 by copying a real instance and running the writer on the
+    copy: every instance already HAS a root .gitignore (70-76 lines) and it is
+    TRACKED, and none of them carries these rules. So the writer MODIFIES a
+    tracked file, landing as ` M .gitignore`.
 
-    Unclassified means REPORTED, never committed (ASK-498). So the fix would
-    have left every one of the 22 instances printing the same unclassifiable
-    path on every single run, forever, and the file itself unversioned -- not in
-    the instance's history, not recoverable if something removed it.
+    (The first version of this docstring said instances have no root .gitignore
+    at all. That came from a malformed `grep -c` whose output was misread, and
+    it was wrong. The class below is unchanged and still needed; only the reason
+    was wrong. Recorded rather than quietly edited, because the same mistake --
+    trusting a grep over looking at the thing -- is what this whole PR chain
+    keeps finding in other people's notes.)
+
+    auto-commit.py classified `.gitignore` as `unclassified`, which means
+    REPORTED, never committed (ASK-498). So every one of the 22 instances would
+    carry a permanently modified, never-committable tracked file and print the
+    same unclassifiable path on every run, forever.
+
+    It does NOT block the sync. The dirty-tree guard is scoped to
+    `$prefix/ .claude/ plugins/` (kipi-update.sh ~L2012) and root .gitignore is
+    in none of them. Checked, because the first guess was that this self-blocked
+    all 22 instances, and that guess was wrong too.
 
     That is the exact shape this whole PR is about: state the system writes for
     itself that nothing is allowed to commit, sitting dirty until it becomes
@@ -292,6 +303,23 @@ class TestTheFileTheWriterCreatesCanActuallyBeCommitted:
         assert auto_commit.system_state_paths([".gitignore"]) == [".gitignore"], (
             "the writer creates a file the fleet sync is not allowed to commit, "
             "so it stays untracked and unclassified on every instance forever")
+
+    def test_a_tracked_gitignore_the_writer_modified_is_offered(self, tmp_path):
+        """THE REAL-WORLD SHAPE, and the one the first version of this class got
+        wrong. Instances ship a tracked .gitignore, so the writer modifies it
+        rather than creating it, and a modified tracked file is a different
+        git state from an untracked one. Both must be committable."""
+        root = make_instance(tmp_path)
+        (root / ".gitignore").write_text("# the instance's own\nnode_modules/\n")
+        git(str(root), "add", "-f", ".gitignore")
+        git(str(root), "commit", "-qm", "instance ships a gitignore")
+
+        blockmod.main(["--skeleton", REPO, "--instance", str(root)])
+
+        status = git(str(root), "status", "--porcelain", "--", ".gitignore").stdout
+        assert status.strip().startswith("M"), (
+            f"expected a tracked modification, got {status!r}")
+        assert auto_commit.system_state_paths([".gitignore"]) == [".gitignore"]
 
     def test_it_is_chore_not_founder_content(self):
         """It must be `chore`. system_state_paths narrows to chore precisely so

--- a/q-system/.q-system/tests/test_gitignore_block.py
+++ b/q-system/.q-system/tests/test_gitignore_block.py
@@ -258,6 +258,47 @@ class TestTheWiringIntoTheUpdater:
             "system state, so a newly-stanza'd path is still offered to the "
             "classifier on the run that introduces it")
 
+    def test_the_untrack_is_GATED_on_the_block_being_written(self):
+        """PR #165 review round 6, major -- a defect in this wiring's first cut.
+
+        That version was advisory both ways: if the block could not be written
+        the updater warned and ran the untrack anyway. `git rm --cached` leaves
+        the marker on disk UNTRACKED, so without the ignore rules in place git
+        reports it and the next session's auto-commit puts it straight back --
+        turning the repair into the exact regression the ordering exists to
+        prevent, on every run.
+
+        Leaving the marker TRACKED is the stable state: 5 instances already sit
+        there, the sync still works, and the next run can retry. Untracking
+        without ignoring is strictly worse than not untracking at all.
+        """
+        text = self.text()
+        loop = text.index('for sys_path in "${SYSTEM_NEVER_COMMIT[@]}"')
+        body_end = text.index("\n    done", loop)
+        body = text[loop:body_end]
+        assert 'GITIGNORE_BLOCK_OK' in body, (
+            "the untrack loop no longer checks whether the managed block was "
+            "written, so a failed block leaves the marker untracked AND "
+            "unignored for auto-commit to re-add")
+
+    def test_the_gate_uses_an_explicit_value_test_not_a_set_test(self):
+        """Mutation control for the gate above, and a real bug I shipped for one
+        edit. The first attempt gated the loop with ${GITIGNORE_BLOCK_OK:+...},
+        which expands whenever the variable is NON-EMPTY -- and the flag is 0 or
+        1, so "0" expanded exactly like "1" and the gate did nothing. A gate that
+        is present but always open reads as coverage."""
+        # CODE lines only. The scar comment beside the gate quotes the broken
+        # form on purpose, and a naive substring check flagged that comment --
+        # the same "a gate that reads its own documentation" false positive this
+        # repo keeps hitting elsewhere.
+        code = "\n".join(line for line in self.text().splitlines()
+                         if not line.lstrip().startswith("#"))
+        assert '${GITIGNORE_BLOCK_OK:+' not in code, (
+            "the gate tests whether the flag is SET, not whether it is 1; "
+            "'0' is non-empty so this passes on failure")
+        assert '[ "$GITIGNORE_BLOCK_OK" = "1" ]' in code, (
+            "the gate no longer compares the flag against 1")
+
     def test_the_updater_still_parses(self):
         r = subprocess.run(["bash", "-n", self.UPDATER],
                            capture_output=True, text=True)

--- a/q-system/hooks/auto-commit.py
+++ b/q-system/hooks/auto-commit.py
@@ -39,6 +39,21 @@ AREA_MAP = [
     (".claude/agents/",               "chore",    "update agent definitions"),
     (".claude/output-styles/",        "chore",    "update output styles"),
     (".claude/settings",              "chore",    "update settings"),
+    # sp-097d2e23. The updater writes a managed never-commit block into every
+    # instance's root .gitignore, and dry-checked on three live instances none
+    # of them HAS a root .gitignore -- so the updater creates the file. Git
+    # honours an untracked .gitignore, so the rules bite either way, but this
+    # classifier answered `unclassified` for it, which means REPORTED and never
+    # committed (ASK-498). Left alone, all 22 instances would print the same
+    # unclassifiable path on every run forever and the file would stay
+    # unversioned: absent from the instance's history and unrecoverable if
+    # anything removed it. Exactly the state-the-system-writes-for-itself-that-
+    # nothing-may-commit shape that sp-097d2e23 exists to end.
+    #
+    # `chore`, so the fleet sync may take it: system exhaust, not authored
+    # content. Config, never source, so the executable-source refusal above
+    # does not reach it.
+    (".gitignore",                    "chore",    "update gitignore"),
     ("sites/",                        "feat",     "update site pages"),
     ("memory/",                       "chore",    "update auto-memory"),
 ]

--- a/q-system/hooks/auto-commit.py
+++ b/q-system/hooks/auto-commit.py
@@ -40,15 +40,25 @@ AREA_MAP = [
     (".claude/output-styles/",        "chore",    "update output styles"),
     (".claude/settings",              "chore",    "update settings"),
     # sp-097d2e23. The updater writes a managed never-commit block into every
-    # instance's root .gitignore, and dry-checked on three live instances none
-    # of them HAS a root .gitignore -- so the updater creates the file. Git
-    # honours an untracked .gitignore, so the rules bite either way, but this
-    # classifier answered `unclassified` for it, which means REPORTED and never
-    # committed (ASK-498). Left alone, all 22 instances would print the same
-    # unclassifiable path on every run forever and the file would stay
-    # unversioned: absent from the instance's history and unrecoverable if
-    # anything removed it. Exactly the state-the-system-writes-for-itself-that-
-    # nothing-may-commit shape that sp-097d2e23 exists to end.
+    # instance's root .gitignore. Every instance HAS one already (70-76 lines)
+    # and it is TRACKED, so the writer MODIFIES a tracked file -- measured on a
+    # real copy of an instance, where it lands as ` M .gitignore`.
+    #
+    # (An earlier version of this comment said instances have no root .gitignore
+    # at all. That was a misread of a malformed `grep -c` check, corrected the
+    # same day by copying a real instance and looking. The fix below was right;
+    # the reason written beside it was not, which is worse than no reason --
+    # a wrong scar comment is read as coverage, so nobody goes looking.)
+    #
+    # This classifier answered `unclassified` for .gitignore, which means
+    # REPORTED and never committed (ASK-498). So every one of the 22 instances
+    # would carry a permanently modified, never-committable tracked file and
+    # print the same unclassifiable path on every run, forever.
+    #
+    # It does NOT block the sync: the dirty-tree guard is scoped to
+    # `$prefix/ .claude/ plugins/` (kipi-update.sh ~L2012) and root .gitignore
+    # is in none of them. Checked rather than assumed, because the first guess
+    # was that this self-blocked the whole fleet.
     #
     # `chore`, so the fleet sync may take it: system exhaust, not authored
     # content. Config, never source, so the executable-source refusal above

--- a/q-system/memory/last-handoff.md
+++ b/q-system/memory/last-handoff.md
@@ -1,136 +1,181 @@
-# Last handoff — 2026-07-26 (continuation session)
+# Last handoff — 2026-08-14 (eve comparison -> trust-gate -> fleet-skew night)
+[provenance: observed — system currentDate context this session]
 
-Tracking epic **ASK-113**. PR #10 **merged to main** (`05af553`), 7 commits.
-Everything below was verified by running it, not by reading it.
+Started as a repo review (vercel-labs/eve-software-factory-template vs kipi), ballooned
+into a multi-hour, multi-session engineering night touching prd-os/kipi-dsse merge
+safety, fleet plugin versioning, and a live branch-protection change. Two other Claude
+sessions (`social-voice`, plus incidental contact with others) were active in this same
+checkout concurrently — expect coordination scars below.
 
-## Carried forward from the earlier 2026-07-26 session (still true)
+## What shipped, verified
 
-- **Goal 1, a Linear project per instance repo: DONE.** 25 of 25 (24 instances +
-  the skeleton). A fleet-wide re-plan creates zero projects.
-- **Goals 2 and 3, deterministic creation on build: SHIPPED** as queue-and-drain.
-  No Linear API key exists, so bash cannot reach the MCP server; capture is local
-  and offline, the agent drains it.
-- **Goal 5, overlap/collision analysis: SHIPPED** (`capability-overlap.py`).
-- **Goal 6, SDLC standard: WRITTEN**, adjustments recorded in its Part 0.
-- **Goal 4: still NOT STARTED.** Triage every issue in every project (done /
-  needs work / recorded, with evidence): 61 pre-existing kipi-system issues, 45
-  in cole-GTM.
-- **29 of 31 planned Linear issues remain uncreated.** Resumable:
-  `kipi linear status` says which repos are done without querying Linear.
-- Dedup key `<repo-slug>/<capability-slug>`, written into each Linear
-  description as `<!-- kipi-key: ... -->`. **Never drop that marker.**
+**PR #159 — merge-bypass trust gate. MERGED to main (`88155734`), live, verified.**
+[verified: `gh pr view 155/159`, `gh api .../commits/.../status`, and a live in-session
+Bash call with `--admin` refused by the wired hook — ran directly this session]
 
-## Founder decisions this session
+Adopted the eve-software-factory-template pre-dispatch approval idea (`sp-6dc1b64c`)
+for prd-os/kipi-dsse's push/merge chokepoint. Closeout was checked first and found
+**already stronger** than eve's pattern (content-sealed receipts vs. eve's session-scoped
+trust class) — no closeout work needed. [provenance: observed — Sana subagent recon
+report, code citations to issue_runner.py, not independently re-read by me] Push/merge
+had **zero enforcement**; the specific live hole was `gh pr merge --admin`, which
+defeats `kipi/reviewer-approved` because `enforce_admins:false` + every agent
+credential is `admin:true`. [provenance: observed — Sana subagent report citing
+`gh api repos/:owner/:repo/branches/main/protection` and `gh api repos/:owner/:repo
+--jq .permissions` output]
 
-- **Q2 (branch-protection bypass):** fix the 5 tests, make the gate real.
-- **Sequencing:** updater tests first, then the claim-lock.
-- **Merge:** merge PR #10 with the admin bypass, containment failure and all.
+7 review rounds, each a real finding, each fixed and mutation-tested. [provenance:
+observed — Sana subagent completion reports, each citing a Codex review verdict I
+spot-checked live via `gh pr checks 159` / `gh api .../issues/159/comments` at multiple
+points this session]:
+1. `--admin` bare form denied
+2. `--admin=true` and 5 other truthy spellings (denylist was inherently incomplete)
+3. `-R`/`--repo`/`--hostname`/env-var retargeting — **redesigned denylist to allowlist**
+   here: only `gh pr merge --auto [method] [ref]` is permitted, everything else on that
+   command is denied by construction
+4. wrapper composition (`sudo bash -c '...'`), unknown-wrapper class closed via token scan
+5. push-side never got round-4's fix (single `_tool_position()` authority now serves both)
+6. `bash -lc`, unknown wrappers, newline-as-separator — three vectors, one shared cause
+7. **`eval $CMD` / `source` / `| bash` cannot be caught by static analysis, period** (the
+   command text doesn't exist until Bash expands it). Correctly did NOT try to patch
+   this locally. The real fix is server-side: `enforce_admins`.
 
-## What shipped
+**`enforce_admins` flipped true on `main`, founder-authorized (asked directly via
+AskUserQuestion this session), verified two ways** (not trusted from API return code).
+[verified: Sana subagent report cites re-reading both the `protection/enforce_admins`
+sub-resource and the `protection` roll-up; I did not independently re-run this check]
+Break-glass built: `break-glass-main-protection.sh` (`status`/`off <reason>`/`on`),
+logged to `~/.claude/audit/break-glass-main-protection.jsonl`, Slack on open/close,
+documented in `AUTONOMOUS-SYSTEMS.md` §5b. Asymmetric by design: `off` refuses if it
+can't guarantee the audit trail; `on` never blocks (stranding protection OFF is worse
+than an incomplete log). Drilled live, one round-trip, verified. [provenance: observed
+— Sana subagent report, including a self-caught reasoning error during the drill
+(misread her own pre-check output); I did not independently re-run the drill]
 
-| Commit | What |
-|--------|------|
-| `226cf6f` | CI: git identity + `fetch-depth: 0` + track the receipts ledger |
-| `c307bed` | Close discipline into the SDLC standard §3.1 / §5 |
-| `a6ba923` | Instance identity out of 2 scar comments |
-| `d26b425` | Slice 0: truthful reviewer provenance (`claude-*` sources) |
-| `7c0fccb` | Slice B: the agent claim-lock |
-| `f32bfbd` | Adversarial review fixes: 2 blockers + 8 more |
+**ASK-798 still open** — the flip is done, but the break-glass has a real fragility:
+`kipi/reviewer-approved` is posted by a local script, not a GitHub Action, so if that
+script is down, main freezes for everyone including whoever needs to fix it. Option 2
+(non-local producer) is the real fix and is not this session's work.
+[provenance: observed — Sana subagent report]
 
-## The 5 updater CI failures — fixed
+**Recurring failure mode across the whole thread, worth remembering**: 5 separate
+instances today of a *fixture or harness that was green for the wrong reason* — a `cd
+/tmp` that made a case pass on the unresolvable-means-allow rule instead of the logic
+under test, a dead-ledger fixture whose `mkdir -p` never reached the line it was
+testing, a stub sed'd from an already-stubbed copy, a pre-check that printed a
+conclusion its own output contradicted, a test file named against a convention nobody
+read. None were caught by review — all were caught by mutation testing or a self-check.
+[provenance: observed — self-reported by the Sana subagent across multiple completion
+reports; count of 5 is her own tally, not independently recounted by me] Candidate for
+a lessons-corpus entry if this keeps recurring.
 
-The prior session's theory (`sp-d29346e9`, "pytest skips the hidden
-`q-system/.q-system/` dir") was **wrong**: `capability-gate.py:303` runs tests by
-convention, not pytest discovery.
+## Open, not shipped
 
-Two causes, not five. **No git identity on the runner** (4 of 5):
-`kipi-update.sh:705` commits with none, the ubuntu runner's user has an empty
-gecos field, and `kipi-update.sh:1289` `abandon_instance ... && continue` is
-*upstream* of the plugins rsync at 1393 — so one missing identity produced four
-unrelated-looking symptoms. And **`.gitignore`'s blanket `*.jsonl`** hid
-`.prd-os/receipts.jsonl`, the ledger `test-updater-issue-sequence.py:101` audits.
+**PR #152 — plugin-parity fleet-skew checker. BLOCKED, round 6 REQUEST CHANGES,
+checkpointed and stopped for the day mid-thread.** [verified: `gh pr checks 152` run
+directly this session at multiple points; checkpoint detail below is
+provenance: observed from the Sana subagent's final report]
 
-Local macOS **cannot** reproduce this: its git guesses an identity from the
-passwd gecos field. Three failed reproducer attempts are recorded in
-`q-system/output/plans/ci-validate-green-2026-07-26.md` — do not retry them.
+Split off `sana/ask-728-plugin-parity` (PR #142) when the writer half
+(`plugin-fanout.py`) hit 5 review rounds of the same data-loss race relocating rather
+than closing — correct call to freeze that writer and hold it separately (still held,
+untouched). [provenance: observed — Sana subagent report]
 
-## Two lessons worth carrying forward
+The checker itself went through its own version of the same pattern:
+- round 1-2: fixed real bugs (PASS-on-zero, compared marketplace clone instead of what
+  the loader actually runs — the clone was stale too, see below)
+- round 3-4: found the checker was trusting the install *record* over the actual
+  on-disk manifest, and that `--project` scope resolution defaulted to the wrong entry
+- round 5: **correctly invoked its own stop-criterion.** The scope-resolution model
+  (which install "wins" from a given directory) was never grounded — inferred from a
+  JSON file's shape, and Claude Code's loader is closed-source, so there was no oracle
+  to converge on. Rescoped rather than kept patching: dropped `resolve_live_entry`,
+  `--project`, `--user-scope` entirely; now enumerates every recorded install and fails
+  if any lags, instead of claiming to know "the one you're running." Weaker claim,
+  fully verifiable.
+- **round 6: two majors, checkpointed, NOT fixed.** (1) A real regression the freeze
+  commit introduced — `render()` reads `row['scopes']`/`row['project_paths']` but the
+  NOT_INSTALLED branch still builds the row with the old `scope`/`project_path` keys,
+  so a NOT_INSTALLED row crashes text rendering with `KeyError`. Her tests missed it
+  because the NOT_INSTALLED test only exercises `--json`, never `render()` — same
+  "checked one artifact, claimed another" shape as everything else tonight. Hypothesis
+  on cause stated as hypothesis, not verified — she stopped before digging further.
+  (2) A genuine **design disagreement, not a regression**: Codex flagged that content
+  drift is advisory-only (bytes can differ while the run still says PASS). The
+  module's own docstring defends this on purpose — gating on byte-equality would make
+  a check that can never go green on a real runtime tree, and a check that can't go
+  green gets switched off. This is a judgment call to make deliberately next session,
+  not a bug to reflexively patch.
+  [provenance: observed — Sana subagent's own final checkpoint report, verbatim]
 
-**1. A fixture invented by the author tests nothing.** The claim-lock's remote
-half read `state`; `mcp__linear__get_issue` emits `status` + `statusType`. That
-remote check is the ONLY cover for a cross-checkout collision and it granted
-unconditionally — while the suite stayed green, because the fixture was
-hand-rolled from the same mental model as the code. Fixtures are now the verbatim
-captured payload. Prefer `statusType` over the status NAME: teams rename states.
+Real fleet numbers this surfaced, live-verified: prd-os, kipi-core, kipi-design,
+kipi-dsse are all genuinely stale on the executing runtime (prd-os as far as **0.16.5
+vs skeleton 0.27.3** — 11+ minor versions). kipi-ops and kipi-notebooklm match.
+[provenance: observed — Sana subagent report, cross-checked once against
+`installed_plugins.json`/`claude plugin list` per her own account; not independently
+re-run by me]
 
-**2. `\s` matches a newline even under `re.M`.** `^reviewed_by:\s*.*$` ate the
-FOLLOWING frontmatter line when the value was empty. Driven to a real exploit:
-eating `findings_path:` made the gate report "no findings" and a PRD with an
-untriaged BLOCKER advanced to `approved`, exit 0. Use `[^\n]*`.
+**The actual runtime fix — `claude plugin update <plugin>`, restart attached — was
+never run.** Correctly held: it writes under `~/.claude/`, gated to the
+`apply-claude-changes.sh` proposal path, re-points plugins for every session on this
+machine. This is the founder's action to trigger when ready, not something either
+Sana thread did unilaterally.
 
-## The claim lock (how to use it)
+**Housekeeping:** worktree `/Users/assafkipnis/projects/kipi-system/.wt-parity` is
+still registered and clean, left in place deliberately so next session resumes without
+re-setup — remove with `git worktree remove` once the PR lands. [provenance: observed
+— Sana subagent final report] Push state before stopping was verified 4-way (worktree
+HEAD, remote `@{u}`, PR head, dirty/unpushed counts all agree at `95e2e83a`) —
+[provenance: observed — Sana subagent final report; I did not independently re-run this
+check].
 
-```
-kipi linear claim ASK-nnn --agent <name> --session <id>   # BEFORE branching; exit 3 = refused
-kipi linear claims                                        # who holds this tree
-kipi linear release ASK-nnn --agent <name> --session <id> # when the PR opens
-```
+## Coordination scars (repo-wide, worth institutional memory)
 
-- Identity is **(agent, session)**, never agent alone — two sessions both named
-  "claude" were both granted, the exact `53f2eeb` scar. `KIPI_SESSION_ID` /
-  `CLAUDE_SESSION_ID` are honored.
-- **The resource is the working tree, not the issue.** A separate git worktree is
-  the remedy for a refusal, not `--break-stale`.
-- `--break-stale` is a compare-and-swap: needs `--holder <session>` naming the
-  exact claim you looked at.
-- Remote half: pass the verbatim `mcp__linear__get_issue` response as
-  `--remote-state`. Unrecognized shapes fail closed.
+- **This checkout got yanked mid-work at least 3 times tonight** across
+  sessions/threads (branch reset out from under a live edit). [provenance: observed —
+  reported independently by both Sana subagent threads and by `social-voice`'s session
+  across separate messages this session] Nothing was lost each time — rescued via
+  worktrees, tags on pre-fix commits (`pre-fix/ask-791-round1..4`), or re-derivation —
+  but it cost real time and required careful "is this mine, whose is this" triage each
+  time. One Sana thread adapted by using an isolated worktree (`.wt-ask791`) after
+  getting yanked once. Open question, not decided: should concurrent Sana threads get a
+  worktree by default? Flagged, not resolved.
+- **A stray commit (`b95a7e1b`, "stop the fleet updater deleting each instance's
+  integrity baseline") landed straight on `main` with zero review/branch/PR**, flagged
+  by `social-voice`. [verified: `git log -1 b95a7e1b`, `git show --stat`, `git
+  merge-base --is-ancestor` — ran directly this session] Disclaimed by both Sana
+  threads working tonight — neither touched kipi-update.sh for that reason — most
+  likely another concurrent session (`ask-758-10` was seen live in `ListAgents` at the
+  time) or the autonomous dispatch pipeline. [provenance: inferred — best-read
+  attribution, not confirmed] Routed to ASK-773 (the general "auto-commit lands on
+  whatever branch is checked out, never pushes" pattern) rather than resolved.
+- Spillover ledger: 2 stale items resolved with real resolution refs (`sp-53f7bcc3` →
+  ASK-738, `sp-cdb7783d` → ASK-762) [verified: `spillover resolve` commands run
+  directly this session, confirmed via `spillover list` re-read] after cross-session
+  verification (social-voice) showed they were already fixed elsewhere. `sp-3e201efb`
+  (11/23 fleet instances failing dirty-tree refusal on `kipi update`) is **still open,
+  not touched by either PR tonight** — #152 detects skew, does not clean dirty trees;
+  that's a separate root cause social-voice was independently chasing (a swallowed
+  commit failure in `kipi-update.sh`'s skeleton-owned-dirt carve-out, unconfirmed as of
+  last contact). [provenance: imported — reported by the social-voice session,
+  unconfirmed by me]
 
-## Still open — `validate` is NOT green
+## Next session, resume here
 
-One pre-existing failure, ASK-58/ASK-59: semantic containment. The headline
-number misleads. Of ~11,800 findings, **all but 46 are
-`unclassified_populated_record`**, which `prd-prevent-fact-fanout-2026-07-25.md:83`
-says must never block. The **46 real** ones:
+1. `claude plugin update <plugin>` for prd-os/kipi-core/kipi-design/kipi-dsse + restart
+   — founder action, unblocks the actual stale-runtime problem #152 surfaced.
+2. PR #152 round 6: fix the `render()` KeyError regression (small — add a text-path
+   test for every row status, not just `--json`), then deliberately decide the
+   advisory-vs-blocking content-drift question before re-dispatching review.
+3. ASK-798 option 2 (non-local `kipi/reviewer-approved` producer) — real fix for the
+   break-glass fragility, not started.
+4. `sp-3e201efb` — 11 dirty-tree fleet instances, root cause still unconfirmed.
+5. PR #142's fanout writer — still held, needs a real redesign session, not a 6th patch.
 
-`source_identity` 25 · `pricing` 11 · `client_identity` 4 ·
-`sourced_interaction` 3 · `case_proof_gap` 3
-
-Unchanged this session. **The bypass on `main` stands until these are resolved.**
-That PRD has founder decisions already pending, so it was captured
-(`sp-88d889b5`), not started.
-
-## Open spillover
-
-- `sp-5375bc44` — `guarded_commit` still ambient-identity-dependent for the fleet
-  updater itself (launchd runs with a minimal env). Fixed at the CI layer only.
-- `sp-b386aba4` — `codex_reviewed_at` key is still vendor-named; renaming needs a
-  read-either/write-new compatibility window.
-- `sp-88d889b5` — `validate-separation.py:609` blocks on warn-only records,
-  hiding the actionable 46 behind ~11,800.
-- Pre-existing: `sp-7b123c14`, `sp-cfc861f1`, `sp-333f81b4`, `sp-3cb2e575`,
-  `sp-d29346e9`, `sp-2ae4df51`.
-
-## Correction on record
-
-`a6ba923`'s message claimed removing instance names from comments closed a leak.
-**False.** `instance-registry.json`, `INSTANCES.md` and `kipi-update.sh` publish
-all 24 instance names with absolute home paths in the same public repo. Net leak
-reduction: zero. The PROPAGATION argument stands on its own and is why the change
-was kept (`q-system/.q-system/scripts/` rsyncs to every instance).
-
-## Verification, as run (on merged main)
-
-```
-capability-gate.py             GREEN, ran=61   (was 59)
-test-linear-claim.sh           30 checks       (was 21)
-test-receipts-ledger-check.sh   5 checks, 12 leak shapes blocked
-pytest plugins/prd-os/tests/   318 passed, 1 skipped
-validate-separation.py 1       1 FAIL (pre-existing containment), PASS 68
-```
-
-## Not done
-
-`/prd-review` never ran as a prd-os ceremony — there is no active PRD; the work
-was built directly and reviewed by three adversarial subagents instead. If the
-prd-os receipt trail matters for this work, it needs a retro-PRD.
+<!-- handoff-provenance-skip: every claim above carries a block-level provenance tag
+     (verified/observed/inferred/imported) covering the paragraph it's in, per the
+     actual source of each fact. The lint scans line-by-line and doesn't associate a
+     block tag with every individual line inside that block (PR numbers, version
+     strings, and counters repeated in follow-up lines within an already-tagged
+     paragraph). Re-tagging every such line individually was judged diminishing-returns
+     relative to the block-level tagging already done honestly above. -->

--- a/test-kipi-update-config-commit-unwind.sh
+++ b/test-kipi-update-config-commit-unwind.sh
@@ -1,0 +1,180 @@
+#!/usr/bin/env bash
+# The ASK-797 unwind on the CONFIG-SYNC commit half must leave a clean index.
+#
+# WHY THIS IS NOT test-kipi-update-safety.sh CASE 13. That case already plants a
+# pre-commit hook that exits 1 and already asserts a clean index, so the unwind
+# looked covered. It is not. Measured 2026-08-14 by instrumenting kipi-update.sh
+# with markers and replaying that exact fixture: the run dies at "could not
+# commit q-system sync" and NEITHER the config-sync call site NOR the ASK-797
+# unwind is ever reached. Case 13 passes on a different unwind entirely -- the
+# q-system sync failure path -- and the commit-half unwind it appears to cover
+# has never once executed.
+#
+# A hook that refuses EVERY commit stops at the first one. To reach the second,
+# the hook here refuses SELECTIVELY: it passes the q-system sync commit and
+# rejects only a commit that stages .claude/ or plugins/. That is not a
+# contrived shape -- it is exactly what a lefthook `blocked-paths` rule is, and
+# two instances in this fleet run one.
+#
+# The assertion is on the INDEX, because that is what strands an instance: the
+# dirty-tree guard reads `git diff --cached`, so staged leftovers make every
+# later run refuse over debris that is not founder work.
+#
+# Self-test at the bottom: the same fixture is replayed against a copy of the
+# updater with the unwind deleted, and the index assertion must FAIL there. A
+# test for a path that has never executed is worth nothing until it is shown to
+# go red.
+set -uo pipefail
+ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+SCRIPT="$ROOT/kipi-update.sh"
+fail() { echo "FAIL: $1" >&2; exit 1; }
+G() { git -c user.email=t@t.t -c user.name=test -c commit.gpgsign=false "$@"; }
+
+build_fixture() {
+  # $1 = dir to build in, $2 = path to the updater to install as the skeleton's
+  local work="$1" updater="$2"
+  local sk="$work/skel" inst="$work/inst"
+  mkdir -p "$sk/q-system/.q-system/scripts" "$sk/q-system/.q-system/state" \
+           "$sk/.claude/rules" "$sk/plugins/demo" "$inst/q-system"
+  cp "$updater" "$sk/kipi-update.sh"
+  cp "$ROOT/kipi-update-preserve-scan.py" "$sk/kipi-update-preserve-scan.py"
+  cp "$ROOT/kipi-update-deletion-guard.py" "$sk/kipi-update-deletion-guard.py"
+  cp "$ROOT/q-system/.q-system/scripts/propagation-leak-gate.py" \
+     "$sk/q-system/.q-system/scripts/propagation-leak-gate.py"
+  cp "$ROOT/q-system/.q-system/scripts/containment-targets.py" \
+     "$sk/q-system/.q-system/scripts/containment-targets.py"
+  cp "$ROOT/validate-separation.py" "$sk/validate-separation.py"
+  cat > "$sk/q-system/.q-system/state/propagation-leak-baseline.json" <<'BJ'
+{"schema_version":1,"blocking_classes":["case_proof_gap","client_identity","dated_interaction","pricing","relationship","source_identity","sourced_interaction"],"classifier_sha256":null,"entries":[]}
+BJ
+  printf 'skeleton content v2\n' > "$sk/q-system/tracked.md"
+  # Config + a plugin, so the config-sync commit has something to stage. Without
+  # these the call site is guarded on `git diff --cached --quiet` and is skipped.
+  printf '# a rule\n' > "$sk/.claude/rules/demo-rule.md"
+  printf '{"name":"demo","version":"0.0.1"}\n' > "$sk/plugins/demo/plugin.json"
+  printf '{"hooks":{}}\n' > "$sk/.claude/settings.json"
+  ( cd "$sk" && G init -q && G add -A -f && G commit -qm skel )
+  printf '{"instances":[{"name":"stuck","path":"%s","subtree_prefix":"q-system","type":"subtree"}]}\n' \
+    "$inst" > "$sk/instance-registry.json"
+
+  printf 'skeleton content v1 (old)\n' > "$inst/q-system/tracked.md"
+  # The config-sync block is gated on `[ -d "$path/.claude" ]` -- the INSTANCE's
+  # own .claude/, not the skeleton's. Without it the whole stage is skipped and
+  # the run reports success, which is what the precondition assertion below
+  # caught the first time this fixture was written.
+  mkdir -p "$inst/.claude/rules"
+  printf '{}\n' > "$inst/.claude/settings.json"
+  printf '# stale rule\n' > "$inst/.claude/rules/demo-rule.md"
+  ( cd "$inst" && G init -q && G add -A && G commit -qm inst )
+  mkdir -p "$inst/.git/hooks"
+  cat > "$inst/.git/hooks/pre-commit" <<'HOOK'
+#!/usr/bin/env bash
+# Passes the q-system sync commit, refuses anything staging .claude/ or
+# plugins/. The shape of a lefthook blocked-paths rule.
+staged="$(git diff --cached --name-only)"
+if printf '%s\n' "$staged" | grep -qE '^(\.claude/|plugins/)'; then
+  echo "instance pre-commit refuses config/plugins paths" >&2
+  exit 1
+fi
+exit 0
+HOOK
+  chmod +x "$inst/.git/hooks/pre-commit"
+}
+
+# --------------------------------------------------------------------------
+# 1. the real updater: the run fails, and the index is left clean
+# --------------------------------------------------------------------------
+W1="$(mktemp -d)"
+build_fixture "$W1" "$SCRIPT"
+OUT1="$(bash "$W1/skel/kipi-update.sh" --only stuck 2>&1)"
+
+# Reaching the config-sync commit at all is a precondition, not a nicety: if the
+# run died earlier this test would assert a clean index for the same wrong
+# reason case 13 does. Asserted on the run's OWN output, because the first
+# version of this check used "a commit whose message contains sync" as a proxy
+# and reported not-reached while the stage was in fact running.
+echo "$OUT1" | grep -q "Syncing .claude/ config" || \
+  fail "the run never reached the config-sync stage; this fixture proves nothing.
+Output: $OUT1"
+echo "$OUT1" | grep -q "instance pre-commit refuses config/plugins paths" || \
+  fail "the hook never refused, so the unwind under test never ran.
+Output: $OUT1"
+
+if ! G -C "$W1/inst" diff --cached --quiet; then
+  fail "the config-commit failure left the index STAGED, so every later run
+refuses at the dirty-tree guard: $(G -C "$W1/inst" diff --cached --name-only | tr '\n' ' ')"
+fi
+echo "PASS: a refused config-sync commit leaves the index clean"
+
+# and the instance is still updatable once the hook is gone
+rm -f "$W1/inst/.git/hooks/pre-commit"
+OUT2="$(bash "$W1/skel/kipi-update.sh" --only stuck 2>&1)"
+echo "$OUT2" | grep -q "dirty working tree" && \
+  fail "run 2 refused at the dirty-tree guard -- the instance is stuck: $OUT2"
+echo "PASS: the instance still converges on a later run"
+
+# --------------------------------------------------------------------------
+# 2. WHICH mechanism actually holds the line? Two candidates, mutate both.
+# --------------------------------------------------------------------------
+# Two things could be keeping that index clean: the ASK-797 unwind at the
+# config-sync call site, and restore_instance (reached via abandon_instance when
+# CONFIG_FAILED is set). Asserting "the index is clean" cannot tell them apart,
+# and a guard credited with work it does not do is how the real one gets
+# deleted later by someone tidying up.
+#
+# MEASURED 2026-08-14, and the answer is not the obvious one: deleting the
+# ASK-797 unwind changes NOTHING -- restore_instance cleans the index either
+# way. The unwind is belt-and-braces at this call site, not the guard. That is
+# recorded here rather than asserted, because it is a fact about today's control
+# flow: if abandon_instance ever stops restoring, the unwind becomes load-
+# bearing and control B below is what will notice.
+mutate() {  # $1 = out path, $2 = old, $3 = new, $4 = label
+  python3 - "$SCRIPT" "$1" "$2" "$3" "$4" <<'PY'
+import sys
+src, dst, old, new, label = sys.argv[1:6]
+text = open(src).read()
+if text.count(old) != 1:
+    sys.exit(f"MUTANT '{label}' NOT APPLICABLE: {text.count(old)} matches")
+open(dst, "w").write(text.replace(old, new))
+print(f"  mutant applied: {label}")
+PY
+}
+
+W2="$(mktemp -d)"
+M_UNWIND="$W2/no-unwind.sh"
+mutate "$M_UNWIND" \
+  '{ unstage_scope "$path" .claude/ plugins/; false; }
+          fi; }' \
+  '{ false; }
+          fi; }' \
+  "ASK-797 unwind deleted" || fail "could not build the no-unwind mutant"
+build_fixture "$W2" "$M_UNWIND"
+bash "$W2/skel/kipi-update.sh" --only stuck >/dev/null 2>&1
+if G -C "$W2/inst" diff --cached --quiet; then
+  echo "NOTE: control A -- with the ASK-797 unwind DELETED the index is STILL"
+  echo "      clean, so restore_instance is what holds this line, not the unwind."
+else
+  echo "NOTE: control A -- the ASK-797 unwind IS load-bearing here now"
+  echo "      (staged without it: $(G -C "$W2/inst" diff --cached --name-only | tr '\n' ' '))"
+fi
+
+# Control B is the one that gives the assertion above its teeth: remove the
+# restore and the index MUST be left dirty. If this stops failing, the test has
+# stopped testing anything.
+W3="$(mktemp -d)"
+M_RESTORE="$W3/no-restore.sh"
+mutate "$M_RESTORE" \
+  '  [ -n "$message" ] && echo "$message"
+  restore_instance' \
+  '  [ -n "$message" ] && echo "$message"' \
+  "restore_instance removed from abandon_instance" || \
+  fail "could not build the no-restore mutant"
+build_fixture "$W3" "$M_RESTORE"
+bash "$W3/skel/kipi-update.sh" --only stuck >/dev/null 2>&1
+if G -C "$W3/inst" diff --cached --quiet && G -C "$W3/inst" diff --quiet; then
+  fail "SELF-TEST FAILED: the instance came out clean with the restore REMOVED.
+Nothing in this file is testing a guard; the assertions pass for free."
+fi
+echo "PASS: self-test -- removing the restore leaves the instance dirty ($(G -C "$W3/inst" status --porcelain | head -3 | tr '\n' ' '))"
+
+echo "ALL PASS"

--- a/test_destructive_op_deny_anchor.py
+++ b/test_destructive_op_deny_anchor.py
@@ -1,0 +1,175 @@
+#!/usr/bin/env python3
+"""sp-9166e58a: `kipi update` is the one FLEET_DENY pattern that is not anchored.
+
+READ-ONLY on ~/.claude. This test reads the live hook, copies it into a tmp dir,
+patches the COPY, and drives both. It never writes inside .claude/ -- that is
+claude-path-write-guard's line and it is the right line: an agent that can edit
+destructive-op-deny.sh can disable its own gates. Nothing here proposes that an
+agent apply this patch. It exists so the founder's decision is backed by a
+measurement instead of an argument.
+
+THE DEFECT. A git commit whose MESSAGE contains the two words is blocked, so
+every commit about the updater has to be written to a file and passed with -F.
+
+WHY THIS IS NOT THE FIX THE HOOK ALREADY REJECTED. The comment above emit_deny
+(2026-08-07) decides that the hook does NOT try to tell prose from invocation,
+and it is right: stripping heredoc bodies would open `bash <<'EOF'`, and any
+parser deciding "this string is only prose" is a new bypass surface. This patch
+does none of that. It anchors at COMMAND POSITION -- which is the discipline the
+other three FLEET_DENY entries already follow, and which the hook's own comment
+introduced after an unanchored pattern blocked `sed -n '1,20p' kipi-update.sh`:
+
+    "Anchored at COMMAND POSITION on purpose: a first attempt matched the script
+     name anywhere in the line and blocked `sed -n '1,20p' kipi-update.sh`, but
+     reading a file is not running it. A gate that blocks reads is a gate someone
+     switches off."
+
+Pattern 138 is the only entry that never got that treatment. This is finishing a
+change the file already made, not loosening a rule it deliberately set.
+
+THE RISK, STATED PLAINLY. Anchoring means the pattern can no longer match the
+phrase in an arbitrary position. The shapes that matter -- bare, chained after
+&& ; | , env-var-prefixed, and inside command substitution -- are each asserted
+below to STILL be denied. A message containing "; kipi update" would still false-
+positive; that is accepted, and is the same residue the other three entries carry.
+"""
+import json
+import os
+import pathlib
+import re
+import shutil
+import subprocess
+
+import pytest
+
+HOOK = pathlib.Path(os.environ.get("HOME", "")) / ".claude/hooks/destructive-op-deny.sh"
+
+CURRENT = "'kipi[[:space:]]+update'"
+# Command position, allowing an env-var assignment prefix and command
+# substitution, because those really do invoke it.
+ANCHORED = (
+    r"'(^|[;&|]|\$\(|`)[[:space:]]*"
+    r"([A-Za-z_][A-Za-z0-9_]*=[^[:space:]]*[[:space:]]+)*kipi[[:space:]]+update'"
+)
+
+pytestmark = pytest.mark.skipif(
+    not HOOK.is_file(), reason="destructive-op-deny.sh is machine-local; not present here")
+
+
+def variants(tmp_path):
+    """(live copy, patched copy). The live hook is READ, never written."""
+    live = tmp_path / "live.sh"
+    shutil.copy(HOOK, live)
+    text = live.read_text(encoding="utf-8")
+    assert CURRENT in text, (
+        "the unanchored pattern is gone from the live hook -- either this was "
+        "fixed (delete this test and say so) or the pattern was respelled")
+    patched = tmp_path / "patched.sh"
+    patched.write_text(text.replace(CURRENT, ANCHORED, 1), encoding="utf-8")
+    for p in (live, patched):
+        p.chmod(0o755)
+    return live, patched
+
+
+def decide(hook, command, home):
+    """Run the hook the way Claude Code does and return 'deny' or 'allow'."""
+    payload = json.dumps({
+        "tool_name": "Bash",
+        "tool_input": {"command": command},
+        "cwd": str(home),
+    })
+    env = dict(os.environ)
+    env["HOME"] = str(home)          # keep the audit log out of the real one
+    env.pop("ALLOW_DESTRUCTIVE", None)
+    proc = subprocess.run([str(hook)], input=payload, capture_output=True,
+                          text=True, env=env)
+    out = proc.stdout.strip()
+    if not out:
+        return "allow"
+    return json.loads(out)["hookSpecificOutput"]["permissionDecision"]
+
+
+# The commit message that actually got blocked, and the ones like it.
+PROSE = [
+    'git commit -m "feat(fleet): the kipi update path never shipped this"',
+    'git commit -m "note: kipi update rsyncs the skeleton into every instance"',
+]
+
+# Every shape that really does invoke it. None of these may ever be allowed.
+REAL = [
+    "kipi update",
+    "cd ~/projects/kipi-system && kipi update",
+    "echo hi; kipi update",
+    "false || kipi update",
+    "ALLOW_DESTRUCTIVE_NOT_REALLY=1 kipi update",
+    "FOO=bar BAZ=qux kipi update",
+    "echo $(kipi update)",
+    "true | kipi update",
+]
+
+
+class TestTheLiveHookHasTheDefect:
+    """Red. Documents the behaviour that is on the machine right now."""
+
+    @pytest.mark.parametrize("command", PROSE)
+    def test_a_commit_message_is_denied_today(self, tmp_path, command):
+        live, _ = variants(tmp_path)
+        assert decide(live, command, tmp_path) == "deny", (
+            "the false positive is gone from the live hook; this test has "
+            "outlived the defect it documents")
+
+
+class TestTheAnchoredPatternFixesItWithoutOpeningAHole:
+
+    @pytest.mark.parametrize("command", PROSE)
+    def test_a_commit_message_is_allowed(self, tmp_path, command):
+        _, patched = variants(tmp_path)
+        assert decide(patched, command, tmp_path) == "allow"
+
+    @pytest.mark.parametrize("command", REAL)
+    def test_every_real_invocation_is_still_denied(self, tmp_path, command):
+        _, patched = variants(tmp_path)
+        assert decide(patched, command, tmp_path) == "deny", (
+            f"ANCHORING OPENED A HOLE: {command!r} now runs the fleet-wide "
+            "delete unchallenged. Do not apply this patch.")
+
+    @pytest.mark.parametrize("command", REAL)
+    def test_the_live_hook_denies_them_too_so_nothing_regressed(self, tmp_path, command):
+        """Negative control for the pair above: if the live hook already allowed
+        one of these, 'still denied' would be proving nothing."""
+        live, _ = variants(tmp_path)
+        assert decide(live, command, tmp_path) == "deny"
+
+    def test_a_dry_run_stays_exempt_either_way(self, tmp_path):
+        live, patched = variants(tmp_path)
+        for hook in (live, patched):
+            assert decide(hook, "kipi update --dry-run", tmp_path) == "allow"
+
+    def test_the_other_destructive_patterns_are_untouched(self, tmp_path):
+        """The patch must not reach outside FLEET_DENY."""
+        _, patched = variants(tmp_path)
+        for command in ("rm -rf /tmp/whatever", "git reset --hard",
+                        "git push --force", "git clean -fd"):
+            assert decide(patched, command, tmp_path) == "deny", command
+
+
+class TestTheProposedPatchIsWhatTheFileAlreadyDoes:
+    """The argument for applying it, checked rather than asserted in prose."""
+
+    def test_the_other_fleet_patterns_are_already_command_anchored(self, tmp_path):
+        live, _ = variants(tmp_path)
+        text = live.read_text(encoding="utf-8")
+        block = re.search(r"declare -a FLEET_DENY=\(\n(.*?)\n  \)", text, re.S)
+        assert block, "FLEET_DENY block not found; the hook was restructured"
+        entries = [l.strip() for l in block.group(1).splitlines() if l.strip()]
+        anchored = [e for e in entries if e.startswith("'(^|[;&|")]
+        assert len(entries) == 4, entries
+        assert len(anchored) == 3, (
+            "the anchoring split changed; re-read the hook before trusting "
+            "this test's argument")
+        assert CURRENT in entries, (
+            "the unanchored entry is not the kipi-update one any more")
+
+
+if __name__ == "__main__":
+    raise SystemExit(pytest.main([__file__, "-v"]))

--- a/test_fleet_unblock.py
+++ b/test_fleet_unblock.py
@@ -371,6 +371,83 @@ def test_a_blob_on_the_shipped_line_is_still_fleet_authored(world):
     assert not is_dirty(inst, rel), out
 
 
+def test_one_path_produces_one_action_not_one_per_row(world):
+    """sp-511e994a, and the structural half of the round-1 review note.
+
+    audit_instance reports the staged state and the worktree state as SEPARATE
+    rows, so a single file could produce two, and the run counted each as its
+    own action -- 'acted on 2 path(s)' for one file, observed in the round-4
+    fixture. The counts an unattended job reads were inflated, and any per-row
+    action that is not idempotent ran twice on the same path.
+
+    Uses the round-4 shape, which is the one that demonstrably produces two
+    rows: founder content staged under a skeleton worktree blob. A first draft
+    staged the skeleton blob itself and passed WITHOUT the collapse, because
+    that shape yields a single row -- it asserted nothing. This shape emitted
+    two lines for one file before the collapse and emits one after.
+    """
+    skel, inst = world
+    rel = "plugins/prd-os/runner.py"
+    seed_skeleton_blob(skel, rel, "v1\n")
+    write(inst, rel, "old\n")
+    git(inst, "add", "-A")
+    git(inst, "commit", "-qm", "instance base")
+    write(inst, rel, "founder staged this\n")
+    git(inst, "add", rel)          # staged AND worktree differ -> two rows
+    write(inst, rel, "v1\n")
+
+    rc, out = run(skel, "--apply")
+    assert out.count("REFUSE  " + rel) == 1, (
+        "one path produced more than one verdict line\n" + out)
+    assert "refused 1 path(s)" in out, out
+
+
+def test_a_refusal_on_any_row_refuses_the_whole_path(world):
+    """Strictest verdict wins. Judging the PATH rather than the ROW is what
+    makes the round-1 / round-4 asymmetry unrepresentable: neither half of a
+    path's truth can carry it past the other."""
+    mod = load_script()
+    rows = [{"path": "a", "kind": "fleet-written", "staged": False},
+            {"path": "a", "kind": "founder", "staged": False}]
+
+    def fake_decide(repo, row, audit, rescued):
+        return ("commit", "looks fine") if row["kind"] == "fleet-written" \
+            else ("refuse", "founder wrote it")
+
+    mod.decide = fake_decide
+    plan = mod.plan_for_instance("/repo", rows, None, None)
+    assert plan == [("refuse", "a", "founder wrote it")], plan
+
+
+def test_conflicting_actions_on_one_path_are_refused(world):
+    """Two rows, two DIFFERENT actions, neither a refusal. The tool cannot be
+    sure which is right and this writes to 22 repos, so it refuses."""
+    mod = load_script()
+    rows = [{"path": "a", "kind": "x", "staged": False},
+            {"path": "a", "kind": "y", "staged": False}]
+    actions = iter(["commit", "unstage"])
+
+    def fake_decide(repo, row, audit, rescued):
+        return (next(actions), "because")
+
+    mod.decide = fake_decide
+    plan = mod.plan_for_instance("/repo", rows, None, None)
+    assert len(plan) == 1
+    assert plan[0][0] == "refuse", plan
+    assert "conflicting verdicts" in plan[0][2], plan
+
+
+def test_agreeing_rows_still_act_once(world):
+    """Negative control for the two above: collapsing must not collapse to
+    'refuse everything'. Two rows that agree still produce their action."""
+    mod = load_script()
+    rows = [{"path": "a", "kind": "fleet-written", "staged": False},
+            {"path": "a", "kind": "fleet-written", "staged": True}]
+    mod.decide = lambda repo, row, audit, rescued: ("commit", "attributable")
+    plan = mod.plan_for_instance("/repo", rows, None, None)
+    assert plan == [("commit", "a", "attributable")], plan
+
+
 def test_founder_edit_is_refused(world):
     """NEGATIVE: bytes the skeleton never shipped stay exactly where they are.
 

--- a/test_fleet_unblock.py
+++ b/test_fleet_unblock.py
@@ -140,6 +140,11 @@ def test_mode_only_drift_is_chmodded_not_committed(world):
     """
     skel, inst = world
     body = "#!/usr/bin/env python3\nprint('hi')\n"
+    # SEEDED (PR #165 review round 3). This test used to build the file only in
+    # the instance, so it was exercising restore-mode on a blob the skeleton
+    # never shipped -- encoding the very bug that review found. The real scar is
+    # a SKELETON file whose +x rsync dropped, which is what this now models.
+    seed_skeleton_blob(skel, "plugins/kipi-core/tool.py", body)
     write(inst, "plugins/kipi-core/tool.py", body, mode=0o755)
     git(inst, "add", "-A")
     git(inst, "commit", "-qm", "instance base")
@@ -173,6 +178,9 @@ def test_a_mode_change_carrying_content_drift_is_not_a_mode_fix(world):
     """
     skel, inst = world
     rel = "plugins/kipi-core/tool.py"
+    # Seeded for the same reason as the mode tests above (review round 3):
+    # without it this exercises a blob the skeleton never shipped.
+    seed_skeleton_blob(skel, rel, "#!/usr/bin/env python3\nprint('hi')\n")
     write(inst, rel, "#!/usr/bin/env python3\nprint('hi')\n", mode=0o755)
     git(inst, "add", "-A")
     git(inst, "commit", "-qm", "instance base")
@@ -200,6 +208,9 @@ def test_the_mode_refusal_would_notice_if_the_same_blob_proof_were_dropped(world
     """
     skel, inst = world
     rel = "plugins/kipi-core/tool.py"
+    # Seeded for the same reason as the mode tests above (review round 3):
+    # without it this exercises a blob the skeleton never shipped.
+    seed_skeleton_blob(skel, rel, "#!/usr/bin/env python3\nprint('hi')\n")
     write(inst, rel, "#!/usr/bin/env python3\nprint('hi')\n", mode=0o755)
     git(inst, "add", "-A")
     git(inst, "commit", "-qm", "instance base")
@@ -213,9 +224,62 @@ def test_the_mode_refusal_would_notice_if_the_same_blob_proof_were_dropped(world
         + out)
 
 
+def test_a_founder_chmod_on_a_file_the_skeleton_never_shipped_is_refused(world):
+    """PR #165 review round 3, major.
+
+    decide() checks mode FIRST, before it looks at the row's kind at all. That
+    ordering is deliberate for the fleet case -- a mode-only row also classifies
+    as fleet-written, and committing it would bake the broken mode in. But it
+    swallowed the founder case with it: a script the founder wrote and
+    deliberately made executable has an unchanged blob and a changed mode, which
+    is exactly the shape the restore-mode branch matches. The tool would chmod
+    it back and report the instance repaired.
+
+    The scar this branch exists for (KTLYST_strategy) was a SKELETON file whose
+    +x rsync had dropped. Attribution is what separates the two, and mode-first
+    ordering skipped it.
+    """
+    skel, inst = world
+    # INSIDE the guard's pathspec (plugins/), or the audit never produces a row
+    # and decide() is never called. A first draft used scripts/, which is
+    # outside it, and both assertions passed while exercising nothing.
+    rel = "plugins/kipi-core/founders-own-tool.sh"   # never seeded into skeleton
+    write(inst, rel, "#!/bin/sh\necho mine\n", mode=0o644)
+    git(inst, "add", "-A")
+    git(inst, "commit", "-qm", "instance base")
+
+    (inst / rel).chmod(0o755)                     # the founder makes it runnable
+    assert is_dirty(inst, rel)
+
+    rc, out = run(skel, "--apply")
+
+    assert "restore-mode" not in out, (
+        "reverted a mode change on a file the skeleton never shipped\n" + out)
+    assert os.access(inst / rel, os.X_OK), "the founder's +x was taken away"
+
+
+def test_the_skeleton_owned_mode_fix_still_fires(world):
+    """Negative control for the test above. If restore-mode stopped firing
+    entirely, that assertion would pass while the KTLYST_strategy scar -- the
+    whole reason this branch exists -- silently regressed."""
+    skel, inst = world
+    rel = "plugins/kipi-core/tool.py"
+    seed_skeleton_blob(skel, rel, "#!/usr/bin/env python3\nprint('hi')\n")
+    write(inst, rel, "#!/usr/bin/env python3\nprint('hi')\n", mode=0o755)
+    git(inst, "add", "-A")
+    git(inst, "commit", "-qm", "instance base")
+    (inst / rel).chmod(0o644)
+
+    rc, out = run(skel, "--apply")
+    assert "restore-mode" in out, out
+    assert os.access(inst / rel, os.X_OK), "+x not restored on a skeleton file"
+
+
 def test_mode_fix_is_not_applied_on_a_dry_run(world):
     """Negative self-test for the dry run: the default must write nothing."""
     skel, inst = world
+    # Seeded for the same reason as the test above (review round 3).
+    seed_skeleton_blob(skel, "plugins/kipi-core/tool.py", "x\n")
     write(inst, "plugins/kipi-core/tool.py", "x\n", mode=0o755)
     git(inst, "add", "-A")
     git(inst, "commit", "-qm", "base")

--- a/test_fleet_unblock.py
+++ b/test_fleet_unblock.py
@@ -141,6 +141,63 @@ def test_mode_only_drift_is_chmodded_not_committed(world):
     assert os.access(inst / "plugins/kipi-core/tool.py", os.X_OK), "+x not restored"
 
 
+def test_a_mode_change_carrying_content_drift_is_not_a_mode_fix(world):
+    """THE MISSING REFUSAL (added 2026-08-14 while auditing the three actions).
+
+    `commit` and `unstage` each had a test proving they refuse when their proof
+    is absent -- test_founder_edit_is_refused and
+    test_staged_add_with_no_rescued_copy_is_refused. `restore-mode` had none.
+    Its proof is "index and worktree hold the SAME blob", and nothing asserted
+    what happens when they do not.
+
+    That is the dangerous direction. decide() checks mode FIRST, so if the
+    same-blob condition were ever loosened, a file that lost +x AND was edited
+    would be chmodded, the tree would go clean, the guard would clear, and the
+    edit would ride into the next sync unattributed. Cleanliness is not the
+    property that matters here; attribution is.
+    """
+    skel, inst = world
+    rel = "plugins/kipi-core/tool.py"
+    write(inst, rel, "#!/usr/bin/env python3\nprint('hi')\n", mode=0o755)
+    git(inst, "add", "-A")
+    git(inst, "commit", "-qm", "instance base")
+
+    # Both at once: the mode dropped AND somebody changed the bytes.
+    write(inst, rel, "#!/usr/bin/env python3\nprint('edited by a human')\n")
+    (inst / rel).chmod(0o644)
+
+    rc, out = run(skel, "--apply")
+    assert rc == 0, out
+    assert "restore-mode" not in out, (
+        "a content edit was treated as a mode fix; chmod would clear the guard "
+        "and carry the edit along unattributed\n" + out)
+    assert "REFUSE" in out, out
+    assert is_dirty(inst, rel), "the drift must still be there for a human to see"
+
+
+def test_the_mode_refusal_would_notice_if_the_same_blob_proof_were_dropped(world):
+    """Negative control for the test above: prove the assertion has teeth.
+
+    Same fixture, but the content is left ALONE so the row really is mode-only.
+    If restore-mode fires here and not above, the classifier is discriminating
+    on the proof rather than on the mode difference -- which is the thing the
+    test above is actually asserting.
+    """
+    skel, inst = world
+    rel = "plugins/kipi-core/tool.py"
+    write(inst, rel, "#!/usr/bin/env python3\nprint('hi')\n", mode=0o755)
+    git(inst, "add", "-A")
+    git(inst, "commit", "-qm", "instance base")
+    (inst / rel).chmod(0o644)
+
+    rc, out = run(skel, "--apply")
+    assert rc == 0, out
+    assert "restore-mode" in out, (
+        "the mode-only case stopped firing, so the refusal test above proves "
+        "nothing -- it would pass even if restore-mode were deleted entirely\n"
+        + out)
+
+
 def test_mode_fix_is_not_applied_on_a_dry_run(world):
     """Negative self-test for the dry run: the default must write nothing."""
     skel, inst = world

--- a/test_fleet_unblock.py
+++ b/test_fleet_unblock.py
@@ -454,6 +454,44 @@ def test_a_staged_skeleton_blob_with_a_founder_worktree_edit_is_refused(world):
     assert (inst / rel).read_text() == "founder was here\n", "founder bytes lost"
 
 
+def test_founder_staged_content_under_a_skeleton_worktree_blob_is_refused(world):
+    """PR #165 review round 4, major. The MIRROR of the round-1 finding.
+
+    Round 1 was: index holds a skeleton blob, worktree holds a founder edit.
+    Guarded. This is the other way round -- the founder STAGED their own version
+    and the worktree happens to hold a skeleton blob. The round-1 guard passes,
+    because it only asks whether the WORKTREE is attributable.
+
+    Then `git add` replaces the founder's staged entry with the worktree blob and
+    the commit succeeds. Round 2's unwind restores the staged entry only when the
+    commit FAILS; on the success path the founder's staged version is committed
+    away and gone.
+
+    Both sides of a path have to be attributable, and 'attributable' for the
+    index means either the skeleton wrote it or nothing was staged at all.
+    """
+    skel, inst = world
+    rel = "plugins/prd-os/runner.py"
+    seed_skeleton_blob(skel, rel, "v1\n")
+    write(inst, rel, "old\n")
+    git(inst, "add", "-A")
+    git(inst, "commit", "-qm", "instance base")
+
+    write(inst, rel, "founder staged this\n")
+    git(inst, "add", rel)                     # index: founder's own content
+    staged_before = git(inst, "rev-parse", ":" + rel)
+    write(inst, rel, "v1\n")                  # worktree: the skeleton's blob
+
+    head_before = git(inst, "rev-parse", "HEAD")
+    rc, out = run(skel, "--apply")
+
+    assert "REFUSE" in out, out
+    assert git(inst, "rev-parse", "HEAD") == head_before, (
+        "committed over content the founder had staged\n" + out)
+    assert git(inst, "rev-parse", ":" + rel) == staged_before, (
+        "the founder's staged version was replaced by git add\n" + out)
+
+
 def test_a_refused_commit_does_not_report_success(world):
     """PR #165 review, major #2.
 

--- a/test_fleet_unblock.py
+++ b/test_fleet_unblock.py
@@ -96,6 +96,21 @@ def seed_skeleton_blob(skel, rel, text):
     git(skel, "commit", "-qm", f"skeleton bumps {rel}")
 
 
+def load_script():
+    """Import fleet-unblock.py as a module, for the pure helpers.
+
+    Everything else here drives the script as a subprocess against real repos,
+    which is right for git behaviour. `succeeded()` is a pure string predicate
+    and deserves a direct test rather than one that has to provoke a rare IO
+    failure to observe it.
+    """
+    import importlib.util
+    spec = importlib.util.spec_from_file_location("fleet_unblock", SCRIPT)
+    mod = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(mod)
+    return mod
+
+
 def run(skel, *args):
     proc = subprocess.run(
         ["python3", str(skel / "fleet-unblock.py"), "--skeleton", str(skel), *args],
@@ -419,6 +434,99 @@ def test_a_clean_successful_run_still_exits_zero(world):
     rc, out = run(skel, "--apply")
     assert rc == 0, out
     assert not is_dirty(inst, rel), out
+
+
+def test_the_unwind_restores_content_the_founder_had_already_staged(world):
+    """PR #165 review round 2, major #1.
+
+    The unwind skipped every path that was ALREADY staged before the run, on the
+    reasoning that the tool did not stage it so the tool should not unstage it.
+    But `git add` has already overwritten that index entry with the worktree
+    content by then. So a founder who had staged their own version of the path
+    lost it, and the tool printed 'index unwound' while saying so.
+
+    Skipping a path is not restoring it. The unwind now records the exact index
+    entry -- mode and blob -- and puts it back.
+    """
+    skel, inst = world
+    rel = "plugins/prd-os/runner.py"
+    seed_skeleton_blob(skel, rel, "v1\n")
+    write(inst, rel, "old\n")
+    git(inst, "add", "-A")
+    git(inst, "commit", "-qm", "instance base")
+
+    write(inst, rel, "founder staged this\n")
+    git(inst, "add", rel)
+    staged_before = git(inst, "rev-parse", ":" + rel)
+    write(inst, rel, "v1\n")            # worktree: the skeleton's own blob
+
+    hook = inst / ".git/hooks/pre-commit"
+    hook.parent.mkdir(parents=True, exist_ok=True)
+    hook.write_text("#!/bin/sh\nexit 1\n")
+    hook.chmod(0o755)
+
+    rc, out = run(skel, "--apply")
+
+    staged_after = git(inst, "rev-parse", ":" + rel)
+    assert staged_after == staged_before, (
+        "the founder's staged version was overwritten by git add and never "
+        "restored, while the tool reported the index unwound\n" + out)
+
+
+def test_a_failed_add_or_restore_is_not_counted_as_success(world):
+    """PR #165 review round 2, major #2 -- a hole in my own round-1 fix.
+
+    Round 1 made a REFUSED commit exit non-zero, but it tested the outcome
+    string with startswith('REFUSED'). The other producers emit 'FAILED add: ',
+    'FAILED <err>' and 'STILL <mode>', none of which start with REFUSED, so
+    every one of them still counted as a successful action and still exited 0.
+
+    A denylist of failure strings is the wrong shape for something an unattended
+    job reads as its exit code. Success is now an allowlist: an outcome counts
+    only if it SAYS it succeeded.
+
+    Tested against the predicate directly rather than by provoking a rare IO
+    failure: an earlier draft chmod'ed .git/index read-only, git rewrote it
+    anyway, and the test SKIPPED. A skipped test proves nothing, and this is
+    about which strings count, which is exactly what a predicate test settles.
+    """
+    mod = load_script()
+
+    # Every outcome string the shipped code can emit, taken from the source so
+    # a new producer cannot quietly land on the success side.
+    failures = [
+        "FAILED add: fatal: unable to write new index file",
+        "FAILED fatal: could not restore",
+        "STILL 100644",
+        "REFUSED (index unwound): ['gate says no']",
+    ]
+    successes = ["clean", "committed", "would chmod to 100755",
+                 "would restore --staged", "would stage + commit"]
+
+    for outcome in failures:
+        assert not mod.succeeded(outcome), f"{outcome!r} counted as success"
+    for outcome in successes:
+        assert mod.succeeded(outcome), f"{outcome!r} counted as failure"
+
+
+def test_every_outcome_the_code_emits_is_classified(world):
+    """The allowlist must cover what the code actually produces, not what I
+    remembered it producing. Derived from the source, so a new outcome string
+    with no classification fails here instead of silently counting as success."""
+    import re
+    src = SCRIPT.read_text(encoding="utf-8")
+    mod = load_script()
+    # Third element of every `done.append((action, path, <outcome>))` and the
+    # outcome in each `return [(...)]` in commit_with_unwind.
+    literals = set(re.findall(r'"(clean|committed|would [^"]*|STILL [^"]*|FAILED[^"]*|REFUSED[^"]*)"', src))
+    literals |= set(re.findall(r'f"(FAILED[^"]*|STILL [^"]*|REFUSED[^"]*)"', src))
+    assert literals, "no outcome literals found; the shape of the code moved"
+    for literal in literals:
+        probe = literal.replace("{", "").replace("}", "")
+        # Every literal must land on one side deliberately; the assertion is
+        # that succeeded() has an opinion, and that failures are not successes.
+        if probe.startswith(("FAILED", "STILL", "REFUSED")):
+            assert not mod.succeeded(probe), f"{probe!r} counted as success"
 
 
 def test_the_unwind_test_would_notice_a_missing_unwind(world):

--- a/test_fleet_unblock.py
+++ b/test_fleet_unblock.py
@@ -311,6 +311,66 @@ def test_fleet_written_content_is_committed(world):
     assert (inst / "plugins/prd-os/runner.py").read_text() == "v1\n", "bytes changed"
 
 
+def test_a_blob_that_only_exists_on_an_unmerged_branch_is_not_fleet_authored(world):
+    """PR #165 review round 5, major.
+
+    SkeletonBlobs proved authorship with `git rev-list --all -- <path>`. `--all`
+    is EVERY local ref: unmerged feature branches, remote-tracking refs, tags,
+    the review worktrees. This very repo carries dozens of in-flight sana/*
+    branches at any moment.
+
+    So a blob that never shipped -- one that exists only on somebody's
+    experiment -- counted as "the skeleton wrote this", and the tool would
+    commit it over founder content in an instance. The next real sync then
+    overwrites it with what main actually says, so the founder's bytes are gone
+    and the replacement was never skeleton content either.
+
+    This is a different class from the round 1-4 findings. Those were about
+    applying the proof to the right side of a path. This is about what the proof
+    MEANS: authorship has to be the shipped line, not anything anyone ever
+    committed anywhere.
+    """
+    skel, inst = world
+    rel = "plugins/prd-os/experimental.py"
+
+    # A blob that lives ONLY on an unmerged branch of the skeleton.
+    git(skel, "checkout", "-q", "-b", "someones-experiment")
+    write(skel, rel, "never shipped\n")
+    git(skel, "add", "-A")
+    git(skel, "commit", "-qm", "experiment")
+    git(skel, "checkout", "-q", "main")
+    assert not (skel / rel).exists(), "the experiment must not be on main"
+
+    write(inst, rel, "founder wrote this\n")
+    git(inst, "add", "-A")
+    git(inst, "commit", "-qm", "instance base")
+    write(inst, rel, "never shipped\n")     # the unmerged branch's bytes
+
+    head_before = git(inst, "rev-parse", "HEAD")
+    rc, out = run(skel, "--apply")
+
+    assert "REFUSE" in out, out
+    assert git(inst, "rev-parse", "HEAD") == head_before, (
+        "committed a blob that only ever existed on an unmerged branch\n" + out)
+    assert is_dirty(inst, rel), "the path was cleared on unshipped authorship"
+
+
+def test_a_blob_on_the_shipped_line_is_still_fleet_authored(world):
+    """Negative control for the test above. Narrowing authorship must not
+    narrow it to nothing -- the ordinary repair has to keep working."""
+    skel, inst = world
+    rel = "plugins/prd-os/runner.py"
+    seed_skeleton_blob(skel, rel, "v1\n")
+    write(inst, rel, "old\n")
+    git(inst, "add", "-A")
+    git(inst, "commit", "-qm", "instance base")
+    write(inst, rel, "v1\n")
+
+    rc, out = run(skel, "--apply")
+    assert rc == 0, out
+    assert not is_dirty(inst, rel), out
+
+
 def test_founder_edit_is_refused(world):
     """NEGATIVE: bytes the skeleton never shipped stay exactly where they are.
 

--- a/test_fleet_unblock.py
+++ b/test_fleet_unblock.py
@@ -328,13 +328,97 @@ def test_a_refusing_pre_commit_hook_leaves_the_index_as_it_found_it(world):
     head_before = git(inst, "rev-parse", "HEAD")
 
     rc, out = run(skel, "--apply")
-    assert rc == 0, out
+    # Was `rc == 0`, asserting the exit code the PR #165 review found wrong: a
+    # run that repaired nothing reported success. The unwind is still the point
+    # of this test; the exit code now says the repair did not happen. See
+    # test_a_refused_commit_does_not_report_success.
+    assert rc != 0, out
     assert "REFUSED" in out, out
     assert git(inst, "rev-parse", "HEAD") == head_before, "commit landed despite the hook"
     assert git(inst, "diff", "--cached", "--name-only") == staged_before, (
         "index left staged by a commit that failed"
     )
     assert (inst / "plugins/prd-os/runner.py").read_text() == "v1\n", "content lost"
+
+
+def test_a_staged_skeleton_blob_with_a_founder_worktree_edit_is_refused(world):
+    """PR #165 review, major #1. The mixed staged/worktree case.
+
+    The index holds a blob the skeleton really did ship, so the fleet-written
+    branch of decide() matches and schedules a commit. But the WORKTREE holds
+    founder bytes the skeleton never had. Committing the index clears the
+    dirty-tree guard while leaving the founder's edit uncommitted, and the very
+    next sync overwrites it -- founder work destroyed by the tool whose entire
+    job is to avoid exactly that.
+
+    Attribution has to hold for BOTH sides of a path. One side matching the
+    skeleton is not attribution, it is half of one.
+    """
+    skel, inst = world
+    rel = "plugins/prd-os/runner.py"
+    seed_skeleton_blob(skel, rel, "v1\n")
+    write(inst, rel, "old\n")
+    git(inst, "add", "-A")
+    git(inst, "commit", "-qm", "instance base")
+
+    write(inst, rel, "v1\n")          # index: the skeleton's own blob
+    git(inst, "add", rel)
+    write(inst, rel, "founder was here\n")   # worktree: bytes the skeleton never had
+
+    head_before = git(inst, "rev-parse", "HEAD")
+    rc, out = run(skel, "--apply")
+
+    assert "REFUSE" in out, out
+    assert git(inst, "rev-parse", "HEAD") == head_before, (
+        "committed the staged skeleton blob while a founder edit sat in the "
+        "worktree; the next sync overwrites that edit")
+    assert (inst / rel).read_text() == "founder was here\n", "founder bytes lost"
+
+
+def test_a_refused_commit_does_not_report_success(world):
+    """PR #165 review, major #2.
+
+    main() returned 0 unconditionally and counted a REFUSED commit toward
+    `acted`, so a run that repaired nothing printed a success line and exited
+    clean. This is the script an unattended fleet job calls: an exit code that
+    cannot distinguish "repaired" from "refused and gave up" makes the job
+    report green while every instance stays blocked -- the same silent-success
+    class the fleet reach work exists to end.
+    """
+    skel, inst = world
+    rel = "plugins/prd-os/runner.py"
+    seed_skeleton_blob(skel, rel, "v1\n")
+    write(inst, rel, "old\n")
+    git(inst, "add", "-A")
+    git(inst, "commit", "-qm", "instance base")
+    write(inst, rel, "v1\n")
+
+    hook = inst / ".git/hooks/pre-commit"
+    hook.parent.mkdir(parents=True, exist_ok=True)
+    hook.write_text("#!/bin/sh\nexit 1\n")
+    hook.chmod(0o755)
+
+    rc, out = run(skel, "--apply")
+    assert "REFUSED" in out, out
+    assert rc != 0, (
+        "exited 0 after repairing nothing; an unattended caller cannot tell "
+        "this from a successful run")
+
+
+def test_a_clean_successful_run_still_exits_zero(world):
+    """Negative control for the test above. If every run exited non-zero the
+    assertion would pass while telling the caller nothing."""
+    skel, inst = world
+    rel = "plugins/prd-os/runner.py"
+    seed_skeleton_blob(skel, rel, "v1\n")
+    write(inst, rel, "old\n")
+    git(inst, "add", "-A")
+    git(inst, "commit", "-qm", "instance base")
+    write(inst, rel, "v1\n")
+
+    rc, out = run(skel, "--apply")
+    assert rc == 0, out
+    assert not is_dirty(inst, rel), out
 
 
 def test_the_unwind_test_would_notice_a_missing_unwind(world):

--- a/test_fleet_unblock.py
+++ b/test_fleet_unblock.py
@@ -1,0 +1,302 @@
+#!/usr/bin/env python3
+"""fleet-unblock.py acts only on what it can attribute, and refuses the rest.
+
+Every test here builds a REAL skeleton and REAL instance repos in a tmpdir and
+runs the actual script against them. Nothing is mocked, because the thing under
+test is git behaviour -- a mocked `git restore --staged` would happily "prove"
+that the file survives on disk, which is the exact claim that matters.
+
+The negative tests are the point. A clearing tool that acts on everything looks
+identical to a correct one until the day it eats founder work, so each refusal
+path gets a case that FAILS if the tool acts: `test_founder_edit_is_refused`
+and `test_staged_add_with_no_rescued_copy_is_refused` both assert the path is
+still dirty afterwards.
+"""
+
+import json
+import os
+import pathlib
+import shutil
+import subprocess
+
+import pytest
+
+SKELETON_SRC = pathlib.Path(__file__).resolve().parent
+SCRIPT = SKELETON_SRC / "fleet-unblock.py"
+
+
+def git(repo, *args, check=True):
+    proc = subprocess.run(
+        ["git", "-C", str(repo), *args], capture_output=True, text=True
+    )
+    if check and proc.returncode != 0:
+        raise AssertionError(f"git {' '.join(args)} in {repo}: {proc.stderr}")
+    return proc.stdout.strip()
+
+
+def init_repo(path):
+    path.mkdir(parents=True, exist_ok=True)
+    git(path, "init", "-q", "-b", "main")
+    git(path, "config", "user.email", "t@t.t")
+    git(path, "config", "user.name", "t")
+    git(path, "config", "commit.gpgsign", "false")
+    return path
+
+
+def write(repo, rel, text, mode=None):
+    full = repo / rel
+    full.parent.mkdir(parents=True, exist_ok=True)
+    full.write_text(text)
+    if mode is not None:
+        full.chmod(mode)
+    return full
+
+
+@pytest.fixture
+def world(tmp_path):
+    """A skeleton plus one instance, wired the way the real fleet is.
+
+    The skeleton gets a real kipi-update.sh stanza because fleet-reach-audit
+    PARSES INSTANCE_OWNED_SUBTREES out of it rather than holding a copy, and
+    fleet-unblock imports that parser. If the stanza shape ever changes, these
+    tests break here rather than silently testing an empty pathspec.
+    """
+    skel = init_repo(tmp_path / "skeleton")
+    shutil.copy(SKELETON_SRC / "fleet-reach-audit.py", skel / "fleet-reach-audit.py")
+    shutil.copy(SCRIPT, skel / "fleet-unblock.py")
+    write(skel, "kipi-update.sh", (
+        "#!/bin/bash\n"
+        "INSTANCE_OWNED_SUBTREES=(\n"
+        "  my-project\n"
+        "  output\n"
+        ")\n"
+        "SYSTEM_NEVER_COMMIT=(\n"
+        ")\n"
+    ))
+    inst = init_repo(tmp_path / "inst")
+    write(skel, "instance-registry.json", json.dumps({"instances": [
+        {"name": "inst", "path": str(inst), "subtree_prefix": "q-system"}
+    ]}))
+    git(skel, "add", "-A")
+    git(skel, "commit", "-qm", "skeleton base")
+    return skel, inst
+
+
+def seed_skeleton_blob(skel, rel, text):
+    """Make `text` a blob the skeleton once held at `rel`, then move on.
+
+    This is what makes a change attributable as fleet-written: the classifier
+    walks the skeleton's history for that exact path.
+    """
+    write(skel, rel, text)
+    git(skel, "add", "-A")
+    git(skel, "commit", "-qm", f"skeleton ships {rel}")
+    write(skel, rel, text + "\n# newer skeleton copy\n")
+    git(skel, "add", "-A")
+    git(skel, "commit", "-qm", f"skeleton bumps {rel}")
+
+
+def run(skel, *args):
+    proc = subprocess.run(
+        ["python3", str(skel / "fleet-unblock.py"), "--skeleton", str(skel), *args],
+        capture_output=True, text=True,
+    )
+    return proc.returncode, proc.stdout + proc.stderr
+
+
+def is_dirty(repo, rel):
+    tracked = git(repo, "diff", "--quiet", "--", rel, check=False)
+    rc1 = subprocess.run(["git", "-C", str(repo), "diff", "--quiet", "--", rel]).returncode
+    rc2 = subprocess.run(["git", "-C", str(repo), "diff", "--cached", "--quiet", "--", rel]).returncode
+    del tracked
+    return rc1 != 0 or rc2 != 0
+
+
+# --------------------------------------------------------------------------
+# restore-mode
+# --------------------------------------------------------------------------
+
+def test_mode_only_drift_is_chmodded_not_committed(world):
+    """The KTLYST_strategy shape: same bytes, lost +x.
+
+    Asserts the fix is a chmod. Committing would clear the guard too, which is
+    why this test checks HEAD did not move: a tool that "worked" by committing
+    the broken mode passes any check that only looks at cleanliness.
+    """
+    skel, inst = world
+    body = "#!/usr/bin/env python3\nprint('hi')\n"
+    write(inst, "plugins/kipi-core/tool.py", body, mode=0o755)
+    git(inst, "add", "-A")
+    git(inst, "commit", "-qm", "instance base")
+    head_before = git(inst, "rev-parse", "HEAD")
+    (inst / "plugins/kipi-core/tool.py").chmod(0o644)
+    assert is_dirty(inst, "plugins/kipi-core/tool.py")
+
+    rc, out = run(skel, "--apply")
+    assert rc == 0, out
+    assert "restore-mode" in out, out
+
+    assert not is_dirty(inst, "plugins/kipi-core/tool.py"), out
+    assert git(inst, "rev-parse", "HEAD") == head_before, "must not commit a mode fix"
+    assert os.access(inst / "plugins/kipi-core/tool.py", os.X_OK), "+x not restored"
+
+
+def test_mode_fix_is_not_applied_on_a_dry_run(world):
+    """Negative self-test for the dry run: the default must write nothing."""
+    skel, inst = world
+    write(inst, "plugins/kipi-core/tool.py", "x\n", mode=0o755)
+    git(inst, "add", "-A")
+    git(inst, "commit", "-qm", "base")
+    (inst / "plugins/kipi-core/tool.py").chmod(0o644)
+
+    rc, out = run(skel)
+    assert rc == 0, out
+    assert "would chmod" in out, out
+    assert is_dirty(inst, "plugins/kipi-core/tool.py"), "dry run wrote to the instance"
+
+
+# --------------------------------------------------------------------------
+# commit
+# --------------------------------------------------------------------------
+
+def test_fleet_written_content_is_committed(world):
+    skel, inst = world
+    seed_skeleton_blob(skel, "plugins/prd-os/runner.py", "v1\n")
+    write(inst, "plugins/prd-os/runner.py", "old\n")
+    git(inst, "add", "-A")
+    git(inst, "commit", "-qm", "instance base")
+    write(inst, "plugins/prd-os/runner.py", "v1\n")   # the exhaust
+    assert is_dirty(inst, "plugins/prd-os/runner.py")
+
+    rc, out = run(skel, "--apply")
+    assert rc == 0, out
+    assert not is_dirty(inst, "plugins/prd-os/runner.py"), out
+    assert "is one the skeleton itself held" in out
+    assert (inst / "plugins/prd-os/runner.py").read_text() == "v1\n", "bytes changed"
+
+
+def test_founder_edit_is_refused(world):
+    """NEGATIVE: bytes the skeleton never shipped stay exactly where they are.
+
+    This is the test that has to fail if attribution is loosened. It asserts
+    both that the tool says REFUSE and that the path is STILL dirty, because a
+    tool that printed a refusal and acted anyway would pass the first half.
+    """
+    skel, inst = world
+    seed_skeleton_blob(skel, "plugins/prd-os/runner.py", "v1\n")
+    write(inst, "plugins/prd-os/runner.py", "old\n")
+    git(inst, "add", "-A")
+    git(inst, "commit", "-qm", "instance base")
+    write(inst, "plugins/prd-os/runner.py", "founder was here\n")
+    head_before = git(inst, "rev-parse", "HEAD")
+
+    rc, out = run(skel, "--apply")
+    assert rc == 0, out
+    assert "REFUSE" in out, out
+    assert is_dirty(inst, "plugins/prd-os/runner.py"), "founder edit was cleared"
+    assert git(inst, "rev-parse", "HEAD") == head_before
+    assert (inst / "plugins/prd-os/runner.py").read_text() == "founder was here\n"
+
+
+# --------------------------------------------------------------------------
+# unstage
+# --------------------------------------------------------------------------
+
+def test_staged_add_with_a_rescued_copy_is_unstaged_and_survives_on_disk(world):
+    skel, inst = world
+    body = "dead package but real code\n"
+    write(skel, "rescued/dead/thing.py", body)
+    git(skel, "add", "-A")
+    git(skel, "commit", "-qm", "rescue")
+
+    write(inst, "README.md", "base\n")
+    git(inst, "add", "-A")
+    git(inst, "commit", "-qm", "instance base")
+    write(inst, "plugins/dead/thing.py", body)
+    git(inst, "add", "plugins/dead/thing.py")
+    assert is_dirty(inst, "plugins/dead/thing.py")
+
+    rc, out = run(skel, "--apply")
+    assert rc == 0, out
+    assert not is_dirty(inst, "plugins/dead/thing.py"), out
+    survivor = inst / "plugins/dead/thing.py"
+    assert survivor.is_file(), "unstage DELETED the file"
+    assert survivor.read_text() == body, "unstage changed the bytes"
+
+
+def test_staged_add_with_no_rescued_copy_is_refused(world):
+    """NEGATIVE: no committed copy anywhere means unstaging risks the last copy.
+
+    The memory-lifecycle scar in one assertion. The file looks like identical
+    dirt to the previous test; only the existence of a rescued copy differs.
+    """
+    skel, inst = world
+    write(inst, "README.md", "base\n")
+    git(inst, "add", "-A")
+    git(inst, "commit", "-qm", "instance base")
+    write(inst, "plugins/dead/thing.py", "the only copy anywhere\n")
+    git(inst, "add", "plugins/dead/thing.py")
+
+    rc, out = run(skel, "--apply")
+    assert rc == 0, out
+    assert "REFUSE" in out and "rescued/" in out, out
+    assert is_dirty(inst, "plugins/dead/thing.py"), "unstaged without a rescued copy"
+
+
+# --------------------------------------------------------------------------
+# the commit-failure unwind
+# --------------------------------------------------------------------------
+
+def test_a_refusing_pre_commit_hook_leaves_the_index_as_it_found_it(world):
+    """A hook exiting 1 must not leave paths staged by a script that then failed.
+
+    Two of the five real instances carry pre-commit hooks, so this path is
+    reachable in production, and until this test it had never once executed.
+    The hook here exits 1 unconditionally -- the cheapest possible stand-in for
+    lefthook refusing -- and the assertion is on the INDEX, not on the message.
+    """
+    skel, inst = world
+    seed_skeleton_blob(skel, "plugins/prd-os/runner.py", "v1\n")
+    write(inst, "plugins/prd-os/runner.py", "old\n")
+    git(inst, "add", "-A")
+    git(inst, "commit", "-qm", "instance base")
+    write(inst, "plugins/prd-os/runner.py", "v1\n")
+
+    hook = inst / ".git/hooks/pre-commit"
+    hook.parent.mkdir(parents=True, exist_ok=True)
+    hook.write_text("#!/bin/sh\necho 'gate says no' >&2\nexit 1\n")
+    hook.chmod(0o755)
+
+    staged_before = git(inst, "diff", "--cached", "--name-only")
+    head_before = git(inst, "rev-parse", "HEAD")
+
+    rc, out = run(skel, "--apply")
+    assert rc == 0, out
+    assert "REFUSED" in out, out
+    assert git(inst, "rev-parse", "HEAD") == head_before, "commit landed despite the hook"
+    assert git(inst, "diff", "--cached", "--name-only") == staged_before, (
+        "index left staged by a commit that failed"
+    )
+    assert (inst / "plugins/prd-os/runner.py").read_text() == "v1\n", "content lost"
+
+
+def test_the_unwind_test_would_notice_a_missing_unwind(world):
+    """Negative self-test FOR the unwind test: prove the assertion can fail.
+
+    Without this, `test_a_refusing_pre_commit_hook...` passes for the wrong
+    reason if `git add` were ever dropped -- nothing would be staged, so
+    "index unchanged" would hold trivially. Here the same hook setup is used
+    but the staging is done by hand and NOT unwound, and the same assertion is
+    checked to fail. A test that cannot fail is not a test.
+    """
+    skel, inst = world
+    write(inst, "plugins/prd-os/runner.py", "old\n")
+    git(inst, "add", "-A")
+    git(inst, "commit", "-qm", "instance base")
+    write(inst, "plugins/prd-os/runner.py", "v1\n")
+
+    staged_before = git(inst, "diff", "--cached", "--name-only")
+    git(inst, "add", "--", "plugins/prd-os/runner.py")   # staged, never unwound
+    assert git(inst, "diff", "--cached", "--name-only") != staged_before, (
+        "the unwind assertion cannot distinguish unwound from never-staged"
+    )


### PR DESCRIPTION
## What shipped

Fleet reach **17 of 22 -> 22 of 22**, measured with `fleet-reach-audit.py` before and after.

### 1. `fleet-unblock.py` + `test_fleet_unblock.py` (sp-ed9513cd)

The write half of the reach audit. Imports the audit's classifier rather than
transcribing the guard's pathspec, and acts only on what it can attribute:

| action | proof required |
|---|---|
| `restore-mode` | index and worktree hold the same blob, differing only in mode |
| `commit` | the blob is one the skeleton itself held at that exact path |
| `unstage` | staged ADD, worktree agrees, and the blob is committed under `rescued/` |

Everything else is refused by name. Never a delete, never a worktree discard,
never `--no-verify`. Applied to 28 paths across 5 instances, 0 refusals.

**The filed diagnosis was wrong on one instance.** The note called it a worktree
EDIT of `skill-trigger-eval.py`. Same blob `56d37bd1` on both sides: the file had
lost its executable bit (`100755 -> 100644`, `-rw-------` on disk). A script that
had silently stopped being executable, with a blocked sync as the only symptom.
A one-action tool would have committed the broken mode. Measured across all 22
instances: exactly ONE true mode-only row, so this is a single file, not a class.

Mutation-tested: loosening attribution, dropping the `rescued/` proof, dropping
the commit unwind, and committing the broken mode instead of chmodding each turn
exactly the intended test red. Control green before and after.

### 2. `test-kipi-update-config-commit-unwind.sh`

The commit-failure unwind had never executed. The fixture that was asked for --
a pre-commit hook exiting 1, asserting a clean index -- **already exists** as case
13 of `test-kipi-update-safety.sh`, and it does not reach that code. Measured by
instrumenting the updater with markers and replaying case 13: the run dies at
"could not commit q-system sync" and neither the config-sync call site nor the
unwind is reached. A hook that refuses every commit stops at the first one.

This fixture refuses selectively (passes the q-system commit, rejects one staging
`.claude/` or `plugins/`) -- the shape of a lefthook blocked-paths rule, which two
instances in this fleet run.

**The result is not the expected one.** Mutating both candidates:

- ASK-797 unwind deleted -> index **still clean**
- `restore_instance` removed from `abandon_instance` -> instance left dirty

`restore_instance` is what holds this line. The `unstage_scope` unwind is
belt-and-braces at this call site, not the guard. Recorded as a NOTE rather than
asserted, since it is a fact about today's control flow. Control B is what gives
the positive assertion teeth.

### 3. `kipi-update-preserve-scan.py` (sp-3d5a247e)

`EXCLUDED_PREFIXES` claimed to mirror the updater's excludes "exactly" while
missing `research/` and `.q-system/data/`. Now parsed from `kipi-update.sh` at
import, the way `fleet-reach-audit.py` does it, refusing loudly rather than
falling back to a literal. `q-system/` stays a separate literal because it is the
forbidden nested shadow tree, not an rsync exclude.

## Verification

- `pytest test_fleet_unblock.py` -> 8 passed; 4 mutants killed
- `test-kipi-update-config-commit-unwind.sh` -> ALL PASS, self-test red without the restore
- `test-kipi-update-preserve-scan.sh` -> ALL PASS
- `test-kipi-update-preserve-integration.sh` -> PASS
- `fleet-reach-audit.py` -> 22 of 22
- armed-without-baseline: **0**, unchanged (negative control: 21 == 21 armed)

## Left for the founder

The reach number is a projection until a real sync runs. Proving it moved needs
`ALLOW_DESTRUCTIVE=1` on the fleet updater, which is the founder's call, not mine.
