### PR TITLE
One scan, at the only stage that can see both facts (ASK-747)

### DIFF
--- a/lefthook.yml
+++ b/lefthook.yml
@@ -36,16 +36,6 @@ pre-commit:
     receipts-ledger:
       run: python3 q-system/.q-system/scripts/receipts-ledger-check.py
 
-    # Client names are not secrets in the credential sense, so gitleaks passes
-    # them and nothing else looked. This repo is PUBLIC (102 stars, 23 forks) and
-    # a name that reaches it cannot be recalled: rewriting history leaves the
-    # objects in every fork and reachable by SHA. Measured 2026-08-13, the list
-    # carries 0 false positives across 59 real posts and 133 lessons. The token
-    # list is LOCAL (~/.config/kipi/client-tokens), never ships, and an absent
-    # list warns and passes so a fresh clone is never blocked.
-    client-names:
-      run: python3 q-system/.q-system/scripts/client-name-guard.py --staged
-
     blocked-paths:
       run: |
         # Block .env, .envrc, .env.<env>, *.pem/*.key (incl. rotations like key.pem.old), *.jsonl,
@@ -106,6 +96,21 @@ commit-msg:
 
     # Both client names that reached this public repo did so in commit SUBJECTS,
     # which no content gate reads. The staged-content half lives in pre-commit.
+    # Client names are not secrets in the credential sense, so gitleaks passes
+    # them and nothing else looked. This repo is PUBLIC (102 stars, 23 forks) and
+    # a name that reaches it cannot be recalled: rewriting history leaves the
+    # objects in every fork and reachable by SHA. Measured 2026-08-13, the list
+    # carries 0 false positives across 59 real posts and 133 lessons. The token
+    # list is LOCAL (~/.config/kipi/client-tokens), never ships, and an absent
+    # list warns and passes so a fresh clone is never blocked.
+    #
+    # THE ONE client-name scan (ASK-747). It lives here, not at pre-commit,
+    # because this is the only stage that sees the real message for THIS commit
+    # AND can still read `git diff --cached` (the commit object does not exist
+    # yet). It scans BOTH. The pre-commit `--staged` stage was removed: it could
+    # not see the message, so it could not honour a legitimate bypass, and it
+    # tested the skip token against its own staged diff -- any commit touching a
+    # file containing the token went unscanned.
     client-names-msg:
       run: python3 q-system/.q-system/scripts/client-name-guard.py --message {1}
 

--- a/q-system/.q-system/capability-manifest.json
+++ b/q-system/.q-system/capability-manifest.json
@@ -51,6 +51,10 @@
       "runner": "bash"
     },
     {
+      "path": "q-system/.q-system/scripts/test/test-ask842-dispatch-decision.sh",
+      "runner": "bash"
+    },
+    {
       "path": "q-system/.q-system/scripts/test/test-attempts-ledger.py",
       "runner": "python3"
     },
@@ -80,12 +84,21 @@
       "runner": "bash"
     },
     {
+      "path": "q-system/.q-system/scripts/test/test-client-name-guard.py",
+      "runner": "python3"
+    },
+    {
       "path": "q-system/.q-system/scripts/test/test-containment-gitlink.py",
       "runner": "python3"
     },
     {
       "path": "q-system/.q-system/scripts/test/test-control-file-propagate.sh",
       "runner": "bash"
+    },
+    {
+      "path": "q-system/.q-system/scripts/test/test-converge-crossrepo-receipt.sh",
+      "runner": "bash",
+      "timeout_s": 120
     },
     {
       "path": "q-system/.q-system/scripts/test/test-converge.sh",
@@ -101,9 +114,18 @@
       "timeout_s": 120
     },
     {
+      "path": "q-system/.q-system/scripts/test/test-dispatch-per-repo-concurrency.sh",
+      "runner": "bash",
+      "timeout_s": 180
+    },
+    {
       "path": "q-system/.q-system/scripts/test/test-dispatch-stale-checkout.sh",
       "runner": "bash",
       "timeout_s": 120
+    },
+    {
+      "path": "q-system/.q-system/scripts/test/test-dor-refuses-unroutable.py",
+      "runner": "python3"
     },
     {
       "path": "q-system/.q-system/scripts/test/test-findings-block-reader.sh",
@@ -329,10 +351,6 @@
       "timeout_s": 600
     },
     {
-      "path": "q-system/.q-system/scripts/test/test-ask842-dispatch-decision.sh",
-      "runner": "bash"
-    },
-    {
       "path": "q-system/.q-system/scripts/test/test-review-artifact-repo-keyed.sh",
       "runner": "bash"
     },
@@ -486,13 +504,13 @@
       "runner": "python3"
     },
     {
-      "path": "q-system/.q-system/scripts/test_dispatch_reachability.py",
-      "runner": "python3"
-    },
-    {
       "path": "q-system/.q-system/scripts/test_dispatch_alias_reachability.py",
       "runner": "python3",
       "timeout_s": 180
+    },
+    {
+      "path": "q-system/.q-system/scripts/test_dispatch_reachability.py",
+      "runner": "python3"
     },
     {
       "path": "q-system/.q-system/scripts/test_evidence_ledger.py",
@@ -627,6 +645,11 @@
       "runner": "python3"
     },
     {
+      "path": "q-system/.q-system/tests/test_capmap_scratch_and_mention.py",
+      "runner": "python3",
+      "timeout_s": 60
+    },
+    {
       "path": "q-system/.q-system/tests/test_fable_cap_page_deleted.py",
       "runner": "python3"
     },
@@ -647,25 +670,6 @@
     {
       "path": "test_dispatch_pinned.sh",
       "runner": "bash"
-    },
-    {
-      "path": "q-system/.q-system/scripts/test/test-dispatch-per-repo-concurrency.sh",
-      "runner": "bash",
-      "timeout_s": 180
-    },
-    {
-      "path": "q-system/.q-system/tests/test_capmap_scratch_and_mention.py",
-      "runner": "python3",
-      "timeout_s": 60
-    },
-    {
-      "path": "q-system/.q-system/scripts/test/test-converge-crossrepo-receipt.sh",
-      "runner": "bash",
-      "timeout_s": 120
-    },
-    {
-      "path": "q-system/.q-system/scripts/test/test-dor-refuses-unroutable.py",
-      "runner": "python3"
     }
   ],
   "required_data": [],

--- a/q-system/.q-system/scripts/client-name-guard.py
+++ b/q-system/.q-system/scripts/client-name-guard.py
@@ -33,12 +33,41 @@ on-a-missing-script-blocks-the-fix-too).
 
 ## Bypass
 
-Intentional (a public case study with recorded permission): put
-`client-name-guard-skip` in the commit message.
+Intentional (a public case study with recorded permission): put the bypass token
+on its OWN LINE in the commit message, optionally with a reason:
+
+    client-name-guard-skip: case study, permission recorded 2026-08-01
+
+Naming the token in prose bypasses nothing. The guard reads a TRAILER, not a
+mention, and the line must start at column 0 so an indented quote of this very
+docstring is not an invocation.
+
+## One stage, and why (ASK-747)
+
+There is ONE scan and it runs at commit-msg. That is the only stage where both
+facts hold at once:
+
+  * the REAL message for THIS commit arrives as the argument -- no persistence,
+    no cross-commit leak, and it is present for `git commit -m` exactly as for an
+    editor commit;
+  * `git diff --cached` still returns the staged content, because the commit
+    object does not exist yet.
+
+The previous shape ran a second scan at pre-commit. That stage cannot see the
+message, so it could not honour a legitimate bypass, and the first fix attempt
+(PR #194) tried to reach the message through $GIT_DIR/COMMIT_EDITMSG. Both
+consequences were measured, not argued:
+
+  * COMMIT_EDITMSG PERSISTS from the previous commit, so a legitimate bypass in
+    commit N authorised the scan of commit N+1 -- a client name passed;
+  * COMMIT_EDITMSG is ABSENT at pre-commit for `git commit -m`, so the documented
+    bypass did not exist there at all, which routes an author to --no-verify and
+    disarms every other hook in the repo.
+
+Earlier feedback is not worth a gate that contradicts its own escape hatch.
 
 Usage:
-    client-name-guard.py --staged            # staged diff content (pre-commit)
-    client-name-guard.py --message <file>    # commit message (commit-msg)
+    client-name-guard.py --message <file>    # commit-msg: the one authoritative scan
 """
 
 import argparse
@@ -50,6 +79,51 @@ from pathlib import Path
 
 TOKENS_FILE = Path.home() / ".config" / "kipi" / "client-tokens"
 SKIP = "client-name-guard-skip"
+
+# A BYPASS IS AN ACT, NOT A WORD (ASK-747).
+#
+# This was `if SKIP in text`, which cannot tell an author INVOKING the bypass
+# from prose that merely NAMES it. The guard's own introducing commit proved it:
+# that message documented the token, both stages printed `bypassed`, and the
+# guard never scanned the commit that introduced it.
+#
+# ANCHORED AT COLUMN 0, deliberately. Allowing leading whitespace would let an
+# indented quote of the usage docstring above count as an invocation -- the same
+# mention-vs-use confusion one level down. Anchoring also means a git comment
+# line cannot match, without needing a claim about when git strips them (it does
+# NOT strip them for `git commit -m`, so a rule that relied on that would be
+# wrong).
+_BYPASS_LINE = re.compile(rf"^{re.escape(SKIP)}(?::[ \t]*\S.*?)?[ \t]*$")
+
+
+def bypass_reason(message):
+    """The trailer authorising a bypass, or None.
+
+    Reads the MESSAGE ONLY. Content is never consent: a diff can contain any
+    text at all, including this file, which is exactly how the pre-commit stage
+    used to disarm itself (it tested the skip token against its own staged
+    diff, so any commit touching a file containing the token was unscanned).
+    """
+    for line in (message or "").splitlines():
+        if _BYPASS_LINE.match(line):
+            return line.strip()
+    return None
+
+
+def staged_added_lines():
+    """Added lines of the staged diff, still readable at commit-msg time.
+
+    The commit object does not exist yet, so --cached IS this commit's content.
+    Only ADDED lines: a diff that REMOVES a client name is the fix, not the
+    defect. Fails CLOSED -- we only reach here with an armed token list, and a
+    guard that cannot see what is being committed must not report all clear.
+    """
+    r = subprocess.run(["git", "diff", "--cached", "-U0"],
+                       capture_output=True, text=True)
+    if r.returncode != 0:
+        raise RuntimeError(r.stderr.strip() or "git diff --cached failed")
+    return "\n".join(l for l in r.stdout.splitlines()
+                      if l.startswith("+") and not l.startswith("+++"))
 
 
 def load_tokens():
@@ -78,8 +152,12 @@ def hits(text, tokens):
 
 def main() -> int:
     ap = argparse.ArgumentParser()
-    ap.add_argument("--staged", action="store_true")
-    ap.add_argument("--message", type=Path)
+    # --staged is GONE. It was a second scan at a stage that cannot see the
+    # message, so it could neither honour a bypass nor be trusted to refuse one;
+    # it tested the skip token against its own staged diff. One stage, one
+    # verdict -- see the module docstring for the measurements behind that.
+    ap.add_argument("--message", type=Path, required=True,
+                    help="the commit message file (lefthook commit-msg passes {1})")
     args = ap.parse_args()
 
     tokens = load_tokens()
@@ -90,31 +168,37 @@ def main() -> int:
     if not tokens:
         return 0
 
-    if args.message:
-        text = args.message.read_text() if args.message.exists() else ""
-        where = "commit message"
-    else:
-        text = subprocess.run(
-            ["git", "diff", "--cached", "-U0"],
-            capture_output=True, text=True).stdout
-        # only ADDED lines; a diff that REMOVES a client name is the fix, not the defect
-        text = "\n".join(l for l in text.splitlines()
-                         if l.startswith("+") and not l.startswith("+++"))
-        where = "staged content"
+    message = args.message.read_text() if args.message.exists() else ""
 
-    if SKIP in text:
-        print(f"client-name-guard: bypassed via {SKIP}")
+    # The bypass is decided by the message and nothing else, before any scan.
+    reason = bypass_reason(message)
+    if reason:
+        print(f"client-name-guard: bypassed via trailer {reason!r}")
         return 0
 
-    found = hits(text, tokens)
+    # BOTH SURFACES IN ONE PASS. The message and the staged content are separate
+    # leak paths, and each used to be checked by a stage the other could disarm.
+    try:
+        content = staged_added_lines()
+    except RuntimeError as exc:
+        print(f"BLOCK: cannot read the staged diff ({exc}).")
+        print("Refusing rather than reporting all clear. The token list is armed,")
+        print("so passing here would be an unverified claim that nothing leaked.")
+        return 1
+
+    found = [(where, hits(text, tokens))
+             for where, text in (("commit message", message),
+                                 ("staged content", content))]
+    found = [(w, h) for w, h in found if h]
     if not found:
         return 0
 
-    print(f"BLOCK: client name in {where}: {', '.join(found)}")
+    for where, names in found:
+        print(f"BLOCK: client name in {where}: {', '.join(names)}")
     print("This repo is PUBLIC. Client names never go public without recorded")
     print("permission. The pattern is the post, the client is not.")
     print("  fix   : rename to a generic label (example_instance, a client engagement)")
-    print(f"  intend: add '{SKIP}' to the commit message")
+    print(f"  intend: put '{SKIP}: <reason>' on its OWN LINE in the commit message")
     return 1
 
 

--- a/q-system/.q-system/scripts/test/test-client-name-guard.py
+++ b/q-system/.q-system/scripts/test/test-client-name-guard.py
@@ -1,0 +1,205 @@
+#!/usr/bin/env python3
+"""Paired test for client-name-guard.py (ASK-747).
+
+WHY THIS FILE EXISTS. The guard shipped with no test, and its own introducing
+commit was the defect: that message DOCUMENTED the bypass token, `if SKIP in
+text` read the mention as an invocation, both stages printed `bypassed`, and the
+guard never scanned the commit that introduced it.
+
+DRIVEN THROUGH REAL `git commit`, NOT THROUGH A HAND-BUILT ARGV.
+
+That is the whole point of this rewrite. The first attempt (PR #194) had a case
+that passed only because it set LEFTHOOK_COMMIT_MSG_FILE -- a variable NOTHING in
+this repo sets -- so a green suite hid a production path that could not work. So
+every case here installs a real `.git/hooks/commit-msg` that calls the guard with
+"$1" exactly as lefthook's `--message {1}` does, then runs a real `git commit`.
+The producer of the message file is git itself. If the production path is broken,
+these cases go red.
+
+Each case also uses a real HOME with a real token list, because TOKENS_FILE is
+resolved from Path.home() at import time.
+
+NEGATIVE SELF-TEST:
+    test-client-name-guard.py --against <path-to-other-guard>
+points the same cases at another implementation. Against the pre-fix guard the
+cases marked REGRESSION must FAIL. A case that passes against both versions is
+not measuring this fix.
+"""
+
+import argparse
+import os
+import subprocess
+import sys
+import tempfile
+from pathlib import Path
+
+HERE = Path(__file__).resolve().parent
+GUARD = HERE.parent / "client-name-guard.py"
+
+# Synthetic. NOT a real client name: this repo is public, which is the premise of
+# the guard under test, and validate-separation Gate 1.2 refuses a shipped file
+# that names a live instance.
+CLIENT = "Zorptech"
+SKIP_TOKEN = "client-name-guard-skip"
+
+results = []
+
+
+def record(name, ok, detail=""):
+    results.append((name, ok))
+    print(f"  [{'PASS' if ok else 'FAIL'}] {name}" + (f" -- {detail}" if detail else ""))
+
+
+def make_repo(tmp, guard, armed=True):
+    """A real git repo whose commit-msg hook calls the guard the way lefthook does.
+
+    THE HOOK IS THE PRODUCTION WIRING, not a stand-in. lefthook.yml runs
+    `client-name-guard.py --message {1}` in commit-msg; git passes the message
+    file as $1. Nothing here invents a slot.
+    """
+    home = Path(tmp) / "home"
+    (home / ".config" / "kipi").mkdir(parents=True)
+    if armed:
+        (home / ".config" / "kipi" / "client-tokens").write_text(
+            f"# one token per line\n{CLIENT}\n")
+    repo = Path(tmp) / "repo"
+    repo.mkdir()
+    for cmd in (["init", "-q"], ["config", "user.email", "t@t"],
+                ["config", "user.name", "t"], ["config", "commit.gpgsign", "false"]):
+        subprocess.run(["git"] + cmd, cwd=repo, check=True, capture_output=True)
+    hook = repo / ".git" / "hooks" / "commit-msg"
+    hook.write_text(f'#!/bin/sh\nexec "{sys.executable}" "{guard}" --message "$1"\n')
+    hook.chmod(0o755)
+    return home, repo
+
+
+def commit(repo, home, message, files=None):
+    """Run a REAL `git commit -m`. Returns (rc, output). No --no-verify, ever."""
+    for name, body in (files or {}).items():
+        (repo / name).write_text(body)
+        subprocess.run(["git", "add", name], cwd=repo, check=True, capture_output=True)
+    env = dict(os.environ, HOME=str(home))
+    env.pop("LEFTHOOK_COMMIT_MSG_FILE", None)   # nothing may depend on this
+    p = subprocess.run(["git", "commit", "-m", message], cwd=repo,
+                       capture_output=True, text=True, env=env)
+    return p.returncode, p.stdout + p.stderr
+
+
+def head_count(repo):
+    p = subprocess.run(["git", "rev-list", "--count", "HEAD"], cwd=repo,
+                       capture_output=True, text=True)
+    return int(p.stdout.strip()) if p.returncode == 0 else 0
+
+
+def main(guard):
+    print(f"client-name-guard self-test against: {guard}\n")
+
+    # --- 1. REGRESSION: staged content is STILL scanned after the stage move ---
+    # The check most likely to be silently lost by consolidating stages. A clean
+    # message must not launder a client name sitting in the staged file.
+    with tempfile.TemporaryDirectory() as tmp:
+        home, repo = make_repo(tmp, guard)
+        rc, out = commit(repo, home, "ordinary commit message",
+                         {"notes.md": f"internal note about {CLIENT}\n"})
+        record("staged content still BLOCKS when the message is clean",
+               rc != 0 and CLIENT.lower() in out.lower() and head_count(repo) == 0,
+               f"rc={rc}")
+
+    # --- 2. REGRESSION: a message that MENTIONS the token is still SCANNED -----
+    # The originally reported hole, and the guard's own origin story.
+    with tempfile.TemporaryDirectory() as tmp:
+        home, repo = make_repo(tmp, guard)
+        rc, out = commit(
+            repo, home,
+            f"Add the guard\n\nAuthors bypass with the {SKIP_TOKEN} token when a\n"
+            f"case study has recorded permission. Rolled out for {CLIENT}.\n",
+            {"a.md": "clean\n"})
+        record("prose mentioning the token is still SCANNED and BLOCKS",
+               rc != 0 and head_count(repo) == 0, f"rc={rc}")
+
+    # --- 3. `git commit -m` HAS a working bypass path -------------------------
+    # The major that killed PR #194: its bypass did not exist for -m at all, so
+    # the only way through was --no-verify. No --no-verify anywhere in this file.
+    with tempfile.TemporaryDirectory() as tmp:
+        home, repo = make_repo(tmp, guard)
+        rc, out = commit(
+            repo, home,
+            f"Publish the case study\n\nPermission recorded.\n\n"
+            f"{SKIP_TOKEN}: case study, permission on file\n",
+            {"study.md": f"# Case study\n\n{CLIENT} shipped it.\n"})
+        record("a trailer bypasses on a real `git commit -m`",
+               rc == 0 and head_count(repo) == 1, f"rc={rc}")
+
+    # --- 4. REGRESSION: THE CROSS-COMMIT LEAK IS CLOSED -----------------------
+    # The blocker that killed PR #194. Commit N bypasses legitimately; commit N+1
+    # stages a client name with a CLEAN message and no bypass of its own. Under
+    # #194 the bypass persisted in $GIT_DIR/COMMIT_EDITMSG and authorised N+1.
+    with tempfile.TemporaryDirectory() as tmp:
+        home, repo = make_repo(tmp, guard)
+        rc1, _ = commit(repo, home,
+                        f"Publish case study\n\n{SKIP_TOKEN}: permission on file\n",
+                        {"study.md": f"{CLIENT} shipped it.\n"})
+        rc2, out2 = commit(repo, home, "unrelated follow-up, no bypass here",
+                           {"leak.md": f"internal note about {CLIENT}\n"})
+        record("a bypass in commit N does NOT authorise commit N+1",
+               rc1 == 0 and rc2 != 0 and head_count(repo) == 1,
+               f"N rc={rc1}, N+1 rc={rc2}")
+
+    # --- 5. REGRESSION: the guard scans ITS OWN file --------------------------
+    # "The guard cannot see itself": its source contains the skip token, and the
+    # old pre-commit stage tested that token against its own staged diff.
+    with tempfile.TemporaryDirectory() as tmp:
+        home, repo = make_repo(tmp, guard)
+        planted = Path(guard).read_text() + f'\n# engagement notes for {CLIENT}\n'
+        rc, out = commit(repo, home, "edit the guard",
+                         {"client-name-guard.py": planted})
+        record("a client name planted in client-name-guard.py itself BLOCKS",
+               rc != 0 and head_count(repo) == 0, f"rc={rc}")
+
+    # --- 6. a client name in the MESSAGE alone still blocks -------------------
+    with tempfile.TemporaryDirectory() as tmp:
+        home, repo = make_repo(tmp, guard)
+        rc, _ = commit(repo, home, f"work done for {CLIENT} today",
+                       {"a.md": "clean content\n"})
+        record("a client name in the message alone BLOCKS", rc != 0, f"rc={rc}")
+
+    # --- 7. an INDENTED trailer is not an invocation --------------------------
+    # Quoting the guard's own usage docstring inside a message must not bypass.
+    with tempfile.TemporaryDirectory() as tmp:
+        home, repo = make_repo(tmp, guard)
+        rc, _ = commit(repo, home,
+                       f"Document the bypass\n\nThe usage block reads:\n\n"
+                       f"    {SKIP_TOKEN}: some reason\n\nMentioned for {CLIENT}.\n",
+                       {"a.md": "clean\n"})
+        record("an INDENTED quote of the trailer does not bypass", rc != 0,
+               f"rc={rc}")
+
+    # --- 8. the ordinary path still works -------------------------------------
+    with tempfile.TemporaryDirectory() as tmp:
+        home, repo = make_repo(tmp, guard)
+        rc, _ = commit(repo, home, "an ordinary clean commit", {"a.md": "clean\n"})
+        record("a clean commit passes", rc == 0 and head_count(repo) == 1,
+               f"rc={rc}")
+
+    # --- 9. no token list => WARN and pass, never block ------------------------
+    # A fresh clone by someone who is not the founder has no clients to protect.
+    with tempfile.TemporaryDirectory() as tmp:
+        home, repo = make_repo(tmp, guard, armed=False)
+        rc, out = commit(repo, home, "ordinary", {"a.md": f"{CLIENT}\n"})
+        record("no token list => WARN and pass, never block",
+               rc == 0 and "no token list" in out, f"rc={rc}")
+
+    failed = [n for n, ok in results if not ok]
+    print()
+    if failed:
+        print(f"client-name-guard self-test: {len(failed)} FAILED")
+        return 1
+    print(f"client-name-guard self-test: all {len(results)} cases passed")
+    return 0
+
+
+if __name__ == "__main__":
+    ap = argparse.ArgumentParser()
+    ap.add_argument("--against", type=Path, default=GUARD,
+                    help="guard implementation to test (for the negative self-test)")
+    sys.exit(main(ap.parse_args().against))


### PR DESCRIPTION
Closes ASK-747. Implements the amended DoR. Supersedes #194 (closed unmerged).

`client-name-guard` had **two holes of one shape**: content was being read as consent.

- `commit-msg --message` tested the skip token as a **substring**, so a message that merely *named* it disarmed the guard. Its own introducing commit proved this and went unscanned.
- `pre-commit --staged` tested that same token against its own **staged diff**, so any commit touching a file whose content contains the token went unscanned. The file that defines the token is the guard itself.

Fixing only the message half leaves the second one open.

## The fix is a stage move, not a smarter test

One scan, at `commit-msg` — the only stage where both facts hold at once:

- the real message for **this** commit arrives as an argument (no persistence, no cross-commit leak, and present for `git commit -m` exactly as for an editor commit);
- `git diff --cached` still returns staged content, because the commit object does not exist yet.

One invocation scans **both** surfaces. The bypass is decided only by the message, as a trailer anchored at column 0.

`--staged` is removed rather than left as a scan nobody calls. `lefthook.yml` was its only caller.

## Evidence: real `git commit`, no env vars

Every case drives a real `git commit -m` through a real `.git/hooks/commit-msg` calling the guard with `"$1"`, exactly as lefthook does. **No case sets an environment variable.** That is deliberate: #194's suite went green because one case set `LEFTHOOK_COMMIT_MSG_FILE`, which nothing in this repo sets, and that is exactly how its blocker hid.

```
this branch:            all 9 cases passed
pre-fix (origin/main):  5 FAILED
```

The five that fail against the old guard are the measurement:

- staged content still BLOCKS when the message is clean
- prose mentioning the token is still SCANNED and BLOCKS
- a bypass in commit N does NOT authorise commit N+1
- a client name planted in `client-name-guard.py` itself BLOCKS
- an INDENTED quote of the trailer does not bypass

## The cross-commit leak, shown not claimed

Commit 1 has clean content and a message that happens to carry a bypass trailer. Commit 2 stages a client name with a clean message and no bypass of its own.

| | commit 1 | commit 2 | client name in history |
|---|---|---|---|
| **PR #194 wiring** | rc=0 | rc=0 | **YES — commit `ad0d133`** |
| **this branch** | rc=0 | rc=1 | no |

Under #194 the name reached a real commit object.

My first attempt at this reproducer was wrong and I corrected it: I had commit 1 carrying the client name, which #194 blocks for an unrelated reason, so the sequence never reached the leak. The faithful path is a *clean* commit whose message poisons `COMMIT_EDITMSG` for the next one.

## Also fixed, from the #194 review

- The trailer is anchored at column 0, so an indented quote of the guard's own usage docstring is not an invocation.
- The claim that git strips `#` lines is **gone**. `git commit -m` does not strip them, so a rule resting on that would be wrong. Column-0 anchoring covers both cases without needing the claim.

## Wiring

- `lefthook validate` → `All good`
- `test-repo-preflight.sh` → 70 passed, 0 failed
- Declared in `capability-manifest.json` so the gate runs it.
- **This PR's own commit was made through the new wiring, with no `--no-verify`.** The pre-commit stage list no longer contains `client-names`, and `client-names-msg` scanned a message that names the token plus a diff containing the guard source.

🤖 Generated with [Claude Code](https://claude.com/claude-code)