### PR TITLE
A bypass is an act, not a word (ASK-747)

### DIFF
--- a/q-system/.q-system/capability-manifest.json
+++ b/q-system/.q-system/capability-manifest.json
@@ -51,6 +51,10 @@
       "runner": "bash"
     },
     {
+      "path": "q-system/.q-system/scripts/test/test-ask842-dispatch-decision.sh",
+      "runner": "bash"
+    },
+    {
       "path": "q-system/.q-system/scripts/test/test-attempts-ledger.py",
       "runner": "python3"
     },
@@ -80,12 +84,21 @@
       "runner": "bash"
     },
     {
+      "path": "q-system/.q-system/scripts/test/test-client-name-guard.py",
+      "runner": "python3"
+    },
+    {
       "path": "q-system/.q-system/scripts/test/test-containment-gitlink.py",
       "runner": "python3"
     },
     {
       "path": "q-system/.q-system/scripts/test/test-control-file-propagate.sh",
       "runner": "bash"
+    },
+    {
+      "path": "q-system/.q-system/scripts/test/test-converge-crossrepo-receipt.sh",
+      "runner": "bash",
+      "timeout_s": 120
     },
     {
       "path": "q-system/.q-system/scripts/test/test-converge.sh",
@@ -99,6 +112,11 @@
       "path": "q-system/.q-system/scripts/test/test-dispatch-liveness.sh",
       "runner": "bash",
       "timeout_s": 120
+    },
+    {
+      "path": "q-system/.q-system/scripts/test/test-dispatch-per-repo-concurrency.sh",
+      "runner": "bash",
+      "timeout_s": 180
     },
     {
       "path": "q-system/.q-system/scripts/test/test-dispatch-stale-checkout.sh",
@@ -325,10 +343,6 @@
       "timeout_s": 600
     },
     {
-      "path": "q-system/.q-system/scripts/test/test-ask842-dispatch-decision.sh",
-      "runner": "bash"
-    },
-    {
       "path": "q-system/.q-system/scripts/test/test-review-artifact-repo-keyed.sh",
       "runner": "bash"
     },
@@ -482,13 +496,13 @@
       "runner": "python3"
     },
     {
-      "path": "q-system/.q-system/scripts/test_dispatch_reachability.py",
-      "runner": "python3"
-    },
-    {
       "path": "q-system/.q-system/scripts/test_dispatch_alias_reachability.py",
       "runner": "python3",
       "timeout_s": 180
+    },
+    {
+      "path": "q-system/.q-system/scripts/test_dispatch_reachability.py",
+      "runner": "python3"
     },
     {
       "path": "q-system/.q-system/scripts/test_evidence_ledger.py",
@@ -619,6 +633,11 @@
       "runner": "python3"
     },
     {
+      "path": "q-system/.q-system/tests/test_capmap_scratch_and_mention.py",
+      "runner": "python3",
+      "timeout_s": 60
+    },
+    {
       "path": "q-system/.q-system/tests/test_fable_cap_page_deleted.py",
       "runner": "python3"
     },
@@ -639,21 +658,6 @@
     {
       "path": "test_dispatch_pinned.sh",
       "runner": "bash"
-    },
-    {
-      "path": "q-system/.q-system/scripts/test/test-dispatch-per-repo-concurrency.sh",
-      "runner": "bash",
-      "timeout_s": 180
-    },
-    {
-      "path": "q-system/.q-system/tests/test_capmap_scratch_and_mention.py",
-      "runner": "python3",
-      "timeout_s": 60
-    },
-    {
-      "path": "q-system/.q-system/scripts/test/test-converge-crossrepo-receipt.sh",
-      "runner": "bash",
-      "timeout_s": 120
     }
   ],
   "required_data": [],

--- a/q-system/.q-system/scripts/client-name-guard.py
+++ b/q-system/.q-system/scripts/client-name-guard.py
@@ -33,8 +33,14 @@ on-a-missing-script-blocks-the-fix-too).
 
 ## Bypass
 
-Intentional (a public case study with recorded permission): put
-`client-name-guard-skip` in the commit message.
+Intentional (a public case study with recorded permission): put the bypass
+token on its OWN LINE in the commit message, optionally with a reason:
+
+    client-name-guard-skip: case study, permission recorded 2026-08-01
+
+Merely naming the token in prose does not bypass anything -- the guard reads a
+trailer, not a mention. Both stages read the bypass from the commit message; the
+staged stage never reads it from the diff, or editing this file would disarm it.
 
 Usage:
     client-name-guard.py --staged            # staged diff content (pre-commit)
@@ -50,6 +56,59 @@ from pathlib import Path
 
 TOKENS_FILE = Path.home() / ".config" / "kipi" / "client-tokens"
 SKIP = "client-name-guard-skip"
+
+# A BYPASS IS AN ACT, NOT A WORD (ASK-747).
+#
+# This used to be `if SKIP in text`. That cannot tell an author INVOKING the
+# bypass from prose that merely NAMES it, and the guard's own introducing commit
+# proved it: that message documented the token, both hook stages printed
+# `bypassed`, and the guard never scanned the commit that introduced it.
+#
+# So the token must now be a TRAILER -- alone on its line, or `token: reason`.
+# That form cannot occur by accident in a sentence, and it is the shape git
+# itself uses for authorial metadata.
+#
+# Comment lines are skipped. Git strips them from the final message, so a token
+# inside the commented template would authorise a bypass that never appears in
+# the recorded message -- a bypass with no audit trail is the thing this gate is.
+_BYPASS_LINE = re.compile(
+    rf"^\s*{re.escape(SKIP)}\s*(?::\s*\S.*)?\s*$", re.IGNORECASE)
+
+
+def bypass_reason(text):
+    """The trailer that authorises a bypass, or None. Prose mentioning the token
+    is NOT a bypass -- that distinction is the whole point of this function."""
+    for line in (text or "").splitlines():
+        if line.lstrip().startswith("#"):
+            continue
+        if _BYPASS_LINE.match(line):
+            return line.strip()
+    return None
+
+
+def commit_message_text():
+    """The message being written, for the --staged stage.
+
+    THE BYPASS LIVES IN THE COMMIT MESSAGE, NEVER IN THE CONTENT (ASK-747).
+    --staged used to test its own DIFF for the token, so any commit that touched
+    a file CONTAINING the token disarmed the staged scan -- and the file that
+    contains it is this one. The guard was structurally unable to see its own
+    changes. Content is not consent: a diff can say anything, only the author's
+    message can authorise.
+    """
+    path = os.environ.get("LEFTHOOK_COMMIT_MSG_FILE")
+    if not path:
+        try:
+            git_dir = subprocess.run(
+                ["git", "rev-parse", "--git-dir"],
+                capture_output=True, text=True, check=True).stdout.strip()
+        except Exception:  # noqa: BLE001 - no git dir means no message, not a crash
+            return ""
+        path = os.path.join(git_dir, "COMMIT_EDITMSG")
+    try:
+        return Path(path).read_text()
+    except Exception:  # noqa: BLE001 - absent message means no bypass, fail closed
+        return ""
 
 
 def load_tokens():
@@ -102,8 +161,10 @@ def main() -> int:
                          if l.startswith("+") and not l.startswith("+++"))
         where = "staged content"
 
-    if SKIP in text:
-        print(f"client-name-guard: bypassed via {SKIP}")
+    # Read the bypass from the MESSAGE in both stages. See commit_message_text().
+    reason = bypass_reason(text if args.message else commit_message_text())
+    if reason:
+        print(f"client-name-guard: bypassed via trailer {reason!r}")
         return 0
 
     found = hits(text, tokens)

--- a/q-system/.q-system/scripts/test/test-client-name-guard.py
+++ b/q-system/.q-system/scripts/test/test-client-name-guard.py
@@ -1,0 +1,196 @@
+#!/usr/bin/env python3
+"""Paired test for client-name-guard.py (ASK-747).
+
+WHY THIS FILE EXISTS. The guard shipped with no test at all, and its own
+introducing commit was the defect: that message DOCUMENTED the bypass token, the
+old `if SKIP in text` read the mention as an invocation, both hook stages printed
+`bypassed`, and the guard never scanned the commit that introduced it. A guard
+any commit can switch off by talking about it is not a gate.
+
+DRIVEN AS A SUBPROCESS, NOT BY IMPORTING AND MONKEYPATCHING. TOKENS_FILE is
+resolved from Path.home() at import time, so a test that patched the module
+constant would be testing a shape the hook never runs. Every case below sets a
+real HOME with a real token list, stages real content in a real git repo, and
+runs the real argv the lefthook stages use (lefthook.yml: `--staged` in
+pre-commit, `--message {1}` in commit-msg).
+
+NEGATIVE SELF-TEST: run with --against <path-to-pre-fix-guard> to point the same
+cases at the pre-fix blob. The four cases marked PRE_FIX_REGRESSION must FAIL
+there. A case that passes against both versions is not measuring this fix.
+"""
+
+import argparse
+import os
+import subprocess
+import sys
+import tempfile
+from pathlib import Path
+
+HERE = Path(__file__).resolve().parent
+GUARD = HERE.parent / "client-name-guard.py"
+
+# A synthetic client token. NOT a real client name: this repo is public, which is
+# the entire premise of the guard under test, and validate-separation Gate 1.2
+# refuses a shipped file that names a live one.
+CLIENT = "Zorptech"
+SKIP_TOKEN = "client-name-guard-skip"
+
+results = []
+
+
+def record(name, ok, detail=""):
+    results.append((name, ok, detail))
+    print(f"  [{'PASS' if ok else 'FAIL'}] {name}" + (f" -- {detail}" if detail else ""))
+
+
+def run_guard(guard, repo, home, argv, msg_file=None):
+    """Run the guard exactly as a lefthook stage does. Returns (rc, stdout)."""
+    env = dict(os.environ, HOME=str(home))
+    env.pop("LEFTHOOK_COMMIT_MSG_FILE", None)
+    if msg_file is not None:
+        env["LEFTHOOK_COMMIT_MSG_FILE"] = str(msg_file)
+    p = subprocess.run([sys.executable, str(guard)] + argv, cwd=repo,
+                       capture_output=True, text=True, env=env)
+    return p.returncode, p.stdout + p.stderr
+
+
+def make_env(tmp):
+    """A HOME carrying an armed token list, and an initialised git repo."""
+    home = Path(tmp) / "home"
+    (home / ".config" / "kipi").mkdir(parents=True)
+    (home / ".config" / "kipi" / "client-tokens").write_text(
+        f"# one token per line\n{CLIENT}\n")
+    repo = Path(tmp) / "repo"
+    repo.mkdir()
+    for cmd in (["init", "-q"], ["config", "user.email", "t@t"],
+                ["config", "user.name", "t"]):
+        subprocess.run(["git"] + cmd, cwd=repo, check=True,
+                       capture_output=True)
+    return home, repo
+
+
+def stage(repo, name, content):
+    (repo / name).write_text(content)
+    subprocess.run(["git", "add", name], cwd=repo, check=True,
+                   capture_output=True)
+
+
+def main(guard):
+    print(f"client-name-guard self-test against: {guard}\n")
+
+    # --- 1. PRE_FIX_REGRESSION: a message that MENTIONS the token is SCANNED ---
+    # The acceptance case from the DoR, and the guard's own origin story.
+    with tempfile.TemporaryDirectory() as tmp:
+        home, repo = make_env(tmp)
+        msg = repo / "MSG"
+        msg.write_text(
+            f"Add the bypass guard\n\n"
+            f"Authors can bypass this with the {SKIP_TOKEN} token when a case\n"
+            f"study has recorded permission. Rolled out for {CLIENT}.\n")
+        rc, out = run_guard(guard, repo, home, ["--message", str(msg)])
+        record("prose mentioning the token is still SCANNED and BLOCKS",
+               rc == 1 and CLIENT.lower() in out.lower(),
+               f"rc={rc} {out.strip().splitlines()[:1]}")
+
+    # --- 2. a real trailer bypass still works -------------------------------
+    # Guards the fix against going permanently strict: a gate with no usable
+    # intentional path gets deleted, not obeyed.
+    with tempfile.TemporaryDirectory() as tmp:
+        home, repo = make_env(tmp)
+        msg = repo / "MSG"
+        msg.write_text(
+            f"Publish the case study\n\n"
+            f"Permission recorded 2026-08-01.\n\n"
+            f"{SKIP_TOKEN}: case study, permission on file\n"
+            f"About {CLIENT} specifically.\n")
+        rc, out = run_guard(guard, repo, home, ["--message", str(msg)])
+        record("a trailer line DOES bypass", rc == 0 and "bypass" in out.lower(),
+               f"rc={rc}")
+
+    # --- 3. the bare token alone on a line is also a valid trailer ----------
+    with tempfile.TemporaryDirectory() as tmp:
+        home, repo = make_env(tmp)
+        msg = repo / "MSG"
+        msg.write_text(f"Publish\n\nAbout {CLIENT}.\n\n{SKIP_TOKEN}\n")
+        rc, _ = run_guard(guard, repo, home, ["--message", str(msg)])
+        record("the token alone on its own line is a valid trailer", rc == 0,
+               f"rc={rc}")
+
+    # --- 4. PRE_FIX_REGRESSION: a git COMMENT line cannot authorise ---------
+    # Git strips '#' lines from the recorded message, so a bypass claimed there
+    # would leave no audit trail at all.
+    with tempfile.TemporaryDirectory() as tmp:
+        home, repo = make_env(tmp)
+        msg = repo / "MSG"
+        msg.write_text(
+            f"Add a note about {CLIENT}\n\n"
+            f"# On branch main\n# {SKIP_TOKEN}\n")
+        rc, _ = run_guard(guard, repo, home, ["--message", str(msg)])
+        record("a token in a stripped '#' comment does NOT bypass", rc == 1,
+               f"rc={rc}")
+
+    # --- 5. PRE_FIX_REGRESSION: --staged never reads the bypass from the DIFF -
+    # THE SELF-BLINDNESS. The file that defines the token is the guard itself, so
+    # under the old rule any commit touching it disarmed the staged scan.
+    with tempfile.TemporaryDirectory() as tmp:
+        home, repo = make_env(tmp)
+        stage(repo, "guardlike.py",
+              f'SKIP = "{SKIP_TOKEN}"\nOWNER = "{CLIENT}"\n')
+        (Path(repo) / ".git" / "COMMIT_EDITMSG").write_text("ordinary commit\n")
+        rc, out = run_guard(guard, repo, home, ["--staged"])
+        record("token in the DIFF does not disarm the staged scan",
+               rc == 1 and CLIENT.lower() in out.lower(), f"rc={rc}")
+
+    # --- 6. PRE_FIX_REGRESSION: the guard scans ITS OWN file ----------------
+    # DoR acceptance: plant a client name in client-name-guard.py itself.
+    with tempfile.TemporaryDirectory() as tmp:
+        home, repo = make_env(tmp)
+        planted = GUARD.read_text() + f'\n# engagement notes for {CLIENT}\n'
+        stage(repo, "client-name-guard.py", planted)
+        (Path(repo) / ".git" / "COMMIT_EDITMSG").write_text("edit the guard\n")
+        rc, out = run_guard(guard, repo, home, ["--staged"])
+        record("a client name planted in client-name-guard.py itself BLOCKS",
+               rc == 1 and CLIENT.lower() in out.lower(), f"rc={rc}")
+
+    # --- 7. a genuine staged bypass, authorised from the message ------------
+    with tempfile.TemporaryDirectory() as tmp:
+        home, repo = make_env(tmp)
+        stage(repo, "study.md", f"# Case study\n\n{CLIENT} shipped it.\n")
+        msg = repo / "MSG"
+        msg.write_text(f"Publish case study\n\n{SKIP_TOKEN}: permission on file\n")
+        rc, _ = run_guard(guard, repo, home, ["--staged"], msg_file=msg)
+        record("a trailer in the message authorises the STAGED stage too",
+               rc == 0, f"rc={rc}")
+
+    # --- 8. clean content passes, absent token list warns and passes --------
+    with tempfile.TemporaryDirectory() as tmp:
+        home, repo = make_env(tmp)
+        stage(repo, "ok.md", "nothing sensitive here\n")
+        (Path(repo) / ".git" / "COMMIT_EDITMSG").write_text("ordinary\n")
+        rc, _ = run_guard(guard, repo, home, ["--staged"])
+        record("clean staged content passes", rc == 0, f"rc={rc}")
+
+    with tempfile.TemporaryDirectory() as tmp:
+        _, repo = make_env(tmp)
+        bare = Path(tmp) / "barehome"
+        bare.mkdir()
+        stage(repo, "x.md", f"{CLIENT}\n")
+        (Path(repo) / ".git" / "COMMIT_EDITMSG").write_text("ordinary\n")
+        rc, out = run_guard(guard, repo, bare, ["--staged"])
+        record("no token list => WARN and pass, never block",
+               rc == 0 and "no token list" in out, f"rc={rc}")
+
+    failed = [n for n, ok, _ in results if not ok]
+    print()
+    if failed:
+        print(f"client-name-guard self-test: {len(failed)} FAILED")
+        return 1
+    print(f"client-name-guard self-test: all {len(results)} cases passed")
+    return 0
+
+
+if __name__ == "__main__":
+    ap = argparse.ArgumentParser()
+    ap.add_argument("--against", type=Path, default=GUARD,
+                    help="guard implementation to test (for the negative self-test)")
+    sys.exit(main(ap.parse_args().against))


### PR DESCRIPTION
Closes ASK-747.

`client-name-guard` treated its bypass token appearing **anywhere** in a commit message as a bypass. It could not tell an author *invoking* the bypass from prose that merely *names* it. Its own introducing commit proved this: that message documented the token, both hook stages printed `bypassed`, and the guard never scanned the commit that introduced it.

This guards a **public** repo from client names and founder paths.

## Two holes, one shape: content was being read as consent

**1. The message test was a substring test.** It is now a **trailer** — the token alone on its line, or `token: reason`. That form cannot occur inside a sentence, and it is the shape git already uses for authorial metadata. `#` lines are skipped: git strips them from the recorded message, and a bypass with no audit trail is exactly what this gate exists to prevent.

**2. Not in the original finding — `--staged` tested its own DIFF for the token.** The file that defines the token is the guard itself, so *any* commit touching it disarmed the staged scan. That is the mechanism behind "the guard cannot see itself". Both stages now read the bypass from the commit message only.

## This PR's own commit message is the demonstration

It names the bypass token repeatedly in prose. The `client-names-msg` stage **scanned** it and passed, rather than printing `bypassed`.

## The guard had no test. It does now.

Nine cases, driven as a **subprocess** with a real `HOME`, a real token list, a real git repo, and the exact argv both lefthook stages use — `TOKENS_FILE` resolves from `Path.home()` at import time, so a monkeypatched constant would test a shape the hook never runs. The client token is synthetic; naming a real one in a public repo is the thing under test.

```
post-fix:                        all 9 cases passed
pre-fix (blob at origin/main):   5 FAILED
```

### The five that fail pre-fix map to the DoR one for one

| case | pre-fix | post-fix |
|---|---|---|
| prose mentioning the token is still SCANNED | `rc=0 bypassed via …` | `rc=1 BLOCK: client name` |
| a token in a stripped `#` comment does NOT bypass | `rc=0` | `rc=1` |
| a token in the DIFF does not disarm the staged scan | `rc=0` | `rc=1` |
| a client name planted in `client-name-guard.py` **itself** blocks | `rc=0` | `rc=1` |
| a trailer in the message authorises the staged stage too | `rc=1` (impossible pre-fix) | `rc=0` |

### The four that pass in both are deliberate

A real trailer still bypasses, the bare token on its own line still bypasses, clean content passes, and an absent token list still WARNs and passes rather than blocking a fresh clone. They guard against this fix going strict enough to get switched off.

## Wiring

Declared in `capability-manifest.json` so the gate actually runs it. An undeclared test file is a test nobody runs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)