### PR TITLE
A park label the redrive never read (ASK-872)

### DIFF
--- a/.prd-os/receipts.jsonl
+++ b/.prd-os/receipts.jsonl
@@ -131,3 +131,4 @@
 {"commit_sha": "53d1b42256ac5b1da930a569e27e458534824089", "issue_id": "ASK-841", "receipts": {"reviewed": "2026-08-15T08:18:54Z"}, "reviewed_at": "2026-08-15T08:18:54Z"}
 {"commit_sha": "d652455f4a1f9d9fe347cba7cc217cba7cb41ec9", "issue_id": "ASK-839", "receipts": {"reviewed": "2026-08-15T10:39:41Z"}, "reviewed_at": "2026-08-15T10:39:41Z"}
 {"commit_sha": "4df16a050d4c08222bde42ab19772bd01046612c", "issue_id": "ASK-860", "receipts": {"reviewed": "2026-08-16T14:38:25Z"}, "reviewed_at": "2026-08-16T14:38:25Z"}
+{"commit_sha": "ca71ea8efbcdaaba9e06dc643083bbaa1f7168ef", "issue_id": "ASK-872", "receipts": {"reviewed": "2026-08-16T20:37:04Z"}, "reviewed_at": "2026-08-16T20:37:04Z"}

--- a/kipi-dispatch.sh
+++ b/kipi-dispatch.sh
@@ -1214,7 +1214,9 @@ fi
 # pr-review-agent.sh now persists, and answers with the action.
 #
 # rc 2 (gh could not answer) leaves the fresh pick standing, same as above.
-REVIEW_REDRIVE="$REPO/q-system/.q-system/scripts/review-redrive.py"
+# $REVIEW_REDRIVE is assigned once, above the red-CI block, which now asks this
+# same script for the park answer. One assignment and not two: a second copy of
+# the path is how a file gets moved and only one of its callers follows.
 REVIEW_ACTION=""; REVIEW_NEXT=""; REVIEW_PR=""; REVIEW_SHA=""
 if [ -z "$REDRIVE_NEXT" ] && [ -f "$REVIEW_REDRIVE" ]; then
   REVIEW_LINE="$(python3 "$REVIEW_REDRIVE" --repo-dir "$TARGET_PATH" select 2>>"$LOG")"

--- a/kipi-dispatch.sh
+++ b/kipi-dispatch.sh
@@ -1130,6 +1130,45 @@ NEXT="$(printf '%s' "$WORK_OUT" | grep -oE '\[dry\] would work ASK-[0-9]+' | gre
 # page is finding 1). Its stderr lands in this log, so the skip is visible here.
 REDRIVE="$REPO/q-system/.q-system/scripts/ci-redrive.py"
 REDRIVE_NEXT=""; REDRIVE_SIG=""; REDRIVE_SHA=""
+
+# --- THE PARK GATE, AND THE RED-CI PATH NEEDS IT MOST (ASK-872, PR #201 r4) ---
+# Three labels mean "a human or a gate decided this must not be worked right now"
+# (park_labels.py). review-redrive.py reads them at its select AND at its claim --
+# but the block below runs FIRST, and the reviewer redrive is reached only when
+# this one offered nothing. So the path WITH priority was the path with no park
+# read: a parked issue whose build was also red got dispatched every heartbeat,
+# and `blocked:capability` there means handing an agent work it provably cannot
+# finish. Red CI outranking a reviewer refusal is correct and stays; being
+# unguarded was not part of that decision.
+#
+# IT ASKS review-redrive.py RATHER THAN ci-redrive.py, on purpose. The reader
+# already exists there, and a fourth consumer with its own copy of the label list
+# is the very defect ASK-872 is about. ci-redrive.py is untouched.
+#
+# READ-ONLY: park-check writes no ledger, so asking costs nothing and a refusal
+# leaves the PR's one machine attempt unspent.
+REVIEW_REDRIVE="$REPO/q-system/.q-system/scripts/review-redrive.py"
+
+park_ok() {   # park_ok <issue> <which-redrive>;  0 = clear to dispatch
+  if [ ! -f "$REVIEW_REDRIVE" ]; then
+    # FAILS CLOSED, and loudly. An instance carrying ci-redrive.py but not the
+    # park reader is a half-installed park, which is the shape of this whole
+    # issue; both files ship in the same rsync, so this is a broken install and
+    # not a supported configuration. Refusing names it in the log; skipping the
+    # check would silently restore the defect on exactly that instance.
+    say "$2 redrive: no park reader at $REVIEW_REDRIVE -- refusing to redrive $1 without checking the park labels"
+    return 1
+  fi
+  local out="" rc=0
+  out="$(python3 "$REVIEW_REDRIVE" park-check --issue "$1" 2>>"$LOG")" || rc=$?
+  case "$rc" in
+    0) return 0 ;;
+    4) say "$2 redrive: $1 is parked by $(printf '%s' "$out" | cut -f1) -- not redriving it, nothing claimed" ;;
+    3) say "$2 redrive: Linear could not answer the park labels for $1 -- not redriving it, nothing claimed" ;;
+    *) say "$2 redrive: the park check for $1 exited $rc -- not redriving it, nothing claimed" ;;
+  esac
+  return 1
+}
 if [ -f "$REDRIVE" ]; then
   REDRIVE_LINE="$(KIPI_NOTIFY="$NOTIFY" python3 "$REDRIVE" \
                     --repo-dir "$TARGET_PATH" redrive 2>>"$LOG")"
@@ -1138,8 +1177,17 @@ if [ -f "$REDRIVE" ]; then
     REDRIVE_NEXT="$(printf '%s' "$REDRIVE_LINE" | cut -f1)"
     REDRIVE_SIG="$(printf '%s' "$REDRIVE_LINE" | cut -f2)"
     REDRIVE_SHA="$(printf '%s' "$REDRIVE_LINE" | cut -f3)"
-    say "red-CI redrive: handing $REDRIVE_NEXT back to its agent ahead of the fresh pick${NEXT:+ ($NEXT waits)}"
-    NEXT="$REDRIVE_NEXT"
+    # THE OFFER IS DISCARDED, NOT THE HEARTBEAT. Clearing the three variables
+    # leaves NEXT as whatever the fresh pick found and lets the reviewer redrive
+    # below have its turn -- exiting here instead would let one parked red PR
+    # starve every other path for as long as the park lasted, which is the shape
+    # of the bug ci-redrive's own converge_live() was added to fix (PR #73 r2).
+    if park_ok "$REDRIVE_NEXT" "red-CI"; then
+      say "red-CI redrive: handing $REDRIVE_NEXT back to its agent ahead of the fresh pick${NEXT:+ ($NEXT waits)}"
+      NEXT="$REDRIVE_NEXT"
+    else
+      REDRIVE_NEXT=""; REDRIVE_SIG=""; REDRIVE_SHA=""
+    fi
   elif [ "$REDRIVE_RC" = "2" ]; then
     say "red-CI redrive: gh could not read PR state in $TARGET_NAME -- fresh pick stands, nothing claimed"
   fi
@@ -1229,6 +1277,12 @@ fi
 # already claimed it (or the ledger could not be written, which is the same
 # answer -- nothing was recorded, so nothing may act as though it was).
 if [ -n "$REDRIVE_SIG" ] && [ "$NEXT" = "$REDRIVE_NEXT" ]; then
+  # RE-READ AT THE POINT OF NO RETURN, for the reason the reviewer path re-reads
+  # it (ASK-872, PR #201 review round 1): the offer above is ~70 lines and several
+  # guards ago, and a label can land in that window. Before the claim, never
+  # after -- refusing after would spend the PR's one attempt on work that never
+  # ran, and lifting the park later would not give it back.
+  park_ok "$NEXT" "red-CI" || exit 0
   if ! python3 "$REDRIVE" mark-dispatched --issue "$NEXT" \
        --signature "$REDRIVE_SIG" --head-sha "$REDRIVE_SHA" 2>>"$LOG"; then
     say "red-CI redrive: the attempt for $NEXT is already claimed -- not dispatching"

--- a/kipi-dispatch.sh
+++ b/kipi-dispatch.sh
@@ -1180,6 +1180,13 @@ if [ -z "$REDRIVE_NEXT" ] && [ -f "$REVIEW_REDRIVE" ]; then
     NEXT="$REVIEW_NEXT"
   elif [ "$REVIEW_RC" = "2" ]; then
     say "reviewer redrive: gh could not read PR state in $TARGET_NAME -- fresh pick stands, nothing claimed"
+  elif [ "$REVIEW_RC" = "3" ]; then
+    # A SEPARATE CODE BECAUSE THIS IS A SEPARATE SYSTEM (ASK-872, PR #201 review).
+    # The selector reads two sources: gh for PR state, Linear for the labels that
+    # park an issue. Both being rc 2 made a Linear outage print the gh sentence,
+    # and this line is the operator's only surface -- so the one person who could
+    # fix it was sent to look at the wrong service.
+    say "reviewer redrive: Linear could not answer the park labels in $TARGET_NAME -- fresh pick stands, nothing claimed"
   fi
 fi
 
@@ -1236,12 +1243,26 @@ fi
 # attempt per PR per action per HEAD SHA, so a PR that pushes a real fix is
 # eligible again while a re-review that keeps coming back phantom at the same sha
 # is not retried.
+#
+# THE CLAIM ALSO RE-READS THE PARK LABELS (ASK-872, PR #201 review). `select`
+# checked them, but that was a separate process and every guard between the two
+# takes time an operator can park an issue in. Non-zero still means "do not
+# dispatch" for all three reasons; they are told apart only so the log names the
+# one that happened, because "already claimed" sent the reader to the ledger for
+# a park and for a Linear outage alike.
 if [ -n "$REVIEW_ACTION" ] && [ "$NEXT" = "$REVIEW_NEXT" ]; then
-  if ! python3 "$REVIEW_REDRIVE" mark-dispatched --issue "$NEXT" \
-       --action "$REVIEW_ACTION" --pr "$REVIEW_PR" --head-sha "$REVIEW_SHA" 2>>"$LOG"; then
-    say "reviewer redrive: the $REVIEW_ACTION attempt for $NEXT PR #$REVIEW_PR is already claimed -- not dispatching"
-    exit 0
-  fi
+  python3 "$REVIEW_REDRIVE" mark-dispatched --issue "$NEXT" \
+    --action "$REVIEW_ACTION" --pr "$REVIEW_PR" --head-sha "$REVIEW_SHA" 2>>"$LOG"
+  MARK_RC=$?
+  case "$MARK_RC" in
+    0) ;;
+    4) say "reviewer redrive: $NEXT was parked by a label after it was selected -- not dispatching, attempt unspent"
+       exit 0 ;;
+    3) say "reviewer redrive: Linear could not answer the park labels for $NEXT -- not dispatching, attempt unspent"
+       exit 0 ;;
+    *) say "reviewer redrive: the $REVIEW_ACTION attempt for $NEXT PR #$REVIEW_PR is already claimed -- not dispatching"
+       exit 0 ;;
+  esac
 fi
 
 # Count BEFORE launching. Counting after would let a crash between the two

--- a/q-system/.q-system/capability-manifest.json
+++ b/q-system/.q-system/capability-manifest.json
@@ -388,6 +388,10 @@
       "runner": "python3"
     },
     {
+      "path": "q-system/.q-system/scripts/test/test-review-redrive-isolation.sh",
+      "runner": "bash"
+    },
+    {
       "path": "q-system/.q-system/scripts/test/test-review-redrive-park.sh",
       "runner": "bash"
     },

--- a/q-system/.q-system/capability-manifest.json
+++ b/q-system/.q-system/capability-manifest.json
@@ -388,6 +388,10 @@
       "runner": "python3"
     },
     {
+      "path": "q-system/.q-system/scripts/test/test-review-redrive-park.sh",
+      "runner": "bash"
+    },
+    {
       "path": "q-system/.q-system/scripts/test/test-review-redrive.sh",
       "runner": "bash"
     },

--- a/q-system/.q-system/scripts/linear-worker.sh
+++ b/q-system/.q-system/scripts/linear-worker.sh
@@ -440,6 +440,12 @@ import importlib.util, json, os, sys, pathlib
 here = pathlib.Path(os.environ["SCRIPT_DIR"])
 spec = importlib.util.spec_from_file_location("ls", here / "linear-sync.py")
 ls = importlib.util.module_from_spec(spec); spec.loader.exec_module(ls)
+# park_labels.py: the three labels that park an issue, shared with
+# review-redrive.py (ASK-872). Loaded by FILENAME like linear-sync.py above --
+# the capability gate scans wiring surfaces for a script filename, and a module
+# imported without its .py reads as a dead engine there (ASK-230).
+_pspec = importlib.util.spec_from_file_location("park_labels", here / "park_labels.py")
+park = importlib.util.module_from_spec(_pspec); _pspec.loader.exec_module(park)
 only = (sys.argv[1] or "").strip()
 
 Q = """query($t:ID!,$a:String){issues(filter:{team:{id:{eq:$t}}},first:250,after:$a){
@@ -555,8 +561,7 @@ def ready(i):
 # this filter could most easily cause.
 def ready_ignoring_project(i):
     labels = {l["name"] for l in i["labels"]["nodes"]}
-    return ("owner:assaf" not in labels and "owner:sana" in labels
-            and "needs-scope" not in labels and "blocked:capability" not in labels
+    return (not park.parked_reason(labels) and "owner:sana" in labels
             and not is_fleet_alert(i)
             and i["state"]["type"] in ("backlog", "unstarted")
             and "Definition of Ready" in (i.get("description") or ""))

--- a/q-system/.q-system/scripts/linear-worker.sh
+++ b/q-system/.q-system/scripts/linear-worker.sh
@@ -526,23 +526,23 @@ def in_this_repo(i):
 
 def ready(i):
     labels = {l["name"] for l in i["labels"]["nodes"]}
-    if "owner:assaf" in labels:      return False   # founder decision, hands off
-    if "owner:sana" not in labels:   return False
-    # A REJECTION BY SANA, MADE MACHINE-READABLE (ASK-275).
+    # THE THREE PARK LABELS COME FROM park_labels.py (ASK-872), not from three
+    # string literals here. owner:assaf is a founder decision, needs-scope is a
+    # rejection by Sana made machine-readable (ASK-275) and blocked:capability is
+    # a runner that lacks something it cannot grant itself -- each routes
+    # somewhere different, all three mean not this one, and the module carries
+    # both the names and the reasons.
+    #
+    # It is a MODULE because this file was one of three consumers and the third,
+    # review-redrive.py, had none of them: a park stopped the fresh pick and not
+    # the redrive. A fourth copy is that defect again.
+    #
     # NOTE: no apostrophes anywhere in this heredoc. It sits inside a $( )
     # command substitution, and bash tracks quote state through a quoted
     # heredoc there -- one apostrophe in a PYTHON COMMENT swallowed the rest of
     # the substitution and the whole script died at "unexpected EOF".
-    # Before this label the only way to get a correctly-refused issue out of the
-    # queue was to relabel it `owner:assaf` -- the FOUNDER queue -- which is how
-    # ASK-149 got there on 2026-07-30. Routing an engineering re-scope to the
-    # founder is the thing this loop exists to avoid, so the refusal needed a
-    # label of its own that means "re-scope this", not "the founder decides".
-    if "needs-scope" in labels:      return False
-    # blocked:capability is the OTHER terminal refusal: the spec is fine, the
-    # runner lacks something it cannot grant itself (a harness permission, a
-    # missing tool). Excluded for the same reason, routed somewhere different.
-    if "blocked:capability" in labels: return False
+    if park.parked_reason(labels):   return False
+    if "owner:sana" not in labels:   return False
     if i["state"]["type"] not in ("backlog", "unstarted"): return False
     if is_fleet_alert(i):            return False   # ASK-839, see ALERT_MARKER
     if not in_this_repo(i):          return False

--- a/q-system/.q-system/scripts/park_labels.py
+++ b/q-system/.q-system/scripts/park_labels.py
@@ -1,0 +1,68 @@
+#!/usr/bin/env python3
+"""The labels that PARK an issue, in one place, for every consumer (ASK-872).
+
+WHY THIS FILE EXISTS
+--------------------
+Three labels mean "a human or a gate decided this must not be worked right now",
+and each routes somewhere different. `linear-worker.sh` applied all three in both
+of its selectors, with a comment saying exactly why:
+
+    564: # BOTH SELECTORS, OR THE FIX IS HALF DONE.
+
+`review-redrive.py` is a THIRD consumer that dispatches the same agents at the
+same issues, and on 2026-08-16 it applied none of them:
+
+    $ grep -n "owner:assaf\\|needs-scope\\|blocked:capability" review-redrive.py
+    (no output)
+
+So a park stopped the fresh-pick path and not the redrive. Parking ASK-830 that
+day was not enough on its own -- the PR had to be converted to draft as well,
+because draft is the only thing the redrive actually honoured.
+
+A FOURTH CONSUMER WITH ITS OWN COPY IS THIS SAME DEFECT AGAIN, which is why the
+list is a module and not three more string literals. The two things a consumer
+needs -- the set, and the human reason each one routes differently -- are the
+same two things, so they live in one table rather than a set here and an
+explanation in whichever docstring happened to get written.
+
+WHAT THIS MODULE IS NOT
+-----------------------
+It answers "is this issue parked, and by what". It does NOT fetch labels: where
+labels come from is the caller's problem (the worker already has them in the
+board query it runs anyway; the redrive reads them itself). Folding a fetch in
+here would make one of the two callers pay for a round trip it does not need.
+"""
+
+# Ordered, and the order is the reporting order when an issue carries more than
+# one: the founder's hold outranks a machine refusal, because "hands off" is the
+# answer a human gave and the other two are answers a runner gave.
+PARK_LABELS = (
+    ("owner:assaf", "founder decision, hands off"),
+    ("needs-scope", "refused as unexecutable; the DoR drafter owns it"),
+    ("blocked:capability", "the runner is missing a credential or a binary"),
+)
+
+PARK_LABEL_NAMES = tuple(name for name, _why in PARK_LABELS)
+
+
+def parked_reason(labels):
+    """(label, why) if any park label is present, else None.
+
+    `labels` is any iterable of label-name strings. Returns the FIRST match in
+    PARK_LABELS order, never a set: a caller that has to report which label
+    stopped it cannot use a boolean, and a caller that only needs the boolean
+    can read this as truthy.
+    """
+    have = set(labels or ())
+    for name, why in PARK_LABELS:
+        if name in have:
+            return (name, why)
+    return None
+
+
+if __name__ == "__main__":
+    # A shell consumer that needs the raw list (none today; the worker imports
+    # this module directly). Kept one line long on purpose -- the moment it grows
+    # a format flag, two consumers are parsing text where one could import.
+    for _name, _why in PARK_LABELS:
+        print("%s\t%s" % (_name, _why))

--- a/q-system/.q-system/scripts/review-redrive.py
+++ b/q-system/.q-system/scripts/review-redrive.py
@@ -167,6 +167,17 @@ PARK = _load("park_labels.py", "park_labels")
 class ParkUnavailable(Exception):
     """The park state could not be read. Not the same as nothing being parked."""
 
+
+# THE EXIT CODES THIS SCRIPT HANDS kipi-dispatch.sh, and each unreadable source
+# gets ITS OWN. rc 2 already meant "gh could not read PR state", and the first
+# cut of the park check reused it for "Linear could not answer the labels" --
+# so the dispatcher, whose `say` line is the operator's only surface, reported a
+# Linear outage as a GitHub one and sent the reader to the wrong system
+# (PR #201 review, minor). Two sources, two codes, one message each.
+RC_GH_UNREADABLE = 2
+RC_PARK_UNREADABLE = 3
+RC_PARKED = 4
+
 # Verdicts that mean a human-equivalent reviewer objected and left a spec behind.
 # Kept as a literal set rather than "not an approval": an EMPTY verdict is not an
 # objection, it is an unstated one, and routing empty to rework is precisely the
@@ -702,7 +713,45 @@ def cmd_select(cands, show_all):
     return 1
 
 
-def cmd_mark_dispatched(issue, action, pr, head_sha):
+def cmd_mark_dispatched(issue, action, pr, head_sha, graphql=None):
+    """The atomic claim -- and the LAST point where the park can still be read.
+
+    THE PARK IS RE-READ HERE, NOT INHERITED FROM `select`. The two are separate
+    processes with the dispatcher's own guards running between them (the converge
+    liveness check, the ps snapshot), so a label applied inside that window was
+    invisible to the only check that had run and the issue launched anyway. This
+    is the argument kipi-dispatch.sh already makes for the ledger claim itself --
+    "past every guard that can still abort, and immediately before the launch" --
+    applied to the other precondition that can change underneath it. A park check
+    that is not at the point of no return is a check the dispatch can outrun.
+
+    It also closes the non-race half: `mark-dispatched` is a subcommand, and any
+    caller reaching it without going through `select` got no park check at all.
+
+    BEFORE THE CLAIM, NEVER AFTER, and the ordering is load-bearing. The flag is
+    one attempt per PR per action per head sha. Claiming and then refusing on the
+    park would spend that attempt on work that never ran, and lifting the park
+    later would not give it back -- the next redrive would skip the PR for having
+    "already had its one attempt". Refusing first leaves the attempt unspent.
+    """
+    try:
+        state = parked([issue], graphql=graphql)
+    except ParkUnavailable as exc:
+        # Fails CLOSED, like every other unreadable source here: the dispatcher
+        # reads any non-zero as "do not dispatch". Reading "I could not ask" as
+        # "nothing is parked" at the launch point is the whole defect, one step
+        # later than where it was found.
+        sys.stderr.write(
+            "review-redrive: could not read the park labels for %s (%s) -- "
+            "refusing to claim the attempt.\n" % (issue, exc))
+        return RC_PARK_UNREADABLE
+    reason = state.get(issue)
+    if reason:
+        sys.stderr.write(
+            "review-redrive: %s PR #%s is parked by %s (%s) -- it was selected "
+            "before the label landed; not claiming the attempt.\n"
+            % (issue, pr, reason[0], reason[1]))
+        return RC_PARKED
     cand = {"action": action, "pr": pr, "head_sha": head_sha}
     return 0 if CI.ledger_claim(CI.attempts_path(), issue, flag(cand)) else 1
 
@@ -732,18 +781,20 @@ def main(argv):
         # rc 2 is NOT "nothing to do": the caller must keep its fresh pick rather
         # than read an unreadable board as an empty one.
         sys.stderr.write("review-redrive: %s -- nothing was claimed.\n" % exc)
-        return 2
+        return RC_GH_UNREADABLE
     try:
         cands = drop_parked(cands)
     except ParkUnavailable as exc:
-        # rc 2 for the same reason GhUnavailable is rc 2: the run could not read
-        # a source it needs, so it must not report an answer. Reading "I cannot
-        # see the labels" as "nothing is parked" re-dispatches every parked issue
-        # on the board at once, and blocked:capability is guaranteed to fail.
+        # NON-ZERO for the same reason GhUnavailable is non-zero: the run could
+        # not read a source it needs, so it must not report an answer. Reading
+        # "I cannot see the labels" as "nothing is parked" re-dispatches every
+        # parked issue on the board at once, and blocked:capability is
+        # guaranteed to fail. A DISTINCT code, not 2, so the dispatcher names
+        # Linear rather than sending the reader to gh -- see RC_PARK_UNREADABLE.
         sys.stderr.write(
             "review-redrive: could not read the park labels (%s) -- refusing to "
             "treat that as nothing being parked. Nothing was claimed.\n" % exc)
-        return 2
+        return RC_PARK_UNREADABLE
     return cmd_select(cands, args.all)
 
 

--- a/q-system/.q-system/scripts/review-redrive.py
+++ b/q-system/.q-system/scripts/review-redrive.py
@@ -530,16 +530,43 @@ def parked(issues, graphql=None):
             data = graphql(_park_query(batch), {})
         except Exception as exc:            # transport, auth, GraphQL errors alike
             raise ParkUnavailable(str(exc)[:200]) from exc
-        for node in (data or {}).values():
+        data = data or {}
+        # READ BY THE ALIAS THIS RUN ASKED UNDER, never by iterating the values.
+        # `graphql` raises on an `errors` array, so everything arriving here is a
+        # clean 200 -- and a clean 200 can still fail to answer: Linear returns
+        # `null` for an id it does not resolve, and an alias can be missing from
+        # `data` outright. Iterating values() saw neither: a null was skipped and
+        # an omission was never looked for, so both left the issue absent from
+        # `out`, which every caller reads as NOT PARKED (PR #201 review round 2).
+        #
+        # That is this module's own defect one layer down. The docstring above
+        # commits to "an unreadable source is never read as permission", and an
+        # answer that says nothing about the issue is unreadable. It raises.
+        #
+        # THE COST OF FAILING CLOSED HERE IS NAMED, NOT HIDDEN: a PR whose branch
+        # carries an identifier Linear does not know now blocks the redrive at rc
+        # 3 every heartbeat instead of being dispatched. That is the intended
+        # trade -- the operator sees a line naming the exact id, where the old
+        # branch dispatched silently on a park it could not verify.
+        for n, ident in enumerate(batch):
+            node = data.get("i%d" % n)
             if not isinstance(node, dict):
-                # A null alias is an issue Linear does not know. Not parked, and
-                # not an outage either -- the redrive simply proceeds on it.
-                continue
-            names = [n.get("name") for n in
+                raise ParkUnavailable(
+                    "Linear answered no issue for %s -- the park state for it is "
+                    "unknown, which is not the same as unparked" % ident)
+            got = node.get("identifier")
+            if got and got != ident:
+                # An alias answering about a different issue would file THAT
+                # issue's park state under this one. Cheap to check, and silently
+                # answering the wrong question is the same class of defect.
+                raise ParkUnavailable(
+                    "Linear answered for %s under the alias asked for %s"
+                    % (got, ident))
+            names = [x.get("name") for x in
                      ((node.get("labels") or {}).get("nodes") or [])]
             reason = PARK.parked_reason(names)
             if reason:
-                out[node.get("identifier")] = reason
+                out[ident] = reason
     return out
 
 
@@ -733,6 +760,33 @@ def cmd_mark_dispatched(issue, action, pr, head_sha, graphql=None):
     park would spend that attempt on work that never ran, and lifting the park
     later would not give it back -- the next redrive would skip the PR for having
     "already had its one attempt". Refusing first leaves the attempt unspent.
+
+    THE RESIDUAL WINDOW IS REAL AND IS NOT CLOSED BY REORDERING (PR #201 review
+    round 2, major: "a label applied after the Linear response but before the
+    ledger claim is ignored"). True, and it stays true after any reorder, because
+    the exposure is measured from THE LAST READ to the launch, not from the read
+    to the claim. Writing both orderings on one clock, with `r` a Linear round
+    trip and `w` the local ledger write:
+
+        this ordering    read -> [w] claim -> [e] launch   missed: labels in (read, launch]   = w + e
+        claim-then-verify   claim -> [r] read -> [e] launch   missed: labels in (read, launch]   = e
+
+    Each design catches everything up to its own last read and misses everything
+    after it; both place that read as late as they can, so the exposure differs
+    by `w`, one local file write. What the reorder buys is not a smaller window,
+    it is the same window shifted across the claim -- and it is paid for with a
+    release path: a crash between the claim and the release spends the attempt
+    permanently on work that never launched, which is the exact harm the
+    paragraph above exists to prevent. A durability hole traded for a write's
+    worth of race is a worse deal than the race.
+
+    The window is irreducible here because the two facts live in two systems --
+    the park in Linear, the attempt in a local ledger -- with no transaction
+    across them. The last read that could shrink it further is not in this
+    process at all: it is inside the agent this dispatch launches, which does not
+    re-read the park today. That is captured as spillover against this issue
+    rather than smuggled in, because it lands in `pr-review-agent.sh` and
+    `converge`, and the ASK-872 DoR scopes neither.
     """
     try:
         state = parked([issue], graphql=graphql)

--- a/q-system/.q-system/scripts/review-redrive.py
+++ b/q-system/.q-system/scripts/review-redrive.py
@@ -507,22 +507,41 @@ def _park_query(issues):
 
 
 def parked(issues, graphql=None):
-    """{issue: (label, why)} for every parked issue in `issues`.
+    """({issue: (label, why)}, {issue: why-it-could-not-be-read}) for `issues`.
 
-    Raises ParkUnavailable if the labels cannot be read. THAT IS NOT THE SAME AS
-    AN EMPTY DICT and the caller must not fold the two together: "the board says
-    nothing is parked" and "I could not ask the board" have opposite consequences,
-    and the second one dispatching is how a `blocked:capability` issue gets handed
-    to an agent that provably cannot finish it, once per heartbeat.
+    Raises ParkUnavailable if the labels cannot be read AT ALL. THAT IS NOT THE
+    SAME AS AN EMPTY DICT and the caller must not fold the two together: "the
+    board says nothing is parked" and "I could not ask the board" have opposite
+    consequences, and the second one dispatching is how a `blocked:capability`
+    issue gets handed to an agent that provably cannot finish it, once per
+    heartbeat.
 
     Same direction main() already takes for GhUnavailable (rc 2, nothing claimed):
     an unreadable source is never read as permission.
+
+    TWO RETURN VALUES BECAUSE THERE ARE TWO BLAST RADII, and collapsing them into
+    one exception was its own defect (PR #201 review round 4, major: "one invalid
+    title-derived issue ID aborts the entire batched park lookup, suppressing
+    every valid reviewer-redrive candidate").
+
+        a BAD INPUT id   -> that issue's park state is unknown. Nothing else in
+                            the batch is affected, so it is REPORTED, not raised.
+        a BAD RESPONSE   -> the mapping from alias to issue cannot be trusted, so
+                            no answer in the batch may be filed. Raised.
+
+    The identifier is derived from the PR, not chosen: ci-redrive's `attribute()`
+    takes the branch tail when it is an issue id and otherwise the ONE id the
+    title names, and `\\b[A-Za-z]{2,6}-\\d+\\b` matches ordinary English -- a PR
+    titled "convert the log writer to UTF-8" yields `UTF-8`. Round 2 raised for
+    the whole batch on that, so one such title took the reviewer redrive offline
+    for every other PR on the board, every heartbeat, and a title does not heal.
     """
     if not issues:
-        return {}
+        return ({}, {})
     if graphql is None:
         graphql = _load("linear-sync.py", "linear_sync").graphql
     out = {}
+    unknown = {}
     ordered = sorted(set(issues))
     for start in range(0, len(ordered), PARK_BATCH):
         batch = ordered[start:start + PARK_BATCH]
@@ -544,21 +563,28 @@ def parked(issues, graphql=None):
         # answer that says nothing about the issue is unreadable. It raises.
         #
         # THE COST OF FAILING CLOSED HERE IS NAMED, NOT HIDDEN: a PR whose branch
-        # carries an identifier Linear does not know now blocks the redrive at rc
-        # 3 every heartbeat instead of being dispatched. That is the intended
-        # trade -- the operator sees a line naming the exact id, where the old
-        # branch dispatched silently on a park it could not verify.
+        # carries an identifier Linear does not know is never redriven, because
+        # its park state cannot be verified. What changed in round 4 is the SCOPE
+        # of that refusal -- it belongs to that candidate, not to the run.
         for n, ident in enumerate(batch):
             node = data.get("i%d" % n)
             if not isinstance(node, dict):
-                raise ParkUnavailable(
+                # PER-ISSUE, NOT PER-BATCH. `null` (or a dropped alias) is what
+                # Linear answers for an id that resolves to nothing, and the id
+                # came off a PR title -- so this is a statement about ONE bad
+                # input, and the other issues in the same response answered fine.
+                unknown[ident] = (
                     "Linear answered no issue for %s -- the park state for it is "
                     "unknown, which is not the same as unparked" % ident)
+                continue
             got = node.get("identifier")
             if got and got != ident:
-                # An alias answering about a different issue would file THAT
-                # issue's park state under this one. Cheap to check, and silently
-                # answering the wrong question is the same class of defect.
+                # STILL BATCH-WIDE, and the asymmetry with the branch above is the
+                # point. A null is a bad question; an alias answering about a
+                # DIFFERENT issue means the alias-to-issue mapping this whole
+                # response was read through is wrong, so every other answer in it
+                # may be filed under the wrong issue too. Nothing here is
+                # salvageable, so nothing here is used.
                 raise ParkUnavailable(
                     "Linear answered for %s under the alias asked for %s"
                     % (got, ident))
@@ -567,7 +593,7 @@ def parked(issues, graphql=None):
             reason = PARK.parked_reason(names)
             if reason:
                 out[ident] = reason
-    return out
+    return (out, unknown)
 
 
 def drop_parked(cands, graphql=None):
@@ -578,7 +604,7 @@ def drop_parked(cands, graphql=None):
     it is that pure; putting a Linear round trip inside it would put a live data
     path into that suite.
     """
-    state = parked([c["issue"] for c in cands], graphql=graphql)
+    state, unknown = parked([c["issue"] for c in cands], graphql=graphql)
     keep = []
     for c in cands:
         reason = state.get(c["issue"])
@@ -586,6 +612,17 @@ def drop_parked(cands, graphql=None):
             sys.stderr.write(
                 "review-redrive: %s PR #%s is parked by %s (%s) -- not "
                 "redriving it.\n" % (c["issue"], c["pr"], reason[0], reason[1]))
+            continue
+        if c["issue"] in unknown:
+            # DROPPED, and the run continues. Same refusal as a park -- an
+            # unverifiable park is never redriven -- scoped to the candidate whose
+            # id could not be resolved. The line names the id because the fix is
+            # on the PR (retitle it, or cut the branch as <agent>/<issue>), and an
+            # operator who cannot see which id failed cannot make it.
+            sys.stderr.write(
+                "review-redrive: %s PR #%s -- %s. Not redriving THIS PR; the rest "
+                "of the batch is unaffected.\n"
+                % (c["issue"], c["pr"], unknown[c["issue"]]))
             continue
         keep.append(c)
     return keep
@@ -789,7 +826,13 @@ def cmd_mark_dispatched(issue, action, pr, head_sha, graphql=None):
     `converge`, and the ASK-872 DoR scopes neither.
     """
     try:
-        state = parked([issue], graphql=graphql)
+        state, unknown = parked([issue], graphql=graphql)
+        if issue in unknown:
+            # A batch of one: "unknown for this issue" and "unreadable for this
+            # run" are the same statement here, and the answer is the same
+            # refusal. The per-issue/per-batch split exists to protect OTHER
+            # candidates, and at the claim there are none.
+            raise ParkUnavailable(unknown[issue])
     except ParkUnavailable as exc:
         # Fails CLOSED, like every other unreadable source here: the dispatcher
         # reads any non-zero as "do not dispatch". Reading "I could not ask" as
@@ -810,6 +853,56 @@ def cmd_mark_dispatched(issue, action, pr, head_sha, graphql=None):
     return 0 if CI.ledger_claim(CI.attempts_path(), issue, flag(cand)) else 1
 
 
+def cmd_park_check(issue, graphql=None):
+    """Is THIS issue parked -- the answer the RED-CI path had no way to ask.
+
+    WHY A SUBCOMMAND HERE AND NOT A CHECK IN ci-redrive.py (PR #201 review round
+    4, major: "park labels do not stop the higher-priority red-CI redrive, so a
+    parked issue with red CI is still dispatched").
+
+    kipi-dispatch.sh runs ci-redrive FIRST and reaches the reviewer redrive only
+    when it offered nothing (`[ -z "$REDRIVE_NEXT" ]`). Red CI outranks a reviewer
+    refusal deliberately -- re-reviewing a tree that does not build spends a codex
+    call to be told the build is broken -- so the path with priority was the path
+    with no park read. Everything select and mark-dispatched enforce was bypassed
+    for exactly the PRs that also had red CI, and `blocked:capability` plus a red
+    build is the most expensive case there is.
+
+    IT LIVES HERE BECAUSE THE READER LIVES HERE. The dispatcher asks this file for
+    the answer instead of ci-redrive.py growing its own park read, for the reason
+    park_labels.py exists at all: a fourth consumer with its own copy is this same
+    defect again. This also keeps the ASK-872 DoR's "not doing: ci-redrive.py"
+    intact -- that file is unchanged.
+
+    READ-ONLY, and that is load-bearing. It touches no ledger, so the dispatcher
+    can ask before it has decided anything and an issue that turns out to be
+    parked has spent nothing. The claim for the red-CI path stays where it was, in
+    ci-redrive.py's own mark-dispatched.
+
+    STDOUT CARRIES THE LABEL so the dispatcher's `say` line can name it. That line
+    is the operator's only surface, and "parked" without "by what" sends the
+    reader to the board to work out which of three labels, each routing somewhere
+    different, is the one in play.
+    """
+    try:
+        state, unknown = parked([issue], graphql=graphql)
+        if issue in unknown:
+            raise ParkUnavailable(unknown[issue])
+    except ParkUnavailable as exc:
+        sys.stderr.write(
+            "review-redrive: could not read the park labels for %s (%s) -- "
+            "refusing to call it unparked.\n" % (issue, exc))
+        return RC_PARK_UNREADABLE
+    reason = state.get(issue)
+    if reason:
+        print("%s\t%s" % (reason[0], reason[1]))
+        sys.stderr.write(
+            "review-redrive: %s is parked by %s (%s).\n"
+            % (issue, reason[0], reason[1]))
+        return RC_PARKED
+    return 0
+
+
 def main(argv):
     ap = argparse.ArgumentParser()
     ap.add_argument("--repo-dir", default=".")
@@ -826,9 +919,18 @@ def main(argv):
     mark.add_argument("--pr", required=True)
     mark.add_argument("--head-sha", default="")
 
+    chk = sub.add_parser("park-check")
+    chk.add_argument("--issue", required=True)
+
     args = ap.parse_args(argv)
     if args.cmd == "mark-dispatched":
         return cmd_mark_dispatched(args.issue, args.action, args.pr, args.head_sha)
+    if args.cmd == "park-check":
+        # BEFORE candidates(), because this command must not read the PR board at
+        # all: its caller is the RED-CI path, which already has its own candidate
+        # and needs one fact about one issue. Running the gh query here would make
+        # a gh outage look like a park answer.
+        return cmd_park_check(args.issue)
     try:
         cands = candidates(args.repo_dir, args.records_dir)
     except CI.GhUnavailable as exc:

--- a/q-system/.q-system/scripts/review-redrive.py
+++ b/q-system/.q-system/scripts/review-redrive.py
@@ -142,6 +142,31 @@ def _load_ci_redrive():
 
 CI = _load_ci_redrive()
 
+
+def _load(name, modname):
+    """Load a sibling script by FILENAME, never by import path.
+
+    Two of the three things this file must agree with live next to it and are not
+    importable by name (`review-redrive.py`, `linear-sync.py`, hyphens). Naming
+    the file literally also keeps the capability gate's inert-engine scan able to
+    see the dependency -- a module imported without its `.py` reads as a dead
+    engine to that scan even with live callers (ASK-230).
+    """
+    spec = importlib.util.spec_from_file_location(modname, os.path.join(HERE, name))
+    mod = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(mod)
+    return mod
+
+
+# The three park labels, IMPORTED, NOT COPIED -- see park_labels.py. This script
+# was the third consumer of that vocabulary and the only one that never read it
+# (ASK-872).
+PARK = _load("park_labels.py", "park_labels")
+
+
+class ParkUnavailable(Exception):
+    """The park state could not be read. Not the same as nothing being parked."""
+
 # Verdicts that mean a human-equivalent reviewer objected and left a spec behind.
 # Kept as a literal set rather than "not an approval": an EMPTY verdict is not an
 # objection, it is an unstated one, and routing empty to rework is precisely the
@@ -450,6 +475,84 @@ def candidates(repo_dir, records_dir):
     return out
 
 
+# One GraphQL call per BATCH, not per PR. Aliasing N `issue(id:)` lookups into a
+# single query is what keeps the cost of this check flat: a redrive run makes ONE
+# call for every candidate it holds, and only when it holds at least one. Chunked
+# so a pathological board cannot post a query of unbounded size.
+PARK_BATCH = 50
+
+
+def _park_query(issues):
+    """One aliased GraphQL document for a batch of issue identifiers.
+
+    Aliased rather than filtered because `issue(id:)` is the only lookup that
+    takes the identifier the PR branch carries. A label-side filter would answer
+    "which issues on the board are parked", which is a different and much larger
+    question than "are THESE four parked".
+    """
+    parts = ['i%d: issue(id: "%s") { identifier labels { nodes { name } } }'
+             % (n, ident) for n, ident in enumerate(issues)]
+    return "query { %s }" % " ".join(parts)
+
+
+def parked(issues, graphql=None):
+    """{issue: (label, why)} for every parked issue in `issues`.
+
+    Raises ParkUnavailable if the labels cannot be read. THAT IS NOT THE SAME AS
+    AN EMPTY DICT and the caller must not fold the two together: "the board says
+    nothing is parked" and "I could not ask the board" have opposite consequences,
+    and the second one dispatching is how a `blocked:capability` issue gets handed
+    to an agent that provably cannot finish it, once per heartbeat.
+
+    Same direction main() already takes for GhUnavailable (rc 2, nothing claimed):
+    an unreadable source is never read as permission.
+    """
+    if not issues:
+        return {}
+    if graphql is None:
+        graphql = _load("linear-sync.py", "linear_sync").graphql
+    out = {}
+    ordered = sorted(set(issues))
+    for start in range(0, len(ordered), PARK_BATCH):
+        batch = ordered[start:start + PARK_BATCH]
+        try:
+            data = graphql(_park_query(batch), {})
+        except Exception as exc:            # transport, auth, GraphQL errors alike
+            raise ParkUnavailable(str(exc)[:200]) from exc
+        for node in (data or {}).values():
+            if not isinstance(node, dict):
+                # A null alias is an issue Linear does not know. Not parked, and
+                # not an outage either -- the redrive simply proceeds on it.
+                continue
+            names = [n.get("name") for n in
+                     ((node.get("labels") or {}).get("nodes") or [])]
+            reason = PARK.parked_reason(names)
+            if reason:
+                out[node.get("identifier")] = reason
+    return out
+
+
+def drop_parked(cands, graphql=None):
+    """The candidates whose issue is not parked, saying which label stopped each.
+
+    OUTSIDE candidates() on purpose. candidates() reads the PR board and nothing
+    else, and test-review-redrive-absent.py calls it in-process precisely because
+    it is that pure; putting a Linear round trip inside it would put a live data
+    path into that suite.
+    """
+    state = parked([c["issue"] for c in cands], graphql=graphql)
+    keep = []
+    for c in cands:
+        reason = state.get(c["issue"])
+        if reason:
+            sys.stderr.write(
+                "review-redrive: %s PR #%s is parked by %s (%s) -- not "
+                "redriving it.\n" % (c["issue"], c["pr"], reason[0], reason[1]))
+            continue
+        keep.append(c)
+    return keep
+
+
 def flag(cand):
     """One attempt per PR per action per head sha. See the module docstring."""
     return "review_%s_pr%s_%s" % (cand["action"].replace("-", ""),
@@ -629,6 +732,17 @@ def main(argv):
         # rc 2 is NOT "nothing to do": the caller must keep its fresh pick rather
         # than read an unreadable board as an empty one.
         sys.stderr.write("review-redrive: %s -- nothing was claimed.\n" % exc)
+        return 2
+    try:
+        cands = drop_parked(cands)
+    except ParkUnavailable as exc:
+        # rc 2 for the same reason GhUnavailable is rc 2: the run could not read
+        # a source it needs, so it must not report an answer. Reading "I cannot
+        # see the labels" as "nothing is parked" re-dispatches every parked issue
+        # on the board at once, and blocked:capability is guaranteed to fail.
+        sys.stderr.write(
+            "review-redrive: could not read the park labels (%s) -- refusing to "
+            "treat that as nothing being parked. Nothing was claimed.\n" % exc)
         return 2
     return cmd_select(cands, args.all)
 

--- a/q-system/.q-system/scripts/test/linear-park-fixture.py
+++ b/q-system/.q-system/scripts/test/linear-park-fixture.py
@@ -1,0 +1,92 @@
+#!/usr/bin/env python3
+"""A fixture Linear GraphQL endpoint that answers park-label lookups (ASK-872).
+
+ONE COPY, TWO SUITES. test-review-redrive-park.sh drives review-redrive.py
+directly; test-ci-redrive.sh drives the REAL kipi-dispatch.sh, whose red-CI path
+now asks the same reader for the same answer. Both need a board they can rewrite
+between two reads. A second copy of this server is the same defect class as a
+second copy of the park-label list (see park_labels.py): the two would drift, and
+the one that drifted would be the one asserting the fix works.
+
+RE-READ PER REQUEST, from the file named by $LABELS_FILE. The board is not a
+constant in life -- the mark-dispatched cases exist precisely because a label can
+land BETWEEN two reads, so a fixture answering from a dict frozen at import
+cannot express the state the defect lives in.
+
+THREE SENTINELS INSTEAD OF A LABEL LIST, because Linear can answer a lookup
+without answering the question, and the three ways it does that have different
+blast radii:
+
+    __null__   the alias is present and null -- the id resolved to no issue.
+               A BAD INPUT: only this issue's park state is unknown.
+    __omit__   the alias is absent from `data` entirely. Also a bad input.
+    __wrong__  the alias answers with a DIFFERENT identifier. Not a bad input --
+               the response mapping itself is untrustworthy, so nothing in the
+               batch can be filed with confidence.
+
+All three arrive with NO `errors` key, so `graphql` returns normally and the
+reader is holding a clean 200 that says nothing about the park.
+
+Prints its port on stdout and serves forever. The caller kills it.
+"""
+
+import json
+import os
+import re
+from http.server import BaseHTTPRequestHandler, HTTPServer
+
+LABELS_FILE = os.environ["LABELS_FILE"]
+
+NULL = "__null__"
+OMIT = "__omit__"
+WRONG = "__wrong__"
+
+
+def _board():
+    return json.load(open(LABELS_FILE))
+
+
+def issue(ident):
+    labels = _board().get(ident, [])
+    if labels == NULL:
+        return None
+    if labels == WRONG:
+        # Answers about a different issue under the alias asked for `ident`.
+        return {"id": "ASK-000", "identifier": "ASK-000",
+                "labels": {"nodes": []}}
+    return {"id": ident, "identifier": ident,
+            "labels": {"nodes": [{"name": n} for n in labels]}}
+
+
+def _aliases(query):
+    # `i0: issue(id: "ASK-901") { ... }` -> ("i0", "ASK-901")
+    return re.findall(r'(\w+)\s*:\s*issue\(\s*id\s*:\s*"([^"]+)"', query)
+
+
+class H(BaseHTTPRequestHandler):
+    def log_message(self, *a):
+        pass
+
+    def do_POST(self):
+        body = self.rfile.read(int(self.headers["Content-Length"])).decode()
+        req = json.loads(body)
+        # Answer whichever identifiers the reader named, under the alias it used,
+        # so the fixture cannot accidentally teach the reader an ordering it does
+        # not have live.
+        data = {}
+        for alias, ident in _aliases(req.get("query") or ""):
+            if _board().get(ident) == OMIT:
+                continue          # the alias never appears in the response
+            data[alias] = issue(ident)
+        out = json.dumps({"data": data}).encode()
+        self.send_response(200)
+        self.send_header("Content-Type", "application/json")
+        self.send_header("Content-Length", str(len(out)))
+        self.end_headers()
+        self.wfile.write(out)
+
+
+if __name__ == "__main__":
+    srv = HTTPServer(("127.0.0.1", 0), H)
+    print(srv.server_port, flush=True)
+    srv.serve_forever()

--- a/q-system/.q-system/scripts/test/test-ci-redrive.sh
+++ b/q-system/.q-system/scripts/test/test-ci-redrive.sh
@@ -501,12 +501,23 @@ D_LEDGER="$DROOT/attempts.json"
 D_PAGES="$DROOT/pages.txt"
 D_PRS="$DROOT/prs.json"
 
+# THE REVIEWER SLOT IS POSTED AND GREEN, DELIBERATELY. This world is now read by
+# TWO selectors: ci-redrive (which excludes reviewer slots from red CI, so the
+# failing `validate` still makes it red) and review-redrive, which the dispatcher
+# reaches whenever ci-redrive offers nothing. With no reviewer slot at all,
+# review-redrive reads the slot as NEVER POSTED and offers a first re-review
+# (sp-d87c5416) -- so case 14g stopped asserting ci-redrive's behaviour and
+# started asserting the reviewer path's. A posted SUCCESS means "a newer review
+# already landed", which takes review-redrive out of every case here and leaves
+# each case measuring the one selector it was written for.
 RED_WORLD="[{\"number\":91,\"headRefName\":\"$RED_BRANCH\",\"isDraft\":false,
   \"headRefOid\":\"9999999999999999999999999999999999999999\",
   \"url\":\"https://x/91\",\"title\":\"t ($RED_ISS)\",
   \"statusCheckRollup\":[{\"__typename\":\"CheckRun\",\"name\":\"validate\",
    \"status\":\"COMPLETED\",\"conclusion\":\"FAILURE\",
-   \"workflowName\":\"Skeleton Validation\"}]}]"
+   \"workflowName\":\"Skeleton Validation\"},
+   {\"__typename\":\"StatusContext\",\"context\":\"kipi/reviewer-approved\",
+    \"state\":\"SUCCESS\"}]}]"
 
 run_dispatch() {  # run_dispatch [GH_RC]
   ( cd "$FAKE_REPO" && HOME="$DROOT/home" PATH="$DROOT/bin:$PATH" \

--- a/q-system/.q-system/scripts/test/test-ci-redrive.sh
+++ b/q-system/.q-system/scripts/test/test-ci-redrive.sh
@@ -448,6 +448,36 @@ mkdir -p "$SCRIPTS" "$DROOT/home/.config/kipi" "$DROOT/bin"
 cp "$REDRIVE" "$SCRIPTS/ci-redrive.py"
 cp "$REPO_ROOT/q-system/.q-system/scripts/attempts-ledger.py" "$SCRIPTS/attempts-ledger.py"
 
+# THE PARK READER, BECAUSE THE RED-CI PATH NOW ASKS IT (ASK-872, PR #201 r4).
+# The dispatcher runs ci-redrive FIRST and only reaches the reviewer redrive when
+# it offered nothing, so a parked issue with red CI was dispatched with no park
+# read at all. The gate calls review-redrive.py's reader rather than growing a
+# fourth copy of the label list, so the fake repo needs that whole chain: the
+# reader, the label module it imports, and the Linear client the reader loads.
+cp "$REPO_ROOT/q-system/.q-system/scripts/review-redrive.py" "$SCRIPTS/review-redrive.py"
+cp "$REPO_ROOT/q-system/.q-system/scripts/park_labels.py" "$SCRIPTS/park_labels.py"
+cp "$REPO_ROOT/q-system/.q-system/scripts/linear-sync.py" "$SCRIPTS/linear-sync.py"
+
+# A fixture Linear on loopback, shared with test-review-redrive-park.sh. No case
+# here reaches the real board and none needs a real key. The default answer is
+# "unparked", so every pre-existing case below is unaffected by its presence --
+# and the two new cases at the end are the only ones that change the board.
+D_FIXTURE="$(dirname "${BASH_SOURCE[0]}")/linear-park-fixture.py"
+[ -f "$D_FIXTURE" ] || { echo "FATAL: park fixture not found at $D_FIXTURE" >&2; exit 1; }
+D_LABELS="$DROOT/labels.json"
+d_set_labels() { printf '%s' "$1" > "$D_LABELS"; }
+d_set_labels "{\"$RED_ISS\": [\"owner:sana\"], \"$FRESH_ISS\": [\"owner:sana\"]}"
+LABELS_FILE="$D_LABELS" python3 "$D_FIXTURE" > "$DROOT/port" 2> "$DROOT/srv.err" &
+D_SRV=$!
+for _ in $(seq 1 100); do
+  D_PORT="$(cat "$DROOT/port" 2>/dev/null)"; [ -n "${D_PORT:-}" ] && break; sleep 0.1
+done
+[ -n "${D_PORT:-}" ] || { echo "FATAL: park fixture did not start: $(cat "$DROOT/srv.err")" >&2; exit 1; }
+# BOTH CLAUSES, because an EXIT trap REPLACES the one set at line 64 rather than
+# adding to it -- dropping the rm would leak a temp dir per run.
+trap 'kill "${D_SRV:-}" 2>/dev/null; rm -rf "$TMP"' EXIT
+D_LINEAR_URL="http://127.0.0.1:$D_PORT/graphql"
+
 cp "$TMP/gh" "$DROOT/bin/gh"
 cp "$TMP/ps" "$DROOT/bin/ps-stub"
 printf '#!/usr/bin/env bash\nsleep 30\n' > "$DROOT/converge.sh"; chmod +x "$DROOT/converge.sh"
@@ -485,6 +515,8 @@ run_dispatch() {  # run_dispatch [GH_RC]
       KIPI_ATTEMPTS="$D_LEDGER" KIPI_GH="$DROOT/bin/gh" KIPI_PS="$DROOT/bin/ps-stub" \
       GH_FIXTURE="$D_PRS" GH_RC="${1:-0}" PS_FIXTURE="${PS_FIXTURE:-$TMP/ps-empty}" \
       NOTIFY_LOG="$D_PAGES" \
+      KIPI_LINEAR_API_URL="${D_URL_OVERRIDE:-$D_LINEAR_URL}" \
+      KIPI_LINEAR_API_KEY="fixture-key-not-a-secret" \
       bash "$DISPATCH" >/dev/null 2>&1 )
 }
 dlog() { cat "$DROOT/home/.config/kipi/dispatch.log" 2>/dev/null; }
@@ -555,6 +587,69 @@ run_dispatch
 check "14i with nothing red the fresh pick is dispatched as before" \
   "$(dispatched)" "$FRESH_ISS"
 lacks "14j and no redrive line is logged" "$(dlog)" "handing"
+pkill -f "$DROOT/converge.sh" 2>/dev/null
+
+# --- 15. the park labels stop the RED-CI redrive too (ASK-872, PR #201 r4) ----
+# THE FINDING: "Park labels do not stop the higher-priority red-CI redrive, so a
+# parked issue with red CI is still dispatched." review-redrive.py reads the park
+# at select AND at its claim, but the dispatcher reaches that block only when
+# ci-redrive offered NOTHING (`[ -z "$REDRIVE_NEXT" ]`). Red CI outranks a
+# reviewer refusal by design, so the higher-priority path was the unguarded one --
+# and `blocked:capability` plus a red build is the case that costs the most, an
+# agent handed work it provably cannot finish, once per heartbeat.
+#
+# ASSERTED THROUGH THE REAL DISPATCHER, off the file the converge stub writes.
+# Nothing here reads a log line to decide whether the gate fired: the question is
+# which issue the dispatcher actually handed to converge.
+echo
+echo "== park labels x the red-CI path =="
+
+# 15a. the parked red issue is not dispatched, AND the fresh pick keeps its slot.
+# Clearing the offer rather than aborting the heartbeat matters: a parked red PR
+# that swallowed NEXT would starve both the reviewer redrive and the fresh pick
+# for as long as the park lasted.
+d_reset
+printf '%s' "$RED_WORLD" > "$D_PRS"
+d_set_labels "{\"$RED_ISS\": [\"owner:sana\", \"owner:assaf\"], \"$FRESH_ISS\": [\"owner:sana\"]}"
+run_dispatch
+check "15a a red PR whose issue is parked is NOT handed back" \
+  "$(dispatched)" "$FRESH_ISS"
+contains "15b the log names the label that stopped it" "$(dlog)" "owner:assaf"
+check "15c a parked red PR claims no attempt" \
+  "$([ -f "$D_LEDGER" ] && grep -c ci_redrive "$D_LEDGER" || echo 0)" "0"
+pkill -f "$DROOT/converge.sh" 2>/dev/null
+
+# 15d. blocked:capability, the sharpest of the three, through the same path.
+d_reset
+printf '%s' "$RED_WORLD" > "$D_PRS"
+d_set_labels "{\"$RED_ISS\": [\"owner:sana\", \"blocked:capability\"], \"$FRESH_ISS\": [\"owner:sana\"]}"
+run_dispatch
+check "15d blocked:capability stops the red-CI redrive as well" \
+  "$(dispatched)" "$FRESH_ISS"
+pkill -f "$DROOT/converge.sh" 2>/dev/null
+
+# 15e. an unreadable park is not an unparked one, at the dispatcher too. Same
+# posture the reader already takes for its own callers: refuse, name Linear, and
+# leave the fresh pick standing.
+d_reset
+printf '%s' "$RED_WORLD" > "$D_PRS"
+d_set_labels "{\"$RED_ISS\": [\"owner:sana\"], \"$FRESH_ISS\": [\"owner:sana\"]}"
+D_URL_OVERRIDE="http://127.0.0.1:1/graphql" run_dispatch
+check "15e an unreadable park does not redrive the red PR" \
+  "$(dispatched)" "$FRESH_ISS"
+contains "15f the log names Linear, not gh" "$(dlog)" "Linear"
+check "15g an unreadable park claims no attempt" \
+  "$([ -f "$D_LEDGER" ] && grep -c ci_redrive "$D_LEDGER" || echo 0)" "0"
+pkill -f "$DROOT/converge.sh" 2>/dev/null
+
+# 15h. THE DISCRIMINATION, and without it "never redrive" passes 15a-15g. The
+# same board, the same red PR, no park label: the hand-back must still happen.
+d_reset
+printf '%s' "$RED_WORLD" > "$D_PRS"
+d_set_labels "{\"$RED_ISS\": [\"owner:sana\"], \"$FRESH_ISS\": [\"owner:sana\"]}"
+run_dispatch
+check "15h an unparked red PR is still handed back after the gate" \
+  "$(dispatched)" "$RED_ISS"
 pkill -f "$DROOT/converge.sh" 2>/dev/null
 
 fi

--- a/q-system/.q-system/scripts/test/test-review-redrive-isolation.sh
+++ b/q-system/.q-system/scripts/test/test-review-redrive-isolation.sh
@@ -49,7 +49,14 @@ run_isolated() {   # run_isolated <suite.sh> <outfile>
     bash "$HERE/$1" > "$2" 2>&1
 }
 
-for SUITE in test-review-redrive.sh test-review-redrive-park.sh; do
+# test-ci-redrive.sh JOINED THIS LIST IN ROUND 4, and for the same reason the
+# other two are in it: the dispatcher's red-CI path now asks review-redrive.py for
+# the park labels, so that suite -- which drives the REAL kipi-dispatch.sh -- began
+# making Linear calls it never used to make. A suite that acquires a live data path
+# through a script it merely CALLS is precisely the leak this launcher exists to
+# catch, and it is the quiet kind: the ids it would ask about are real, so a leaked
+# call would answer correctly and nothing would fail.
+for SUITE in test-review-redrive.sh test-review-redrive-park.sh test-ci-redrive.sh; do
   [ -f "$HERE/$SUITE" ] || { bad "$SUITE is missing"; continue; }
   OUT="$(mktemp)"
   run_isolated "$SUITE" "$OUT"

--- a/q-system/.q-system/scripts/test/test-review-redrive-isolation.sh
+++ b/q-system/.q-system/scripts/test/test-review-redrive-isolation.sh
@@ -1,0 +1,94 @@
+#!/usr/bin/env bash
+# Pairs with test-review-redrive.sh and test-review-redrive-park.sh (ASK-872).
+#
+# THE PROPERTY: neither redrive suite talks to anything but its own fixtures.
+#
+# WHY IT NEEDS ITS OWN FILE. A suite cannot assert its own isolation from the
+# inside -- the assertion runs in the same environment as the leak, so a case
+# that reaches the real Linear passes exactly like one that reaches the fixture.
+# The only thing that tells them apart is the endpoint, and the endpoint is set
+# by whoever launches the suite. So the check is a launcher.
+#
+# THE DEFECT THIS PINS (PR #201 review round 3, major). `select` grew a Linear
+# park read, and test-review-redrive.sh stubbed it at the API seam -- for the
+# `select` call sites. Two `mark-dispatched` calls were written before
+# `mark-dispatched` re-read the park, and were left as bare `env KIPI_ATTEMPTS=`
+# invocations. When the claim started reading the park too, those two lines
+# silently began calling the REAL Linear board with the founder's real key,
+# asking about ASK-298 and ASK-301. The suite stayed green because those issues
+# exist and are unparked. On a machine with no key, no network, or with either
+# issue parked, the claim returns rc 3, nothing is claimed, and the cases that
+# depend on the claim fail for a reason that has nothing to do with the code.
+#
+# Green-because-the-real-board-agreed is not isolation. Same class as the
+# notify-sink leak that test-review-redrive.sh's own header documents: quiet
+# because nothing was configured, not because nothing was called.
+#
+# HOW IT FAILS. The suites are run with the DEFAULT Linear endpoint pointed at a
+# closed port. Every call site that passes its own fixture env overrides it and
+# is unaffected; every call site that forgot one gets ECONNREFUSED, raises
+# ParkUnavailable, and takes its case down with it. So a leak is loud here and
+# nowhere else, and this file fails RED the moment a new call site forgets.
+set -uo pipefail
+
+HERE="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+PASS=0; FAIL=0
+ok()  { PASS=$((PASS+1)); echo "  ok   - $1"; }
+bad() { FAIL=$((FAIL+1)); echo "  FAIL - $1"; }
+
+# Port 1 is never listening and refuses instantly, so a leaked call fails fast
+# rather than hanging the suite on a connect timeout. The key is a real-looking
+# string on purpose: an EMPTY key would make linear-sync fall back to
+# ~/.config/kipi/linear-api-key, and on the founder's own machine that file
+# exists -- the fallback would quietly restore the very leak being tested for.
+DEAD_URL="http://127.0.0.1:1/graphql"
+DEAD_KEY="isolation-probe-not-a-real-key"
+
+run_isolated() {   # run_isolated <suite.sh> <outfile>
+  env KIPI_LINEAR_API_URL="$DEAD_URL" KIPI_LINEAR_API_KEY="$DEAD_KEY" \
+    bash "$HERE/$1" > "$2" 2>&1
+}
+
+for SUITE in test-review-redrive.sh test-review-redrive-park.sh; do
+  [ -f "$HERE/$SUITE" ] || { bad "$SUITE is missing"; continue; }
+  OUT="$(mktemp)"
+  run_isolated "$SUITE" "$OUT"
+  RC=$?
+  TALLY="$(grep -E '^ *[0-9]+ passed, [0-9]+ failed' "$OUT" | tail -1)"
+
+  # Asserted on the suite's own tally, not on its exit code alone: these suites
+  # exit non-zero on failure, but a tally line saying "3 failed" with a stray
+  # zero exit would otherwise read as a pass.
+  case "$TALLY" in
+    *" 0 failed") ok "$SUITE is green with the real Linear endpoint unreachable ($TALLY)" ;;
+    "") bad "$SUITE printed no tally under an unreachable Linear -- it did not finish: $(tail -3 "$OUT")" ;;
+    *)  bad "$SUITE leaks a live Linear call: $TALLY. Failing cases:
+$(grep 'FAIL -' "$OUT")" ;;
+  esac
+  [ "$RC" = "0" ] && ok "$SUITE exited 0 under an unreachable Linear" \
+    || bad "$SUITE exited $RC under an unreachable Linear"
+  rm -f "$OUT"
+done
+
+# THE NEGATIVE SELF-TEST. Everything above passes trivially if the probe env is
+# not actually reaching the code -- a typo'd variable name, a suite that stopped
+# reading it, an `env` that dropped it. So a call is made that has NO fixture to
+# override the default and MUST fail. If this one succeeds, the probe is inert
+# and every "ok" above is worthless.
+SEL="$(cd "$HERE/../../../.." && pwd)/q-system/.q-system/scripts/review-redrive.py"
+PROBE_LEDGER="$(mktemp)"; echo '{}' > "$PROBE_LEDGER"
+env KIPI_LINEAR_API_URL="$DEAD_URL" KIPI_LINEAR_API_KEY="$DEAD_KEY" \
+    KIPI_ATTEMPTS="$PROBE_LEDGER" \
+  python3 "$SEL" mark-dispatched --issue ASK-1 --action rework --pr 1 \
+    --head-sha aaaa1111 >/dev/null 2>&1
+PROBE_RC=$?
+[ "$PROBE_RC" = "3" ] \
+  && ok "the probe env is live: an unfixtured claim exits 3 (park unreadable)" \
+  || bad "the probe env is INERT -- an unfixtured claim exited $PROBE_RC, want 3. Every check above is vacuous."
+[ "$(cat "$PROBE_LEDGER")" = '{}' ] \
+  && ok "and that refused claim spent no attempt" \
+  || bad "the refused claim wrote to the ledger: $(cat "$PROBE_LEDGER")"
+rm -f "$PROBE_LEDGER"
+
+echo "  $PASS passed, $FAIL failed"
+[ "$FAIL" = "0" ]

--- a/q-system/.q-system/scripts/test/test-review-redrive-park.sh
+++ b/q-system/.q-system/scripts/test/test-review-redrive-park.sh
@@ -1,0 +1,189 @@
+#!/usr/bin/env bash
+# Pairs with review-redrive.py + park_labels.py (ASK-872): the three labels that
+# PARK an issue stop the fresh-pick path in linear-worker.sh and did not stop the
+# redrive.
+#
+# THE DEFECT, measured 2026-08-16:
+#   $ grep -n "owner:assaf\|needs-scope\|blocked:capability" review-redrive.py
+#   (no output)
+# A third consumer dispatching the same agents at the same issues, reading none
+# of the vocabulary the other two use to say "not this one".
+#
+# THE PROPERTY UNDER TEST is the DISCRIMINATION, same posture as
+# test-review-redrive.sh: a selector that skips everything passes any test that
+# only checks the three parked fixtures, so the fourth fixture -- identical in
+# every field except its labels -- must still be offered. Without it the fix
+# "skip all PRs" is green.
+#
+# ISOLATION. The park check reads labels from Linear, so every case here points
+# KIPI_LINEAR_API_URL at a fixture HTTP server on 127.0.0.1. No case reaches the
+# real board and no case needs a real API key.
+set -uo pipefail
+
+REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/../../../.." && pwd)"
+SEL="$REPO_ROOT/q-system/.q-system/scripts/review-redrive.py"
+[ -f "$SEL" ] || { echo "FATAL: review-redrive.py not found at $SEL" >&2; exit 1; }
+SEL="${REVIEW_REDRIVE_UNDER_TEST:-$SEL}"
+
+WORK="$(mktemp -d)"
+trap 'kill "${SRV_PID:-}" 2>/dev/null; rm -rf "$WORK"' EXIT
+PASS=0; FAIL=0
+ok()  { PASS=$((PASS+1)); echo "  ok   - $1"; }
+bad() { FAIL=$((FAIL+1)); echo "  FAIL - $1"; }
+
+RECORDS="$WORK/records"; mkdir -p "$RECORDS"
+BIN="$WORK/bin"; mkdir -p "$BIN"
+
+# --- the notify sink, stubbed for every case --------------------------------
+# review-redrive escalates from inside `select`. With no stub that is the REAL
+# slack-notify.sh: a live data path in a test suite, quiet only because no
+# webhook resolves on this machine.
+PAGES="$WORK/pages.txt"; : > "$PAGES"
+cat > "$BIN/notify.sh" <<EOS
+#!/usr/bin/env bash
+printf '%s\n' "\$*" >> "$PAGES"
+EOS
+chmod +x "$BIN/notify.sh"
+
+# --- the board, stubbed at the gh seam --------------------------------------
+cat > "$BIN/gh" <<'EOS'
+#!/usr/bin/env bash
+cat "$BOARD"
+EOS
+chmod +x "$BIN/gh"
+
+# --- fixture Linear: one label set per issue --------------------------------
+# The four issues are byte-identical except for `labels`, which is the only
+# field the park check may read.
+cat > "$WORK/fixture-server.py" <<'PY'
+import json
+from http.server import BaseHTTPRequestHandler, HTTPServer
+
+LABELS = {
+    "ASK-901": ["owner:sana", "owner:assaf"],
+    "ASK-902": ["owner:sana", "needs-scope"],
+    "ASK-903": ["owner:sana", "blocked:capability"],
+    "ASK-904": ["owner:sana"],
+}
+
+def issue(ident):
+    return {"id": ident, "identifier": ident,
+            "labels": {"nodes": [{"name": n} for n in LABELS.get(ident, [])]}}
+
+class H(BaseHTTPRequestHandler):
+    def log_message(self, *a): pass
+    def do_POST(self):
+        body = self.rfile.read(int(self.headers["Content-Length"])).decode()
+        req = json.loads(body)
+        # The reader asks for a batch of aliased issues. Answer whichever
+        # identifiers it named, under the alias it used, so the fixture cannot
+        # accidentally teach the reader an ordering it does not have live.
+        data = {}
+        for alias, ident in _aliases(req.get("query") or ""):
+            data[alias] = issue(ident)
+        out = json.dumps({"data": data}).encode()
+        self.send_response(200); self.send_header("Content-Type", "application/json")
+        self.send_header("Content-Length", str(len(out))); self.end_headers()
+        self.wfile.write(out)
+
+def _aliases(query):
+    # `i0: issue(id: "ASK-901") { ... }` -> ("i0", "ASK-901")
+    import re
+    return re.findall(r'(\w+)\s*:\s*issue\(\s*id\s*:\s*"([^"]+)"', query)
+
+srv = HTTPServer(("127.0.0.1", 0), H)
+print(srv.server_port, flush=True)
+srv.serve_forever()
+PY
+python3 "$WORK/fixture-server.py" > "$WORK/port" 2> "$WORK/server.err" &
+SRV_PID=$!
+for _ in $(seq 1 100); do PORT="$(cat "$WORK/port" 2>/dev/null)"; [ -n "${PORT:-}" ] && break; sleep 0.1; done
+[ -n "${PORT:-}" ] || { echo "fixture server did not start"; cat "$WORK/server.err"; exit 1; }
+
+# A PR entry with a failing reviewer slot. Everything except pr/branch/sha is
+# fixed, so a difference in outcome can only come from the issue's labels.
+pr_entry() {   # pr_entry <number> <issue-lower> <sha>
+  cat <<EOS
+{"number": $1, "headRefName": "sana/$2", "headRefOid": "$3",
+ "url": "https://example.invalid/pr/$1", "title": "work ($(echo "$2" | tr a-z A-Z))",
+ "isDraft": false,
+ "statusCheckRollup": [
+   {"__typename": "StatusContext", "context": "kipi/reviewer-approved", "state": "FAILURE"},
+   {"__typename": "CheckRun", "name": "validate", "status": "COMPLETED", "conclusion": "SUCCESS"}
+ ]}
+EOS
+}
+
+record() {   # record <pr> <issue> <sha>
+  python3 - "$RECORDS/pr-$1.verdict.json" "$1" "$2" "$3" <<'PY'
+import json, sys
+out, pr, issue, sha = sys.argv[1:5]
+json.dump({"pr": int(pr), "issue": issue, "verdict": "REQUEST CHANGES",
+           "stated": "REQUEST CHANGES", "derived": "", "source": "findings",
+           "engine": "codex", "round": 1, "review": "", "usable": True,
+           "head_sha": sha, "ts": "now"}, open(out, "w"), indent=2)
+PY
+}
+
+run_select() {   # run_select [extra env assignments via RR_URL]
+  env PATH="$BIN:$PATH" BOARD="$WORK/board.json" KIPI_NOTIFY="$BIN/notify.sh" \
+    KIPI_LINEAR_API_URL="${RR_URL:-http://127.0.0.1:$PORT/graphql}" \
+    KIPI_LINEAR_API_KEY="fixture-key-not-a-secret" \
+    python3 "$SEL" --repo-dir "$WORK" --records-dir "$RECORDS" select --all \
+    > "$WORK/out.txt" 2> "$WORK/err.txt"
+  echo $?
+}
+
+echo "== review-redrive park labels =="
+
+printf '[%s,%s,%s,%s]\n' \
+  "$(pr_entry 90 ask-901 aaaa1111)" "$(pr_entry 91 ask-902 bbbb2222)" \
+  "$(pr_entry 92 ask-903 cccc3333)" "$(pr_entry 93 ask-904 dddd4444)" \
+  > "$WORK/board.json"
+record 90 ASK-901 aaaa1111
+record 91 ASK-902 bbbb2222
+record 92 ASK-903 cccc3333
+record 93 ASK-904 dddd4444
+
+RC="$(run_select)"
+OUT="$(cat "$WORK/out.txt")"
+ERR="$(cat "$WORK/err.txt")"
+
+# --- the three parked issues --------------------------------------------------
+for pair in "90:owner:assaf" "91:needs-scope" "92:blocked:capability"; do
+  PR="${pair%%:*}"; LABEL="${pair#*:}"
+  if printf '%s' "$OUT" | awk -F'\t' -v pr="$PR" '$3 == pr {found=1} END {exit !found}'; then
+    bad "PR #$PR is parked by $LABEL and was still offered"
+  else
+    ok "PR #$PR is parked by $LABEL and is not offered"
+  fi
+  case "$ERR" in
+    *"$LABEL"*) ok "the run names $LABEL as what stopped PR #$PR" ;;
+    *) bad "nothing in stderr names $LABEL -- a silent skip is the same park, quieter" ;;
+  esac
+done
+
+# --- the negative fixture: the fix must not be "skip everything" -------------
+if printf '%s' "$OUT" | awk -F'\t' -v pr="93" '$3 == pr {found=1} END {exit !found}'; then
+  ok "PR #93 carries none of the three and is still offered"
+else
+  bad "PR #93 carries none of the three and was dropped -- the fix skips everything"
+fi
+
+# --- an unreadable board is not an empty one ---------------------------------
+# Same posture as GhUnavailable (rc 2): if the park state cannot be read, the
+# run must not decide that nothing is parked. It refuses and says so.
+#
+# 127.0.0.1:1 is chosen over an unroutable address on purpose: a closed port on
+# loopback refuses the connection immediately, so this case cannot hang on a
+# 30s socket timeout.
+RC2="$(RR_URL="http://127.0.0.1:1/graphql" run_select)"
+OUT2="$(cat "$WORK/out.txt")"
+[ "$RC2" = "2" ] && ok "an unreadable park state exits 2, not 0" \
+  || bad "an unreadable park state exited '$RC2' -- the caller reads that as a verdict"
+[ -z "$OUT2" ] && ok "an unreadable park state offers nothing" \
+  || bad "an unreadable park state still offered: $OUT2"
+
+echo
+echo "  $PASS passed, $FAIL failed"
+[ "$FAIL" -eq 0 ] || exit 1

--- a/q-system/.q-system/scripts/test/test-review-redrive-park.sh
+++ b/q-system/.q-system/scripts/test/test-review-redrive-park.sh
@@ -55,58 +55,12 @@ chmod +x "$BIN/gh"
 # --- fixture Linear: one label set per issue --------------------------------
 # The four issues are byte-identical except for `labels`, which is the only
 # field the park check may read.
-cat > "$WORK/fixture-server.py" <<'PY'
-import json, os
-from http.server import BaseHTTPRequestHandler, HTTPServer
-
-# RE-READ PER REQUEST, from a file the cases rewrite. The board is not a
-# constant in life: the whole point of the mark-dispatched cases below is that a
-# label lands BETWEEN two reads, so a fixture that answers from a dict frozen at
-# import cannot express the state the defect lives in.
-LABELS_FILE = os.environ["LABELS_FILE"]
-
-# TWO SENTINELS INSTEAD OF A LABEL LIST, because Linear can answer a lookup
-# without answering the question. `__null__` is the alias present and null (the
-# id resolved to no issue); `__omit__` is the alias absent from `data` entirely.
-# Both arrive with NO `errors` key, so `graphql` returns normally and the reader
-# is holding a response that says nothing about the park.
-NULL = "__null__"
-OMIT = "__omit__"
-
-def issue(ident):
-    labels = json.load(open(LABELS_FILE)).get(ident, [])
-    if labels == NULL:
-        return None
-    return {"id": ident, "identifier": ident,
-            "labels": {"nodes": [{"name": n} for n in labels]}}
-
-class H(BaseHTTPRequestHandler):
-    def log_message(self, *a): pass
-    def do_POST(self):
-        body = self.rfile.read(int(self.headers["Content-Length"])).decode()
-        req = json.loads(body)
-        # The reader asks for a batch of aliased issues. Answer whichever
-        # identifiers it named, under the alias it used, so the fixture cannot
-        # accidentally teach the reader an ordering it does not have live.
-        data = {}
-        for alias, ident in _aliases(req.get("query") or ""):
-            if json.load(open(LABELS_FILE)).get(ident) == OMIT:
-                continue          # the alias never appears in the response
-            data[alias] = issue(ident)
-        out = json.dumps({"data": data}).encode()
-        self.send_response(200); self.send_header("Content-Type", "application/json")
-        self.send_header("Content-Length", str(len(out))); self.end_headers()
-        self.wfile.write(out)
-
-def _aliases(query):
-    # `i0: issue(id: "ASK-901") { ... }` -> ("i0", "ASK-901")
-    import re
-    return re.findall(r'(\w+)\s*:\s*issue\(\s*id\s*:\s*"([^"]+)"', query)
-
-srv = HTTPServer(("127.0.0.1", 0), H)
-print(srv.server_port, flush=True)
-srv.serve_forever()
-PY
+#
+# THE SERVER IS A COMMITTED FILE, NOT A HEREDOC. test-ci-redrive.sh drives the
+# real dispatcher against the same reader and needs the same board, and a second
+# copy of this fixture would drift exactly like a second copy of the label list.
+FIXTURE_SRV="$(dirname "${BASH_SOURCE[0]}")/linear-park-fixture.py"
+[ -f "$FIXTURE_SRV" ] || { echo "FATAL: fixture server not found at $FIXTURE_SRV" >&2; exit 1; }
 LABELS_FILE="$WORK/labels.json"
 set_labels() { printf '%s' "$1" > "$LABELS_FILE"; }
 set_labels '{"ASK-901": ["owner:sana", "owner:assaf"],
@@ -115,7 +69,7 @@ set_labels '{"ASK-901": ["owner:sana", "owner:assaf"],
              "ASK-904": ["owner:sana"],
              "ASK-905": ["owner:sana"]}'
 export LABELS_FILE
-python3 "$WORK/fixture-server.py" > "$WORK/port" 2> "$WORK/server.err" &
+python3 "$FIXTURE_SRV" > "$WORK/port" 2> "$WORK/server.err" &
 SRV_PID=$!
 for _ in $(seq 1 100); do PORT="$(cat "$WORK/port" 2>/dev/null)"; [ -n "${PORT:-}" ] && break; sleep 0.1; done
 [ -n "${PORT:-}" ] || { echo "fixture server did not start"; cat "$WORK/server.err"; exit 1; }
@@ -307,10 +261,18 @@ else
   bad "PR #95 was not offered on a normal answer (rc=$RCP) -- the cases below prove nothing"
 fi
 
+# THE UNIT OF REFUSAL IS THE ISSUE, NOT THE RUN (PR #201 review round 4, major).
+# Round 2 raised for the whole batch on a null lookup, which is why these two
+# cases used to assert rc 3. That was over-wide: the id comes off the PR (branch
+# tail, else title), so ONE badly-titled PR made the reader refuse the entire
+# board, every heartbeat, permanently. The property is unchanged -- an
+# unverifiable park is never read as unparked -- but it is enforced against the
+# candidate that could not be verified, and nothing else. With a one-PR board
+# that leaves nothing to offer, which is rc 1: nothing red, not a Linear outage.
 set_labels '{"ASK-906": "__null__"}'
 RCN="$(run_select)"
-[ "$RCN" = "3" ] && ok "a null issue lookup exits 3, not 0" \
-  || bad "a null issue lookup exited '$RCN' -- an unverifiable park reads as unparked"
+[ "$RCN" = "1" ] && ok "a null issue lookup leaves nothing offerable (rc 1)" \
+  || bad "a null issue lookup exited '$RCN' -- want 1: the candidate is dropped, the run is not"
 [ -z "$(cat "$WORK/out.txt")" ] && ok "a null issue lookup offers nothing" \
   || bad "a null issue lookup still offered: $(cat "$WORK/out.txt")"
 case "$(cat "$WORK/err.txt")" in
@@ -320,8 +282,10 @@ esac
 
 set_labels '{"ASK-906": "__omit__"}'
 RCO="$(run_select)"
-[ "$RCO" = "3" ] && ok "an alias missing from the response exits 3, not 0" \
-  || bad "a missing alias exited '$RCO' -- a dropped alias reads as unparked"
+[ "$RCO" = "1" ] && ok "an alias missing from the response leaves nothing offerable (rc 1)" \
+  || bad "a missing alias exited '$RCO' -- want 1: a dropped alias drops its candidate"
+[ -z "$(cat "$WORK/out.txt")" ] && ok "a missing alias offers nothing" \
+  || bad "a missing alias still offered: $(cat "$WORK/out.txt")"
 
 # THE SAME AT THE CLAIM, which is where the attempt is at stake.
 set_labels '{"ASK-906": "__null__"}'
@@ -333,6 +297,136 @@ set_labels '{"ASK-906": ["owner:sana"]}'
 RCMU="$(run_mark ASK-906 rework 95 99996666)"
 [ "$RCMU" = "0" ] && ok "the null-lookup refusal left the attempt unspent" \
   || bad "after a readable answer the claim returned '$RCMU' -- the refusal spent the attempt"
+
+# --- one bad id must not suppress the batch ----------------------------------
+# FINDING (PR #201 review round 4, major): "One invalid title-derived issue ID
+# aborts the entire batched park lookup, suppressing every valid reviewer-redrive
+# candidate."
+#
+# THE ID IS DERIVED FROM THE PR, so it is attacker-free but not trustworthy:
+# ci-redrive's attribute() takes the branch tail when it is an issue id, else the
+# ONE id the title names via `\b[A-Za-z]{2,6}-\d+\b`. "convert the log writer to
+# UTF-8" satisfies that pattern. So a PR nobody wrote carelessly -- just titled
+# in English -- yields the identifier `UTF-8`, Linear resolves nothing for it,
+# and round 2's whole-batch raise then took the reviewer redrive offline for
+# every OTHER PR on the board. Not transient: that title does not heal.
+#
+# The fixture uses that exact title rather than a sentinel id, because the id
+# under test has to be one the producer really emits (fixtures-from-producers).
+echo
+echo "== one unresolvable id drops its own candidate, not the batch =="
+
+# ask-907 on the branch tail -> a normal, verifiable candidate.
+# A branch tail that is NOT an issue id -> attribute() falls through to the title.
+cat > "$WORK/board.json" <<EOS
+[$(pr_entry 96 ask-907 77771111),
+ {"number": 97, "headRefName": "sana/encoding-fix", "headRefOid": "88882222",
+  "url": "https://example.invalid/pr/97",
+  "title": "convert the log writer to UTF-8 (no issue id here)",
+  "isDraft": false,
+  "statusCheckRollup": [
+    {"__typename": "StatusContext", "context": "kipi/reviewer-approved", "state": "FAILURE"},
+    {"__typename": "CheckRun", "name": "validate", "status": "COMPLETED", "conclusion": "SUCCESS"}
+  ]}]
+EOS
+record 96 ASK-907 77771111
+record 97 UTF-8 88882222
+
+set_labels '{"ASK-907": ["owner:sana"], "UTF-8": "__null__"}'
+RCB="$(run_select)"
+OUTB="$(cat "$WORK/out.txt")"; ERRB="$(cat "$WORK/err.txt")"
+[ "$RCB" = "0" ] && ok "a batch holding one unresolvable id still answers (rc 0)" \
+  || bad "the batch exited '$RCB' -- one bad PR title suppressed every valid candidate"
+if printf '%s' "$OUTB" | awk -F'\t' '$3 == "96" {f=1} END {exit !f}'; then
+  ok "the valid candidate PR #96 survives a sibling Linear cannot resolve"
+else
+  bad "PR #96 was suppressed by PR #97's unresolvable id -- the finding, unfixed"
+fi
+if printf '%s' "$OUTB" | awk -F'\t' '$3 == "97" {f=1} END {exit !f}'; then
+  bad "PR #97 was offered on a park nobody could verify"
+else
+  ok "PR #97, whose park state is unknown, is not offered"
+fi
+case "$ERRB" in
+  *UTF-8*) ok "the run names UTF-8 as the id it could not resolve" ;;
+  *) bad "nothing in stderr names UTF-8 -- the operator cannot find the mistitled PR" ;;
+esac
+
+# THE OTHER DIRECTION, and without it "drop the ones you cannot read" passes by
+# reading nothing. A batch-level failure is still a batch-level refusal: the
+# whole response is missing, so no candidate in it was verified.
+RCB2="$(RR_URL="http://127.0.0.1:1/graphql" run_select)"
+[ "$RCB2" = "3" ] && ok "a Linear outage still refuses the whole batch (rc 3)" \
+  || bad "a Linear outage exited '$RCB2' -- per-issue isolation swallowed a real outage"
+[ -z "$(cat "$WORK/out.txt")" ] && ok "a Linear outage offers nothing from the batch" \
+  || bad "a Linear outage still offered: $(cat "$WORK/out.txt")"
+
+# AND A RESPONSE THAT MIS-FILES ONE ALIAS IS ALSO BATCH-WIDE, deliberately: a
+# bad INPUT id makes one issue unknown, but an alias answering about a different
+# issue means the response mapping itself cannot be trusted, so nothing in it may
+# be filed. Two failure shapes, two blast radii, and the split is the whole fix.
+set_labels '{"ASK-907": "__wrong__", "UTF-8": "__null__"}'
+RCB3="$(run_select)"
+[ "$RCB3" = "3" ] && ok "an alias answering for another issue refuses the batch (rc 3)" \
+  || bad "a mis-filed alias exited '$RCB3' -- park state was filed under the wrong issue"
+
+# --- park-check: the read-only answer the dispatcher asks for ----------------
+# FINDING (PR #201 review round 4, major): "Park labels do not stop the
+# higher-priority red-CI redrive, so a parked issue with red CI is still
+# dispatched." kipi-dispatch.sh runs ci-redrive.py FIRST and only reaches the
+# reviewer redrive when it offered nothing, so everything this file proves about
+# select/mark-dispatched was bypassed whenever a parked issue also had red CI.
+#
+# The dispatcher needs the park answer for an issue it did not select here, so
+# this is a subcommand and not a flag on select. READ-ONLY: it must never touch
+# the attempts ledger, or asking the question would spend the answer.
+echo
+echo "== park-check: one issue, one answer, no writes =="
+
+run_check() {   # run_check <issue>
+  env PATH="$BIN:$PATH" KIPI_NOTIFY="$BIN/notify.sh" KIPI_ATTEMPTS="$LEDGER" \
+    KIPI_LINEAR_API_URL="${RR_URL:-http://127.0.0.1:$PORT/graphql}" \
+    KIPI_LINEAR_API_KEY="fixture-key-not-a-secret" \
+    python3 "$SEL" park-check --issue "$1" \
+    > "$WORK/cout.txt" 2> "$WORK/cerr.txt"
+  echo $?
+}
+
+set_labels '{"ASK-910": ["owner:sana"],
+             "ASK-911": ["owner:sana", "owner:assaf"],
+             "ASK-912": ["owner:sana", "blocked:capability"],
+             "ASK-913": "__null__"}'
+
+LEDGER_BEFORE="$(cat "$LEDGER" 2>/dev/null || echo absent)"
+
+RCC="$(run_check ASK-910)"
+[ "$RCC" = "0" ] && ok "an unparked issue answers 0 -- the redrive may proceed" \
+  || bad "an unparked issue exited '$RCC' (stderr: $(cat "$WORK/cerr.txt"))"
+
+RCC2="$(run_check ASK-911)"
+[ "$RCC2" = "4" ] && ok "an issue parked by owner:assaf answers 4" \
+  || bad "a parked issue exited '$RCC2' -- the dispatcher would redrive it"
+case "$(cat "$WORK/cout.txt")" in
+  *owner:assaf*) ok "park-check prints the label on stdout so the say line can name it" ;;
+  *) bad "park-check printed no label -- dispatch.log would say 'parked' and not by what" ;;
+esac
+
+RCC3="$(run_check ASK-912)"
+[ "$RCC3" = "4" ] && ok "an issue parked by blocked:capability answers 4" \
+  || bad "blocked:capability exited '$RCC3' -- the sharpest case, an agent that cannot finish"
+
+RCC4="$(run_check ASK-913)"
+[ "$RCC4" = "3" ] && ok "an id Linear cannot resolve answers 3, not 0" \
+  || bad "an unresolvable id exited '$RCC4' -- the dispatcher would read that as unparked"
+
+RCC5="$(RR_URL="http://127.0.0.1:1/graphql" run_check ASK-910)"
+[ "$RCC5" = "3" ] && ok "a Linear outage answers 3, not 0" \
+  || bad "a Linear outage exited '$RCC5' -- an unreadable source read as permission"
+
+LEDGER_AFTER="$(cat "$LEDGER" 2>/dev/null || echo absent)"
+[ "$LEDGER_BEFORE" = "$LEDGER_AFTER" ] \
+  && ok "five park-checks wrote nothing to the attempts ledger" \
+  || bad "park-check moved the ledger -- asking the question spent an attempt"
 
 echo
 echo "  $PASS passed, $FAIL failed"

--- a/q-system/.q-system/scripts/test/test-review-redrive-park.sh
+++ b/q-system/.q-system/scripts/test/test-review-redrive-park.sh
@@ -268,7 +268,7 @@ RCM3="$(run_mark ASK-905 rework 94 eeee5555)"
   || bad "the second claim returned '$RCM3' -- the one-attempt cap is broken"
 
 # 5. an unreadable park state at the claim fails CLOSED, with its own code.
-RCM4="$(RR_URL="http://127.0.0.1:1/graphql" run_mark ASK-905 rereview 94 ffff6666)"
+RCM4="$(RR_URL="http://127.0.0.1:1/graphql" run_mark ASK-905 re-review 94 ffff6666)"
 [ "$RCM4" = "3" ] && ok "an unreadable park state at the claim exits 3, not 0" \
   || bad "an unreadable park state at the claim exited '$RCM4' -- it would dispatch"
 

--- a/q-system/.q-system/scripts/test/test-review-redrive-park.sh
+++ b/q-system/.q-system/scripts/test/test-review-redrive-park.sh
@@ -56,19 +56,19 @@ chmod +x "$BIN/gh"
 # The four issues are byte-identical except for `labels`, which is the only
 # field the park check may read.
 cat > "$WORK/fixture-server.py" <<'PY'
-import json
+import json, os
 from http.server import BaseHTTPRequestHandler, HTTPServer
 
-LABELS = {
-    "ASK-901": ["owner:sana", "owner:assaf"],
-    "ASK-902": ["owner:sana", "needs-scope"],
-    "ASK-903": ["owner:sana", "blocked:capability"],
-    "ASK-904": ["owner:sana"],
-}
+# RE-READ PER REQUEST, from a file the cases rewrite. The board is not a
+# constant in life: the whole point of the mark-dispatched cases below is that a
+# label lands BETWEEN two reads, so a fixture that answers from a dict frozen at
+# import cannot express the state the defect lives in.
+LABELS_FILE = os.environ["LABELS_FILE"]
 
 def issue(ident):
+    labels = json.load(open(LABELS_FILE))
     return {"id": ident, "identifier": ident,
-            "labels": {"nodes": [{"name": n} for n in LABELS.get(ident, [])]}}
+            "labels": {"nodes": [{"name": n} for n in labels.get(ident, [])]}}
 
 class H(BaseHTTPRequestHandler):
     def log_message(self, *a): pass
@@ -95,6 +95,14 @@ srv = HTTPServer(("127.0.0.1", 0), H)
 print(srv.server_port, flush=True)
 srv.serve_forever()
 PY
+LABELS_FILE="$WORK/labels.json"
+set_labels() { printf '%s' "$1" > "$LABELS_FILE"; }
+set_labels '{"ASK-901": ["owner:sana", "owner:assaf"],
+             "ASK-902": ["owner:sana", "needs-scope"],
+             "ASK-903": ["owner:sana", "blocked:capability"],
+             "ASK-904": ["owner:sana"],
+             "ASK-905": ["owner:sana"]}'
+export LABELS_FILE
 python3 "$WORK/fixture-server.py" > "$WORK/port" 2> "$WORK/server.err" &
 SRV_PID=$!
 for _ in $(seq 1 100); do PORT="$(cat "$WORK/port" 2>/dev/null)"; [ -n "${PORT:-}" ] && break; sleep 0.1; done
@@ -125,12 +133,29 @@ json.dump({"pr": int(pr), "issue": issue, "verdict": "REQUEST CHANGES",
 PY
 }
 
-run_select() {   # run_select [extra env assignments via RR_URL]
-  env PATH="$BIN:$PATH" BOARD="$WORK/board.json" KIPI_NOTIFY="$BIN/notify.sh" \
+# KIPI_ATTEMPTS IS PINNED AT A TEMP PATH FOR EVERY CASE. Without it the ledger
+# ops below write to the real attempts ledger -- a live data path inside a test
+# suite, and one that would silently spend a real PR's one machine attempt.
+LEDGER="$WORK/attempts.json"
+
+run_select() {   # run_select   (RR_URL / RR_BOARD override the two sources)
+  env PATH="$BIN:$PATH" BOARD="${RR_BOARD:-$WORK/board.json}" KIPI_NOTIFY="$BIN/notify.sh" \
+    KIPI_ATTEMPTS="$LEDGER" \
     KIPI_LINEAR_API_URL="${RR_URL:-http://127.0.0.1:$PORT/graphql}" \
     KIPI_LINEAR_API_KEY="fixture-key-not-a-secret" \
     python3 "$SEL" --repo-dir "$WORK" --records-dir "$RECORDS" select --all \
     > "$WORK/out.txt" 2> "$WORK/err.txt"
+  echo $?
+}
+
+run_mark() {   # run_mark <issue> <action> <pr> <sha>
+  env PATH="$BIN:$PATH" BOARD="$WORK/board.json" KIPI_NOTIFY="$BIN/notify.sh" \
+    KIPI_ATTEMPTS="$LEDGER" \
+    KIPI_LINEAR_API_URL="${RR_URL:-http://127.0.0.1:$PORT/graphql}" \
+    KIPI_LINEAR_API_KEY="fixture-key-not-a-secret" \
+    python3 "$SEL" --repo-dir "$WORK" --records-dir "$RECORDS" mark-dispatched \
+    --issue "$1" --action "$2" --pr "$3" --head-sha "$4" \
+    > "$WORK/mout.txt" 2> "$WORK/merr.txt"
   echo $?
 }
 
@@ -171,18 +196,81 @@ else
 fi
 
 # --- an unreadable board is not an empty one ---------------------------------
-# Same posture as GhUnavailable (rc 2): if the park state cannot be read, the
-# run must not decide that nothing is parked. It refuses and says so.
+# Same posture as GhUnavailable: if the park state cannot be read, the run must
+# not decide that nothing is parked. It refuses and says so.
 #
 # 127.0.0.1:1 is chosen over an unroutable address on purpose: a closed port on
 # loopback refuses the connection immediately, so this case cannot hang on a
 # 30s socket timeout.
 RC2="$(RR_URL="http://127.0.0.1:1/graphql" run_select)"
 OUT2="$(cat "$WORK/out.txt")"
-[ "$RC2" = "2" ] && ok "an unreadable park state exits 2, not 0" \
+[ "$RC2" = "3" ] && ok "an unreadable park state exits 3, not 0" \
   || bad "an unreadable park state exited '$RC2' -- the caller reads that as a verdict"
 [ -z "$OUT2" ] && ok "an unreadable park state offers nothing" \
   || bad "an unreadable park state still offered: $OUT2"
+
+# THE OTHER HALF OF THAT CODE, and without it "return 3 for everything" passes.
+# The selector reads TWO sources and the dispatcher prints a different sentence
+# per source, so the codes have to discriminate: gh down is still 2, Linear down
+# is 3. Both being 2 is what made a Linear outage read as a GitHub outage on the
+# operator's only surface (PR #201 review, minor).
+RC3="$(RR_BOARD="$WORK/no-such-board.json" run_select)"
+[ "$RC3" = "2" ] && ok "a gh outage still exits 2, distinct from the park code" \
+  || bad "a gh outage exited '$RC3' -- the dispatcher cannot tell the two sources apart"
+
+# --- the claim re-reads the park: a label that lands AFTER select -------------
+# FINDING 1 (PR #201 review, major). `select` and `mark-dispatched` are separate
+# processes with the dispatcher's own guards running between them. The park was
+# read only in the first, so a label applied in that window was invisible at the
+# point the work actually launches.
+#
+# The sequence below IS the window, played out: offer it, park it, then claim.
+echo
+echo "== the park is re-read at the atomic claim =="
+
+printf '[%s]\n' "$(pr_entry 94 ask-905 eeee5555)" > "$WORK/board.json"
+record 94 ASK-905 eeee5555
+
+# 1. unparked, so it is genuinely selectable. Without this the case below could
+#    pass because the PR was never a candidate at all.
+RCS="$(run_select)"
+if printf '%s' "$(cat "$WORK/out.txt")" | awk -F'\t' '$3 == "94" {f=1} END {exit !f}'; then
+  ok "PR #94 is offered while ASK-905 carries no park label"
+else
+  bad "PR #94 was not offered even unparked (rc=$RCS) -- the case below proves nothing"
+fi
+
+# 2. the label lands in the window between the offer and the claim.
+set_labels '{"ASK-905": ["owner:sana", "blocked:capability"]}'
+RCM="$(run_mark ASK-905 rework 94 eeee5555)"
+MERR="$(cat "$WORK/merr.txt")"
+[ "$RCM" = "4" ] && ok "a park that lands after select refuses the claim (rc 4)" \
+  || bad "the claim returned '$RCM' -- the dispatcher launches work on a parked issue"
+case "$MERR" in
+  *blocked:capability*) ok "the refusal names blocked:capability as what stopped it" ;;
+  *) bad "nothing in stderr names the label -- a silent refusal is unreadable in dispatch.log" ;;
+esac
+
+# 3. THE ATTEMPT MUST STILL BE UNSPENT. The flag is one attempt per PR per action
+#    per head sha. Claiming and then refusing would burn it on work that never
+#    ran, and lifting the park would not give it back -- the next redrive would
+#    skip PR #94 for having "already had its one attempt". Lifting the park and
+#    getting rc 0 is the only thing that proves the ordering.
+set_labels '{"ASK-905": ["owner:sana"]}'
+RCM2="$(run_mark ASK-905 rework 94 eeee5555)"
+[ "$RCM2" = "0" ] && ok "the refused claim left the attempt unspent: it claims once the park lifts" \
+  || bad "after the park lifted the claim returned '$RCM2' -- the refusal spent the attempt"
+
+# 4. and the ledger claim itself still works, so the fix did not turn
+#    mark-dispatched into a park check that forgot its original job.
+RCM3="$(run_mark ASK-905 rework 94 eeee5555)"
+[ "$RCM3" = "1" ] && ok "a second claim on the same attempt is still refused as claimed" \
+  || bad "the second claim returned '$RCM3' -- the one-attempt cap is broken"
+
+# 5. an unreadable park state at the claim fails CLOSED, with its own code.
+RCM4="$(RR_URL="http://127.0.0.1:1/graphql" run_mark ASK-905 rereview 94 ffff6666)"
+[ "$RCM4" = "3" ] && ok "an unreadable park state at the claim exits 3, not 0" \
+  || bad "an unreadable park state at the claim exited '$RCM4' -- it would dispatch"
 
 echo
 echo "  $PASS passed, $FAIL failed"

--- a/q-system/.q-system/scripts/test/test-review-redrive-park.sh
+++ b/q-system/.q-system/scripts/test/test-review-redrive-park.sh
@@ -65,10 +65,20 @@ from http.server import BaseHTTPRequestHandler, HTTPServer
 # import cannot express the state the defect lives in.
 LABELS_FILE = os.environ["LABELS_FILE"]
 
+# TWO SENTINELS INSTEAD OF A LABEL LIST, because Linear can answer a lookup
+# without answering the question. `__null__` is the alias present and null (the
+# id resolved to no issue); `__omit__` is the alias absent from `data` entirely.
+# Both arrive with NO `errors` key, so `graphql` returns normally and the reader
+# is holding a response that says nothing about the park.
+NULL = "__null__"
+OMIT = "__omit__"
+
 def issue(ident):
-    labels = json.load(open(LABELS_FILE))
+    labels = json.load(open(LABELS_FILE)).get(ident, [])
+    if labels == NULL:
+        return None
     return {"id": ident, "identifier": ident,
-            "labels": {"nodes": [{"name": n} for n in labels.get(ident, [])]}}
+            "labels": {"nodes": [{"name": n} for n in labels]}}
 
 class H(BaseHTTPRequestHandler):
     def log_message(self, *a): pass
@@ -80,6 +90,8 @@ class H(BaseHTTPRequestHandler):
         # accidentally teach the reader an ordering it does not have live.
         data = {}
         for alias, ident in _aliases(req.get("query") or ""):
+            if json.load(open(LABELS_FILE)).get(ident) == OMIT:
+                continue          # the alias never appears in the response
             data[alias] = issue(ident)
         out = json.dumps({"data": data}).encode()
         self.send_response(200); self.send_header("Content-Type", "application/json")
@@ -271,6 +283,56 @@ RCM3="$(run_mark ASK-905 rework 94 eeee5555)"
 RCM4="$(RR_URL="http://127.0.0.1:1/graphql" run_mark ASK-905 re-review 94 ffff6666)"
 [ "$RCM4" = "3" ] && ok "an unreadable park state at the claim exits 3, not 0" \
   || bad "an unreadable park state at the claim exited '$RCM4' -- it would dispatch"
+
+# --- a lookup that answers nothing ------------------------------------------
+# FINDING 2 (PR #201 review round 2, minor). `graphql` raises on an `errors`
+# array, so the reader only ever sees a clean response -- but a clean response
+# can still say nothing about an issue. Linear answers `null` for an id it does
+# not resolve, and an alias can be absent from `data` outright. Both were read
+# as "no park labels found", which is the module's stated defect one layer down:
+# I COULD NOT ASK is not NOTHING IS PARKED.
+echo
+echo "== a lookup that answers nothing is unreadable, not unparked =="
+
+printf '[%s]\n' "$(pr_entry 95 ask-906 99996666)" > "$WORK/board.json"
+record 95 ASK-906 99996666
+
+# The discrimination first, on the same PR: without it "exit 3 whenever the
+# response is not a full label set" would pass every case below.
+set_labels '{"ASK-906": ["owner:sana"]}'
+RCP="$(run_select)"
+if printf '%s' "$(cat "$WORK/out.txt")" | awk -F'\t' '$3 == "95" {f=1} END {exit !f}'; then
+  ok "PR #95 is offered while ASK-906 answers normally"
+else
+  bad "PR #95 was not offered on a normal answer (rc=$RCP) -- the cases below prove nothing"
+fi
+
+set_labels '{"ASK-906": "__null__"}'
+RCN="$(run_select)"
+[ "$RCN" = "3" ] && ok "a null issue lookup exits 3, not 0" \
+  || bad "a null issue lookup exited '$RCN' -- an unverifiable park reads as unparked"
+[ -z "$(cat "$WORK/out.txt")" ] && ok "a null issue lookup offers nothing" \
+  || bad "a null issue lookup still offered: $(cat "$WORK/out.txt")"
+case "$(cat "$WORK/err.txt")" in
+  *ASK-906*) ok "the refusal names the issue Linear did not answer for" ;;
+  *) bad "nothing in stderr names ASK-906 -- the operator cannot tell which id failed" ;;
+esac
+
+set_labels '{"ASK-906": "__omit__"}'
+RCO="$(run_select)"
+[ "$RCO" = "3" ] && ok "an alias missing from the response exits 3, not 0" \
+  || bad "a missing alias exited '$RCO' -- a dropped alias reads as unparked"
+
+# THE SAME AT THE CLAIM, which is where the attempt is at stake.
+set_labels '{"ASK-906": "__null__"}'
+RCMN="$(run_mark ASK-906 rework 95 99996666)"
+[ "$RCMN" = "3" ] && ok "a null lookup at the claim exits 3, not 0" \
+  || bad "a null lookup at the claim exited '$RCMN' -- it would dispatch"
+
+set_labels '{"ASK-906": ["owner:sana"]}'
+RCMU="$(run_mark ASK-906 rework 95 99996666)"
+[ "$RCMU" = "0" ] && ok "the null-lookup refusal left the attempt unspent" \
+  || bad "after a readable answer the claim returned '$RCMU' -- the refusal spent the attempt"
 
 echo
 echo "  $PASS passed, $FAIL failed"

--- a/q-system/.q-system/scripts/test/test-review-redrive.sh
+++ b/q-system/.q-system/scripts/test/test-review-redrive.sh
@@ -249,6 +249,37 @@ select_one() {
       KIPI_NOTIFY="$BIN/notify.sh" "${LINEAR_ENV[@]}" \
     python3 "$SEL" --repo-dir "$WORK" --records-dir "$RECORDS" select 2>/dev/null
 }
+
+# THE CLAIM GOES THROUGH ONE DOOR TOO, for the same reason `select` does.
+#
+# This was two bare `env KIPI_ATTEMPTS=` lines until PR #201 review round 3
+# (major). They were written when `mark-dispatched` did nothing but touch the
+# ledger, so no fixture was needed. Then the claim started re-reading the park
+# labels, and those two lines quietly began asking the REAL Linear board, with
+# the real key, about ASK-298 and ASK-301. Nothing failed: both issues exist and
+# are unparked, so the live answer happened to match the fixture's. On a machine
+# with no key or no network the same lines exit 3, claim nothing, and take five
+# unrelated cases down with them.
+#
+# A helper rather than two more copies of the env: the defect was per-call-site
+# and a third call site would reintroduce it. `test-review-redrive-isolation.sh`
+# is what makes a future omission fail out loud instead of going live.
+mark_dispatched() {   # mark_dispatched <issue> <action> <pr> <sha>
+  env KIPI_ATTEMPTS="$LEDGER" "${LINEAR_ENV[@]}" python3 "$SEL" mark-dispatched \
+    --issue "$1" --action "$2" --pr "$3" --head-sha "$4" >/dev/null 2>&1
+}
+
+# rc IS CHECKED, and that is half the fix. Both call sites discarded it, so a
+# claim that refused was indistinguishable from one that landed -- the assertion
+# that followed just read "the pick is still offered" and blamed the cap. A
+# refused claim now says so where it happened, not three lines later under
+# another name.
+claims() {   # claims <issue> <action> <pr> <sha> <what-it-is-for>
+  mark_dispatched "$1" "$2" "$3" "$4"
+  local rc=$?
+  [ "$rc" = "0" ] && ok "the claim for $1/$2 landed ($5)" \
+    || bad "mark-dispatched exited $rc for $1/$2 -- it claimed nothing, so every assertion after this one is testing the wrong thing"
+}
 printf '[%s]\n' "$(pr_entry 98 ask-298 cccc9999)" > "$WORK/board.json"
 record 98 "REQUEST CHANGES" "REQUEST CHANGES" true cccc9999
 
@@ -269,8 +300,7 @@ PICK2="$(select_one)"
 
 # And the claim, when it is made deliberately, DOES suppress the next offer.
 # Without this the case above is satisfied by a cap that never fires at all.
-env KIPI_ATTEMPTS="$LEDGER" python3 "$SEL" mark-dispatched \
-  --issue ASK-298 --action rework --pr 98 --head-sha cccc9999 >/dev/null 2>&1
+claims ASK-298 rework 98 cccc9999 "the suppression case below depends on it"
 [ -z "$(select_one)" ] && ok "after mark-dispatched the pick is suppressed -- the cap is real" \
   || bad "the pick survived mark-dispatched -- the cap never fires"
 
@@ -394,8 +424,7 @@ PICK4="$(select_ps "$WORK/ps-idle.txt")"
 
 # Now the page. The flag is claimed exactly as the dispatcher claims it, one
 # breath before the reviewer starts, which is the state that produced the bug.
-env KIPI_ATTEMPTS="$LEDGER" python3 "$SEL" mark-dispatched \
-  --issue ASK-301 --action re-review --pr 101 --head-sha ffff9999 >/dev/null 2>&1
+claims ASK-301 re-review 101 ffff9999 "the escalation cases below depend on it"
 PAGES_BEFORE="$(pages_count)"
 select_ps "$WORK/ps-live.txt" >/dev/null
 [ "$(pages_count)" = "$PAGES_BEFORE" ] \

--- a/q-system/.q-system/scripts/test/test-review-redrive.sh
+++ b/q-system/.q-system/scripts/test/test-review-redrive.sh
@@ -50,6 +50,45 @@ cat "$BOARD"
 EOS
 chmod +x "$BIN/gh"
 
+# --- Linear, stubbed at the API seam (ASK-872) -------------------------------
+# `select` now reads the three park labels off each candidate's issue before it
+# offers anything, so this suite acquired a Linear dependency it did not have.
+# Left alone it would reach the REAL board with the real key -- a live data path
+# in a test, and one whose answers change as issues get labelled, so a case here
+# could start failing because someone parked ASK-317 in the morning.
+#
+# The fixture answers every issue with an EMPTY label set, which is what every
+# case in this file already assumed. No assertion below changes. The park
+# behaviour itself is held by test-review-redrive-park.sh.
+cat > "$WORK/linear-fixture.py" <<'PY'
+import json, re
+from http.server import BaseHTTPRequestHandler, HTTPServer
+
+class H(BaseHTTPRequestHandler):
+    def log_message(self, *a): pass
+    def do_POST(self):
+        body = self.rfile.read(int(self.headers["Content-Length"])).decode()
+        query = (json.loads(body).get("query") or "")
+        data = {alias: {"identifier": ident, "labels": {"nodes": []}}
+                for alias, ident in
+                re.findall(r'(\w+)\s*:\s*issue\(\s*id\s*:\s*"([^"]+)"', query)}
+        out = json.dumps({"data": data}).encode()
+        self.send_response(200); self.send_header("Content-Type", "application/json")
+        self.send_header("Content-Length", str(len(out))); self.end_headers()
+        self.wfile.write(out)
+
+srv = HTTPServer(("127.0.0.1", 0), H)
+print(srv.server_port, flush=True)
+srv.serve_forever()
+PY
+python3 "$WORK/linear-fixture.py" > "$WORK/port" 2> "$WORK/linear.err" &
+SRV_PID=$!
+trap 'kill "${SRV_PID:-}" 2>/dev/null; rm -rf "$WORK"' EXIT
+for _ in $(seq 1 100); do PORT="$(cat "$WORK/port" 2>/dev/null)"; [ -n "${PORT:-}" ] && break; sleep 0.1; done
+[ -n "${PORT:-}" ] || { echo "FATAL: linear fixture did not start" >&2; exit 1; }
+LINEAR_ENV=(KIPI_LINEAR_API_URL="http://127.0.0.1:$PORT/graphql"
+            KIPI_LINEAR_API_KEY="fixture-key-not-a-secret")
+
 # A PR entry with a failing reviewer slot. Everything except pr/branch/sha is
 # fixed, so a difference in outcome can only come from the verdict record.
 pr_entry() {   # pr_entry <number> <issue-lower> <sha>
@@ -79,6 +118,7 @@ PY
 
 select_all() {
   env PATH="$BIN:$PATH" BOARD="$WORK/board.json" KIPI_NOTIFY="$BIN/notify.sh" \
+      "${LINEAR_ENV[@]}" \
     python3 "$SEL" --repo-dir "$WORK" --records-dir "$RECORDS" select --all 2>/dev/null
 }
 action_for() {   # action_for <pr>
@@ -206,7 +246,7 @@ A42="$(action_for 42)"
 LEDGER="$WORK/attempts.json"; echo '{}' > "$LEDGER"
 select_one() {
   env PATH="$BIN:$PATH" BOARD="$WORK/board.json" KIPI_ATTEMPTS="$LEDGER" \
-      KIPI_NOTIFY="$BIN/notify.sh" \
+      KIPI_NOTIFY="$BIN/notify.sh" "${LINEAR_ENV[@]}" \
     python3 "$SEL" --repo-dir "$WORK" --records-dir "$RECORDS" select 2>/dev/null
 }
 printf '[%s]\n' "$(pr_entry 98 ask-298 cccc9999)" > "$WORK/board.json"
@@ -317,7 +357,7 @@ A99="$(action_for 99)"; A100="$(action_for 100)"
 # process is spawned and nothing reads the real one.
 select_ps() {   # select_ps <ps-table-file>
   env PATH="$BIN:$PATH" BOARD="$WORK/board.json" KIPI_ATTEMPTS="$LEDGER" \
-      KIPI_NOTIFY="$BIN/notify.sh" KIPI_PS="cat $1" \
+      KIPI_NOTIFY="$BIN/notify.sh" KIPI_PS="cat $1" "${LINEAR_ENV[@]}" \
     python3 "$SEL" --repo-dir "$WORK" --records-dir "$RECORDS" select 2>/dev/null
 }
 printf '[%s]\n' "$(pr_entry 101 ask-301 ffff9999)" > "$WORK/board.json"


### PR DESCRIPTION
Closes ASK-872 (do not merge on my say-so; closeout runs through /issue-verify and /issue-closeout).

## The defect

Three labels park an issue, and each means "a human or a gate decided this must not be worked right now":

* `owner:assaf` -- founder decision, hands off
* `needs-scope` -- the agent refused it as unexecutable, the DoR drafter owns it
* `blocked:capability` -- the runner is missing a credential or a binary

`linear-worker.sh` applies all three in **both** of its selectors. `review-redrive.py` is a third consumer that dispatches the same agents at the same issues, and it read none of them:

```
$ grep -n "owner:assaf\|needs-scope\|blocked:capability" review-redrive.py
(no output)
```

Parking ASK-830 on 2026-08-16 was not enough on its own: the PR had to be converted to draft as well, because draft is the only thing the redrive honoured. `blocked:capability` is the sharpest case -- the redrive kept handing the issue to an agent that provably cannot finish it.

## What changed

| File | Change |
|---|---|
| `park_labels.py` (new) | The three labels plus the reason each routes differently, in one place. `parked_reason(labels)` returns `(label, why)` or `None`. |
| `review-redrive.py` | `drop_parked()` filters candidates and names the label that stopped each. |
| `linear-worker.sh` | Both selectors import `park_labels.py` instead of carrying the literals. |
| `test-review-redrive-park.sh` (new) | The reproducer. Registered in `capability-manifest.json`. |
| `test-review-redrive.sh` | Gains a fixture Linear server. **No assertion changed.** |

### The shared-helper call, since the DoR asked for it explicitly

A shared helper is the right call here and the module is 60 lines. The list already had two consumers that had to agree and a third that silently did not; a deliberate duplicate with a pointer comment would have been a fourth copy of the thing that broke. The worker change is two call sites and one loader.

### API cost, since the DoR asked for it bounded

**One GraphQL call per redrive run**, not one per PR. The candidate issue ids are aliased into a single `query { i0: issue(id:"ASK-1"){...} i1: ... }` document, chunked at 50 issues per call, and the call is skipped entirely when there are no candidates. A heartbeat that offers nothing costs nothing extra.

### Two decisions worth a reviewer's eye

1. **An unreadable park state exits 2 and claims nothing.** Same posture `main()` already takes for `GhUnavailable`. "I cannot see the labels" must never read as "nothing is parked" -- that direction re-dispatches every parked issue on the board at once. The other direction costs one heartbeat of park, which the next run recovers.
2. **The filter sits outside `candidates()`.** `candidates()` reads the PR board and nothing else, and `test-review-redrive-absent.py` calls it in-process precisely because it is that pure. A Linear round trip inside it would put a live data path in that suite.

## Check: reproducer first, observed RED

```
bash test-review-redrive-park.sh
  before:  1 passed, 8 failed
  after:   9 passed, 0 failed
```

The 8 RED were the three parked fixtures being offered, their labels going unnamed, and the unreadable-board case exiting 0. The case that was **already green** is the negative fixture -- a PR carrying none of the three -- so "skip everything" could never have passed.

Regression guards, green after:

```
bash test-review-redrive.sh              30 passed, 0 failed
python3 test-review-redrive-absent.py    PASS
bash test-worker-refusal.sh              50 passed, 0 failed
bash test-worker-project-scope.sh        24 passed, 0 failed
```

**Mutation-tested the new isolation rather than trusting it.** With the fixture server labelling every issue `owner:assaf`, `test-review-redrive.sh` goes to 10 passed / 20 failed. It reads the fixture, not the live board.

`test-terminal-states.sh` fails 1 of 14 ("live registry does NOT validate against linear-worker.sh") **both before and after** -- pre-existing, verified by stashing.

## Not doing (per the DoR)

The draft check at `review-redrive.py:347`, the label semantics, `ci-redrive.py`, new labels, and the picker's own logic beyond what the shared helper needed.

The spillover ratchet surfaced 5 open notes on `review-redrive.py` and 2 on `test-review-redrive.sh` (sp-7d658588, sp-833a2b76, sp-d039286e and others). All pre-existing, all already captured in the ledger, none touched here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
