### PR TITLE
An exit-7 that recorded nothing let one issue eat the budget forever (ASK-833)

### DIFF
--- a/q-system/.q-system/scripts/com.kipi.dispatch.plist
+++ b/q-system/.q-system/scripts/com.kipi.dispatch.plist
@@ -78,9 +78,20 @@
 		     12 x 6 = 72 `claude -p` sessions a day; one interactive night on
 		     2026-07-28 spent 89, so this stays inside a night the founder has
 		     already paid for once. Lower it here if that is too much; nothing
-		     in the code depends on the number. -->
+		     in the code depends on the number.
+
+		     LOWERED 12 -> 10, founder-set 2026-08-15, after a run hit the
+		     account's usage limit. The limit did NOT arrive as an error: a
+		     killed agent exits 0 having written nothing, and the worker reads
+		     that as "ran, opened no PR" and retries. Measured that day, three
+		     issues (ASK-734, ASK-747, ASK-833) each reached attempt 4 of a
+		     3-attempt cap with empty branches, and the live plist had drifted
+		     to 40 while this committed copy still read 12 -- so the ceiling
+		     the founder had set was not the ceiling that ran. 10 is the
+		     founder's number; the drift is the part that made the spend
+		     unbounded, and it is fixed by writing BOTH copies. -->
 		<key>KIPI_DISPATCH_DAILY_MAX</key>
-		<string>12</string>
+		<string>10</string>
 
 		<!-- WHEN THE ALLOWANCE REFILLS, local hour. Founder-set 2026-07-28,
 		     for safety rather than tidiness: a midnight reset hands a full

--- a/q-system/.q-system/scripts/converge.sh
+++ b/q-system/.q-system/scripts/converge.sh
@@ -769,6 +769,14 @@ while [ "$ROUND" -lt "$MAX_ROUNDS" ]; do
   # READ THE COUNTER FIRST so the exit-7 branch below can tell "the worker
   # recorded this failure" from "nobody did" (ASK-833).
   ATT_BEFORE="$(attempt_count "$ISSUE")"
+  # CLEAR THE REFUSAL MARKER FIRST so only THIS round's worker can set it. A
+  # marker left behind by an earlier round (converge killed between the worker
+  # setting it and the exit-7 branch reading it) would otherwise suppress a real
+  # failure's attempt forever, which is the bug this file is fixing, inverted.
+  # Best-effort on purpose: the safety-critical write is the bump below, and an
+  # unwritable ledger is caught there with exit 8 rather than twice.
+  python3 "$LEDGER" "$ATTEMPTS" clear-flag "$ISSUE" refused_no_pr >>"$LOG" 2>&1 \
+    || say "note: could not clear the stale refusal marker for $ISSUE; see $LOG"
   $WORKER_CMD --apply --limit 1 --issue "$ISSUE" >>"$LOG" 2>&1
   WRC=$?
 
@@ -782,7 +790,17 @@ while [ "$ROUND" -lt "$MAX_ROUNDS" ]; do
     # A refusal is NOT counted here for the same reason the worker does not count
     # it: a correctly-refused issue is labelled and left, never marked stuck.
     ATT_AFTER="$(attempt_count "$ISSUE")"
-    if [ "$ATT_AFTER" = "$ATT_BEFORE" ]; then
+    # A REFUSAL IS A CORRECT TERMINAL OUTCOME, NOT A FAILED ATTEMPT (PR #192
+    # review round 2, major). An unchanged counter cannot on its own tell "the
+    # worker refused this spec" from "the worker was interrupted": both leave no
+    # PR and touch nothing. Charging the first would let three CORRECT refusals
+    # reach the 3-attempt cap and falsely mark the issue stuck -- the founder-queue
+    # routing ASK-275 removed, re-entering from the driver instead of the worker.
+    # The worker now records the refusal in the shared ledger; this reads it.
+    REFUSED_MARK="$(python3 "$LEDGER" "$ATTEMPTS" get "$ISSUE" refused_no_pr "" 2>/dev/null || echo "")"
+    if [ -n "$REFUSED_MARK" ] && [ "$REFUSED_MARK" != "None" ]; then
+      say "$ISSUE was REFUSED by the worker and left no PR. A refusal is a correct terminal outcome, so it costs no attempt; the issue is held at its refusal label, not marked stuck."
+    elif [ "$ATT_AFTER" = "$ATT_BEFORE" ]; then
       # A FAILED BUMP IS NOT A DETAIL TO SWALLOW (PR #192 review, major).
       # The first cut ended this call in `|| true`. That converts an unwritable
       # ledger into a silent success, the counter stays put, and the retry-forever

--- a/q-system/.q-system/scripts/converge.sh
+++ b/q-system/.q-system/scripts/converge.sh
@@ -40,6 +40,19 @@ NOTIFY="${KIPI_NOTIFY:-$SCRIPT_DIR/slack-notify.sh}"
 STATE_DIR="${KIPI_STATE_DIR:-$HOME/.config/kipi}"
 REVIEWS_DIR="$STATE_DIR/pr-reviews"
 LOG="$STATE_DIR/linear-worker.log"
+# THE SAME LEDGER THE WORKER WRITES, AND DELIBERATELY NOT A SECOND ONE (ASK-833).
+# The 3-attempt cap keys on this file. converge stops at exit-7 without the worker
+# having recorded anything whenever the worker did not RUN TO COMPLETION -- the
+# account's usage limit, a timeout, a SIGTERM. The worker's own "exited 0 but
+# opened no PR" bump cannot cover that: it is a line inside the worker, and a
+# killed worker never reaches its own lines. With no entry the cap never trips, so
+# the issue is re-picked every cycle it wins the rotation, spending a budget slot
+# each time and producing nothing. Measured 2026-08-15: ASK-128 stopped at exit-7
+# twice in one hour and was absent from the ledger entirely; ASK-734, ASK-747 and
+# ASK-833 each reached attempt 4 of a 3-attempt cap on empty branches.
+ATTEMPTS="$STATE_DIR/linear-worker-attempts.json"
+LEDGER="$SCRIPT_DIR/attempts-ledger.py"
+attempt_count() { python3 "$LEDGER" "$ATTEMPTS" get "$1" count 0 2>/dev/null || echo 0; }
 . "$SCRIPT_DIR/pr-verdict-lib.sh"
 # THE ONE SLUG DERIVATION (ASK-738). gh binds to cwd and ignores every path
 # variable here, so every gh call below is scoped with -R from this lib.
@@ -753,11 +766,27 @@ while [ "$ROUND" -lt "$MAX_ROUNDS" ]; do
   # One full round: work phase, then the adversarial review, both bounded inside
   # the worker. A nonzero rc is the worker's own failure handling (it already
   # bumped attempts and pinged); the verdict check below decides what to do.
+  # READ THE COUNTER FIRST so the exit-7 branch below can tell "the worker
+  # recorded this failure" from "nobody did" (ASK-833).
+  ATT_BEFORE="$(attempt_count "$ISSUE")"
   $WORKER_CMD --apply --limit 1 --issue "$ISSUE" >>"$LOG" 2>&1
   WRC=$?
 
   PR="$(pr_for_branch)"
   if [ -z "$PR" ]; then
+    # CHARGE THE ATTEMPT ONLY IF THE WORKER DID NOT (ASK-833). Comparing the
+    # counter across the run is what makes this idempotent: the worker's own
+    # "exited 0 but opened no PR" bump already moved it, and charging a second
+    # one for the same round would mark a retryable issue stuck after two
+    # failures instead of three -- the same starvation bug pointed the other way.
+    # A refusal is NOT counted here for the same reason the worker does not count
+    # it: a correctly-refused issue is labelled and left, never marked stuck.
+    ATT_AFTER="$(attempt_count "$ISSUE")"
+    if [ "$ATT_AFTER" = "$ATT_BEFORE" ]; then
+      python3 "$LEDGER" "$ATTEMPTS" bump-attempt "$ISSUE" \
+        "converge stopped at exit-7: no PR on $BRANCH after round $ROUND (worker rc=$WRC, recorded nothing itself)" \
+        >/dev/null 2>&1 || true
+    fi
     say "STOP exit-7: no PR on $BRANCH after round $ROUND (worker rc=$WRC). Sana could not open one; see $LOG"
     bash "$NOTIFY" "converge $ISSUE: stopped, no PR after round $ROUND" 2>/dev/null || true
     exit 7

--- a/q-system/.q-system/scripts/converge.sh
+++ b/q-system/.q-system/scripts/converge.sh
@@ -783,9 +783,22 @@ while [ "$ROUND" -lt "$MAX_ROUNDS" ]; do
     # it: a correctly-refused issue is labelled and left, never marked stuck.
     ATT_AFTER="$(attempt_count "$ISSUE")"
     if [ "$ATT_AFTER" = "$ATT_BEFORE" ]; then
-      python3 "$LEDGER" "$ATTEMPTS" bump-attempt "$ISSUE" \
-        "converge stopped at exit-7: no PR on $BRANCH after round $ROUND (worker rc=$WRC, recorded nothing itself)" \
-        >/dev/null 2>&1 || true
+      # A FAILED BUMP IS NOT A DETAIL TO SWALLOW (PR #192 review, major).
+      # The first cut ended this call in `|| true`. That converts an unwritable
+      # ledger into a silent success, the counter stays put, and the retry-forever
+      # bug this whole change closes comes straight back -- now with a fix in
+      # place that reads as working. Reproduced by the reviewer against a ledger
+      # path that cannot be written: before=0 after=0 final=0, branch reported
+      # success. An attempt that was not PERSISTED did not happen, so the run
+      # says so and stops on its own exit code rather than blending into the
+      # ordinary no-PR case that the dispatcher expects to see repeatedly.
+      if ! python3 "$LEDGER" "$ATTEMPTS" bump-attempt "$ISSUE" \
+           "converge stopped at exit-7: no PR on $BRANCH after round $ROUND (worker rc=$WRC, recorded nothing itself)" \
+           >>"$LOG" 2>&1; then
+        say "STOP exit-8: could not record the attempt in $ATTEMPTS. The 3-attempt cap keys on that file, so it cannot trip while the write fails and this issue would retry forever. Fix the ledger before re-dispatching; see $LOG"
+        bash "$NOTIFY" "converge $ISSUE: attempts ledger unwritable -- the retry cap is not enforceable until it is fixed" 2>/dev/null || true
+        exit 8
+      fi
     fi
     say "STOP exit-7: no PR on $BRANCH after round $ROUND (worker rc=$WRC). Sana could not open one; see $LOG"
     bash "$NOTIFY" "converge $ISSUE: stopped, no PR after round $ROUND" 2>/dev/null || true

--- a/q-system/.q-system/scripts/linear-worker.sh
+++ b/q-system/.q-system/scripts/linear-worker.sh
@@ -2204,6 +2204,15 @@ json.dump(d,open('$ATTEMPTS','w'),indent=2); print(e['rounds'])" 2>/dev/null || 
     # ASK-275 removed.
     if [ -n "$REFUSED" ]; then
       say "$ISSUE: refused ($REFUSED) and left no PR -- nothing to review, and a refusal is not a failed attempt"
+      # SAY SO WHERE converge CAN READ IT (PR #192 review round 2). converge
+      # stops at exit-7 on "no PR" and charges an attempt when nothing else did.
+      # It cannot tell this refusal from an interrupted worker: both leave the
+      # counter untouched and no PR. Without a durable marker three CORRECT
+      # refusals reach the 3-attempt cap and the issue is falsely marked stuck --
+      # the founder-queue routing ASK-275 removed, re-entering from the driver.
+      # The sentinel files cannot carry it: they are deleted before this line.
+      # The ledger can -- both scripts already share it, through one locked writer.
+      python3 "$LEDGER" "$ATTEMPTS" claim-flag "$ISSUE" refused_no_pr >/dev/null 2>&1 || true
     else
       bump_attempt "$ISSUE" "run exited 0 but opened no PR on $BRANCH (no output)"
     fi

--- a/q-system/.q-system/scripts/test/test-converge.sh
+++ b/q-system/.q-system/scripts/test/test-converge.sh
@@ -319,6 +319,25 @@ set -e
 ok "an attempt the worker already recorded is not charged twice"
 unset REAL_LEDGER ISSUE_UNDER_TEST
 
+# AN ATTEMPT THAT WAS NOT PERSISTED DID NOT HAPPEN (PR #192 review, major).
+# The first cut of the fix above ended its bump in `|| true`, so an unwritable
+# ledger became a silent success: counter unmoved, run reports the ordinary
+# exit-7, and the retry-forever bug returns with a fix in place that reads as
+# working. The cap keys on this file; if the write fails the cap cannot trip, so
+# that case gets its own exit code instead of blending into the no-PR case the
+# dispatcher expects to see repeatedly.
+# A DIRECTORY where the ledger file belongs is the portable unwritable path --
+# no chmod, no root, and it fails the same way on every platform.
+rm -rf "$ATT"; mkdir -p "$ATT"
+echo "" > "$FAKE_PR_FILE"; echo "0" > "$FAKE_ROUND_FILE"
+export FAKE_SEQ="REQUEST CHANGES;sha1"
+set +e; bash "$CONV" --issue ASK-T835 --max-rounds 4 >"$WORK/out" 2>&1; RC=$?; set -e
+[ "$RC" = "8" ] \
+  || fail "an unrecordable attempt must exit 8, not blend into exit-7: got rc=$RC"
+grep -q 'exit-8' "$WORK/out" || fail "exit-8 produced no operator-readable line"
+ok "a ledger that cannot be written stops the run loudly, it is not swallowed"
+rm -rf "$ATT"
+
 # --- wiring ------------------------------------------------------------------
 grep -q 'pr-verdict-lib.sh' "$CONV" || fail "converge.sh must use the shared verdict lib"
 grep -q 'rework_gate'       "$CONV" || fail "converge.sh must gate on rework_gate, not its own regex"

--- a/q-system/.q-system/scripts/test/test-converge.sh
+++ b/q-system/.q-system/scripts/test/test-converge.sh
@@ -338,6 +338,35 @@ grep -q 'exit-8' "$WORK/out" || fail "exit-8 produced no operator-readable line"
 ok "a ledger that cannot be written stops the run loudly, it is not swallowed"
 rm -rf "$ATT"
 
+# A REFUSAL COSTS NO ATTEMPT (PR #192 review round 2, major).
+# An unchanged counter cannot by itself tell "the worker refused this spec" from
+# "the worker was interrupted": both leave no PR and touch nothing. Charging the
+# first would let three CORRECT refusals reach the cap and falsely mark the issue
+# stuck -- the founder-queue routing ASK-275 removed, re-entering from the driver.
+# This worker refuses the way the real one does: it records the refusal marker in
+# the shared ledger and opens no PR.
+cat > "$WORK/bin/refusingworker" <<'EOF'
+#!/usr/bin/env bash
+python3 "$REAL_LEDGER" "$KIPI_STATE_DIR/linear-worker-attempts.json" \
+  claim-flag "$ISSUE_UNDER_TEST" refused_no_pr >/dev/null 2>&1
+exit 0
+EOF
+chmod +x "$WORK/bin/refusingworker"
+export REAL_LEDGER="$ROOT/q-system/.q-system/scripts/attempts-ledger.py"
+export ISSUE_UNDER_TEST=ASK-T836
+rm -f "$ATT"
+echo "" > "$FAKE_PR_FILE"; echo "0" > "$FAKE_ROUND_FILE"
+set +e
+KIPI_CONVERGE_WORKER="$WORK/bin/refusingworker" \
+  bash "$CONV" --issue ASK-T836 --max-rounds 4 >"$WORK/out" 2>&1
+RC=$?
+set -e
+[ "$RC" = "7" ] || fail "a refusal still ends the run at exit 7, got rc=$RC"
+[ "$(att_count ASK-T836)" = "0" ] \
+  || fail "a REFUSAL was charged as a failed attempt; three would falsely mark the issue stuck (ASK-275): count=$(att_count ASK-T836)"
+ok "a refusal costs no attempt, so correct refusals never accumulate into stuck"
+unset REAL_LEDGER ISSUE_UNDER_TEST
+
 # --- wiring ------------------------------------------------------------------
 grep -q 'pr-verdict-lib.sh' "$CONV" || fail "converge.sh must use the shared verdict lib"
 grep -q 'rework_gate'       "$CONV" || fail "converge.sh must gate on rework_gate, not its own regex"

--- a/q-system/.q-system/scripts/test/test-converge.sh
+++ b/q-system/.q-system/scripts/test/test-converge.sh
@@ -264,6 +264,61 @@ ok "kill case leaves no orphan behind (nothing outlives the suite)"
 grep -q 'trap .*TERM' "$CONV" || fail "converge lost its TERM trap"
 ok "TERM/INT/HUP traps wired"
 
+# --- ASK-833: a converge that dies before opening a PR must COST an attempt ---
+# THE DEFECT: exit-7 stops the run but records nothing. The 3-attempt cap keys on
+# the attempts ledger, so an issue that fails this way is re-picked every cycle it
+# wins the rotation, forever -- spending a budget slot each time and producing
+# nothing. Measured 2026-08-15: ASK-128 stopped at exit-7 twice in one hour and
+# was ABSENT from the ledger entirely.
+#
+# WHY THE WORKER'S OWN BUMP DOES NOT COVER THIS. linear-worker.sh already bumps on
+# "exited 0 but opened no PR". That line is only reached by a worker that RUNS TO
+# COMPLETION. A worker killed mid-flight -- the account's usage limit, a timeout,
+# a SIGTERM -- never reaches it, and that is precisely the case converge sees as
+# "no PR". The fake worker here writes no ledger entry, which models exactly that.
+ATT="$WORK/state/linear-worker-attempts.json"
+att_count() { python3 -c "
+import json,sys
+try: d=json.load(open(sys.argv[1]))
+except Exception: d={}
+print(d.get(sys.argv[2],{}).get('count',0))" "$ATT" "$1"; }
+
+rm -f "$ATT"
+echo "" > "$FAKE_PR_FILE"; echo "0" > "$FAKE_ROUND_FILE"
+export FAKE_SEQ="REQUEST CHANGES;sha1"
+set +e; bash "$CONV" --issue ASK-T833 --max-rounds 4 >"$WORK/out" 2>&1; RC=$?; set -e
+[ "$RC" = "7" ] || fail "no-PR must still exit 7, got rc=$RC"
+[ "$(att_count ASK-T833)" = "1" ] \
+  || fail "exit-7 recorded NO attempt, so the cap can never trip (ASK-833): count=$(att_count ASK-T833)"
+ok "exit-7 with no PR costs an attempt, so three of them mark the issue stuck"
+
+# IDEMPOTENCE, THE OTHER HALF. When the worker DID reach its own bump, converge
+# must not charge a second one for the same round: double-counting would mark a
+# genuinely-retryable issue stuck after two failures instead of three, which is
+# the same starvation bug pointed the other way.
+cat > "$WORK/bin/bumpingworker" <<'EOF'
+#!/usr/bin/env bash
+python3 "$REAL_LEDGER" "$KIPI_STATE_DIR/linear-worker-attempts.json" \
+  bump-attempt "$ISSUE_UNDER_TEST" "worker bumped this one itself"
+exit 0
+EOF
+chmod +x "$WORK/bin/bumpingworker"
+export REAL_LEDGER="$ROOT/q-system/.q-system/scripts/attempts-ledger.py"
+export ISSUE_UNDER_TEST=ASK-T834
+rm -f "$ATT"
+echo "" > "$FAKE_PR_FILE"; echo "0" > "$FAKE_ROUND_FILE"
+# set +e: this case also ends at exit-7, and run_case leaves `set -e` in effect,
+# so an unguarded call aborts the whole suite silently at rc=7 -- which reads as
+# a pass to anything that only greps for FAIL.
+set +e
+KIPI_CONVERGE_WORKER="$WORK/bin/bumpingworker" \
+  bash "$CONV" --issue ASK-T834 --max-rounds 4 >"$WORK/out" 2>&1
+set -e
+[ "$(att_count ASK-T834)" = "1" ] \
+  || fail "converge double-charged an attempt the worker already recorded: count=$(att_count ASK-T834)"
+ok "an attempt the worker already recorded is not charged twice"
+unset REAL_LEDGER ISSUE_UNDER_TEST
+
 # --- wiring ------------------------------------------------------------------
 grep -q 'pr-verdict-lib.sh' "$CONV" || fail "converge.sh must use the shared verdict lib"
 grep -q 'rework_gate'       "$CONV" || fail "converge.sh must gate on rework_gate, not its own regex"


### PR DESCRIPTION
## What was stuck

Three issues (ASK-734, ASK-747, ASK-833) sat at attempt **4** of a **3**-attempt cap, on branches holding no commits. The cap could not trip because nothing had been recorded.

## The defect

`converge.sh` stops at exit-7 when the worker returns no PR, and recorded no attempt there. The 3-attempt cap keys on the attempts ledger, so an issue failing this way was re-picked every cycle it won the rotation, spending a budget slot each time and producing nothing.

The worker's own "exited 0 but opened no PR" bump does not cover it. That line is only reached by a worker that runs to completion. A worker killed mid-flight (usage limit, timeout, SIGTERM) never reaches its own lines, and that is exactly the case converge sees as "no PR".

Measured 2026-08-15: ASK-128 stopped at exit-7 twice in one hour and was **absent from the ledger entirely**.

## The fix

Read the counter before the worker runs, read it again at exit-7, charge an attempt only if nobody else did. Idempotent by construction: double-charging would mark a retryable issue stuck after two failures instead of three, which is the same starvation bug pointed the other way.

## Verification

`test-converge.sh` **19/19, exit 0**. The new reproducer is red against HEAD (`count=0`) and green after. The idempotence half is covered by a second case.

That second case needed an explicit `set +e`: `run_case` leaves `set -e` in effect, so an unguarded call ending at exit-7 aborted the suite silently at rc=7 — which reads as a pass to anything that only greps for FAIL.

## Also in this branch

The dispatch daily cap is now **10** (founder-set). The committed template read 12 while the installed job read 40, so the ceiling the founder had set was not the ceiling that ran. Both are 10 now, written by rendering through `install-plist.sh`. ASK-860 carries the unfixed half: nothing *detects* that drift.

🤖 Generated with [Claude Code](https://claude.com/claude-code)