### PR TITLE
Stop the prd-os lock files standing dirty forever (sp-a21cb27c, sp-455ed238)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -109,6 +109,16 @@ q-system/output/.update-check-*
 q-system/output/capability-maps/
 .runs/
 
+# Lock files beside the prd-os ledgers. flock targets, recreated on every
+# resolve/reclassify, and they were standing untracked-and-unignored inside a
+# TRACKED directory. sp-a21cb27c predicted an unattended auto-commit would sweep
+# them in; measured 2026-08-14 that is false -- auto-commit.py's NEVER list
+# already refuses any .lock, so system_state_paths returns [] for both. What was
+# left was permanent noise in `git status`, which is its own cost: a status that
+# is never clean is a status nobody reads.
+.prd-os/*.lock
+.prd-os/.judgments.lock
+
 # THE STANZA BETWEEN THESE MARKERS IS SHIPPED TO EVERY INSTANCE (sp-097d2e23).
 # kipi-update-gitignore-block.py parses it out of this file and writes it into
 # each instance's root .gitignore as a managed block. Root .gitignore is not in

--- a/q-system/.q-system/tests/test_gitignore_block.py
+++ b/q-system/.q-system/tests/test_gitignore_block.py
@@ -238,6 +238,26 @@ class TestTheWiringIntoTheUpdater:
             "the .gitignore block is written AFTER the untrack migration, so "
             "every untracked marker is visible to auto-commit until the next run")
 
+    def test_it_also_runs_before_the_updater_scans_for_system_state(self):
+        """Belt and braces, and worth pinning.
+
+        SYSTEM_NEVER_COMMIT already stops the updater committing the three
+        integrity paths, so this ordering is not what protects them today. It is
+        what protects the NEXT path added to the stanza: a path that is ignored
+        before `git status` runs is never offered to the classifier at all, so it
+        needs no second entry in a hand-kept array to be safe. Ignoring is the
+        layer every writer reads; the array is one writer's opt-out list."""
+        text = self.text()
+        block_at = text.index("kipi-update-gitignore-block.py")
+        # The INVOCATION, not the first mention. `--system-state` appears in a
+        # comment ~1300 lines above the call site, and anchoring on that made
+        # this test pass for the wrong reason on its first run.
+        scan_at = text.index('"$sys_classifier" --system-state')
+        assert block_at < scan_at, (
+            "the .gitignore block is written after the updater scans for "
+            "system state, so a newly-stanza'd path is still offered to the "
+            "classifier on the run that introduces it")
+
     def test_the_updater_still_parses(self):
         r = subprocess.run(["bash", "-n", self.UPDATER],
                            capture_output=True, text=True)


### PR DESCRIPTION
Replaces #169, which went DIRTY after #166 and #167 squash-merged into this base. Rebuilt clean: **30 lines, two files.**

## sp-a21cb27c — premise falsified

The note predicted an unattended auto-commit would sweep `.prd-os/spillover.jsonl.lock` into a commit.

Measured: it will not. `auto-commit.py`'s NEVER list already refuses any `.lock`, and `system_state_paths` returns `[]` for both lock files. Pinned by `TestTheNeverList::test_a_lock_file_is_never_taken`. There was never a path from those files into a commit.

What *was* real is smaller and still worth closing: both stood untracked-and-unignored inside a **tracked** directory, recreated on every resolve, so `git status` was never clean.

A status that is never clean is a status nobody reads. That is how the five committed integrity markers in #166 went unnoticed. Both paths now ignored, verified with `git check-ignore`. Voided with the measurement.

## sp-455ed238 — duplicate

Same root cause as sp-097d2e23. Filed 2026-07-28 from ASK-113, re-filed independently 2026-08-14. **The re-file is the evidence**: a note nobody can close gets rediscovered rather than fixed. The shipped stanza covers this exact case, pinned by `test_the_update_check_stamp_is_ignored_too`.

## The ordering assertion

`SYSTEM_NEVER_COMMIT` already stops the updater committing the three integrity paths, so this ordering is not what protects them today. It protects the **next** path added to the stanza: a path ignored before `git status` runs is never offered to the classifier at all, so it needs no second entry in a hand-kept array to be safe.

Ignoring is the layer every writer reads. The array is one writer's opt-out list.

It went red on first run and **the test was wrong, not the code** — `--system-state` appears in a comment ~1300 lines above the call site, so anchoring on the first textual match compared the block against prose. Now anchored on the invocation.

## Verification

51 green across the three affected test files. The block writer is unaffected: the stanza is delimited by its own markers and the new lines sit outside them.

🤖 Generated with [Claude Code](https://claude.com/claude-code)