### PR TITLE
One live run per repo, absolute (ASK-811)

### DIFF
--- a/kipi-dispatch.sh
+++ b/kipi-dispatch.sh
@@ -906,48 +906,34 @@ TARGET_PATH=""
 # early `exit 0` here would leave the cap at 1 by another name.
 LIVE_REPOS="$(live_repos)"
 
-# A PREFERENCE, NOT AN EXCLUSION -- AND THE DIFFERENCE IS A TESTED CONTRACT.
+# ONE LIVE RUN PER REPO. ABSOLUTE. Founder decision 2026-08-15 [USER-DIRECTED],
+# recorded in ASK-811: asked whether two agents may work one repo at once, the
+# answer was "no, only one per repo".
 #
-# The first cut of this made "one live run per repo" absolute: a repo with a live
-# converge was skipped, full stop. CI caught two tests that say otherwise, and
-# both are right:
+# A repo with a live run is SKIPPED and the rotation continues to the next repo.
+# If every dispatchable repo is busy, this cycle enters nothing and the next
+# 900s tick tries again. There is no fallback; that is the point of the decision.
 #
-#   test-ci-redrive 14g "a live converge does not cost the fresh pick its slot"
-#     exists BECAUSE a live converge used to starve the ready queue: a redrive
-#     offered the already-live issue, NEXT was overwritten with it, and the issue
-#     that WAS dispatchable was thrown away every heartbeat for the whole run.
-#   test-dispatch-liveness 6a requires the per-ISSUE duplicate guard to fire on
-#     every attempt -- it cannot fire if selection exits before reaching it.
+# WHAT THIS COSTS, STATED PLAINLY. test-ci-redrive 14g was written because a live
+# converge used to starve the ready queue: a redrive offered the already-live
+# issue, NEXT was overwritten with it, and the issue that WAS dispatchable was
+# thrown away every heartbeat. Under this rule a busy repo genuinely does defer
+# its other ready issues. The difference from that scar is that the deferral is
+# now DELIBERATE, LOGGED, and costs no budget -- the issue stays ready and is
+# picked up as soon as the repo frees. 14g is updated to assert exactly that,
+# because the protection worth keeping is "nothing is silently consumed", not
+# "something is always dispatched".
 #
-# Both scenarios are one repo with one live run, which an absolute rule refuses,
-# so it re-created the exact starvation 14g was written to prevent. Same-issue
-# collision is already handled downstream by the duplicate guard; what this rule
-# adds is SPREAD.
-#
-# So: prefer a repo with nothing live, and fall back to a busy one only when it
-# is the only candidate. With several dispatchable repos the work spreads one per
-# repo, which is the whole throughput win. With exactly one, behaviour is
-# unchanged from before this change.
-#
-# THIS IS DELIBERATELY WEAKER THAN "never two runs in one repo". A single-repo
-# fleet at cap 3 can still put two agents on one repo, which is the file-conflict
-# risk the plist documents. That is why KIPI_DISPATCH_MAX is sized to the number
-# of dispatchable repos rather than to appetite: the cap, not this loop, is what
-# bounds same-repo overlap. Making it absolute needs the starvation answered
-# first, and that is ASK-811.
-#
-# Unattributed runs (a hand-run `kipi converge`, anything this script did not
-# launch) are simply not known-busy. An earlier version halted the cycle on them;
-# that also broke 6a by exiting before the duplicate guard, and it turned a
-# hand-run converge into a fleet-wide stall.
-FALLBACK_NAME=""; FALLBACK_PATH=""
+# The conflict risk this removes is the reason: the dispatcher picks by readiness
+# and has NO idea which files an issue touches, so two runs in one repo can edit
+# the same region (observed 2026-07-28, ASK-223 vs live ASK-222) and hand back
+# conflicting PRs for a human to untangle.
 while IFS=$'\t' read -r PNAME PPATH; do
   [ -n "$PNAME" ] || continue
   # Exact line match. A substring test would let ~/projects/foo suppress
   # ~/projects/foo-bar, silently starving a repo nothing is running in.
   if [ -n "$LIVE_REPOS" ] && printf '%s\n' "$LIVE_REPOS" | grep -qxF -- "$PPATH"; then
-    say "deprioritising $PNAME: a converge run is already live in $PPATH"
-    [ -n "$FALLBACK_NAME" ] || { FALLBACK_NAME="$PNAME"; FALLBACK_PATH="$PPATH"; }
+    say "skip $PNAME: a converge run is already live in $PPATH (one run per repo, ASK-811)"
     continue
   fi
   TARGET_NAME="$PNAME"
@@ -957,34 +943,8 @@ done <<PICKEOF
 $PICKS
 PICKEOF
 
-# Every candidate was busy. Take the first rather than idling -- an idle cycle
-# here is the starvation 14g forbids -- but the fallback is BOUNDED.
-#
-# THE UNBOUNDED VERSION WAS A REAL EXPOSURE (codex major, PR #163 r3), and it
-# described tonight's actual configuration rather than a hypothetical: preflight
-# REFUSES interview-coach on a dirty tree, so only two repos are available, and if
-# ktlyst has nothing ready the sole candidate is the home repo. At cap 3 an
-# unbounded fallback would put THREE unattended agents in one repo and hand back a
-# pile of conflicting PRs for a human to untangle. My earlier "the cap is sized to
-# the number of dispatchable repos" reasoning assumed all of them are AVAILABLE;
-# preflight collapses that at runtime and the cap does not adapt.
-#
-# 2 IS DERIVED FROM THE TESTS, NOT CHOSEN. test-ci-redrive 14g requires that a
-# repo with ONE live run still yield its fresh pick, so a per-repo ceiling of 1
-# would break the suite. 2 is therefore the tightest bound the existing contract
-# allows, and every run past the second buys nothing 14g asked for while adding
-# exactly the collision risk the plist documents.
-FALLBACK_LIVE=0
-if [ -n "$FALLBACK_PATH" ] && [ -n "$LIVE_REPOS" ]; then
-  FALLBACK_LIVE="$(printf '%s\n' "$LIVE_REPOS" | grep -cxF -- "$FALLBACK_PATH" || true)"
-  FALLBACK_LIVE="${FALLBACK_LIVE:-0}"
-fi
-if [ -z "$TARGET_NAME" ] && [ -n "$FALLBACK_NAME" ] && [ "$FALLBACK_LIVE" -lt 2 ]; then
-  say "every dispatchable repo has a live run; proceeding in $FALLBACK_NAME (${FALLBACK_LIVE} live there, ceiling 2; the per-issue duplicate guard still applies)"
-  TARGET_NAME="$FALLBACK_NAME"
-  TARGET_PATH="$FALLBACK_PATH"
-elif [ -z "$TARGET_NAME" ] && [ -n "$FALLBACK_NAME" ]; then
-  say "skip: $FALLBACK_NAME already has $FALLBACK_LIVE live run(s), the per-repo ceiling; not stacking a third unattended agent on one repo"
+if [ -z "$TARGET_NAME" ]; then
+  say "no free repo this cycle: every dispatchable repo already has a live run; nothing entered, nothing claimed, retrying next tick"
 fi
 # --- END REPO SELECTION ---
 # The marker is load-bearing. The test cuts this whole block out and sources it,

--- a/kipi-dispatch.sh
+++ b/kipi-dispatch.sh
@@ -906,9 +906,19 @@ TARGET_PATH=""
 # early `exit 0` here would leave the cap at 1 by another name.
 LIVE_REPOS="$(live_repos)"
 
-# ONE LIVE RUN PER REPO. ABSOLUTE. Founder decision 2026-08-15 [USER-DIRECTED],
-# recorded in ASK-811: asked whether two agents may work one repo at once, the
-# answer was "no, only one per repo".
+# ONE LIVE RUN PER REPO, for every run DISPATCH LAUNCHES. Founder decision
+# 2026-08-15 [USER-DIRECTED], recorded in ASK-811: asked whether two agents may
+# work one repo at once, the answer was "no, only one per repo".
+#
+# NOT THE WORD "ABSOLUTE", AND THE PRECISION IS THE POINT (codex major, PR #178).
+# This binds what dispatch itself starts, because the ledger is the only thing
+# that can say WHICH REPO a run is in. A converge started by hand carries its
+# target repo in an env var; environment is not in the process table, so no
+# pgrep can attribute it, and such a run does not mark its repo busy. A failed
+# ledger write leaves the same hole, loudly -- record_live_run pages when it
+# cannot record. Calling the rule absolute would promise a guarantee the
+# mechanism cannot keep, which is how someone later raises the cap believing
+# they are safe. The residual is ASK-824.
 #
 # A repo with a live run is SKIPPED and the rotation continues to the next repo.
 # If every dispatchable repo is busy, this cycle enters nothing and the next

--- a/q-system/.q-system/scripts/test/test-dispatch-per-repo-concurrency.sh
+++ b/q-system/.q-system/scripts/test/test-dispatch-per-repo-concurrency.sh
@@ -118,7 +118,7 @@ sed -n '/^LIVE_REPOS="\$(live_repos)"$/,/^# --- END REPO SELECTION ---$/p' "$DIS
 # Ending the cut at PICKEOF stopped one line short of the fallback, so the suite
 # tested a loop that could never fall back and blamed the code. Assert both
 # halves are present -- the skip AND the fallback.
-for sym in deprioritising FALLBACK_NAME 'every dispatchable repo has a live run'; do
+for sym in 'one run per repo' 'no free repo this cycle'; do
   grep -q "$sym" "$LOOPF" \
     || { echo "FATAL: '$sym' missing from the selection-loop extract of $DISPATCH" >&2; exit 1; }
 done
@@ -138,48 +138,22 @@ SEL="$(run_selection "$(printf 'alpha\t/repos/alpha\nbeta\t/repos/beta\n')")"
 echo "$SEL" | grep -q 'PICKED=beta' \
   && ok "alpha is busy, so beta is dispatched -- the fleet does not stall" \
   || bad "the busy repo was not skipped to the next one (got: $SEL)"
-echo "$SEL" | grep -q 'deprioritising' \
+echo "$SEL" | grep -q 'one run per repo' \
   && ok "the skip states WHY, so the log explains the decision" \
   || bad "the skip was silent"
 
-echo "== 3. a LONE busy repo is still taken (starvation is worse than overlap) =="
-# test-ci-redrive 14g exists because a live converge used to starve the ready
-# queue. An absolute one-run-per-repo rule re-creates exactly that, so the rule
-# is a PREFERENCE: fall back to the busy repo when it is the only candidate. The
-# per-ISSUE duplicate guard downstream still stops a second run of the SAME issue.
+echo "== 3. a LONE busy repo is NOT taken -- one run per repo is absolute =="
+# Founder decision 2026-08-15 (ASK-811): asked whether two agents may work one
+# repo at once, the answer was "no, only one per repo". The fallback that used to
+# take a busy repo when it was the only candidate is GONE. A cycle that finds
+# every repo busy enters nothing and retries on the next tick.
 SEL_ONE="$(run_selection "$(printf 'alpha\t/repos/alpha\n')")"
 echo "$SEL_ONE" | grep -q 'PICKED=alpha' \
-  && ok "alpha alone and busy is still dispatched -- the ready queue is not starved" \
-  || bad "a lone busy repo yielded no pick, which is the 14g starvation (got: $SEL_ONE)"
-echo "$SEL_ONE" | grep -q 'every dispatchable repo has a live run' \
-  && ok "the fallback says it is a fallback" \
-  || bad "the fallback was silent"
-
-echo "== 3b. the fallback is BOUNDED: no THIRD agent stacks on one repo =="
-# codex major r3, describing the live configuration: preflight refuses one repo
-# and another has nothing ready, so the sole candidate is a busy repo. Unbounded,
-# cap 3 would put three unattended agents there and hand back conflicting PRs.
-# The ceiling is 2 because 14g requires a repo with ONE live run to still yield
-# its fresh pick -- so 1 would break the suite and 2 is the tightest legal bound.
-PID_S1="$(spawn_fake_converge ASK-810)"
-PID_S2="$(spawn_fake_converge ASK-811)"
-record_live_run "$PID_S1" "ASK-810" "/repos/stack"
-record_live_run "$PID_S2" "ASK-811" "/repos/stack"
-SEL_ST="$(run_selection "$(printf 'stack\t/repos/stack\n')")"
-echo "$SEL_ST" | grep -q 'PICKED=stack' \
-  && bad "a THIRD run was stacked on one repo" "unattended same-repo agents produce conflicting PRs (got: $SEL_ST)" \
-  || ok "two live runs is the ceiling; a third is refused"
-echo "$SEL_ST" | grep -q 'per-repo ceiling' \
-  && ok "the refusal names the ceiling, so the log explains the idle cycle" \
-  || bad "the ceiling refusal was silent"
-
-# 3b-neg: with only ONE live there, the fallback must still fire (that is 14g).
-kill "$PID_S2" 2>/dev/null; wait "$PID_S2" 2>/dev/null
-SEL_ST1="$(run_selection "$(printf 'stack\t/repos/stack\n')")"
-echo "$SEL_ST1" | grep -q 'PICKED=stack' \
-  && ok "3b-neg one live run still yields the fresh pick (14g preserved)" \
-  || bad "3b-neg the ceiling over-tightened" "a repo with one live run was starved (got: $SEL_ST1)"
-kill "$PID_S1" 2>/dev/null; wait "$PID_S1" 2>/dev/null
+  && bad "a second run was allowed in the SAME repo" "the founder's rule is one per repo (got: $SEL_ONE)" \
+  || ok "alpha alone and busy yields no pick -- no second agent in one repo"
+echo "$SEL_ONE" | grep -q 'no free repo this cycle' \
+  && ok "the idle cycle says WHY, so it is a deferral and not a silent stall" \
+  || bad "the idle cycle was silent" "an operator cannot tell it from a hang (got: $SEL_ONE)"
 
 echo "== 4. MUTATION: break the skip and case 2 must go RED =="
 MUT="$WORK/loop-mutant.sh"

--- a/q-system/.q-system/scripts/test/test-dispatch-per-repo-concurrency.sh
+++ b/q-system/.q-system/scripts/test/test-dispatch-per-repo-concurrency.sh
@@ -2,15 +2,22 @@
 # Pairs with the PER-REPO CONCURRENCY block in kipi-dispatch.sh (sp-e45251f7).
 #
 # The claim under test: dispatch may run several converges at once ACROSS repos,
-# and PREFERS a repo with nothing live. That is what lets KIPI_DISPATCH_MAX rise
-# above 1 without rebuilding the same-file collision the cap was set to 1 to
-# avoid.
+# and never puts a SECOND RUN OF ITS OWN into a repo that already has one. That
+# is what lets KIPI_DISPATCH_MAX rise above 1 without rebuilding the same-file
+# collision the cap was set to 1 to avoid. Founder decision, ASK-811.
 #
-# IT IS NOT "never two in ONE repo", and this file used to say that it was. When
-# only one repo is dispatchable, dispatch takes it anyway -- case 3 asserts
-# exactly that -- because an absolute rule re-created the ready-queue starvation
-# test-ci-redrive 14g exists to prevent. A test file that overstates its own
-# guarantee is how a reader concludes the cap is safer than it is (ASK-811).
+# READ THAT SCOPE LITERALLY: "a second run OF ITS OWN". The rule binds runs
+# DISPATCH LAUNCHED, because the ledger is the only thing that can say which repo
+# a run is in. A converge someone starts by hand carries its target repo in an
+# ENV VAR, and environment is not in the process table, so no pgrep can attribute
+# it. Such a run does not mark its repo busy and dispatch may still enter there.
+# A failed ledger write has the same effect, loudly (record_live_run pages).
+#
+# This header previously said "PREFERS a repo with nothing live", which was true
+# of the superseded fallback design and is now wrong; and an earlier version
+# claimed "never two in ONE repo", which overstated the guarantee in the other
+# direction. Both are recorded because a test file that misdescribes its own
+# scope is how a reader concludes the cap is safer than it is.
 #
 # THIS TEST READS THE REAL SCRIPT, IT DOES NOT RESTATE IT. Both the helper
 # functions and the selection loop are cut out of kipi-dispatch.sh by marker and


### PR DESCRIPTION
## Founder decision

2026-08-15, `[USER-DIRECTED]`. Asked whether two agents may work one repo at once: **"no, only one per repo."**

The busy-repo fallback is removed. A repo with a live run is skipped, the rotation continues to the next repo, and a cycle that finds every repo busy enters nothing and retries on the next tick.

## The test I expected to break, and didn't

`test-ci-redrive` 14g exists because a live converge once starved the ready queue. I assumed an absolute rule would contradict it, and started rewriting it.

**The run showed 14g passes unchanged**, and the reason matters: its decoy converge is hand-spawned, so it has no ledger row, so the repo is never marked busy and dispatch proceeds exactly as before. I reverted my edit rather than keep a test change that bought nothing.

`65 passed, 0 failed` with 14g untouched.

## The limit that follows, stated plainly

This rule binds runs **dispatch launched**, because the ledger is the only thing that can attribute a run to a repo. A converge started by hand does not mark its repo busy, so dispatch can still enter a repo a human is working in.

Closing that needs repo attribution for unattributed processes, which `pgrep` cannot provide — sp-0c3775ee measured why: `pgrep -f` matches the invocation string, not the work, so a lingering wrapper shell counts as live forever.

## What changed in the tests

Case 3 flips from "a lone busy repo is still taken" to "a lone busy repo is NOT taken", and additionally asserts the idle cycle **says why** — an operator cannot distinguish a silent stall from a hang.

The per-repo ceiling case (3b) is deleted along with the fallback it tested.

```
test-dispatch-per-repo-concurrency  20 passed, 0 failed
test-ci-redrive                     65 passed, 0 failed
test-dispatch-liveness              18 passed, 0 failed
```

Closes ASK-811.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0151EYtGH6at3XTWqbBHAxEi