### PR TITLE
Correct a false claim I put in the .gitignore fix's own comments

### DIFF
--- a/q-system/.q-system/tests/test_gitignore_block.py
+++ b/q-system/.q-system/tests/test_gitignore_block.py
@@ -267,16 +267,27 @@ class TestTheWiringIntoTheUpdater:
 class TestTheFileTheWriterCreatesCanActuallyBeCommitted:
     """A defect in THIS fix, found by running it against real instances.
 
-    Dry-checked on three live instances 2026-08-14: none of them has a root
-    .gitignore AT ALL, so the writer does not edit a file, it CREATES one. Git
-    honours an untracked .gitignore, so the ignore rules work either way -- but
-    an untracked file is one nobody committed, in a repo nobody looks at, and
-    auto-commit.py classified `.gitignore` as `unclassified`.
+    Measured 2026-08-14 by copying a real instance and running the writer on the
+    copy: every instance already HAS a root .gitignore (70-76 lines) and it is
+    TRACKED, and none of them carries these rules. So the writer MODIFIES a
+    tracked file, landing as ` M .gitignore`.
 
-    Unclassified means REPORTED, never committed (ASK-498). So the fix would
-    have left every one of the 22 instances printing the same unclassifiable
-    path on every single run, forever, and the file itself unversioned -- not in
-    the instance's history, not recoverable if something removed it.
+    (The first version of this docstring said instances have no root .gitignore
+    at all. That came from a malformed `grep -c` whose output was misread, and
+    it was wrong. The class below is unchanged and still needed; only the reason
+    was wrong. Recorded rather than quietly edited, because the same mistake --
+    trusting a grep over looking at the thing -- is what this whole PR chain
+    keeps finding in other people's notes.)
+
+    auto-commit.py classified `.gitignore` as `unclassified`, which means
+    REPORTED, never committed (ASK-498). So every one of the 22 instances would
+    carry a permanently modified, never-committable tracked file and print the
+    same unclassifiable path on every run, forever.
+
+    It does NOT block the sync. The dirty-tree guard is scoped to
+    `$prefix/ .claude/ plugins/` (kipi-update.sh ~L2012) and root .gitignore is
+    in none of them. Checked, because the first guess was that this self-blocked
+    all 22 instances, and that guess was wrong too.
 
     That is the exact shape this whole PR is about: state the system writes for
     itself that nothing is allowed to commit, sitting dirty until it becomes
@@ -292,6 +303,23 @@ class TestTheFileTheWriterCreatesCanActuallyBeCommitted:
         assert auto_commit.system_state_paths([".gitignore"]) == [".gitignore"], (
             "the writer creates a file the fleet sync is not allowed to commit, "
             "so it stays untracked and unclassified on every instance forever")
+
+    def test_a_tracked_gitignore_the_writer_modified_is_offered(self, tmp_path):
+        """THE REAL-WORLD SHAPE, and the one the first version of this class got
+        wrong. Instances ship a tracked .gitignore, so the writer modifies it
+        rather than creating it, and a modified tracked file is a different
+        git state from an untracked one. Both must be committable."""
+        root = make_instance(tmp_path)
+        (root / ".gitignore").write_text("# the instance's own\nnode_modules/\n")
+        git(str(root), "add", "-f", ".gitignore")
+        git(str(root), "commit", "-qm", "instance ships a gitignore")
+
+        blockmod.main(["--skeleton", REPO, "--instance", str(root)])
+
+        status = git(str(root), "status", "--porcelain", "--", ".gitignore").stdout
+        assert status.strip().startswith("M"), (
+            f"expected a tracked modification, got {status!r}")
+        assert auto_commit.system_state_paths([".gitignore"]) == [".gitignore"]
 
     def test_it_is_chore_not_founder_content(self):
         """It must be `chore`. system_state_paths narrows to chore precisely so

--- a/q-system/hooks/auto-commit.py
+++ b/q-system/hooks/auto-commit.py
@@ -40,15 +40,25 @@ AREA_MAP = [
     (".claude/output-styles/",        "chore",    "update output styles"),
     (".claude/settings",              "chore",    "update settings"),
     # sp-097d2e23. The updater writes a managed never-commit block into every
-    # instance's root .gitignore, and dry-checked on three live instances none
-    # of them HAS a root .gitignore -- so the updater creates the file. Git
-    # honours an untracked .gitignore, so the rules bite either way, but this
-    # classifier answered `unclassified` for it, which means REPORTED and never
-    # committed (ASK-498). Left alone, all 22 instances would print the same
-    # unclassifiable path on every run forever and the file would stay
-    # unversioned: absent from the instance's history and unrecoverable if
-    # anything removed it. Exactly the state-the-system-writes-for-itself-that-
-    # nothing-may-commit shape that sp-097d2e23 exists to end.
+    # instance's root .gitignore. Every instance HAS one already (70-76 lines)
+    # and it is TRACKED, so the writer MODIFIES a tracked file -- measured on a
+    # real copy of an instance, where it lands as ` M .gitignore`.
+    #
+    # (An earlier version of this comment said instances have no root .gitignore
+    # at all. That was a misread of a malformed `grep -c` check, corrected the
+    # same day by copying a real instance and looking. The fix below was right;
+    # the reason written beside it was not, which is worse than no reason --
+    # a wrong scar comment is read as coverage, so nobody goes looking.)
+    #
+    # This classifier answered `unclassified` for .gitignore, which means
+    # REPORTED and never committed (ASK-498). So every one of the 22 instances
+    # would carry a permanently modified, never-committable tracked file and
+    # print the same unclassifiable path on every run, forever.
+    #
+    # It does NOT block the sync: the dirty-tree guard is scoped to
+    # `$prefix/ .claude/ plugins/` (kipi-update.sh ~L2012) and root .gitignore
+    # is in none of them. Checked rather than assumed, because the first guess
+    # was that this self-blocked the whole fleet.
     #
     # `chore`, so the fleet sync may take it: system exhaust, not authored
     # content. Config, never source, so the executable-source refusal above


### PR DESCRIPTION
Replaces #172 (went DIRTY after #171 squash-merged). Follows #171: the fix there is right, **the reason written beside it was not**. A wrong scar comment is worse than no comment — it is read as coverage, so nobody goes looking.

## What I claimed

Instances have no root `.gitignore` at all, so the writer creates the file. Stated in two code comments, a commit message, #171's body, and a spillover note.

## What is true

Measured by copying a real instance and running the writer on the copy, rather than by grepping:

- Every instance **has** a root `.gitignore` — 70 to 76 lines — and it is **tracked**.
- None carries the integrity rules, so sp-097d2e23's premise is untouched.
- The writer **modifies** a tracked file. It lands as ` M .gitignore`.

The false claim came from a malformed `grep -c` whose output I misread. That is the same mistake this chain keeps finding in other people's notes — trusting a grep over looking at the thing — and I made it while writing the fix for it. What caught it: `.DS_Store` and `.pytest_cache` appeared in an `--ignored` listing when my block contains neither pattern.

## I guessed the consequence wrong too

Both now checked, not asserted:

- A modified tracked `.gitignore` does **not** block the sync. The dirty-tree guard is scoped to `$prefix/ .claude/ plugins/` (`kipi-update.sh` ~L2012); root `.gitignore` is in none of them. My first guess was that this self-blocked all 22 instances. Wrong.
- What it **does** cause: a permanently modified, never-committable tracked file in all 22 instances, plus the same unclassifiable path reported every run. That is what #171 fixes, and it is still needed.

## Test

Pins the real-world shape: a **tracked** `.gitignore` the writer modified is offered to the fleet sync. The earlier tests only covered the untracked-created case — the case that does not happen. Went red first for a fourth mistake: the helper returns a `CompletedProcess`, not a string.

## Ledger

- `sp-58b21276` voided — filed on the false measurement.
- `sp-5d61ca3a` filed in its place: instances' `.gitignore` is a **stale fork** of the skeleton's, drifting since the instance was created. Narrower and accurate, with an explicit warning not to fix it by rsyncing the whole file over a tracked one.

**337 passed, 0 failed** on the full suite; 54 on the two affected files here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)