### PR TITLE
The concurrency cap counted strangers' reviews and stopped the loop (ASK-804)

### DIFF
--- a/kipi-dispatch.sh
+++ b/kipi-dispatch.sh
@@ -316,27 +316,48 @@ stale_check || exit 0
 
 # `pgrep -c` exits 1 with no match, which under `set -e` would look like failure
 # and under a bare assignment yields an empty string. Force a number.
-# COUNTS RE-REVIEW CHILDREN TOO (codex major, PR #163 r1).
+# COUNTS DISPATCH'S OWN RE-REVIEW CHILDREN -- AND ONLY ITS OWN.
 #
 # A dispatch does not always launch a converge. On a reviewer redrive it launches
 #   bash .../pr-review-agent.sh <PR> --issue ASK-nnn --post
-# which the old `converge.sh --issue` pattern never matched. So a re-review child
-# was invisible to the concurrency cap: at cap 3, three converges plus any number
-# of live re-reviews could run at once, each spending a `claude -p` pair. The cap
-# is the spend bound, and it was bounding only half of what it launches.
+# which a `converge.sh --issue` pattern never matched, so those children spent a
+# `claude -p` pair outside the cap.
 #
-# It also made the two counters speak about DIFFERENT POPULATIONS. live_repos()
-# matches on `--issue <id>`, which a re-review child DOES carry, so the ledger
-# counted it while pgrep did not -- and the attributed-vs-total comparison below
-# was comparing apples to oranges. One population, both counters.
-# The pattern is overridable ONLY so the test suite can be hermetic. This counts
-# by scanning the machine-wide process table, so a real review running in another
-# terminal is indistinguishable from a fixture -- which made the counting cases
-# fail against a correct implementation (observed: three live pr-review-agent
-# processes from an interactive session). Production never sets this.
-LIVE_PATTERN="${KIPI_DISPATCH_LIVE_PATTERN:-converge\.sh --issue|pr-review-agent\.sh .*--issue}"
+# WIDENING THE pgrep PATTERN TO MATCH THEM WAS WRONG, AND IT STOPPED DISPATCH IN
+# PRODUCTION. Measured 2026-08-14T23:46:15Z, first tick after arming:
+#   skip: 5 converge run(s) live, cap 3
+# There were ZERO converges. All five were pr-review-agent processes belonging to
+# an interactive session reviewing PRs by hand. pgrep reads the machine-wide
+# process table and cannot tell dispatch's child from anyone else's, so ordinary
+# review work became a hard block on the whole loop. That is strictly worse than
+# the under-count it replaced: the old bug leaked some spend, this one dispatched
+# nothing at all.
+#
+# So the two populations are counted from the two sources that can actually
+# identify them:
+#   - CONVERGES via pgrep, because a hand-run converge SHOULD count -- it is real
+#     work in a repo and the cap exists to bound exactly that;
+#   - RE-REVIEWS via the ledger, because only dispatch writes it, so a row there
+#     is by construction a child dispatch launched.
+# A third party's review is in neither, which is the point.
+LIVE_PATTERN="${KIPI_DISPATCH_LIVE_PATTERN:-converge\.sh --issue}"
+
 live_converges() {
-  pgrep -f "$LIVE_PATTERN" 2>/dev/null | grep -c . || true
+  local conv rr pid issue repo
+  conv="$(pgrep -f "$LIVE_PATTERN" 2>/dev/null | grep -c . || true)"
+  conv="${conv:-0}"
+  rr=0
+  if [ -f "$LIVE_LEDGER" ]; then
+    while IFS=$'\t' read -r pid issue repo; do
+      case "$pid" in ''|*[!0-9]*) continue ;; esac
+      kill -0 "$pid" 2>/dev/null || continue
+      # Only the re-review shape; a dispatch-launched converge is already in conv.
+      ps -p "$pid" -o args= 2>/dev/null | grep -q 'pr-review-agent' || continue
+      ps -p "$pid" -o args= 2>/dev/null | grep -qE -- "--issue $issue([[:space:]]|\$)" || continue
+      rr=$((rr + 1))
+    done < "$LIVE_LEDGER"
+  fi
+  printf '%s' "$((conv + rr))"
 }
 
 # --- PER-REPO CONCURRENCY (sp-e45251f7) --------------------------------------

--- a/q-system/.q-system/scripts/test/test-dispatch-per-repo-concurrency.sh
+++ b/q-system/.q-system/scripts/test/test-dispatch-per-repo-concurrency.sh
@@ -65,7 +65,7 @@ export KIPI_DISPATCH_LIVE_LEDGER="$WORK/live.tsv"
 # counting cases went red against correct code. Every fixture below carries the
 # FIXTURETAG marker and the counter is scoped to it, so this suite measures only
 # processes it started.
-export KIPI_DISPATCH_LIVE_PATTERN="FIXTURETAG.*--issue"
+export KIPI_DISPATCH_LIVE_PATTERN="FIXTURETAG converge"
 # shellcheck disable=SC1090
 . "$HELPERS"
 
@@ -249,30 +249,36 @@ echo "$SEL_U" | grep -q 'PICKED=beta' \
 kill "$PID_H" 2>/dev/null; wait "$PID_H" 2>/dev/null
 
 kill_all_fakes
-echo "== 10. a RE-REVIEW child counts against the concurrency cap =="
-# A dispatch does not always launch a converge. On a reviewer redrive it runs
-#   bash .../pr-review-agent.sh <PR> --issue ASK-nnn --post
-# which the old `converge.sh --issue` pattern never matched, so re-review
-# children spent a `claude -p` pair outside the cap entirely.
+echo "== 10. dispatch's OWN re-review child counts; a stranger's review does NOT =="
+# Widening the pgrep pattern to catch re-reviews stopped dispatch in production:
+#   2026-08-14T23:46:15Z skip: 5 converge run(s) live, cap 3
+# with ZERO converges -- all five were an interactive session's pr-review-agent
+# processes. pgrep cannot tell dispatch's child from anyone else's, so the two
+# populations are counted from the two sources that can: converges by pgrep,
+# re-reviews by the LEDGER, which only dispatch writes.
 spawn_fake_rereview() {
   bash -c 'exec -a "FIXTURETAG bash /x/pr-review-agent.sh 163 --issue '"$1"' --post" sleep 60' >/dev/null 2>&1 &
   echo $! >> "$WORK/pids"
   echo $!
 }
 BASE="$(live_converges)"; BASE="${BASE:-0}"
-PID_R="$(spawn_fake_rereview ASK-600)"
-sleep 1
-NOW="$(live_converges)"; NOW="${NOW:-0}"
-[ "$NOW" -gt "$BASE" ] \
-  && ok "a live re-review child is counted by live_converges ($BASE -> $NOW)" \
-  || bad "a re-review child is invisible to the cap" "count stayed $BASE; it would run outside the spend bound"
 
-# T10-neg: the OLD pattern must NOT see it, or case 10 proves nothing.
-OLD="$(pgrep -f 'FIXTURETAG converge\.sh --issue' 2>/dev/null | grep -c . || true)"; OLD="${OLD:-0}"
-[ "$OLD" -eq "$BASE" ] \
-  && ok "T10-neg the old converge-only pattern is blind to it (the gap was real)" \
-  || bad "T10-neg the assertion CAN fail" "the old pattern already matched, so nothing was fixed"
-kill "$PID_R" 2>/dev/null; wait "$PID_R" 2>/dev/null
+# A stranger's review: live, matching pr-review-agent, but NOT in the ledger.
+PID_X="$(spawn_fake_rereview ASK-900)"
+sleep 1
+STRANGER="$(live_converges)"; STRANGER="${STRANGER:-0}"
+[ "$STRANGER" -eq "$BASE" ] \
+  && ok "a review this dispatch never launched does NOT count ($BASE unchanged)" \
+  || bad "an unrelated review counted against the cap ($BASE -> $STRANGER)" \
+        "this is the 5-live-0-converges production stall"
+
+# The same process, once ATTRIBUTED to dispatch, does count.
+record_live_run "$PID_X" "ASK-900" "/repos/rr"
+MINE="$(live_converges)"; MINE="${MINE:-0}"
+[ "$MINE" -gt "$BASE" ] \
+  && ok "dispatch's own re-review child DOES count ($BASE -> $MINE)" \
+  || bad "a dispatch-launched re-review escaped the cap" "it spends a claude -p pair unbounded"
+kill "$PID_X" 2>/dev/null; wait "$PID_X" 2>/dev/null
 
 echo "== 11. a FAILED ledger write is loud, not silently successful =="
 # An unwritten row silently disables per-repo exclusion for that repo. Point the


### PR DESCRIPTION
## Caught in production, on the first tick after arming

```
2026-08-14T23:46:15Z skip: 5 converge run(s) live, cap 3
```

**There were zero converges.** All five were `pr-review-agent` processes belonging to an interactive session reviewing PRs by hand. Dispatch was armed, healthy, had 25 ready issues in one repo and 4 in another, and dispatched nothing.

## I introduced this earlier today

A previous codex finding was correct: re-review children escaped the cap, because on a reviewer redrive dispatch launches `pr-review-agent.sh`, not `converge.sh`. I fixed it by widening the `pgrep` pattern to match both.

`pgrep` reads the machine-wide process table and cannot tell dispatch's child from anyone else's. So ordinary review work became a hard block on the whole loop.

**That is strictly worse than the bug it replaced.** The old under-count leaked some spend. This one dispatched nothing at all. A guard that stops the thing it guards is not a stricter guard.

## The fix

Two populations, counted from the two sources that can actually identify them:

- **Converges via `pgrep`** — a hand-run converge *should* count. It is real work in a repo, and bounding that is what the cap is for.
- **Re-reviews via the ledger** — only dispatch writes it, so a row there is by construction a child dispatch launched.

A third party's review is in neither. That is the point.

## Verification

Case 10 proves **both directions against the same process**, which is the only way the claim means anything:

- live, matching `pr-review-agent`, NOT in the ledger → count unchanged
- the same pid recorded via `record_live_run` → count rises

```
test-dispatch-per-repo-concurrency  23 passed, 0 failed
test-dispatch-liveness              18 passed, 0 failed
test-ci-redrive                     65 passed, 0 failed
```

## Note

This was not findable from the test suite. The suite scopes its counter to tagged fixtures precisely so it is hermetic — which is correct for a test and is exactly what hid this. It took arming the job and reading the log.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0151EYtGH6at3XTWqbBHAxEi