### PR TITLE
Reachability is a fact about a checkout, and a checkout is not a permit (ASK-840)

### DIFF
--- a/instance-registry.json
+++ b/instance-registry.json
@@ -26,6 +26,7 @@
     },
     {
       "name": "ASK_AI_consultant",
+      "linear_project": "ASK Consulting",
       "path": "/Users/assafkipnis/projects/consulting",
       "subtree_prefix": "q-system",
       "instance_q_dir": "q-consult",
@@ -110,6 +111,7 @@
     },
     {
       "name": "gtm-partner",
+      "linear_project": "cole-GTM",
       "path": "/Users/assafkipnis/projects/cole-gtm",
       "subtree_prefix": "q-system",
       "instance_q_dir": null,

--- a/q-system/.q-system/capability-manifest.json
+++ b/q-system/.q-system/capability-manifest.json
@@ -486,6 +486,11 @@
       "runner": "python3"
     },
     {
+      "path": "q-system/.q-system/scripts/test_dispatch_alias_reachability.py",
+      "runner": "python3",
+      "timeout_s": 180
+    },
+    {
       "path": "q-system/.q-system/scripts/test_evidence_ledger.py",
       "runner": "python3"
     },

--- a/q-system/.q-system/scripts/daily-linear-digest.py
+++ b/q-system/.q-system/scripts/daily-linear-digest.py
@@ -126,6 +126,12 @@ BLOCKED_PATTERNS = (
     # stranded and why, every day, instead of the gap living in one log line
     # nobody reads.
     re.compile(r"\d+ ready-shaped issue\(s\) UNREACHABLE: no local checkout[^\n]*"),
+    # ASK-840. The third bucket: the checkout exists, and repo-preflight refuses
+    # entry anyway. It needs its own line here because the response differs from
+    # both neighbours -- a routine skip resolves on a later rotation turn, an
+    # unreachable repo needs a clone, and this one needs a cure or is permanent
+    # (a client engagement repo is refused forever, whatever its name resolves to).
+    re.compile(r"\d+ ready-shaped issue\(s\) REFUSED by preflight[^\n]*"),
     re.compile(r"\d+ repo\(s\) HELD \(cross-repo gh scoping[^\n]*"),
 )
 

--- a/q-system/.q-system/scripts/linear-worker.sh
+++ b/q-system/.q-system/scripts/linear-worker.sh
@@ -367,6 +367,21 @@ fi
 # unreadable registry means reachability is UNKNOWN, and reporting unknown as
 # unreachable would fire a loud false alarm on every project at once -- the
 # failure mode this issue exists to remove, pointed the other way.
+#
+# THE ALIAS IS A FIELD, NOT A GUESS (ASK-840). The row's `name` was read as if it
+# WERE the Linear project name. Nothing ever required those two namespaces to
+# agree, and measured against the live board on 2026-08-15 they do not: two rows
+# whose checkouts were on disk that minute carried registry names spelled
+# differently from their board projects, and 17 of the 44 issues reported
+# UNREACHABLE were on them. The log told the operator to clone repos he already
+# had. `linear_project` states the mapping instead of deriving it, because a
+# name-derivation guess is what produced the bug and a smarter guess would only
+# move the day it breaks.
+#
+# ONE DERIVATION, BOTH QUESTIONS. linear_project() below answers "what is this
+# row called on the board" for the repo-identity lookup AND for the reachability
+# set. Deriving the same logical value two ways is how the two sides drifted in
+# the first place, so there is exactly one function and both callers use it.
 REGISTRY_FACTS="$(SKEL_PATH="$TARGET_REPO" REG="$SKEL/instance-registry.json" python3 - <<'PY' 2>/dev/null
 import json, os
 skel = os.path.realpath(os.environ["SKEL_PATH"])
@@ -378,29 +393,46 @@ except Exception:
 entries = reg.get("instances", reg) if isinstance(reg, dict) else reg
 name = ""
 local = []
+
+
+def linear_project(entry):
+    """The name this row carries ON THE BOARD. Explicit field first, name second."""
+    return (entry.get("linear_project") or entry.get("name") or "").strip()
+
+
 for e in entries if isinstance(entries, list) else []:
     if not isinstance(e, dict):
         continue
-    p, n = e.get("path"), e.get("name") or ""
+    p = e.get("path")
     if not p:
         continue
+    proj = linear_project(e)
     if not name and os.path.realpath(p) == skel:
-        name = n
-    if n and os.path.isdir(p):
-        local.append(n)
-print(json.dumps({"name": name, "local_projects": sorted(set(local)), "ok": ok}))
+        name = proj
+    if proj and os.path.isdir(p):
+        # The pinned remote travels WITH the row, because repo-preflight needs it
+        # and re-reading the registry to find it is the second reader ASK-729
+        # already refused to add.
+        d = e.get("dispatch") if isinstance(e.get("dispatch"), dict) else {}
+        local.append({"project": proj, "path": p,
+                      "remote": d.get("expected_remote") or ""})
+local.sort(key=lambda r: r["project"])
+print(json.dumps({"name": name, "local_repos": local, "ok": ok}))
 PY
 )"
 _facts_get() { printf '%s' "$REGISTRY_FACTS" | python3 -c "import json,sys;d=json.load(sys.stdin);v=d.get('$1');print('\n'.join(v) if isinstance(v,list) else v)" 2>/dev/null; }
+# Structured facts travel as JSON. _facts_get flattens a list to newlines, which
+# silently mangles a list of objects into the string "[object]"-shaped nonsense.
+_facts_json() { printf '%s' "$REGISTRY_FACTS" | python3 -c "import json,sys;print(json.dumps(json.load(sys.stdin).get('$1')))" 2>/dev/null; }
 
 REPO_PROJECT="${KIPI_LINEAR_PROJECT:-}"
 [ -n "$REPO_PROJECT" ] || REPO_PROJECT="$(_facts_get name)"
 [ -n "$REPO_PROJECT" ] || REPO_PROJECT="$(basename "$TARGET_REPO")"
 export REPO_PROJECT
 
-LOCAL_PROJECTS="$(_facts_get local_projects)"
+LOCAL_REPOS="$(_facts_json local_repos)"
 REGISTRY_OK="$(_facts_get ok)"
-export LOCAL_PROJECTS REGISTRY_OK
+export LOCAL_REPOS REGISTRY_OK
 
 # --- pick ready issues ------------------------------------------------------
 PICKED="$(python3 - "$ONLY_ISSUE" <<'PY'
@@ -426,8 +458,13 @@ while True:
     after = p["pageInfo"]["endCursor"]
 
 repo_project = os.environ["REPO_PROJECT"]
-# Reachability, from the SAME registry read that produced repo_project (ASK-729).
-local_projects = {p for p in os.environ.get("LOCAL_PROJECTS", "").splitlines() if p}
+# Reachability, from the SAME registry read that produced repo_project (ASK-729),
+# now carrying the board name, the path and the pinned remote per row (ASK-840).
+try:
+    local_repos = json.loads(os.environ.get("LOCAL_REPOS") or "[]") or []
+except Exception:
+    local_repos = []
+local_by_project = {r["project"]: r for r in local_repos if r.get("project")}
 registry_ok = os.environ.get("REGISTRY_OK", "") == "True"
 
 def project_of(i):
@@ -489,18 +526,45 @@ dropped = [i for i in issues if ready_ignoring_project(i) and not in_this_repo(i
 # Reporting the second as the first is why 45 issues read as a filter doing its
 # job for 13 days. An unset project is UNREACHABLE, not skipped: "target unknown"
 # is not "target is elsewhere", and it needs a human to set the project.
+#
+# A THIRD BUCKET, BECAUSE TWO OF THEM WERE BOTH WRONG FOR THE SAME REPOS
+# (ASK-840). Resolving the alias moves 17 issues out of UNREACHABLE, and the
+# tempting next step -- drop them in with the routine skips -- swaps one false
+# sentence for another. "The rotation reaches it on a later turn" is false
+# FOREVER for a client engagement repo: repo-preflight check 0 refuses it whether
+# or not its name resolves, and no waiting changes that. So reachability answers
+# only "is there a checkout", and the preflight verdict (taken from the REAL
+# script, in the shell, never re-implemented here) splits what is left.
 def has_local_checkout(i):
     name = project_of(i)
-    return bool(name) and name in local_projects
+    return bool(name) and name in local_by_project
 
 # An unreadable registry means reachability is UNKNOWN. Calling every project
 # unreachable there would be a false alarm on the whole board at once, so the
 # classification collapses back to the old single bucket and the shell says why.
 if registry_ok:
-    skipped_local = [i for i in dropped if has_local_checkout(i)]
+    reachable = [i for i in dropped if has_local_checkout(i)]
     unreachable = [i for i in dropped if not has_local_checkout(i)]
 else:
-    skipped_local, unreachable = dropped, []
+    reachable, unreachable = dropped, []
+
+# One row per reachable project, carrying what the shell needs to run preflight
+# against it: the path, the pinned remote, and how many issues ride on the answer.
+# An empty path means "no registry row backs this" -- the unreadable-registry
+# collapse above -- and the shell treats that as the routine skip it reports
+# today, rather than calling a gate it has no target for. NO APOSTROPHE IN THIS
+# HEREDOC: it sits inside a $( ) and bash tracks quote state straight through a
+# quoted heredoc there, so one in a PYTHON COMMENT takes the whole script to
+# "unexpected EOF" 800 lines away. The file carries this scar twice already.
+def reachable_rows():
+    rows = {}
+    for i in reachable:
+        proj = project_of(i) or "(unset)"
+        row = local_by_project.get(proj) or {}
+        r = rows.setdefault(proj, {"project": proj, "path": row.get("path", ""),
+                                   "remote": row.get("remote", ""), "count": 0})
+        r["count"] += 1
+    return [rows[k] for k in sorted(rows)]
 # HELD IS A STATEMENT ABOUT OPEN WORK (ASK-841). The team fetch above is the whole
 # board, closed rows included, and this helper used to select on label + project
 # alone. A refusal label is never removed when the issue finishes -- grep confirms
@@ -548,8 +612,10 @@ print(json.dumps({
     "dropped_out_of_repo": len(dropped),
     "dropped_projects": sorted({project_of(i) or "(unset)" for i in dropped}),
     # ASK-729: the same population, split by whether anyone here can act on it.
-    "skipped_local": len(skipped_local),
-    "skipped_local_projects": sorted({project_of(i) or "(unset)" for i in skipped_local}),
+    # ASK-840: the reachable half is emitted as rows, not a count, because the
+    # shell has to ask repo-preflight about each one before it can say which of
+    # them a later rotation turn actually reaches.
+    "reachable_rows": reachable_rows(),
     "unreachable": len(unreachable),
     "unreachable_projects": sorted({project_of(i) or "(unset)" for i in unreachable}),
     "unreachable_ids": [i["identifier"] for i in unreachable],
@@ -592,8 +658,44 @@ if [ "$PROJECT_KNOWN" = "False" ]; then
   exit 9
 fi
 
-DROPPED="$(printf '%s' "$PICKED" | python3 -c 'import json,sys;print(json.load(sys.stdin).get("skipped_local",0))' 2>/dev/null)"
-DROPPED_IN="$(printf '%s' "$PICKED" | python3 -c 'import json,sys;print(", ".join(json.load(sys.stdin).get("skipped_local_projects",[])))' 2>/dev/null)"
+# THE REACHABLE HALF IS SPLIT BY THE REAL GATE, NOT BY A COPY OF ITS RULES
+# (ASK-840). A project with a checkout is not therefore dispatchable, and the
+# difference is exactly what repo-preflight.sh already decides. Re-implementing
+# its client-repo test here would be a second copy of the one refusal the founder
+# said must hold everywhere -- and the copy is what goes stale. So preflight is
+# executed, once per distinct project, and its own words become the reason.
+#
+# CHEAP FOR THE CASE THAT MATTERS: check 0 is decided on path shape and exits
+# before any network call, so every client repo costs a fork and nothing else.
+# The handful that get past it pay a few gh calls once per run, not per issue.
+PREFLIGHT="$SCRIPT_DIR/repo-preflight.sh"
+REACH_ROWS="$(printf '%s' "$PICKED" | python3 -c 'import json,sys
+for r in json.load(sys.stdin).get("reachable_rows", []):
+    print("\t".join([r.get("project",""), r.get("path",""), r.get("remote",""), str(r.get("count",0))]))' 2>/dev/null)"
+
+DROPPED=0; DROPPED_IN=""; REFUSED_N=0; REFUSED_IN=""
+while IFS="$(printf '\t')" read -r _proj _path _remote _cnt; do
+  [ -n "${_proj:-}" ] || continue
+  _cnt="${_cnt:-0}"
+  # No path means no registry row backs this project (the unreadable-registry
+  # collapse). Reporting it as today's routine skip is the honest answer: we
+  # cannot ask the gate anything without a target.
+  if [ -z "${_path:-}" ] || _pf_out="$(bash "$PREFLIGHT" "$_path" "${_remote:-}" 2>&1)"; then
+    DROPPED=$((DROPPED + _cnt))
+    DROPPED_IN="${DROPPED_IN:+$DROPPED_IN, }$_proj"
+  else
+    REFUSED_N=$((REFUSED_N + _cnt))
+    # THE CHECK NAMES, NOT THE FULL MESSAGES. One failed check carries a fix
+    # command long enough to bury the line it is on, and this is read in a daily
+    # digest. The class of refusal is what tells a permanent one (client-repo)
+    # from a curable one (control-code), which is the decision being supported.
+    _why="$(printf '%s' "$_pf_out" | grep '^FAIL' | sed 's/^FAIL \([^:]*\):.*/\1/' | tr '\n' ',' | sed 's/,$//')"
+    REFUSED_IN="${REFUSED_IN:+$REFUSED_IN; }$_proj (${_why:-refused})"
+  fi
+done <<REACHEOF
+$REACH_ROWS
+REACHEOF
+
 UNREACH="$(printf '%s' "$PICKED" | python3 -c 'import json,sys;print(json.load(sys.stdin).get("unreachable",0))' 2>/dev/null)"
 UNREACH_IN="$(printf '%s' "$PICKED" | python3 -c 'import json,sys;print(", ".join(json.load(sys.stdin).get("unreachable_projects",[])))' 2>/dev/null)"
 REG_OK="$(printf '%s' "$PICKED" | python3 -c 'import json,sys;print(json.load(sys.stdin).get("registry_ok",True))' 2>/dev/null)"
@@ -603,6 +705,13 @@ say "worker: $READY_COUNT ready issue(s) (owner:sana, has a DoR, not owner:assaf
 # Accounted for, never silently dropped. These two lines are what let an operator
 # tell a working filter from a broken query without re-querying Linear by hand.
 [ "${DROPPED:-0}" != "0" ] && say "worker: $DROPPED ready-shaped issue(s) skipped as out-of-repo (other project: $DROPPED_IN) -- this checkout is $REPO_PROJECT and cannot check those out"
+# THE THIRD BUCKET (ASK-840). Reachable, and refused anyway. Stated on its own
+# line for the same reason UNREACHABLE was: the response differs. A routine skip
+# resolves itself on a later rotation turn, an unreachable repo needs a clone, and
+# this one needs either a cure (control-code drift) or nothing at all ever
+# (client-repo, which no rotation and no cure will change). Collapsing it into the
+# skip line promises the operator a turn that is never coming.
+[ "${REFUSED_N:-0}" != "0" ] && say "worker: $REFUSED_N ready-shaped issue(s) REFUSED by preflight: the checkout exists but the gate will not let a dispatcher in -- $REFUSED_IN"
 # UNREACHABLE IS NOT A ROUTINE SKIP, AND NEVER SHARES ITS LINE (ASK-729). A skip
 # resolves itself on a later rotation turn; this does not resolve at all until a
 # human clones or registers the repo. It is stated separately, with the project

--- a/q-system/.q-system/scripts/linear-worker.sh
+++ b/q-system/.q-system/scripts/linear-worker.sh
@@ -669,12 +669,20 @@ fi
 # before any network call, so every client repo costs a fork and nothing else.
 # The handful that get past it pay a few gh calls once per run, not per issue.
 PREFLIGHT="$SCRIPT_DIR/repo-preflight.sh"
+# UNIT SEPARATOR, NOT TAB. Tab is an IFS WHITESPACE character, so bash collapses
+# runs of it however IFS is set -- and an unpinned row has an EMPTY remote, which
+# is the common case here (only two registry rows pin one). Measured with a probe
+# on a 4-field row whose third field was empty: read landed the COUNT in $_remote
+# and left $_cnt unset, so every reachable project scored 0 issues and both report
+# lines below vanished entirely. \037 is not IFS whitespace, so an empty field
+# stays an empty field. kipi-dispatch.sh:640 reads its rotation rows the same way
+# and carries the same latent hole (captured as spillover, not fixed here).
 REACH_ROWS="$(printf '%s' "$PICKED" | python3 -c 'import json,sys
 for r in json.load(sys.stdin).get("reachable_rows", []):
-    print("\t".join([r.get("project",""), r.get("path",""), r.get("remote",""), str(r.get("count",0))]))' 2>/dev/null)"
+    print("\037".join([r.get("project",""), r.get("path",""), r.get("remote",""), str(r.get("count",0))]))' 2>/dev/null)"
 
 DROPPED=0; DROPPED_IN=""; REFUSED_N=0; REFUSED_IN=""
-while IFS="$(printf '\t')" read -r _proj _path _remote _cnt; do
+while IFS=$'\037' read -r _proj _path _remote _cnt; do
   [ -n "${_proj:-}" ] || continue
   _cnt="${_cnt:-0}"
   # No path means no registry row backs this project (the unreadable-registry

--- a/q-system/.q-system/scripts/test_dispatch_alias_reachability.py
+++ b/q-system/.q-system/scripts/test_dispatch_alias_reachability.py
@@ -219,3 +219,38 @@ def test_resolved_name_does_not_promote_a_client_repo_into_the_queue(client_repo
         f"a client repo can never be reached by a later rotation turn: {skipped}")
     assert "Board Side Name" not in _line(out, "UNREACHABLE"), (
         "the checkout exists; calling it unreachable sends the operator to clone it")
+
+
+def test_digest_can_see_the_refused_line(client_repo):
+    """A third bucket nobody surfaces is the state this issue started in.
+
+    The daily digest is the one place the founder reads this, and its patterns are
+    matched against REAL worker output rather than a hand-typed sample -- a sample
+    would only prove the pattern agrees with my idea of the wording. sp-123bc141
+    already records the same gap for the DISPATCHER refusal line, which is a
+    different producer and stays captured rather than fixed here.
+    """
+    digest = SCRIPTS / "daily-linear-digest.py"
+    if not digest.exists():
+        pytest.skip("daily-linear-digest.py not present in this checkout")
+
+    import re
+    pats = re.findall(r're\.compile\(r"([^"]+)"\)', digest.read_text())
+    assert pats, "no BLOCKED_PATTERNS found in daily-linear-digest.py"
+
+    line = _line(client_repo(), "REFUSED by preflight")
+    assert line, "worker wrote no REFUSED line"
+    assert any(re.search(p, line) for p in pats), (
+        "the digest recognises no pattern for the worker's REFUSED line, so the "
+        f"third bucket stays invisible in the daily report:\n  {line}")
+
+
+if __name__ == "__main__":
+    # THE MANIFEST RUNNER IS `python3 <file>`, AND THE ALLOWED SET IS python3|bash
+    # (capability-gate.py:127). A pytest module with no __main__ collects nothing
+    # under that runner and exits 0, so the manifest reports coverage that never
+    # ran -- sp-bbdcf57b, verified across 12 declared tests. Fixing those twelve is
+    # not this issue; not adding a thirteenth is free, so this file runs itself.
+    import sys
+    raise SystemExit(subprocess.call(
+        [sys.executable, "-m", "pytest", "-q", os.path.abspath(__file__)]))

--- a/q-system/.q-system/scripts/test_dispatch_alias_reachability.py
+++ b/q-system/.q-system/scripts/test_dispatch_alias_reachability.py
@@ -1,0 +1,221 @@
+#!/usr/bin/env python3
+"""Reachability is a fact about a CHECKOUT, not a string match on two names (ASK-840).
+
+why this shape: ASK-729 split the worker's out-of-repo population into SKIPPED and
+UNREACHABLE, and answered "is there a checkout" with
+
+    project_of(issue) in {registry row name for every row whose path exists}
+
+That is a string equality between two namespaces nothing ever required to agree.
+Measured 2026-08-15 against the live board, they do not:
+
+    Linear project        registry name          path                exists
+    ASK Consulting        ASK_AI_consultant      ~/projects/...      YES
+    cole-GTM              gtm-partner            ~/projects/...      YES
+
+14 + 3 = 17 of the 44 UNREACHABLE issues were on repos cloned and registered right
+then, and the log told the operator to clone repos he already had.
+
+TWO DEFECTS, TWO TESTS, and the second is the one with teeth:
+
+  1. the alias. A row whose Linear project name differs from its registry name must
+     classify as reachable. This is the reproducer the issue names.
+  2. reachable is not dispatchable. Promoting those 17 into the routine-skip line
+     would say "the rotation reaches them later", which for a CLIENT repo is false
+     forever -- repo-preflight check 0 refuses it whatever its name resolves to. So
+     the third bucket is asserted through the REAL repo-preflight.sh, never a stub:
+     a test that stubs the gate it is claiming to consult proves nothing about the
+     gate.
+
+Both run the SHIPPED linear-worker.sh end to end against a throwaway skeleton and a
+stubbed Linear, and assert on the log the worker actually writes -- same reason as
+test_dispatch_reachability.py, whose harness this mirrors: the defect is in what the
+run SAID, and a unit test over a predicate cannot see a reporting line.
+"""
+import json
+import os
+import shutil
+import subprocess
+from pathlib import Path
+
+import pytest
+
+SCRIPTS = Path(__file__).resolve().parent
+
+# Stands in for linear-sync.py: the ONE seam that reaches the network.
+STUB_SYNC = '''
+import json, os
+def graphql(q, v):
+    if "teams(" in q:
+        return {"teams": {"nodes": [{"id": "TEAM"}]}}
+    issues = json.load(open(os.environ["FIXTURE_ISSUES"]))
+    return {"issues": {"nodes": issues,
+                       "pageInfo": {"hasNextPage": False, "endCursor": None}}}
+'''
+
+# A preflight that clears everything. Used ONLY for the rows this test wants on the
+# far side of the gate; the client-repo row is judged by the real script.
+STUB_PREFLIGHT_OK = '''#!/usr/bin/env bash
+printf 'OK %s\\n' "${1:-}"
+exit 0
+'''
+
+
+def _issue(ident, project, labels=("owner:sana",)):
+    return {
+        "id": ident,
+        "identifier": ident,
+        "title": "t " + ident,
+        "description": "## Definition of Ready\nstuff",
+        "state": {"name": "Backlog", "type": "backlog"},
+        "project": {"name": project} if project else None,
+        "labels": {"nodes": [{"name": l} for l in labels]},
+    }
+
+
+def _build(tmp_path, registry_rows, board, preflight_stub=None):
+    """A skeleton, a target repo with a real origin, a stubbed Linear, a runner."""
+    skel = tmp_path / "skel"
+    (skel / "q-system" / ".q-system").mkdir(parents=True)
+    shutil.copytree(SCRIPTS, skel / "q-system" / ".q-system" / "scripts")
+    scripts = skel / "q-system" / ".q-system" / "scripts"
+    (scripts / "linear-sync.py").write_text(STUB_SYNC)
+    if preflight_stub is not None:
+        (scripts / "repo-preflight.sh").write_text(preflight_stub)
+        (scripts / "repo-preflight.sh").chmod(0o755)
+
+    # git fetch runs before any of the reporting under test, so origin has to be
+    # real or the run exits 9 and this test measures the guard instead.
+    subprocess.run(["git", "init", "-q", "--bare", str(tmp_path / "origin.git")], check=True)
+    target = tmp_path / "target"
+    subprocess.run(["git", "init", "-q", str(target)], check=True)
+    for k, v in (("user.email", "t@t"), ("user.name", "t")):
+        subprocess.run(["git", "-C", str(target), "config", k, v], check=True)
+    (target / "f.txt").write_text("x")
+    subprocess.run(["git", "-C", str(target), "add", "-A"], check=True)
+    subprocess.run(["git", "-C", str(target), "commit", "-qm", "init"], check=True)
+    subprocess.run(["git", "-C", str(target), "remote", "add", "origin",
+                    str(tmp_path / "origin.git")], check=True)
+    subprocess.run(["git", "-C", str(target), "push", "-q", "origin", "HEAD:main"], check=True)
+
+    rows = [{"name": "targetproj", "path": str(target)}] + registry_rows
+    (skel / "instance-registry.json").write_text(json.dumps({"instances": rows}))
+
+    fixture = tmp_path / "fixture.json"
+    fixture.write_text(json.dumps(board))
+    state = tmp_path / "state"
+    state.mkdir()
+
+    def run():
+        env = dict(os.environ)
+        env.update({
+            "KIPI_SKEL": str(skel),
+            "KIPI_STATE_DIR": str(state),
+            "FIXTURE_ISSUES": str(fixture),
+            "KIPI_NOTIFY": "/bin/true",
+        })
+        p = subprocess.run(
+            ["bash", str(scripts / "linear-worker.sh"), "--repo", str(target)],
+            capture_output=True, text=True, env=env, timeout=300)
+        return p.stdout + p.stderr
+
+    return run
+
+
+def _line(out, needle):
+    for ln in out.splitlines():
+        if needle in ln:
+            return ln
+    return ""
+
+
+@pytest.fixture()
+def aliased(tmp_path):
+    """One row whose registry name and Linear project name deliberately disagree."""
+    # The alias row's checkout EXISTS. `nolocal` deliberately does not, and is the
+    # negative half: a fix that simply empties the UNREACHABLE bucket would pass
+    # every positive assertion below.
+    (tmp_path / "aliased-dir").mkdir()
+    rows = [
+        {"name": "registry_side_name", "linear_project": "Board Side Name",
+         "path": str(tmp_path / "aliased-dir")},
+        {"name": "nolocal", "path": str(tmp_path / "no-such-checkout")},
+    ]
+    board = [
+        # project_known guard: some issue must name this repo's project, or the run
+        # exits 9 before reporting anything.
+        _issue("ASK-900", "targetproj", ("owner:assaf",)),
+        _issue("ASK-901", "Board Side Name"),
+        _issue("ASK-902", "Board Side Name"),
+        _issue("ASK-903", "nolocal"),
+    ]
+    return _build(tmp_path, rows, board, preflight_stub=STUB_PREFLIGHT_OK)
+
+
+def test_registry_name_differing_from_linear_project_is_reachable(aliased):
+    """The reproducer ASK-840 names. RED at HEAD: no alias field is read at all."""
+    out = aliased()
+
+    unreachable = _line(out, "UNREACHABLE")
+    assert "Board Side Name" not in unreachable, (
+        "a project whose checkout is on disk right now was reported UNREACHABLE "
+        "because its Linear name is spelled differently from its registry name. "
+        f"That line asks the operator to clone a repo he already has:\n  {unreachable}")
+
+    skipped = _line(out, "skipped as out-of-repo")
+    assert "Board Side Name" in skipped, (
+        "the aliased project cleared preflight and has a local checkout, so it is a "
+        f"routine skip the rotation reaches on a later turn. Output was:\n{out}")
+
+    # NEGATIVE SELF-TEST. Deleting the UNREACHABLE bucket outright would satisfy the
+    # first assertion, so the row that genuinely has no checkout must still land in
+    # it -- otherwise this test rewards the opposite bug.
+    assert "nolocal" in unreachable, (
+        f"nolocal has no checkout anywhere and must stay UNREACHABLE: {unreachable}")
+
+
+@pytest.fixture()
+def client_repo(tmp_path):
+    """An aliased row whose path has the shape repo-preflight check 0 refuses.
+
+    NO PREFLIGHT STUB. The point of this test is that resolving the name does not
+    resolve the safety question, and the only thing that can show that is the real
+    gate. Check 0 is decided on path shape alone and exits before any network call,
+    so running it for real here is both honest and cheap.
+    """
+    client = tmp_path / "consulting" / "projects" / "someclient"
+    client.mkdir(parents=True)
+    rows = [
+        {"name": "registry_side_name", "linear_project": "Board Side Name",
+         "path": str(client)},
+        {"name": "nolocal", "path": str(tmp_path / "no-such-checkout")},
+    ]
+    board = [
+        _issue("ASK-900", "targetproj", ("owner:assaf",)),
+        _issue("ASK-901", "Board Side Name"),
+        _issue("ASK-903", "nolocal"),
+    ]
+    return _build(tmp_path, rows, board)
+
+
+def test_resolved_name_does_not_promote_a_client_repo_into_the_queue(client_repo):
+    """Reachable is not dispatchable, and the worker must say which one it means."""
+    out = client_repo()
+
+    refused = _line(out, "REFUSED by preflight")
+    assert refused, (
+        "an aliased project on a client-repo path has a checkout but repo-preflight "
+        "refuses it forever, so it is neither a routine skip nor unreachable. The "
+        f"worker reported no third bucket at all. Output was:\n{out}")
+    assert "Board Side Name" in refused, f"expected the project named: {refused}"
+    assert "client-repo" in refused, (
+        "the refusal must carry the reason the real gate gave, or the operator "
+        f"cannot tell a permanent refusal from a curable one: {refused}")
+
+    # It must NOT read as a routine skip -- that is the sentence that would be false
+    # forever, because no rotation turn will ever make a client repo dispatchable.
+    skipped = _line(out, "skipped as out-of-repo")
+    assert "Board Side Name" not in skipped, (
+        f"a client repo can never be reached by a later rotation turn: {skipped}")
+    assert "Board Side Name" not in _line(out, "UNREACHABLE"), (
+        "the checkout exists; calling it unreachable sends the operator to clone it")

--- a/q-system/.q-system/scripts/test_dispatch_reachability.py
+++ b/q-system/.q-system/scripts/test_dispatch_reachability.py
@@ -70,6 +70,17 @@ def harness(tmp_path):
     (skel / "q-system" / ".q-system").mkdir(parents=True)
     shutil.copytree(SCRIPTS, skel / "q-system" / ".q-system" / "scripts")
     (skel / "q-system" / ".q-system" / "scripts" / "linear-sync.py").write_text(STUB_SYNC)
+    # PREFLIGHT STUBBED, AND ONLY HERE (ASK-840). This file asserts ONE thing: a
+    # project with a checkout is not the same fact as a project without one. Since
+    # ASK-840 the worker also asks repo-preflight whether the checkout it found may
+    # be entered, and `haslocal` below is a bare mkdir -- not a git repo, no remote
+    # -- so the real gate refuses it and it lands in the third bucket. That would
+    # make this file fail for a reason it is not about. The bucket the real gate
+    # feeds is asserted against the REAL script in
+    # test_dispatch_alias_reachability.py, which is where that claim belongs.
+    pf = skel / "q-system" / ".q-system" / "scripts" / "repo-preflight.sh"
+    pf.write_text('#!/usr/bin/env bash\nprintf "OK %s\\n" "${1:-}"\nexit 0\n')
+    pf.chmod(0o755)
 
     # git fetch runs before any of the reporting under test, so origin has to be
     # real or the run exits 9 and this test measures the guard instead.


### PR DESCRIPTION
## What was wrong

`linear-worker.sh has_local_checkout()` answered reachability with

```
project_of(issue) in {registry row `name` for every row whose path exists}
```

That is a string equality between two namespaces nothing ever required to agree.
Measured against the live board on 2026-08-15, they do not:

| Linear project | Registry name | Path exists |
| -- | -- | -- |
| `ASK Consulting` | `ASK_AI_consultant` | YES |
| `cole-GTM` | `gtm-partner` | YES |

14 + 3 = **17 of the 44 UNREACHABLE issues** were on repos cloned and registered
that minute. The line telling the operator to "clone and register those repos"
asked for work already done.

## What changed

**The alias is a field, not a guess.** `instance-registry.json` gains
`linear_project` on the two rows whose board name differs from their registry
name. A name-derivation guess produced this bug; a smarter guess would only move
the day it breaks. One function, `linear_project()`, answers "what is this row
called on the board" for BOTH the repo-identity lookup and the reachability set,
so the two sides cannot drift again.

**A third bucket, because two of them were wrong for the same repos.** Resolving
the alias moves 17 issues out of UNREACHABLE, and dropping them in with the
routine skips would swap one false sentence for another: "the rotation reaches it
on a later turn" is false *forever* for a client engagement repo. So reachability
answers only "is there a checkout", and the verdict from the **real
`repo-preflight.sh`** splits what is left. Check 0 is not weakened, not bypassed,
and consulted no later than before -- the worker executes the gate rather than
re-implementing its rules, so a client repo stays refused whether or not its name
resolves.

**Also fixed on the way (it was blocking the fix, not scope creep):** the reachable
rows crossed from python to the shell tab-separated, and tab is an IFS *whitespace*
character -- bash collapses runs of it however IFS is set. A row with an empty
`expected_remote` (the common case; only two rows pin one) shifted its fields left,
landing the count in `$_remote` and leaving `$_cnt` unset, so every reachable
project scored 0 issues and both report lines vanished. Now `\037`.

## Evidence

Reproducers first, RED at HEAD on the exact live defect:

```
$ python3 -m pytest q-system/.q-system/scripts/test_dispatch_alias_reachability.py -q
E  AssertionError: a project whose checkout is on disk right now was reported
   UNREACHABLE because its Linear name is spelled differently from its registry
   name. That line asks the operator to clone a repo he already has:
     worker: 3 ready-shaped issue(s) UNREACHABLE: no local checkout for
     Board Side Name, nolocal -- ...
E  AssertionError: an aliased project on a client-repo path has a checkout but
   repo-preflight refuses it forever, so it is neither a routine skip nor
   unreachable. The worker reported no third bucket at all.
2 failed in 0.94s
```

Green after, including the ASK-729 suite this touches:

```
$ python3 -m pytest q-system/.q-system/scripts/test_dispatch_alias_reachability.py \
                    q-system/.q-system/scripts/test_dispatch_reachability.py -q
6 passed in 2.91s
```

Live worker dry run (`--issue ASK-000000` forces an empty pool, so the run cannot
reach the claim; scratch state dir; notify stubbed):

```
worker: 0 ready issue(s) (owner:sana, has a DoR, not owner:assaf, project=kipi-system)
worker: 35 ready-shaped issue(s) REFUSED by preflight: the checkout exists but the
  gate will not let a dispatcher in -- 4_points_consulting (client-repo);
  ASK Consulting (client-repo); Alice (client-repo); Prodigy_Gold (client-repo);
  Pure_spectrum_Q (client-repo); accountant (client-repo);
  cole-GTM (control-code,hooks,remote,dirty,credentials,branch-protection);
  investigations (client-repo);
  reddit-build-radar (control-code,hooks,remote,dirty,credentials,branch-protection)
worker: 20 ready-shaped issue(s) UNREACHABLE: no local checkout for (unset),
  lane-h-digest-repeats -- ...
worker: 1 issue(s) held at needs-scope
nothing ready.
```

UNREACHABLE now names only projects with no checkout anywhere: `(unset)` (19
issues needing a human to set the project) and `lane-h-digest-repeats`. Down from
44. `ASK Consulting` and `cole-GTM` read reachable-but-refused with the gate's own
reason, which is the DoR outcome.

## Two directions pinned, not one

An UNREACHABLE bucket that fires on nothing is the same single-bucket defect
wearing a quieter word, so both reproducers carry a negative self-test: the row
with genuinely no checkout must STAY unreachable, and the aliased client repo must
NOT appear in the routine-skip line.

`test_dispatch_alias_reachability.py` runs the client-repo case against the REAL
`repo-preflight.sh` with no stub -- a test that stubs the gate it claims to consult
proves nothing about the gate. Check 0 decides on path shape and exits before any
network call, so that is honest and cheap. The ASK-729 suite gets a stub, because
its `haslocal` fixture is a bare `mkdir` the real gate correctly refuses, and it is
asserting a different claim.

## Wiring

- `daily-linear-digest.py` learns a pattern for the REFUSED line, asserted against
  real worker output rather than a hand-typed sample.
- `capability-manifest.json` registers the new test. Its `__main__` shells pytest
  on itself, because the manifest runner is `python3 <file>` and a pytest module
  without one collects nothing while exiting 0 (sp-bbdcf57b, 12 existing files).
  Not fixing those twelve here; not adding a thirteenth is free.

## Captured, not fixed

- `sp-059b0ea6`: `kipi-dispatch.sh:640` reads its rotation rows with `IFS=$'\t'`
  and carries the identical empty-field collapse. Same one-line cure, out of scope
  for a DoR about the worker report.
- `sp-123bc141` (pre-existing) stays open: the digest drops the *dispatcher's*
  client-repo refusal line. Different producer.

## Out of scope

Nothing here enables dispatch anywhere. This makes the report true.

Closes ASK-840.
