### PR TITLE
Attribute both sides of a path, and stop reporting a failed repair as success (PR #165 review)

### DIFF
--- a/fleet-unblock.py
+++ b/fleet-unblock.py
@@ -136,6 +136,31 @@ def decide(repo, row, audit, rescued):
         )
 
     if row["kind"] == "fleet-written":
+        # BOTH SIDES OF THE PATH, NOT ONE (PR #165 review, major).
+        #
+        # The index can hold a blob the skeleton really did ship while the
+        # WORKTREE holds bytes it never had -- a founder edit on top of a staged
+        # skeleton write. This branch used to match on the index alone and
+        # schedule a commit. `git commit` takes the INDEX, so the run would clear
+        # the dirty-tree guard, report the path repaired, and leave the founder's
+        # edit uncommitted for the next sync to overwrite. Founder work destroyed
+        # by the tool whose entire job is avoiding exactly that.
+        #
+        # One side matching the skeleton is not attribution, it is half of one.
+        # Reproducer: test_a_staged_skeleton_blob_with_a_founder_worktree_edit_is_refused.
+        #
+        # Scoped to the WORKTREE differing from the index, deliberately. In the
+        # ordinary case nothing is staged, so the index still holds the HEAD blob
+        # -- which the skeleton never wrote and never should have -- and
+        # demanding both sides be skeleton blobs would refuse every real repair.
+        # What matters is what is LEFT BEHIND after committing the index.
+        if work_sha and work_sha != index_sha and not audit_wrote(audit, path, work_sha):
+            return "refuse", (
+                f"index holds skeleton blob {index_sha[:12]} but the worktree "
+                f"holds {work_sha[:12]}, which the skeleton never wrote; "
+                "committing the index would leave that edit for the next sync "
+                "to overwrite"
+            )
         which = index_sha if audit_wrote(audit, path, index_sha) else work_sha
         return "commit", (
             f"blob {which[:12]} is one the skeleton itself held at {path}"
@@ -265,6 +290,7 @@ def main():
 
     print(f"MODE: {'APPLY' if args.apply else 'dry run'}\n")
     refused = 0
+    failed = 0
     acted = 0
     for entry in entries:
         result = audit.audit_instance(entry, owned, audit.SKEL_BLOBS)
@@ -285,12 +311,30 @@ def main():
         for action, path, reason in actionable:
             print(f"    {action:12s} {path}\n              {reason}")
         for action, path, outcome in apply_instance(repo, actionable, args.apply, args.message):
-            acted += 1
+            # A REFUSED outcome is not an action (PR #165 review, major).
+            # Counting it toward `acted` made "acted on 3 path(s)" the printed
+            # result of a run that repaired nothing.
+            if outcome.startswith("REFUSED"):
+                failed += 1
+            else:
+                acted += 1
             print(f"    -> {action:12s} {path}: {outcome}")
         print()
 
-    print(f"acted on {acted} path(s); refused {refused} path(s)")
-    return 0
+    print(f"acted on {acted} path(s); refused {refused} path(s)"
+          + (f"; {failed} action(s) FAILED" if failed else ""))
+    # NON-ZERO WHEN AN ACTION WE ACCEPTED THEN FAILED (PR #165 review, major).
+    #
+    # `refused` is a decision and is a SUCCESSFUL outcome: the script looked,
+    # could not attribute the change, and correctly left it alone. `failed` is
+    # different -- the script accepted the path, tried, and the repair did not
+    # happen (a pre-commit hook rejected it). Exiting 0 there tells an unattended
+    # fleet job the run succeeded while every instance stays blocked, which is
+    # the silent-success class this whole effort exists to end.
+    #
+    # Reproducers: test_a_refused_commit_does_not_report_success, and its
+    # negative control test_a_clean_successful_run_still_exits_zero.
+    return 1 if failed else 0
 
 
 if __name__ == "__main__":

--- a/test_fleet_unblock.py
+++ b/test_fleet_unblock.py
@@ -328,13 +328,97 @@ def test_a_refusing_pre_commit_hook_leaves_the_index_as_it_found_it(world):
     head_before = git(inst, "rev-parse", "HEAD")
 
     rc, out = run(skel, "--apply")
-    assert rc == 0, out
+    # Was `rc == 0`, asserting the exit code the PR #165 review found wrong: a
+    # run that repaired nothing reported success. The unwind is still the point
+    # of this test; the exit code now says the repair did not happen. See
+    # test_a_refused_commit_does_not_report_success.
+    assert rc != 0, out
     assert "REFUSED" in out, out
     assert git(inst, "rev-parse", "HEAD") == head_before, "commit landed despite the hook"
     assert git(inst, "diff", "--cached", "--name-only") == staged_before, (
         "index left staged by a commit that failed"
     )
     assert (inst / "plugins/prd-os/runner.py").read_text() == "v1\n", "content lost"
+
+
+def test_a_staged_skeleton_blob_with_a_founder_worktree_edit_is_refused(world):
+    """PR #165 review, major #1. The mixed staged/worktree case.
+
+    The index holds a blob the skeleton really did ship, so the fleet-written
+    branch of decide() matches and schedules a commit. But the WORKTREE holds
+    founder bytes the skeleton never had. Committing the index clears the
+    dirty-tree guard while leaving the founder's edit uncommitted, and the very
+    next sync overwrites it -- founder work destroyed by the tool whose entire
+    job is to avoid exactly that.
+
+    Attribution has to hold for BOTH sides of a path. One side matching the
+    skeleton is not attribution, it is half of one.
+    """
+    skel, inst = world
+    rel = "plugins/prd-os/runner.py"
+    seed_skeleton_blob(skel, rel, "v1\n")
+    write(inst, rel, "old\n")
+    git(inst, "add", "-A")
+    git(inst, "commit", "-qm", "instance base")
+
+    write(inst, rel, "v1\n")          # index: the skeleton's own blob
+    git(inst, "add", rel)
+    write(inst, rel, "founder was here\n")   # worktree: bytes the skeleton never had
+
+    head_before = git(inst, "rev-parse", "HEAD")
+    rc, out = run(skel, "--apply")
+
+    assert "REFUSE" in out, out
+    assert git(inst, "rev-parse", "HEAD") == head_before, (
+        "committed the staged skeleton blob while a founder edit sat in the "
+        "worktree; the next sync overwrites that edit")
+    assert (inst / rel).read_text() == "founder was here\n", "founder bytes lost"
+
+
+def test_a_refused_commit_does_not_report_success(world):
+    """PR #165 review, major #2.
+
+    main() returned 0 unconditionally and counted a REFUSED commit toward
+    `acted`, so a run that repaired nothing printed a success line and exited
+    clean. This is the script an unattended fleet job calls: an exit code that
+    cannot distinguish "repaired" from "refused and gave up" makes the job
+    report green while every instance stays blocked -- the same silent-success
+    class the fleet reach work exists to end.
+    """
+    skel, inst = world
+    rel = "plugins/prd-os/runner.py"
+    seed_skeleton_blob(skel, rel, "v1\n")
+    write(inst, rel, "old\n")
+    git(inst, "add", "-A")
+    git(inst, "commit", "-qm", "instance base")
+    write(inst, rel, "v1\n")
+
+    hook = inst / ".git/hooks/pre-commit"
+    hook.parent.mkdir(parents=True, exist_ok=True)
+    hook.write_text("#!/bin/sh\nexit 1\n")
+    hook.chmod(0o755)
+
+    rc, out = run(skel, "--apply")
+    assert "REFUSED" in out, out
+    assert rc != 0, (
+        "exited 0 after repairing nothing; an unattended caller cannot tell "
+        "this from a successful run")
+
+
+def test_a_clean_successful_run_still_exits_zero(world):
+    """Negative control for the test above. If every run exited non-zero the
+    assertion would pass while telling the caller nothing."""
+    skel, inst = world
+    rel = "plugins/prd-os/runner.py"
+    seed_skeleton_blob(skel, rel, "v1\n")
+    write(inst, rel, "old\n")
+    git(inst, "add", "-A")
+    git(inst, "commit", "-qm", "instance base")
+    write(inst, rel, "v1\n")
+
+    rc, out = run(skel, "--apply")
+    assert rc == 0, out
+    assert not is_dirty(inst, rel), out
 
 
 def test_the_unwind_test_would_notice_a_missing_unwind(world):


### PR DESCRIPTION
Fixes both **major** findings the codex reviewer raised on #165. Each was reproduced before it was fixed, and each reproducer failed first.

## Major 1 — a staged skeleton blob with a founder worktree edit was scheduled for commit

The index can hold a blob the skeleton really did ship while the **worktree** holds bytes it never had: a founder edit on top of a staged skeleton write. The fleet-written branch matched on the index alone.

A commit takes the **index**. So the run cleared the dirty-tree guard, reported the path repaired, and left the founder's edit uncommitted for the next sync to overwrite — founder work destroyed by the tool whose entire job is avoiding exactly that.

One side matching the skeleton is not attribution. It is half of one.

Scoped to the worktree **differing from the index**, deliberately. In the ordinary case nothing is staged, so the index still holds the HEAD blob — which the skeleton never wrote — and demanding both sides be skeleton blobs would refuse every real repair. What matters is what is left behind after committing the index.

## Major 2 — exited 0 after a commit was refused

`main` returned 0 unconditionally and counted a REFUSED outcome toward `acted`, so a run that repaired nothing printed a success line and exited clean.

This is the script an unattended fleet job calls. An exit code that cannot separate *repaired* from *tried and failed* makes the job report green while every instance stays blocked — the silent-success class this whole effort exists to end.

`refused` and `failed` are now different, and only one is an error. **A refusal is a successful outcome**: the script looked, could not attribute the change, and correctly left it alone. A failure is a path it accepted, tried, and did not repair.

## Also

`test_a_refusing_pre_commit_hook_leaves_the_index_as_it_found_it` asserted `rc == 0` — it was pinning the exact behaviour the reviewer found wrong. The unwind is still its point; the exit code now says the repair did not happen.

## Verification

| Check | Result |
|---|---|
| Both findings reproduced first | 2 failing, then green |
| Negative control on the exit code | `test_a_clean_successful_run_still_exits_zero` — so "non-zero on failure" cannot pass by always exiting non-zero |
| Real fleet dry run | finds nothing to do across all 22 instances, exits 0 — the new code does not false-positive |
| Full suite | **340 passed, 0 failed** |

🤖 Generated with [Claude Code](https://claude.com/claude-code)