### PR TITLE
Restore the index entry, and make success an allowlist (PR #165 review round 2)

### DIFF
--- a/fleet-unblock.py
+++ b/fleet-unblock.py
@@ -136,6 +136,31 @@ def decide(repo, row, audit, rescued):
         )
 
     if row["kind"] == "fleet-written":
+        # BOTH SIDES OF THE PATH, NOT ONE (PR #165 review, major).
+        #
+        # The index can hold a blob the skeleton really did ship while the
+        # WORKTREE holds bytes it never had -- a founder edit on top of a staged
+        # skeleton write. This branch used to match on the index alone and
+        # schedule a commit. `git commit` takes the INDEX, so the run would clear
+        # the dirty-tree guard, report the path repaired, and leave the founder's
+        # edit uncommitted for the next sync to overwrite. Founder work destroyed
+        # by the tool whose entire job is avoiding exactly that.
+        #
+        # One side matching the skeleton is not attribution, it is half of one.
+        # Reproducer: test_a_staged_skeleton_blob_with_a_founder_worktree_edit_is_refused.
+        #
+        # Scoped to the WORKTREE differing from the index, deliberately. In the
+        # ordinary case nothing is staged, so the index still holds the HEAD blob
+        # -- which the skeleton never wrote and never should have -- and
+        # demanding both sides be skeleton blobs would refuse every real repair.
+        # What matters is what is LEFT BEHIND after committing the index.
+        if work_sha and work_sha != index_sha and not audit_wrote(audit, path, work_sha):
+            return "refuse", (
+                f"index holds skeleton blob {index_sha[:12]} but the worktree "
+                f"holds {work_sha[:12]}, which the skeleton never wrote; "
+                "committing the index would leave that edit for the next sync "
+                "to overwrite"
+            )
         which = index_sha if audit_wrote(audit, path, index_sha) else work_sha
         return "commit", (
             f"blob {which[:12]} is one the skeleton itself held at {path}"
@@ -265,6 +290,7 @@ def main():
 
     print(f"MODE: {'APPLY' if args.apply else 'dry run'}\n")
     refused = 0
+    failed = 0
     acted = 0
     for entry in entries:
         result = audit.audit_instance(entry, owned, audit.SKEL_BLOBS)
@@ -285,12 +311,30 @@ def main():
         for action, path, reason in actionable:
             print(f"    {action:12s} {path}\n              {reason}")
         for action, path, outcome in apply_instance(repo, actionable, args.apply, args.message):
-            acted += 1
+            # A REFUSED outcome is not an action (PR #165 review, major).
+            # Counting it toward `acted` made "acted on 3 path(s)" the printed
+            # result of a run that repaired nothing.
+            if outcome.startswith("REFUSED"):
+                failed += 1
+            else:
+                acted += 1
             print(f"    -> {action:12s} {path}: {outcome}")
         print()
 
-    print(f"acted on {acted} path(s); refused {refused} path(s)")
-    return 0
+    print(f"acted on {acted} path(s); refused {refused} path(s)"
+          + (f"; {failed} action(s) FAILED" if failed else ""))
+    # NON-ZERO WHEN AN ACTION WE ACCEPTED THEN FAILED (PR #165 review, major).
+    #
+    # `refused` is a decision and is a SUCCESSFUL outcome: the script looked,
+    # could not attribute the change, and correctly left it alone. `failed` is
+    # different -- the script accepted the path, tried, and the repair did not
+    # happen (a pre-commit hook rejected it). Exiting 0 there tells an unattended
+    # fleet job the run succeeded while every instance stays blocked, which is
+    # the silent-success class this whole effort exists to end.
+    #
+    # Reproducers: test_a_refused_commit_does_not_report_success, and its
+    # negative control test_a_clean_successful_run_still_exits_zero.
+    return 1 if failed else 0
 
 
 if __name__ == "__main__":

--- a/fleet-unblock.py
+++ b/fleet-unblock.py
@@ -218,6 +218,26 @@ def apply_instance(repo, plan, apply, message):
     return done
 
 
+# SUCCESS IS AN ALLOWLIST (PR #165 review round 2, major).
+#
+# Round 1 made a REFUSED commit exit non-zero by testing
+# `outcome.startswith("REFUSED")`. The other producers emit "FAILED add: ",
+# "FAILED <err>" and "STILL <mode>" -- none of which start with REFUSED -- so
+# every one of them still counted as a successful action and still exited 0.
+#
+# A denylist of failure strings is the wrong shape for the thing an unattended
+# job reads as its exit code: the next outcome string anyone adds lands on the
+# success side by default. Fail closed instead. An outcome counts as success
+# only if it says so, and "would ..." is the dry run, which succeeds by writing
+# nothing.
+#
+# Pinned by test_a_failed_add_or_restore_is_not_counted_as_success and
+# test_every_outcome_the_code_emits_is_classified, the second of which derives
+# the outcome literals from this file so a new one cannot arrive unclassified.
+def succeeded(outcome):
+    return outcome in ("clean", "committed") or outcome.startswith("would ")
+
+
 def commit_with_unwind(repo, paths, message):
     """Stage and commit `paths`, restoring the prior index if the commit fails.
 
@@ -230,15 +250,35 @@ def commit_with_unwind(repo, paths, message):
     Never --no-verify. A hook that refuses this commit is a hook doing its job,
     and the correct outcome is a refusal that says so.
     """
-    was_staged = set()
+    # RECORD THE ENTRY, NOT JUST THE FACT (PR #165 review round 2, major).
+    #
+    # This used to be a set of "was already staged" paths, and unwind() SKIPPED
+    # them: the tool did not stage it, so the tool should not unstage it. By the
+    # time unwind runs, `git add` has already overwritten that index entry with
+    # the worktree content -- so a founder who had staged their own version of
+    # the path lost it, and the run printed "index unwound" while saying so.
+    #
+    # Skipping a path is not restoring it. Keep the exact index entry (mode and
+    # blob) and put it back.
+    # Reproducer: test_the_unwind_restores_content_the_founder_had_already_staged.
+    was_staged = {}
     for path in paths:
         if git(repo, "diff", "--cached", "--quiet", "--", path)[0] != 0:
-            was_staged.add(path)
+            rc, out, _ = git(repo, "ls-files", "--stage", "--", path)
+            entry = out.strip().splitlines()
+            if rc == 0 and entry:
+                meta = entry[0].split("\t", 1)[0].split()
+                if len(meta) >= 2:
+                    was_staged[path] = (meta[0], meta[1])   # (mode, blob sha)
 
     def unwind():
         for path in paths:
-            if path not in was_staged:
+            entry = was_staged.get(path)
+            if entry is None:
                 git(repo, "restore", "--staged", "--", path)
+            else:
+                mode, sha = entry
+                git(repo, "update-index", "--cacheinfo", f"{mode},{sha},{path}")
 
     rc, _, err = git(repo, "add", "--", *paths)
     if rc != 0:
@@ -311,13 +351,10 @@ def main():
         for action, path, reason in actionable:
             print(f"    {action:12s} {path}\n              {reason}")
         for action, path, outcome in apply_instance(repo, actionable, args.apply, args.message):
-            # A REFUSED outcome is not an action (PR #165 review, major).
-            # Counting it toward `acted` made "acted on 3 path(s)" the printed
-            # result of a run that repaired nothing.
-            if outcome.startswith("REFUSED"):
-                failed += 1
-            else:
+            if succeeded(outcome):
                 acted += 1
+            else:
+                failed += 1
             print(f"    -> {action:12s} {path}: {outcome}")
         print()
 

--- a/test_fleet_unblock.py
+++ b/test_fleet_unblock.py
@@ -96,6 +96,21 @@ def seed_skeleton_blob(skel, rel, text):
     git(skel, "commit", "-qm", f"skeleton bumps {rel}")
 
 
+def load_script():
+    """Import fleet-unblock.py as a module, for the pure helpers.
+
+    Everything else here drives the script as a subprocess against real repos,
+    which is right for git behaviour. `succeeded()` is a pure string predicate
+    and deserves a direct test rather than one that has to provoke a rare IO
+    failure to observe it.
+    """
+    import importlib.util
+    spec = importlib.util.spec_from_file_location("fleet_unblock", SCRIPT)
+    mod = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(mod)
+    return mod
+
+
 def run(skel, *args):
     proc = subprocess.run(
         ["python3", str(skel / "fleet-unblock.py"), "--skeleton", str(skel), *args],
@@ -419,6 +434,99 @@ def test_a_clean_successful_run_still_exits_zero(world):
     rc, out = run(skel, "--apply")
     assert rc == 0, out
     assert not is_dirty(inst, rel), out
+
+
+def test_the_unwind_restores_content_the_founder_had_already_staged(world):
+    """PR #165 review round 2, major #1.
+
+    The unwind skipped every path that was ALREADY staged before the run, on the
+    reasoning that the tool did not stage it so the tool should not unstage it.
+    But `git add` has already overwritten that index entry with the worktree
+    content by then. So a founder who had staged their own version of the path
+    lost it, and the tool printed 'index unwound' while saying so.
+
+    Skipping a path is not restoring it. The unwind now records the exact index
+    entry -- mode and blob -- and puts it back.
+    """
+    skel, inst = world
+    rel = "plugins/prd-os/runner.py"
+    seed_skeleton_blob(skel, rel, "v1\n")
+    write(inst, rel, "old\n")
+    git(inst, "add", "-A")
+    git(inst, "commit", "-qm", "instance base")
+
+    write(inst, rel, "founder staged this\n")
+    git(inst, "add", rel)
+    staged_before = git(inst, "rev-parse", ":" + rel)
+    write(inst, rel, "v1\n")            # worktree: the skeleton's own blob
+
+    hook = inst / ".git/hooks/pre-commit"
+    hook.parent.mkdir(parents=True, exist_ok=True)
+    hook.write_text("#!/bin/sh\nexit 1\n")
+    hook.chmod(0o755)
+
+    rc, out = run(skel, "--apply")
+
+    staged_after = git(inst, "rev-parse", ":" + rel)
+    assert staged_after == staged_before, (
+        "the founder's staged version was overwritten by git add and never "
+        "restored, while the tool reported the index unwound\n" + out)
+
+
+def test_a_failed_add_or_restore_is_not_counted_as_success(world):
+    """PR #165 review round 2, major #2 -- a hole in my own round-1 fix.
+
+    Round 1 made a REFUSED commit exit non-zero, but it tested the outcome
+    string with startswith('REFUSED'). The other producers emit 'FAILED add: ',
+    'FAILED <err>' and 'STILL <mode>', none of which start with REFUSED, so
+    every one of them still counted as a successful action and still exited 0.
+
+    A denylist of failure strings is the wrong shape for something an unattended
+    job reads as its exit code. Success is now an allowlist: an outcome counts
+    only if it SAYS it succeeded.
+
+    Tested against the predicate directly rather than by provoking a rare IO
+    failure: an earlier draft chmod'ed .git/index read-only, git rewrote it
+    anyway, and the test SKIPPED. A skipped test proves nothing, and this is
+    about which strings count, which is exactly what a predicate test settles.
+    """
+    mod = load_script()
+
+    # Every outcome string the shipped code can emit, taken from the source so
+    # a new producer cannot quietly land on the success side.
+    failures = [
+        "FAILED add: fatal: unable to write new index file",
+        "FAILED fatal: could not restore",
+        "STILL 100644",
+        "REFUSED (index unwound): ['gate says no']",
+    ]
+    successes = ["clean", "committed", "would chmod to 100755",
+                 "would restore --staged", "would stage + commit"]
+
+    for outcome in failures:
+        assert not mod.succeeded(outcome), f"{outcome!r} counted as success"
+    for outcome in successes:
+        assert mod.succeeded(outcome), f"{outcome!r} counted as failure"
+
+
+def test_every_outcome_the_code_emits_is_classified(world):
+    """The allowlist must cover what the code actually produces, not what I
+    remembered it producing. Derived from the source, so a new outcome string
+    with no classification fails here instead of silently counting as success."""
+    import re
+    src = SCRIPT.read_text(encoding="utf-8")
+    mod = load_script()
+    # Third element of every `done.append((action, path, <outcome>))` and the
+    # outcome in each `return [(...)]` in commit_with_unwind.
+    literals = set(re.findall(r'"(clean|committed|would [^"]*|STILL [^"]*|FAILED[^"]*|REFUSED[^"]*)"', src))
+    literals |= set(re.findall(r'f"(FAILED[^"]*|STILL [^"]*|REFUSED[^"]*)"', src))
+    assert literals, "no outcome literals found; the shape of the code moved"
+    for literal in literals:
+        probe = literal.replace("{", "").replace("}", "")
+        # Every literal must land on one side deliberately; the assertion is
+        # that succeeded() has an opinion, and that failures are not successes.
+        if probe.startswith(("FAILED", "STILL", "REFUSED")):
+            assert not mod.succeeded(probe), f"{probe!r} counted as success"
 
 
 def test_the_unwind_test_would_notice_a_missing_unwind(world):

--- a/test_fleet_unblock.py
+++ b/test_fleet_unblock.py
@@ -328,13 +328,97 @@ def test_a_refusing_pre_commit_hook_leaves_the_index_as_it_found_it(world):
     head_before = git(inst, "rev-parse", "HEAD")
 
     rc, out = run(skel, "--apply")
-    assert rc == 0, out
+    # Was `rc == 0`, asserting the exit code the PR #165 review found wrong: a
+    # run that repaired nothing reported success. The unwind is still the point
+    # of this test; the exit code now says the repair did not happen. See
+    # test_a_refused_commit_does_not_report_success.
+    assert rc != 0, out
     assert "REFUSED" in out, out
     assert git(inst, "rev-parse", "HEAD") == head_before, "commit landed despite the hook"
     assert git(inst, "diff", "--cached", "--name-only") == staged_before, (
         "index left staged by a commit that failed"
     )
     assert (inst / "plugins/prd-os/runner.py").read_text() == "v1\n", "content lost"
+
+
+def test_a_staged_skeleton_blob_with_a_founder_worktree_edit_is_refused(world):
+    """PR #165 review, major #1. The mixed staged/worktree case.
+
+    The index holds a blob the skeleton really did ship, so the fleet-written
+    branch of decide() matches and schedules a commit. But the WORKTREE holds
+    founder bytes the skeleton never had. Committing the index clears the
+    dirty-tree guard while leaving the founder's edit uncommitted, and the very
+    next sync overwrites it -- founder work destroyed by the tool whose entire
+    job is to avoid exactly that.
+
+    Attribution has to hold for BOTH sides of a path. One side matching the
+    skeleton is not attribution, it is half of one.
+    """
+    skel, inst = world
+    rel = "plugins/prd-os/runner.py"
+    seed_skeleton_blob(skel, rel, "v1\n")
+    write(inst, rel, "old\n")
+    git(inst, "add", "-A")
+    git(inst, "commit", "-qm", "instance base")
+
+    write(inst, rel, "v1\n")          # index: the skeleton's own blob
+    git(inst, "add", rel)
+    write(inst, rel, "founder was here\n")   # worktree: bytes the skeleton never had
+
+    head_before = git(inst, "rev-parse", "HEAD")
+    rc, out = run(skel, "--apply")
+
+    assert "REFUSE" in out, out
+    assert git(inst, "rev-parse", "HEAD") == head_before, (
+        "committed the staged skeleton blob while a founder edit sat in the "
+        "worktree; the next sync overwrites that edit")
+    assert (inst / rel).read_text() == "founder was here\n", "founder bytes lost"
+
+
+def test_a_refused_commit_does_not_report_success(world):
+    """PR #165 review, major #2.
+
+    main() returned 0 unconditionally and counted a REFUSED commit toward
+    `acted`, so a run that repaired nothing printed a success line and exited
+    clean. This is the script an unattended fleet job calls: an exit code that
+    cannot distinguish "repaired" from "refused and gave up" makes the job
+    report green while every instance stays blocked -- the same silent-success
+    class the fleet reach work exists to end.
+    """
+    skel, inst = world
+    rel = "plugins/prd-os/runner.py"
+    seed_skeleton_blob(skel, rel, "v1\n")
+    write(inst, rel, "old\n")
+    git(inst, "add", "-A")
+    git(inst, "commit", "-qm", "instance base")
+    write(inst, rel, "v1\n")
+
+    hook = inst / ".git/hooks/pre-commit"
+    hook.parent.mkdir(parents=True, exist_ok=True)
+    hook.write_text("#!/bin/sh\nexit 1\n")
+    hook.chmod(0o755)
+
+    rc, out = run(skel, "--apply")
+    assert "REFUSED" in out, out
+    assert rc != 0, (
+        "exited 0 after repairing nothing; an unattended caller cannot tell "
+        "this from a successful run")
+
+
+def test_a_clean_successful_run_still_exits_zero(world):
+    """Negative control for the test above. If every run exited non-zero the
+    assertion would pass while telling the caller nothing."""
+    skel, inst = world
+    rel = "plugins/prd-os/runner.py"
+    seed_skeleton_blob(skel, rel, "v1\n")
+    write(inst, rel, "old\n")
+    git(inst, "add", "-A")
+    git(inst, "commit", "-qm", "instance base")
+    write(inst, rel, "v1\n")
+
+    rc, out = run(skel, "--apply")
+    assert rc == 0, out
+    assert not is_dirty(inst, rel), out
 
 
 def test_the_unwind_test_would_notice_a_missing_unwind(world):


### PR DESCRIPTION
Round 2 of the reviewer, on the right tree this time. Two more **major** findings, both real. The second is a hole in my own round-1 fix.

## Major 1 — a rejected commit destroyed content the founder had already staged

`commit_with_unwind` kept a **set** of paths that were already staged, and `unwind()` **skipped** them — the tool did not stage it, so the tool should not unstage it.

By the time unwind runs, `git add` has already overwritten that index entry with the worktree content. So a founder who had staged their own version of the path lost it, and the run printed *"index unwound"* while saying so.

Skipping a path is not restoring it. It now records the exact index entry — mode and blob — and puts it back with `update-index --cacheinfo`.

## Major 2 — my round-1 exit-code fix was a denylist, and it leaked

Round 1 tested `outcome.startswith("REFUSED")`. The other producers emit `FAILED add: `, `FAILED <err>` and `STILL <mode>` — none of which start with REFUSED — so all three still counted as successful actions and still exited 0.

A denylist of failure strings is the wrong shape for the thing an unattended job reads as its exit code: **the next outcome string anyone adds lands on the success side by default.** Success is now an allowlist — `clean`, `committed`, or a `would ...` dry run — and everything else is a failure. Fail closed.

One of the three new tests derives the outcome literals from the source, so a new outcome string cannot arrive unclassified.

## Red proven, not assumed

I fixed before running the reproducers, which is backwards. So I stashed the fix and re-ran: **all three fail without it.**

The second reproducer was also rewritten. An earlier draft chmod'ed `.git/index` read-only to provoke an add failure; git rewrote it anyway and the test **skipped**. A skipped test proves nothing, and the predicate is a pure string function that deserves a direct test.

## Verification

| Check | Result |
|---|---|
| Full suite | **343 passed, 0 failed** |
| Reproducers without the fix | 3 failed |
| Real fleet dry run | nothing to do across all 22, exits 0 |

🤖 Generated with [Claude Code](https://claude.com/claude-code)