### PR TITLE
The committed copy is what you read; the installed copy is what runs (ASK-860)

### DIFF
--- a/.prd-os/receipts.jsonl
+++ b/.prd-os/receipts.jsonl
@@ -130,3 +130,4 @@
 {"commit_sha": "ed1a901e0a5b7e8e9c004032c836123c6f49bb7c", "issue_id": "ASK-842", "receipts": {"reviewed": "2026-08-15T06:47:50Z"}, "reviewed_at": "2026-08-15T06:47:50Z"}
 {"commit_sha": "53d1b42256ac5b1da930a569e27e458534824089", "issue_id": "ASK-841", "receipts": {"reviewed": "2026-08-15T08:18:54Z"}, "reviewed_at": "2026-08-15T08:18:54Z"}
 {"commit_sha": "d652455f4a1f9d9fe347cba7cc217cba7cb41ec9", "issue_id": "ASK-839", "receipts": {"reviewed": "2026-08-15T10:39:41Z"}, "reviewed_at": "2026-08-15T10:39:41Z"}
+{"commit_sha": "4df16a050d4c08222bde42ab19772bd01046612c", "issue_id": "ASK-860", "receipts": {"reviewed": "2026-08-16T14:38:25Z"}, "reviewed_at": "2026-08-16T14:38:25Z"}

--- a/q-system/.q-system/capability-manifest.json
+++ b/q-system/.q-system/capability-manifest.json
@@ -144,6 +144,10 @@
       "runner": "python3"
     },
     {
+      "path": "q-system/.q-system/scripts/test/test-plist-drift.py",
+      "runner": "python3"
+    },
+    {
       "path": "q-system/.q-system/scripts/test/test-gh-repo-scope-converge.sh",
       "runner": "bash"
     },

--- a/q-system/.q-system/scripts/fleet-health-daily.py
+++ b/q-system/.q-system/scripts/fleet-health-daily.py
@@ -1225,7 +1225,255 @@ def detect_stale_runtime_plugins(_ctx) -> list:
     }]
 
 
+# ---------------------------------------------------------------------------
+# The INSTALLED job vs its RENDERED COMMITTED template (ASK-860)
+#
+# THE SCAR. 2026-08-15 the dispatch daily cap read 12 in
+# `q-system/.q-system/scripts/com.kipi.dispatch.plist` and **40** in
+# `~/Library/LaunchAgents/com.kipi.dispatch.plist`. The committed file is the one
+# a reader inspects to answer "what is the cap?"; the installed one is the cap
+# that actually runs. For an unknown period the loop was authorised to start 40
+# issues a day against a stated ceiling of 12 -- roughly 240 agent sessions a day
+# against a stated 72 -- and nothing in the fleet compared the two copies.
+#
+# `install-plist.sh` makes rendering correct when it is USED. It cannot notice a
+# job installed some other way, or edited in place after the fact. This detector
+# is the thing that notices.
+#
+# WHY HERE AND NOT A COMMIT HOOK. The drift lives on the MACHINE, not in the
+# diff: both copies can be individually correct in git and still disagree at
+# rest. CI has no `~/Library/LaunchAgents` to look at, so a CI-only check is
+# structurally blind -- the same reasoning `detect_stale_runtime_plugins`
+# documents for the plugin registry.
+#
+# REPORT, NEVER REPAIR. A live value may have been set deliberately during an
+# incident. Overwriting it silently is how a deliberate change becomes an
+# unexplained regression, so the finding names the divergence and offers the
+# render command; the human chooses.
+# ---------------------------------------------------------------------------
+
+PLIST_TEMPLATE_DIR = HERE
+PLIST_INSTALLER = HERE / "install-plist.sh"
+
+# A published value is capped, not redacted. This bounds a body, it does not
+# pretend to be a secret filter -- that job is done structurally below.
+_VALUE_CAP = 200
+
+# An XML comment, stripped before parsing. NOT a leniency about plist DATA:
+# comments carry none. It exists because the fleet's own committed templates
+# contain `--` inside comments (they are long prose blocks citing PR rounds),
+# which CoreFoundation accepts -- so launchd loads them and the jobs run -- while
+# expat, the parser behind `plistlib`, rejects the document outright. Reading a
+# live job with a stricter parser than the one launchd uses would report every
+# commented template as unreadable, which is a blind spot wearing an error's
+# clothes. Non-greedy: a comment containing `--` but not `-->` is one comment.
+# A literal `<!--` cannot appear inside a plist <string>, which would have to
+# escape the `<` as `&lt;` to be XML at all.
+_XML_COMMENT_RE = re.compile(r"<!--.*?-->", re.S)
+
+
+def plist_pairs(text: str) -> dict:
+    """A plist's leaf values, keyed by dotted path. Raises ValueError if unreadable.
+
+    Flattened rather than compared as nested objects so a finding can NAME THE
+    KEY that moved (`EnvironmentVariables.KIPI_DISPATCH_DAILY_MAX`) instead of
+    saying two dicts differ, which is what the operator needs to act.
+    """
+    import plistlib
+
+    try:
+        data = plistlib.loads(_XML_COMMENT_RE.sub("", text).encode())
+    except Exception as exc:  # noqa: BLE001 - any parse failure is "unreadable"
+        raise ValueError(f"{type(exc).__name__}: {exc}") from exc
+    out: dict = {}
+    _flatten(data, "", out)
+    return out
+
+
+def _flatten(node, prefix: str, out: dict) -> None:
+    if isinstance(node, dict):
+        for key, value in node.items():
+            _flatten(value, f"{prefix}.{key}" if prefix else str(key), out)
+    elif isinstance(node, (list, tuple)):
+        for index, value in enumerate(node):
+            _flatten(value, f"{prefix}[{index}]", out)
+    else:
+        out[prefix] = str(node)
+
+
+def _render_committed(path: Path) -> str:
+    """The committed template AS INSTALL-PLIST.SH WOULD WRITE IT.
+
+    Shelling the installer rather than re-implementing its `sed` is the point:
+    two substituters would be two definitions of "rendered", and the drift
+    between THEM would be invisible in exactly the way this detector exists to
+    end. `--render-only` writes to a path and touches no live job.
+    """
+    import tempfile
+
+    label = path.stem
+    with tempfile.TemporaryDirectory() as work:
+        out = Path(work) / f"{label}.plist"
+        res = subprocess.run(
+            ["bash", str(PLIST_INSTALLER), label, "--render-only", str(out)],
+            capture_output=True, text=True, timeout=60)
+        if res.returncode != 0 or not out.is_file():
+            raise RuntimeError(
+                f"install-plist.sh --render-only exited {res.returncode}")
+        return out.read_text()
+
+
+def _shown(value: str) -> str:
+    return value if len(value) <= _VALUE_CAP else f"{value[:_VALUE_CAP]}... (truncated)"
+
+
+def _unrenderable(label: str, reason: str) -> dict:
+    """A job whose two copies could not be COMPARED. Unknown, never clean.
+
+    The silent-disable shape this file has been corrected for three times over:
+    a `return []` here would make "I could not look" print identically to "I
+    looked and the job matches". Its own subject, so it cannot collide with a
+    real drift finding for the same label.
+    """
+    return {
+        "subject": f"{label}--unrenderable",
+        "title": f"cannot compare {label} against its committed template",
+        "body": (
+            f"`{label}` could not be compared with its committed template: {reason}\n\n"
+            "While this is true, NOTHING checks whether the installed copy of this "
+            "job matches the one in the repo. Absence of a drift finding for "
+            f"`{label}` is not evidence the two copies agree.\n\n"
+            "## Action\n```bash\n"
+            f"bash q-system/.q-system/scripts/install-plist.sh {label} "
+            "--render-only /tmp/render.plist\n"
+            f"diff /tmp/render.plist ~/Library/LaunchAgents/{label}.plist\n```\n"
+            "Fix what that reports, then confirm this issue stops re-filing."
+        ),
+    }
+
+
+def _drift_finding(label: str, changed: list, only_committed: list,
+                   only_live: list) -> dict:
+    sections = []
+    if changed:
+        sections.append(
+            "## Values that differ\n"
+            "| Key | Committed | Live |\n| -- | -- | -- |\n"
+            + "\n".join(f"| `{k}` | `{_shown(c)}` | `{_shown(l)}` |"
+                        for k, c, l in changed))
+    if only_committed:
+        sections.append(
+            "## Declared in the repo, absent from the installed job\n"
+            + "\n".join(f"- `{k}` (committed `{_shown(v)}`)" for k, v in only_committed))
+    if only_live:
+        # KEY NAMES ONLY, and that is structural rather than a filter over the
+        # text (ASK-204). A key the repo DECLARES is the repo's own knob, so its
+        # live value is the answer the operator came for. A key that exists only
+        # on the installed copy is operator-authored -- the one place a
+        # hand-added credential could sit -- and a Linear issue is permanent.
+        # Nine review rounds found nine bypasses of a value-shaped denylist; this
+        # splits on WHO AUTHORED THE KEY, which has no bypass to find.
+        sections.append(
+            "## Present only on the installed job\n"
+            "Key names only: these were not authored in the repo, and a Linear "
+            "issue is permanent (ASK-204). Read the values in the file itself.\n"
+            + "\n".join(f"- `{k}`" for k in only_live))
+    sections.append(
+        "## Action — read it, then decide\n"
+        "This is REPORTED, not repaired. A live value may have been set "
+        "deliberately during an incident, and overwriting it silently is how a "
+        "deliberate change becomes an unexplained regression.\n\n"
+        "```bash\n"
+        f"bash q-system/.q-system/scripts/install-plist.sh {label} "
+        "--render-only /tmp/render.plist\n"
+        f"diff /tmp/render.plist ~/Library/LaunchAgents/{label}.plist\n```\n"
+        "Then EITHER commit the live value into the template, OR re-install from "
+        f"the template (`install-plist.sh {label}`, which also reloads the job). "
+        "Whichever you pick, both copies end up saying the same thing."
+    )
+    return {
+        # The LABEL, so one job is one permanent issue however many keys move.
+        # A key-set subject would fork a new permanent issue every time the set
+        # of divergent keys changed.
+        "subject": label,
+        "title": f"installed job drifted from its committed template: {label} "
+                 f"({len(changed) + len(only_committed) + len(only_live)} key(s))",
+        "body": "\n\n".join(sections),
+    }
+
+
+def plist_drift_findings(template_dir=None, launch_agents=None, render=None) -> list:
+    """Every committed `com.kipi.*` template vs the job installed from it.
+
+    Injectable so the compare is provable against fixtures: a test that pointed
+    at the real `~/Library/LaunchAgents` would pass or fail on the state of
+    whoever's laptop ran it.
+    """
+    templates = Path(template_dir) if template_dir else PLIST_TEMPLATE_DIR
+    agents = Path(launch_agents) if launch_agents else LAUNCH_AGENTS
+    render = render or _render_committed
+
+    out = []
+    for template in sorted(templates.glob("com.kipi.*.plist")):
+        label = template.stem
+        live_path = agents / f"{label}.plist"
+        # NOT INSTALLED IS NOT DRIFT. `detect_dark_jobs` already owns "a job that
+        # should be running is not"; filing it here too would put one condition
+        # on two permanent issues.
+        if not live_path.is_file():
+            continue
+        try:
+            committed = plist_pairs(render(template))
+            live = plist_pairs(live_path.read_text(errors="ignore"))
+        except (ValueError, RuntimeError, OSError) as exc:
+            out.append(_unrenderable(label, str(exc)))
+            continue
+        changed = [(k, committed[k], live[k]) for k in sorted(committed)
+                   if k in live and committed[k] != live[k]]
+        only_committed = [(k, committed[k]) for k in sorted(committed) if k not in live]
+        only_live = [k for k in sorted(live) if k not in committed]
+        if changed or only_committed or only_live:
+            out.append(_drift_finding(label, changed, only_committed, only_live))
+    return out
+
+
+def detect_plist_drift(_ctx) -> list:
+    """`plist_drift_findings`, refused from a worktree.
+
+    `install-plist.sh` resolves `__KIPI_REPO__` from ITS OWN location, so
+    rendering from a git worktree produces `ProgramArguments` pointing at that
+    worktree -- and EVERY installed job would read as drifted on a path nobody
+    changed. A permanent false issue per job is the most expensive outcome
+    available here, so a worktree render is reported as UNKNOWN rather than
+    guessed at. Same discriminator `install-plist.sh --all` already refuses on:
+    a worktree's `.git` is a file, a primary checkout's is a directory.
+    """
+    if not (REPO_ROOT / ".git").is_dir():
+        return [{
+            "subject": "render-root-is-a-worktree",
+            "title": "plist drift cannot be checked from a worktree",
+            "body": (
+                f"`{REPO_ROOT}` is a git worktree, not the primary checkout. "
+                "`install-plist.sh` resolves `__KIPI_REPO__` from its own location, "
+                "so every rendered template would point at this directory and every "
+                "installed job would read as drifted on a path nobody touched.\n\n"
+                "No comparison was made. That is UNKNOWN, not clean.\n\n"
+                "## Action\nRun `kipi health` from the primary checkout. The 08:15 "
+                "LaunchAgent already does; this finding means something ran it from "
+                "somewhere else."
+            ),
+        }]
+    return plist_drift_findings()
+
+
 DETECTORS = [
+    {
+        "id": "plist-drift",
+        "description": "an installed launchd job disagrees with its rendered committed template",
+        "detect": detect_plist_drift,
+        "action": "file_issue",
+        "lesson": "the-running-code-may-not-be-the-code-you-read",
+    },
     {
         "id": "runtime-plugin-stale",
         "description": "the RUNNING plugin copy is older than the merged one, or hand-edited",

--- a/q-system/.q-system/scripts/fleet-health-daily.py
+++ b/q-system/.q-system/scripts/fleet-health-daily.py
@@ -1271,18 +1271,45 @@ _VALUE_CAP = 200
 # escape the `<` as `&lt;` to be XML at all.
 _XML_COMMENT_RE = re.compile(r"<!--.*?-->", re.S)
 
+# A binary plist's magic. An installed job is NOT required to be XML: `defaults
+# write <plist> KEY value` -- the canonical in-place launchd edit, and exactly
+# the hand-edit this detector exists to catch -- rewrites the file as bplist00,
+# as does `plutil -convert binary1` and every GUI launchd editor. launchd loads
+# both formats, so both are legitimate live jobs and both must be READ, not
+# decoded at.
+_BINARY_PLIST_MAGIC = b"bplist00"
 
-def plist_pairs(text: str) -> dict:
+
+def plist_pairs(source) -> dict:
     """A plist's leaf values, keyed by dotted path. Raises ValueError if unreadable.
 
-    Flattened rather than compared as nested objects so a finding can NAME THE
-    KEY that moved (`EnvironmentVariables.KIPI_DISPATCH_DAILY_MAX`) instead of
-    saying two dicts differ, which is what the operator needs to act.
+    Takes str (XML) or bytes (either format). Flattened rather than compared as
+    nested objects so a finding can NAME THE KEY that moved
+    (`EnvironmentVariables.KIPI_DISPATCH_DAILY_MAX`) instead of saying two dicts
+    differ, which is what the operator needs to act.
+
+    BYTES ARE NEVER DECODED LENIENTLY, and that is the whole point of this
+    signature. Reading a live job with `read_text(errors="ignore")` silently
+    drops every byte that is not valid UTF-8; re-encoding then yields a SHORTER
+    binary plist whose offset table still parses, so `plistlib` ACCEPTS the
+    corrupted document instead of raising. The result was the worst of both:
+    a byte-identical binary job filed a permanent 13-key "your dispatcher has no
+    ProgramArguments" issue, while the real cap drift it was built for went
+    unnamed, and `_unrenderable` never engaged because nothing ever failed
+    (PR #196 round 1). So a binary plist reaches plistlib untouched, and an XML
+    one is decoded STRICTLY -- a decode failure becomes a finding rather than a
+    confident wrong answer.
     """
     import plistlib
 
     try:
-        data = plistlib.loads(_XML_COMMENT_RE.sub("", text).encode())
+        raw = source.encode() if isinstance(source, str) else bytes(source)
+        if not raw.startswith(_BINARY_PLIST_MAGIC):
+            # Comment stripping is an XML-only leniency (see _XML_COMMENT_RE);
+            # binary plists carry no comments, and a `<!--` byte run inside one
+            # would be payload, not syntax.
+            raw = _XML_COMMENT_RE.sub("", raw.decode("utf-8")).encode()
+        data = plistlib.loads(raw)
     except Exception as exc:  # noqa: BLE001 - any parse failure is "unreadable"
         raise ValueError(f"{type(exc).__name__}: {exc}") from exc
     out: dict = {}
@@ -1323,8 +1350,26 @@ def _render_committed(path: Path) -> str:
         return out.read_text()
 
 
-def _shown(value: str) -> str:
-    return value if len(value) <= _VALUE_CAP else f"{value[:_VALUE_CAP]}... (truncated)"
+def _shown(value: str, other: str = None) -> str:
+    """A value capped for display, WINDOWED ON THE DIVERGENCE when there is one.
+
+    Head-truncating both sides renders two values that first differ past
+    `_VALUE_CAP` as two byte-identical cells, so the finding asserts a
+    difference while displaying none (PR #196 round 1). With a counterpart
+    supplied, the window is centred on the first offset at which they differ,
+    which is the only part of a long value the operator came to read.
+    """
+    if len(value) <= _VALUE_CAP:
+        return value
+    start = 0
+    if other is not None:
+        shared = min(len(value), len(other))
+        first_diff = next((i for i in range(shared) if value[i] != other[i]), shared)
+        if first_diff >= _VALUE_CAP:
+            start = first_diff - _VALUE_CAP // 2
+    head = "" if start == 0 else "(truncated) ..."
+    tail = "" if start + _VALUE_CAP >= len(value) else "... (truncated)"
+    return f"{head}{value[start:start + _VALUE_CAP]}{tail}"
 
 
 def _unrenderable(label: str, reason: str) -> dict:
@@ -1359,7 +1404,7 @@ def _drift_finding(label: str, changed: list, only_committed: list,
         sections.append(
             "## Values that differ\n"
             "| Key | Committed | Live |\n| -- | -- | -- |\n"
-            + "\n".join(f"| `{k}` | `{_shown(c)}` | `{_shown(l)}` |"
+            + "\n".join(f"| `{k}` | `{_shown(c, l)}` | `{_shown(l, c)}` |"
                         for k, c, l in changed))
     if only_committed:
         sections.append(
@@ -1411,7 +1456,18 @@ def plist_drift_findings(template_dir=None, launch_agents=None, render=None) -> 
     """
     templates = Path(template_dir) if template_dir else PLIST_TEMPLATE_DIR
     agents = Path(launch_agents) if launch_agents else LAUNCH_AGENTS
-    render = render or _render_committed
+    if render is None:
+        # THE TWO KNOBS ARE NOT INDEPENDENT. `_render_committed` shells
+        # install-plist.sh, which resolves its templates from ITS OWN directory
+        # and cannot be pointed at another one. So a caller who moves
+        # `template_dir` without supplying a matching `render` would compare
+        # files from one tree against renders from a different tree and read the
+        # difference as drift. Refuse rather than compare (PR #196 round 1).
+        if templates != PLIST_TEMPLATE_DIR:
+            raise ValueError(
+                f"template_dir={templates} needs a matching render=; "
+                "install-plist.sh renders only from its own directory")
+        render = _render_committed
 
     out = []
     for template in sorted(templates.glob("com.kipi.*.plist")):
@@ -1424,7 +1480,10 @@ def plist_drift_findings(template_dir=None, launch_agents=None, render=None) -> 
             continue
         try:
             committed = plist_pairs(render(template))
-            live = plist_pairs(live_path.read_text(errors="ignore"))
+            # BYTES, not text: the installed copy may be binary (`defaults
+            # write` writes bplist00) and a lenient decode mangles it into a
+            # confident wrong answer. See plist_pairs.
+            live = plist_pairs(live_path.read_bytes())
         except (ValueError, RuntimeError, OSError) as exc:
             out.append(_unrenderable(label, str(exc)))
             continue

--- a/q-system/.q-system/scripts/test/test-plist-drift.py
+++ b/q-system/.q-system/scripts/test/test-plist-drift.py
@@ -78,15 +78,19 @@ check("the rendered fixture carries the cap key that drifted",
       "KIPI_DISPATCH_DAILY_MAX" in BASE["EnvironmentVariables"], True)
 
 
-def _dirs(live_plist_by_label):
-    """(template dir, LaunchAgents dir) holding the real render plus mutations."""
+def _dirs(live_plist_by_label, fmt=plistlib.FMT_XML):
+    """(template dir, LaunchAgents dir) holding the real render plus mutations.
+
+    `fmt` is the format the LIVE copy is written in. Both are legitimate: a job
+    edited with `defaults write` ends up as FMT_BINARY, and launchd loads it.
+    """
     root = Path(tempfile.mkdtemp(prefix="ask860-case-", dir=WORK))
     templates, agents = root / "templates", root / "LaunchAgents"
     templates.mkdir()
     agents.mkdir()
     shutil.copy(RENDERED, templates / "com.kipi.dispatch.plist")
     for label, data in live_plist_by_label.items():
-        (agents / f"{label}.plist").write_bytes(plistlib.dumps(data))
+        (agents / f"{label}.plist").write_bytes(plistlib.dumps(data, fmt=fmt))
     return templates, agents
 
 
@@ -99,11 +103,11 @@ def _mutated(**env):
     return data
 
 
-def _drift(live_by_label):
+def _drift(live_by_label, fmt=plistlib.FMT_XML):
     """Run the detector over a fixture pair. Templates are ALREADY rendered here,
     so the renderer is the identity: the case under test is the COMPARE, not the
     substitution (which the producer above already exercised for real)."""
-    templates, agents = _dirs(live_by_label)
+    templates, agents = _dirs(live_by_label, fmt=fmt)
     return fh.plist_drift_findings(
         template_dir=templates,
         launch_agents=agents,
@@ -170,14 +174,72 @@ def _boom(_path):
     raise RuntimeError("render failed")
 
 
+# ONE fixture root, not two: taking templates from one _dirs() call and agents
+# from a second builds a pair that never existed on any machine.
+_blind_templates, _blind_agents = _dirs({"com.kipi.dispatch": BASE})
 _blind = fh.plist_drift_findings(
-    template_dir=_dirs({"com.kipi.dispatch": BASE})[0],
-    launch_agents=_dirs({"com.kipi.dispatch": BASE})[1],
+    template_dir=_blind_templates,
+    launch_agents=_blind_agents,
     render=_boom,
 )
 check("an unrenderable template yields a finding, not silence", len(_blind), 1)
 check("the cannot-run finding has its own subject, so it cannot collide",
       _blind[0]["subject"] if _blind else None, "com.kipi.dispatch--unrenderable")
+
+# === A BINARY INSTALLED JOB IS A REAL JOB, NOT GARBAGE =====================
+# `defaults write <plist> KEY value` is THE canonical in-place launchd edit --
+# the exact hand-edit this detector exists to catch -- and it rewrites the file
+# as bplist00. Reading that with `read_text(errors="ignore")` drops every
+# non-UTF-8 byte; plistlib then ACCEPTS the shortened binary rather than
+# raising, so the detector both cried wolf on a healthy job and went blind to
+# the drift it was built for. Neither failure announced itself.
+_bin_identical = _drift({"com.kipi.dispatch": BASE}, fmt=plistlib.FMT_BINARY)
+check("a BINARY installed job identical to its template files NOTHING",
+      _bin_identical, [])
+
+_bin_incident = _drift({"com.kipi.dispatch": _mutated(KIPI_DISPATCH_DAILY_MAX="40")},
+                       fmt=plistlib.FMT_BINARY)
+check("the 2026-08-15 drift is still caught when the live job is BINARY",
+      len(_bin_incident), 1)
+_bin_body = body_of(_bin_incident, "com.kipi.dispatch")
+check("the BINARY finding names the key", "KIPI_DISPATCH_DAILY_MAX" in _bin_body, True)
+check("the BINARY finding carries the live value", "`40`" in _bin_body, True)
+check("the BINARY finding carries the committed value", f"`{_live_cap}`" in _bin_body, True)
+
+# A live copy that is neither valid XML nor a real binary plist stays UNKNOWN.
+# Strict decoding is what keeps this from parsing into a confident wrong answer.
+_junk_templates, _junk_agents = _dirs({})
+(_junk_agents / "com.kipi.dispatch.plist").write_bytes(b"\xff\xfe not a plist \x00\x01")
+_junk = fh.plist_drift_findings(
+    template_dir=_junk_templates, launch_agents=_junk_agents,
+    render=lambda path: path.read_text())
+check("an undecodable live job is UNKNOWN, not silently clean",
+      [f["subject"] for f in _junk], ["com.kipi.dispatch--unrenderable"])
+
+# === A DIFFERENCE PAST THE DISPLAY CAP MUST STILL BE VISIBLE ===============
+# Head-truncating both sides renders a late divergence as two identical cells:
+# the issue asserts a difference while showing none. No committed template holds
+# a value this long today, which is exactly why nothing would have caught it.
+_cap = fh._VALUE_CAP
+_long_a, _long_b = "x" * (_cap + 50) + "AAA", "x" * (_cap + 50) + "BBB"
+_long_row = fh._drift_finding("com.kipi.demo", [("Env.LONG", _long_a, _long_b)], [], [])
+check("the two truncated cells are NOT identical",
+      fh._shown(_long_a, _long_b) == fh._shown(_long_b, _long_a), False)
+check("the committed side of the divergence is shown", "AAA" in _long_row["body"], True)
+check("the live side of the divergence is shown", "BBB" in _long_row["body"], True)
+check("a value under the cap is still shown whole", fh._shown("short", "other"), "short")
+
+# === THE TWO INJECTION KNOBS ARE PAIRED, AND SAY SO ========================
+# The default renderer shells install-plist.sh, which resolves templates from
+# ITS OWN directory. Moving template_dir without a matching render would compare
+# one tree's files against another tree's renders and read that as drift.
+_moved, _moved_agents = _dirs({"com.kipi.dispatch": BASE})
+try:
+    fh.plist_drift_findings(template_dir=_moved, launch_agents=_moved_agents)
+    _refused = False
+except ValueError:
+    _refused = True
+check("a moved template_dir with the default renderer is REFUSED", _refused, True)
 
 # === REGISTRY WIRING =======================================================
 # A detector not in DETECTORS is a function nobody calls.

--- a/q-system/.q-system/scripts/test/test-plist-drift.py
+++ b/q-system/.q-system/scripts/test/test-plist-drift.py
@@ -1,0 +1,195 @@
+#!/usr/bin/env python3
+"""Pairs with fleet-health-daily.py's `plist-drift` detector (ASK-860).
+
+THE SCAR THIS PINS. 2026-08-15 the dispatch daily cap read 12 in the committed
+template `com.kipi.dispatch.plist` and **40** in the installed job at
+`~/Library/LaunchAgents/com.kipi.dispatch.plist`. The committed copy is what a
+reader inspects to answer "what is the cap?"; the installed copy is the cap that
+actually runs. Nothing in the fleet compared them, so for an unknown period the
+loop was authorised to start 40 issues a day against a stated ceiling of 12.
+
+`install-plist.sh` makes rendering correct when it is USED. It cannot notice a
+job installed some other way or edited in place. This detector is what notices.
+
+Run: python3 test-plist-drift.py   (exit 0 = pass)
+"""
+
+import importlib.util
+import plistlib
+import shutil
+import subprocess
+import sys
+import tempfile
+from pathlib import Path
+
+SCRIPTS = Path(__file__).resolve().parents[1]
+HEALTH = SCRIPTS / "fleet-health-daily.py"
+INSTALLER = SCRIPTS / "install-plist.sh"
+
+_spec = importlib.util.spec_from_file_location("fh", HEALTH)
+fh = importlib.util.module_from_spec(_spec)
+_spec.loader.exec_module(fh)
+
+failures = []
+
+
+def check(name, got, want):
+    if got != want:
+        failures.append(f"{name}: got {got!r}, want {want!r}")
+    else:
+        print(f"  ok: {name}")
+
+
+def body_of(findings, subject):
+    for f in findings:
+        if f["subject"] == subject:
+            return f["body"]
+    return ""
+
+
+# ---------------------------------------------------------------------------
+# The fixture comes from the PRODUCER, never from this file's imagination.
+#
+# A plist I hand-write tests my mental model of install-plist.sh, not
+# install-plist.sh. So the "committed" side of every drift case below is the real
+# `com.kipi.dispatch.plist` put through the real installer's `--render-only`, and
+# the "live" side is that same rendered output with ONE value moved. That is
+# exactly the shape of the 2026-08-15 incident.
+# ---------------------------------------------------------------------------
+
+WORK = Path(tempfile.mkdtemp(prefix="ask860-"))
+RENDERED = WORK / "rendered-dispatch.plist"
+_render = subprocess.run(
+    ["bash", str(INSTALLER), "com.kipi.dispatch", "--render-only", str(RENDERED)],
+    capture_output=True, text=True, timeout=60)
+check("the producer rendered a real template (rc)", _render.returncode, 0)
+if _render.returncode != 0:
+    print(_render.stderr, file=sys.stderr)
+    print("FAIL: cannot build a producer-derived fixture", file=sys.stderr)
+    sys.exit(1)
+
+# Through the module's OWN comment rule, not a second one invented here. The
+# committed templates carry `--` inside their XML comments (long prose blocks
+# citing PR rounds); CoreFoundation accepts that, so launchd loads them and the
+# jobs run, while expat rejects the document outright. A fixture builder with its
+# own parser would drift from the detector's.
+BASE = plistlib.loads(fh._XML_COMMENT_RE.sub("", RENDERED.read_text()).encode())
+check("the rendered fixture carries the cap key that drifted",
+      "KIPI_DISPATCH_DAILY_MAX" in BASE["EnvironmentVariables"], True)
+
+
+def _dirs(live_plist_by_label):
+    """(template dir, LaunchAgents dir) holding the real render plus mutations."""
+    root = Path(tempfile.mkdtemp(prefix="ask860-case-", dir=WORK))
+    templates, agents = root / "templates", root / "LaunchAgents"
+    templates.mkdir()
+    agents.mkdir()
+    shutil.copy(RENDERED, templates / "com.kipi.dispatch.plist")
+    for label, data in live_plist_by_label.items():
+        (agents / f"{label}.plist").write_bytes(plistlib.dumps(data))
+    return templates, agents
+
+
+def _mutated(**env):
+    """The rendered plist with EnvironmentVariables values replaced."""
+    import copy
+
+    data = copy.deepcopy(BASE)
+    data["EnvironmentVariables"].update(env)
+    return data
+
+
+def _drift(live_by_label):
+    """Run the detector over a fixture pair. Templates are ALREADY rendered here,
+    so the renderer is the identity: the case under test is the COMPARE, not the
+    substitution (which the producer above already exercised for real)."""
+    templates, agents = _dirs(live_by_label)
+    return fh.plist_drift_findings(
+        template_dir=templates,
+        launch_agents=agents,
+        render=lambda path: path.read_text(),
+    )
+
+
+# === THE REPRODUCER: the 2026-08-15 incident, replayed =====================
+# Committed says 10 (whatever the template holds), live says 40. RED at HEAD,
+# where nothing looks at the installed copy at all.
+_live_cap = BASE["EnvironmentVariables"]["KIPI_DISPATCH_DAILY_MAX"]
+_incident = _drift({"com.kipi.dispatch": _mutated(KIPI_DISPATCH_DAILY_MAX="40")})
+check("a drifted live value is DETECTED", len(_incident), 1)
+check("the finding's subject is the job label, so it is ONE issue forever",
+      _incident[0]["subject"] if _incident else None, "com.kipi.dispatch")
+
+_body = body_of(_incident, "com.kipi.dispatch")
+check("the body NAMES THE KEY", "KIPI_DISPATCH_DAILY_MAX" in _body, True)
+check("the body carries the COMMITTED value", f"`{_live_cap}`" in _body, True)
+check("the body carries the LIVE value", "`40`" in _body, True)
+
+# === THE NEGATIVE SELF-TEST ================================================
+# A check that cannot go green for the right reason is decoration. An installed
+# job that MATCHES its rendered template must produce nothing at all -- otherwise
+# the detector files a permanent Linear issue for every job, every morning.
+check("an identical installed job produces NO finding",
+      _drift({"com.kipi.dispatch": BASE}), [])
+
+# === REPORT, DO NOT AUTO-REPAIR ============================================
+# A live value may have been set deliberately during an incident. The detector
+# must not carry a repair as a side effect, and must not tell the operator the
+# machine was changed for them.
+check("the detector never writes to the live plist",
+      plistlib.loads((_dirs({"com.kipi.dispatch": _mutated(KIPI_DISPATCH_DAILY_MAX='40')})[1]
+                      / "com.kipi.dispatch.plist").read_bytes())
+      ["EnvironmentVariables"]["KIPI_DISPATCH_DAILY_MAX"], "40")
+check("the body offers the render command rather than claiming a fix",
+      "install-plist.sh" in _body and "auto" not in _body.lower(), True)
+
+# === ASK-204: what a finding CARRIES =======================================
+# A key the repo declares is the repo's own knob, and its live value is the
+# answer the operator needs. A key that exists ONLY on the live copy is operator-
+# authored -- the one place a hand-added credential could sit -- so it is named
+# and never quoted. That is a STRUCTURAL split (who authored the key), not a
+# denylist over value text, which is the architecture ASK-204 threw out.
+_secret = _mutated(SOME_TOKEN="lin_api_realvalue")
+_leak = _drift({"com.kipi.dispatch": _secret})
+_leak_body = body_of(_leak, "com.kipi.dispatch")
+check("a live-only key IS reported", "SOME_TOKEN" in _leak_body, True)
+check("a live-only key's VALUE is never published",
+      "lin_api_realvalue" in _leak_body, False)
+
+# === A JOB WITH NO INSTALLED COPY IS NOT DRIFT =============================
+# `detect_dark_jobs` already owns "a job that should be running is not". A
+# template with nothing installed is a job that was never armed on this machine,
+# and filing it here would fork a second permanent issue for one condition.
+check("a template with no installed job produces no drift finding",
+      _drift({}), [])
+
+# === A DETECTOR THAT CANNOT LOOK SAYS SO ===================================
+# The silent-disable shape this file has already been corrected for three times:
+# quiet is indistinguishable from healthy. An unrenderable template is UNKNOWN.
+def _boom(_path):
+    raise RuntimeError("render failed")
+
+
+_blind = fh.plist_drift_findings(
+    template_dir=_dirs({"com.kipi.dispatch": BASE})[0],
+    launch_agents=_dirs({"com.kipi.dispatch": BASE})[1],
+    render=_boom,
+)
+check("an unrenderable template yields a finding, not silence", len(_blind), 1)
+check("the cannot-run finding has its own subject, so it cannot collide",
+      _blind[0]["subject"] if _blind else None, "com.kipi.dispatch--unrenderable")
+
+# === REGISTRY WIRING =======================================================
+# A detector not in DETECTORS is a function nobody calls.
+_ids = [d["id"] for d in fh.DETECTORS]
+check("plist-drift is registered", "plist-drift" in _ids, True)
+check("the registry still satisfies its own contract", fh.validate_detectors(), [])
+
+shutil.rmtree(WORK, ignore_errors=True)
+
+if failures:
+    print("\nFAILED:")
+    for f in failures:
+        print(f"  - {f}")
+    sys.exit(1)
+print("\nall plist-drift checks passed")


### PR DESCRIPTION
Closes the drift half of ASK-860. The cap number itself (founder's 10) and ASK-833 are out of scope per the DoR.

## What was missing

On 2026-08-15 the dispatch daily cap read **12** in the committed template and **40** in the installed job at `~/Library/LaunchAgents/com.kipi.dispatch.plist`. The committed file is what a reader inspects to answer "what is the cap?"; the installed one is the cap that actually runs. Nothing compared them, so for an unknown period the loop was authorised to start 40 issues a day against a stated ceiling of 12.

`install-plist.sh` makes rendering correct when it is USED. It cannot notice a job installed some other way, or edited in place afterwards.

## What this adds

A `plist-drift` detector on the fleet health path (`kipi health`, the 08:15 LaunchAgent). It renders every committed `com.kipi.*` template through `install-plist.sh --render-only` and diffs it against the job on disk, reporting each divergence by key with the committed value and the live value.

Not a commit hook: the drift lives on the machine, not in the diff. Both copies can be individually correct in git and still disagree at rest, and CI has no `~/Library/LaunchAgents` to look at.

## Design calls worth a reviewer's attention

- **One substituter.** The render shells `install-plist.sh --render-only` rather than re-implementing its `sed`. Two definitions of "rendered" would drift in exactly the way this detector exists to end.
- **Report, never repair.** A live value may have been set deliberately during an incident. The finding names the divergence and offers the render+diff command; the human chooses.
- **Values are published by who authored the key, not by a filter over the text.** A key the repo declares gets its live value printed, because that is the answer the operator came for. A key present only on the installed job is named and never quoted: that is the one place a hand-added credential could sit, and a Linear issue is permanent. This is ASK-204's structural split, so there is no denylist to bypass.
- **Comments are stripped before parsing.** The fleet's own templates carry `--` inside XML comments (long prose blocks citing PR rounds). CoreFoundation accepts that, so launchd loads them and the jobs run; expat, behind `plistlib`, rejects the document outright. Reading a live job with a stricter parser than launchd's would report every commented template as unreadable.
- **A worktree render is refused.** `install-plist.sh` resolves `__KIPI_REPO__` from its own location, so rendering from a worktree points every `ProgramArguments` at that worktree and every job reads as drifted on a path nobody changed. Same discriminator `install-plist.sh --all` already refuses on.
- **Unrenderable / unparseable is its own finding, never silence.** The silent-disable shape this file has been corrected for three times: quiet must not be indistinguishable from healthy.
- **Not installed is not drift.** `detect_dark_jobs` already owns "a job that should be running is not". Filing it here too would put one condition on two permanent issues.

## Verification

Reproducer first, RED observed against HEAD (the detector stashed away):

```
$ python3 q-system/.q-system/scripts/test/test-plist-drift.py
AttributeError: module 'fh' has no attribute '_XML_COMMENT_RE'
EXIT_AT_HEAD=1
```

Green with the change, 17 checks:

```
$ python3 q-system/.q-system/scripts/test/test-plist-drift.py
  ok: a drifted live value is DETECTED
  ok: the body NAMES THE KEY
  ok: the body carries the COMMITTED value
  ok: the body carries the LIVE value
  ok: an identical installed job produces NO finding
  ok: a live-only key's VALUE is never published
  ok: an unrenderable template yields a finding, not silence
  ok: plist-drift is registered
  ...
all plist-drift checks passed
EXIT=0
```

The paired suite still passes, and its "all N shipped detectors run" line moved 7 -> 8:

```
$ python3 q-system/.q-system/scripts/test/test-fleet-health-daily.py
  ok: all 8 shipped detectors run and return findings with subjects
PASS: fleet-health-daily contract holds
FLEET_EXIT=0
```

The fixture is producer-derived: the committed side of every case is the real `com.kipi.dispatch.plist` put through the real installer, with one value moved. The negative self-test (identical job files nothing) is what stops the check being decoration.

Registered in `capability-manifest.json`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
