### PR TITLE
Measure the destructive-op-deny false positive, and the one-line fix (sp-9166e58a)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -109,6 +109,17 @@ q-system/output/.update-check-*
 q-system/output/capability-maps/
 .runs/
 
+# THE STANZA BETWEEN THESE MARKERS IS SHIPPED TO EVERY INSTANCE (sp-097d2e23).
+# kipi-update-gitignore-block.py parses it out of this file and writes it into
+# each instance's root .gitignore as a managed block. Root .gitignore is not in
+# the updater's sync set, so until 2026-08-14 these rules existed only here --
+# and an instance that does not ignore these paths has git report them, which
+# hands them straight to auto-commit.py (q-system/.q-system/ classifies as
+# "chore", which the fleet sync commits unattended). Five of 22 instances had
+# already committed their own baseline or armed marker, the most recent that
+# same day. Add a path here and every instance gets it on the next update; the
+# writer refuses rather than guessing if these markers ever go missing.
+# >>> kipi-instance-local-stanza >>>
 # .claude/ integrity baseline is INSTANCE-LOCAL (ASK-282). Never commit it:
 # kipi update propagates the skeleton, but each instance regenerates
 # .claude/settings.json from settings-template.json, so a shared baseline can
@@ -121,6 +132,11 @@ q-system/output/claude-integrity/
 # update, so every fresh instance would claim prior arming, refuse to arm, and
 # Slack-page SECURITY on its first run -- the round-2 outage exactly.
 q-system/.q-system/.claude-integrity-armed
+# Daily update stamps. Pure updater exhaust, and the reason this line moved
+# into the shipped stanza: instances carry hundreds of them, many already
+# committed by the pre-ASK-498 generic-fallback sweep.
+q-system/output/.update-check-*
+# <<< kipi-instance-local-stanza <<<
 
 # PR-review scratch trees. 537 of these files were swept into the repo by an
 # unattended `chore: update project files` auto-commit (ec5efddf). Removing them

--- a/kipi-update-gitignore-block.py
+++ b/kipi-update-gitignore-block.py
@@ -1,0 +1,186 @@
+#!/usr/bin/env python3
+"""Ship the skeleton's instance-local-never-commit stanza into an instance's
+root .gitignore, as a managed block.
+
+WHY (sp-097d2e23, sp-bd9bae14, measured 2026-08-14). The skeleton's root
+.gitignore says three things must never be committed, and says why:
+
+  * claude-integrity-baseline.json  -- instance-local (ASK-282); a shared
+    baseline can never match and Slack-pages every instance daily.
+  * .claude-integrity-armed         -- a committed marker makes a fresh
+    instance claim prior arming, refuse to arm, and page SECURITY on its
+    first run (the ASK-291 round-2 outage).
+  * q-system/output/.update-check-* -- daily update stamps, pure exhaust.
+
+Root .gitignore is NOT in the updater's sync set (the set is q-system/,
+.claude/{agents,output-styles,rules}/*.md, .claude/settings.json, plugins/),
+so no instance has ever received those rules. In the skeleton the gitignore
+makes those paths invisible to `git status`; in an instance it does not, so
+auto-commit.py sees them, classifies `q-system/.q-system/` as ("chore",
+"update system infrastructure"), and commits them unattended.
+
+That is not hypothetical. Measured across the 22 skeleton-managed instances:
+five had already committed the baseline and/or the armed marker, the most
+recent at 2026-08-14 14:22 under exactly that subject line. The two spillover
+notes were filed as separate minor defects; they are one defect, and the
+gitignore gap is the cause rather than a cosmetic side effect.
+
+DERIVED, NOT TRANSCRIBED. The stanza is parsed out of the skeleton's own root
+.gitignore between the two markers, so adding a fourth never-commit path there
+cannot leave this script behind. Same discipline the preserve scan adopted for
+INSTANCE_OWNED_PATHS in sp-3d5a247e, and for the same reason: a hand-kept
+second copy of a list drifts the moment anyone adds an entry.
+
+Refuses loudly rather than falling back to a literal. A silent fallback would
+write a block that does not match what the skeleton actually declares, and the
+failure mode -- an instance quietly committing its own tripwire state again --
+is invisible until something pages.
+
+Idempotent: rewrites the managed block in place, leaving every other line of
+the instance's .gitignore untouched. An instance that already ignores one of
+these paths on its own keeps that line; the block is additive.
+
+Usage:
+  kipi-update-gitignore-block.py --skeleton DIR --instance DIR [--check]
+
+  --check  report whether the block is current, write nothing. Exit 0 when
+           the instance block already matches the skeleton stanza, 1 when it
+           would change.
+"""
+import argparse
+import os
+import re
+import sys
+
+BEGIN = "# >>> kipi-managed: instance-local, never commit >>>"
+END = "# <<< kipi-managed: instance-local, never commit <<<"
+
+# The markers as they appear in the SKELETON's .gitignore. Kept distinct from
+# the block markers written into an instance so that the skeleton's own copy is
+# never mistaken for a managed block and rewritten by a stray --instance run
+# pointed at the skeleton.
+SKELETON_BEGIN = "# >>> kipi-instance-local-stanza >>>"
+SKELETON_END = "# <<< kipi-instance-local-stanza <<<"
+
+
+def skeleton_stanza(skeleton_dir):
+    """The never-commit path lines declared by the skeleton's root .gitignore."""
+    path = os.path.join(skeleton_dir, ".gitignore")
+    try:
+        with open(path, encoding="utf-8") as handle:
+            text = handle.read()
+    except OSError as exc:
+        raise RuntimeError(f"cannot read skeleton .gitignore at {path}: {exc}")
+    match = re.search(
+        re.escape(SKELETON_BEGIN) + r"\n(.*?)^" + re.escape(SKELETON_END),
+        text,
+        re.S | re.M,
+    )
+    if not match:
+        raise RuntimeError(
+            f"{SKELETON_BEGIN} markers not found in {path}; the gitignore block "
+            "writer cannot mirror the skeleton's never-commit stanza and refuses "
+            "to guess it"
+        )
+    lines = [line.rstrip() for line in match.group(1).splitlines()]
+    # Comments inside the stanza are the WHY, and an instance reading its own
+    # .gitignore deserves them as much as the skeleton does. Blank lines are
+    # dropped so the emitted block is stable regardless of skeleton spacing.
+    lines = [line for line in lines if line.strip()]
+    if not any(line and not line.startswith("#") for line in lines):
+        raise RuntimeError(
+            f"the stanza between the markers in {path} declares no paths; "
+            "refusing to write an empty managed block"
+        )
+    return lines
+
+
+def render_block(stanza):
+    return "\n".join([BEGIN] + stanza + [END]) + "\n"
+
+
+def existing_block(text):
+    """(before, block, after) for the managed block, or None when absent."""
+    match = re.search(
+        re.escape(BEGIN) + r"\n.*?^" + re.escape(END) + r"\n?",
+        text,
+        re.S | re.M,
+    )
+    if not match:
+        return None
+    return text[: match.start()], match.group(0), text[match.end():]
+
+
+def apply_block(instance_dir, stanza, check_only=False):
+    """Write/refresh the managed block. Returns (changed, action)."""
+    path = os.path.join(instance_dir, ".gitignore")
+    try:
+        with open(path, encoding="utf-8") as handle:
+            text = handle.read()
+    except FileNotFoundError:
+        text = ""
+    except OSError as exc:
+        raise RuntimeError(f"cannot read {path}: {exc}")
+
+    block = render_block(stanza)
+    found = existing_block(text)
+    if found is None:
+        # Append. A leading newline only when the file has content and does not
+        # already end in one, so repeated runs cannot grow blank lines.
+        prefix = text
+        if prefix and not prefix.endswith("\n"):
+            prefix += "\n"
+        if prefix:
+            prefix += "\n"
+        new_text = prefix + block
+        action = "added"
+    else:
+        before, current, after = found
+        if current.rstrip("\n") == block.rstrip("\n"):
+            return False, "current"
+        new_text = before + block + after
+        action = "refreshed"
+
+    if check_only:
+        return True, action
+
+    tmp = path + ".kipi-tmp"
+    with open(tmp, "w", encoding="utf-8") as handle:
+        handle.write(new_text)
+    os.replace(tmp, path)
+    return True, action
+
+
+def main(argv=None):
+    ap = argparse.ArgumentParser(description=__doc__)
+    ap.add_argument("--skeleton", required=True)
+    ap.add_argument("--instance", required=True)
+    ap.add_argument("--check", action="store_true")
+    args = ap.parse_args(argv)
+
+    if os.path.abspath(args.skeleton) == os.path.abspath(args.instance):
+        print("refusing to write a managed block into the skeleton itself",
+              file=sys.stderr)
+        return 2
+
+    try:
+        stanza = skeleton_stanza(args.skeleton)
+        changed, action = apply_block(args.instance, stanza, args.check)
+    except RuntimeError as exc:
+        print(f"ERROR: {exc}", file=sys.stderr)
+        return 2
+
+    if args.check:
+        if changed:
+            print(f"  .gitignore managed block would be {action}")
+            return 1
+        return 0
+
+    if changed:
+        print(f"  .gitignore managed block {action} "
+              f"({sum(1 for l in stanza if not l.startswith('#'))} path(s))")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/kipi-update.sh
+++ b/kipi-update.sh
@@ -1610,6 +1610,40 @@ PY
       git merge --abort 2>/dev/null || true
     fi
 
+    # THE OTHER HALF OF THE UNTRACK BELOW, and it must run FIRST (sp-097d2e23).
+    #
+    # `git rm --cached` leaves the file on disk, UNTRACKED. In the skeleton that
+    # is invisible, because root .gitignore has covered these paths since
+    # .gitignore:123. No instance has ever had those lines: root .gitignore is
+    # not in this script's sync set (q-system/, .claude/{agents,output-styles,
+    # rules}/*.md, .claude/settings.json, plugins/). So on an instance the
+    # untracked marker is REPORTED by git status, auto-commit.py classifies
+    # q-system/.q-system/ as `chore` exhaust, and the next ordinary session
+    # commits it straight back. The migration below would then have to run
+    # again, and again, forever.
+    #
+    # That is not a prediction. SYSTEM_NEVER_COMMIT closes this script's own
+    # commit path; the commit that re-added the marker to an instance at
+    # 2026-08-14 14:22 carried auto-commit.py's subject ("chore: update system
+    # infrastructure"), not this script's ("...before skeleton sync"). Two
+    # writers, and the array only ever guarded one of them.
+    #
+    # Ignoring the path guards every writer at once -- this script, the Stop
+    # hook, a stray `git add -A`, the founder's own commit -- because it works
+    # at the layer all of them read. The stanza is PARSED from the skeleton's
+    # own .gitignore, so adding a fourth never-commit path there reaches all 22
+    # instances without touching this file.
+    #
+    # Advisory: an instance that cannot take the block is not a reason to
+    # abandon an otherwise good update, and the untrack below still runs.
+    GITIGNORE_BLOCK="$SCRIPT_DIR/kipi-update-gitignore-block.py"
+    if [ -f "$GITIGNORE_BLOCK" ]; then
+      python3 "$GITIGNORE_BLOCK" --skeleton "$SCRIPT_DIR" --instance "$path" ||
+        echo "    WARN: could not write the .gitignore managed block; never-commit paths stay visible to auto-commit here"
+    else
+      echo "    WARN: .gitignore block writer missing; never-commit paths stay visible to auto-commit here"
+    fi
+
     # ONE-TIME MIGRATION, and it must run BEFORE the block below (measured 2026-08-14, 6 instances).
     #
     # The chokepoint stops the baseline from BECOMING tracked. It does nothing for

--- a/q-system/.q-system/tests/separation/test_update_propagation.py
+++ b/q-system/.q-system/tests/separation/test_update_propagation.py
@@ -44,6 +44,7 @@ UPDATER_HELPERS = (
     "kipi-update-preserve-scan.py",
     "kipi-update-deletion-guard.py",
     "kipi-settings-merge.py",
+    "kipi-update-gitignore-block.py",
     "settings-template.json",
 )
 

--- a/q-system/.q-system/tests/test_gitignore_block.py
+++ b/q-system/.q-system/tests/test_gitignore_block.py
@@ -1,0 +1,216 @@
+#!/usr/bin/env python3
+"""The skeleton's never-commit stanza must reach every instance (sp-097d2e23).
+
+RED FIRST. The reproducer that opens this file is
+TestTheDefectThatWasMeasured::test_an_instance_without_the_stanza_commits_its_own_tripwire_state
+-- it drives the REAL auto-commit classifier against a REAL git repo laid out
+like an instance, and asserts the integrity paths are not offered to the fleet
+sync. Before the managed block existed that test failed, because git reported
+the paths as untracked and auto-commit classified them ("chore", "update system
+infrastructure"). That is not a hypothetical: five of the 22 skeleton-managed
+instances had already committed them, most recently 2026-08-14 14:22.
+
+Nothing here touches a live instance. Every test builds its own tree under
+tmp_path, which is the whole point -- a test that reads the real fleet would
+pass or fail on whatever state the fleet happened to be in that morning.
+"""
+import importlib.util
+import os
+import subprocess
+import sys
+
+import pytest
+
+REPO = os.path.dirname(os.path.dirname(os.path.dirname(os.path.dirname(
+    os.path.abspath(__file__)))))
+SCRIPT = os.path.join(REPO, "kipi-update-gitignore-block.py")
+HOOK = os.path.join(REPO, "q-system", "hooks", "auto-commit.py")
+
+
+def load(name, path):
+    spec = importlib.util.spec_from_file_location(name, path)
+    mod = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(mod)
+    return mod
+
+
+blockmod = load("gitignore_block", SCRIPT)
+auto_commit = load("auto_commit", HOOK)
+
+
+# The paths the skeleton's .gitignore says are instance-local. Named here so a
+# test can fail on a path SILENTLY LEAVING the stanza, which a test that only
+# read the stanza back could never notice.
+INSTANCE_LOCAL = (
+    "q-system/.q-system/claude-integrity-baseline.json",
+    "q-system/.q-system/claude-integrity-baseline.json.lock",
+    "q-system/.q-system/.claude-integrity-armed",
+)
+
+
+def git(repo, *args):
+    return subprocess.run(["git", "-C", repo, *args],
+                          capture_output=True, text=True, check=False)
+
+
+def make_instance(tmp_path, name="instance"):
+    """A git repo laid out the way a kipi instance is."""
+    root = tmp_path / name
+    (root / "q-system" / ".q-system").mkdir(parents=True)
+    (root / "q-system" / "output").mkdir(parents=True)
+    git(str(root), "init", "-q")
+    git(str(root), "config", "user.email", "t@t")
+    git(str(root), "config", "user.name", "t")
+    (root / "README.md").write_text("instance\n")
+    git(str(root), "add", "-A")
+    git(str(root), "commit", "-qm", "init")
+    return root
+
+
+def write_tripwire_state(root):
+    """Exactly what the tripwire and the update-check write into an instance."""
+    (root / "q-system" / ".q-system" / "claude-integrity-baseline.json").write_text(
+        '{"entries": {}}\n')
+    (root / "q-system" / ".q-system" / "claude-integrity-baseline.json.lock").write_text("")
+    (root / "q-system" / ".q-system" / ".claude-integrity-armed").write_text("armed\n")
+    (root / "q-system" / "output" / ".update-check-2026-08-14").write_text("")
+
+
+def untracked(root):
+    out = git(str(root), "status", "--porcelain", "--untracked-files=all").stdout
+    return [line[3:] for line in out.splitlines() if line.startswith("??")]
+
+
+class TestTheDefectThatWasMeasured:
+    """The reproducer. It fails with no managed block and passes with one."""
+
+    def test_an_instance_without_the_stanza_commits_its_own_tripwire_state(self, tmp_path):
+        """THE red test. Drives the real classifier, not a restatement of it."""
+        root = make_instance(tmp_path)
+        write_tripwire_state(root)
+
+        # Before: git reports the tripwire state, so the fleet sync takes it.
+        offered_before = auto_commit.system_state_paths(untracked(root))
+        assert any(p in offered_before for p in INSTANCE_LOCAL), (
+            "precondition: without the managed block the classifier must offer "
+            "the integrity paths -- if this fails the defect changed shape")
+
+        rc = blockmod.main(["--skeleton", REPO, "--instance", str(root)])
+        assert rc == 0
+
+        offered_after = auto_commit.system_state_paths(untracked(root))
+        for path in INSTANCE_LOCAL:
+            assert path not in offered_after, (
+                f"{path} is still offered to the fleet sync after the block")
+
+    def test_the_update_check_stamp_is_ignored_too(self, tmp_path):
+        root = make_instance(tmp_path)
+        write_tripwire_state(root)
+        blockmod.main(["--skeleton", REPO, "--instance", str(root)])
+        assert "q-system/output/.update-check-2026-08-14" not in untracked(root)
+
+
+class TestTheStanzaIsDerivedNotTranscribed:
+    """sp-3d5a247e's lesson, applied before it can happen again here."""
+
+    def test_every_instance_local_path_comes_from_the_skeleton_gitignore(self):
+        stanza = blockmod.skeleton_stanza(REPO)
+        paths = [l for l in stanza if not l.startswith("#")]
+        for path in INSTANCE_LOCAL:
+            assert path in paths, (
+                f"{path} left the skeleton stanza; either it is genuinely no "
+                "longer instance-local (update this test and say why) or the "
+                "stanza lost a line")
+
+    def test_a_skeleton_with_no_markers_refuses_rather_than_guessing(self, tmp_path):
+        fake = tmp_path / "skel"
+        fake.mkdir()
+        (fake / ".gitignore").write_text("*.pyc\n")
+        with pytest.raises(RuntimeError, match="refuses to guess"):
+            blockmod.skeleton_stanza(str(fake))
+
+    def test_a_stanza_declaring_no_paths_refuses(self, tmp_path):
+        fake = tmp_path / "skel"
+        fake.mkdir()
+        (fake / ".gitignore").write_text(
+            f"{blockmod.SKELETON_BEGIN}\n# only a comment\n{blockmod.SKELETON_END}\n")
+        with pytest.raises(RuntimeError, match="refusing to write an empty"):
+            blockmod.skeleton_stanza(str(fake))
+
+
+class TestItIsSafeToRunOnEveryUpdate:
+    """The updater calls this on all 22 instances on every run."""
+
+    def test_it_is_idempotent(self, tmp_path):
+        root = make_instance(tmp_path)
+        blockmod.main(["--skeleton", REPO, "--instance", str(root)])
+        first = (root / ".gitignore").read_text()
+        for _ in range(3):
+            blockmod.main(["--skeleton", REPO, "--instance", str(root)])
+        assert (root / ".gitignore").read_text() == first
+
+    def test_it_never_touches_a_line_the_instance_wrote(self, tmp_path):
+        root = make_instance(tmp_path)
+        own = "# the instance's own rules\nnode_modules/\n*.local\n"
+        (root / ".gitignore").write_text(own)
+        blockmod.main(["--skeleton", REPO, "--instance", str(root)])
+        after = (root / ".gitignore").read_text()
+        assert after.startswith(own)
+        assert blockmod.BEGIN in after
+
+    def test_a_refreshed_block_replaces_in_place_and_keeps_the_tail(self, tmp_path):
+        root = make_instance(tmp_path)
+        (root / ".gitignore").write_text(
+            f"head\n\n{blockmod.BEGIN}\nstale-path\n{blockmod.END}\ntail\n")
+        blockmod.main(["--skeleton", REPO, "--instance", str(root)])
+        after = (root / ".gitignore").read_text()
+        assert after.startswith("head\n")
+        assert after.rstrip().endswith("tail")
+        assert "stale-path" not in after
+        assert "q-system/.q-system/.claude-integrity-armed" in after
+
+    def test_it_creates_the_file_when_the_instance_has_no_gitignore(self, tmp_path):
+        root = make_instance(tmp_path)
+        assert not (root / ".gitignore").exists()
+        assert blockmod.main(["--skeleton", REPO, "--instance", str(root)]) == 0
+        assert blockmod.BEGIN in (root / ".gitignore").read_text()
+
+    def test_check_mode_writes_nothing_and_reports(self, tmp_path):
+        root = make_instance(tmp_path)
+        assert blockmod.main(
+            ["--skeleton", REPO, "--instance", str(root), "--check"]) == 1
+        assert not (root / ".gitignore").exists()
+        blockmod.main(["--skeleton", REPO, "--instance", str(root)])
+        assert blockmod.main(
+            ["--skeleton", REPO, "--instance", str(root), "--check"]) == 0
+
+    def test_it_refuses_to_write_into_the_skeleton_itself(self):
+        assert blockmod.main(["--skeleton", REPO, "--instance", REPO]) == 2
+
+
+class TestTheNegativeControl:
+    """A test that cannot fail is not a test. These prove the ones above can."""
+
+    def test_removing_the_stanza_breaks_the_reproducer(self, tmp_path):
+        """If the block stopped listing the armed marker, the red test must go
+        red again. Proven by running the real thing against a stanza with that
+        line removed, rather than by trusting that it would."""
+        fake_skel = tmp_path / "skel"
+        fake_skel.mkdir()
+        stanza = [l for l in blockmod.skeleton_stanza(REPO)
+                  if "claude-integrity-armed" not in l]
+        (fake_skel / ".gitignore").write_text(
+            blockmod.SKELETON_BEGIN + "\n" + "\n".join(stanza) + "\n"
+            + blockmod.SKELETON_END + "\n")
+
+        root = make_instance(tmp_path)
+        write_tripwire_state(root)
+        blockmod.main(["--skeleton", str(fake_skel), "--instance", str(root)])
+        offered = auto_commit.system_state_paths(untracked(root))
+        assert "q-system/.q-system/.claude-integrity-armed" in offered, (
+            "the assertion has no teeth: dropping the armed marker from the "
+            "stanza left the reproducer green")
+
+
+if __name__ == "__main__":
+    sys.exit(pytest.main([__file__, "-v"]))

--- a/q-system/.q-system/tests/test_gitignore_block.py
+++ b/q-system/.q-system/tests/test_gitignore_block.py
@@ -212,5 +212,79 @@ class TestTheNegativeControl:
             "stanza left the reproducer green")
 
 
+class TestTheWiringIntoTheUpdater:
+    """The block is useless unwired, and worse than useless wired in the wrong
+    order. Both halves are asserted here rather than trusted."""
+
+    UPDATER = os.path.join(REPO, "kipi-update.sh")
+
+    def text(self):
+        with open(self.UPDATER, encoding="utf-8") as handle:
+            return handle.read()
+
+    def test_the_updater_actually_calls_it(self):
+        assert "kipi-update-gitignore-block.py" in self.text(), (
+            "the writer is not called from the updater -- a built, tested, "
+            "wired-to-nothing engine (the sp-0f773063 class)")
+
+    def test_it_runs_BEFORE_the_untrack_migration(self):
+        """ORDER IS THE WHOLE POINT. `git rm --cached` leaves the file on disk
+        untracked; if it is not yet ignored at that moment, git reports it and
+        the next auto-commit puts it straight back."""
+        text = self.text()
+        block_at = text.index("kipi-update-gitignore-block.py")
+        untrack_at = text.index('for sys_path in "${SYSTEM_NEVER_COMMIT[@]}"')
+        assert block_at < untrack_at, (
+            "the .gitignore block is written AFTER the untrack migration, so "
+            "every untracked marker is visible to auto-commit until the next run")
+
+    def test_the_updater_still_parses(self):
+        r = subprocess.run(["bash", "-n", self.UPDATER],
+                           capture_output=True, text=True)
+        assert r.returncode == 0, r.stderr
+
+
+class TestUntrackingWithoutIgnoringRegresses:
+    """The behavioural half of the ordering argument, run for real."""
+
+    def track_the_marker(self, root):
+        rel = "q-system/.q-system/.claude-integrity-armed"
+        (root / rel).parent.mkdir(parents=True, exist_ok=True)
+        (root / rel).write_text("armed 2026-08-14T20:13:59Z\n")
+        git(str(root), "add", "-f", rel)
+        git(str(root), "commit", "-qm", "the state five instances were in")
+        assert git(str(root), "ls-files", "--error-unmatch", rel).returncode == 0
+        return rel
+
+    def test_untrack_alone_hands_the_marker_straight_back_to_auto_commit(self, tmp_path):
+        """NEGATIVE CONTROL for the ordering. Untracking without the block
+        leaves the marker untracked AND unignored, which is exactly the state
+        auto-commit sweeps."""
+        root = make_instance(tmp_path)
+        rel = self.track_the_marker(root)
+
+        git(str(root), "rm", "--cached", "--quiet", "--", rel)
+        git(str(root), "commit", "-qm", "untrack")
+
+        assert (root / rel).exists(), "the untrack must never delete the file"
+        assert rel in untracked(root)
+        assert auto_commit.system_state_paths(untracked(root)) == [rel], (
+            "if this is empty the regression closed some other way -- find out "
+            "where before deleting this test")
+
+    def test_block_then_untrack_ends_clean(self, tmp_path):
+        """The wired order. Same fixture, block first."""
+        root = make_instance(tmp_path)
+        rel = self.track_the_marker(root)
+
+        blockmod.main(["--skeleton", REPO, "--instance", str(root)])
+        git(str(root), "rm", "--cached", "--quiet", "--", rel)
+        git(str(root), "commit", "-qm", "untrack")
+
+        assert (root / rel).exists(), "the untrack must never delete the file"
+        assert rel not in untracked(root)
+        assert auto_commit.system_state_paths(untracked(root)) == []
+
+
 if __name__ == "__main__":
     sys.exit(pytest.main([__file__, "-v"]))

--- a/q-system/memory/last-handoff.md
+++ b/q-system/memory/last-handoff.md
@@ -1,136 +1,181 @@
-# Last handoff — 2026-07-26 (continuation session)
+# Last handoff — 2026-08-14 (eve comparison -> trust-gate -> fleet-skew night)
+[provenance: observed — system currentDate context this session]
 
-Tracking epic **ASK-113**. PR #10 **merged to main** (`05af553`), 7 commits.
-Everything below was verified by running it, not by reading it.
+Started as a repo review (vercel-labs/eve-software-factory-template vs kipi), ballooned
+into a multi-hour, multi-session engineering night touching prd-os/kipi-dsse merge
+safety, fleet plugin versioning, and a live branch-protection change. Two other Claude
+sessions (`social-voice`, plus incidental contact with others) were active in this same
+checkout concurrently — expect coordination scars below.
 
-## Carried forward from the earlier 2026-07-26 session (still true)
+## What shipped, verified
 
-- **Goal 1, a Linear project per instance repo: DONE.** 25 of 25 (24 instances +
-  the skeleton). A fleet-wide re-plan creates zero projects.
-- **Goals 2 and 3, deterministic creation on build: SHIPPED** as queue-and-drain.
-  No Linear API key exists, so bash cannot reach the MCP server; capture is local
-  and offline, the agent drains it.
-- **Goal 5, overlap/collision analysis: SHIPPED** (`capability-overlap.py`).
-- **Goal 6, SDLC standard: WRITTEN**, adjustments recorded in its Part 0.
-- **Goal 4: still NOT STARTED.** Triage every issue in every project (done /
-  needs work / recorded, with evidence): 61 pre-existing kipi-system issues, 45
-  in cole-GTM.
-- **29 of 31 planned Linear issues remain uncreated.** Resumable:
-  `kipi linear status` says which repos are done without querying Linear.
-- Dedup key `<repo-slug>/<capability-slug>`, written into each Linear
-  description as `<!-- kipi-key: ... -->`. **Never drop that marker.**
+**PR #159 — merge-bypass trust gate. MERGED to main (`88155734`), live, verified.**
+[verified: `gh pr view 155/159`, `gh api .../commits/.../status`, and a live in-session
+Bash call with `--admin` refused by the wired hook — ran directly this session]
 
-## Founder decisions this session
+Adopted the eve-software-factory-template pre-dispatch approval idea (`sp-6dc1b64c`)
+for prd-os/kipi-dsse's push/merge chokepoint. Closeout was checked first and found
+**already stronger** than eve's pattern (content-sealed receipts vs. eve's session-scoped
+trust class) — no closeout work needed. [provenance: observed — Sana subagent recon
+report, code citations to issue_runner.py, not independently re-read by me] Push/merge
+had **zero enforcement**; the specific live hole was `gh pr merge --admin`, which
+defeats `kipi/reviewer-approved` because `enforce_admins:false` + every agent
+credential is `admin:true`. [provenance: observed — Sana subagent report citing
+`gh api repos/:owner/:repo/branches/main/protection` and `gh api repos/:owner/:repo
+--jq .permissions` output]
 
-- **Q2 (branch-protection bypass):** fix the 5 tests, make the gate real.
-- **Sequencing:** updater tests first, then the claim-lock.
-- **Merge:** merge PR #10 with the admin bypass, containment failure and all.
+7 review rounds, each a real finding, each fixed and mutation-tested. [provenance:
+observed — Sana subagent completion reports, each citing a Codex review verdict I
+spot-checked live via `gh pr checks 159` / `gh api .../issues/159/comments` at multiple
+points this session]:
+1. `--admin` bare form denied
+2. `--admin=true` and 5 other truthy spellings (denylist was inherently incomplete)
+3. `-R`/`--repo`/`--hostname`/env-var retargeting — **redesigned denylist to allowlist**
+   here: only `gh pr merge --auto [method] [ref]` is permitted, everything else on that
+   command is denied by construction
+4. wrapper composition (`sudo bash -c '...'`), unknown-wrapper class closed via token scan
+5. push-side never got round-4's fix (single `_tool_position()` authority now serves both)
+6. `bash -lc`, unknown wrappers, newline-as-separator — three vectors, one shared cause
+7. **`eval $CMD` / `source` / `| bash` cannot be caught by static analysis, period** (the
+   command text doesn't exist until Bash expands it). Correctly did NOT try to patch
+   this locally. The real fix is server-side: `enforce_admins`.
 
-## What shipped
+**`enforce_admins` flipped true on `main`, founder-authorized (asked directly via
+AskUserQuestion this session), verified two ways** (not trusted from API return code).
+[verified: Sana subagent report cites re-reading both the `protection/enforce_admins`
+sub-resource and the `protection` roll-up; I did not independently re-run this check]
+Break-glass built: `break-glass-main-protection.sh` (`status`/`off <reason>`/`on`),
+logged to `~/.claude/audit/break-glass-main-protection.jsonl`, Slack on open/close,
+documented in `AUTONOMOUS-SYSTEMS.md` §5b. Asymmetric by design: `off` refuses if it
+can't guarantee the audit trail; `on` never blocks (stranding protection OFF is worse
+than an incomplete log). Drilled live, one round-trip, verified. [provenance: observed
+— Sana subagent report, including a self-caught reasoning error during the drill
+(misread her own pre-check output); I did not independently re-run the drill]
 
-| Commit | What |
-|--------|------|
-| `226cf6f` | CI: git identity + `fetch-depth: 0` + track the receipts ledger |
-| `c307bed` | Close discipline into the SDLC standard §3.1 / §5 |
-| `a6ba923` | Instance identity out of 2 scar comments |
-| `d26b425` | Slice 0: truthful reviewer provenance (`claude-*` sources) |
-| `7c0fccb` | Slice B: the agent claim-lock |
-| `f32bfbd` | Adversarial review fixes: 2 blockers + 8 more |
+**ASK-798 still open** — the flip is done, but the break-glass has a real fragility:
+`kipi/reviewer-approved` is posted by a local script, not a GitHub Action, so if that
+script is down, main freezes for everyone including whoever needs to fix it. Option 2
+(non-local producer) is the real fix and is not this session's work.
+[provenance: observed — Sana subagent report]
 
-## The 5 updater CI failures — fixed
+**Recurring failure mode across the whole thread, worth remembering**: 5 separate
+instances today of a *fixture or harness that was green for the wrong reason* — a `cd
+/tmp` that made a case pass on the unresolvable-means-allow rule instead of the logic
+under test, a dead-ledger fixture whose `mkdir -p` never reached the line it was
+testing, a stub sed'd from an already-stubbed copy, a pre-check that printed a
+conclusion its own output contradicted, a test file named against a convention nobody
+read. None were caught by review — all were caught by mutation testing or a self-check.
+[provenance: observed — self-reported by the Sana subagent across multiple completion
+reports; count of 5 is her own tally, not independently recounted by me] Candidate for
+a lessons-corpus entry if this keeps recurring.
 
-The prior session's theory (`sp-d29346e9`, "pytest skips the hidden
-`q-system/.q-system/` dir") was **wrong**: `capability-gate.py:303` runs tests by
-convention, not pytest discovery.
+## Open, not shipped
 
-Two causes, not five. **No git identity on the runner** (4 of 5):
-`kipi-update.sh:705` commits with none, the ubuntu runner's user has an empty
-gecos field, and `kipi-update.sh:1289` `abandon_instance ... && continue` is
-*upstream* of the plugins rsync at 1393 — so one missing identity produced four
-unrelated-looking symptoms. And **`.gitignore`'s blanket `*.jsonl`** hid
-`.prd-os/receipts.jsonl`, the ledger `test-updater-issue-sequence.py:101` audits.
+**PR #152 — plugin-parity fleet-skew checker. BLOCKED, round 6 REQUEST CHANGES,
+checkpointed and stopped for the day mid-thread.** [verified: `gh pr checks 152` run
+directly this session at multiple points; checkpoint detail below is
+provenance: observed from the Sana subagent's final report]
 
-Local macOS **cannot** reproduce this: its git guesses an identity from the
-passwd gecos field. Three failed reproducer attempts are recorded in
-`q-system/output/plans/ci-validate-green-2026-07-26.md` — do not retry them.
+Split off `sana/ask-728-plugin-parity` (PR #142) when the writer half
+(`plugin-fanout.py`) hit 5 review rounds of the same data-loss race relocating rather
+than closing — correct call to freeze that writer and hold it separately (still held,
+untouched). [provenance: observed — Sana subagent report]
 
-## Two lessons worth carrying forward
+The checker itself went through its own version of the same pattern:
+- round 1-2: fixed real bugs (PASS-on-zero, compared marketplace clone instead of what
+  the loader actually runs — the clone was stale too, see below)
+- round 3-4: found the checker was trusting the install *record* over the actual
+  on-disk manifest, and that `--project` scope resolution defaulted to the wrong entry
+- round 5: **correctly invoked its own stop-criterion.** The scope-resolution model
+  (which install "wins" from a given directory) was never grounded — inferred from a
+  JSON file's shape, and Claude Code's loader is closed-source, so there was no oracle
+  to converge on. Rescoped rather than kept patching: dropped `resolve_live_entry`,
+  `--project`, `--user-scope` entirely; now enumerates every recorded install and fails
+  if any lags, instead of claiming to know "the one you're running." Weaker claim,
+  fully verifiable.
+- **round 6: two majors, checkpointed, NOT fixed.** (1) A real regression the freeze
+  commit introduced — `render()` reads `row['scopes']`/`row['project_paths']` but the
+  NOT_INSTALLED branch still builds the row with the old `scope`/`project_path` keys,
+  so a NOT_INSTALLED row crashes text rendering with `KeyError`. Her tests missed it
+  because the NOT_INSTALLED test only exercises `--json`, never `render()` — same
+  "checked one artifact, claimed another" shape as everything else tonight. Hypothesis
+  on cause stated as hypothesis, not verified — she stopped before digging further.
+  (2) A genuine **design disagreement, not a regression**: Codex flagged that content
+  drift is advisory-only (bytes can differ while the run still says PASS). The
+  module's own docstring defends this on purpose — gating on byte-equality would make
+  a check that can never go green on a real runtime tree, and a check that can't go
+  green gets switched off. This is a judgment call to make deliberately next session,
+  not a bug to reflexively patch.
+  [provenance: observed — Sana subagent's own final checkpoint report, verbatim]
 
-**1. A fixture invented by the author tests nothing.** The claim-lock's remote
-half read `state`; `mcp__linear__get_issue` emits `status` + `statusType`. That
-remote check is the ONLY cover for a cross-checkout collision and it granted
-unconditionally — while the suite stayed green, because the fixture was
-hand-rolled from the same mental model as the code. Fixtures are now the verbatim
-captured payload. Prefer `statusType` over the status NAME: teams rename states.
+Real fleet numbers this surfaced, live-verified: prd-os, kipi-core, kipi-design,
+kipi-dsse are all genuinely stale on the executing runtime (prd-os as far as **0.16.5
+vs skeleton 0.27.3** — 11+ minor versions). kipi-ops and kipi-notebooklm match.
+[provenance: observed — Sana subagent report, cross-checked once against
+`installed_plugins.json`/`claude plugin list` per her own account; not independently
+re-run by me]
 
-**2. `\s` matches a newline even under `re.M`.** `^reviewed_by:\s*.*$` ate the
-FOLLOWING frontmatter line when the value was empty. Driven to a real exploit:
-eating `findings_path:` made the gate report "no findings" and a PRD with an
-untriaged BLOCKER advanced to `approved`, exit 0. Use `[^\n]*`.
+**The actual runtime fix — `claude plugin update <plugin>`, restart attached — was
+never run.** Correctly held: it writes under `~/.claude/`, gated to the
+`apply-claude-changes.sh` proposal path, re-points plugins for every session on this
+machine. This is the founder's action to trigger when ready, not something either
+Sana thread did unilaterally.
 
-## The claim lock (how to use it)
+**Housekeeping:** worktree `/Users/assafkipnis/projects/kipi-system/.wt-parity` is
+still registered and clean, left in place deliberately so next session resumes without
+re-setup — remove with `git worktree remove` once the PR lands. [provenance: observed
+— Sana subagent final report] Push state before stopping was verified 4-way (worktree
+HEAD, remote `@{u}`, PR head, dirty/unpushed counts all agree at `95e2e83a`) —
+[provenance: observed — Sana subagent final report; I did not independently re-run this
+check].
 
-```
-kipi linear claim ASK-nnn --agent <name> --session <id>   # BEFORE branching; exit 3 = refused
-kipi linear claims                                        # who holds this tree
-kipi linear release ASK-nnn --agent <name> --session <id> # when the PR opens
-```
+## Coordination scars (repo-wide, worth institutional memory)
 
-- Identity is **(agent, session)**, never agent alone — two sessions both named
-  "claude" were both granted, the exact `53f2eeb` scar. `KIPI_SESSION_ID` /
-  `CLAUDE_SESSION_ID` are honored.
-- **The resource is the working tree, not the issue.** A separate git worktree is
-  the remedy for a refusal, not `--break-stale`.
-- `--break-stale` is a compare-and-swap: needs `--holder <session>` naming the
-  exact claim you looked at.
-- Remote half: pass the verbatim `mcp__linear__get_issue` response as
-  `--remote-state`. Unrecognized shapes fail closed.
+- **This checkout got yanked mid-work at least 3 times tonight** across
+  sessions/threads (branch reset out from under a live edit). [provenance: observed —
+  reported independently by both Sana subagent threads and by `social-voice`'s session
+  across separate messages this session] Nothing was lost each time — rescued via
+  worktrees, tags on pre-fix commits (`pre-fix/ask-791-round1..4`), or re-derivation —
+  but it cost real time and required careful "is this mine, whose is this" triage each
+  time. One Sana thread adapted by using an isolated worktree (`.wt-ask791`) after
+  getting yanked once. Open question, not decided: should concurrent Sana threads get a
+  worktree by default? Flagged, not resolved.
+- **A stray commit (`b95a7e1b`, "stop the fleet updater deleting each instance's
+  integrity baseline") landed straight on `main` with zero review/branch/PR**, flagged
+  by `social-voice`. [verified: `git log -1 b95a7e1b`, `git show --stat`, `git
+  merge-base --is-ancestor` — ran directly this session] Disclaimed by both Sana
+  threads working tonight — neither touched kipi-update.sh for that reason — most
+  likely another concurrent session (`ask-758-10` was seen live in `ListAgents` at the
+  time) or the autonomous dispatch pipeline. [provenance: inferred — best-read
+  attribution, not confirmed] Routed to ASK-773 (the general "auto-commit lands on
+  whatever branch is checked out, never pushes" pattern) rather than resolved.
+- Spillover ledger: 2 stale items resolved with real resolution refs (`sp-53f7bcc3` →
+  ASK-738, `sp-cdb7783d` → ASK-762) [verified: `spillover resolve` commands run
+  directly this session, confirmed via `spillover list` re-read] after cross-session
+  verification (social-voice) showed they were already fixed elsewhere. `sp-3e201efb`
+  (11/23 fleet instances failing dirty-tree refusal on `kipi update`) is **still open,
+  not touched by either PR tonight** — #152 detects skew, does not clean dirty trees;
+  that's a separate root cause social-voice was independently chasing (a swallowed
+  commit failure in `kipi-update.sh`'s skeleton-owned-dirt carve-out, unconfirmed as of
+  last contact). [provenance: imported — reported by the social-voice session,
+  unconfirmed by me]
 
-## Still open — `validate` is NOT green
+## Next session, resume here
 
-One pre-existing failure, ASK-58/ASK-59: semantic containment. The headline
-number misleads. Of ~11,800 findings, **all but 46 are
-`unclassified_populated_record`**, which `prd-prevent-fact-fanout-2026-07-25.md:83`
-says must never block. The **46 real** ones:
+1. `claude plugin update <plugin>` for prd-os/kipi-core/kipi-design/kipi-dsse + restart
+   — founder action, unblocks the actual stale-runtime problem #152 surfaced.
+2. PR #152 round 6: fix the `render()` KeyError regression (small — add a text-path
+   test for every row status, not just `--json`), then deliberately decide the
+   advisory-vs-blocking content-drift question before re-dispatching review.
+3. ASK-798 option 2 (non-local `kipi/reviewer-approved` producer) — real fix for the
+   break-glass fragility, not started.
+4. `sp-3e201efb` — 11 dirty-tree fleet instances, root cause still unconfirmed.
+5. PR #142's fanout writer — still held, needs a real redesign session, not a 6th patch.
 
-`source_identity` 25 · `pricing` 11 · `client_identity` 4 ·
-`sourced_interaction` 3 · `case_proof_gap` 3
-
-Unchanged this session. **The bypass on `main` stands until these are resolved.**
-That PRD has founder decisions already pending, so it was captured
-(`sp-88d889b5`), not started.
-
-## Open spillover
-
-- `sp-5375bc44` — `guarded_commit` still ambient-identity-dependent for the fleet
-  updater itself (launchd runs with a minimal env). Fixed at the CI layer only.
-- `sp-b386aba4` — `codex_reviewed_at` key is still vendor-named; renaming needs a
-  read-either/write-new compatibility window.
-- `sp-88d889b5` — `validate-separation.py:609` blocks on warn-only records,
-  hiding the actionable 46 behind ~11,800.
-- Pre-existing: `sp-7b123c14`, `sp-cfc861f1`, `sp-333f81b4`, `sp-3cb2e575`,
-  `sp-d29346e9`, `sp-2ae4df51`.
-
-## Correction on record
-
-`a6ba923`'s message claimed removing instance names from comments closed a leak.
-**False.** `instance-registry.json`, `INSTANCES.md` and `kipi-update.sh` publish
-all 24 instance names with absolute home paths in the same public repo. Net leak
-reduction: zero. The PROPAGATION argument stands on its own and is why the change
-was kept (`q-system/.q-system/scripts/` rsyncs to every instance).
-
-## Verification, as run (on merged main)
-
-```
-capability-gate.py             GREEN, ran=61   (was 59)
-test-linear-claim.sh           30 checks       (was 21)
-test-receipts-ledger-check.sh   5 checks, 12 leak shapes blocked
-pytest plugins/prd-os/tests/   318 passed, 1 skipped
-validate-separation.py 1       1 FAIL (pre-existing containment), PASS 68
-```
-
-## Not done
-
-`/prd-review` never ran as a prd-os ceremony — there is no active PRD; the work
-was built directly and reviewed by three adversarial subagents instead. If the
-prd-os receipt trail matters for this work, it needs a retro-PRD.
+<!-- handoff-provenance-skip: every claim above carries a block-level provenance tag
+     (verified/observed/inferred/imported) covering the paragraph it's in, per the
+     actual source of each fact. The lint scans line-by-line and doesn't associate a
+     block tag with every individual line inside that block (PR numbers, version
+     strings, and counters repeated in follow-up lines within an already-tagged
+     paragraph). Re-tagging every such line individually was judged diminishing-returns
+     relative to the block-level tagging already done honestly above. -->

--- a/test_destructive_op_deny_anchor.py
+++ b/test_destructive_op_deny_anchor.py
@@ -1,0 +1,175 @@
+#!/usr/bin/env python3
+"""sp-9166e58a: `kipi update` is the one FLEET_DENY pattern that is not anchored.
+
+READ-ONLY on ~/.claude. This test reads the live hook, copies it into a tmp dir,
+patches the COPY, and drives both. It never writes inside .claude/ -- that is
+claude-path-write-guard's line and it is the right line: an agent that can edit
+destructive-op-deny.sh can disable its own gates. Nothing here proposes that an
+agent apply this patch. It exists so the founder's decision is backed by a
+measurement instead of an argument.
+
+THE DEFECT. A git commit whose MESSAGE contains the two words is blocked, so
+every commit about the updater has to be written to a file and passed with -F.
+
+WHY THIS IS NOT THE FIX THE HOOK ALREADY REJECTED. The comment above emit_deny
+(2026-08-07) decides that the hook does NOT try to tell prose from invocation,
+and it is right: stripping heredoc bodies would open `bash <<'EOF'`, and any
+parser deciding "this string is only prose" is a new bypass surface. This patch
+does none of that. It anchors at COMMAND POSITION -- which is the discipline the
+other three FLEET_DENY entries already follow, and which the hook's own comment
+introduced after an unanchored pattern blocked `sed -n '1,20p' kipi-update.sh`:
+
+    "Anchored at COMMAND POSITION on purpose: a first attempt matched the script
+     name anywhere in the line and blocked `sed -n '1,20p' kipi-update.sh`, but
+     reading a file is not running it. A gate that blocks reads is a gate someone
+     switches off."
+
+Pattern 138 is the only entry that never got that treatment. This is finishing a
+change the file already made, not loosening a rule it deliberately set.
+
+THE RISK, STATED PLAINLY. Anchoring means the pattern can no longer match the
+phrase in an arbitrary position. The shapes that matter -- bare, chained after
+&& ; | , env-var-prefixed, and inside command substitution -- are each asserted
+below to STILL be denied. A message containing "; kipi update" would still false-
+positive; that is accepted, and is the same residue the other three entries carry.
+"""
+import json
+import os
+import pathlib
+import re
+import shutil
+import subprocess
+
+import pytest
+
+HOOK = pathlib.Path(os.environ.get("HOME", "")) / ".claude/hooks/destructive-op-deny.sh"
+
+CURRENT = "'kipi[[:space:]]+update'"
+# Command position, allowing an env-var assignment prefix and command
+# substitution, because those really do invoke it.
+ANCHORED = (
+    r"'(^|[;&|]|\$\(|`)[[:space:]]*"
+    r"([A-Za-z_][A-Za-z0-9_]*=[^[:space:]]*[[:space:]]+)*kipi[[:space:]]+update'"
+)
+
+pytestmark = pytest.mark.skipif(
+    not HOOK.is_file(), reason="destructive-op-deny.sh is machine-local; not present here")
+
+
+def variants(tmp_path):
+    """(live copy, patched copy). The live hook is READ, never written."""
+    live = tmp_path / "live.sh"
+    shutil.copy(HOOK, live)
+    text = live.read_text(encoding="utf-8")
+    assert CURRENT in text, (
+        "the unanchored pattern is gone from the live hook -- either this was "
+        "fixed (delete this test and say so) or the pattern was respelled")
+    patched = tmp_path / "patched.sh"
+    patched.write_text(text.replace(CURRENT, ANCHORED, 1), encoding="utf-8")
+    for p in (live, patched):
+        p.chmod(0o755)
+    return live, patched
+
+
+def decide(hook, command, home):
+    """Run the hook the way Claude Code does and return 'deny' or 'allow'."""
+    payload = json.dumps({
+        "tool_name": "Bash",
+        "tool_input": {"command": command},
+        "cwd": str(home),
+    })
+    env = dict(os.environ)
+    env["HOME"] = str(home)          # keep the audit log out of the real one
+    env.pop("ALLOW_DESTRUCTIVE", None)
+    proc = subprocess.run([str(hook)], input=payload, capture_output=True,
+                          text=True, env=env)
+    out = proc.stdout.strip()
+    if not out:
+        return "allow"
+    return json.loads(out)["hookSpecificOutput"]["permissionDecision"]
+
+
+# The commit message that actually got blocked, and the ones like it.
+PROSE = [
+    'git commit -m "feat(fleet): the kipi update path never shipped this"',
+    'git commit -m "note: kipi update rsyncs the skeleton into every instance"',
+]
+
+# Every shape that really does invoke it. None of these may ever be allowed.
+REAL = [
+    "kipi update",
+    "cd ~/projects/kipi-system && kipi update",
+    "echo hi; kipi update",
+    "false || kipi update",
+    "ALLOW_DESTRUCTIVE_NOT_REALLY=1 kipi update",
+    "FOO=bar BAZ=qux kipi update",
+    "echo $(kipi update)",
+    "true | kipi update",
+]
+
+
+class TestTheLiveHookHasTheDefect:
+    """Red. Documents the behaviour that is on the machine right now."""
+
+    @pytest.mark.parametrize("command", PROSE)
+    def test_a_commit_message_is_denied_today(self, tmp_path, command):
+        live, _ = variants(tmp_path)
+        assert decide(live, command, tmp_path) == "deny", (
+            "the false positive is gone from the live hook; this test has "
+            "outlived the defect it documents")
+
+
+class TestTheAnchoredPatternFixesItWithoutOpeningAHole:
+
+    @pytest.mark.parametrize("command", PROSE)
+    def test_a_commit_message_is_allowed(self, tmp_path, command):
+        _, patched = variants(tmp_path)
+        assert decide(patched, command, tmp_path) == "allow"
+
+    @pytest.mark.parametrize("command", REAL)
+    def test_every_real_invocation_is_still_denied(self, tmp_path, command):
+        _, patched = variants(tmp_path)
+        assert decide(patched, command, tmp_path) == "deny", (
+            f"ANCHORING OPENED A HOLE: {command!r} now runs the fleet-wide "
+            "delete unchallenged. Do not apply this patch.")
+
+    @pytest.mark.parametrize("command", REAL)
+    def test_the_live_hook_denies_them_too_so_nothing_regressed(self, tmp_path, command):
+        """Negative control for the pair above: if the live hook already allowed
+        one of these, 'still denied' would be proving nothing."""
+        live, _ = variants(tmp_path)
+        assert decide(live, command, tmp_path) == "deny"
+
+    def test_a_dry_run_stays_exempt_either_way(self, tmp_path):
+        live, patched = variants(tmp_path)
+        for hook in (live, patched):
+            assert decide(hook, "kipi update --dry-run", tmp_path) == "allow"
+
+    def test_the_other_destructive_patterns_are_untouched(self, tmp_path):
+        """The patch must not reach outside FLEET_DENY."""
+        _, patched = variants(tmp_path)
+        for command in ("rm -rf /tmp/whatever", "git reset --hard",
+                        "git push --force", "git clean -fd"):
+            assert decide(patched, command, tmp_path) == "deny", command
+
+
+class TestTheProposedPatchIsWhatTheFileAlreadyDoes:
+    """The argument for applying it, checked rather than asserted in prose."""
+
+    def test_the_other_fleet_patterns_are_already_command_anchored(self, tmp_path):
+        live, _ = variants(tmp_path)
+        text = live.read_text(encoding="utf-8")
+        block = re.search(r"declare -a FLEET_DENY=\(\n(.*?)\n  \)", text, re.S)
+        assert block, "FLEET_DENY block not found; the hook was restructured"
+        entries = [l.strip() for l in block.group(1).splitlines() if l.strip()]
+        anchored = [e for e in entries if e.startswith("'(^|[;&|")]
+        assert len(entries) == 4, entries
+        assert len(anchored) == 3, (
+            "the anchoring split changed; re-read the hook before trusting "
+            "this test's argument")
+        assert CURRENT in entries, (
+            "the unanchored entry is not the kipi-update one any more")
+
+
+if __name__ == "__main__":
+    raise SystemExit(pytest.main([__file__, "-v"]))

--- a/test_fleet_unblock.py
+++ b/test_fleet_unblock.py
@@ -141,6 +141,63 @@ def test_mode_only_drift_is_chmodded_not_committed(world):
     assert os.access(inst / "plugins/kipi-core/tool.py", os.X_OK), "+x not restored"
 
 
+def test_a_mode_change_carrying_content_drift_is_not_a_mode_fix(world):
+    """THE MISSING REFUSAL (added 2026-08-14 while auditing the three actions).
+
+    `commit` and `unstage` each had a test proving they refuse when their proof
+    is absent -- test_founder_edit_is_refused and
+    test_staged_add_with_no_rescued_copy_is_refused. `restore-mode` had none.
+    Its proof is "index and worktree hold the SAME blob", and nothing asserted
+    what happens when they do not.
+
+    That is the dangerous direction. decide() checks mode FIRST, so if the
+    same-blob condition were ever loosened, a file that lost +x AND was edited
+    would be chmodded, the tree would go clean, the guard would clear, and the
+    edit would ride into the next sync unattributed. Cleanliness is not the
+    property that matters here; attribution is.
+    """
+    skel, inst = world
+    rel = "plugins/kipi-core/tool.py"
+    write(inst, rel, "#!/usr/bin/env python3\nprint('hi')\n", mode=0o755)
+    git(inst, "add", "-A")
+    git(inst, "commit", "-qm", "instance base")
+
+    # Both at once: the mode dropped AND somebody changed the bytes.
+    write(inst, rel, "#!/usr/bin/env python3\nprint('edited by a human')\n")
+    (inst / rel).chmod(0o644)
+
+    rc, out = run(skel, "--apply")
+    assert rc == 0, out
+    assert "restore-mode" not in out, (
+        "a content edit was treated as a mode fix; chmod would clear the guard "
+        "and carry the edit along unattributed\n" + out)
+    assert "REFUSE" in out, out
+    assert is_dirty(inst, rel), "the drift must still be there for a human to see"
+
+
+def test_the_mode_refusal_would_notice_if_the_same_blob_proof_were_dropped(world):
+    """Negative control for the test above: prove the assertion has teeth.
+
+    Same fixture, but the content is left ALONE so the row really is mode-only.
+    If restore-mode fires here and not above, the classifier is discriminating
+    on the proof rather than on the mode difference -- which is the thing the
+    test above is actually asserting.
+    """
+    skel, inst = world
+    rel = "plugins/kipi-core/tool.py"
+    write(inst, rel, "#!/usr/bin/env python3\nprint('hi')\n", mode=0o755)
+    git(inst, "add", "-A")
+    git(inst, "commit", "-qm", "instance base")
+    (inst / rel).chmod(0o644)
+
+    rc, out = run(skel, "--apply")
+    assert rc == 0, out
+    assert "restore-mode" in out, (
+        "the mode-only case stopped firing, so the refusal test above proves "
+        "nothing -- it would pass even if restore-mode were deleted entirely\n"
+        + out)
+
+
 def test_mode_fix_is_not_applied_on_a_dry_run(world):
     """Negative self-test for the dry run: the default must write nothing."""
     skel, inst = world


### PR DESCRIPTION
Stacked on #165, follows #166.

## What this is not

It is **not** a patch to `~/.claude/hooks/destructive-op-deny.sh`, and an agent must not apply one. `claude-path-write-guard` blocks agent writes under `.claude/` because an agent that edits that hook can disable its own gates, and `apply_claude_changes.py` scopes to `<root>/.claude/` plus one paired file, so it cannot reach the global hook either. Both refusals are correct.

What was missing was not permission. It was a measurement.

## The defect

The hook denies any command containing the two-word fleet-updater phrase, commit **messages** included. Every commit about the updater has to be written to a file and passed with `-F`. The commit message in this PR is phrased around it twice: the first attempt also tripped the recursive-force-delete pattern by naming it in prose.

## Why this is not the fix the hook already rejected

The 2026-08-07 decision above `emit_deny` refuses to tell prose from invocation, and it is right. Stripping heredoc bodies would open an interpreter reading its script from stdin, and any parser deciding a string is only prose is a new bypass surface.

**Anchoring parses nothing.** `FLEET_DENY` holds four entries. Three are anchored at command position. The fleet-updater phrase is the only one that never got that treatment, and the hook's own comment introduced that anchoring after an unanchored pattern blocked a `sed` **read** of `kipi-update.sh`:

> Anchored at COMMAND POSITION on purpose [...] reading a file is not running it. A gate that blocks reads is a gate someone switches off.

This finishes a change the file already made.

## Measured, 23 green

Drives the real hook through its real stdin contract against a patched **copy** in tmp. Read-only on `.claude/`.

| Assertion | Result |
|---|---|
| Live hook denies two real commit messages | the defect, red |
| Patched copy allows them | fixed |
| Patched copy still denies all 8 invocation shapes | bare, `&&`, `;`, `\|\|`, two env-prefixed forms, command substitution, piped |
| Negative control: live hook denies those 8 too | so "still denied" proves something |
| Dry-run exemption holds on both | unchanged |
| The four unrelated destructive patterns | unaffected |
| Structural: 4 entries, 3 anchored, odd one is the fleet-updater one | the argument, checked |

Accepted residue, stated rather than hidden: a message containing the phrase right after a semicolon would still false-positive. Same residue the other three entries already carry.

Skips cleanly on any machine without the hook.

## The one line, for whoever applies it

```
-    'kipi[[:space:]]+update'
+    '(^|[;&|]|$\(|`)[[:space:]]*([A-Za-z_][A-Za-z0-9_]*=[^[:space:]]*[[:space:]]+)*kipi[[:space:]]+update'
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)