### PR TITLE
The .gitignore the updater creates must be committable (sp-097d2e23)

### DIFF
--- a/q-system/.q-system/tests/test_gitignore_block.py
+++ b/q-system/.q-system/tests/test_gitignore_block.py
@@ -264,6 +264,46 @@ class TestTheWiringIntoTheUpdater:
         assert r.returncode == 0, r.stderr
 
 
+class TestTheFileTheWriterCreatesCanActuallyBeCommitted:
+    """A defect in THIS fix, found by running it against real instances.
+
+    Dry-checked on three live instances 2026-08-14: none of them has a root
+    .gitignore AT ALL, so the writer does not edit a file, it CREATES one. Git
+    honours an untracked .gitignore, so the ignore rules work either way -- but
+    an untracked file is one nobody committed, in a repo nobody looks at, and
+    auto-commit.py classified `.gitignore` as `unclassified`.
+
+    Unclassified means REPORTED, never committed (ASK-498). So the fix would
+    have left every one of the 22 instances printing the same unclassifiable
+    path on every single run, forever, and the file itself unversioned -- not in
+    the instance's history, not recoverable if something removed it.
+
+    That is the exact shape this whole PR is about: state the system writes for
+    itself that nothing is allowed to commit, sitting dirty until it becomes
+    background noise. Fixing it in the same breath rather than filing it.
+    """
+
+    def test_a_created_gitignore_is_offered_to_the_fleet_sync(self, tmp_path):
+        root = make_instance(tmp_path)
+        assert not (root / ".gitignore").exists()
+        blockmod.main(["--skeleton", REPO, "--instance", str(root)])
+
+        assert ".gitignore" in untracked(root), "precondition: it is untracked"
+        assert auto_commit.system_state_paths([".gitignore"]) == [".gitignore"], (
+            "the writer creates a file the fleet sync is not allowed to commit, "
+            "so it stays untracked and unclassified on every instance forever")
+
+    def test_it_is_chore_not_founder_content(self):
+        """It must be `chore`. system_state_paths narrows to chore precisely so
+        an unattended fleet-wide sweep never takes founder-authored content."""
+        assert auto_commit.classify(".gitignore")[0] == "chore"
+
+    def test_an_instance_gitignore_is_not_swept_as_unclassified(self):
+        """The negative half: `unclassified` is what REPORTS a path instead of
+        committing it. If this regresses, the noise comes straight back."""
+        assert auto_commit.classify(".gitignore") != auto_commit.SKIP_UNCLASSIFIED
+
+
 class TestUntrackingWithoutIgnoringRegresses:
     """The behavioural half of the ordering argument, run for real."""
 
@@ -303,7 +343,14 @@ class TestUntrackingWithoutIgnoringRegresses:
 
         assert (root / rel).exists(), "the untrack must never delete the file"
         assert rel not in untracked(root)
-        assert auto_commit.system_state_paths(untracked(root)) == []
+        # Names the MARKER rather than asserting the offered list is empty.
+        # The broad version was written before .gitignore itself became
+        # committable, and it then failed for the right reason: the writer
+        # creates a root .gitignore, which IS now offered to the fleet sync on
+        # purpose (see TestTheFileTheWriterCreatesCanActuallyBeCommitted). An
+        # assertion that breaks when an unrelated path is correctly added was
+        # testing the wrong thing.
+        assert rel not in auto_commit.system_state_paths(untracked(root))
 
 
 if __name__ == "__main__":

--- a/q-system/hooks/auto-commit.py
+++ b/q-system/hooks/auto-commit.py
@@ -39,6 +39,21 @@ AREA_MAP = [
     (".claude/agents/",               "chore",    "update agent definitions"),
     (".claude/output-styles/",        "chore",    "update output styles"),
     (".claude/settings",              "chore",    "update settings"),
+    # sp-097d2e23. The updater writes a managed never-commit block into every
+    # instance's root .gitignore, and dry-checked on three live instances none
+    # of them HAS a root .gitignore -- so the updater creates the file. Git
+    # honours an untracked .gitignore, so the rules bite either way, but this
+    # classifier answered `unclassified` for it, which means REPORTED and never
+    # committed (ASK-498). Left alone, all 22 instances would print the same
+    # unclassifiable path on every run forever and the file would stay
+    # unversioned: absent from the instance's history and unrecoverable if
+    # anything removed it. Exactly the state-the-system-writes-for-itself-that-
+    # nothing-may-commit shape that sp-097d2e23 exists to end.
+    #
+    # `chore`, so the fleet sync may take it: system exhaust, not authored
+    # content. Config, never source, so the executable-source refusal above
+    # does not reach it.
+    (".gitignore",                    "chore",    "update gitignore"),
     ("sites/",                        "feat",     "update site pages"),
     ("memory/",                       "chore",    "update auto-memory"),
 ]


### PR DESCRIPTION
A defect in my own fix from #166, found by running it against real instances instead of only its fixtures.

## What running it on live trees showed

Dry-checked the block writer on three real instances. **None of them has a root `.gitignore` at all.**

So the writer does not edit a file, it **creates** one. Git honours an untracked `.gitignore`, so the rules bite either way. But `auto-commit.py` classified `.gitignore` as `unclassified`, and unclassified means REPORTED, never committed (ASK-498).

Left alone: all 22 instances print the same unclassifiable path on every run, forever, and the file stays unversioned — absent from the instance's history, unrecoverable if anything removes it.

That is precisely the shape this PR chain exists to end. State the system writes for itself that nothing is allowed to commit, sitting dirty until it becomes background noise nobody reads. A status that is never clean is a status nobody reads — which is how five instances committed their own tripwire state unnoticed.

## The fix

One `AREA_MAP` entry: `.gitignore` → `chore`, "update gitignore".

`chore` so the fleet sync may take it — system exhaust, not authored content. `system_state_paths` narrows to `chore` precisely so an unattended fleet-wide sweep never takes founder-authored work. Config and never source, so the executable-source refusal does not reach it.

## Red first

Three tests, all three failing before the entry:

- a created `.gitignore` is offered to the fleet sync
- it is `chore`, not founder content
- it is not `SKIP_UNCLASSIFIED`, the value that reports instead of committing

## It broke an existing assertion, correctly

`test_block_then_untrack_ends_clean` asserted the offered list was **empty**. It is now `['.gitignore']`, which is the intended new behaviour.

That assertion predates `.gitignore` being committable and was testing the wrong thing — it breaks whenever an unrelated path is correctly added. Retightened to name the armed marker, which is what it was always about.

## Verification

**336 passed, 0 failed** across the skeleton suite plus both root test files.

🤖 Generated with [Claude Code](https://claude.com/claude-code)