### PR TITLE
Attribute the INDEX too, not only the worktree (PR #165 review round 4)

### DIFF
--- a/fleet-unblock.py
+++ b/fleet-unblock.py
@@ -98,6 +98,16 @@ def in_head(repo, path):
     return git(repo, "cat-file", "-e", f"HEAD:{path}")[0] == 0
 
 
+def head_blob(repo, path):
+    """Blob sha at HEAD for `path`, or "" when the path is not in HEAD.
+
+    Needed to tell "nothing is staged, so the index still mirrors HEAD" from
+    "somebody deliberately staged something". The index alone cannot say which.
+    """
+    rc, out, _ = git(repo, "rev-parse", f"HEAD:{path}")
+    return out.strip() if rc == 0 else ""
+
+
 class RescuedBlobs:
     """Blobs the skeleton has COMMITTED under rescued/, by sha.
 
@@ -176,6 +186,32 @@ def decide(repo, row, audit, rescued):
                 f"holds {work_sha[:12]}, which the skeleton never wrote; "
                 "committing the index would leave that edit for the next sync "
                 "to overwrite"
+            )
+        # THE MIRROR OF THE GUARD ABOVE (PR #165 review round 4, major).
+        #
+        # That one asks whether the WORKTREE is attributable. This asks the same
+        # of the INDEX, and the case it catches is the reverse: the founder
+        # STAGED their own version and the worktree happens to hold a skeleton
+        # blob. The guard above passes, `git add` then replaces the founder's
+        # staged entry with the worktree blob, and the commit SUCCEEDS -- so the
+        # unwind added in round 2 never runs, because nothing failed. The
+        # founder's staged version is committed away and gone.
+        #
+        # "Attributable" for the index means the skeleton wrote it, or nothing
+        # was staged at all -- an unstaged path still has the HEAD blob in its
+        # index, which is why this compares against HEAD rather than just
+        # checking for skeleton authorship.
+        #
+        # Scoped inside the fleet-written branch on purpose: a staged ADD is not
+        # in HEAD at all, and that case has its own rescued/ proof further down.
+        # Reproducer: test_founder_staged_content_under_a_skeleton_worktree_blob_is_refused.
+        if (in_head(repo, path) and index_sha
+                and index_sha != head_blob(repo, path)
+                and not audit_wrote(audit, path, index_sha)):
+            return "refuse", (
+                f"the index holds {index_sha[:12]}, which the skeleton never "
+                "wrote and which differs from HEAD, so the founder staged it "
+                "deliberately; committing would replace it with the worktree copy"
             )
         which = index_sha if audit_wrote(audit, path, index_sha) else work_sha
         return "commit", (

--- a/test_fleet_unblock.py
+++ b/test_fleet_unblock.py
@@ -454,6 +454,44 @@ def test_a_staged_skeleton_blob_with_a_founder_worktree_edit_is_refused(world):
     assert (inst / rel).read_text() == "founder was here\n", "founder bytes lost"
 
 
+def test_founder_staged_content_under_a_skeleton_worktree_blob_is_refused(world):
+    """PR #165 review round 4, major. The MIRROR of the round-1 finding.
+
+    Round 1 was: index holds a skeleton blob, worktree holds a founder edit.
+    Guarded. This is the other way round -- the founder STAGED their own version
+    and the worktree happens to hold a skeleton blob. The round-1 guard passes,
+    because it only asks whether the WORKTREE is attributable.
+
+    Then `git add` replaces the founder's staged entry with the worktree blob and
+    the commit succeeds. Round 2's unwind restores the staged entry only when the
+    commit FAILS; on the success path the founder's staged version is committed
+    away and gone.
+
+    Both sides of a path have to be attributable, and 'attributable' for the
+    index means either the skeleton wrote it or nothing was staged at all.
+    """
+    skel, inst = world
+    rel = "plugins/prd-os/runner.py"
+    seed_skeleton_blob(skel, rel, "v1\n")
+    write(inst, rel, "old\n")
+    git(inst, "add", "-A")
+    git(inst, "commit", "-qm", "instance base")
+
+    write(inst, rel, "founder staged this\n")
+    git(inst, "add", rel)                     # index: founder's own content
+    staged_before = git(inst, "rev-parse", ":" + rel)
+    write(inst, rel, "v1\n")                  # worktree: the skeleton's blob
+
+    head_before = git(inst, "rev-parse", "HEAD")
+    rc, out = run(skel, "--apply")
+
+    assert "REFUSE" in out, out
+    assert git(inst, "rev-parse", "HEAD") == head_before, (
+        "committed over content the founder had staged\n" + out)
+    assert git(inst, "rev-parse", ":" + rel) == staged_before, (
+        "the founder's staged version was replaced by git add\n" + out)
+
+
 def test_a_refused_commit_does_not_report_success(world):
     """PR #165 review, major #2.
 


### PR DESCRIPTION
Round 4, right tree. One new **major**, and it is the exact mirror of round 1.

## The finding

**Round 1:** the index holds a skeleton blob, the worktree holds a founder edit. I guarded it — by asking whether the **worktree** is attributable.

**Round 4:** the founder *staged* their own version, and the worktree happens to hold a skeleton blob. The round-1 guard passes, because it only ever asked about the worktree. `git add` then replaces the founder's staged entry with the worktree blob and the commit **succeeds** — so the unwind added in round 2 never runs, because nothing failed. The founder's staged version is committed away and gone.

I wrote a guard for one direction and never asked what the same argument said about the other.

Round 2's unwind covered the *failure* path of this same scenario, which is probably why it read as handled: the reproducer I wrote then asserted the founder's staged content survived a **rejected** commit, and never asked what happens when the commit succeeds.

## The fix

"Attributable" for the index means the skeleton wrote it, **or nothing was staged at all**. An unstaged path still has the HEAD blob in its index, so the check compares against HEAD rather than only asking about skeleton authorship.

Scoped inside the fleet-written branch: a staged ADD is not in HEAD at all, and that case has its own `rescued/` proof further down.

## Captured, not bundled

The reproducer output also shows one path producing **two rows**, with the run reporting `acted on 2 path(s)` for a single file. The round-1 reviewer named that duplicate-row shape too. Filed as `sp-511e994a` rather than fixed here — rounds 1-4 addressed the *attribution* of each row, not their multiplicity, and that is a different change.

## Verification

| Check | Result |
|---|---|
| Red proven by stashing the fix | reproducer fails without it |
| Full suite | **346 passed, 0 failed** |

🤖 Generated with [Claude Code](https://claude.com/claude-code)