### PR TITLE
Correct a false claim I put in the .gitignore fix's own comments

### DIFF
--- a/q-system/.q-system/tests/test_gitignore_block.py
+++ b/q-system/.q-system/tests/test_gitignore_block.py
@@ -264,6 +264,46 @@ class TestTheWiringIntoTheUpdater:
         assert r.returncode == 0, r.stderr
 
 
+class TestTheFileTheWriterCreatesCanActuallyBeCommitted:
+    """A defect in THIS fix, found by running it against real instances.
+
+    Dry-checked on three live instances 2026-08-14: none of them has a root
+    .gitignore AT ALL, so the writer does not edit a file, it CREATES one. Git
+    honours an untracked .gitignore, so the ignore rules work either way -- but
+    an untracked file is one nobody committed, in a repo nobody looks at, and
+    auto-commit.py classified `.gitignore` as `unclassified`.
+
+    Unclassified means REPORTED, never committed (ASK-498). So the fix would
+    have left every one of the 22 instances printing the same unclassifiable
+    path on every single run, forever, and the file itself unversioned -- not in
+    the instance's history, not recoverable if something removed it.
+
+    That is the exact shape this whole PR is about: state the system writes for
+    itself that nothing is allowed to commit, sitting dirty until it becomes
+    background noise. Fixing it in the same breath rather than filing it.
+    """
+
+    def test_a_created_gitignore_is_offered_to_the_fleet_sync(self, tmp_path):
+        root = make_instance(tmp_path)
+        assert not (root / ".gitignore").exists()
+        blockmod.main(["--skeleton", REPO, "--instance", str(root)])
+
+        assert ".gitignore" in untracked(root), "precondition: it is untracked"
+        assert auto_commit.system_state_paths([".gitignore"]) == [".gitignore"], (
+            "the writer creates a file the fleet sync is not allowed to commit, "
+            "so it stays untracked and unclassified on every instance forever")
+
+    def test_it_is_chore_not_founder_content(self):
+        """It must be `chore`. system_state_paths narrows to chore precisely so
+        an unattended fleet-wide sweep never takes founder-authored content."""
+        assert auto_commit.classify(".gitignore")[0] == "chore"
+
+    def test_an_instance_gitignore_is_not_swept_as_unclassified(self):
+        """The negative half: `unclassified` is what REPORTS a path instead of
+        committing it. If this regresses, the noise comes straight back."""
+        assert auto_commit.classify(".gitignore") != auto_commit.SKIP_UNCLASSIFIED
+
+
 class TestUntrackingWithoutIgnoringRegresses:
     """The behavioural half of the ordering argument, run for real."""
 
@@ -303,7 +343,14 @@ class TestUntrackingWithoutIgnoringRegresses:
 
         assert (root / rel).exists(), "the untrack must never delete the file"
         assert rel not in untracked(root)
-        assert auto_commit.system_state_paths(untracked(root)) == []
+        # Names the MARKER rather than asserting the offered list is empty.
+        # The broad version was written before .gitignore itself became
+        # committable, and it then failed for the right reason: the writer
+        # creates a root .gitignore, which IS now offered to the fleet sync on
+        # purpose (see TestTheFileTheWriterCreatesCanActuallyBeCommitted). An
+        # assertion that breaks when an unrelated path is correctly added was
+        # testing the wrong thing.
+        assert rel not in auto_commit.system_state_paths(untracked(root))
 
 
 if __name__ == "__main__":

--- a/q-system/.q-system/tests/test_gitignore_block.py
+++ b/q-system/.q-system/tests/test_gitignore_block.py
@@ -267,16 +267,27 @@ class TestTheWiringIntoTheUpdater:
 class TestTheFileTheWriterCreatesCanActuallyBeCommitted:
     """A defect in THIS fix, found by running it against real instances.
 
-    Dry-checked on three live instances 2026-08-14: none of them has a root
-    .gitignore AT ALL, so the writer does not edit a file, it CREATES one. Git
-    honours an untracked .gitignore, so the ignore rules work either way -- but
-    an untracked file is one nobody committed, in a repo nobody looks at, and
-    auto-commit.py classified `.gitignore` as `unclassified`.
+    Measured 2026-08-14 by copying a real instance and running the writer on the
+    copy: every instance already HAS a root .gitignore (70-76 lines) and it is
+    TRACKED, and none of them carries these rules. So the writer MODIFIES a
+    tracked file, landing as ` M .gitignore`.
 
-    Unclassified means REPORTED, never committed (ASK-498). So the fix would
-    have left every one of the 22 instances printing the same unclassifiable
-    path on every single run, forever, and the file itself unversioned -- not in
-    the instance's history, not recoverable if something removed it.
+    (The first version of this docstring said instances have no root .gitignore
+    at all. That came from a malformed `grep -c` whose output was misread, and
+    it was wrong. The class below is unchanged and still needed; only the reason
+    was wrong. Recorded rather than quietly edited, because the same mistake --
+    trusting a grep over looking at the thing -- is what this whole PR chain
+    keeps finding in other people's notes.)
+
+    auto-commit.py classified `.gitignore` as `unclassified`, which means
+    REPORTED, never committed (ASK-498). So every one of the 22 instances would
+    carry a permanently modified, never-committable tracked file and print the
+    same unclassifiable path on every run, forever.
+
+    It does NOT block the sync. The dirty-tree guard is scoped to
+    `$prefix/ .claude/ plugins/` (kipi-update.sh ~L2012) and root .gitignore is
+    in none of them. Checked, because the first guess was that this self-blocked
+    all 22 instances, and that guess was wrong too.
 
     That is the exact shape this whole PR is about: state the system writes for
     itself that nothing is allowed to commit, sitting dirty until it becomes
@@ -292,6 +303,23 @@ class TestTheFileTheWriterCreatesCanActuallyBeCommitted:
         assert auto_commit.system_state_paths([".gitignore"]) == [".gitignore"], (
             "the writer creates a file the fleet sync is not allowed to commit, "
             "so it stays untracked and unclassified on every instance forever")
+
+    def test_a_tracked_gitignore_the_writer_modified_is_offered(self, tmp_path):
+        """THE REAL-WORLD SHAPE, and the one the first version of this class got
+        wrong. Instances ship a tracked .gitignore, so the writer modifies it
+        rather than creating it, and a modified tracked file is a different
+        git state from an untracked one. Both must be committable."""
+        root = make_instance(tmp_path)
+        (root / ".gitignore").write_text("# the instance's own\nnode_modules/\n")
+        git(str(root), "add", "-f", ".gitignore")
+        git(str(root), "commit", "-qm", "instance ships a gitignore")
+
+        blockmod.main(["--skeleton", REPO, "--instance", str(root)])
+
+        status = git(str(root), "status", "--porcelain", "--", ".gitignore").stdout
+        assert status.strip().startswith("M"), (
+            f"expected a tracked modification, got {status!r}")
+        assert auto_commit.system_state_paths([".gitignore"]) == [".gitignore"]
 
     def test_it_is_chore_not_founder_content(self):
         """It must be `chore`. system_state_paths narrows to chore precisely so

--- a/q-system/hooks/auto-commit.py
+++ b/q-system/hooks/auto-commit.py
@@ -39,6 +39,21 @@ AREA_MAP = [
     (".claude/agents/",               "chore",    "update agent definitions"),
     (".claude/output-styles/",        "chore",    "update output styles"),
     (".claude/settings",              "chore",    "update settings"),
+    # sp-097d2e23. The updater writes a managed never-commit block into every
+    # instance's root .gitignore, and dry-checked on three live instances none
+    # of them HAS a root .gitignore -- so the updater creates the file. Git
+    # honours an untracked .gitignore, so the rules bite either way, but this
+    # classifier answered `unclassified` for it, which means REPORTED and never
+    # committed (ASK-498). Left alone, all 22 instances would print the same
+    # unclassifiable path on every run forever and the file would stay
+    # unversioned: absent from the instance's history and unrecoverable if
+    # anything removed it. Exactly the state-the-system-writes-for-itself-that-
+    # nothing-may-commit shape that sp-097d2e23 exists to end.
+    #
+    # `chore`, so the fleet sync may take it: system exhaust, not authored
+    # content. Config, never source, so the executable-source refusal above
+    # does not reach it.
+    (".gitignore",                    "chore",    "update gitignore"),
     ("sites/",                        "feat",     "update site pages"),
     ("memory/",                       "chore",    "update auto-memory"),
 ]

--- a/q-system/hooks/auto-commit.py
+++ b/q-system/hooks/auto-commit.py
@@ -40,15 +40,25 @@ AREA_MAP = [
     (".claude/output-styles/",        "chore",    "update output styles"),
     (".claude/settings",              "chore",    "update settings"),
     # sp-097d2e23. The updater writes a managed never-commit block into every
-    # instance's root .gitignore, and dry-checked on three live instances none
-    # of them HAS a root .gitignore -- so the updater creates the file. Git
-    # honours an untracked .gitignore, so the rules bite either way, but this
-    # classifier answered `unclassified` for it, which means REPORTED and never
-    # committed (ASK-498). Left alone, all 22 instances would print the same
-    # unclassifiable path on every run forever and the file would stay
-    # unversioned: absent from the instance's history and unrecoverable if
-    # anything removed it. Exactly the state-the-system-writes-for-itself-that-
-    # nothing-may-commit shape that sp-097d2e23 exists to end.
+    # instance's root .gitignore. Every instance HAS one already (70-76 lines)
+    # and it is TRACKED, so the writer MODIFIES a tracked file -- measured on a
+    # real copy of an instance, where it lands as ` M .gitignore`.
+    #
+    # (An earlier version of this comment said instances have no root .gitignore
+    # at all. That was a misread of a malformed `grep -c` check, corrected the
+    # same day by copying a real instance and looking. The fix below was right;
+    # the reason written beside it was not, which is worse than no reason --
+    # a wrong scar comment is read as coverage, so nobody goes looking.)
+    #
+    # This classifier answered `unclassified` for .gitignore, which means
+    # REPORTED and never committed (ASK-498). So every one of the 22 instances
+    # would carry a permanently modified, never-committable tracked file and
+    # print the same unclassifiable path on every run, forever.
+    #
+    # It does NOT block the sync: the dirty-tree guard is scoped to
+    # `$prefix/ .claude/ plugins/` (kipi-update.sh ~L2012) and root .gitignore
+    # is in none of them. Checked rather than assumed, because the first guess
+    # was that this self-blocked the whole fleet.
     #
     # `chore`, so the fleet sync may take it: system exhaust, not authored
     # content. Config, never source, so the executable-source refusal above


### PR DESCRIPTION
Follows #171. The fix there is right. **The reason written beside it was not**, and a wrong scar comment is worse than no comment — it is read as coverage, so nobody goes looking.

## What I claimed

Instances have no root `.gitignore` at all, so the writer creates the file. Stated in two code comments, a commit message, #171's body, and a spillover note.

## What is true

Measured by copying a real instance and running the writer on the copy, rather than by grepping:

- Every instance **has** a root `.gitignore` — 70 to 76 lines — and it is **tracked**.
- None of them carries the integrity rules, so sp-097d2e23's premise is untouched.
- The writer **modifies** a tracked file. It lands as ` M .gitignore`.

The false claim came from a malformed `grep -c` whose output I misread. That is the same mistake this PR chain keeps finding in other people's filed notes — trusting a grep over looking at the thing — and I made it while writing the fix for it. What caught it was noticing `.DS_Store` and `.pytest_cache` in an `--ignored` listing when my block contains neither pattern.

## I guessed wrong about the consequence too

Both now checked rather than asserted:

- A modified tracked `.gitignore` does **not** block the sync. The dirty-tree guard is scoped to `$prefix/ .claude/ plugins/` (`kipi-update.sh` ~L2012) and root `.gitignore` is in none of them. My first guess was that this self-blocked all 22 instances. Wrong.
- What it **does** cause: a permanently modified, never-committable tracked file in all 22 instances, plus the same unclassifiable path reported every run. That is what #171's classifier entry fixes, and it is still needed.

## Test

New test pins the real-world shape: a **tracked** `.gitignore` the writer modified is offered to the fleet sync. The previous tests only covered the untracked-created case — the case that does not happen. It went red first for a fourth mistake: the helper returns a `CompletedProcess`, not a string.

## Ledger

- `sp-58b21276` voided — filed on the false measurement.
- `sp-5d61ca3a` filed in its place: instances' `.gitignore` is a **stale fork** of the skeleton's, drifting since the instance was created. Narrower and more accurate than "no ignore rules at all", with an explicit warning not to fix it by rsyncing the whole file.

**337 passed, 0 failed.**

🤖 Generated with [Claude Code](https://claude.com/claude-code)