### PR TITLE
Write the receipt into the TARGET repo, not the skeleton (ASK-821)

### DIFF
--- a/q-system/.q-system/capability-manifest.json
+++ b/q-system/.q-system/capability-manifest.json
@@ -640,6 +640,11 @@
       "path": "q-system/.q-system/tests/test_capmap_scratch_and_mention.py",
       "runner": "python3",
       "timeout_s": 60
+    },
+    {
+      "path": "q-system/.q-system/scripts/test/test-converge-crossrepo-receipt.sh",
+      "runner": "bash",
+      "timeout_s": 120
     }
   ],
   "required_data": [],

--- a/q-system/.q-system/scripts/converge.sh
+++ b/q-system/.q-system/scripts/converge.sh
@@ -198,8 +198,23 @@ trap 'on_interrupt HUP  129' HUP
 # Read from git rather than rebuilt from linear-worker.sh's path convention: a
 # convention with two implementations is a convention with two meanings, and this
 # one already burned ASK-210 (the gate carrying its own copy of the branch regex).
+# THE TARGET REPO, NOT THE SKELETON (ASK-821). linear-worker.sh cuts the issue
+# branch in the repo the work is FOR, so a cross-repo run's branch never exists in
+# the skeleton's worktree list. Searching $SKEL there found nothing, the receipt
+# was skipped, and the PR went green and sat with nothing proving it was reviewed.
+#
+# Measured on the first real cross-repo run, 2026-08-15T00:21:54Z, ASK-144 in
+# ktlyst: "no worktree under .../dispatch-checkout is on sana/ask-144" while the
+# branch was sitting in ktlyst's worktrees the whole time. Post-ASK-447 $SKEL is
+# the PINNED kipi-system checkout, so this was guaranteed to miss for every
+# cross-repo issue -- and it was unreachable before, because dispatch was capped
+# at 1 and bound to the home repo, so no cross-repo run had ever finished.
+#
+# TARGET_REPO is already derived at the top of this file from KIPI_TARGET_REPO,
+# the carrier kipi-dispatch.sh sets. The information was here; this line was
+# reading the wrong variable.
 receipt_tree() {
-  git -C "$SKEL" worktree list --porcelain 2>/dev/null \
+  git -C "$TARGET_REPO" worktree list --porcelain 2>/dev/null \
     | awk -v want="branch refs/heads/$1" \
         '/^worktree /{p=substr($0,10)} $0==want{print p; exit}'
 }
@@ -563,9 +578,9 @@ receipt_ensure() {
   fi
   tree="$(receipt_tree "$BRANCH")"
   if [ -z "$tree" ]; then
-    say "receipt: no worktree under $SKEL is on $BRANCH, so there is no tree to commit a receipt into. Write one by hand or PR #23's gate will refuse this PR."
-    RECEIPT_MISS="no worktree under $SKEL is on $BRANCH, so there was no tree to commit into"
-    RECEIPT_FIX="git -C $SKEL worktree add <path> $BRANCH, then write a receipt for $ISSUE at $sha and push it"
+    say "receipt: no worktree under $TARGET_REPO is on $BRANCH, so there is no tree to commit a receipt into. Write one by hand or PR #23's gate will refuse this PR."
+    RECEIPT_MISS="no worktree under $TARGET_REPO is on $BRANCH, so there was no tree to commit into"
+    RECEIPT_FIX="git -C $TARGET_REPO worktree add <path> $BRANCH, then write a receipt for $ISSUE at $sha and push it"
     return 0
   fi
   # Everything from the ledger read through the push is ONE transaction under one

--- a/q-system/.q-system/scripts/converge.sh
+++ b/q-system/.q-system/scripts/converge.sh
@@ -204,8 +204,11 @@ trap 'on_interrupt HUP  129' HUP
 # was skipped, and the PR went green and sat with nothing proving it was reviewed.
 #
 # Measured on the first real cross-repo run, 2026-08-15T00:21:54Z, ASK-144 in
-# ktlyst: "no worktree under .../dispatch-checkout is on sana/ask-144" while the
-# branch was sitting in ktlyst's worktrees the whole time. Post-ASK-447 $SKEL is
+# a non-home dispatch repo: "no worktree under .../dispatch-checkout is on
+# sana/ask-144" while the branch was sitting in THAT repo's worktrees the whole
+# time. (No instance is named here on purpose: this file ships to every instance
+# and validate-separation Gate 1.2 refuses a live instance name. The measurement
+# is the durable part; the repo name belongs in the PR body.) Post-ASK-447 $SKEL is
 # the PINNED kipi-system checkout, so this was guaranteed to miss for every
 # cross-repo issue -- and it was unreachable before, because dispatch was capped
 # at 1 and bound to the home repo, so no cross-repo run had ever finished.

--- a/q-system/.q-system/scripts/test/test-converge-crossrepo-receipt.sh
+++ b/q-system/.q-system/scripts/test/test-converge-crossrepo-receipt.sh
@@ -1,0 +1,76 @@
+#!/usr/bin/env bash
+# Pairs with receipt_tree() in converge.sh (ASK-821).
+#
+# THE DEFECT: receipt_tree searched $SKEL -- the skeleton, and post-ASK-447 the
+# PINNED kipi-system checkout -- for a worktree on the issue branch. But
+# linear-worker.sh cuts that branch in the repo the work is FOR. So for every
+# cross-repo issue the search was guaranteed to miss, the receipt was skipped,
+# and the PR went green and sat with nothing proving it was reviewed.
+#
+# Measured on the first real cross-repo run, 2026-08-15T00:21:54Z, ASK-144 in
+# ktlyst. It was unreachable before that: dispatch was capped at 1 and bound to
+# the home repo, so no cross-repo run had ever completed.
+set -uo pipefail
+HERE="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+CONVERGE="$HERE/../converge.sh"
+[ -f "$CONVERGE" ] || { echo "FATAL: no converge.sh at $CONVERGE" >&2; exit 1; }
+
+PASS=0; FAIL=0
+ok()  { echo "  PASS: $*"; PASS=$((PASS+1)); }
+bad() { echo "  FAIL: $*"; FAIL=$((FAIL+1)); }
+# PHYSICAL path. On macOS /var is a symlink to /private/var, so mktemp hands
+# back /var/... while `git worktree list` reports the RESOLVED /private/var/...
+# Comparing the two made a correct fix read as a failure on the first run.
+WORK="$(cd "$(mktemp -d)" && pwd -P)"
+cleanup() { [ -n "${WORK:-}" ] && [ -d "$WORK" ] && /bin/rm -rf -- "$WORK"; }
+trap cleanup EXIT
+
+# Two throwaway repos: a stand-in skeleton and a stand-in target. The branch
+# exists ONLY in the target, which is the whole point.
+mk() {
+  git init -q -b main "$1"
+  ( cd "$1" && git config user.email t@e.com && git config user.name t \
+    && echo x > f && git add f && git commit -qm init )
+}
+mk "$WORK/skel"; mk "$WORK/target"
+git -C "$WORK/target" branch sana/ask-999
+git -C "$WORK/target" worktree add -q "$WORK/tree999" sana/ask-999
+
+# receipt_tree cut from the shipped file, so this exercises real code rather than
+# a restatement that could pass forever while converge.sh drifted.
+FN="$WORK/fn.sh"
+sed -n '/^receipt_tree() {/,/^}$/p' "$CONVERGE" > "$FN"
+grep -q 'worktree list' "$FN" \
+  || { echo "FATAL: could not extract receipt_tree from $CONVERGE" >&2; exit 1; }
+
+echo "== the branch lives in the TARGET repo, not the skeleton =="
+FOUND="$(SKEL="$WORK/skel" TARGET_REPO="$WORK/target" bash -c ". '$FN'; receipt_tree sana/ask-999")"
+[ "$FOUND" = "$WORK/tree999" ] \
+  && ok "receipt_tree finds the worktree in the target repo" \
+  || bad "receipt_tree did not find the target's worktree (got: '${FOUND:-empty}')"
+
+echo "== NEGATIVE: the old \$SKEL behaviour must FAIL this =="
+# Rebuild the pre-fix line and prove it returns nothing. Without this, the case
+# above cannot tell a real fix from a test that would have passed either way.
+sed 's|git -C "$TARGET_REPO" worktree list|git -C "$SKEL" worktree list|' "$FN" > "$WORK/fn-old.sh"
+grep -q 'git -C "$SKEL" worktree list' "$WORK/fn-old.sh" \
+  || bad "the mutant was not applied, so this negative proves nothing"
+OLD="$(SKEL="$WORK/skel" TARGET_REPO="$WORK/target" bash -c ". '$WORK/fn-old.sh'; receipt_tree sana/ask-999")"
+[ -z "$OLD" ] \
+  && ok "the old \$SKEL lookup returns nothing -- this is the shipped defect" \
+  || bad "the old lookup also found it, so the fix changed nothing (got: '$OLD')"
+
+echo "== same-repo still works (TARGET_REPO defaults to SKEL) =="
+# Guarding the fix against being its own bug: the home-repo path is the common
+# case and must be untouched.
+git -C "$WORK/skel" branch sana/ask-100
+git -C "$WORK/skel" worktree add -q "$WORK/tree100" sana/ask-100
+HOME_FOUND="$(SKEL="$WORK/skel" TARGET_REPO="$WORK/skel" bash -c ". '$FN'; receipt_tree sana/ask-100")"
+[ "$HOME_FOUND" = "$WORK/tree100" ] \
+  && ok "the home-repo path is unchanged" \
+  || bad "the fix broke same-repo receipts (got: '${HOME_FOUND:-empty}')"
+
+echo
+echo "-------- $PASS passed, $FAIL failed --------"
+[ "$FAIL" -eq 0 ] || exit 1
+echo "PASS: converge-crossrepo-receipt"

--- a/q-system/.q-system/scripts/test/test-converge-crossrepo-receipt.sh
+++ b/q-system/.q-system/scripts/test/test-converge-crossrepo-receipt.sh
@@ -7,9 +7,15 @@
 # cross-repo issue the search was guaranteed to miss, the receipt was skipped,
 # and the PR went green and sat with nothing proving it was reviewed.
 #
-# Measured on the first real cross-repo run, 2026-08-15T00:21:54Z, ASK-144 in
-# ktlyst. It was unreachable before that: dispatch was capped at 1 and bound to
-# the home repo, so no cross-repo run had ever completed.
+# Measured on the first real cross-repo run, 2026-08-15T00:21:54Z, ASK-144 in a
+# non-home dispatch repo. It was unreachable before that: dispatch was capped at
+# 1 and bound to the home repo, so no cross-repo run had ever completed.
+#
+# NO INSTANCE IS NAMED HERE, DELIBERATELY. This file ships to every instance and
+# validate-separation Gate 1.2 sweeps skeleton files for live instance names. The
+# founder flagged this exact trap before I started and I walked into it anyway:
+# the first cut named the repo in both this file and converge.sh, and CI refused
+# the PR. A text check cannot tell a rule from a mention of one.
 set -uo pipefail
 HERE="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 CONVERGE="$HERE/../converge.sh"

--- a/q-system/.q-system/scripts/test/test-converge-crossrepo-receipt.sh
+++ b/q-system/.q-system/scripts/test/test-converge-crossrepo-receipt.sh
@@ -18,11 +18,39 @@ CONVERGE="$HERE/../converge.sh"
 PASS=0; FAIL=0
 ok()  { echo "  PASS: $*"; PASS=$((PASS+1)); }
 bad() { echo "  FAIL: $*"; FAIL=$((FAIL+1)); }
-# PHYSICAL path. On macOS /var is a symlink to /private/var, so mktemp hands
-# back /var/... while `git worktree list` reports the RESOLVED /private/var/...
+# THE TEMP DIR IS VALIDATED BEFORE IT IS EVER RESOLVED, AND THE CLEANUP REFUSES
+# ANYTHING THAT IS NOT A TEMP DIR (codex blocker, PR #181).
+#
+# The first cut was  WORK="$(cd "$(mktemp -d)" && pwd -P)"  which is a repo
+# shredder waiting for a bad day. In bash, cd with an empty operand SUCCEEDS as a
+# no-op. So if mktemp ever failed -- full disk, TMPDIR pointing somewhere
+# unwritable -- the substitution collapsed to a cd that went nowhere followed by
+# pwd -P, WORK became the CURRENT DIRECTORY (this checkout), and the EXIT trap
+# recursively deleted the founder's working tree along with any uncommitted work.
+#
+# So: capture, prove it is a real temp directory, and only then resolve it. The
+# cleanup re-checks at DELETION TIME rather than trusting the assignment, because
+# a guard that runs only once cannot protect against anything that reassigns WORK
+# later.
+WORK="$(mktemp -d)" || { echo "FATAL: mktemp failed" >&2; exit 1; }
+case "$WORK" in
+  /tmp/*|/private/tmp/*|/var/folders/*|/private/var/folders/*) : ;;
+  *) echo "FATAL: mktemp returned an unexpected path: '$WORK'" >&2; exit 1 ;;
+esac
+[ -d "$WORK" ] || { echo "FATAL: mktemp path is not a directory: '$WORK'" >&2; exit 1; }
+# PHYSICAL path. On macOS /var is a symlink to /private/var, so mktemp hands back
+# /var/... while `git worktree list` reports the RESOLVED /private/var/...
 # Comparing the two made a correct fix read as a failure on the first run.
-WORK="$(cd "$(mktemp -d)" && pwd -P)"
-cleanup() { [ -n "${WORK:-}" ] && [ -d "$WORK" ] && /bin/rm -rf -- "$WORK"; }
+WORK="$(cd "$WORK" && pwd -P)" || { echo "FATAL: could not resolve temp dir" >&2; exit 1; }
+
+cleanup() {
+  # Re-checked HERE, because this is the line that actually deletes.
+  case "${WORK:-}" in
+    /tmp/*|/private/tmp/*|/var/folders/*|/private/var/folders/*)
+      [ -d "$WORK" ] && /bin/rm -rf -- "$WORK" ;;
+    *) echo "cleanup refused: WORK is not a temp dir ('${WORK:-unset}')" >&2 ;;
+  esac
+}
 trap cleanup EXIT
 
 # Two throwaway repos: a stand-in skeleton and a stand-in target. The branch


### PR DESCRIPTION
## Found by running it, not by a test

First real cross-repo dispatch, 2026-08-15T00:21:54Z, ASK-144 into `ktlyst`:

```
receipt: no worktree under .../dispatch-checkout is on sana/ask-144,
  so there is no tree to commit a receipt into.
DONE exit-1: PR #1 verdict 'APPROVE WITH NITS' ...
  Auto-merge is NOT armed on it, so it goes green and sits ...
  Nothing proves it was reviewed.
```

The work ran. The PR opened. Codex approved it. Then the receipt step searched **the wrong repository** and left the PR unmergeable.

## One line, wrong variable

`receipt_tree()` asked `$SKEL` for a worktree on the issue branch. `linear-worker.sh` cuts that branch in the repo the work is **for**, and post-ASK-447 `$SKEL` is the pinned kipi-system checkout — so for every cross-repo issue the search was guaranteed to miss. The branch was in ktlyst's worktree list the whole time.

**The information was already in the file.** `TARGET_REPO` is derived at line 79 from `KIPI_TARGET_REPO`, the carrier dispatch sets precisely so converge knows which repo it is working. This line read the wrong one.

Three operator messages named `$SKEL` too, sending a human to `git -C <skeleton> worktree add` — which would not have helped either.

## Why it was latent until tonight

Dispatch was capped at 1 and bound to the home repo, so **no cross-repo run had ever completed**. ASK-804 raised the cap and the first cross-repo run hit this immediately. Enabling the path is what exposed it.

## Scope checked before editing

8 uses of `$SKEL` in this file. Four are correct and untouched: the definition, the `TARGET_REPO` fallback, the `instance-registry.json` path (the registry genuinely does live in the skeleton), and a comment. Only `receipt_tree` and its three messages were wrong.

## Verification

`test-converge-crossrepo-receipt.sh` — 3 checks, all green. It cuts `receipt_tree` out of the shipped file rather than restating it.

- the branch exists **only** in the target repo, and is found;
- **NEGATIVE:** the pre-fix `$SKEL` line is rebuilt and returns **nothing**, so the passing case cannot be a test that would have passed either way;
- same-repo is unchanged — `TARGET_REPO` defaults to `SKEL`, and the home path is the common case.

`test-converge.sh` still 17/17.

One test defect fixed alongside: `mktemp` returns `/var/...` while `git worktree list` reports the resolved `/private/var/...`, so a correct fix read as a failure on the first run. `WORK` is a physical path now.

Closes ASK-821.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0151EYtGH6at3XTWqbBHAxEi