### PR TITLE
held_with() counts open work only, so a Done issue leaves the held count (ASK-841)

### DIFF
--- a/.prd-os/receipts.jsonl
+++ b/.prd-os/receipts.jsonl
@@ -128,3 +128,4 @@
 {"commit_sha": "22a5e26299635a9de3a958ab742e82e514a2a7cf", "issue_id": "ASK-700", "receipts": {"reviewed": "2026-08-13T16:41:18Z"}, "reviewed_at": "2026-08-13T16:41:18Z"}
 {"commit_sha": "1b9e8f0d58cf71a10d295d7d6091491ea4b0d436", "issue_id": "ASK-758", "receipts": {"reviewed": "2026-08-14T20:14:57Z"}, "reviewed_at": "2026-08-14T20:14:57Z"}
 {"commit_sha": "ed1a901e0a5b7e8e9c004032c836123c6f49bb7c", "issue_id": "ASK-842", "receipts": {"reviewed": "2026-08-15T06:47:50Z"}, "reviewed_at": "2026-08-15T06:47:50Z"}
+{"commit_sha": "53d1b42256ac5b1da930a569e27e458534824089", "issue_id": "ASK-841", "receipts": {"reviewed": "2026-08-15T08:18:54Z"}, "reviewed_at": "2026-08-15T08:18:54Z"}

--- a/q-system/.q-system/scripts/linear-worker.sh
+++ b/q-system/.q-system/scripts/linear-worker.sh
@@ -501,9 +501,30 @@ if registry_ok:
     unreachable = [i for i in dropped if not has_local_checkout(i)]
 else:
     skipped_local, unreachable = dropped, []
+# HELD IS A STATEMENT ABOUT OPEN WORK (ASK-841). The team fetch above is the whole
+# board, closed rows included, and this helper used to select on label + project
+# alone. A refusal label is never removed when the issue finishes -- grep confirms
+# nothing in this file calls issueRemoveLabel -- so every issue that was ever
+# refused stayed in these counts after it was Done, and the counts could only rise.
+# Measured 2026-08-15: the run said "2 issue(s) held at blocked:capability
+# (ASK-284 ASK-281)" while ASK-281 was Done. The true number was 1.
+#
+# That matters because the blocked:capability count is the ONLY signal that this
+# loop is starving on a capability nobody granted (see its reporting site below).
+# A number that never falls reports the same alarm whether or not anything is
+# blocked, which is the same as reporting nothing.
+#
+# TERMINAL types are excluded rather than open types allowlisted, deliberately.
+# An allowlist of (backlog, unstarted, started) would silently drop an issue
+# parked in `triage` -- still open, still refused, still needing someone -- and a
+# held issue missing from the count is invisible in a way an extra one is not.
+# ASK-288 owns re-testing whether a block still applies; this is only the count.
+TERMINAL_STATES = ("completed", "canceled")
+
 def held_with(label):
     return [i for i in issues
-            if label in {l["name"] for l in i["labels"]["nodes"]} and in_this_repo(i)]
+            if label in {l["name"] for l in i["labels"]["nodes"]} and in_this_repo(i)
+            and i["state"]["type"] not in TERMINAL_STATES]
 deferred = held_with("needs-scope")
 # Counted SEPARATELY from needs-scope. A rising blocked:capability count is a
 # claim about the ENVIRONMENT, and averaging it into "held" would hide the one

--- a/q-system/.q-system/scripts/test/test-worker-project-scope.sh
+++ b/q-system/.q-system/scripts/test/test-worker-project-scope.sh
@@ -76,6 +76,16 @@ BOARD = [
     # pre-existing rules, kept as regression guards
     issue("ASK-904", "kipi-system", ["owner:assaf", "owner:sana"]),
     issue("ASK-905", "kipi-system", ["owner:sana"], dor=False),
+    # ASK-841: the HELD counts. held_with() selected on label + project and never
+    # looked at state, so a finished issue that still carries its refusal label was
+    # counted as held forever. The live board read "2 issue(s) held at
+    # blocked:capability (ASK-284 ASK-281)" while ASK-281 was Done.
+    # One open + two terminal of each kind, so the expected count (1) cannot be
+    # reached by an off-by-one or by dropping the wrong row.
+    issue("ASK-906", "kipi-system", ["owner:sana", "blocked:capability"]),
+    issue("ASK-907", "kipi-system", ["owner:sana", "blocked:capability"], state="completed"),
+    issue("ASK-908", "kipi-system", ["owner:sana", "blocked:capability"], state="canceled"),
+    issue("ASK-909", "kipi-system", ["owner:sana", "needs-scope"], state="completed"),
 ]
 
 class H(BaseHTTPRequestHandler):
@@ -185,7 +195,11 @@ for pair in "ASK-901:foreign project (accountant)" \
             "ASK-902:unset project" \
             "ASK-903:needs-scope (Sana already rejected it)" \
             "ASK-904:owner:assaf" \
-            "ASK-905:no Definition of Ready"; do
+            "ASK-905:no Definition of Ready" \
+            "ASK-906:blocked:capability" \
+            "ASK-907:blocked:capability and completed" \
+            "ASK-908:blocked:capability and canceled" \
+            "ASK-909:needs-scope and completed"; do
   id="${pair%%:*}"; why="${pair#*:}"
   if printf '%s\n' "$PICKED" | grep -q "$id"; then
     bad "excludes $id -- $why" "it was picked"
@@ -203,6 +217,46 @@ if printf '%s\n' "$OUT" | grep -qi "out-of-repo\|other project\|not this repo"; 
 else
   bad "names the out-of-repo issues it dropped" "no line accounting for the drops in: $(printf '%s' "$OUT" | tr '\n' '|' | cut -c1-300)"
 fi
+
+# --- case 2b: the HELD counts describe OPEN work only (ASK-841) --------------
+# held_with() selected on label + project and never read state, so a Done issue
+# still carrying its refusal label was counted as held on every run, forever.
+# Measured on the live board 2026-08-15: "2 issue(s) held at blocked:capability
+# (ASK-284 ASK-281)" while ASK-281 was Done (completed). The real number was 1.
+#
+# Why the number matters and not just the label: this count is the ONLY signal
+# that the loop is starving on a capability nobody granted (linear-worker.sh:596
+# says so at the reporting site). A count that can only rise, because finished
+# work never leaves it, cannot report starvation -- it reports the same alarm
+# whether or not anything is actually blocked. Hand-clearing the label on the
+# closed issue would have made the line read 1 without fixing that.
+#
+# Asserted on the reported LINE, not on a re-derived pool: the line is what an
+# operator reads at 3am, and it is the artifact that was wrong.
+CAP_LINE="$(printf '%s\n' "$OUT" | grep 'held at blocked:capability' | head -1)"
+case "$CAP_LINE" in
+  *"worker: 1 issue(s) held at blocked:capability"*)
+    ok "blocked:capability count excludes closed issues (reports 1, not 3)" ;;
+  "") bad "blocked:capability count excludes closed issues" "no held-at-blocked:capability line at all in the run output" ;;
+  *)  bad "blocked:capability count excludes closed issues" "line reads: $CAP_LINE" ;;
+esac
+
+# The ids on that same line, asserted separately. A count of 1 reached by
+# counting the WRONG one is still broken, and only the id list can tell.
+case "$CAP_LINE" in
+  *"(ASK-906)"*) ok "names the open blocked issue (ASK-906) and no closed one" ;;
+  *)             bad "names the open blocked issue (ASK-906) and no closed one" "line reads: $CAP_LINE" ;;
+esac
+
+# needs-scope goes through the SAME helper, so it carried the same defect. Its
+# line has no id list, so this asserts the count only.
+SCOPE_LINE="$(printf '%s\n' "$OUT" | grep 'held at needs-scope' | head -1)"
+case "$SCOPE_LINE" in
+  *"worker: 1 issue(s) held at needs-scope"*)
+    ok "needs-scope count excludes closed issues (reports 1, not 2)" ;;
+  "") bad "needs-scope count excludes closed issues" "no held-at-needs-scope line at all in the run output" ;;
+  *)  bad "needs-scope count excludes closed issues" "line reads: $SCOPE_LINE" ;;
+esac
 
 # --- case 3: FAIL LOUD on a repo identity that matches no project -----------
 # The dangerous failure mode of this whole change. If the derived name matches


### PR DESCRIPTION
## The defect

`linear-worker.sh` `held_with()` selected on label + project and never read state. The team fetch is the whole board, closed rows included, and nothing in the worker ever removes a refusal label (`issueRemoveLabel` appears nowhere in the file) -- so every issue that was ever refused stayed in the `blocked:capability` and `needs-scope` counts after it finished. Those counts could only rise.

That breaks the one thing the `blocked:capability` line exists to say. It is the only signal that the loop is starving on a capability nobody granted; a number that never falls reports the same alarm whether or not anything is blocked.

## Live measurement, old predicate vs new (2026-08-15)

```
blocked:capability OLD=2 [ASK-284 In Progress, ASK-281 Done] -> NEW=1 [ASK-284]
needs-scope        OLD=2 [ASK-700 Done, ASK-312 In Progress] -> NEW=1 [ASK-312]
```

## The fix

Terminal state types (`completed`, `canceled`) are excluded rather than open types allowlisted. An allowlist of `(backlog, unstarted, started)` would silently drop an issue parked in `triage` -- still open, still refused, still needing someone -- and a held issue missing from the count is invisible in a way an extra one is not.

## Reproducer, observed RED first

`test-worker-project-scope.sh` gains four fixture issues (open + completed + canceled at `blocked:capability`, completed at `needs-scope`) and asserts the reported LINE, not a re-derived pool -- the line is what an operator reads at 3am and it is the artifact that was wrong.

RED against HEAD:

```
FAIL blocked:capability count excludes closed issues
   line reads: worker: 3 issue(s) held at blocked:capability ... (ASK-906 ASK-907 ASK-908)
FAIL names the open blocked issue (ASK-906) and no closed one
FAIL needs-scope count excludes closed issues
   line reads: worker: 2 issue(s) held at needs-scope
18 passed, 3 failed
```

Green after the fix: **21 passed, 0 failed**.

## Checks

- `test-worker-project-scope.sh` -- 21 passed, 0 failed
- `test-worker-refusal.sh` -- 50 passed, 0 failed
- Worker dry run: **not run.** The invocation needs a Bash permission this session could not grant, and routing around it was not attempted. The live-board measurement above is the substitute evidence: it applies both predicates to the real board through the same GraphQL query the picker uses.

## Second DoR finding: ASK-284

Its `blocked:capability` was declared 2026-08-12 for a stale `index.lock` that made `git add` fail. Three commits landed on this branch at 17:00-17:27 that same day and a full Codex review ran at 17:44, so that block is gone. Today PR #66 is OPEN with the `validate` check FAILURE -- ordinary rework, not a missing capability. Decision recorded on the issue; the label is being removed with that reasoning.

## Out of scope

The re-test loop that would expire a stale `blocked:capability` label. ASK-288 owns it and is In Progress.

Fixes ASK-841.