### PR TITLE
Record the cole-gtm / reddit-build-radar dispatch decision as a value, not an absence (ASK-842)

### DIFF
--- a/.prd-os/receipts.jsonl
+++ b/.prd-os/receipts.jsonl
@@ -127,3 +127,4 @@
 {"commit_sha": "f590ed790ee23d5d076c6d943a75ebf63c4714b8", "issue_id": "ASK-291", "receipts": {"reviewed": "2026-08-10T16:24:51Z"}, "reviewed_at": "2026-08-10T16:24:51Z"}
 {"commit_sha": "22a5e26299635a9de3a958ab742e82e514a2a7cf", "issue_id": "ASK-700", "receipts": {"reviewed": "2026-08-13T16:41:18Z"}, "reviewed_at": "2026-08-13T16:41:18Z"}
 {"commit_sha": "1b9e8f0d58cf71a10d295d7d6091491ea4b0d436", "issue_id": "ASK-758", "receipts": {"reviewed": "2026-08-14T20:14:57Z"}, "reviewed_at": "2026-08-14T20:14:57Z"}
+{"commit_sha": "ed1a901e0a5b7e8e9c004032c836123c6f49bb7c", "issue_id": "ASK-842", "receipts": {"reviewed": "2026-08-15T06:47:50Z"}, "reviewed_at": "2026-08-15T06:47:50Z"}

--- a/instance-registry.json
+++ b/instance-registry.json
@@ -114,7 +114,12 @@
       "subtree_prefix": "q-system",
       "instance_q_dir": null,
       "type": "subtree",
-      "has_git": true
+      "has_git": true,
+      "dispatch": {
+        "enabled": false,
+        "decision": "ASK-842",
+        "reason": "Decided OFF 2026-08-14, recorded as a value because an absent dispatch key is a default and a default is not a refusal. This path is a ROOT, not a leaf: measured, it tracks 0 files under projects/ while holding 9 nested SEPARATE git repos there (strategy, website, personal-brand, event_coordinator, signal-desk, vc-signals-feed, competitive-analysis, notebooklm-daily-podcast, reddit-build-radar). That is the exact shape ASK-754 refused at the consulting root: preflight check 5 (dirty) is structurally blind to all nine while a dispatched agent still has filesystem reach into them, so an OK here would be an OK the gate cannot back. The root also tracks 3001 files under gtm/, the live outbound engine, so an agent-authored PR can reach an audience. Its 3 issues (ASK-127, ASK-717, ASK-718) are audits and a watchdog fix -- read-then-report work a supervised founder-initiated run handles without an unattended self-merging loop. NOT blocked on preflight: the 5 remaining failures are all curable (worker drift, merge-bypass-gate.py, pin the remote, commit WIP, enable branch protection). The reason is blast radius, not cost."
+      }
     },
     {
       "name": "travel-agent",
@@ -161,6 +166,11 @@
       "has_git": true,
       "skip_agent_check": true,
       "skeleton_managed": false,
+      "dispatch": {
+        "enabled": false,
+        "decision": "ASK-842",
+        "reason": "Decided OFF 2026-08-14. Its preflight failure was filed as control-code DRIFT, curable by propagating one file. Measured, it is not drift, it is ABSENCE: linear-worker.sh is missing entirely (no worker to run) and .claude/settings.json is missing (no hook fires). That follows directly from skeleton_managed=false above -- the deliberate ASK-117 record that this repo takes zero skeleton propagation and therefore carries none of the fleet enforcement layer. Curing the failure means onboarding it into skeleton management, which reverses ASK-117 rather than clearing drift, so option (c) is the expensive path and not the cheap one it looks like from outside. Its 1 issue (ASK-146, audit 11 unwired engines) is read-then-report work for a supervised founder-initiated run."
+      },
       "note": "Standalone Reddit consensus signal engine for weekly build recommendations. No q-system subtree because local git lacks git-subtree. skeleton_managed=false is the deliberate record (ASK-117): it receives zero skeleton propagation, so it carries none of the fleet enforcement layer (no token-guard.py, no .claude/rules/, no capability gate) and must be excluded from fleet-wide governance counts rather than counted as a governed instance."
     },
     {

--- a/q-system/.q-system/capability-manifest.json
+++ b/q-system/.q-system/capability-manifest.json
@@ -325,6 +325,10 @@
       "timeout_s": 600
     },
     {
+      "path": "q-system/.q-system/scripts/test/test-ask842-dispatch-decision.sh",
+      "runner": "bash"
+    },
+    {
       "path": "q-system/.q-system/scripts/test/test-review-artifact-repo-keyed.sh",
       "runner": "bash"
     },

--- a/q-system/.q-system/scripts/test/test-ask842-dispatch-decision.sh
+++ b/q-system/.q-system/scripts/test/test-ask842-dispatch-decision.sh
@@ -1,0 +1,123 @@
+#!/usr/bin/env bash
+# Pairs with: instance-registry.json (the two rows ASK-842 decided) and
+# repo-preflight.sh check 0 (the constraint ASK-842 was forbidden to touch).
+#
+# WHY A TEST FOR A DECISION
+# -------------------------
+# ASK-842 decided that `cole-gtm` (registry name `gtm-partner`) and
+# `reddit-build-radar` stay OFF for unattended dispatch, and that the 4 issues on
+# those surfaces get worked as supervised founder-initiated runs instead.
+#
+# "Leave them off" is not a thing a repo can be left in. repo-preflight.sh states
+# the reason at its own check 0: `dispatch.enabled` ABSENT is a DEFAULT, and a
+# default is not a refusal -- it records that nobody switched the repo on yet, and
+# it evaporates the moment anyone writes `true`. A decision stored as an absence is
+# indistinguishable from a decision never taken, so the next reader of the bucket
+# re-derives it from scratch, which is the specific waste ASK-842 exists to end.
+#
+# So the decision is stored as an explicit `enabled: false` carrying its issue id,
+# and this file is what makes that storage load-bearing rather than a comment: a
+# later flip to `true` turns this red and has to argue with the recorded reason.
+#
+# THE FLIP IS NOT FORBIDDEN, IT IS MADE VISIBLE. This is a ratchet on the WRITE,
+# not a veto. Whoever enables one of these rows edits the decision record in the
+# same change (decisions.md RULE-016) and updates the expectation here. That is one
+# extra minute for a deliberate change and a red suite for an accidental one.
+#
+# NEVER A LIVE DATA PATH. This reads the registry and shells the preflight against
+# a mktemp fixture. It dispatches nothing, enters no repo, and makes no network
+# call: check 0 in repo-preflight.sh exits before every network-touching check, so
+# the constraint assertion below costs nothing and reaches nobody.
+set -uo pipefail
+
+HERE="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+# Derived from the SCRIPT, never from $PWD: a test that asks whatever checkout it
+# happens to run in proves nothing about the caller (test-dispatch-stale-checkout
+# learned this first, test-repo-preflight repeats it).
+REPO="$(cd "$HERE" && git rev-parse --show-toplevel)"
+# $1 overrides the registry under test. That exists for ONE reason: to run this
+# suite against a deliberately mutated copy and watch it go red, because a guard
+# nobody has seen fail is decoration. The mutation that matters is flipping either
+# decided row to `enabled: true` -- see the header. Default is the real registry.
+REGISTRY="${1:-${KIPI_ASK842_REGISTRY:-$REPO/instance-registry.json}}"
+PREFLIGHT="$REPO/q-system/.q-system/scripts/repo-preflight.sh"
+
+PASS=0; FAIL=0
+ok()   { PASS=$((PASS+1)); echo "  PASS: $1"; }
+bad()  { FAIL=$((FAIL+1)); echo "  FAIL: $1"; }
+
+echo "== ASK-842: the recorded dispatch decision for cole-gtm and reddit-build-radar =="
+
+# --- 1. the decision exists, in the registry, as a value and not as an absence ---
+# Checked per row so a failure names WHICH row regressed. `enabled` must be the
+# JSON boolean false, not the string "false" and not a missing key -- the same
+# strictness the dispatcher applies on the true side (`is not True`).
+for ROW in gtm-partner reddit-build-radar; do
+  OUT="$(REG="$REGISTRY" ROW="$ROW" python3 - <<'PY' 2>&1
+import json, os
+reg, want = os.environ["REG"], os.environ["ROW"]
+rows = [e for e in json.load(open(reg)).get("instances", []) if e.get("name") == want]
+if len(rows) != 1:
+    print("ROWCOUNT:%d" % len(rows)); raise SystemExit(0)
+d = rows[0].get("dispatch")
+if not isinstance(d, dict):
+    print("NODISPATCH"); raise SystemExit(0)
+if d.get("enabled") is not False:
+    print("NOTFALSE:%r" % (d.get("enabled"),)); raise SystemExit(0)
+if "ASK-842" not in str(d.get("decision", "")):
+    print("NODECISIONREF:%r" % (d.get("decision"),)); raise SystemExit(0)
+if len(str(d.get("reason", ""))) < 40:
+    print("NOREASON:%r" % (d.get("reason"),)); raise SystemExit(0)
+print("OK")
+PY
+)"
+  case "$OUT" in
+    OK) ok "$ROW carries dispatch.enabled=false with the ASK-842 decision and its reason" ;;
+    *)  bad "$ROW does not carry the recorded decision ($OUT)" ;;
+  esac
+done
+
+# --- 2. the decision agrees with what the dispatcher actually does --------------
+# Rule 1 asserts the RECORD. This asserts the EFFECT, read with the dispatcher's
+# own predicate from fleet_candidates() in kipi-dispatch.sh. Two sides deriving one
+# answer from different sources is how a record drifts into decoration: a row could
+# say `enabled: false` while some later reader keyed off a different field.
+OUT="$(REG="$REGISTRY" python3 - <<'PY' 2>&1
+import json, os
+enabled = []
+for e in json.load(open(os.environ["REG"])).get("instances", []):
+    d = e.get("dispatch")
+    if isinstance(d, dict) and d.get("enabled") is True:
+        enabled.append(e.get("path", ""))
+leaked = [p for p in enabled if p.rstrip("/").endswith("/cole-gtm")
+          or "/cole-gtm/projects/reddit-build-radar" in p]
+print("LEAKED:" + ",".join(leaked) if leaked else "OK")
+PY
+)"
+case "$OUT" in
+  OK) ok "neither decided path is emitted as a dispatch candidate" ;;
+  *)  bad "a decided-off path is dispatchable ($OUT)" ;;
+esac
+
+# --- 3. the hard constraint: check 0 is untouched -------------------------------
+# ASK-842's DoR forbade softening the client-repo refusal to raise a throughput
+# number. The 17 out-of-repo issues stay refused, so the refusal is asserted here
+# rather than assumed -- a constraint nothing checks is a sentence, not a
+# constraint. Shape-derived, so a mktemp path is a faithful fixture.
+TMP="$(mktemp -d)"
+trap 'rm -rf "$TMP"' EXIT
+mkdir -p "$TMP/consulting/projects/some_client" "$TMP/consulting" "$TMP/persona/projects/own_thing"
+
+for CASE in "consulting/projects/some_client:refuse" "consulting:refuse" "persona/projects/own_thing:pass0"; do
+  P="$TMP/${CASE%%:*}"; WANT="${CASE##*:}"
+  OUT="$(bash "$PREFLIGHT" "$P" "" 2>&1)"
+  case "$OUT:$WANT" in
+    *"FAIL client-repo:"*:refuse)  ok "check 0 still refuses $(basename "$P") as a client engagement path" ;;
+    *:refuse)                      bad "check 0 NO LONGER refuses $P -- the hard constraint is broken" ;;
+    *"FAIL client-repo:"*:pass0)   bad "check 0 over-refuses $P; the founder's own project roots must pass it" ;;
+    *:pass0)                       ok "check 0 does not touch the founder's own project roots" ;;
+  esac
+done
+
+echo "-- $PASS passed, $FAIL failed"
+[ "$FAIL" -eq 0 ]

--- a/q-system/canonical/decisions.md
+++ b/q-system/canonical/decisions.md
@@ -180,3 +180,29 @@ Monthly audit (1st of month): count decisions by origin tag. If >60% are rubber-
   this; they get decided by an agent with evidence rather than escalated as questions.
 - **Date:** 2026-08-05
 - **Revisit:** Permanent
+
+### RULE-016: A Root That Holds Nested Repos Is Not Dispatchable, Even Outside An Engagement Root
+- **Origin:** [SYSTEM-INFERRED]
+- **Decision:** ASK-842 option (b). `cole-gtm` (registry `gtm-partner`) and
+  `reddit-build-radar` stay OFF for unattended dispatch. Their 4 issues (ASK-127,
+  ASK-717, ASK-718, ASK-146) are worked as supervised founder-initiated runs. The
+  decision is stored as `dispatch.enabled: false` carrying its issue id and reason,
+  not as an absent key, and `test-ask842-dispatch-decision.sh` turns red if either
+  row is flipped without editing the record.
+- **Reason:** Measured 2026-08-14. `cole-gtm` tracks **0 files under `projects/`**
+  while holding **9 nested separate git repos** there, and tracks 3001 files under
+  `gtm/`, the live outbound engine. That is the identical shape ASK-754 refused at
+  the consulting root: preflight check 5 (dirty) is structurally blind to all nine
+  nested repos while a dispatched agent still has filesystem reach into them, so an
+  `OK` from the gate would be an OK the gate cannot back. Check 0 does not catch it
+  because `cole-gtm` is a persona root, not an engagement root, so the blast-radius
+  property is present with no refusal in front of it. `reddit-build-radar` was filed
+  as curable control-code *drift*; it is *absence* -- no `linear-worker.sh` and no
+  `.claude/settings.json` at all, which follows from its deliberate
+  `skeleton_managed: false` (ASK-117). Curing it reverses ASK-117 rather than
+  clearing drift, so option (c) is the expensive path, not the cheap one.
+  Explicitly NOT decided on cost: every remaining `cole-gtm` preflight failure is
+  curable. The reason is blast radius.
+- **Date:** 2026-08-14
+- **Revisit:** When preflight can see into nested repos a dispatch root does not
+  track (`sp` captured), or when the 4 issues are worked and the surfaces go quiet


### PR DESCRIPTION
## The decision: option (b)

`cole-gtm` (registry `gtm-partner`) and `reddit-build-radar` stay **OFF** for
unattended dispatch. Their 4 issues (ASK-127, ASK-717, ASK-718, ASK-146) are
worked as supervised founder-initiated runs.

## Why not (a) — enable cole-gtm

Measured 2026-08-14, not argued:

```
git -C ~/projects/cole-gtm ls-files projects/ | wc -l   ->  0
nested git repos under projects/                        ->  9
git -C ~/projects/cole-gtm ls-files | cut -d/ -f1       ->  3001 gtm/, 955 q-system/, 769 products/
```

That is the **identical shape ASK-754 refused at the consulting root**: `projects/`
holds every sub-project as a nested *separate* git repo, the root tracks **0** files
under it, so preflight **check 5 (dirty) is structurally blind to all nine** while a
dispatched agent still has filesystem reach into them — including `strategy` (the
positioning canonical authority) and `website` (a public deploy surface).

Check 0 does not catch it because `cole-gtm` is a *persona* root, not an engagement
root. So the blast-radius property is present with **no refusal in front of it**. An
`OK` from preflight here would be an OK the gate cannot back.

Plus the counter-argument the issue already named, now with a number: the root tracks
3001 files under `gtm/`, the live outbound engine. An agent-authored PR there can
reach an audience.

**Explicitly NOT decided on cost.** Every remaining `cole-gtm` preflight failure is
curable — worker drift, one absent guard (`merge-bypass-gate.py`), pin the remote,
commit WIP, enable branch protection. On branch protection specifically: the repo is
private, and `repo-preflight.sh` carries a comment saying private repos on this
account return `403 Upgrade to GitHub Pro`. **That comment is now stale.**
`ktlyst-saas-product` is also private and passes preflight with 3 required checks, and
`cole-gtm` returns a plain `404 Branch not protected` — a settable toggle, not a plan
limit. So "blocked anyway" would have been the wrong reason. The reason is blast radius.

## Why not (c) — enable only reddit-build-radar

It was filed as curable control-code **drift**. It is **absence**:

```
FAIL control-code: .../linear-worker.sh is missing, the repo carries no worker to run
FAIL hooks:        .../.claude/settings.json is missing, so no hook fires in this repo
```

That follows directly from its `skeleton_managed: false` — the deliberate ASK-117
record that it takes zero skeleton propagation and therefore carries none of the fleet
enforcement layer. Curing it means **onboarding it into skeleton management**, which
reverses ASK-117 rather than clearing drift. Option (c) is the expensive path, not the
cheap one it looks like from outside.

## Why the decision is stored as `false` and not left absent

`repo-preflight.sh` check 0 already makes this argument about the *true* side, and it
cuts both ways: an absent `dispatch` key is a **default**, and a default is not a
refusal — it records that nobody switched the repo on yet, and it evaporates the moment
anyone writes `true`. A decision stored as an absence is indistinguishable from a
decision never taken, which is the exact re-derivation waste this issue exists to end.

Both rows now carry `dispatch.enabled: false` with the issue id and the full reason, and
`test-ask842-dispatch-decision.sh` makes that storage load-bearing: a later flip turns it
red and has to argue with the recorded reason. **A ratchet on the write, not a veto** —
whoever enables one edits `decisions.md` RULE-016 in the same change.

## Hard constraint held

Check 0 is untouched. The test asserts it **still refuses** both the engagement root and
a nested engagement repo, and **still does not touch** the founder's own project roots.
The 17 client-repo refusals stay refused. Nothing here softens a gate to raise a
throughput number.

## Reproducer first

| Run | Result |
|---|---|
| `bash test-ask842-dispatch-decision.sh` **before** | `4 passed, 2 failed` — `NODISPATCH` on both rows |
| `bash test-ask842-dispatch-decision.sh` **after** | `6 passed, 0 failed` |
| **Mutant** (`gtm-partner` flipped to `enabled: true`) | `4 passed, 2 failed` — `NOTFALSE:True` and `LEAKED:/Users/.../cole-gtm` |
| `capability-gate.py --check-only` | `156 tests declared` · `capability-gate: GREEN` |

The mutation is runnable by anyone: the suite takes the registry path as `$1`.

## Captured, not mentioned

`sp-e8c5b029` — preflight check 5 is structurally blind to nested separate git repos a
dispatch root does not track. `cole-gtm` is the live proof that the property is not
specific to engagement roots. A new fleet-wide preflight check earns its own issue
rather than arriving as a side effect of a decision record.

## Out of scope, untouched

The 17 client-repo issues, dispatch caps, concurrency.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
