### PR TITLE
One verdict per PATH, strictest wins (sp-511e994a, PR #165 round-1 structural note)

### DIFF
--- a/fleet-unblock.py
+++ b/fleet-unblock.py
@@ -232,6 +232,56 @@ def decide(repo, row, audit, rescued):
     return "refuse", f"kind={row['kind']}; not attributable to the fleet"
 
 
+def plan_for_instance(repo, rows, audit, rescued):
+    """One verdict per PATH, strictest wins. Returns [(action, path, reason)].
+
+    THE STRUCTURAL FIX the PR #165 round-1 reviewer asked for, done after round 6
+    rather than after round 1 -- and rounds 1 and 4 are both what not doing it
+    cost. Those two findings were the SAME defect seen from opposite sides:
+    round 1 was an unattributable worktree under an attributable index, round 4
+    the mirror. Each got its own guard inside decide(). A third asymmetry would
+    have needed a third.
+
+    The cause is that a single path can produce SEVERAL rows -- audit_instance
+    reports the staged state and the worktree state separately -- and decide()
+    only ever saw one row at a time. So each row was judged on its own half of
+    the truth, and whichever half looked attributable won. Reproduced in the
+    round-4 fixture: one file, two rows, "acted on 2 path(s)" for a single path
+    (sp-511e994a).
+
+    Judging the PATH instead of the ROW makes the asymmetry unrepresentable:
+
+      any row refuses            -> the path refuses, carrying every reason
+      rows disagree on an action -> refuse; the tool cannot be sure, and this
+                                    writes to 22 repos
+      all rows agree             -> that action, ONCE
+
+    The per-side guards inside decide() stay. They are now belt and braces
+    rather than the only thing standing between a founder's staged edit and a
+    commit, and each still has its own reproducer from the round it came from.
+    """
+    by_path = {}
+    for row in rows:
+        by_path.setdefault(row["path"], []).append(row)
+
+    plan = []
+    for path, path_rows in by_path.items():
+        verdicts = [decide(repo, row, audit, rescued) for row in path_rows]
+        refusals = [reason for action, reason in verdicts if action == "refuse"]
+        if refusals:
+            plan.append(("refuse", path, "; ".join(dict.fromkeys(refusals))))
+            continue
+        actions = {action for action, _ in verdicts}
+        if len(actions) > 1:
+            plan.append(("refuse", path, (
+                "this path produced conflicting verdicts across its staged and "
+                f"worktree rows ({', '.join(sorted(actions))}); refusing rather "
+                "than picking one")))
+            continue
+        plan.append((verdicts[0][0], path, verdicts[0][1]))
+    return plan
+
+
 def audit_wrote(audit, path, sha):
     return audit.SKEL_BLOBS.wrote(path, sha) if sha else False
 
@@ -389,10 +439,7 @@ def main():
         if result["verdict"] not in ("BLOCKED-FLEET", "BLOCKED-FOUNDER"):
             continue
         repo = pathlib.Path(entry["path"])
-        plan = []
-        for row in result["blocked_by"]:
-            action, reason = decide(repo, row, audit, rescued)
-            plan.append((action, row["path"], reason))
+        plan = plan_for_instance(repo, result["blocked_by"], audit, rescued)
 
         print(f"{entry['name']}  [{result['verdict']}]")
         for action, path, reason in plan:

--- a/test_fleet_unblock.py
+++ b/test_fleet_unblock.py
@@ -371,6 +371,83 @@ def test_a_blob_on_the_shipped_line_is_still_fleet_authored(world):
     assert not is_dirty(inst, rel), out
 
 
+def test_one_path_produces_one_action_not_one_per_row(world):
+    """sp-511e994a, and the structural half of the round-1 review note.
+
+    audit_instance reports the staged state and the worktree state as SEPARATE
+    rows, so a single file could produce two, and the run counted each as its
+    own action -- 'acted on 2 path(s)' for one file, observed in the round-4
+    fixture. The counts an unattended job reads were inflated, and any per-row
+    action that is not idempotent ran twice on the same path.
+
+    Uses the round-4 shape, which is the one that demonstrably produces two
+    rows: founder content staged under a skeleton worktree blob. A first draft
+    staged the skeleton blob itself and passed WITHOUT the collapse, because
+    that shape yields a single row -- it asserted nothing. This shape emitted
+    two lines for one file before the collapse and emits one after.
+    """
+    skel, inst = world
+    rel = "plugins/prd-os/runner.py"
+    seed_skeleton_blob(skel, rel, "v1\n")
+    write(inst, rel, "old\n")
+    git(inst, "add", "-A")
+    git(inst, "commit", "-qm", "instance base")
+    write(inst, rel, "founder staged this\n")
+    git(inst, "add", rel)          # staged AND worktree differ -> two rows
+    write(inst, rel, "v1\n")
+
+    rc, out = run(skel, "--apply")
+    assert out.count("REFUSE  " + rel) == 1, (
+        "one path produced more than one verdict line\n" + out)
+    assert "refused 1 path(s)" in out, out
+
+
+def test_a_refusal_on_any_row_refuses_the_whole_path(world):
+    """Strictest verdict wins. Judging the PATH rather than the ROW is what
+    makes the round-1 / round-4 asymmetry unrepresentable: neither half of a
+    path's truth can carry it past the other."""
+    mod = load_script()
+    rows = [{"path": "a", "kind": "fleet-written", "staged": False},
+            {"path": "a", "kind": "founder", "staged": False}]
+
+    def fake_decide(repo, row, audit, rescued):
+        return ("commit", "looks fine") if row["kind"] == "fleet-written" \
+            else ("refuse", "founder wrote it")
+
+    mod.decide = fake_decide
+    plan = mod.plan_for_instance("/repo", rows, None, None)
+    assert plan == [("refuse", "a", "founder wrote it")], plan
+
+
+def test_conflicting_actions_on_one_path_are_refused(world):
+    """Two rows, two DIFFERENT actions, neither a refusal. The tool cannot be
+    sure which is right and this writes to 22 repos, so it refuses."""
+    mod = load_script()
+    rows = [{"path": "a", "kind": "x", "staged": False},
+            {"path": "a", "kind": "y", "staged": False}]
+    actions = iter(["commit", "unstage"])
+
+    def fake_decide(repo, row, audit, rescued):
+        return (next(actions), "because")
+
+    mod.decide = fake_decide
+    plan = mod.plan_for_instance("/repo", rows, None, None)
+    assert len(plan) == 1
+    assert plan[0][0] == "refuse", plan
+    assert "conflicting verdicts" in plan[0][2], plan
+
+
+def test_agreeing_rows_still_act_once(world):
+    """Negative control for the two above: collapsing must not collapse to
+    'refuse everything'. Two rows that agree still produce their action."""
+    mod = load_script()
+    rows = [{"path": "a", "kind": "fleet-written", "staged": False},
+            {"path": "a", "kind": "fleet-written", "staged": True}]
+    mod.decide = lambda repo, row, audit, rescued: ("commit", "attributable")
+    plan = mod.plan_for_instance("/repo", rows, None, None)
+    assert plan == [("commit", "a", "attributable")], plan
+
+
 def test_founder_edit_is_refused(world):
     """NEGATIVE: bytes the skeleton never shipped stay exactly where they are.
 


### PR DESCRIPTION
The structural fix the round-1 reviewer asked for, done after round 6 rather than after round 1. **Rounds 1 and 4 are both what not doing it cost.**

## The cause

Those two findings were the same defect from opposite sides — round 1 an unattributable worktree under an attributable index, round 4 the mirror. Each got its own guard inside `decide()`. A third asymmetry would have needed a third guard.

One path can produce **several rows**: `audit_instance` reports the staged state and the worktree state separately, and `decide()` only ever saw one at a time. Each row was judged on its own half of the truth, and whichever half looked attributable won.

## The rule

Judging the **path** instead of the **row** makes the asymmetry unrepresentable:

| Case | Verdict |
|---|---|
| Any row refuses | the path refuses, carrying every reason |
| Rows disagree on an action | refuse — the tool cannot be sure, and it writes to 22 repos |
| All rows agree | that action, **once** |

The per-side guards from rounds 1 and 4 stay. They are belt and braces now rather than the only thing between a founder's staged edit and a commit, and each keeps its own reproducer.

## Why now and not after round 1

**21 tests written across six review rounds pin every case those rounds found.** A restructure that keeps all of them green is defended in a way it would not have been this morning. All 21 passed unchanged on the first run after the rewrite.

## The first dedupe test had no teeth and I nearly shipped it

It staged the skeleton blob itself, which yields a single row — so it passed without the collapse and asserted nothing. Re-aimed at the round-4 shape, which demonstrably produces two rows. It now fails without the fix.

Found by stashing the fix and re-running, not by reading it.

## Verification

| Check | Result |
|---|---|
| Existing tests after rewrite | 21/21 unchanged |
| New tests | 4, all failing without the fix |
| Full suite | **354 passed, 0 failed** |
| Real fleet | nothing to do across 22, reach **22 of 22** |

Closes sp-511e994a.

🤖 Generated with [Claude Code](https://claude.com/claude-code)