### PR TITLE
A fleet alert is a notification, not dispatch work (ASK-839)

### DIFF
--- a/.prd-os/receipts.jsonl
+++ b/.prd-os/receipts.jsonl
@@ -129,3 +129,4 @@
 {"commit_sha": "1b9e8f0d58cf71a10d295d7d6091491ea4b0d436", "issue_id": "ASK-758", "receipts": {"reviewed": "2026-08-14T20:14:57Z"}, "reviewed_at": "2026-08-14T20:14:57Z"}
 {"commit_sha": "ed1a901e0a5b7e8e9c004032c836123c6f49bb7c", "issue_id": "ASK-842", "receipts": {"reviewed": "2026-08-15T06:47:50Z"}, "reviewed_at": "2026-08-15T06:47:50Z"}
 {"commit_sha": "53d1b42256ac5b1da930a569e27e458534824089", "issue_id": "ASK-841", "receipts": {"reviewed": "2026-08-15T08:18:54Z"}, "reviewed_at": "2026-08-15T08:18:54Z"}
+{"commit_sha": "d652455f4a1f9d9fe347cba7cc217cba7cb41ec9", "issue_id": "ASK-839", "receipts": {"reviewed": "2026-08-15T10:39:41Z"}, "reviewed_at": "2026-08-15T10:39:41Z"}

--- a/instance-registry.json
+++ b/instance-registry.json
@@ -1,7 +1,8 @@
 {
   "skeleton": {
     "path": "/Users/assafkipnis/projects/kipi-system",
-    "remote": "https://github.com/assafkip/kipi-system.git"
+    "remote": "https://github.com/assafkip/kipi-system.git",
+    "linear_project": "kipi-system"
   },
   "instances": [
     {

--- a/q-system/.q-system/capability-manifest.json
+++ b/q-system/.q-system/capability-manifest.json
@@ -279,6 +279,10 @@
       "runner": "bash"
     },
     {
+      "path": "q-system/.q-system/scripts/test/test-notify-supplies-repo-path.sh",
+      "runner": "bash"
+    },
+    {
       "path": "q-system/.q-system/scripts/test/test-open-loops-heartbeat-exit.sh",
       "runner": "bash"
     },

--- a/q-system/.q-system/capability-manifest.json
+++ b/q-system/.q-system/capability-manifest.json
@@ -654,6 +654,10 @@
       "path": "q-system/.q-system/scripts/test/test-converge-crossrepo-receipt.sh",
       "runner": "bash",
       "timeout_s": 120
+    },
+    {
+      "path": "q-system/.q-system/scripts/test/test-dor-refuses-unroutable.py",
+      "runner": "python3"
     }
   ],
   "required_data": [],

--- a/q-system/.q-system/scripts/alert-to-linear.py
+++ b/q-system/.q-system/scripts/alert-to-linear.py
@@ -217,10 +217,12 @@ def _registry_path() -> str:
     checkout) were dead at once -- in the instances, which is where alerts are
     raised. Measured 2026-08-15 against the live registry: 24 of 25 instances
     ship this writer, 25 of 25 lack the registry, and 8 have a basename that is
-    not their board alias (strategy/KTLYST_strategy, consulting/ASK Consulting,
-    product/ktlyst, website/ktlyst-website, lawyer/ktlyst_lawyer,
-    kipi-investigations/investigations, cole-gtm/cole-GTM, and one client
-    engagement this public repo does not name).
+    not their board alias. The shapes: an alias that adds a brand prefix the
+    directory lacks, one written as spaced prose, one that drops a prefix the
+    directory keeps, and one client engagement. The live pairs stay in
+    instance-registry.json and are deliberately not copied here -- this file
+    ships to every instance of a PUBLIC repo, so naming them is the leak
+    validate-separation Gate 1.2 exists to refuse.
     For those 8, rung 4 offers the bare directory name, no project carries it,
     and the alert files unset -- the defect this issue is about, still live in
     every instance after three rounds fixed it in the skeleton.

--- a/q-system/.q-system/scripts/alert-to-linear.py
+++ b/q-system/.q-system/scripts/alert-to-linear.py
@@ -197,6 +197,170 @@ def _write_state(fp: str, data: dict) -> None:
         pass
 
 
+def _registry_path() -> str:
+    """instance-registry.json, which lives at the SKELETON ROOT, three levels up
+    from this scripts/ directory. KIPI_INSTANCE_REGISTRY is the test seam."""
+    env = os.environ.get("KIPI_INSTANCE_REGISTRY")
+    if env:
+        return env
+    here = os.path.dirname(os.path.abspath(__file__))
+    return os.path.join(here, "..", "..", "..", "instance-registry.json")
+
+
+def _registry_rows() -> list:
+    """Every registry row, or [] when it cannot be read. Never raises."""
+    try:
+        with open(_registry_path(), encoding="utf-8") as fh:
+            reg = json.load(fh)
+    except (OSError, ValueError):
+        return []
+    entries = reg.get("instances", reg) if isinstance(reg, dict) else reg
+    return [e for e in entries if isinstance(e, dict)] if isinstance(entries, list) else []
+
+
+def _linear_project_of(entry: dict) -> str:
+    """The name this row carries ON THE BOARD.
+
+    THE ALIAS IS A FIELD, NOT A GUESS -- the same rule linear-worker.sh applies
+    (ASK-840), and the same order: explicit `linear_project` first, `name`
+    second. Deriving the board name from the directory is what produced that bug,
+    and a smarter derivation would only move the day it breaks. Measured on the
+    live board 2026-08-15: of the 81 unset alert tickets, only 33 carried a
+    `[label]` prefix that is an exact project name.
+    """
+    return (entry.get("linear_project") or entry.get("name") or "").strip()
+
+
+def project_candidates(message: str) -> list[str]:
+    """Board-project names to try for this alert, best evidence FIRST.
+
+    A LIST, not one answer, and that is the load-bearing part. The first cut
+    returned a single name and the `[/]` case proved it wrong immediately: 22 of
+    the 81 unset tickets carry the prefix `[/]` (a cwd of `/`), and another 16
+    carry a worktree directory (`.wt-ask791`, `kipi-wt-ask729`, `cleanmain`).
+    Each of those is a plausible-looking label that matches no project, so
+    returning it as THE answer filed the ticket unset all over again while
+    looking like a fix. Returning candidates lets an unresolvable label fall
+    through to the fallback instead of consuming the decision.
+
+    1. KIPI_ALERT_PROJECT -- an explicit statement by the caller.
+    2. The repo PATH the alert was raised from, through the registry. This is the
+       only rung that survives a worktree or a renamed directory, which is why
+       slack-notify.sh resolves the path rather than passing its own label.
+    3. The `[label]` prefix matched against a registry row's own name. Covers a
+       caller that set KIPI_INSTANCE_NAME but no path.
+    4. The `[label]` prefix taken at face value, resolved case-insensitively
+       against the board later (`cole-gtm` is `cole-GTM` there).
+    5. The checkout THIS SCRIPT runs from. 22 of the 81 unset tickets were raised
+       from a cwd of `/` with no repo at all; the code that raised them still ran
+       out of a registered checkout, so this is a derivation and not an invention.
+    """
+    out: list[str] = []
+
+    def offer(name: str) -> None:
+        name = (name or "").strip()
+        if name and name not in out:
+            out.append(name)
+
+    offer(os.environ.get("KIPI_ALERT_PROJECT") or "")
+
+    rows = _registry_rows()
+    path = (os.environ.get("KIPI_ALERT_REPO_PATH") or "").strip()
+    if path:
+        try:
+            want = os.path.realpath(path)
+        except OSError:
+            want = ""
+        for row in rows:
+            row_path = row.get("path")
+            if not row_path:
+                continue
+            try:
+                if want and os.path.realpath(row_path) == want:
+                    offer(_linear_project_of(row))
+            except OSError:
+                continue
+
+    match = re.match(r"^\[([^\]]+)\]", message.strip())
+    label = (match.group(1).strip() if match else "")
+    if label:
+        for row in rows:
+            if (row.get("name") or "").strip().lower() == label.lower():
+                offer(_linear_project_of(row))
+        offer(label)
+
+    offer(os.environ.get("KIPI_ALERT_FALLBACK_PROJECT") or "")
+    offer(_own_checkout_project(rows))
+    return out
+
+
+def _own_checkout_project(rows: list) -> str:
+    """The board project of the checkout THIS SCRIPT lives in.
+
+    The last rung, and a derivation rather than a guess: an alert raised from a
+    cwd of `/` still came from code executing out of a registered checkout, and
+    that checkout is the one honest thing left to say about its origin.
+    """
+    try:
+        root = os.path.realpath(os.path.join(
+            os.path.dirname(os.path.abspath(__file__)), "..", "..", ".."))
+    except OSError:
+        return ""
+    for row in rows:
+        row_path = row.get("path")
+        if not row_path:
+            continue
+        try:
+            if os.path.realpath(row_path) == root:
+                return _linear_project_of(row)
+        except OSError:
+            continue
+    return ""
+
+
+# This file already keeps its own copies of TEAM_QUERY and LABELS_QUERY rather
+# than reaching into linear-sync for them, and this follows that shape. Reaching
+# for `ln.TEAM_PROJECTS_QUERY` was tried first and failed silently in exactly the
+# way this path must never fail: the attribute read sits inside the never-raises
+# try, so a stub without that constant returned "no project" instead of erroring,
+# and the reproducer stayed red with the fix already in place.
+PROJECTS_QUERY = """
+query($teamId: String!) {
+  team(id: $teamId) { projects(first: 250) { nodes { id name } } }
+}
+"""
+
+
+def _project_id_for(ln, team_id: str, names: list) -> str | None:
+    """First of `names` that resolves to a board project id, or None.
+
+    Matched case-insensitively on purpose: registry names and board names differ
+    only by case for real rows (`cole-gtm` vs `cole-GTM`), and a case-sensitive
+    compare would file those tickets unset -- the exact defect being fixed.
+
+    NEVER RAISES, for the same reason _owner_label_id does not: a ticket with no
+    project is worth far more than a dropped alert. The alert path exists because
+    a swallowed alert is the worst outcome available here.
+    """
+    if not names:
+        return None
+    try:
+        team = (ln.graphql(PROJECTS_QUERY, {"teamId": team_id}) or {}).get("team") or {}
+        nodes = ((team.get("projects") or {}).get("nodes")) or []
+    except Exception:
+        return None
+    by_lower = {}
+    for node in nodes:
+        key = (node.get("name") or "").strip().lower()
+        if key and key not in by_lower:
+            by_lower[key] = node.get("id")
+    for name in names:
+        found = by_lower.get(name.strip().lower())
+        if found:
+            return found
+    return None
+
+
 def _owner_label_id(ln, team_id: str) -> str | None:
     """The owner:sana label id, created once if the team lacks it.
 
@@ -283,6 +447,20 @@ def file_alert(message: str, now: float | None = None) -> tuple[int, str]:
         label_id = _owner_label_id(ln, team_id)
         if label_id:
             payload["labelIds"] = [label_id]
+
+        # A PROJECT IS ROUTING, NOT DECORATION (ASK-839). This payload carried
+        # teamId + labelIds and nothing else, so every alert landed project-unset.
+        # An unset project cannot route to any checkout: linear-worker.sh's
+        # in_this_repo() is false for it in every repo at once, so no rotation, no
+        # cursor and no clone reaches it. Measured on the live board 2026-08-15:
+        # 81 open alert tickets, all unset, and the DoR drafter had already
+        # promoted 19 of them into ready-shaped work that was therefore
+        # permanently UNREACHABLE -- 43% of that whole bucket. The `[repo]` prefix
+        # this file already writes into the TITLE was that same fact, sitting in a
+        # field no query can filter on.
+        project_id = _project_id_for(ln, team_id, project_candidates(message))
+        if project_id:
+            payload["projectId"] = project_id
 
         data = ln.graphql(ISSUE_CREATE, {"input": payload})
         issue = ((data or {}).get("issueCreate") or {}).get("issue") or {}

--- a/q-system/.q-system/scripts/alert-to-linear.py
+++ b/q-system/.q-system/scripts/alert-to-linear.py
@@ -208,14 +208,44 @@ def _registry_path() -> str:
 
 
 def _registry_rows() -> list:
-    """Every registry row, or [] when it cannot be read. Never raises."""
+    """Every registry row, or [] when it cannot be read. Never raises.
+
+    THE SKELETON IS A ROW TOO, and reading only `instances` dropped it (ASK-839,
+    PR #191 review round 3). The skeleton is not an instance: it is the
+    registry's own top-level `skeleton` key, and it is the checkout this script
+    LIVES in and the fleet's single biggest alert producer. Both rungs that
+    search these rows -- the repo path (2) and this script's own checkout (5) --
+    were therefore dead for it, so an alert raised from kipi-system or any of its
+    worktrees resolved to no project at all unless its bare `[label]` happened to
+    name a board project.
+
+    Measured on the live board 2026-08-15, 82 open alert tickets: 22 labelled `/`
+    (a cwd with no repo, so nothing is exported and no label resolves -- rung 5
+    is their only cover) and 18 labelled with a kipi-system worktree directory,
+    whose --git-common-dir path is the skeleton -- rung 2. 40 of 82 had no live
+    rung.
+
+    `standalone` rows stay out on purpose rather than by oversight: they carry
+    `has_skeleton: false`, so they ship no slack-notify.sh and cannot reach this
+    code path at all. Adding them would lengthen the candidate list with names no
+    alert can ever arrive under.
+    """
     try:
         with open(_registry_path(), encoding="utf-8") as fh:
             reg = json.load(fh)
     except (OSError, ValueError):
         return []
-    entries = reg.get("instances", reg) if isinstance(reg, dict) else reg
-    return [e for e in entries if isinstance(e, dict)] if isinstance(entries, list) else []
+    if not isinstance(reg, dict):
+        entries = reg
+        return [e for e in entries if isinstance(e, dict)] if isinstance(entries, list) else []
+    entries = reg.get("instances", reg)
+    rows = [e for e in entries if isinstance(e, dict)] if isinstance(entries, list) else []
+    skeleton = reg.get("skeleton")
+    if isinstance(skeleton, dict) and skeleton.get("path"):
+        # Tagged rather than positional so a caller can ask "which row is the
+        # skeleton" without counting on it being first.
+        rows = [dict(skeleton, is_skeleton=True)] + rows
+    return rows
 
 
 def _linear_project_of(entry: dict) -> str:
@@ -294,16 +324,57 @@ def project_candidates(message: str) -> list[str]:
     return out
 
 
+def _own_checkout_root() -> str:
+    """The directory three levels up from this scripts/ dir. The test seam for
+    the rung below, so a worktree layout can be exercised without one."""
+    return os.path.join(os.path.dirname(os.path.abspath(__file__)),
+                        "..", "..", "..")
+
+
+def _common_repo_root(root: str) -> str:
+    """`root`, or the repo it is a linked worktree OF.
+
+    A worktree is never its own registry row, and the fleet's agents all run in
+    one -- 18 of the 82 live alert tickets on 2026-08-15 were labelled with a
+    worktree directory. Without this, rung 5 misses in exactly the checkouts that
+    raise the most alerts.
+
+    Read from the `.git` FILE rather than shelled out to `git rev-parse
+    --git-common-dir`: this function is on the never-raises alert path, where a
+    subprocess is a new way to lose the ticket, and the file is the same fact.
+    slack-notify.sh does shell out, and that is not a second derivation of one
+    value -- it answers a different question (the repo the CALLER was in) at a
+    point where git is already required.
+    """
+    try:
+        with open(os.path.join(root, ".git"), encoding="utf-8") as fh:
+            head = fh.read(4096).strip()
+    except (OSError, ValueError):
+        return root
+    if not head.startswith("gitdir:"):
+        return root
+    gitdir = head.split(":", 1)[1].strip()
+    marker = os.path.join(".git", "worktrees")
+    if marker not in gitdir:
+        return root
+    common = gitdir.split(marker)[0]
+    return common or root
+
+
 def _own_checkout_project(rows: list) -> str:
     """The board project of the checkout THIS SCRIPT lives in.
 
     The last rung, and a derivation rather than a guess: an alert raised from a
     cwd of `/` still came from code executing out of a registered checkout, and
     that checkout is the one honest thing left to say about its origin.
+
+    It is also the ONLY rung covering the 22 `[/]` tickets, since no path is
+    exported and no label resolves for them. KIPI_ALERT_FALLBACK_PROJECT is not
+    that cover: nothing in this repo sets it (one reader, no writer), so a case
+    that supplies it by hand is testing an invention.
     """
     try:
-        root = os.path.realpath(os.path.join(
-            os.path.dirname(os.path.abspath(__file__)), "..", "..", ".."))
+        root = os.path.realpath(_common_repo_root(_own_checkout_root()))
     except OSError:
         return ""
     for row in rows:

--- a/q-system/.q-system/scripts/alert-to-linear.py
+++ b/q-system/.q-system/scripts/alert-to-linear.py
@@ -42,6 +42,7 @@ import importlib.util
 import json
 import os
 import re
+import shutil
 import sys
 import time
 
@@ -197,14 +198,74 @@ def _write_state(fp: str, data: dict) -> None:
         pass
 
 
+# The fleet convention for where the skeleton sits when nothing else can say.
+# Same constant voice-dna-loader.py:63 already falls back to, deliberately: two
+# scripts guessing the skeleton two different ways is a derivation split waiting
+# to be found. LAST rung, never first -- see _registry_path.
+CANONICAL_SKELETON = os.path.join(os.path.expanduser("~"), "projects",
+                                  "kipi-system")
+
+
 def _registry_path() -> str:
-    """instance-registry.json, which lives at the SKELETON ROOT, three levels up
-    from this scripts/ directory. KIPI_INSTANCE_REGISTRY is the test seam."""
+    """instance-registry.json. KIPI_INSTANCE_REGISTRY is the test seam.
+
+    THE REGISTRY LIVES ONLY AT THE SKELETON ROOT, AND THIS SCRIPT SHIPS TO EVERY
+    INSTANCE (ASK-839, PR #191 review round 4). The fleet updater copies
+    `q-system/` and nothing at the repo root, so three-levels-up from an
+    INSTANCE's scripts/ named a file that is not there. `_registry_rows()` then
+    returned [] and rungs 2 (repo path), 3 (label vs registry name) and 5 (own
+    checkout) were dead at once -- in the instances, which is where alerts are
+    raised. Measured 2026-08-15 against the live registry: 24 of 25 instances
+    ship this writer, 25 of 25 lack the registry, and 8 have a basename that is
+    not their board alias (strategy/KTLYST_strategy, consulting/ASK Consulting,
+    product/ktlyst, website/ktlyst-website, lawyer/ktlyst_lawyer,
+    kipi-investigations/investigations, cole-gtm/cole-GTM, and one client
+    engagement this public repo does not name).
+    For those 8, rung 4 offers the bare directory name, no project carries it,
+    and the alert files unset -- the defect this issue is about, still live in
+    every instance after three rounds fixed it in the skeleton.
+
+    A LADDER, and the first rung that EXISTS wins:
+
+    1. The path beside this script. FIRST so a skeleton checkout always reads its
+       own registry and can never be answered by a stale copy under the canonical
+       home path -- including this repo's own worktrees and CI clones.
+    2. The `kipi` CLI on PATH, resolved through its symlink. A derivation from
+       how the CLI is actually installed, not a constant, so it is correct for a
+       skeleton at any location. `shutil.which` reads PATH in-process: no
+       subprocess on the never-raises alert path, the same rule
+       `_common_repo_root()` follows.
+    3. CANONICAL_SKELETON. This is what covers a launchd job, whose PATH carries
+       no `/opt/homebrew` -- 3 of this repo's 5 plists set no PATH at all and
+       inherit the minimal one, and those are alert producers.
+
+    NO RUNG INVENTS A NAME. When every rung misses, this returns the in-place
+    path so `_registry_rows()` reads nothing and the candidate list is whatever
+    the caller's own label supplied. A ladder that ended in a guess would file
+    every instance's alerts under one wrong project and look fixed
+    (test_an_instance_with_no_registry_anywhere_invents_nothing).
+    """
     env = os.environ.get("KIPI_INSTANCE_REGISTRY")
     if env:
         return env
     here = os.path.dirname(os.path.abspath(__file__))
-    return os.path.join(here, "..", "..", "..", "instance-registry.json")
+    in_place = os.path.join(here, "..", "..", "..", "instance-registry.json")
+    candidates = [in_place]
+    try:
+        cli = shutil.which("kipi")
+        if cli:
+            candidates.append(os.path.join(
+                os.path.dirname(os.path.realpath(cli)), "instance-registry.json"))
+    except OSError:
+        pass
+    candidates.append(os.path.join(CANONICAL_SKELETON, "instance-registry.json"))
+    for candidate in candidates:
+        try:
+            if os.path.isfile(candidate):
+                return candidate
+        except OSError:
+            continue
+    return in_place
 
 
 def _registry_rows() -> list:

--- a/q-system/.q-system/scripts/linear-dor-drafter.py
+++ b/q-system/.q-system/scripts/linear-dor-drafter.py
@@ -90,7 +90,26 @@ FAILURE_MARKER = f"<!-- kipi-key: {FAILURE_KEY} -->"
 # marker rather than the title prefix or the owner label: the prefix is prose a
 # human can edit and the label is shared with every other Sana issue, while this
 # is the writer's own machine-readable claim about what the ticket IS.
+#
+# MATCHED IN THE WRITER'S STRUCTURAL FORM, NOT AS A BARE NAME (ASK-839, PR #191
+# review round 4). alert-to-linear.py:515 emits
+# `<!-- kipi-alert-fingerprint: <fp> -->`; testing for the bare name matched any
+# issue whose body merely DISCUSSES the alert mechanism, and dropped it from
+# drafting forever with no counter and no line of output. ASK-839 itself is that
+# issue -- its own description says the tickets "carry `kipi-alert-fingerprint`",
+# so the issue that built this exclusion was excluded by it. Same class as the
+# bare "Definition of Ready" substring that removed a founder's issue from this
+# drafter (sp-b784a19a): a comment marker is structure, a sentence naming it is
+# not.
 ALERT_FINGERPRINT_MARKER = "kipi-alert-fingerprint"
+ALERT_FINGERPRINT_RE = re.compile(r"<!--\s*" + re.escape(ALERT_FINGERPRINT_MARKER)
+                                  + r"\s*:")
+
+
+def is_alert_ticket(description: str) -> bool:
+    """ONE definition of "alert-to-linear.py filed this", used by the selector and
+    by the reporting count. Two substring tests in two places is how they drift."""
+    return bool(ALERT_FINGERPRINT_RE.search(description or ""))
 
 # The single founder-ping channel (.claude/rules/founder-notifications.md).
 # Used ONLY when the report itself could not reach the board -- an open Linear
@@ -545,7 +564,7 @@ def selection_mode(issue: dict) -> str | None:
     # board 2026-08-15: 81 open alert tickets, 19 already drafted onto, and all 19
     # sat in the permanently-UNREACHABLE bucket. This drip is what converted them,
     # at the rate of one batch a night, out of the remaining 62.
-    if ALERT_FINGERPRINT_MARKER in desc:
+    if is_alert_ticket(desc):
         return None
 
     # AN UNROUTABLE ISSUE MUST NOT BE PROMOTED (ASK-839, the second question the
@@ -723,7 +742,7 @@ def fetch_draftable(ls, team_id: str) -> list:
     # is read in a digest, and a list that can reach 60 buries it.
     unrouted = [i for i in issues
                 if not ((i.get("project") or {}).get("name") or "").strip()
-                and ALERT_FINGERPRINT_MARKER not in (i.get("description") or "")
+                and not is_alert_ticket(i.get("description") or "")
                 and (i.get("state") or {}).get("type") in DRAFTABLE_STATE_TYPES
                 and not has_dor_section(i.get("description") or "")]
     if unrouted:

--- a/q-system/.q-system/scripts/linear-dor-drafter.py
+++ b/q-system/.q-system/scripts/linear-dor-drafter.py
@@ -86,6 +86,12 @@ FAILURE_TITLE = "linear-dor: nightly DoR drafter reported failures"
 # items and a DoR helps them. (PR #12 round-2 review, nit.)
 FAILURE_MARKER = f"<!-- kipi-key: {FAILURE_KEY} -->"
 
+# The marker alert-to-linear.py stamps into every ticket it files. Matched on the
+# marker rather than the title prefix or the owner label: the prefix is prose a
+# human can edit and the label is shared with every other Sana issue, while this
+# is the writer's own machine-readable claim about what the ticket IS.
+ALERT_FINGERPRINT_MARKER = "kipi-alert-fingerprint"
+
 # The single founder-ping channel (.claude/rules/founder-notifications.md).
 # Used ONLY when the report itself could not reach the board -- an open Linear
 # issue is the signal on a normal failing night, and a nightly Slack line on top
@@ -179,7 +185,7 @@ REDRAFT_CAP = 3
 
 # The redraft counter lives in the ISSUE DESCRIPTION, not in the state file and
 # not in attempts-ledger.py.
-#   - not the ledger: out of scope by founder deferral (sp-626e9452), and a
+#   - not the ledger: out of scope by founder deferral (sp-626e9452), and a  # spillover-skip
 #     read-then-write from a second process is the race that file exists to stop.
 #   - not ~/.config/kipi/linear-dor-state.json: that is one machine's scratch. A
 #     cap whose count evaporates on a new laptop is not a cap, and the terminal
@@ -530,6 +536,28 @@ def selection_mode(issue: dict) -> str | None:
     if FAILURE_MARKER in desc:
         return None
 
+    # A FLEET ALERT IS A NOTIFICATION, NOT A SPEC (ASK-839).
+    #
+    # alert-to-linear.py files these; their body is a raw alert line ("auto-commit
+    # left 3 file(s) uncommitted"), not work anyone scoped. Writing a Definition
+    # of Ready onto one does not make it executable -- it makes it READY-SHAPED,
+    # which is what admits it to linear-worker.sh's queue. Measured on the live
+    # board 2026-08-15: 81 open alert tickets, 19 already drafted onto, and all 19
+    # sat in the permanently-UNREACHABLE bucket. This drip is what converted them,
+    # at the rate of one batch a night, out of the remaining 62.
+    if ALERT_FINGERPRINT_MARKER in desc:
+        return None
+
+    # AN UNROUTABLE ISSUE MUST NOT BE PROMOTED (ASK-839, the second question the
+    # issue asked in so many words). A project is how the worker decides which
+    # checkout can serve an issue; with none set, in_this_repo() is false in every
+    # repo at once, so drafting a DoR moves the issue from "not ready" to "ready
+    # and reachable by nobody". The first state is honest and the second is not.
+    # Refused rather than drafted, and counted at the call site so a legitimately
+    # unrouted issue is visible instead of silently skipped forever.
+    if not ((issue.get("project") or {}).get("name") or "").strip():
+        return None
+
     if NEEDS_SCOPE_LABEL in label_names(issue):
         done, terminal = redraft_state(desc)
         if terminal:
@@ -684,6 +712,26 @@ def fetch_draftable(ls, team_id: str) -> list:
         if not page["pageInfo"]["hasNextPage"]:
             break
         after = page["pageInfo"]["endCursor"]
+
+    # REFUSALS ARE REPORTED, NOT SILENT (ASK-839). Two shapes now leave this
+    # selection: fleet alert tickets and project-unset issues. An alert ticket
+    # never coming back is the intended end state, but a REAL issue that nobody
+    # gave a project to would otherwise sit unqueued and unmentioned forever --
+    # the drip would look healthy while that issue was invisible to every run.
+    # So the second class is counted and named on stdout, which is where this
+    # job's nightly digest reads from. Bounded to the first few ids: this line
+    # is read in a digest, and a list that can reach 60 buries it.
+    unrouted = [i for i in issues
+                if not ((i.get("project") or {}).get("name") or "").strip()
+                and ALERT_FINGERPRINT_MARKER not in (i.get("description") or "")
+                and (i.get("state") or {}).get("type") in DRAFTABLE_STATE_TYPES
+                and not has_dor_section(i.get("description") or "")]
+    if unrouted:
+        shown = " ".join(i["identifier"] for i in unrouted[:8])
+        more = f" (+{len(unrouted) - 8} more)" if len(unrouted) > 8 else ""
+        print(f"dor-drafter: {len(unrouted)} issue(s) NOT drafted -- no project, "
+              f"so no checkout could ever be routed one: {shown}{more}")
+
     return [i for i in issues if needs_dor(i)]
 
 

--- a/q-system/.q-system/scripts/linear-worker.sh
+++ b/q-system/.q-system/scripts/linear-worker.sh
@@ -499,7 +499,24 @@ def project_of(i):
 ALERT_MARKER = "kipi-alert-fingerprint"
 
 def is_fleet_alert(i):
-    return ALERT_MARKER in (i.get("description") or "")
+    # MATCHED IN THE WRITERS OWN STRUCTURAL FORM (ASK-839, PR #191 round 4):
+    # alert-to-linear.py:515 emits <!-- kipi-alert-fingerprint: <fp> -->. The
+    # bare-name test matched any issue whose body merely DISCUSSES the alert
+    # mechanism and silently dropped it from this queue -- ASK-839 itself is one,
+    # since its description says the tickets carry that marker. Fixed at all three
+    # readers together (here, and both call sites in linear-dor-drafter.py):
+    # leaving one behind splits the predicate, so the drafter would write a DoR
+    # onto an issue this side still refuses to pick.
+    #
+    # Parsed rather than regexed because there is no re import in this heredoc and
+    # adding one is a wider edit than the fix. A comment key must be the WHOLE key,
+    # so prose inside some other HTML comment cannot match either.
+    for chunk in (i.get("description") or "").split("<!--")[1:]:
+        head = chunk.split("-->", 1)[0]
+        name, sep, _rest = head.partition(":")
+        if sep and name.strip() == ALERT_MARKER:
+            return True
+    return False
 
 def in_this_repo(i):
     # Unset project is NOT this repo. "Target unknown" and "target is here" are

--- a/q-system/.q-system/scripts/linear-worker.sh
+++ b/q-system/.q-system/scripts/linear-worker.sh
@@ -470,6 +470,37 @@ registry_ok = os.environ.get("REGISTRY_OK", "") == "True"
 def project_of(i):
     return (i.get("project") or {}).get("name")
 
+# A FLEET ALERT IS A NOTIFICATION, NOT DISPATCH WORK (ASK-839).
+#
+# alert-to-linear.py files these and stamps this marker into every one. Their
+# body is a raw alert line -- "auto-commit left 3 file(s) uncommitted" -- and
+# nobody scoped it. The DoR drafter was writing a Definition of Ready onto them
+# anyway, which does not make one executable; it makes it READY-SHAPED, and that
+# is the only thing this queue checks.
+#
+# Measured against the live board 2026-08-15: 19 issues were ready-shaped AND
+# project-unset, and ALL 19 were alert tickets -- 43 percent of the whole
+# UNREACHABLE bucket, growing by one drafter batch a night out of the remaining
+# 62. THE FORK THIS ANSWERS: backfill a project onto the 81, or declare them not
+# dispatch work. Backfill was refused on the measurement -- only 33 of the 81
+# carry a label that names a real project, 22 were raised from a cwd of / and 16
+# from a worktree directory, so a backfill invents routing for the majority and
+# then hands a worker an alert line as if it were a spec. They stay on the board,
+# labelled and now project-attributed, for a human or a triage pass to convert
+# into a real issue; they do not enter the automatic queue.
+#
+# Keyed on the MARKER THE WRITER ITSELF STAMPS, not the title prefix (prose a
+# human edits) and not owner:sana (shared with every real Sana issue).
+# NO APOSTROPHE IN THIS HEREDOC. It sits inside a $( ) and bash tracks quote
+# state straight through a quoted heredoc there, so one apostrophe in a PYTHON
+# COMMENT takes the whole script to "unexpected EOF" 800 lines away. This comment
+# is the third time that scar has been earned in this file; the first draft of it
+# wrote WRITER-apostrophe-S and the suite went from 24 green to 11 failures.
+ALERT_MARKER = "kipi-alert-fingerprint"
+
+def is_fleet_alert(i):
+    return ALERT_MARKER in (i.get("description") or "")
+
 def in_this_repo(i):
     # Unset project is NOT this repo. "Target unknown" and "target is here" are
     # different claims, and treating the first as the second is how 18 foreign
@@ -496,6 +527,7 @@ def ready(i):
     # missing tool). Excluded for the same reason, routed somewhere different.
     if "blocked:capability" in labels: return False
     if i["state"]["type"] not in ("backlog", "unstarted"): return False
+    if is_fleet_alert(i):            return False   # ASK-839, see ALERT_MARKER
     if not in_this_repo(i):          return False
     d = i.get("description") or ""
     return "## Definition of Ready" in d or "Definition of Ready" in d
@@ -508,8 +540,16 @@ def ready_ignoring_project(i):
     labels = {l["name"] for l in i["labels"]["nodes"]}
     return ("owner:assaf" not in labels and "owner:sana" in labels
             and "needs-scope" not in labels and "blocked:capability" not in labels
+            and not is_fleet_alert(i)
             and i["state"]["type"] in ("backlog", "unstarted")
             and "Definition of Ready" in (i.get("description") or ""))
+
+# BOTH SELECTORS, OR THE FIX IS HALF DONE. ready() alone would stop an alert
+# ticket being WORKED while leaving it in `dropped`, so it would keep being
+# reported UNREACHABLE forever -- the same 19-issue line, now describing work the
+# loop has already decided it will never take. A bucket nobody can act on and
+# nobody intends to act on is not a backlog, it is noise on the one line an
+# operator reads at 3am.
 
 dropped = [i for i in issues if ready_ignoring_project(i) and not in_this_repo(i)]
 

--- a/q-system/.q-system/scripts/slack-notify.sh
+++ b/q-system/.q-system/scripts/slack-notify.sh
@@ -60,9 +60,10 @@ MSG="[$LABEL] $MSG"
 # on rung 5 -- the checkout alert-to-linear.py itself lives in -- so the ticket is
 # filed against kipi-system instead of the repo that raised the alert. Measured
 # against the live registry 2026-08-15: 7 of 25 instances are that shape
-# (`strategy`/`KTLYST_strategy`, `consulting`/`ASK Consulting`, `product`/
-# `ktlyst`, `kipi-investigations`/`investigations`, ...), plus every worktree,
-# which is how the fleet's own agents run.
+# (an alias that adds a brand prefix the directory lacks, one written as spaced
+# prose, one that drops a prefix the directory keeps), plus every worktree,
+# which is how the fleet's own agents run. The live pairs stay in
+# instance-registry.json: this script ships to every instance of a PUBLIC repo.
 #
 # --git-common-dir, NOT --show-toplevel. From a worktree, --show-toplevel returns
 # the WORKTREE, which equals no registry row, so rung 2 would still match nothing

--- a/q-system/.q-system/scripts/slack-notify.sh
+++ b/q-system/.q-system/scripts/slack-notify.sh
@@ -47,6 +47,49 @@ if [ -z "$LABEL" ]; then
 fi
 MSG="[$LABEL] $MSG"
 
+# THE LABEL ABOVE IS NOT ROUTING, AND WAS BEING ASKED TO BE (ASK-839, PR #191
+# review). alert-to-linear.py resolves the ticket's Linear project from a
+# candidate list whose second rung is the repo PATH through
+# instance-registry.json -- "the only rung that survives a worktree or a renamed
+# directory", per its own docstring, which then said this script resolves that
+# path. It did not. KIPI_ALERT_REPO_PATH was unset on every real alert, so rung 2
+# was dead in production and only the basename above was left to route on.
+#
+# WHAT THAT COSTS. A checkout whose basename is not its board alias misses rung 3
+# (basename vs registry `name`) and rung 4 (basename as a project name) and lands
+# on rung 5 -- the checkout alert-to-linear.py itself lives in -- so the ticket is
+# filed against kipi-system instead of the repo that raised the alert. Measured
+# against the live registry 2026-08-15: 7 of 25 instances are that shape
+# (`strategy`/`KTLYST_strategy`, `consulting`/`ASK Consulting`, `product`/
+# `ktlyst`, `kipi-investigations`/`investigations`, ...), plus every worktree,
+# which is how the fleet's own agents run.
+#
+# --git-common-dir, NOT --show-toplevel. From a worktree, --show-toplevel returns
+# the WORKTREE, which equals no registry row, so rung 2 would still match nothing
+# while looking supplied. --git-common-dir points at the MAIN checkout's .git in
+# both a worktree and an ordinary clone, and the main checkout is what the
+# registry stores. Same correction linear-claim.py needed at ASK-188.
+#
+# NOTHING IS INVENTED OUTSIDE A REPO. 22 of the 81 unset alert tickets were
+# raised from a cwd of `/`. Exporting that would hand rung 2 a guaranteed miss and
+# make the candidate list longer without making it truer; rung 5 already covers
+# that case honestly. An explicit caller value is never overwritten -- rung 1 is
+# "an explicit statement by the caller" and a derived value must not outrank it.
+if [ -z "${KIPI_ALERT_REPO_PATH:-}" ]; then
+  # --path-format is git 2.31+; without it --git-common-dir is relative to the
+  # cwd in an ordinary clone (`.git`) and must be resolved before dirname.
+  _KCOMMON="$(git rev-parse --path-format=absolute --git-common-dir 2>/dev/null)" \
+    || _KCOMMON=""
+  if [ -z "$_KCOMMON" ]; then
+    _KCOMMON="$(git rev-parse --git-common-dir 2>/dev/null)" || _KCOMMON=""
+    case "$_KCOMMON" in ""|/*) ;; *) _KCOMMON="$PWD/$_KCOMMON" ;; esac
+  fi
+  if [ -n "$_KCOMMON" ]; then
+    _KREPO="$(cd "$(dirname "$_KCOMMON")" 2>/dev/null && pwd -P)" || _KREPO=""
+    [ -n "$_KREPO" ] && export KIPI_ALERT_REPO_PATH="$_KREPO"
+  fi
+fi
+
 # --- fixture-run guard: a test must never open a live ticket -------------------
 # SCAR 2026-08-01. Three tests were found paging the founder's real Slack and
 # were fixed by stubbing KIPI_NOTIFY per test (PR #54). While that PR sat open,

--- a/q-system/.q-system/scripts/test/test-dor-refuses-unroutable.py
+++ b/q-system/.q-system/scripts/test/test-dor-refuses-unroutable.py
@@ -115,6 +115,37 @@ def run(mod, label):
             f"selection_mode returned {mod.selection_mode(unset)!r} -- drafting "
             "onto an unroutable ticket promotes it into a queue nothing serves")
 
+    # AN ISSUE THAT TALKS ABOUT ALERTS IS NOT AN ALERT (ASK-839, PR #191 round 4).
+    # The exclusion matched the bare marker NAME anywhere in the body, so any
+    # issue whose prose merely names the mechanism was dropped from drafting
+    # forever, silently. The body below is copied out of ASK-839's own live
+    # description -- the issue that BUILT this exclusion is excluded by it, which
+    # is how the defect was found. Same class as the bare "Definition of Ready"
+    # substring that removed a founder's issue from this drafter (sp-b784a19a): a
+    # comment marker is structure, a sentence naming it is not.
+    about_alerts = issue(
+        "ASK-805", project="kipi-system",
+        desc="| Population | Count |\n| -- | -- |\n"
+             "| Open project-unset alert tickets (carry `kipi-alert-fingerprint`) | 81 |\n\n"
+             "The writer stamps kipi-alert-fingerprint into every ticket it files.")
+    if mod.selection_mode(about_alerts) == "draft":
+        ok("drafts an ordinary issue that only DISCUSSES the alert marker (ASK-805)")
+    else:
+        bad("drafts an ordinary issue that only DISCUSSES the alert marker (ASK-805)",
+            f"selection_mode returned {mod.selection_mode(about_alerts)!r} -- "
+            "matching the bare name silently excludes real work from drafting")
+
+    # The other half of the same predicate: the writer's real stamp still has to
+    # be caught. Asserting only the new case would let the fix be "delete the
+    # exclusion", which is the original defect back.
+    odd_spacing = issue("ASK-806", project="kipi-system",
+                        desc="alert body\n\n<!--kipi-alert-fingerprint:abc123-->")
+    if mod.selection_mode(odd_spacing) is None:
+        ok("still refuses the writer's stamp with no spaces around it (ASK-806)")
+    else:
+        bad("still refuses the writer's stamp with no spaces around it (ASK-806)",
+            f"selection_mode returned {mod.selection_mode(odd_spacing)!r}")
+
     # The redrive path runs BEFORE the project test in selection_mode, so it has
     # its own case: an issue Sana refused is re-scoped by this job, and losing
     # that path would silently strand every needs-scope issue.

--- a/q-system/.q-system/scripts/test/test-dor-refuses-unroutable.py
+++ b/q-system/.q-system/scripts/test/test-dor-refuses-unroutable.py
@@ -1,0 +1,134 @@
+#!/usr/bin/env python3
+"""The DoR drafter refuses the two issue shapes a DoR cannot help (ASK-839).
+
+THE DEFECT. linear-dor-drafter.py selected on state + description alone. It
+therefore drafted a Definition of Ready onto:
+
+  1. fleet alert tickets filed by alert-to-linear.py, whose body is a raw alert
+     line ("auto-commit left 3 file(s) uncommitted") that nobody scoped, and
+  2. issues with no project at all, which linear-worker.sh cannot route to any
+     checkout because in_this_repo() is false for them in every repo at once.
+
+Writing a DoR onto either does not make it executable. It makes it READY-SHAPED,
+and ready-shaped is the only thing the worker queue checks. So the drip was
+manufacturing permanently-unreachable work, one batch a night.
+
+MEASURED against the live ASK board 2026-08-15: 81 open alert tickets, 19 of
+them already drafted onto, and all 19 sat in the UNREACHABLE bucket -- 43% of it.
+62 more were still queued for the same treatment.
+
+This is the second question ASK-839 asked in so many words ("should the DoR
+drafter refuse to draft onto a project-unset issue?"). The answer is yes, and
+this file is the answer in a form that can fail.
+
+Run: python3 q-system/.q-system/scripts/test/test-dor-refuses-unroutable.py
+"""
+import importlib.util
+import os
+import sys
+
+HERE = os.path.dirname(os.path.abspath(__file__))
+# REF HATCH, copied from test-worker-project-scope.sh. Points the suite at a
+# different copy of the drafter so the PRE-FIX one can be checked out of a git
+# ref and watched to FAIL. A regression case added after its own fix has never
+# been observed red, and an unobserved-red case asserts nothing.
+#
+#   git show <ref>:q-system/.q-system/scripts/linear-dor-drafter.py > /tmp/old.py
+#   KIPI_DRAFTER_UNDER_TEST=/tmp/old.py python3 test-dor-refuses-unroutable.py
+DRAFTER = os.environ.get("KIPI_DRAFTER_UNDER_TEST") or os.path.join(
+    HERE, "..", "linear-dor-drafter.py")
+
+PASS, FAIL = 0, 0
+
+
+def ok(name):
+    global PASS
+    PASS += 1
+    print(f"  ok   {name}")
+
+
+def bad(name, detail=""):
+    global FAIL
+    FAIL += 1
+    print(f"  FAIL {name}\n     {detail}")
+
+
+def load(path):
+    spec = importlib.util.spec_from_file_location("dor_drafter_under_test", path)
+    mod = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(mod)
+    return mod
+
+
+def issue(ident, project=None, desc="", labels=(), state="backlog"):
+    """The shape ISSUES_Q returns. Fields copied from that query, not invented:
+    a fixture built from a guess tests the guess (feedback_fixtures_from_producers)."""
+    return {
+        "id": ident, "identifier": ident, "title": "fixture " + ident,
+        "description": desc,
+        "project": ({"name": project} if project else None),
+        "state": {"name": state, "type": state},
+        "labels": {"nodes": [{"id": n, "name": n} for n in labels]},
+    }
+
+
+ALERT_BODY = (
+    "Filed automatically by the fleet alert path.\n\n"
+    "```\n[consulting] auto-commit left 3 file(s) uncommitted\n```\n\n"
+    "<!-- kipi-alert-fingerprint: deadbeefdeadbeef -->"
+)
+
+
+def run(mod, label):
+    print(f"== DoR drafter selection ({label})")
+
+    # The control. Without it every assertion below is satisfied by a
+    # selection_mode() that returns None for everything.
+    normal = issue("ASK-800", project="kipi-system", desc="just a description")
+    if mod.selection_mode(normal) == "draft":
+        ok("still drafts an ordinary routable issue (ASK-800)")
+    else:
+        bad("still drafts an ordinary routable issue (ASK-800)",
+            f"selection_mode returned {mod.selection_mode(normal)!r}")
+
+    alert_routed = issue("ASK-801", project="kipi-system", desc=ALERT_BODY)
+    if mod.selection_mode(alert_routed) is None:
+        ok("refuses a fleet alert ticket even when it HAS a project (ASK-801)")
+    else:
+        bad("refuses a fleet alert ticket even when it HAS a project (ASK-801)",
+            f"selection_mode returned {mod.selection_mode(alert_routed)!r} -- "
+            "an alert is not dispatch work whether or not it is routable")
+
+    alert_unset = issue("ASK-802", project=None, desc=ALERT_BODY)
+    if mod.selection_mode(alert_unset) is None:
+        ok("refuses a project-unset fleet alert ticket (ASK-802)")
+    else:
+        bad("refuses a project-unset fleet alert ticket (ASK-802)",
+            f"selection_mode returned {mod.selection_mode(alert_unset)!r}")
+
+    unset = issue("ASK-803", project=None, desc="a real engineering issue, no project")
+    if mod.selection_mode(unset) is None:
+        ok("refuses a project-unset issue: a DoR would make it ready and "
+           "unreachable (ASK-803)")
+    else:
+        bad("refuses a project-unset issue (ASK-803)",
+            f"selection_mode returned {mod.selection_mode(unset)!r} -- drafting "
+            "onto an unroutable ticket promotes it into a queue nothing serves")
+
+    # The redrive path runs BEFORE the project test in selection_mode, so it has
+    # its own case: an issue Sana refused is re-scoped by this job, and losing
+    # that path would silently strand every needs-scope issue.
+    redrive = issue("ASK-804", project="kipi-system",
+                    desc="## Definition of Ready\nOutcome: x",
+                    labels=(mod.NEEDS_SCOPE_LABEL,))
+    if mod.selection_mode(redrive) == "redraft":
+        ok("the needs-scope redrive still works (ASK-804)")
+    else:
+        bad("the needs-scope redrive still works (ASK-804)",
+            f"selection_mode returned {mod.selection_mode(redrive)!r}")
+
+
+run(load(DRAFTER), os.path.basename(DRAFTER))
+print()
+print(f"  {PASS} passed, {FAIL} failed")
+sys.exit(0 if FAIL == 0 else 1)

--- a/q-system/.q-system/scripts/test/test-linear-dor-drafter-redrive.sh
+++ b/q-system/.q-system/scripts/test/test-linear-dor-drafter-redrive.sh
@@ -178,7 +178,15 @@ PY
 }
 
 run_drafter() {  # run_drafter <args...>  -> stdout+stderr in $WORK/out.txt
-  STUB_MODE="${STUB_MODE:-good}" python3 "$DRAFTER" "$@" > "$WORK/out.txt" 2>&1
+  # KIPI_NOTIFY IS PART OF THE ISOLATION, NOT A NICETY. The drafter's notify()
+  # shells slack-notify.sh, which now FILES A LIVE LINEAR TICKET rather than
+  # posting to a webhook, and this suite drives paths that call it. The scar is
+  # already on the board twice: three tests were found paging the founder's real
+  # channel on 2026-08-01, and a worktree cut before the fix paged again while
+  # that fix sat unmerged. Per-test stubbing only protects tests someone
+  # remembered, so the stub lives at the single runner every case goes through.
+  STUB_MODE="${STUB_MODE:-good}" KIPI_NOTIFY="/usr/bin/true" \
+    python3 "$DRAFTER" "$@" > "$WORK/out.txt" 2>&1
 }
 
 board() { cat > "$WORK/board.json"; }

--- a/q-system/.q-system/scripts/test/test-linear-dor-failure-reporting.py
+++ b/q-system/.q-system/scripts/test/test-linear-dor-failure-reporting.py
@@ -347,13 +347,19 @@ check("...and that one does ping, because nothing reached the board",
 # prose onto the operator's failure log.
 ls = FakeLinear()
 dor.report_failures(ls, FAILS)
+# Both fixtures carry a project: selection_mode refuses an issue with no project
+# set (ASK-839, "unroutable"). Without one, the NEXT check would read False for
+# the wrong reason -- it would pass with the FAILURE_MARKER branch deleted, which
+# is a test that cannot fail for the thing it names.
 _filed_issue = {"identifier": "ASK-999", "title": dor.FAILURE_TITLE,
                 "description": ls.created[0]["description"],
+                "project": {"name": "kipi-system"},
                 "state": {"name": "Backlog", "type": "backlog"}}
 check("the job's own failure record is not a draft target",
       dor.needs_dor(_filed_issue), False)
 check("...but an ordinary backlog issue still is",
       dor.needs_dor({"identifier": "ASK-1", "description": "a human wrote this",
+                     "project": {"name": "kipi-system"},
                      "state": {"name": "Backlog", "type": "backlog"}}), True)
 
 # --- a clean run reports nothing -------------------------------------------

--- a/q-system/.q-system/scripts/test/test-notify-supplies-repo-path.sh
+++ b/q-system/.q-system/scripts/test/test-notify-supplies-repo-path.sh
@@ -15,10 +15,10 @@
 # rung 4 (basename as a project) to rung 5 -- the checkout THIS SCRIPT lives in
 # -- and the alert is filed against kipi-system's project instead of the repo
 # that raised it. Measured against the live instance-registry.json 2026-08-15:
-# 7 of 25 registered instances have basename != alias (`strategy`/
-# `KTLYST_strategy`, `consulting`/`ASK Consulting`, `product`/`ktlyst`,
-# `kipi-investigations`/`investigations`, ...). Every git worktree is the same
-# shape, which is how the fleet's own agents run.
+# 7 of 25 registered instances have basename != alias (aliases that add a brand
+# prefix, spell the name as spaced prose, or drop a prefix the directory keeps).
+# The live pairs are read from the registry, never copied into a shipped file.
+# Every git worktree is the same shape, which is how the fleet's own agents run.
 #
 # WHY THE MAIN CHECKOUT AND NOT `--show-toplevel`. From a worktree,
 # --show-toplevel returns the WORKTREE path, which equals no registry row, so

--- a/q-system/.q-system/scripts/test/test-notify-supplies-repo-path.sh
+++ b/q-system/.q-system/scripts/test/test-notify-supplies-repo-path.sh
@@ -1,0 +1,160 @@
+#!/bin/bash
+# ASK-839 review finding (PR #191, codex major): the alert writer's project
+# resolution has a rung that no production caller ever reaches.
+#
+# THE DEFECT. alert-to-linear.py::project_candidates() rung 2 is the repo PATH
+# through instance-registry.json, and its own docstring calls it "the only rung
+# that survives a worktree or a renamed directory, which is why slack-notify.sh
+# resolves the path rather than passing its own label". slack-notify.sh did not.
+# It computed a LABEL (KIPI_INSTANCE_NAME, else the checkout basename) and
+# exported nothing, so KIPI_ALERT_REPO_PATH was unset on every real alert and
+# rung 2 was dead code in production.
+#
+# WHY THAT IS NOT COSMETIC. With rung 2 skipped, a checkout whose basename is
+# not its board alias falls through rung 3 (basename vs registry `name`) and
+# rung 4 (basename as a project) to rung 5 -- the checkout THIS SCRIPT lives in
+# -- and the alert is filed against kipi-system's project instead of the repo
+# that raised it. Measured against the live instance-registry.json 2026-08-15:
+# 7 of 25 registered instances have basename != alias (`strategy`/
+# `KTLYST_strategy`, `consulting`/`ASK Consulting`, `product`/`ktlyst`,
+# `kipi-investigations`/`investigations`, ...). Every git worktree is the same
+# shape, which is how the fleet's own agents run.
+#
+# WHY THE MAIN CHECKOUT AND NOT `--show-toplevel`. From a worktree,
+# --show-toplevel returns the WORKTREE path, which equals no registry row, so
+# rung 2 would match nothing and the misattribution would survive the fix while
+# the test went green. --git-common-dir points at the main checkout's .git in
+# both a worktree and an ordinary clone, which is the path the registry stores.
+# Same rule linear-claim.py learned the hard way at ASK-188.
+#
+# NO REAL TICKET CAN BE FILED FROM HERE, two independent nets, because the scar
+# in slack-notify.sh is a suite that paged the founder live:
+#   1. a `python3` shim first on PATH records argv/env and never runs the writer
+#   2. PYTEST_CURRENT_TEST is exported, which alert-to-linear.py refuses on
+#      (exit 4) even if the shim were somehow bypassed
+# The loopback guard is NOT usable here: it exits 4 before reaching the writer,
+# which is the handoff this suite has to observe.
+set -uo pipefail
+
+HERE="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+NOTIFY="$HERE/../slack-notify.sh"
+WRITER="$HERE/../alert-to-linear.py"
+[ -f "$NOTIFY" ] || { echo "FAIL: slack-notify.sh not found at $NOTIFY"; exit 1; }
+[ -f "$WRITER" ] || { echo "FAIL: alert-to-linear.py not found at $WRITER"; exit 1; }
+
+TMP="$(mktemp -d)"
+trap 'rm -rf "$TMP" 2>/dev/null' EXIT
+
+PASS=0; FAIL=0
+ok()  { PASS=$((PASS+1)); echo "PASS: $1"; }
+bad() { FAIL=$((FAIL+1)); echo "FAIL: $1"; }
+eq()  { # want, got, label
+  if [ "$2" = "$1" ]; then ok "$3"; else bad "$3 -- wanted [$1], got [$2]"; fi
+}
+
+# --- the python3 shim: records the env the writer was handed, files nothing ---
+mkdir -p "$TMP/bin"
+cat > "$TMP/bin/python3" <<'SH'
+#!/bin/bash
+{
+  printf 'REPO_PATH=%s\n' "${KIPI_ALERT_REPO_PATH-<UNSET>}"
+  printf 'ARGV=%s\n' "$*"
+} > "$KIPI_TEST_CAPTURE"
+exit 0
+SH
+chmod +x "$TMP/bin/python3"
+
+# --- a registry whose alias is deliberately NOT the directory basename --------
+MAIN="$TMP/checkout-basename"
+mkdir -p "$MAIN"
+git -C "$MAIN" init -q 2>/dev/null
+git -C "$MAIN" config user.email t@t.t
+git -C "$MAIN" config user.name t
+: > "$MAIN/f"
+git -C "$MAIN" add f >/dev/null 2>&1
+git -C "$MAIN" commit -qm init >/dev/null 2>&1
+
+MAIN_REAL="$(cd "$MAIN" && pwd -P)"
+cat > "$TMP/registry.json" <<JSON
+{"instances": [
+  {"name": "some-other-name", "path": "$MAIN_REAL", "linear_project": "Board Alias"}
+]}
+JSON
+
+WT="$TMP/.wt-ask999"
+git -C "$MAIN" worktree add -q -b probe "$WT" >/dev/null 2>&1
+WT_REAL="$(cd "$WT" && pwd -P)"
+
+run_notify() { # cwd -> writes capture file, echoes nothing
+  local cwd="$1"
+  : > "$TMP/capture"
+  ( cd "$cwd" 2>/dev/null || exit 0
+    PATH="$TMP/bin:$PATH" \
+    KIPI_TEST_CAPTURE="$TMP/capture" \
+    PYTEST_CURRENT_TEST="test-notify-supplies-repo-path" \
+    KIPI_INSTANCE_REGISTRY="$TMP/registry.json" \
+    bash "$NOTIFY" "a probe alert" ) >/dev/null 2>&1
+}
+captured() { sed -n 's/^REPO_PATH=//p' "$TMP/capture"; }
+
+# 1. The plain checkout: the path reaches the writer at all.
+run_notify "$MAIN"
+eq "$MAIN_REAL" "$(captured)" "ordinary checkout: KIPI_ALERT_REPO_PATH is the checkout"
+
+# 2. A WORKTREE resolves to the MAIN checkout, which is what the registry holds.
+#    --show-toplevel would give $WT_REAL here and match no row.
+run_notify "$WT"
+eq "$MAIN_REAL" "$(captured)" "worktree: resolves to the main checkout, not the worktree"
+
+# 3. A SUBDIRECTORY is still the repo root, not the cwd.
+mkdir -p "$MAIN/deep/er"
+run_notify "$MAIN/deep/er"
+eq "$MAIN_REAL" "$(captured)" "subdirectory: resolves to the repo root"
+
+# 4. NO REPO AT ALL invents nothing. 22 of the 81 unset alert tickets were
+#    raised from a cwd of `/`; supplying that as a repo path would hand rung 2 a
+#    guaranteed-miss and make the candidate list longer without making it truer.
+NOREPO="$TMP/norepo"; mkdir -p "$NOREPO"
+run_notify "$NOREPO"
+got4="$(captured)"
+if [ "$got4" = "<UNSET>" ] || [ -z "$got4" ]; then
+  ok "outside a repo: no path invented"
+else
+  bad "outside a repo: no path invented -- got [$got4]"
+fi
+
+# 5. An EXPLICIT caller value is not overwritten. Rung 1 of the candidate list
+#    is "an explicit statement by the caller"; a derived value that clobbers it
+#    would silently outrank it.
+: > "$TMP/capture"
+( cd "$MAIN" && PATH="$TMP/bin:$PATH" KIPI_TEST_CAPTURE="$TMP/capture" \
+  PYTEST_CURRENT_TEST="t" KIPI_INSTANCE_REGISTRY="$TMP/registry.json" \
+  KIPI_ALERT_REPO_PATH="/explicitly/set/by/caller" \
+  bash "$NOTIFY" "a probe alert" ) >/dev/null 2>&1
+eq "/explicitly/set/by/caller" "$(captured)" "explicit KIPI_ALERT_REPO_PATH survives"
+
+# 6. THE OUTCOME THE FINDING IS ABOUT. Hand project_candidates() exactly what
+#    slack-notify.sh now hands the writer -- the path AND the "[basename] "
+#    prefix it puts on the message -- and the board alias must come out FIRST.
+#    Pre-fix this returned only the basename and the skeleton's own project.
+run_notify "$WT"
+RESOLVED="$(captured)"
+cand="$(
+  KIPI_INSTANCE_REGISTRY="$TMP/registry.json" \
+  KIPI_ALERT_REPO_PATH="$RESOLVED" \
+  KIPI_NOTIFY=/usr/bin/true \
+  /usr/bin/env python3 - "$WRITER" <<'PY' 2>/dev/null
+import importlib.util, sys
+spec = importlib.util.spec_from_file_location("a2l", sys.argv[1])
+mod = importlib.util.module_from_spec(spec)
+spec.loader.exec_module(mod)
+# the exact message shape slack-notify.sh builds: "[<basename>] <text>"
+print("|".join(mod.project_candidates("[.wt-ask999] a probe alert")))
+PY
+)"
+first="${cand%%|*}"
+eq "Board Alias" "$first" "worktree alert resolves to the board alias, best evidence first"
+
+echo "---"
+echo "$PASS passed, $FAIL failed"
+[ "$FAIL" -eq 0 ]

--- a/q-system/.q-system/scripts/test/test-worker-project-scope.sh
+++ b/q-system/.q-system/scripts/test/test-worker-project-scope.sh
@@ -53,10 +53,16 @@ cat > "$WORK/fixture-server.py" <<'PY'
 import json, sys
 from http.server import BaseHTTPRequestHandler, HTTPServer
 
-def issue(ident, project, labels, dor=True, state="backlog"):
+def issue(ident, project, labels, dor=True, state="backlog", alert=False):
+    body = "## Definition of Ready\nOutcome: x" if dor else "no readiness heading here"
+    # ASK-839: what alert-to-linear.py stamps into every ticket IT files. The
+    # DoR text is deliberately present too -- the defect is precisely an alert
+    # ticket the drafter had already made ready-shaped.
+    if alert:
+        body += "\n\n<!-- kipi-alert-fingerprint: deadbeefdeadbeef -->"
     return {
         "id": ident, "identifier": ident, "title": "fixture " + ident,
-        "description": "## Definition of Ready\nOutcome: x" if dor else "no readiness heading here",
+        "description": body,
         "state": {"name": state, "type": state},
         "project": ({"name": project} if project else None),
         "labels": {"nodes": [{"name": n} for n in labels]},
@@ -86,6 +92,16 @@ BOARD = [
     issue("ASK-907", "kipi-system", ["owner:sana", "blocked:capability"], state="completed"),
     issue("ASK-908", "kipi-system", ["owner:sana", "blocked:capability"], state="canceled"),
     issue("ASK-909", "kipi-system", ["owner:sana", "needs-scope"], state="completed"),
+    # ASK-839: a fleet alert ticket the DoR drafter already made ready-shaped,
+    # project-unset because the writer never set one. On the live board
+    # 2026-08-15 there were 19 of exactly this, and they were 100% of the
+    # ready-shaped unset population and 43% of the whole UNREACHABLE bucket.
+    issue("ASK-910", None, ["owner:sana"], alert=True),
+    # An alert ticket that DOES carry a project. It must still be excluded: the
+    # decision is "an alert is not dispatch work", not "an alert is unroutable".
+    # Without this case the exclusion could be implemented as a project test and
+    # nothing here would notice.
+    issue("ASK-911", "kipi-system", ["owner:sana"], alert=True),
 ]
 
 class H(BaseHTTPRequestHandler):
@@ -199,7 +215,9 @@ for pair in "ASK-901:foreign project (accountant)" \
             "ASK-906:blocked:capability" \
             "ASK-907:blocked:capability and completed" \
             "ASK-908:blocked:capability and canceled" \
-            "ASK-909:needs-scope and completed"; do
+            "ASK-909:needs-scope and completed" \
+            "ASK-910:fleet alert ticket, project-unset (ASK-839)" \
+            "ASK-911:fleet alert ticket, project set (ASK-839)"; do
   id="${pair%%:*}"; why="${pair#*:}"
   if printf '%s\n' "$PICKED" | grep -q "$id"; then
     bad "excludes $id -- $why" "it was picked"
@@ -314,6 +332,28 @@ PICKED_OVR="$(printf '%s\n' "$OUT_OVR" | grep -o 'would work ASK-[0-9]*' | sed '
 case "$PICKED_OVR" in
   "ASK-900 ") ok "KIPI_LINEAR_PROJECT still outranks the registry" ;;
   *)          bad "KIPI_LINEAR_PROJECT still outranks the registry" "picked: [$PICKED_OVR] -- expected [ASK-900 ]" ;;
+esac
+
+# --- case 4c: alert tickets leave the UNREACHABLE bucket too (ASK-839) -------
+# Excluding them from ready() alone would be half a fix: they would stop being
+# WORKED and keep being COUNTED, so the same 19-issue UNREACHABLE line would run
+# every night describing work the loop has already decided it will never take.
+# Run against SKEL_REG because it is the only skel here carrying a registry, and
+# without one reachability is UNKNOWN and the whole classification collapses.
+#
+# The expected number is 2, not 0, and that is deliberate. ASK-902 is a genuine
+# non-alert unset issue and ASK-900 is a foreign project with no checkout -- both
+# are really unreachable and must keep being reported. Only the two alert tickets
+# leave. An assertion of 0 would pass for a worker that stopped reporting at all.
+OUT_ALERT="$(run_worker "$SKEL_REG")"
+UNREACH_N="$(printf '%s\n' "$OUT_ALERT" | sed -n 's/.*worker: \([0-9]*\) ready-shaped issue(s) UNREACHABLE.*/\1/p' | head -1)"
+case "${UNREACH_N:-none}" in
+  2)    ok "alert tickets leave the UNREACHABLE bucket (2 left, not 4)" ;;
+  4)    bad "alert tickets leave the UNREACHABLE bucket" \
+            "still 4 -- ASK-910/ASK-911 are counted as unreachable dispatch work" ;;
+  none) bad "alert tickets leave the UNREACHABLE bucket" \
+            "no UNREACHABLE line at all: $(printf '%s' "$OUT_ALERT" | tr '\n' '|' | cut -c1-300)" ;;
+  *)    bad "alert tickets leave the UNREACHABLE bucket" "count reads '$UNREACH_N', expected 2" ;;
 esac
 
 # --- case 5: NEGATIVE SELF-TEST ---------------------------------------------

--- a/q-system/.q-system/scripts/test_spillover_promote_selection.py
+++ b/q-system/.q-system/scripts/test_spillover_promote_selection.py
@@ -81,9 +81,31 @@ def worker_predicates(repo_project: str):
 
     tree = ast.parse(hits[0])
     want = {"project_of", "in_this_repo", "ready"}
+    # KEEP EVERY FUNCTION, NOT AN ALLOWLIST OF THREE (ASK-839, PR #191).
+    # This used to keep only `want`. ready() then grew one helper call
+    # (is_fleet_alert, reading the module-level ALERT_MARKER) and this extractor
+    # silently dropped both, so the shipped predicate raised NameError from
+    # inside the test -- three suites red on a fix that was itself correct. An
+    # allowlist of callees is a second copy of the consumer's call graph, and it
+    # goes stale the first time the consumer adds a line. Defining a function
+    # does not run its body, so carrying the unused ones costs nothing.
+    #
+    # Module-level names are carried only when they are literal constants. The
+    # heredoc also assigns `here`/`ls`/`pool`/`dropped` from Calls and
+    # comprehensions over names that only exist mid-run; exec-ing those would
+    # run the worker instead of extracting from it.
+    def _is_literal(node):
+        if isinstance(node, ast.Constant):
+            return True
+        if isinstance(node, (ast.Tuple, ast.List, ast.Set)):
+            return all(isinstance(e, ast.Constant) for e in node.elts)
+        return False
+
     keep = [n for n in tree.body
-            if isinstance(n, ast.FunctionDef) and n.name in want]
-    missing = want - {n.name for n in keep}
+            if isinstance(n, ast.FunctionDef)
+            or (isinstance(n, ast.Assign) and _is_literal(n.value))]
+    got = {n.name for n in keep if isinstance(n, ast.FunctionDef)}
+    missing = want - got
     if missing:
         raise AssertionError(f"linear-worker.sh no longer defines {missing}")
 

--- a/q-system/.q-system/terminal-states.json
+++ b/q-system/.q-system/terminal-states.json
@@ -164,6 +164,15 @@
       "rationale": "A correct exclusion, not a dead end. An issue in any other state either has an owner working it or is finished. Consuming this would mean re-opening closed work."
     },
     {
+      "id": "fleet-alert-not-a-spec",
+      "class": "selection-filter",
+      "marker": "is_fleet_alert(i):",
+      "sites": 1,
+      "what": "The issue is a ticket alert-to-linear.py filed, identified by the <!-- kipi-alert-fingerprint: ... --> marker the writer itself stamps.",
+      "terminal": true,
+      "rationale": "A notification is not work, so refusing it here is the correct end and not a dead end. The body is a raw alert line, not a spec anyone scoped; drafting a DoR onto one would only make it READY-SHAPED and admit it to this queue. Measured on the live board 2026-08-15: 81 open alert tickets, and all 19 already drafted onto sat in the permanently-UNREACHABLE bucket. The consumer of an alert is the operator who reads it; the paired refusal in linear-dor-drafter.py stops the conversion at source. Registered with its own marker rather than left under state-not-open, whose row it would otherwise silently inflate to two sites -- which is exactly how this was caught."
+    },
+    {
       "id": "out-of-repo",
       "class": "selection-filter",
       "marker": "not in_this_repo(i)",

--- a/q-system/.q-system/tests/test_alert_to_linear.py
+++ b/q-system/.q-system/tests/test_alert_to_linear.py
@@ -7,6 +7,7 @@ evidence, not an invention -- an invented fixture would let the dedup pass here
 and still flood Linear on the first real run.
 """
 import importlib.util
+import json
 import os
 import sys
 import time
@@ -111,6 +112,12 @@ class FakeLinear:
         self.state_type = state_type
         self.created = 0
         self.comments = 0
+        # The payload the last issueCreate actually sent. ASK-839 is a defect in
+        # a FIELD OF THE PAYLOAD, so the fixture has to keep the payload; a test
+        # that only reads the returned identifier cannot see the field at all.
+        self.create_input = None
+        self.projects = [{"id": "proj-kipi", "name": "kipi-system",
+                          "description": ""}]
 
     def linear_api_key(self):
         return "stub"
@@ -122,8 +129,11 @@ class FakeLinear:
         if "labels(first" in query:
             return {"team": {"labels": {"nodes": [
                 {"id": "lab-1", "name": "owner:sana"}]}}}
+        if "projects(first" in query:
+            return {"team": {"projects": {"nodes": self.projects}}}
         if "issueCreate" in query:
             self.created += 1
+            self.create_input = variables["input"]
             return {"issueCreate": {"success": True, "issue": {
                 "id": f"iss-{self.created}", "identifier": f"ASK-{100 + self.created}",
                 "url": "https://linear.app/x"}}}
@@ -252,6 +262,93 @@ def test_punctuation_alone_never_decides_a_ticket():
     for variant in (base + ".", base + "!", base.replace(":", " --"),
                     base.replace("BLOCKED:", "BLOCKED --"), '"' + base + '"'):
         assert mod.fingerprint(variant) == mod.fingerprint(base), variant
+
+
+# --- ASK-839: every filed ticket carries a project ---------------------------
+#
+# THE DEFECT. issueCreate was built with teamId + labelIds and no projectId, so
+# every alert landed project-unset. Measured against the live board 2026-08-15:
+# 81 open alert tickets, all unset; the DoR drafter had already promoted 19 of
+# them into ready-shaped work, and an unset project cannot route to any checkout,
+# so those 19 were 43% of the worker's permanently-UNREACHABLE bucket.
+#
+# Asserted on the PAYLOAD, not on the returned identifier. The old fixture read
+# only the identifier back, which is why a suite of 15 cases could not see a
+# missing field in the input it never inspected.
+
+def test_a_filed_ticket_carries_the_project_of_the_alerting_repo(isolated_state, monkeypatch, tmp_path):
+    fake = FakeLinear()
+    monkeypatch.setattr(mod, "_load_linear", lambda: fake)
+    repo = tmp_path / "some-checkout"
+    repo.mkdir()
+    reg = tmp_path / "instance-registry.json"
+    reg.write_text(json.dumps([{"name": "kipi-system", "path": str(repo)}]))
+    monkeypatch.setenv("KIPI_INSTANCE_REGISTRY", str(reg))
+    monkeypatch.setenv("KIPI_ALERT_REPO_PATH", str(repo))
+
+    code, _ = mod.file_alert(AUTOCOMMIT[0], now=1000.0)
+    assert code == mod.EXIT_OK
+    assert fake.create_input.get("projectId") == "proj-kipi", (
+        "the ticket was filed with no project, so no checkout can ever route it")
+
+
+def test_the_registry_alias_decides_the_project_not_the_directory_name(
+        isolated_state, monkeypatch, tmp_path):
+    """A registry row's board name and its directory routinely differ (ASK-840).
+
+    Measured on the live board: of 81 unset alert tickets, only 33 carried a
+    `[label]` prefix that is an exact project name. `consulting` lives on the
+    board as another name entirely, so deriving from the directory would file
+    those into nothing."""
+    fake = FakeLinear()
+    fake.projects = [{"id": "proj-cons", "name": "ASK Consulting", "description": ""}]
+    monkeypatch.setattr(mod, "_load_linear", lambda: fake)
+    repo = tmp_path / "consulting"
+    repo.mkdir()
+    reg = tmp_path / "instance-registry.json"
+    reg.write_text(json.dumps(
+        [{"name": "consulting", "linear_project": "ASK Consulting", "path": str(repo)}]))
+    monkeypatch.setenv("KIPI_INSTANCE_REGISTRY", str(reg))
+    monkeypatch.setenv("KIPI_ALERT_REPO_PATH", str(repo))
+
+    mod.file_alert(AUTOCOMMIT[0], now=1000.0)
+    assert fake.create_input.get("projectId") == "proj-cons"
+
+
+def test_an_unresolvable_repo_still_gets_a_project_and_still_files(
+        isolated_state, monkeypatch, tmp_path):
+    """22 of the 81 were raised from a cwd of `/` with no repo at all.
+
+    They must not go back to being unset, and they must never be dropped: losing
+    an alert is the failure this whole path exists to prevent. The fallback is
+    the checkout this script itself runs from, which is a derivation, not a guess.
+    """
+    fake = FakeLinear()
+    monkeypatch.setattr(mod, "_load_linear", lambda: fake)
+    reg = tmp_path / "instance-registry.json"
+    reg.write_text(json.dumps([]))
+    monkeypatch.setenv("KIPI_INSTANCE_REGISTRY", str(reg))
+    monkeypatch.delenv("KIPI_ALERT_REPO_PATH", raising=False)
+    monkeypatch.setenv("KIPI_ALERT_FALLBACK_PROJECT", "kipi-system")
+
+    code, _ = mod.file_alert("[/] Meeting loop could not run: token missing", now=1000.0)
+    assert code == mod.EXIT_OK
+    assert fake.create_input.get("projectId") == "proj-kipi"
+
+
+def test_a_broken_project_lookup_never_costs_the_alert(isolated_state, monkeypatch):
+    """Same posture as the label: a ticket with no project is worth far more than
+    a dropped alert, so a lookup failure degrades rather than raises."""
+    class NoProjects(FakeLinear):
+        def graphql(self, query, variables):
+            if "projects(first" in query:
+                raise RuntimeError("no project read perms")
+            return FakeLinear.graphql(self, query, variables)
+
+    fake = NoProjects()
+    monkeypatch.setattr(mod, "_load_linear", lambda: fake)
+    code, _ = mod.file_alert(AUTOCOMMIT[0], now=1000.0)
+    assert code == mod.EXIT_OK and fake.created == 1
 
 
 def test_the_punctuation_strip_did_not_collapse_everything():

--- a/q-system/.q-system/tests/test_alert_to_linear.py
+++ b/q-system/.q-system/tests/test_alert_to_linear.py
@@ -609,11 +609,14 @@ def test_a_launchd_alert_finds_the_registry_with_no_cli_on_path(
     skel.mkdir(parents=True)
     (skel / "instance-registry.json").write_text(json.dumps({
         "skeleton": {"path": str(skel), "linear_project": "kipi-system"},
-        "instances": [{"name": "KTLYST_strategy", "path": str(inst)}],
+        # Synthetic alias, not a live instance name: this repo is public and
+        # validate-separation Gate 1.2 refuses a shipped file that names one.
+        # What the case needs is only basename != alias, which this has.
+        "instances": [{"name": "Brandprefix_strategy", "path": str(inst)}],
     }), encoding="utf-8")
     m = _load_at(writer, "launchd")
     got = m.project_candidates("[strategy] harvest failed")
-    assert "KTLYST_strategy" in got, got
+    assert "Brandprefix_strategy" in got, got
 
 
 def test_an_instance_with_no_registry_anywhere_invents_nothing(

--- a/q-system/.q-system/tests/test_alert_to_linear.py
+++ b/q-system/.q-system/tests/test_alert_to_linear.py
@@ -351,6 +351,166 @@ def test_a_broken_project_lookup_never_costs_the_alert(isolated_state, monkeypat
     assert code == mod.EXIT_OK and fake.created == 1
 
 
+# --- the skeleton is a registry row too (ASK-839, PR #191 review round 3) ----
+#
+# `_registry_rows()` read only `reg["instances"]`, and the skeleton -- the
+# checkout this script itself lives in and the single biggest alert producer on
+# the board -- is NOT an instances row. It is the registry's own top-level
+# `skeleton` key. So the skeleton was absent from the rows that rung 2 (repo
+# path) and rung 5 (own checkout) both search, and both rungs were dead for it.
+#
+# Measured on the live board 2026-08-15, 82 open alert tickets: 22 carry the
+# label `/` (a cwd with no repo, so no path is exported and no label resolves --
+# rung 5 is their ONLY cover) and 18 carry a kipi-system worktree directory
+# (`.wt-ask791`, `kipi-wt-ask729`, `cleanmain`, `dispatch-checkout`, ...), whose
+# --git-common-dir path is the skeleton -- rung 2. 40 of 82 had no live rung at
+# all.
+#
+# The registry fixture below carries the REAL file's shape, top-level `skeleton`
+# alongside `instances`, because that shape IS the defect. A fixture shaped as a
+# bare list -- which is what every earlier case in this file uses -- cannot see
+# it, which is how a 21-case suite stayed green over a dead production path.
+
+SKELETON_REGISTRY_SHAPE = {
+    "skeleton": {"path": "/tmp/skel", "remote": "https://example.invalid/x.git",
+                 "linear_project": "kipi-system"},
+    "instances": [{"name": "consulting", "linear_project": "ASK Consulting",
+                   "path": "/tmp/consulting"}],
+}
+
+
+def _registry_with_skeleton(tmp_path, skel_path, **skel_extra):
+    reg = tmp_path / "instance-registry.json"
+    body = json.loads(json.dumps(SKELETON_REGISTRY_SHAPE))
+    body["skeleton"]["path"] = str(skel_path)
+    body["skeleton"].update(skel_extra)
+    reg.write_text(json.dumps(body))
+    return reg
+
+
+def test_the_skeleton_is_one_of_the_registry_rows(monkeypatch, tmp_path):
+    """Rungs 2 and 5 both search `_registry_rows()`. A skeleton missing from that
+    list is a skeleton neither rung can ever resolve."""
+    reg = _registry_with_skeleton(tmp_path, tmp_path / "skel")
+    monkeypatch.setenv("KIPI_INSTANCE_REGISTRY", str(reg))
+
+    paths = {r.get("path") for r in mod._registry_rows()}
+    assert str(tmp_path / "skel") in paths, (
+        "the skeleton is absent from the rows, so an alert raised from it "
+        "resolves to no project at all")
+
+
+def test_an_alert_raised_from_the_skeleton_carries_the_skeleton_project(
+        isolated_state, monkeypatch, tmp_path):
+    """Rung 2, for the 18 worktree-labelled tickets.
+
+    slack-notify.sh exports --git-common-dir, so a worktree alert arrives with
+    the SKELETON path and a label (`.wt-ask791`) that names no project. Rung 2 is
+    the whole answer for that shape."""
+    fake = FakeLinear()
+    monkeypatch.setattr(mod, "_load_linear", lambda: fake)
+    skel = tmp_path / "kipi-system"
+    skel.mkdir()
+    monkeypatch.setenv("KIPI_INSTANCE_REGISTRY",
+                       str(_registry_with_skeleton(tmp_path, skel)))
+    monkeypatch.setenv("KIPI_ALERT_REPO_PATH", str(skel))
+    monkeypatch.delenv("KIPI_ALERT_FALLBACK_PROJECT", raising=False)
+
+    code, _ = mod.file_alert(
+        "[.wt-ask791] auto-commit left 3 file(s) uncommitted", now=1000.0)
+    assert code == mod.EXIT_OK
+    assert fake.create_input.get("projectId") == "proj-kipi"
+
+
+def test_the_last_resort_rung_works_without_an_env_production_never_sets(
+        isolated_state, monkeypatch, tmp_path):
+    """Rung 5, for the 22 `[/]` tickets.
+
+    The existing `[/]` case sets KIPI_ALERT_FALLBACK_PROJECT by hand, and NOTHING
+    in this repo sets it -- grep finds one reader and no writer. So that case was
+    passing on an invented fixture while the rung it claims to cover returned "".
+    This one removes the env and leaves rung 5 to do the work it documents."""
+    fake = FakeLinear()
+    monkeypatch.setattr(mod, "_load_linear", lambda: fake)
+    # Through _common_repo_root, so this case reads the same root the rung does
+    # whether the suite runs in the skeleton or in a worktree of it. Hardcoding
+    # SCRIPTS/../../.. passed only in the skeleton and is a false RED elsewhere.
+    own_root = os.path.realpath(mod._common_repo_root(mod._own_checkout_root()))
+    monkeypatch.setenv("KIPI_INSTANCE_REGISTRY",
+                       str(_registry_with_skeleton(tmp_path, own_root)))
+    monkeypatch.delenv("KIPI_ALERT_REPO_PATH", raising=False)
+    monkeypatch.delenv("KIPI_ALERT_FALLBACK_PROJECT", raising=False)
+
+    code, _ = mod.file_alert("[/] Meeting loop could not run: token missing",
+                             now=1000.0)
+    assert code == mod.EXIT_OK
+    assert fake.create_input.get("projectId") == "proj-kipi"
+
+
+def test_a_skeleton_row_with_no_alias_offers_nothing_rather_than_a_guess(
+        monkeypatch, tmp_path):
+    """The negative self-test. Including the skeleton row must not smuggle in a
+    basename derivation -- that is the ASK-840 defect this file's own docstring
+    refuses. A skeleton with no `linear_project` contributes no candidate."""
+    reg = tmp_path / "instance-registry.json"
+    reg.write_text(json.dumps({
+        "skeleton": {"path": str(tmp_path / "kipi-system"),
+                     "remote": "https://example.invalid/x.git"},
+        "instances": []}))
+    monkeypatch.setenv("KIPI_INSTANCE_REGISTRY", str(reg))
+    monkeypatch.setenv("KIPI_ALERT_REPO_PATH", str(tmp_path / "kipi-system"))
+    monkeypatch.delenv("KIPI_ALERT_PROJECT", raising=False)
+    monkeypatch.delenv("KIPI_ALERT_FALLBACK_PROJECT", raising=False)
+
+    assert "kipi-system" not in mod.project_candidates("[x] something broke")
+
+
+def test_rung_five_survives_running_out_of_a_worktree(
+        isolated_state, monkeypatch, tmp_path):
+    """A worktree is never its own registry row, and the fleet's agents all run
+    in one -- 18 of the 82 live alert tickets are labelled with a worktree
+    directory. The last-resort rung has to reach the common repo root, the same
+    fact slack-notify.sh resolves with --git-common-dir, or it is dead in exactly
+    the checkouts that raise the most alerts."""
+    fake = FakeLinear()
+    monkeypatch.setattr(mod, "_load_linear", lambda: fake)
+    skel = tmp_path / "kipi-system"
+    (skel / ".git" / "worktrees" / "wt").mkdir(parents=True)
+    wt = tmp_path / "wt-ask999"
+    wt.mkdir()
+    # The real shape git writes for a linked worktree: .git is a FILE naming the
+    # common dir, and the common dir's parent is the skeleton.
+    (wt / ".git").write_text(f"gitdir: {skel}/.git/worktrees/wt\n")
+    monkeypatch.setenv("KIPI_INSTANCE_REGISTRY",
+                       str(_registry_with_skeleton(tmp_path, skel)))
+    monkeypatch.setattr(mod, "_own_checkout_root", lambda: str(wt))
+    monkeypatch.delenv("KIPI_ALERT_REPO_PATH", raising=False)
+    monkeypatch.delenv("KIPI_ALERT_FALLBACK_PROJECT", raising=False)
+
+    code, _ = mod.file_alert("[/] Meeting loop could not run: token missing",
+                             now=1000.0)
+    assert code == mod.EXIT_OK
+    assert fake.create_input.get("projectId") == "proj-kipi"
+
+
+def test_the_shipped_registry_states_its_own_board_name(monkeypatch):
+    """The data half, which the code half cannot supply.
+
+    The board alias is a FIELD, never derived (ASK-840), so the skeleton row has
+    to carry one or the rung stays dead with the code correct. Reading the real
+    file on purpose: a fixture would pass while the shipped registry drifted.
+
+    Asserted on the SKELETON row, not on "the checkout this test runs from" --
+    the first draft did the latter and it is false by construction in a worktree,
+    which is where the fleet's agents run."""
+    monkeypatch.delenv("KIPI_INSTANCE_REGISTRY", raising=False)
+    skel = [r for r in mod._registry_rows() if r.get("is_skeleton")]
+    assert skel, "the shipped registry contributes no skeleton row"
+    assert mod._linear_project_of(skel[0]), (
+        "the skeleton row names no board project, so rungs 2 and 5 resolve "
+        "nothing for the checkout this script lives in")
+
+
 def test_the_punctuation_strip_did_not_collapse_everything():
     """Re-guards the negative case at the new, more aggressive normalization."""
     distinct = [

--- a/q-system/.q-system/tests/test_alert_to_linear.py
+++ b/q-system/.q-system/tests/test_alert_to_linear.py
@@ -520,3 +520,132 @@ def test_the_punctuation_strip_did_not_collapse_everything():
         "[a] huntkit sync BLOCKED: not a git repo",
     ]
     assert len({mod.fingerprint(m) for m in distinct}) == len(distinct)
+
+
+# --- the registry lives at the SKELETON root; this script ships to instances ---
+# ASK-839, PR #191 review round 4. The fleet updater copies q-system/ and nothing
+# at the repo root, so three-levels-up from an INSTANCE's scripts/ names a file
+# that is not there. Measured 2026-08-15 against the live registry: 24 of 25
+# instances ship this writer, 25 of 25 lack the registry, and 8 have a basename
+# that is not their board alias -- so rungs 2, 3 and 5 were dead in every instance
+# at once and rung 4 handed back a name no project carries.
+#
+# These cases load the writer FROM the copied instance tree rather than patching a
+# path, because the defect is a property of where the running copy sits.
+
+import shutil as _shutil
+
+
+def _instance_checkout(tmp_path, name):
+    """A kipi instance as the fleet updater leaves it: q-system/ copied in, and
+    no instance-registry.json at the repo root."""
+    scripts = tmp_path / name / "q-system" / ".q-system" / "scripts"
+    scripts.mkdir(parents=True)
+    _shutil.copy2(os.path.join(SCRIPTS, "alert-to-linear.py"),
+                  scripts / "alert-to-linear.py")
+    _shutil.copy2(os.path.join(SCRIPTS, "linear-sync.py"), scripts / "linear-sync.py")
+    return tmp_path / name, scripts / "alert-to-linear.py"
+
+
+def _load_at(path, tag):
+    spec = importlib.util.spec_from_file_location(f"alert_at_{tag}", str(path))
+    m = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(m)
+    return m
+
+
+def _kipi_on_path(tmp_path, skeleton, monkeypatch):
+    """The CLI as it is actually installed: a symlink on PATH whose realpath is
+    the skeleton root (measured on this machine, /opt/homebrew/bin/kipi)."""
+    # The executable bit is load-bearing, not housekeeping: shutil.which tests
+    # X_OK, so a 0644 stand-in makes this fixture answer "no CLI on PATH" and the
+    # case would pass or fail for a reason that has nothing to do with the rung.
+    (skeleton / "kipi").write_text("#!/bin/sh\n", encoding="utf-8")
+    os.chmod(skeleton / "kipi", 0o755)
+    bindir = tmp_path / "bin"
+    bindir.mkdir()
+    os.symlink(str(skeleton / "kipi"), str(bindir / "kipi"))
+    monkeypatch.setenv("PATH", str(bindir))
+
+
+@pytest.fixture
+def no_registry_env(monkeypatch, tmp_path):
+    """Nothing about the real machine may decide these cases."""
+    for var in ("KIPI_INSTANCE_REGISTRY", "KIPI_ALERT_PROJECT",
+                "KIPI_ALERT_REPO_PATH", "KIPI_ALERT_FALLBACK_PROJECT"):
+        monkeypatch.delenv(var, raising=False)
+    empty_home = tmp_path / "home"
+    empty_home.mkdir()
+    monkeypatch.setenv("HOME", str(empty_home))
+    monkeypatch.setenv("PATH", str(tmp_path / "nowhere"))
+    return empty_home
+
+
+def test_an_instance_alert_resolves_its_board_alias_through_the_cli(
+        no_registry_env, monkeypatch, tmp_path):
+    """`consulting` is `ASK Consulting` on the board. Rung 4 offers the bare
+    label and no project carries it, so the registry is the only thing that can
+    answer -- and from an instance it is only reachable off the skeleton."""
+    inst, writer = _instance_checkout(tmp_path, "consulting")
+    skel = tmp_path / "skel"
+    skel.mkdir()
+    (skel / "instance-registry.json").write_text(json.dumps({
+        "skeleton": {"path": str(skel), "linear_project": "kipi-system"},
+        "instances": [{"name": "ASK_AI_consultant",
+                       "linear_project": "ASK Consulting", "path": str(inst)}],
+    }), encoding="utf-8")
+    _kipi_on_path(tmp_path, skel, monkeypatch)
+    m = _load_at(writer, "cli")
+    got = m.project_candidates("[consulting] auto-commit left 3 file(s)")
+    assert "ASK Consulting" in got, got
+
+
+def test_a_launchd_alert_finds_the_registry_with_no_cli_on_path(
+        no_registry_env, tmp_path):
+    """3 of this repo's 5 plists set no PATH, so they inherit the minimal one and
+    /opt/homebrew is absent. The canonical-home rung is what covers them."""
+    inst, writer = _instance_checkout(tmp_path, "strategy")
+    skel = no_registry_env / "projects" / "kipi-system"
+    skel.mkdir(parents=True)
+    (skel / "instance-registry.json").write_text(json.dumps({
+        "skeleton": {"path": str(skel), "linear_project": "kipi-system"},
+        "instances": [{"name": "KTLYST_strategy", "path": str(inst)}],
+    }), encoding="utf-8")
+    m = _load_at(writer, "launchd")
+    got = m.project_candidates("[strategy] harvest failed")
+    assert "KTLYST_strategy" in got, got
+
+
+def test_an_instance_with_no_registry_anywhere_invents_nothing(
+        no_registry_env, tmp_path):
+    """THE NEGATIVE SELF-TEST. A ladder that ends in a guess is worse than the
+    dead rung it replaces: it would file every instance's alerts under one wrong
+    project and still look fixed. With no registry on any rung, the only candidate
+    left is the bare label the caller supplied."""
+    _inst, writer = _instance_checkout(tmp_path, "website")
+    m = _load_at(writer, "nothing")
+    assert m.project_candidates("[website] deploy failed") == ["website"]
+
+
+def test_a_skeleton_checkout_still_reads_the_registry_beside_it(
+        no_registry_env, tmp_path):
+    """The in-place rung stays FIRST: a skeleton checkout must read its own
+    registry, never a stale one under the canonical home path."""
+    root = tmp_path / "skelroot"
+    scripts = root / "q-system" / ".q-system" / "scripts"
+    scripts.mkdir(parents=True)
+    _shutil.copy2(os.path.join(SCRIPTS, "alert-to-linear.py"),
+                  scripts / "alert-to-linear.py")
+    _shutil.copy2(os.path.join(SCRIPTS, "linear-sync.py"), scripts / "linear-sync.py")
+    (root / "instance-registry.json").write_text(json.dumps({
+        "skeleton": {"path": str(root), "linear_project": "in-place"}}),
+        encoding="utf-8")
+    stale = no_registry_env / "projects" / "kipi-system"
+    stale.mkdir(parents=True)
+    (stale / "instance-registry.json").write_text(json.dumps({
+        "skeleton": {"path": str(root), "linear_project": "stale"}}),
+        encoding="utf-8")
+    m = _load_at(scripts / "alert-to-linear.py", "inplace")
+    got = m.project_candidates("[skelroot] auto-commit left 1 file(s)")
+    assert "in-place" in got, got
+    assert "stale" not in got, got

--- a/q-system/canonical/decisions.md
+++ b/q-system/canonical/decisions.md
@@ -206,3 +206,42 @@ Monthly audit (1st of month): count decisions by origin tag. If >60% are rubber-
 - **Date:** 2026-08-14
 - **Revisit:** When preflight can see into nested repos a dispatch root does not
   track (`sp` captured), or when the 4 issues are worked and the surfaces go quiet
+
+## A fleet alert is a notification, not dispatch work (ASK-839)
+
+- **Origin:** [SYSTEM-INFERRED]
+- **Decision:** Two halves, both shipped together.
+  1. `alert-to-linear.py` now sets a `projectId` on every ticket it files,
+     derived from the alerting repo through `instance-registry.json`'s
+     `linear_project` field. Attribution, so a ticket says which instance raised
+     it in a field a query can filter on.
+  2. Alert tickets are **excluded from the automatic dispatch queue** by their
+     `kipi-alert-fingerprint` marker: `linear-worker.sh` drops them from both
+     `ready()` and `ready_ignoring_project()`, and `linear-dor-drafter.py`
+     refuses to draft onto them. They stay on the board, labelled `owner:sana`
+     and now project-attributed, for a human or a triage pass to convert into a
+     real issue. They do not enter the loop as pre-scoped work.
+- **The fork this answers:** ASK-839 asked for the 81 existing project-unset
+  alert tickets to be BACKFILLED with a project, OR for an explicit decision
+  that they are not dispatch work. Backfill was refused on the measurement, not
+  on taste: of the 81 open unset alert tickets, only 33 carry a `[label]` prefix
+  that names a real project. 22 were raised from a cwd of `/` and 16 more from a
+  worktree directory (`.wt-ask791`, `kipi-wt-ask729`, `cleanmain`). A backfill
+  invents routing for the majority and then hands a worker a raw alert line
+  ("auto-commit left 3 file(s) uncommitted") as if it were a spec.
+- **Second question, answered in the same change:** yes, the DoR drafter refuses
+  to draft onto a project-unset issue. Drafting a Definition of Ready onto an
+  unroutable ticket does not make it executable, it makes it READY-SHAPED, and
+  ready-shaped is the only thing the worker queue checks. That promotion is what
+  moved these from "not ready" (honest) to "ready and reachable by nobody".
+  Refusals of REAL unrouted issues are counted and named on stdout rather than
+  silently skipped.
+- **Measured 2026-08-15, live ASK board (832 issues):** 81 open alert tickets,
+  all project-unset. 19 already drafted onto, and all 19 were ready-shaped and
+  unset -- 100% of that population and 43% of the 20-issue UNREACHABLE bucket.
+  After the change the worker dry run reports 1 unreachable issue and no
+  `(unset)` at all.
+- **Date:** 2026-08-15
+- **Revisit:** If alert tickets start needing to be worked automatically, the
+  right move is a converter that turns one into a scoped issue, not re-admitting
+  raw alert bodies to the queue.


### PR DESCRIPTION
Closes the ASK-839 DoR. Two commits: the writer half, then the queue decision.

## The defect

`alert-to-linear.py` built its `issueCreate` payload with `teamId` + `labelIds` and **no `projectId`**, so every fleet alert landed project-unset. An unset project cannot route to any checkout: `linear-worker.sh`'s `in_this_repo()` is false for it in every repo at once, so no rotation, no cursor and no clone reaches it. The DoR drafter then appended a Definition of Ready to those tickets, which made them ready-shaped and therefore permanently UNREACHABLE.

Measured against the live ASK board 2026-08-15 (832 issues): **81 open alert tickets, all unset. 19 already drafted onto, and all 19 were ready-shaped and unset** — 100% of that population and 43% of the 20-issue UNREACHABLE bucket. The remaining 62 were being converted one drafter batch a night.

## What changed

**1. The writer sets a project** (`2b67f88a`). Resolution is a candidate list, best evidence first: explicit env, the repo path through `instance-registry.json`, the `[label]` prefix through a registry row, the label itself, then this script's own checkout. The alias comes from the registry's `linear_project` field, never derived from the directory name — the rule ASK-840 landed in the worker.

A single-answer version was written first and the live data refuted it immediately: 22 of the 81 carry the prefix for a cwd of `/` and 16 more carry a worktree directory, each a plausible label matching no project, so returning it *as* the answer filed the ticket unset again while looking fixed.

**2. Alert tickets leave the dispatch queue** (`21c99933`). `linear-worker.sh` drops them from **both** `ready()` and `ready_ignoring_project()` by the `kipi-alert-fingerprint` marker; `linear-dor-drafter.py` refuses to draft onto them.

## The fork the DoR asked me to name

Backfill the 81, **or** declare them not dispatch work. **Picked: not dispatch work.** Refused the backfill on the measurement, not on taste — only 33 of the 81 carry a label naming a real project, so a backfill invents routing for the majority and then hands a worker a raw alert line (`auto-commit left 3 file(s) uncommitted`) as if it were a spec. Recorded in `canonical/decisions.md` with a `[SYSTEM-INFERRED]` origin tag.

## The second question, answered in the same change

*Should the drafter refuse a project-unset issue?* **Yes.** A DoR does not make an unroutable ticket executable, it makes it ready-shaped, and ready-shaped is the only thing the queue checks. Real unrouted issues are counted and named on stdout rather than silently skipped.

## Evidence

Reproducers first, both observed RED against the `origin/main` copies through each suite's own ref hatch:

| Suite | pre-fix | after |
|---|---|---|
| `test_alert_to_linear.py` | 3 failed, 18 passed | **21 passed** |
| `test/test-worker-project-scope.sh` | 19 passed, 5 failed | **24 passed** |
| `test/test-dor-refuses-unroutable.py` (new) | 2 passed, 3 failed | **5 passed** |
| `test/test-linear-dor-drafter-redrive.sh` | — | **52 passed** |

The pre-fix worker **picked** ASK-911 (an alert ticket dispatched as engineering work) and counted 4 unreachable instead of 2. The pre-fix drafter returned `draft` for all three refused shapes.

**The check the DoR names**, live:

```
worker: 31 ready issue(s) (project=kipi-system)
worker: 1 ready-shaped issue(s) UNREACHABLE: no local checkout for lane-h-digest-repeats
```

Was 20 unreachable, of which 19 were `(unset)`. **`(unset)` count is now 0.**

## Also in here

`test-linear-dor-drafter-redrive.sh` now stubs `KIPI_NOTIFY`. `slack-notify.sh` files a live Linear ticket now, and the fable-discipline lint blocks editing a pager-capable runner while a test drives it unstubbed.

## Out of scope (per the DoR)

Dispatch caps, concurrency, registration of other repos.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
