### PR TITLE
A failed .gitignore block must stop the untrack, not just warn (PR #165 review round 6)

### DIFF
--- a/kipi-update.sh
+++ b/kipi-update.sh
@@ -1634,14 +1634,34 @@ PY
     # own .gitignore, so adding a fourth never-commit path there reaches all 22
     # instances without touching this file.
     #
-    # Advisory: an instance that cannot take the block is not a reason to
-    # abandon an otherwise good update, and the untrack below still runs.
+    # ADVISORY FOR THE UPDATE, A HARD PRECONDITION FOR THE UNTRACK
+    # (PR #165 review round 6, major -- a defect in this block's first version).
+    #
+    # That version said: "an instance that cannot take the block is not a reason
+    # to abandon an otherwise good update, and the untrack below still runs."
+    # The first half is right and the second half is the bug. `git rm --cached`
+    # leaves the marker on disk UNTRACKED; if the ignore rules are not in place
+    # at that moment, git reports it and the next ordinary session's auto-commit
+    # puts it straight back. So a failed block turned the untrack from a repair
+    # into the exact regression the ordering exists to prevent -- and it would do
+    # it again on every run, because the marker's one line is a timestamp the
+    # tripwire rewrites on every arm.
+    #
+    # Leaving the marker TRACKED is the stable state. It is where 5 instances
+    # already sit, the sync still works, and the next run can retry. Untracking
+    # without ignoring is strictly worse than not untracking at all.
+    #
+    # So: the sync continues (advisory), the untrack does not (gated).
     GITIGNORE_BLOCK="$SCRIPT_DIR/kipi-update-gitignore-block.py"
+    GITIGNORE_BLOCK_OK=0
     if [ -f "$GITIGNORE_BLOCK" ]; then
-      python3 "$GITIGNORE_BLOCK" --skeleton "$SCRIPT_DIR" --instance "$path" ||
-        echo "    WARN: could not write the .gitignore managed block; never-commit paths stay visible to auto-commit here"
+      if python3 "$GITIGNORE_BLOCK" --skeleton "$SCRIPT_DIR" --instance "$path"; then
+        GITIGNORE_BLOCK_OK=1
+      else
+        echo "    WARN: could not write the .gitignore managed block; skipping the never-commit untrack so the marker is not left untracked AND unignored"
+      fi
     else
-      echo "    WARN: .gitignore block writer missing; never-commit paths stay visible to auto-commit here"
+      echo "    WARN: .gitignore block writer missing; skipping the never-commit untrack so the marker is not left untracked AND unignored"
     fi
 
     # ONE-TIME MIGRATION, and it must run BEFORE the block below (measured 2026-08-14, 6 instances).
@@ -1670,6 +1690,11 @@ PY
     # package, same rule as the dirty guard below), then by asserting the staged set
     # is exactly this one path before committing.
     for sys_path in "${SYSTEM_NEVER_COMMIT[@]}"; do
+      # Gated on the managed block being in place -- see the WARN above. A first
+      # attempt at this guard used ${GITIGNORE_BLOCK_OK:+...} on the array, which
+      # is wrong: the flag is 0 or 1 and "0" is non-empty, so it expanded on
+      # failure exactly as before. Plain and readable beats clever here.
+      [ "$GITIGNORE_BLOCK_OK" = "1" ] || continue
       git ls-files --error-unmatch -- "$sys_path" >/dev/null 2>&1 || continue
       if [ -n "$(git diff --cached --name-only 2>/dev/null)" ]; then
         say "  WARNING: $sys_path is tracked, but the index already holds staged work."

--- a/q-system/.q-system/tests/test_gitignore_block.py
+++ b/q-system/.q-system/tests/test_gitignore_block.py
@@ -258,6 +258,47 @@ class TestTheWiringIntoTheUpdater:
             "system state, so a newly-stanza'd path is still offered to the "
             "classifier on the run that introduces it")
 
+    def test_the_untrack_is_GATED_on_the_block_being_written(self):
+        """PR #165 review round 6, major -- a defect in this wiring's first cut.
+
+        That version was advisory both ways: if the block could not be written
+        the updater warned and ran the untrack anyway. `git rm --cached` leaves
+        the marker on disk UNTRACKED, so without the ignore rules in place git
+        reports it and the next session's auto-commit puts it straight back --
+        turning the repair into the exact regression the ordering exists to
+        prevent, on every run.
+
+        Leaving the marker TRACKED is the stable state: 5 instances already sit
+        there, the sync still works, and the next run can retry. Untracking
+        without ignoring is strictly worse than not untracking at all.
+        """
+        text = self.text()
+        loop = text.index('for sys_path in "${SYSTEM_NEVER_COMMIT[@]}"')
+        body_end = text.index("\n    done", loop)
+        body = text[loop:body_end]
+        assert 'GITIGNORE_BLOCK_OK' in body, (
+            "the untrack loop no longer checks whether the managed block was "
+            "written, so a failed block leaves the marker untracked AND "
+            "unignored for auto-commit to re-add")
+
+    def test_the_gate_uses_an_explicit_value_test_not_a_set_test(self):
+        """Mutation control for the gate above, and a real bug I shipped for one
+        edit. The first attempt gated the loop with ${GITIGNORE_BLOCK_OK:+...},
+        which expands whenever the variable is NON-EMPTY -- and the flag is 0 or
+        1, so "0" expanded exactly like "1" and the gate did nothing. A gate that
+        is present but always open reads as coverage."""
+        # CODE lines only. The scar comment beside the gate quotes the broken
+        # form on purpose, and a naive substring check flagged that comment --
+        # the same "a gate that reads its own documentation" false positive this
+        # repo keeps hitting elsewhere.
+        code = "\n".join(line for line in self.text().splitlines()
+                         if not line.lstrip().startswith("#"))
+        assert '${GITIGNORE_BLOCK_OK:+' not in code, (
+            "the gate tests whether the flag is SET, not whether it is 1; "
+            "'0' is non-empty so this passes on failure")
+        assert '[ "$GITIGNORE_BLOCK_OK" = "1" ]' in code, (
+            "the gate no longer compares the flag against 1")
+
     def test_the_updater_still_parses(self):
         r = subprocess.run(["bash", "-n", self.UPDATER],
                            capture_output=True, text=True)


### PR DESCRIPTION
Round 6, right tree. One **major**, and it is in my own wiring from earlier in this chain.

## The comment I wrote is the bug in plain sight

> *"an instance that cannot take the block is not a reason to abandon an otherwise good update, and the untrack below still runs."*

First half right. Second half is the defect.

`git rm --cached` leaves the marker on disk **untracked**. Without the ignore rules in place at that moment, git reports it and the next ordinary session's auto-commit puts it straight back — turning the repair into the exact regression the ordering exists to prevent. Every run, forever, because the marker's one line is a timestamp the tripwire rewrites on every arm.

Leaving the marker **tracked** is the stable state. Five instances already sit there, the sync still works, the next run can retry. Untracking without ignoring is strictly worse than not untracking at all.

**Advisory for the sync. Hard precondition for the untrack.**

## I shipped a broken gate for one edit

The first attempt gated the loop with `${GITIGNORE_BLOCK_OK:+...}`. That expands whenever the variable is **non-empty** — and the flag is 0 or 1, so `"0"` expanded exactly like `"1"` and the gate did nothing.

A gate that is present but always open reads as coverage. Replaced with an explicit value test, pinned by its own mutation control so the clever form cannot come back.

That control needed a fix too: a naive substring check flagged the scar comment that quotes the broken form on purpose. It reads **code lines only** now — the same "gate trips on its own documentation" shape this repo keeps hitting.

## Verification

| Check | Result |
|---|---|
| Red proven by stashing `kipi-update.sh` | both new tests fail without it |
| `bash -n` | clean |
| Full suite | **350 passed, 0 failed** |

🤖 Generated with [Claude Code](https://claude.com/claude-code)