### PR TITLE
Route new automated Linear issues away from silent Backlog noise (ASK-882)

### DIFF
--- a/.claude/rules/automated-filer-marking.md
+++ b/.claude/rules/automated-filer-marking.md
@@ -1,0 +1,100 @@
+---
+description: Any code that files Linear issues without a human in the loop marks them needs-triage, so machine inflow is a filterable set instead of indistinguishable backlog.
+paths:
+  - "**/scripts/**"
+  - "**/hooks/**"
+  - "**/*.py"
+  - "**/*.sh"
+---
+
+# Automated filers mark their own output (ENFORCED for the alert path, ADVISORY elsewhere)
+
+Read the heading narrowly, because this repo has been burned by a rule claiming
+ENFORCED while naming no executable. What is actually enforced today:
+
+| Piece | Status |
+|---|---|
+| `alert-to-linear.py` writes `needs-triage` on every ticket it creates | CODE, and `test_linear_triage_health.py` pins it |
+| `linear-triage-health.py` measures the resulting queue and alerts on a breach | CODE, wired via `com.kipi.linear-triage-health.plist` |
+| Any OTHER filer doing the same | ADVISORY. No hook inspects a new script for this |
+
+There is no gate that catches a future filer which skips the mark. Writing one
+would mean statically deciding "is this call site creating a Linear issue without
+a human", which is a judgment a regex loses. So this is a convention with one
+worked reference implementation, not a checked invariant. If it drifts, nothing
+will say so.
+
+## The rule
+
+Any code path that creates a Linear issue **without a human deciding it should
+exist** adds the `needs-triage` label alongside its owner label.
+
+```python
+label_ids = _label_ids(ln, team_id, [OWNER_LABEL, TRIAGE_LABEL])
+if label_ids:
+    payload["labelIds"] = label_ids
+```
+
+Three properties matter more than the label name:
+
+1. **Additive, never a gate.** The issue still lands in a `backlog`-type state.
+   `linear-worker.sh:546` and `linear-dor-drafter.py:194` both refuse anything
+   whose state type is not `("backlog", "unstarted")`, so moving automated inflow
+   into a different state stops the drain, not the flood.
+2. **On CREATE only.** A repeat or an update must not re-mark an issue a human
+   already routed. In `alert-to-linear.py` this is structural: repeats return
+   from an earlier branch and never reach the label code.
+3. **Cleared by routing, not by a person remembering.** The mark comes off when
+   the issue gets a project or gets closed. Nothing asks the founder to clear it.
+
+## Why this and not Linear's Triage feature
+
+Team Triage is real and it IS reachable from the API: `TeamUpdateInput
+.triageEnabled` exists, and team ASK reads `triageEnabled: false` /
+`triageIssueState: null` (introspected 2026-08-16, so this is measured, not
+inherited from a doc). It is a live option, not a blocked one.
+
+It was still the wrong instrument here:
+
+- A triage-type state is invisible to both drains, per the filter above. Enabling
+  the flag without teaching those two consumers first is an outage wearing a
+  feature's name.
+- Linear Triage terminates in a human pressing accept or decline. The measured
+  problem on 2026-08-16 was 229 issues with no project -- not that inflow was
+  invisible, but that outflow is manual while inflow is not. A queue whose exit
+  is a person does not fix a queue whose problem is that its exit is a person.
+
+If Triage is ever enabled, both consumers need the triage state type added to
+their accepted set in the same change, and this convention becomes redundant
+rather than wrong.
+
+## What the marking is NOT for
+
+- **Not a junk flag.** Volume from one detector is a signal about the detector,
+  not N separate problems. 44 issues from one scanner may be 44 real jobs; the
+  mark says "nobody routed this yet", never "this is noise".
+- **Not a reason to skip triage.** A marked issue still gets a decision recorded
+  on it (`linear-triage.py` writes the verdict and the why).
+- **Not a founder queue.** Nothing in this design routes to the founder's desk.
+
+## Measuring it
+
+```bash
+python3 q-system/.q-system/scripts/linear-triage-health.py            # report
+python3 q-system/.q-system/scripts/linear-triage-health.py --apply    # flag dormant
+```
+
+Reports unrouted count, `needs-triage` depth, oldest untouched, and dormancy past
+`--dormant-days` (default 75). It flags dormant work with a comment and never
+closes it: a bot that silently closes real work teaches people the tracker lies.
+
+It alerts through `slack-notify.sh` only on a threshold breach. That path files a
+Linear ticket rather than sending to Slack, so the script excludes its own
+tickets from its own counts -- otherwise a backlog monitor reports the backlog it
+just created.
+
+## Cross-references
+
+`founder-notifications.md` (the single alert sink) · `linear-first.md` (work that
+is not recorded did not happen) · `no-orphan-findings.md` (a mention is not a
+capture) · `skill-hook-pairing.md` (why the advisory half stays advisory).

--- a/.claude/rules/automated-filer-marking.md
+++ b/.claude/rules/automated-filer-marking.md
@@ -16,13 +16,33 @@ ENFORCED while naming no executable. What is actually enforced today:
 |---|---|
 | `alert-to-linear.py` writes `needs-triage` on every ticket it creates | CODE, and `test_linear_triage_health.py` pins it |
 | `linear-triage-health.py` measures the resulting queue and alerts on a breach | CODE, wired via `com.kipi.linear-triage-health.plist` |
-| Any OTHER filer doing the same | ADVISORY. No hook inspects a new script for this |
+| Any OTHER filer doing the same | PARTLY CODE. `linear-filer-label-lint.py` demands a DECLARED posture, never the label itself |
 
-There is no gate that catches a future filer which skips the mark. Writing one
-would mean statically deciding "is this call site creating a Linear issue without
-a human", which is a judgment a regex loses. So this is a convention with one
-worked reference implementation, not a checked invariant. If it drifts, nothing
-will say so.
+A gate now exists here, and it is narrower than the row above may suggest. The
+original text said no hook could inspect a new script for this, because deciding
+"is this call site creating a Linear issue without a human" statically is a
+judgment a regex loses. That reasoning was right and the gate does not overturn
+it -- it splits the question along `skill-hook-pairing.md`'s decision rule:
+
+- **Deterministic (the script):** does this file construct an `issueCreate`?
+- **Judgment (the author):** is a human deciding each of those issues?
+
+The second is never inferred, it is declared once in the file. So a compliant
+filer passes one of exactly two ways: it references `needs-triage`, or it carries
+`# linear-filer: human-in-the-loop -- <why a person decides each issue>`.
+Wired PostToolUse on Edit/Write/MultiEdit in BOTH `.claude/settings.json` and
+`settings-template.json`, tested by `test_linear_filer_label_lint.py`.
+
+Measured before it shipped: 8 files in this repo construct `issueCreate`, and one
+referenced `needs-triage`. A gate demanding the label outright would have been red
+on 7 files the day it landed -- unsatisfiable for its own population, which is how
+a gate gets switched off and then protects nothing.
+
+**Do not read its silence as proof.** It matches the string `issueCreate`, so a
+filer reaching Linear through some future helper is invisible to it. It cannot
+tell whether a posture marker is TRUE: `human-in-the-loop` on a nightly sweep
+passes and is a lie the gate cannot see. And it checks the label is REFERENCED,
+never that it is attached to the payload on every branch.
 
 ## The rule
 

--- a/.claude/rules/concurrent-session-worktrees.md
+++ b/.claude/rules/concurrent-session-worktrees.md
@@ -1,0 +1,93 @@
+---
+description: Two or more Claude Code sessions active in one repo each get their own git worktree, because sharing the default checkout lets one session move another's HEAD and sweep its files into the wrong commit.
+paths:
+  - "**/scripts/**"
+  - "**/hooks/**"
+  - "**/*.sh"
+---
+
+# Concurrent sessions each get their own worktree (ADVISORY, not enforced)
+
+Read the heading exactly as written. **Nothing in this repo can enforce this**,
+and the file says so up front rather than at the bottom, because this repo has
+been burned by rules claiming ENFORCED while naming no executable.
+
+Paths-scoped on purpose. An earlier draft of this file used `paths: "**/*"`,
+which is always-on, and the `instruction-budget-audit.py` ratchet refused the
+commit outright (512 -> 576 lines against a 300 target). A rule that does not
+have to be always-on must not be. These globs are the surfaces where branch,
+worktree and session work actually happens.
+
+Session launching happens in the harness, outside this repo's code. No hook fires
+before a session picks its working directory, so no script here can observe two
+sessions sharing one checkout, let alone refuse it. Per `skill-hook-pairing.md`'s
+decision rule this is the judgment half: it lives in the instruction, and if it
+drifts, no gate will say so.
+
+| Piece | Status |
+|---|---|
+| The convention below | ADVISORY. Read by a person or an agent, checked by nothing |
+| A hook that detects two sessions in one checkout | DOES NOT EXIST and cannot, at this layer |
+| `git worktree` itself | Real, and the only mechanical part here |
+
+## The rule
+
+When two or more Claude Code sessions are likely to be active in this repo at the
+same time, each session works from its **own** `git worktree`, never the shared
+default checkout.
+
+```bash
+# From the repo root, one per session:
+git worktree add ../kipi-wt-<session-name> -b <branch-name> origin/main
+
+# When the session's work is merged and the tree is clean:
+git worktree remove ../kipi-wt-<session-name>
+git worktree list          # confirm it is gone
+```
+
+Branch off the ref you actually mean. `origin/main` is the default; if the work
+builds on another session's unmerged branch, name that branch instead and say so,
+because a worktree cut from the wrong base is the first incident below.
+
+## The two incidents this comes from (2026-08-16)
+
+Both happened in one day, between this session and a concurrent `social-voice`
+session sharing one working directory.
+
+1. **A branch built on the wrong ancestor.** Two sessions took turns checking out
+   branches in the same tree. A branch created while the other session's checkout
+   was live inherited that state as its base, so it carried commits nobody
+   intended it to carry, and the diff read as work it had not done.
+
+2. **An unattended auto-commit landing a stale-state revert.** A Stop-hook
+   auto-commit swept the working tree while the other session had it in an
+   intermediate state. The commit captured the other session's half-applied
+   files, which read afterward as a deliberate revert of work that was in fact
+   still in progress.
+
+Neither is a merge conflict, and that is the point: git never complained. Both
+sessions were doing legal operations on one tree, and the damage was to history
+rather than to files, which is where it is expensive to see and expensive to undo.
+
+## Why a worktree rather than "coordinate better"
+
+A worktree gives each session its own HEAD, index, and working files against one
+shared object store. That makes the failure mode structurally impossible instead
+of merely discouraged: one session cannot move another's HEAD because they do not
+share one. Coordination is a prompt-level fix for a state-level problem, and
+prompt-level fixes fail on the first tired night.
+
+Cheap, and the tell that you needed it is always retrospective.
+
+## When this does not apply
+
+- A single session in the repo. One checkout is correct; a worktree is overhead.
+- Read-only work (reviews, audits, greps) that never checks out a branch or writes.
+- Sessions in genuinely different repos. This is about one repo, many sessions.
+
+## Cross-references
+
+`skill-hook-pairing.md` (why the judgment half stays interpretive and gets no
+hook) · `wiring-check.md` (load-path proof: a worktree is also how you keep one
+session's edits from being read as another's) · `linear-first.md` (a branch that
+carries the wrong base still has to name its issue).

--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -238,6 +238,11 @@
           },
           {
             "type": "command",
+            "command": "python3 \"$CLAUDE_PROJECT_DIR/q-system/.q-system/scripts/linear-filer-label-lint.py\"",
+            "timeout": 5
+          },
+          {
+            "type": "command",
             "command": "python3 \"$CLAUDE_PROJECT_DIR/q-system/.q-system/scripts/audhd-lint.py\"",
             "timeout": 5
           },

--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -199,7 +199,7 @@
         ]
       },
       {
-        "matcher": "Edit|Write",
+        "matcher": "Edit|Write|MultiEdit",
         "hooks": [
           {
             "type": "command",

--- a/q-system/.q-system/scripts/alert-to-linear.py
+++ b/q-system/.q-system/scripts/alert-to-linear.py
@@ -560,7 +560,24 @@ def _label_ids(ln, team_id: str, wanted: list, missing: list | None = None) -> l
             name = (node.get("name") or "").lower()
             if name in wanted and name not in found:
                 found[name] = node.get("id")
-    except Exception:
+    except Exception as exc:
+        # THE EARLY RETURN MUST STILL REPORT, and this one did not. The round-4
+        # fix taught the per-label create path to record an unresolved name, so
+        # a lost-then-unrecoverable label reached the caller's `[DEGRADED: ...]`
+        # suffix. This branch -- the LABELS_QUERY itself failing -- kept its
+        # original bare `return []` and skipped both out-lists, so a labels
+        # endpoint timeout filed a ticket with NO labels at all, exit 0, and a
+        # result line reading `filed ASK-9` with nothing to distinguish it from
+        # a fully-labelled file. Reproduced on the PR head: degraded_visible=
+        # False, labelIds absent (Codex major round 5, PR #204).
+        #
+        # Same posture as every other failure here: never block the alert, never
+        # let the failure be silent. Nothing is resolvable when the read failed,
+        # so every wanted name is unresolved.
+        for name in wanted:
+            _warn_label_unresolved(name, exc)
+        if missing is not None:
+            missing.extend(wanted)
         return []
 
     for name in wanted:

--- a/q-system/.q-system/scripts/alert-to-linear.py
+++ b/q-system/.q-system/scripts/alert-to-linear.py
@@ -54,6 +54,43 @@ EXIT_REFUSED_FIXTURE = 4
 TEAM_KEY = os.environ.get("KIPI_LINEAR_TEAM", "ASK")
 OWNER_LABEL = "owner:sana"
 
+# THE MARK THAT SAYS "A MACHINE FILED THIS, NOBODY ROUTED IT" (ASK-882).
+#
+# Measured on the live board 2026-08-16: 873 issues, 229 of them carrying no
+# project at all -- created, never routed. Automated inflow outran manual triage,
+# and the reason it could is that an auto-filed ticket lands in Backlog looking
+# exactly like work a human scoped and put there. There is no field to filter on,
+# so "everything a scanner filed today" is not a query anyone can write.
+#
+# WHY A LABEL AND NOT LINEAR'S OWN TRIAGE FEATURE. Team Triage is real and it IS
+# reachable from the API -- `TeamUpdateInput.triageEnabled` exists, and ASK reads
+# `triageEnabled: false` (introspected 2026-08-16, so this is measured, not
+# assumed). It was still the wrong instrument here, for two reasons:
+#
+#   1. A triage-type state is NOT a backlog-type state, and both drains filter on
+#      the type: linear-worker.sh:546 refuses anything whose state type is not in
+#      ("backlog", "unstarted"), and linear-dor-drafter.py:194 draws its
+#      DRAFTABLE_STATE_TYPES from the same pair. Flipping the flag would route
+#      every new automated ticket into a state neither consumer can see, which
+#      stops the flood by stopping the drain. That is not a gate, it is an outage.
+#   2. Linear Triage terminates in a human pressing accept or decline. The board
+#      problem was never that nobody could SEE the inflow; it was that outflow is
+#      manual while inflow is not. A queue whose exit is a person is the same
+#      bottleneck wearing a feature's name.
+#
+# So the mark is additive: the ticket still lands in Backlog where the existing
+# drain already reaches it, and it carries one extra label that makes "unrouted
+# machine output" a filterable set for the first time. Nothing is gated OFF.
+TRIAGE_LABEL = "needs-triage"
+
+TRIAGE_LABEL_DESCRIPTION = (
+    "Filed by an automated producer, not routed by a human or a process. "
+    "The issue is real work until triage says otherwise -- volume from one "
+    "detector is a signal about the detector, not N separate problems. "
+    "Cleared by giving the issue a project (routing it) or closing it. "
+    "Written by any automated filer; measured by linear-triage-health.py."
+)
+
 # A repeat inside this window updates the counter silently. Past it, the ticket
 # gets a comment so a condition that is STILL true a day later is visible as
 # still-true rather than as one stale ticket nobody has touched.
@@ -495,23 +532,53 @@ def _project_id_for(ln, team_id: str, names: list) -> str | None:
     return None
 
 
-def _owner_label_id(ln, team_id: str) -> str | None:
-    """The owner:sana label id, created once if the team lacks it.
+def _label_ids(ln, team_id: str, wanted: list) -> list:
+    """Ids for `wanted` label names, creating any the team lacks.
+
+    ONE ROUND TRIP FOR ALL OF THEM, not one per label. The previous shape took a
+    single name and did its own LABELS_QUERY; adding `needs-triage` beside
+    `owner:sana` by copying it would have doubled the query count on the alert
+    path for no new information, and given two places to fix when Linear changes.
 
     A missing label must never cost the ticket: an alert filed with no label is
     still an alert Sana can find, whereas raising here would drop it entirely.
+    That is also why this returns the ids it DID resolve rather than all-or-
+    nothing -- losing the `needs-triage` mark is a worse board, losing the ticket
+    is a lost alert, and those are not the same size of mistake.
+
+    Names are compared lowercased because that is how the previous single-label
+    version compared, and `owner:sana` on the live board is stored lowercase.
     """
+    found: dict = {}
     try:
         team = (ln.graphql(LABELS_QUERY, {"teamId": team_id}) or {}).get("team") or {}
         for node in ((team.get("labels") or {}).get("nodes") or []):
-            if (node.get("name") or "").lower() == OWNER_LABEL:
-                return node.get("id")
-        made = ln.graphql(LABEL_CREATE,
-                          {"input": {"name": OWNER_LABEL, "teamId": team_id}})
-        return (((made or {}).get("issueLabelCreate") or {})
-                .get("issueLabel") or {}).get("id")
+            name = (node.get("name") or "").lower()
+            if name in wanted and name not in found:
+                found[name] = node.get("id")
     except Exception:
-        return None
+        return []
+
+    for name in wanted:
+        if name in found:
+            continue
+        # Created one at a time and each in its own try: a team that already has
+        # `owner:sana` but not `needs-triage` must still come away with the id it
+        # did have. A single try around the whole loop would throw away a
+        # resolved id because a LATER create failed.
+        try:
+            payload = {"name": name, "teamId": team_id}
+            if name == TRIAGE_LABEL:
+                payload["description"] = TRIAGE_LABEL_DESCRIPTION
+            made = ln.graphql(LABEL_CREATE, {"input": payload})
+            new_id = (((made or {}).get("issueLabelCreate") or {})
+                      .get("issueLabel") or {}).get("id")
+            if new_id:
+                found[name] = new_id
+        except Exception:
+            continue
+
+    return [found[n] for n in wanted if n in found]
 
 
 def file_alert(message: str, now: float | None = None) -> tuple[int, str]:
@@ -578,9 +645,14 @@ def file_alert(message: str, now: float | None = None) -> tuple[int, str]:
                 f"<!-- kipi-alert-fingerprint: {fp} -->"
             ),
         }
-        label_id = _owner_label_id(ln, team_id)
-        if label_id:
-            payload["labelIds"] = [label_id]
+        # BOTH labels, and `needs-triage` only on a ticket being CREATED. A
+        # repeat lands in the branch above and never reaches here, so re-marking
+        # an issue a human already routed is structurally impossible rather than
+        # merely avoided -- if this ran on the repeat path it would undo triage
+        # every time the condition fired again.
+        label_ids = _label_ids(ln, team_id, [OWNER_LABEL, TRIAGE_LABEL])
+        if label_ids:
+            payload["labelIds"] = label_ids
 
         # A PROJECT IS ROUTING, NOT DECORATION (ASK-839). This payload carried
         # teamId + labelIds and nothing else, so every alert landed project-unset.

--- a/q-system/.q-system/scripts/alert-to-linear.py
+++ b/q-system/.q-system/scripts/alert-to-linear.py
@@ -532,8 +532,12 @@ def _project_id_for(ln, team_id: str, names: list) -> str | None:
     return None
 
 
-def _label_ids(ln, team_id: str, wanted: list) -> list:
+def _label_ids(ln, team_id: str, wanted: list, missing: list | None = None) -> list:
     """Ids for `wanted` label names, creating any the team lacks.
+
+    `missing` is an optional out-list: names that could not be resolved are
+    appended to it, so a caller can report a degraded file without this
+    function changing its return shape or gaining the power to block.
 
     ONE ROUND TRIP FOR ALL OF THEM, not one per label. The previous shape took a
     single name and did its own LABELS_QUERY; adding `needs-triage` beside
@@ -575,7 +579,7 @@ def _label_ids(ln, team_id: str, wanted: list) -> list:
                       .get("issueLabel") or {}).get("id")
             if new_id:
                 found[name] = new_id
-        except Exception:
+        except Exception as exc:
             # LOSING THE CREATE RACE IS NOT THE SAME AS HAVING NO LABEL. Two
             # filers running at once both read the team before either created
             # `needs-triage`; the loser's create fails because the label now
@@ -591,9 +595,37 @@ def _label_ids(ln, team_id: str, wanted: list) -> list:
             existing = _refetch_label_id(ln, team_id, name)
             if existing:
                 found[name] = existing
+                continue
+            # The refetch answered "still absent", so this was NOT a lost create
+            # race -- it is a real failure (a permission error looks exactly like
+            # this). Still never raises, per the rule above; it gets said out
+            # loud instead.
+            _warn_label_unresolved(name, exc)
             continue
 
+    if missing is not None:
+        missing.extend(n for n in wanted if n not in found)
     return [found[n] for n in wanted if n in found]
+
+
+def _warn_label_unresolved(name: str, exc: Exception) -> None:
+    """Say out loud that a label could not be attached. Never raises.
+
+    THE ALERT STILL GOES OUT. This file's standing posture is that a secondary
+    failure must never cost the primary alert, because a dropped alert is worse
+    than an unlabelled one. But "never blocks" had quietly become "never
+    observable": a create that failed for a REAL reason (a permission error,
+    not a lost create race) refetched nothing, dropped the name, and the run
+    still reported `filed ASK-9` with no hint the mark was missing.
+    `needs-triage` is the field the entire ASK-882 queue measurement reads, so
+    losing it silently makes the queue depth quietly WRONG rather than loudly
+    broken -- a monitor that undercounts is worse than one that errors
+    (Codex major round 4, PR #204).
+    """
+    print(f"alert-to-linear: WARNING could not attach the {name!r} label "
+          f"({exc}). The ticket is still being filed. While {TRIAGE_LABEL!r} "
+          f"is missing, the triage-queue measurement undercounts this ticket "
+          f"and it needs backfilling by hand.", file=sys.stderr)
 
 
 def _refetch_label_id(ln, team_id: str, name: str) -> str | None:
@@ -659,6 +691,12 @@ def file_alert(message: str, now: float | None = None) -> tuple[int, str]:
         # ticket on purpose -- reopening a closed one hides the recurrence,
         # which is the signal worth having.
 
+    # Bound BEFORE the try, never inside it. A name first assigned inside a
+    # try/except is only bound on the paths that got that far, and the read of
+    # it below sits outside the block -- the shape that turns one failure into a
+    # NameError wearing the wrong failure's name.
+    unresolved_labels: list = []
+
     try:
         teams = (ln.graphql(TEAM_QUERY, {"key": TEAM_KEY}) or {}).get("teams") or {}
         nodes = teams.get("nodes") or []
@@ -683,7 +721,8 @@ def file_alert(message: str, now: float | None = None) -> tuple[int, str]:
         # an issue a human already routed is structurally impossible rather than
         # merely avoided -- if this ran on the repeat path it would undo triage
         # every time the condition fired again.
-        label_ids = _label_ids(ln, team_id, [OWNER_LABEL, TRIAGE_LABEL])
+        label_ids = _label_ids(ln, team_id, [OWNER_LABEL, TRIAGE_LABEL],
+                               unresolved_labels)
         if label_ids:
             payload["labelIds"] = label_ids
 
@@ -712,7 +751,13 @@ def file_alert(message: str, now: float | None = None) -> tuple[int, str]:
                       "identifier": issue.get("identifier"),
                       "count": 1, "first_at": now, "last_at": now,
                       "last_comment_at": now})
-    return EXIT_OK, f"filed {issue.get('identifier')} {issue.get('url', '')}".strip()
+    line = f"filed {issue.get('identifier')} {issue.get('url', '')}".strip()
+    if unresolved_labels:
+        # STILL EXIT_OK: the alert landed, which is the job. The suffix is so the
+        # run's own summary line cannot read as an unqualified success while the
+        # label the triage measurement depends on is absent.
+        line += f" [DEGRADED: no {', '.join(unresolved_labels)} label]"
+    return EXIT_OK, line
 
 
 def main(argv: list[str]) -> int:

--- a/q-system/.q-system/scripts/alert-to-linear.py
+++ b/q-system/.q-system/scripts/alert-to-linear.py
@@ -576,9 +576,42 @@ def _label_ids(ln, team_id: str, wanted: list) -> list:
             if new_id:
                 found[name] = new_id
         except Exception:
+            # LOSING THE CREATE RACE IS NOT THE SAME AS HAVING NO LABEL. Two
+            # filers running at once both read the team before either created
+            # `needs-triage`; the loser's create fails because the label now
+            # EXISTS, and dropping the name here filed that ticket unmarked and
+            # invisible to the health script -- the failure mode being silent is
+            # what made it worth a fix (Codex major, PR #204).
+            #
+            # The recheck is a refetch, not a parse of Linear's error prose: the
+            # question "does this label exist now" is answerable directly, and
+            # an answer beats matching a message string this fleet has never
+            # measured. A create that failed for any OTHER reason finds nothing
+            # and falls through to the old behaviour unchanged.
+            existing = _refetch_label_id(ln, team_id, name)
+            if existing:
+                found[name] = existing
             continue
 
     return [found[n] for n in wanted if n in found]
+
+
+def _refetch_label_id(ln, team_id: str, name: str) -> str | None:
+    """The team's id for `name`, read fresh. None when it is still absent.
+
+    Its own function so the create loop keeps one level of nesting, and so the
+    "never let a lookup cost the ticket" rule holds here too: this runs on a
+    path that is ALREADY failing, so it swallows and returns None rather than
+    turning a missing label into a lost alert.
+    """
+    try:
+        team = (ln.graphql(LABELS_QUERY, {"teamId": team_id}) or {}).get("team") or {}
+    except Exception:
+        return None
+    for node in ((team.get("labels") or {}).get("nodes") or []):
+        if (node.get("name") or "").lower() == name.lower():
+            return node.get("id")
+    return None
 
 
 def file_alert(message: str, now: float | None = None) -> tuple[int, str]:

--- a/q-system/.q-system/scripts/com.kipi.linear-triage-health.plist
+++ b/q-system/.q-system/scripts/com.kipi.linear-triage-health.plist
@@ -1,0 +1,52 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<!-- Triage-queue health: is the owner:sana -> kipi-dispatch.sh drain keeping pace,
+     and what has gone dormant? (ASK-882)
+
+     Measured 2026-08-16: 873 issues, 229 with no project. Inflow is automated and
+     outflow is manual, so nothing was watching the gap. This is the meter.
+
+     TEMPLATE, not a loadable plist: __KIPI_REPO__ and __HOME__ are materialized by
+     install-plist.sh, the same as every sibling here. A plist written straight into
+     ~/Library/LaunchAgents with a home path baked in is the b2df00e / ASK-113 scar:
+     unusable on another machine, invisible to validate-separation, and it makes the
+     script it runs read as an inert engine to the capability gate because nothing in
+     the repo references it.
+
+     WHY 09:00 DAILY, AND WHY --apply IS ON.
+
+     Daily rather than hourly because the numbers move on a human timescale; an
+     hourly meter on a queue that changes daily is a cry-wolf generator. 09:00 local
+     puts the read before the 03:00 DoR drafter's output has been sitting all day and
+     before the 16:00 digest, so the digest reports a board this already looked at.
+
+     --apply lets it write dormancy comments. That is safe to automate in a way
+     closing is not: the comment is idempotent (DORMANT_MARKER is checked per issue
+     before writing) and it changes no state. Nothing here closes an issue.
+
+     THE ALERT IS SELF-LIMITING. It fires only on a threshold breach, and
+     slack-notify.sh dedupes by alert SHAPE with every digit stripped, so a daily
+     breach collapses onto ONE ticket with a counter rather than one ticket a day.
+     The script also excludes its own tickets from its own counts.
+
+     Install: bash q-system/.q-system/scripts/install-plist.sh com.kipi.linear-triage-health -->
+<plist version="1.0">
+<dict>
+  <key>Label</key><string>com.kipi.linear-triage-health</string>
+  <key>ProgramArguments</key>
+  <array>
+    <string>/bin/bash</string><string>-lc</string>
+    <!-- Through a login shell so the Linear API key resolves the same way it does
+         for a human. launchd does NOT inherit a login environment, and a job that
+         runs blind because its credentials are absent is what com.cole.delivery-watch
+         did for 19 days before anyone noticed (ASK-718). -->
+    <string>python3 __KIPI_REPO__/q-system/.q-system/scripts/linear-triage-health.py --apply</string>
+  </array>
+  <!-- Local 09:00. launchd calendar intervals are LOCAL time, so this is 9am
+       Pacific year-round without tracking PST/PDT. -->
+  <key>StartCalendarInterval</key><dict><key>Hour</key><integer>9</integer><key>Minute</key><integer>0</integer></dict>
+  <key>RunAtLoad</key><false/>
+  <key>StandardOutPath</key><string>__HOME__/.config/kipi/logs/linear-triage-health.out.log</string>
+  <key>StandardErrorPath</key><string>__HOME__/.config/kipi/logs/linear-triage-health.err.log</string>
+</dict>
+</plist>

--- a/q-system/.q-system/scripts/fleet-health-daily.py
+++ b/q-system/.q-system/scripts/fleet-health-daily.py
@@ -1871,6 +1871,11 @@ def _create_one(ls, finding: dict, apply: bool, team_id: str, project,
     if project:
         payload["projectId"] = project["id"]
     data = ls.graphql(ls.ISSUE_CREATE, {"input": payload})
+    # linear-filer-lint-skip: AUTOMATED and currently unmarked. A nightly launchd
+    # detector sweep files one issue per finding, so this SHOULD attach
+    # TRIAGE_LABEL. Captured as sp-1306aca4 (see also sp-2ea6e19c, which named the
+    # same five-writer class) rather than changed here -- relabelling live inflow
+    # is a behaviour change, not a lint fix.
     node = (data.get("issueCreate") or {}).get("issue") or {}
     if not node.get("id"):
         # A create that returned no issue is a FAILURE, not a quiet zero. The

--- a/q-system/.q-system/scripts/linear-dor-drafter.py
+++ b/q-system/.q-system/scripts/linear-dor-drafter.py
@@ -1134,6 +1134,10 @@ def report_failures(ls, failures: list, carried: int = 0) -> str:
         if project:
             payload["projectId"] = project["id"]
         node = (ls.graphql(ls.ISSUE_CREATE, {"input": payload})
+                # linear-filer-lint-skip: AUTOMATED and currently unmarked. The
+                # nightly launchd job files its own run-failure report, machine-
+                # authored and nobody asked for it, so this SHOULD attach
+                # TRIAGE_LABEL. Captured as sp-1306aca4 rather than changed here.
                 .get("issueCreate") or {}).get("issue") or {}
         if not node.get("id"):
             print("  failure report refused by Linear", file=sys.stderr)

--- a/q-system/.q-system/scripts/linear-filer-label-lint.py
+++ b/q-system/.q-system/scripts/linear-filer-label-lint.py
@@ -1,0 +1,202 @@
+#!/usr/bin/env python3
+"""Pairs with `.claude/rules/automated-filer-marking.md`: a file that files Linear
+issues must SAY which kind of filer it is (ASK-882).
+
+WHAT THIS GATE ACTUALLY DECIDES, AND WHAT IT REFUSES TO DECIDE
+
+The rule this pairs with originally shipped with an explicit note that no gate
+could exist here, because catching a future filer "would mean statically deciding
+'is this call site creating a Linear issue without a human', which is a judgment
+a regex loses". That reasoning is correct and this script does not overturn it.
+
+So the gate is split along `skill-hook-pairing.md`'s own decision rule:
+
+  DETERMINISTIC (this script)  does this file construct a Linear issueCreate?
+  JUDGMENT      (the author)   is a human deciding that issue should exist?
+
+A regex can see the first perfectly. It cannot see the second, so the second is
+not guessed -- it is DECLARED, once, in the file, by the person who knows. The
+gate's only demand is that the declaration exists. It never infers a posture and
+it never rewrites one.
+
+That is why a compliant file has exactly two ways to pass, and both are explicit:
+
+  1. It references the triage label (`needs-triage`). It marks its own output,
+     which is the reference implementation in `alert-to-linear.py`.
+  2. It carries a posture marker naming itself human-driven, WITH a reason:
+         # linear-filer: human-in-the-loop -- <why a person decides each issue>
+
+WHY A MARKER AND NOT AN ALLOWLIST OF FILENAMES
+
+An allowlist answers "is this file exempt" in a place the next author never
+opens, and it goes stale silently the moment a human-driven script grows a
+scheduled path. The marker sits on the code that does the filing, so a script
+that changes posture has to move its own line to keep passing.
+
+MEASURED BEFORE IT WAS WRITTEN (this is why it is not stricter)
+
+Run across this repo 2026-08-16: 8 files construct `issueCreate`, and only ONE
+referenced `needs-triage`. A gate demanding the label outright would have been
+red on 7 files the day it landed -- unsatisfiable for its own population, which
+is how a gate gets switched off and then protects nothing. Demanding a DECLARED
+posture is satisfiable by every one of them and still blocks the case that
+matters: a NEW filer that thought about neither.
+
+HONEST BOUNDARY -- read this before trusting the gate's silence
+
+- It matches a SHAPE (`issueCreate` in the text), not a behaviour. A filer that
+  reaches Linear through some future helper without that string is invisible here.
+- It cannot verify a posture marker is TRUE. `# linear-filer: human-in-the-loop`
+  on a nightly sweep passes this gate and is a lie the gate cannot see. It
+  removes ambiguity, not the possibility of being wrong.
+- It checks that the label is REFERENCED, never that it is attached to the
+  create payload on every code path. Referencing `needs-triage` while omitting it
+  from one branch passes.
+- Tests and fixtures are skipped on purpose (they construct the mutation to
+  assert on it), so a real filer disguised as a test file is not seen.
+
+Exit codes follow the PostToolUse contract: 2 blocks and feeds stderr back, 0
+passes. Any internal error exits 0 -- a broken linter must never wedge every
+edit in the repo.
+"""
+from __future__ import annotations
+
+import json
+import os
+import re
+import sys
+
+EXIT_PASS = 0
+EXIT_BLOCK = 2
+
+# The label an automated filer attaches. Must equal alert-to-linear.py's
+# TRIAGE_LABEL and linear-triage-health.py's; test_triage_label_constant_matches
+# already pins those two to each other, and this file's test pins it to them.
+TRIAGE_LABEL = "needs-triage"
+
+# The shape that says "this file creates Linear issues". Linear's mutation name
+# is stable API surface, so matching it is matching the thing itself rather than
+# a naming convention someone may rename.
+FILER_PATTERN = re.compile(r"\bissueCreate\b")
+
+# The explicit posture declaration. A reason is REQUIRED -- a bare marker is a
+# mute exemption, and the point of the marker is that it says something.
+# The reason's first character may not itself be a separator. Without that the
+# alternation backtracks: on a bare `-- ` the separator matches ONE dash and the
+# SECOND dash satisfies "a non-space reason", so a mute marker passed. Caught by
+# test_a_bare_posture_marker_without_a_reason_is_still_blocked before it shipped.
+HUMAN_MARKER = re.compile(
+    r"linear-filer:\s*human-in-the-loop\s*[-:]+\s*([^\s\-:].*)", re.IGNORECASE)
+
+# Last-resort per-file bypass, one marker, no stacking (skill-hook-pairing.md).
+SKIP_MARKER = "linear-filer-lint-skip"
+
+SCANNED_SUFFIXES = (".py", ".sh")
+
+# Test files construct the mutation in order to ASSERT on it. Gating them would
+# make the reference implementation's own suite unwritable.
+TEST_HINTS = ("/tests/", "/test/", "test_", "test-", "_test.", "-test.")
+
+
+def is_test_path(path: str) -> bool:
+    """True for a fixture/suite path, which this gate deliberately ignores."""
+    norm = path.replace(os.sep, "/")
+    base = norm.rsplit("/", 1)[-1]
+    if any(hint in norm for hint in ("/tests/", "/test/")):
+        return True
+    return any(base.startswith(h) or h in base
+               for h in ("test_", "test-", "_test.", "-test."))
+
+
+def in_scope(path: str) -> bool:
+    """Only source files this repo actually writes filers in."""
+    return bool(path) and path.endswith(SCANNED_SUFFIXES) and not is_test_path(path)
+
+
+def creates_linear_issues(text: str) -> bool:
+    """Does this file construct a Linear issue-create mutation?"""
+    return bool(FILER_PATTERN.search(text))
+
+
+def declares_posture(text: str) -> tuple:
+    """(ok, how). The two accepted declarations, checked in no priority order.
+
+    Returns the reason string for a human-in-the-loop marker so a caller can
+    show it; an empty reason is treated as no declaration at all.
+    """
+    if SKIP_MARKER in text:
+        return True, "bypass marker"
+    match = HUMAN_MARKER.search(text)
+    if match and match.group(1).strip():
+        return True, "human-in-the-loop: " + match.group(1).strip()[:60]
+    if TRIAGE_LABEL in text:
+        return True, "marks its output with " + TRIAGE_LABEL
+    return False, ""
+
+
+def message(path: str) -> str:
+    """The block text. It teaches the fix, because a gate that only says no
+    gets worked around rather than satisfied."""
+    return (
+        f"linear-filer-label-lint: {path} creates Linear issues "
+        f"(constructs `issueCreate`) but never declares whether a human decides "
+        f"they should exist.\n\n"
+        f"Automated inflow has to be a filterable set -- inflow here is automated "
+        f"and outflow is manual, so an unmarked filer is indistinguishable from "
+        f"backlog nobody can drain. Pick ONE and put it in the file:\n\n"
+        f"  1. It files WITHOUT a human deciding each issue -> attach the label:\n"
+        f"       label_ids = _label_ids(ln, team_id, [OWNER_LABEL, TRIAGE_LABEL])\n"
+        f"       if label_ids:\n"
+        f"           payload[\"labelIds\"] = label_ids\n"
+        f"     (worked reference: q-system/.q-system/scripts/alert-to-linear.py)\n\n"
+        f"  2. A human decides each issue -> declare it, with a reason:\n"
+        f"       # linear-filer: human-in-the-loop -- <why a person decides each one>\n\n"
+        f"Rule: .claude/rules/automated-filer-marking.md\n"
+        f"Last resort, one file only: {SKIP_MARKER}"
+    )
+
+
+def check_text(path: str, text: str) -> tuple:
+    """(exit_code, note). Pure, so the test drives this and not argv."""
+    if not in_scope(path):
+        return EXIT_PASS, "not a scanned path"
+    if not creates_linear_issues(text):
+        return EXIT_PASS, "not a filer"
+    ok, how = declares_posture(text)
+    if ok:
+        return EXIT_PASS, how
+    return EXIT_BLOCK, "undeclared filer"
+
+
+def main() -> int:
+    try:
+        payload = json.load(sys.stdin)
+    except Exception:
+        # No parsable hook payload is not a violation. Fail open.
+        return EXIT_PASS
+
+    path = (payload.get("tool_input") or {}).get("file_path") or ""
+    if not in_scope(path):
+        return EXIT_PASS
+
+    try:
+        with open(path, "r", encoding="utf-8", errors="replace") as handle:
+            text = handle.read()
+    except OSError:
+        # The file may have been moved between the write and this hook. Not a
+        # violation, and a linter must never block on its own read failure.
+        return EXIT_PASS
+
+    code, _ = check_text(path, text)
+    if code == EXIT_BLOCK:
+        print(message(path), file=sys.stderr)
+    return code
+
+
+if __name__ == "__main__":
+    try:
+        sys.exit(main())
+    except Exception as exc:  # never wedge every edit in the repo
+        print(f"linear-filer-label-lint: internal error, passing ({exc})",
+              file=sys.stderr)
+        sys.exit(EXIT_PASS)

--- a/q-system/.q-system/scripts/linear-job-migration.py
+++ b/q-system/.q-system/scripts/linear-job-migration.py
@@ -205,6 +205,10 @@ def main() -> int:
         if project:
             payload["projectId"] = project["id"]
         data = ls.graphql(ls.ISSUE_CREATE, {"input": payload})
+        # linear-filer-lint-skip: AUTOMATED and currently unmarked. inventory()
+        # enumerates every plist and files one templated issue per discovered
+        # job, so this SHOULD attach TRIAGE_LABEL. Captured as sp-1306aca4
+        # rather than changed here -- a behaviour change to live inflow.
         node = (data.get("issueCreate") or {}).get("issue") or {}
         if not node.get("id"):
             print(f"BLOCK: create returned nothing for {issue['key']}", file=sys.stderr)

--- a/q-system/.q-system/scripts/linear-sync.py
+++ b/q-system/.q-system/scripts/linear-sync.py
@@ -422,6 +422,12 @@ mutation($input: ProjectCreateInput!) {
 }
 """
 
+# linear-filer-lint-skip: AUTOMATED and currently unmarked. cmd_create bulk-files
+# from a scanner-generated CAPABILITY-MAP.json, so a human triggers the run but
+# nobody decides the N issues individually -- this SHOULD attach TRIAGE_LABEL.
+# Captured as sp-1306aca4 rather than changed here: adding a label to four live
+# filers is a behaviour change to production inflow, not a lint fix, and it earns
+# its own issue. The marker is an address for that item, never an exemption.
 ISSUE_CREATE = """
 mutation($input: IssueCreateInput!) {
   issueCreate(input: $input) { success issue { id identifier } }

--- a/q-system/.q-system/scripts/linear-triage-health.py
+++ b/q-system/.q-system/scripts/linear-triage-health.py
@@ -159,7 +159,7 @@ ISSUE_COMMENTS_QUERY = """
 query($id: String!, $after: String) {
   issue(id: $id) {
     comments(first: 100, after: $after) {
-      nodes { body }
+      nodes { body createdAt }
       pageInfo { hasNextPage endCursor }
     }
   }
@@ -380,8 +380,18 @@ class FlagCheckFailed(Exception):
     """
 
 
-def already_flagged(ln, issue_id: str) -> bool:
-    """True when a dormancy comment is already on the issue.
+def already_flagged(ln, issue_id: str, issue_updated_at: str | None = None) -> bool:
+    """True when a CURRENT dormancy comment is already on the issue.
+
+    CURRENT is the round-5 word. A marker is not a permanent silencer; it stops
+    applying once the issue is touched after it was posted, which is exactly
+    what `dormancy_comment()` promises the operator in writing. See
+    `marker_superseded()` for that comparison and the measurement behind it.
+
+    `issue_updated_at` defaults to None, and None means "no clock available, so
+    the marker stands". That keeps every existing caller and any future one safe
+    by default: forgetting the argument can only cause silence, never a
+    duplicate permanent comment.
 
     Checked per issue rather than trusting the label alone: the label can be
     removed by a human who disagrees, and re-adding a comment they already read
@@ -415,7 +425,29 @@ def already_flagged(ln, issue_id: str) -> bool:
     never be reported as "no marker" -- the same lesson the FlagCheckFailed
     branch above already paid for, applied to a second way of not finishing.
     """
-    after = None
+    latest = latest_marker_at(ln, issue_id)
+    if latest is None:
+        return False
+    return not marker_superseded(latest, issue_updated_at)
+
+
+def latest_marker_at(ln, issue_id: str) -> str | None:
+    """The NEWEST dormancy marker's `createdAt`, or None if there is no marker.
+
+    NEWEST, so every page is walked even after a marker is found. Returning on
+    the first hit was correct while the only question was "is there a marker",
+    and it becomes wrong the moment the answer is compared against a clock: an
+    issue that was flagged, revived, went quiet and was flagged AGAIN carries
+    two markers, and the older one is the one that reads as superseded. Judging
+    by the first marker would re-flag an issue that already holds a current
+    flag, which is the duplicate-comment failure this whole read exists to
+    prevent, rebuilt from the other end.
+
+    Raises `FlagCheckFailed` for every way of not finishing, for the reason
+    already_flagged() documents: a read that did not complete must never be
+    answered as "no marker".
+    """
+    after, newest = None, None
     for _ in range(COMMENT_PAGE_CAP):
         try:
             issue = (ln.graphql(ISSUE_COMMENTS_QUERY,
@@ -425,11 +457,19 @@ def already_flagged(ln, issue_id: str) -> bool:
             raise FlagCheckFailed(str(exc)) from exc
         comments = issue.get("comments") or {}
         for node in (comments.get("nodes") or []):
-            if DORMANT_MARKER in (node.get("body") or ""):
-                return True
+            if DORMANT_MARKER not in (node.get("body") or ""):
+                continue
+            stamp = node.get("createdAt") or ""
+            # A marker with no readable stamp is still a marker. It sorts as
+            # the newest so it can never be judged superseded: silence beats a
+            # duplicate permanent comment when the timestamp is unusable.
+            if not stamp or _parse_iso(stamp) is None:
+                return ""
+            if newest is None or stamp > newest:
+                newest = stamp
         page = comments.get("pageInfo") or {}
         if not page.get("hasNextPage"):
-            return False
+            return newest
         cursor = page.get("endCursor")
         if not cursor or cursor == after:
             raise FlagCheckFailed(
@@ -438,6 +478,48 @@ def already_flagged(ln, issue_id: str) -> bool:
     raise FlagCheckFailed(
         f"more than {COMMENT_PAGE_CAP} comment pages on {issue_id}; "
         f"the already-flagged check did not complete")
+
+
+def marker_superseded(marker_at: str, issue_updated_at: str | None) -> bool:
+    """Did the issue get touched AFTER this marker was posted?
+
+    This is the sentence `dormancy_comment()` prints to the operator -- "still
+    wanted -> comment or update it and this clears" -- expressed as code. It was
+    a promise nothing implemented: `already_flagged()` found the marker forever,
+    so an issue that was flagged, revived by a real human, and then went quiet a
+    SECOND time could never be flagged again. Reproduced on the PR head:
+    second_sweep_outcome=already-flagged, new_comment_writes=0, on an issue
+    whose updatedAt was three months newer than its marker (Codex blocker round
+    5, PR #204). A monitor that goes permanently silent on exactly the issues it
+    already identified once is worse than one that never ran.
+
+    MEASURED, not assumed, because the answer decides whether this is safe:
+    Linear DOES bump an issue's `updatedAt` when a comment is created. Sampled
+    2026-08-17 across 14 ASK issues -- in 7 the issue's `updatedAt` equals the
+    newest comment's own `updatedAt` to the exact millisecond, and Linear stamps
+    a comment's `updatedAt` 15-200ms BEFORE its `createdAt`. So the bot's own
+    dormancy comment lands with `issue.updatedAt` fractionally EARLIER than
+    `marker.createdAt` and does not supersede itself.
+
+    That ordering is a nicety, not the safety argument, and this does not lean
+    on it. Even if a bump did land after the marker, `find_dormant()` still
+    requires a FULL fresh threshold of silence measured from that same
+    `updatedAt` before the issue is eligible again. The worst case is therefore
+    one comment per threshold period of continuous silence -- a bounded drip
+    that keeps saying something true -- never the comment stack the marker was
+    introduced to prevent.
+
+    An unreadable or absent `updatedAt` answers False: the marker stands, and
+    the issue stays quiet. Erring toward silence is the standing posture here,
+    because a comment is permanent and has no undo.
+    """
+    if not marker_at:
+        return False
+    marker = _parse_iso(marker_at)
+    updated = _parse_iso(issue_updated_at or "")
+    if marker is None or updated is None:
+        return False
+    return updated > marker
 
 
 def dormancy_comment(days: float, threshold: int) -> str:
@@ -452,8 +534,9 @@ def dormancy_comment(days: float, threshold: int) -> str:
         f"- superseded or done -> close it with the reason\n"
         f"- real but not now -> say so here, so the next sweep reads an answer "
         f"instead of silence\n\n"
-        f"<sub>`linear-triage-health.py`. Flagged once; a re-run finds this "
-        f"comment and skips.</sub>"
+        f"<sub>`linear-triage-health.py`. A re-run finds this comment and "
+        f"skips, until the issue is updated after it -- then the flag above "
+        f"stops applying and a later silence can be flagged again.</sub>"
     )
 
 
@@ -595,7 +678,7 @@ def flag_dormant(ln, issue: dict, days: float, threshold: int) -> str:
     succeeded and declined.
     """
     try:
-        if already_flagged(ln, issue["id"]):
+        if already_flagged(ln, issue["id"], issue.get("updatedAt")):
             return "already-flagged"
     except FlagCheckFailed as exc:
         # UNKNOWN is not "no", so nothing is written; and it is not

--- a/q-system/.q-system/scripts/linear-triage-health.py
+++ b/q-system/.q-system/scripts/linear-triage-health.py
@@ -35,7 +35,18 @@ readings of it.
 
 IT FLAGS, IT NEVER CLOSES. GitHub's stale-bot pattern is the reference and the
 warning: a bot that silently closes real work teaches people the tracker lies.
-A dormant issue gets ONE comment and a label. Closing stays a judgment call.
+A dormant issue gets ONE COMMENT. Closing stays a judgment call.
+
+The comment is the ONLY mutation this script makes -- it writes no label. This
+line used to promise "a comment and a label" while no label mutation existed
+anywhere in the file (Codex minor round 2, PR #204). The promise was corrected
+rather than implemented, because the comment already carries the whole message
+and a second write would double the ways a flag can half-land: nothing here
+needs to query BY the flag, which is the only thing a label would buy.
+
+The `dormant` LABEL is still READ, and that asymmetry is deliberate. A human who
+disagrees with a flag can apply the label by hand to suppress future sweeps, so
+the label is a human-owned override this script honours and never sets.
 
 WHY IT EXCLUDES ITS OWN TICKETS
 
@@ -53,8 +64,15 @@ EXIT CODES -- this script never lies about failure
   5  a threshold was breached and the alert did NOT send. The numbers are good;
      nobody was told. Printing the failure and exiting 0 made launchd record a
      silent 3am success, so the delivery result reaches the exit code.
+  6  --apply ran and at least one dormancy write did not land. Same rule as 5,
+     one layer down: the per-issue outcome decides the code, never the print.
+  7  --apply refused because another --apply run holds the lock. Nothing was
+     written and nothing was corrupted; re-run when the other finishes.
   9  the run could not complete its measurement (API failure mid-walk). Partial
      numbers are still printed, but the exit code says they are partial.
+
+Precedence when several apply: 9 (the measurement is untrustworthy) then 5 then
+6. A run reports its worst outcome, and stderr names every one of them.
 
 Deliberately not `exit 0 always`: that shape is its own defect class in this repo
 (ASK-213, three silent-success bugs shipped in one day).
@@ -68,11 +86,14 @@ Usage:
 from __future__ import annotations
 
 import argparse
+import fcntl
+import hashlib
 import importlib.util
 import json
 import os
 import subprocess
 import sys
+import tempfile
 from datetime import datetime, timezone
 
 EXIT_OK = 0
@@ -80,6 +101,8 @@ EXIT_USAGE = 1
 EXIT_NO_KEY = 3
 EXIT_REFUSED_FIXTURE = 4
 EXIT_ALERT_FAILED = 5
+EXIT_WRITE_FAILED = 6
+EXIT_LOCKED = 7
 EXIT_INCOMPLETE = 9
 
 HERE = os.path.dirname(os.path.abspath(__file__))
@@ -273,16 +296,30 @@ def find_dormant(issues: list, now: datetime, threshold_days: int) -> list:
     the first place. Dormancy is a question about work someone routed and then
     nobody touched.
 
-    Also skips anything already carrying `needs-triage` (it is inflow that has
-    not been decided yet, not work that stalled) and anything already labelled
-    dormant (the flag is not re-applied).
+    Also skips anything still AWAITING TRIAGE (it is inflow that has not been
+    decided yet, not work that stalled) and anything already labelled dormant
+    (the flag is not re-applied).
+
+    THE TRIAGE SKIP CALLS `is_awaiting_triage()` RATHER THAN RE-TESTING THE
+    LABEL, and that is the fix for a hole this function opened by disagreeing
+    with the count beside it. `is_awaiting_triage()` was narrowed to "label AND
+    unrouted" because nothing removes the label when a human routes an issue.
+    This skip kept the OLD, label-only definition, so a routed issue carrying a
+    stale `needs-triage` label matched NEITHER predicate: not awaiting triage
+    (it has a project), not dormancy-eligible (it has the label). It fell out of
+    both readings of the same page and was invisible at any age. Reproduced on
+    the PR head: a 100-day-old routed issue gave awaiting_triage=False and
+    dormant_matches=0 (Codex major round 2, PR #204).
+
+    Two predicates deciding one question is how they drift apart, so there is
+    now one definition and this is a caller of it, not a copy.
     """
     out = []
     for issue in issues:
         if is_unrouted(issue):
             continue
         labels = label_names(issue)
-        if TRIAGE_LABEL in labels or DORMANT_LABEL in labels:
+        if is_awaiting_triage(issue) or DORMANT_LABEL in labels:
             continue
         days = age_days(issue.get("updatedAt") or "", now)
         if days is not None and days >= threshold_days:
@@ -322,6 +359,17 @@ def fetch_open_issues(ln, team_id: str) -> tuple:
             return issues, False
 
 
+class FlagCheckFailed(Exception):
+    """The already-flagged READ failed, so the flagged state is UNKNOWN.
+
+    A distinct type, and not a bool, because the two safe answers to "is this
+    already flagged" are yes and no -- and "I could not find out" is neither.
+    Raising makes the unknown state impossible to ignore: a caller that forgets
+    it gets a traceback, where a sentinel return value would be silently
+    truthy-or-falsy and pick one of the two wrong answers by accident.
+    """
+
+
 def already_flagged(ln, issue_id: str) -> bool:
     """True when a dormancy comment is already on the issue.
 
@@ -329,14 +377,23 @@ def already_flagged(ln, issue_id: str) -> bool:
     removed by a human who disagrees, and re-adding a comment they already read
     is the comment-stack failure this marker exists to prevent.
 
-    On an API failure this returns True -- skip rather than risk a duplicate.
-    Erring toward silence is right here: a missed flag costs one issue staying
-    quiet, a duplicated flag costs trust in every flag.
+    RAISES `FlagCheckFailed` WHEN THE READ ITSELF FAILS, and does not answer
+    True. Returning True on an API error meant a Linear timeout was reported to
+    the operator as `already-flagged` -- a sentence about work someone else had
+    already done, produced by a run that in fact learned nothing and wrote
+    nothing. The run then looked complete. Reproduced on the PR head: a raising
+    comments-read returned `already-flagged` with zero mutations attempted
+    (Codex major round 2, PR #204).
+
+    Erring toward silence is still right -- the caller must NOT write on an
+    unknown -- but silence has to be reported as a failure rather than as a
+    skip. A missed flag costs one issue staying quiet; a missed flag the run
+    calls "already handled" costs the operator the ability to notice.
     """
     try:
         issue = (ln.graphql(ISSUE_COMMENTS_QUERY, {"id": issue_id}) or {}).get("issue") or {}
-    except Exception:
-        return True
+    except Exception as exc:
+        raise FlagCheckFailed(str(exc)) from exc
     for node in ((issue.get("comments") or {}).get("nodes") or []):
         if DORMANT_MARKER in (node.get("body") or ""):
             return True
@@ -360,6 +417,68 @@ def dormancy_comment(days: float, threshold: int) -> str:
     )
 
 
+def apply_lock_path() -> str:
+    """One lock per INSTALLED COPY of this script.
+
+    Keyed on the script's own directory rather than a fixed name so that a copy
+    running out of a tmpdir (the suite does exactly this) cannot contend with
+    the real installation, while two runs of the SAME installation -- the
+    launchd job and a founder's manual run, which is the actual collision --
+    resolve to the same path. Lives in the system temp dir, not in the repo:
+    `kipi update` rsyncs this tree, and a lock file inside it would be fleet
+    cargo.
+    """
+    override = os.environ.get("KIPI_TRIAGE_HEALTH_LOCK")
+    if override:
+        return override
+    key = hashlib.sha256(HERE.encode("utf-8")).hexdigest()[:16]
+    return os.path.join(tempfile.gettempdir(), f"kipi-triage-health-{key}.lock")
+
+
+def acquire_apply_lock():
+    """Take the exclusive --apply lock, or return None if another run holds it.
+
+    THE CHECK AND THE WRITE ARE NOT ONE OPERATION, which is the whole reason
+    this exists. `already_flagged()` reads Linear, then `flag_dormant()` writes
+    to Linear, and nothing links them: two concurrent --apply runs both read
+    "no marker", both write, and the issue carries two permanent dormancy
+    comments. Permanent is the operative word -- there is no undo on a comment,
+    and a duplicate flag costs trust in every flag. Reproduced on the PR head:
+    two overlapping --apply processes landed 2 comment mutations on one issue
+    (Codex major round 2, PR #204).
+
+    NON-BLOCKING ON PURPOSE. The loser refuses and says so rather than queueing:
+    this runs daily against a 75-day threshold, so skipping one sweep costs
+    nothing, while a launchd job silently waiting on a founder's interactive run
+    is a job that looks hung.
+
+    `fcntl.flock` and not a pid/token file, following `attempts-ledger.py`,
+    which paid for that lesson: liveness-by-pid asks whether SOME process has
+    that number, not whether it holds this lock, and pids wrap. The kernel
+    releases this on process exit however the process dies, so there is no
+    corpse to break. This lock file is never unlinked, so unlike the ledger's it
+    also needs no inode re-check -- nothing can swap the path underneath it.
+
+    HONEST BOUNDARY: this is one machine. Two runs on two hosts against the same
+    Linear workspace would still race, because the only authority that could
+    stop that is Linear, and `commentCreate` has no idempotency key. The named
+    threat (a manual run overlapping the scheduled one) is same-host.
+    """
+    path = apply_lock_path()
+    try:
+        handle = open(path, "a")
+    except OSError as exc:
+        print(f"WARN: cannot open the --apply lock at {path} ({exc})",
+              file=sys.stderr)
+        return None
+    try:
+        fcntl.flock(handle.fileno(), fcntl.LOCK_EX | fcntl.LOCK_NB)
+    except OSError:
+        handle.close()
+        return None
+    return handle
+
+
 def flag_dormant(ln, issue: dict, days: float, threshold: int) -> str:
     """Write one dormancy comment. Returns a short outcome for the report.
 
@@ -375,8 +494,14 @@ def flag_dormant(ln, issue: dict, days: float, threshold: int) -> str:
     different animals: the exception is a call that failed, this is a call that
     succeeded and declined.
     """
-    if already_flagged(ln, issue["id"]):
-        return "already-flagged"
+    try:
+        if already_flagged(ln, issue["id"]):
+            return "already-flagged"
+    except FlagCheckFailed as exc:
+        # UNKNOWN is not "no", so nothing is written; and it is not
+        # "already-flagged" either, so the run does not claim this issue was
+        # handled. It lands in `failed=` and reaches the exit code.
+        return f"FAILED (already-flagged check did not complete: {exc})"
     try:
         res = ln.graphql(COMMENT_CREATE, {"input": {
             "issueId": issue["id"],
@@ -473,6 +598,33 @@ def main(argv: list) -> int:
         print("linear-triage-health: REFUSED under pytest.", file=sys.stderr)
         return EXIT_REFUSED_FIXTURE
 
+    # Taken BEFORE the key lookup and the paginated walk: a run that cannot
+    # write should not spend the API calls to work out what it would have
+    # written. Report-only runs never take it -- they mutate nothing, so two of
+    # them are harmless and serialising them would be a cost with no buyer.
+    lock = None
+    if args.apply:
+        lock = acquire_apply_lock()
+        if lock is None:
+            print(f"REFUSED: another --apply run holds {apply_lock_path()}. "
+                  f"Nothing was written; re-run when it finishes.",
+                  file=sys.stderr)
+            return EXIT_LOCKED
+    try:
+        return _run(args, lock is not None)
+    finally:
+        if lock is not None:
+            lock.close()  # the kernel drops the flock with the last fd
+
+
+def _run(args, holding_lock: bool) -> int:
+    """The measurement and the writes, inside the lock when --apply is set."""
+    # Fail closed. The lock is acquired by the caller, so this function could be
+    # reached by a future caller that forgot it; the write path must refuse
+    # rather than proceed unguarded.
+    if args.apply and not holding_lock:
+        raise RuntimeError("refusing to write dormancy comments without the "
+                           "--apply lock")
     ln = _load_linear()
     try:
         ln.linear_api_key()
@@ -514,6 +666,12 @@ def main(argv: list) -> int:
               f"{m['oldest_triage_id']}")
         print(f"  dormant (>={args.dormant_days}d)      : {m['dormant']}")
 
+    # Declared out here, not inside `if dormant:`, because the exit code below
+    # reads it. A per-issue result that only the display loop can see is exactly
+    # how a refused write reached the operator as a printed line and reached
+    # launchd as success.
+    outcomes = {}
+
     if dormant:
         # The WRITE loop is separate from the DISPLAY loop on purpose, and this
         # separation is the fix for a real defect, not a style preference. Both
@@ -523,7 +681,6 @@ def main(argv: list) -> int:
         # 2026-08-16: 193 dormant at a 7-day threshold, so 173 would have been
         # silently skipped. A display bound must never decide what gets written.
         to_flag = select_to_flag(dormant, args.limit)
-        outcomes = {}
         if args.apply:
             for issue, days in to_flag:
                 outcomes[issue["identifier"]] = flag_dormant(
@@ -575,6 +732,18 @@ def main(argv: list) -> int:
     else:
         print("\nno threshold breached; staying quiet")
 
+    # A REFUSED WRITE IS A FAILED RUN, and the per-issue result is the only
+    # place that fact exists. `flag_dormant()` was fixed to stop reporting a
+    # declined mutation as "flagged", and then main() threw that answer away
+    # when it chose its exit code: a run where EVERY commentCreate came back
+    # success=false still returned 0, so launchd recorded a clean sweep that
+    # wrote nothing. Reproduced on the PR head: failed=3, RETURN_CODE 0 (Codex
+    # major round 2, PR #204). The same shape as the alert bug beside it, one
+    # layer down, which is why both now terminate in a code and not a print.
+    failed_writes = sorted(k for k, v in outcomes.items() if v.startswith("FAILED"))
+
+    # Precedence is worst-measurement-first: a partial walk means the dormancy
+    # set itself is untrustworthy, so it outranks what happened to the writes.
     if not complete:
         print("INCOMPLETE: the issue walk did not finish; numbers are partial.",
               file=sys.stderr)
@@ -583,6 +752,10 @@ def main(argv: list) -> int:
         print("ALERT FAILED: a threshold was breached and the alert did not send.",
               file=sys.stderr)
         return EXIT_ALERT_FAILED
+    if failed_writes:
+        print(f"WRITE FAILED: {len(failed_writes)} of {len(outcomes)} dormancy "
+              f"write(s) did not land: {', '.join(failed_writes)}", file=sys.stderr)
+        return EXIT_WRITE_FAILED
     return EXIT_OK
 
 

--- a/q-system/.q-system/scripts/linear-triage-health.py
+++ b/q-system/.q-system/scripts/linear-triage-health.py
@@ -157,10 +157,21 @@ mutation($input: CommentCreateInput!) {
 """
 
 ISSUE_COMMENTS_QUERY = """
-query($id: String!) {
-  issue(id: $id) { comments(first: 100) { nodes { body } } }
+query($id: String!, $after: String) {
+  issue(id: $id) {
+    comments(first: 100, after: $after) {
+      nodes { body }
+      pageInfo { hasNextPage endCursor }
+    }
+  }
 }
 """
+
+# Runaway-loop stop for the marker walk, NOT a search bound. Exceeding it raises
+# rather than answering "no marker" -- see already_flagged(). 50 pages is 5000
+# comments on one issue; the board's busiest issue is nowhere near that, so this
+# firing at all means something is wrong with the cursor, not with the issue.
+COMMENT_PAGE_CAP = 50
 
 
 def _load_linear():
@@ -389,15 +400,45 @@ def already_flagged(ln, issue_id: str) -> bool:
     unknown -- but silence has to be reported as a failure rather than as a
     skip. A missed flag costs one issue staying quiet; a missed flag the run
     calls "already handled" costs the operator the ability to notice.
+
+    WALKS EVERY COMMENT PAGE, AND THAT IS THE CORRECTNESS GUARANTEE FOR
+    FLAG-ONCE. This read used to ask for `comments(first: 100)` and stop, so a
+    marker sitting at comment 101 was invisible and the sweep wrote a SECOND
+    permanent dormancy comment on an issue it had already flagged -- on one
+    host, with no concurrency involved at all. Reproduced on the PR head: a
+    marker at index 100 returned `flagged` and landed 1 duplicate mutation
+    (Codex major round 4, PR #204).
+
+    A bound would have rebuilt the same defect one page further out, so there
+    is no bound: `False` is returned ONLY after Linear reports
+    `hasNextPage: false`. `COMMENT_PAGE_CAP` and the stalled-cursor branch both
+    RAISE instead of returning False, because a read that did not finish must
+    never be reported as "no marker" -- the same lesson the FlagCheckFailed
+    branch above already paid for, applied to a second way of not finishing.
     """
-    try:
-        issue = (ln.graphql(ISSUE_COMMENTS_QUERY, {"id": issue_id}) or {}).get("issue") or {}
-    except Exception as exc:
-        raise FlagCheckFailed(str(exc)) from exc
-    for node in ((issue.get("comments") or {}).get("nodes") or []):
-        if DORMANT_MARKER in (node.get("body") or ""):
-            return True
-    return False
+    after = None
+    for _ in range(COMMENT_PAGE_CAP):
+        try:
+            issue = (ln.graphql(ISSUE_COMMENTS_QUERY,
+                                {"id": issue_id, "after": after})
+                     or {}).get("issue") or {}
+        except Exception as exc:
+            raise FlagCheckFailed(str(exc)) from exc
+        comments = issue.get("comments") or {}
+        for node in (comments.get("nodes") or []):
+            if DORMANT_MARKER in (node.get("body") or ""):
+                return True
+        page = comments.get("pageInfo") or {}
+        if not page.get("hasNextPage"):
+            return False
+        cursor = page.get("endCursor")
+        if not cursor or cursor == after:
+            raise FlagCheckFailed(
+                f"comment paging stalled on {issue_id} at cursor {cursor!r}")
+        after = cursor
+    raise FlagCheckFailed(
+        f"more than {COMMENT_PAGE_CAP} comment pages on {issue_id}; "
+        f"the already-flagged check did not complete")
 
 
 def dormancy_comment(days: float, threshold: int) -> str:
@@ -418,15 +459,23 @@ def dormancy_comment(days: float, threshold: int) -> str:
 
 
 def apply_lock_path() -> str:
-    """One lock per INSTALLED COPY of this script.
+    """One lock per INSTALLED COPY. AN OPTIMIZATION, NOT THE FLAG-ONCE GUARANTEE.
+
+    Read this before reasoning about duplicate dormancy comments. The guarantee
+    that an issue is flagged once lives in `already_flagged()`, which walks
+    every comment page. This lock only spares a same-host loser a whole sweep
+    of wasted API calls.
 
     Keyed on the script's own directory rather than a fixed name so that a copy
     running out of a tmpdir (the suite does exactly this) cannot contend with
     the real installation, while two runs of the SAME installation -- the
-    launchd job and a founder's manual run, which is the actual collision --
-    resolve to the same path. Lives in the system temp dir, not in the repo:
-    `kipi update` rsyncs this tree, and a lock file inside it would be fleet
-    cargo.
+    launchd job and a founder's manual run -- resolve to the same path. That
+    keying is also precisely why it can never be the guarantee: two installs,
+    or two hosts, hash to different paths and never contend. Reproduced on the
+    PR head: two install directories produced distinct lock paths and both
+    wrote (Codex major round 4, PR #204). Lives in the system temp dir, not in
+    the repo: `kipi update` rsyncs this tree, and a lock file inside it would
+    be fleet cargo.
     """
     override = os.environ.get("KIPI_TRIAGE_HEALTH_LOCK")
     if override:
@@ -438,14 +487,20 @@ def apply_lock_path() -> str:
 def acquire_apply_lock():
     """Take the exclusive --apply lock, or return None if another run holds it.
 
-    THE CHECK AND THE WRITE ARE NOT ONE OPERATION, which is the whole reason
-    this exists. `already_flagged()` reads Linear, then `flag_dormant()` writes
-    to Linear, and nothing links them: two concurrent --apply runs both read
-    "no marker", both write, and the issue carries two permanent dormancy
-    comments. Permanent is the operative word -- there is no undo on a comment,
-    and a duplicate flag costs trust in every flag. Reproduced on the PR head:
-    two overlapping --apply processes landed 2 comment mutations on one issue
-    (Codex major round 2, PR #204).
+    BEST-EFFORT, AND DELIBERATELY NOT THE CORRECTNESS STORY. A future reader
+    who finds a duplicate comment must not reach for a bigger lock. A
+    filesystem lock cannot coordinate two installs or two hosts, and this one
+    is keyed on `HERE`, so it does not even try. What makes flag-once hold is
+    `already_flagged()` reading every comment page before the write.
+
+    What this DOES buy: the check and the write are not one operation --
+    `already_flagged()` reads Linear, then `flag_dormant()` writes, and nothing
+    links them -- so two overlapping runs of the SAME installation would both
+    read "no marker" and both leave a permanent dormancy comment. Permanent is
+    the operative word; there is no undo on a comment. Serialising same-host
+    runs removes that window and saves the loser the whole sweep. Reproduced on
+    the PR head: two overlapping --apply processes landed 2 comment mutations
+    on one issue (Codex major round 2, PR #204).
 
     NON-BLOCKING ON PURPOSE. The loser refuses and says so rather than queueing:
     this runs daily against a 75-day threshold, so skipping one sweep costs
@@ -459,10 +514,15 @@ def acquire_apply_lock():
     corpse to break. This lock file is never unlinked, so unlike the ledger's it
     also needs no inode re-check -- nothing can swap the path underneath it.
 
-    HONEST BOUNDARY: this is one machine. Two runs on two hosts against the same
-    Linear workspace would still race, because the only authority that could
-    stop that is Linear, and `commentCreate` has no idempotency key. The named
-    threat (a manual run overlapping the scheduled one) is same-host.
+    HONEST BOUNDARY, AND IT IS NARROW NOW. Two hosts, or two installs on one
+    host, still race inside the window between a completed read and the write,
+    because the only authority that could close that is Linear and
+    `commentCreate` has no idempotency key. What the paginated read removed is
+    the LARGE case: an unbounded, permanent blind spot that fired on any issue
+    past 100 comments, on one host, with nothing concurrent about it. What is
+    left needs two sweeps to overlap on the same issue on the same day. Do not
+    try to close the remainder with a wider filesystem lock; it gets closed at
+    Linear or it stays documented.
     """
     path = apply_lock_path()
     try:

--- a/q-system/.q-system/scripts/linear-triage-health.py
+++ b/q-system/.q-system/scripts/linear-triage-health.py
@@ -348,6 +348,24 @@ def flag_dormant(ln, issue: dict, days: float, threshold: int) -> str:
     return "flagged"
 
 
+def select_to_flag(dormant: list, limit: int) -> list:
+    """Which dormant issues this run may WRITE to. Never a display concern.
+
+    Split out of main() so it is testable, because the defect it replaces was
+    invisible exactly where it lived. The write and the print used to share one
+    loop over `dormant[:20]`, so --apply flagged 20 and skipped the rest while
+    printing "... and N more" -- a display sentence that read as a work report.
+    Measured 2026-08-16: 193 dormant at a 7-day threshold, 173 silently skipped.
+
+    limit 0 means no cap: every dormant issue is eligible. A caller that wants a
+    bounded first run passes --limit N explicitly rather than inheriting a
+    number that happened to be a print width.
+    """
+    if limit < 0:
+        raise ValueError("limit must be >= 0")
+    return dormant[:limit] if limit else list(dormant)
+
+
 def breaches(m: dict) -> list:
     """Which thresholds this measurement crosses. Empty means stay quiet."""
     out = []
@@ -394,10 +412,17 @@ def main(argv: list) -> int:
     ap.add_argument("--no-notify", action="store_true",
                     help="never call the alert path")
     ap.add_argument("--json", action="store_true", help="print the measurement as JSON")
+    ap.add_argument("--limit", type=int, default=0, metavar="N",
+                    help="write at most N dormancy comments this run (0 = no cap). "
+                         "Bounds the blast radius of a first live --apply.")
     args = ap.parse_args(argv[1:])
 
     if args.dormant_days < 1:
         print("--dormant-days must be >= 1", file=sys.stderr)
+        return EXIT_USAGE
+
+    if args.limit < 0:
+        print("--limit must be >= 0", file=sys.stderr)
         return EXIT_USAGE
 
     # FIXTURE GUARD, the same chokepoint alert-to-linear.py uses. A suite written
@@ -449,14 +474,44 @@ def main(argv: list) -> int:
         print(f"  dormant (>={args.dormant_days}d)      : {m['dormant']}")
 
     if dormant:
-        print(f"\nDORMANT ({'APPLY' if args.apply else 'report only, writes nothing'}):")
+        # The WRITE loop is separate from the DISPLAY loop on purpose, and this
+        # separation is the fix for a real defect, not a style preference. Both
+        # used to be one loop over `dormant[:20]`, so --apply silently flagged
+        # only the first 20 and skipped the rest while printing "... and N more"
+        # -- a line about DISPLAY that read as a line about work done. Measured
+        # 2026-08-16: 193 dormant at a 7-day threshold, so 173 would have been
+        # silently skipped. A display bound must never decide what gets written.
+        to_flag = select_to_flag(dormant, args.limit)
+        outcomes = {}
+        if args.apply:
+            for issue, days in to_flag:
+                outcomes[issue["identifier"]] = flag_dormant(
+                    ln, issue, days, args.dormant_days)
+
+        if args.apply:
+            capped = f", capped at {args.limit}" if args.limit else ""
+            header = f"APPLY: wrote to {len(to_flag)} of {len(dormant)}{capped}"
+        else:
+            header = "report only, writes nothing"
+        print(f"\nDORMANT ({header}):")
+
         for issue, days in dormant[:20]:
             line = f"  {issue['identifier']:<10} {days:6.0f}d  {issue['title'][:58]}"
+            outcome = outcomes.get(issue["identifier"])
             if args.apply:
-                line += "  [" + flag_dormant(ln, issue, days, args.dormant_days) + "]"
+                # "not-attempted" is said out loud rather than left blank: a blank
+                # next to a listed issue is what made the old cap invisible.
+                line += "  [" + (outcome or "not-attempted (over --limit)") + "]"
             print(line)
         if len(dormant) > 20:
-            print(f"  ... and {len(dormant) - 20} more")
+            print(f"  ... and {len(dormant) - 20} more (display cap, not a write cap)")
+
+        if args.apply:
+            wrote = sum(1 for v in outcomes.values() if v == "flagged")
+            print(f"  flagged={wrote} already-flagged="
+                  f"{sum(1 for v in outcomes.values() if v == 'already-flagged')} "
+                  f"failed={sum(1 for v in outcomes.values() if v.startswith('FAILED'))} "
+                  f"not-attempted={len(dormant) - len(to_flag)}")
 
     hits = breaches(m)
     if hits and not args.no_notify:

--- a/q-system/.q-system/scripts/linear-triage-health.py
+++ b/q-system/.q-system/scripts/linear-triage-health.py
@@ -1,0 +1,481 @@
+#!/usr/bin/env python3
+"""Is the triage queue draining, and what has gone quiet? (ASK-882)
+
+WHY THIS EXISTS
+
+Measured on the live board 2026-08-16: 873 issues on team ASK, 229 of them with
+no project at all -- created, never routed. That is not a discipline failure. It
+is arithmetic: inflow is automated (scanners, alert filers, the DoR drafter) and
+outflow is manual, so the board can only grow. `owner:sana` -> `kipi-dispatch.sh`
+is the intended drain, and NOTHING measured whether it was keeping pace. A drain
+nobody meters is indistinguishable from a drain that stopped.
+
+WHAT IT MEASURES (the three numbers, and why these three)
+
+  unrouted        open issues with no project. This is the 229. An unset project
+                  is not cosmetic: linear-worker.sh `in_this_repo()` reads unset
+                  as "not this repo", so an unrouted issue is unreachable by every
+                  checkout at once. It is the count that best predicts work that
+                  can never be picked up.
+  needs-triage    open issues carrying the mark an automated filer left. Depth of
+                  the queue nobody has routed yet.
+  oldest          age in days of the oldest untouched issue in that queue. A
+                  count alone hides the shape: 40 issues filed this morning and
+                  40 filed in June are the same number and different problems.
+
+DORMANCY LIVES HERE TOO, ON PURPOSE
+
+The dormancy sweep needs exactly the same page of open issues this already
+fetches. Splitting it into a second script would mean two paginated walks of the
+same board and two places to fix when the query changes. So one fetch, two
+readings of it.
+
+IT FLAGS, IT NEVER CLOSES. GitHub's stale-bot pattern is the reference and the
+warning: a bot that silently closes real work teaches people the tracker lies.
+A dormant issue gets ONE comment and a label. Closing stays a judgment call.
+
+WHY IT EXCLUDES ITS OWN TICKETS
+
+`slack-notify.sh` no longer sends to Slack -- it files a Linear ticket (founder-
+directed 2026-08-10, "I dont want to see any of these"). So this script's own
+alert becomes an issue on the board this script counts. Left alone, a backlog
+monitor would inflate the backlog it reports and then report the inflation. The
+exclusion is by title marker and is tested; see SELF_MARKER.
+
+EXIT CODES -- this script never lies about failure
+  0  measured cleanly (whether or not it alerted)
+  1  usage error
+  3  no Linear API key configured -- a setup state, not an error
+  4  refused: running under pytest
+  9  the run could not complete its measurement (API failure mid-walk). Partial
+     numbers are still printed, but the exit code says they are partial.
+
+Deliberately not `exit 0 always`: that shape is its own defect class in this repo
+(ASK-213, three silent-success bugs shipped in one day).
+
+Usage:
+  linear-triage-health.py                       # measure, print, alert if breached
+  linear-triage-health.py --dormant-days 90     # different dormancy threshold
+  linear-triage-health.py --apply               # also write dormancy comments
+  linear-triage-health.py --no-notify           # never call the alert path
+"""
+from __future__ import annotations
+
+import argparse
+import importlib.util
+import json
+import os
+import subprocess
+import sys
+from datetime import datetime, timezone
+
+EXIT_OK = 0
+EXIT_USAGE = 1
+EXIT_NO_KEY = 3
+EXIT_REFUSED_FIXTURE = 4
+EXIT_INCOMPLETE = 9
+
+HERE = os.path.dirname(os.path.abspath(__file__))
+
+TEAM_KEY = os.environ.get("KIPI_LINEAR_TEAM", "ASK")
+TRIAGE_LABEL = "needs-triage"
+DORMANT_LABEL = "dormant"
+
+# Default dormancy threshold. 75 days sits inside the 60-90 band the stale-bot
+# research describes, and is deliberately NOT 90: the board itself is 22 days old
+# as of 2026-08-16, so a 90-day threshold could not fire at all for another two
+# months and would read as protection while doing nothing. A guard that cannot
+# fire on the population it runs against is decoration.
+DEFAULT_DORMANT_DAYS = 75
+
+# Thresholds that make the run worth an alert. Below these the run says nothing:
+# "still fine" every day is how a channel stops being read, which is the exact
+# scar `slack-notify.sh` was rewritten for.
+UNROUTED_ALERT_AT = 50
+TRIAGE_ALERT_AT = 40
+OLDEST_ALERT_DAYS = 30
+
+# Every alert line this script emits opens with this. It is how the script
+# recognises and excludes its OWN tickets from its OWN counts -- see the module
+# docstring. Changing it silently re-includes every past self-ticket, so it is
+# pinned by test_self_tickets_are_excluded.
+SELF_MARKER = "linear-triage-health:"
+
+# Written into every dormancy comment. A re-run finds it and skips, so a nightly
+# sweep cannot grow a comment stack on a permanent object. Same device as
+# linear-triage.py's MARKER, and for the same reason.
+DORMANT_MARKER = "<!-- kipi-dormancy-flag -->"
+
+OPEN_ISSUES_QUERY = """
+query($teamId: ID!, $after: String) {
+  issues(filter: {team: {id: {eq: $teamId}}}, first: 250, after: $after) {
+    nodes {
+      id identifier title createdAt updatedAt
+      state { name type }
+      project { id name }
+      labels { nodes { name } }
+    }
+    pageInfo { hasNextPage endCursor }
+  }
+}
+"""
+
+COMMENT_CREATE = """
+mutation($input: CommentCreateInput!) {
+  commentCreate(input: $input) { success }
+}
+"""
+
+ISSUE_COMMENTS_QUERY = """
+query($id: String!) {
+  issue(id: $id) { comments(first: 100) { nodes { body } } }
+}
+"""
+
+
+def _load_linear():
+    """Import linear-sync.py for its auth + graphql. Hyphen forces importlib.
+
+    SINGLE WRITER for how this fleet talks to Linear, the same rule
+    alert-to-linear.py follows. Reimplementing the key lookup or the errors-array
+    handling here would be a second place to fix when Linear changes, and
+    linear-sync.py's graphql() already knows Linear returns HTTP 200 with an
+    `errors` key on application failures.
+    """
+    path = os.path.join(HERE, "linear-sync.py")
+    spec = importlib.util.spec_from_file_location("kipi_linear_sync", path)
+    if spec is None or spec.loader is None:
+        raise RuntimeError(f"cannot load {path}")
+    mod = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(mod)
+    return mod
+
+
+def _parse_iso(stamp: str) -> datetime | None:
+    """Linear's ISO-8601 into an aware datetime, or None.
+
+    Linear sends a trailing `Z`, which `fromisoformat` rejected before 3.11. The
+    replace keeps this working on whatever python3 a launchd job happens to get,
+    rather than on the one this was written against.
+    """
+    if not stamp:
+        return None
+    try:
+        return datetime.fromisoformat(stamp.replace("Z", "+00:00"))
+    except (ValueError, TypeError):
+        return None
+
+
+def age_days(stamp: str, now: datetime) -> float | None:
+    """Days between `stamp` and `now`, or None when unparseable."""
+    when = _parse_iso(stamp)
+    if when is None:
+        return None
+    return (now - when).total_seconds() / 86400.0
+
+
+def is_open(issue: dict) -> bool:
+    """Open means not completed and not canceled.
+
+    Read off `state.type`, never `state.name`: the names are per-team strings a
+    human can rename, the types are Linear's own closed set. This team also
+    carries a `Duplicate` state whose type is `duplicate`, which is neither open
+    work nor a completion -- treating it as open would keep dead issues in the
+    count forever.
+    """
+    state_type = ((issue.get("state") or {}).get("type") or "").lower()
+    return state_type not in ("completed", "canceled", "duplicate")
+
+
+def label_names(issue: dict) -> set:
+    """Lowercased label names on an issue."""
+    nodes = ((issue.get("labels") or {}).get("nodes")) or []
+    return {(n.get("name") or "").lower() for n in nodes}
+
+
+def is_self_ticket(issue: dict) -> bool:
+    """A ticket THIS script's own alert path filed.
+
+    Excluded from every count. `slack-notify.sh` files a Linear ticket rather
+    than sending to Slack, so without this a backlog monitor reports its own
+    output as backlog and then alerts about the number it just caused.
+    """
+    return SELF_MARKER in (issue.get("title") or "")
+
+
+def is_unrouted(issue: dict) -> bool:
+    """Open, and carrying no project.
+
+    An unset project is what makes an issue unreachable rather than merely
+    untidy: linear-worker.sh `in_this_repo()` reads unset as "not this repo", so
+    no checkout claims it.
+    """
+    return not ((issue.get("project") or {}).get("id"))
+
+
+def measure(issues: list, now: datetime) -> dict:
+    """The three numbers, over already-filtered open non-self issues.
+
+    Pure: takes the list, returns the dict, touches no network. That is what
+    lets the test drive it with fixtures and assert literal numbers rather than
+    asserting a value it computed the same way the code did.
+    """
+    unrouted = [i for i in issues if is_unrouted(i)]
+    triage = [i for i in issues if TRIAGE_LABEL in label_names(i)]
+
+    oldest_days, oldest_id = 0.0, ""
+    for issue in triage:
+        days = age_days(issue.get("updatedAt") or "", now)
+        if days is not None and days > oldest_days:
+            oldest_days, oldest_id = days, issue.get("identifier") or ""
+
+    return {
+        "open": len(issues),
+        "unrouted": len(unrouted),
+        "needs_triage": len(triage),
+        "oldest_triage_days": round(oldest_days, 1),
+        "oldest_triage_id": oldest_id,
+    }
+
+
+def find_dormant(issues: list, now: datetime, threshold_days: int) -> list:
+    """Real work that has gone quiet past the threshold.
+
+    REAL, meaning it has a project. An unrouted issue is already counted as
+    unrouted; flagging it dormant as well would double-report one problem and
+    put a dormancy comment on the noise this system is trying to stop filing in
+    the first place. Dormancy is a question about work someone routed and then
+    nobody touched.
+
+    Also skips anything already carrying `needs-triage` (it is inflow that has
+    not been decided yet, not work that stalled) and anything already labelled
+    dormant (the flag is not re-applied).
+    """
+    out = []
+    for issue in issues:
+        if is_unrouted(issue):
+            continue
+        labels = label_names(issue)
+        if TRIAGE_LABEL in labels or DORMANT_LABEL in labels:
+            continue
+        days = age_days(issue.get("updatedAt") or "", now)
+        if days is not None and days >= threshold_days:
+            out.append((issue, round(days, 1)))
+    out.sort(key=lambda pair: pair[1], reverse=True)
+    return out
+
+
+def fetch_open_issues(ln, team_id: str) -> tuple:
+    """(issues, complete). One paginated walk, shared by both readings.
+
+    `complete` is False when the walk broke partway. The caller PRINTS the
+    partial numbers and exits 9 rather than presenting a short count as the
+    answer -- an undercount here reads as "the queue is draining", which is the
+    one wrong conclusion this script exists to prevent.
+    """
+    issues, after = [], None
+    while True:
+        try:
+            page = (ln.graphql(OPEN_ISSUES_QUERY,
+                               {"teamId": team_id, "after": after}) or {})
+            data = page.get("issues") or {}
+        except Exception as exc:
+            print(f"WARN: issue walk failed after {len(issues)} issue(s): {exc}",
+                  file=sys.stderr)
+            return issues, False
+        issues.extend(data.get("nodes") or [])
+        info = data.get("pageInfo") or {}
+        if not info.get("hasNextPage"):
+            return issues, True
+        after = info.get("endCursor")
+        if not after:
+            # hasNextPage true with no cursor would spin forever on the same
+            # page. Stop and say the walk is partial.
+            print("WARN: pagination reported more pages but gave no cursor",
+                  file=sys.stderr)
+            return issues, False
+
+
+def already_flagged(ln, issue_id: str) -> bool:
+    """True when a dormancy comment is already on the issue.
+
+    Checked per issue rather than trusting the label alone: the label can be
+    removed by a human who disagrees, and re-adding a comment they already read
+    is the comment-stack failure this marker exists to prevent.
+
+    On an API failure this returns True -- skip rather than risk a duplicate.
+    Erring toward silence is right here: a missed flag costs one issue staying
+    quiet, a duplicated flag costs trust in every flag.
+    """
+    try:
+        issue = (ln.graphql(ISSUE_COMMENTS_QUERY, {"id": issue_id}) or {}).get("issue") or {}
+    except Exception:
+        return True
+    for node in ((issue.get("comments") or {}).get("nodes") or []):
+        if DORMANT_MARKER in (node.get("body") or ""):
+            return True
+    return False
+
+
+def dormancy_comment(days: float, threshold: int) -> str:
+    """The body written onto a dormant issue. Flags, never closes."""
+    return (
+        f"{DORMANT_MARKER}\n"
+        f"**Dormant: no activity in {days:.0f} days** (threshold {threshold}).\n\n"
+        f"This is a flag, not a verdict, and nothing was closed. It means nobody "
+        f"has touched this since it was routed, which is worth a decision one way "
+        f"or the other:\n\n"
+        f"- still wanted -> comment or update it and this clears\n"
+        f"- superseded or done -> close it with the reason\n"
+        f"- real but not now -> say so here, so the next sweep reads an answer "
+        f"instead of silence\n\n"
+        f"<sub>`linear-triage-health.py`. Flagged once; a re-run finds this "
+        f"comment and skips.</sub>"
+    )
+
+
+def flag_dormant(ln, issue: dict, days: float, threshold: int) -> str:
+    """Write one dormancy comment. Returns a short outcome for the report."""
+    if already_flagged(ln, issue["id"]):
+        return "already-flagged"
+    try:
+        ln.graphql(COMMENT_CREATE, {"input": {
+            "issueId": issue["id"],
+            "body": dormancy_comment(days, threshold),
+        }})
+    except Exception as exc:
+        return f"FAILED ({exc})"
+    return "flagged"
+
+
+def breaches(m: dict) -> list:
+    """Which thresholds this measurement crosses. Empty means stay quiet."""
+    out = []
+    if m["unrouted"] >= UNROUTED_ALERT_AT:
+        out.append(f"{m['unrouted']} unrouted (no project)")
+    if m["needs_triage"] >= TRIAGE_ALERT_AT:
+        out.append(f"{m['needs_triage']} awaiting triage")
+    if m["oldest_triage_days"] >= OLDEST_ALERT_DAYS:
+        out.append(f"oldest untriaged {m['oldest_triage_id']} "
+                   f"at {m['oldest_triage_days']:.0f}d")
+    return out
+
+
+def notify(line: str) -> int:
+    """Send one line through the fleet's single alert path.
+
+    `slack-notify.sh` is the only sanctioned sink (founder-notifications.md), and
+    it dedupes by alert SHAPE -- every digit is stripped before fingerprinting --
+    so a daily run of this script collapses onto ONE ticket with a counter rather
+    than one ticket a day. That property is why a daily cadence is safe here.
+
+    Never raises: a monitoring script that can crash on its own alert is worse
+    than the alert being lost.
+    """
+    script = os.path.join(HERE, "slack-notify.sh")
+    if not os.path.isfile(script):
+        print(f"WARN: no slack-notify.sh at {script}; not alerting", file=sys.stderr)
+        return 1
+    try:
+        res = subprocess.run(["bash", script, line], capture_output=True,
+                             text=True, timeout=120)
+    except (OSError, subprocess.SubprocessError) as exc:
+        print(f"WARN: alert path failed ({exc})", file=sys.stderr)
+        return 1
+    return res.returncode
+
+
+def main(argv: list) -> int:
+    ap = argparse.ArgumentParser(description=__doc__.split("\n")[0])
+    ap.add_argument("--dormant-days", type=int, default=DEFAULT_DORMANT_DAYS,
+                    help=f"dormancy threshold in days (default {DEFAULT_DORMANT_DAYS})")
+    ap.add_argument("--apply", action="store_true",
+                    help="write dormancy comments (default: report only)")
+    ap.add_argument("--no-notify", action="store_true",
+                    help="never call the alert path")
+    ap.add_argument("--json", action="store_true", help="print the measurement as JSON")
+    args = ap.parse_args(argv[1:])
+
+    if args.dormant_days < 1:
+        print("--dormant-days must be >= 1", file=sys.stderr)
+        return EXIT_USAGE
+
+    # FIXTURE GUARD, the same chokepoint alert-to-linear.py uses. A suite written
+    # tomorrow must not be able to comment on a real issue or file a real ticket,
+    # so the refusal lives here rather than in each test.
+    if os.environ.get("PYTEST_CURRENT_TEST"):
+        print("linear-triage-health: REFUSED under pytest.", file=sys.stderr)
+        return EXIT_REFUSED_FIXTURE
+
+    ln = _load_linear()
+    try:
+        ln.linear_api_key()
+    except Exception as exc:
+        print(f"no Linear key configured ({exc})", file=sys.stderr)
+        return EXIT_NO_KEY
+
+    try:
+        teams = (ln.graphql(ln.TEAM_QUERY, {"key": TEAM_KEY}) or {}).get("teams") or {}
+        nodes = teams.get("nodes") or []
+    except Exception as exc:
+        print(f"team lookup failed ({exc})", file=sys.stderr)
+        return EXIT_INCOMPLETE
+    if not nodes:
+        print(f"no Linear team {TEAM_KEY!r}", file=sys.stderr)
+        return EXIT_INCOMPLETE
+    team_id = nodes[0]["id"]
+
+    raw, complete = fetch_open_issues(ln, team_id)
+    # Filter ONCE, here, so measure() and find_dormant() cannot disagree about
+    # which population they describe.
+    issues = [i for i in raw if is_open(i) and not is_self_ticket(i)]
+    now = datetime.now(timezone.utc)
+
+    m = measure(issues, now)
+    dormant = find_dormant(issues, now, args.dormant_days)
+    m["dormant"] = len(dormant)
+    m["dormant_threshold_days"] = args.dormant_days
+    m["complete"] = complete
+
+    if args.json:
+        print(json.dumps(m, indent=2))
+    else:
+        print(f"team {TEAM_KEY}: {m['open']} open "
+              f"({len(raw)} fetched, {len(raw) - len(issues)} closed/self)")
+        print(f"  unrouted (no project) : {m['unrouted']}")
+        print(f"  needs-triage          : {m['needs_triage']}")
+        print(f"  oldest untriaged      : {m['oldest_triage_days']:.0f}d "
+              f"{m['oldest_triage_id']}")
+        print(f"  dormant (>={args.dormant_days}d)      : {m['dormant']}")
+
+    if dormant:
+        print(f"\nDORMANT ({'APPLY' if args.apply else 'report only, writes nothing'}):")
+        for issue, days in dormant[:20]:
+            line = f"  {issue['identifier']:<10} {days:6.0f}d  {issue['title'][:58]}"
+            if args.apply:
+                line += "  [" + flag_dormant(ln, issue, days, args.dormant_days) + "]"
+            print(line)
+        if len(dormant) > 20:
+            print(f"  ... and {len(dormant) - 20} more")
+
+    hits = breaches(m)
+    if hits and not args.no_notify:
+        line = (f"{SELF_MARKER} " + "; ".join(hits) +
+                f". {m['dormant']} dormant >={args.dormant_days}d. "
+                f"Drain is owner:sana -> kipi-dispatch.sh.")
+        rc = notify(line)
+        print(f"\nalerted (exit {rc}): {line}")
+    elif hits:
+        print(f"\nwould alert (suppressed by --no-notify): {'; '.join(hits)}")
+    else:
+        print("\nno threshold breached; staying quiet")
+
+    if not complete:
+        print("INCOMPLETE: the issue walk did not finish; numbers are partial.",
+              file=sys.stderr)
+        return EXIT_INCOMPLETE
+    return EXIT_OK
+
+
+if __name__ == "__main__":
+    sys.exit(main(sys.argv))

--- a/q-system/.q-system/scripts/linear-triage-health.py
+++ b/q-system/.q-system/scripts/linear-triage-health.py
@@ -17,8 +17,11 @@ WHAT IT MEASURES (the three numbers, and why these three)
                   as "not this repo", so an unrouted issue is unreachable by every
                   checkout at once. It is the count that best predicts work that
                   can never be picked up.
-  needs-triage    open issues carrying the mark an automated filer left. Depth of
-                  the queue nobody has routed yet.
+  needs-triage    open issues carrying the mark an automated filer left AND
+                  still holding no project. Depth of the queue nobody has routed
+                  yet. Both halves are required: nothing removes the label when
+                  an issue is routed, so counting the label alone counted routed
+                  work as untriaged forever.
   oldest          age in days of the oldest untouched issue in that queue. A
                   count alone hides the shape: 40 issues filed this morning and
                   40 filed in June are the same number and different problems.
@@ -43,10 +46,13 @@ monitor would inflate the backlog it reports and then report the inflation. The
 exclusion is by title marker and is tested; see SELF_MARKER.
 
 EXIT CODES -- this script never lies about failure
-  0  measured cleanly (whether or not it alerted)
+  0  measured cleanly, and any alert it owed was delivered
   1  usage error
   3  no Linear API key configured -- a setup state, not an error
   4  refused: running under pytest
+  5  a threshold was breached and the alert did NOT send. The numbers are good;
+     nobody was told. Printing the failure and exiting 0 made launchd record a
+     silent 3am success, so the delivery result reaches the exit code.
   9  the run could not complete its measurement (API failure mid-walk). Partial
      numbers are still printed, but the exit code says they are partial.
 
@@ -73,6 +79,7 @@ EXIT_OK = 0
 EXIT_USAGE = 1
 EXIT_NO_KEY = 3
 EXIT_REFUSED_FIXTURE = 4
+EXIT_ALERT_FAILED = 5
 EXIT_INCOMPLETE = 9
 
 HERE = os.path.dirname(os.path.abspath(__file__))
@@ -213,6 +220,25 @@ def is_unrouted(issue: dict) -> bool:
     return not ((issue.get("project") or {}).get("id"))
 
 
+def is_awaiting_triage(issue: dict) -> bool:
+    """Carrying the filer's mark AND still unrouted.
+
+    BOTH halves, and the second one is a fix, not a refinement. `alert-to-linear
+    .py` sets `projectId` and the `needs-triage` label in the SAME issueCreate
+    payload, and NOTHING anywhere removes that label once a human routes the
+    issue. So a label-only count reported every routed alert ticket as still
+    awaiting triage, forever -- a queue that can only grow, reported by the
+    script whose whole job is noticing a queue that only grows (Codex major on
+    PR #204, reproduced: one routed ticket, needs_triage=1).
+
+    Routing is the event that ends the wait, so routing is what the measurement
+    reads. The alternative was a label-removal writer, which needs a mutation,
+    a second write path, and something to run it; a predicate needs neither and
+    cannot drift out of sync with the board.
+    """
+    return TRIAGE_LABEL in label_names(issue) and is_unrouted(issue)
+
+
 def measure(issues: list, now: datetime) -> dict:
     """The three numbers, over already-filtered open non-self issues.
 
@@ -221,7 +247,7 @@ def measure(issues: list, now: datetime) -> dict:
     asserting a value it computed the same way the code did.
     """
     unrouted = [i for i in issues if is_unrouted(i)]
-    triage = [i for i in issues if TRIAGE_LABEL in label_names(i)]
+    triage = [i for i in issues if is_awaiting_triage(i)]
 
     oldest_days, oldest_id = 0.0, ""
     for issue in triage:
@@ -335,16 +361,31 @@ def dormancy_comment(days: float, threshold: int) -> str:
 
 
 def flag_dormant(ln, issue: dict, days: float, threshold: int) -> str:
-    """Write one dormancy comment. Returns a short outcome for the report."""
+    """Write one dormancy comment. Returns a short outcome for the report.
+
+    THE MUTATION'S OWN `success` FIELD IS THE EVIDENCE, not the absence of an
+    exception. `COMMENT_CREATE` selects `success` and this used to discard it,
+    so a `commentCreate: {success: false}` reply came back through a clean call
+    and was reported as "flagged" -- the run counted a write that never landed
+    and the summary line said flagged=N (Codex major on PR #204, reproduced).
+    A monitoring script that overstates its own writes is the failure it was
+    built to catch, one layer up.
+
+    `graphql()` already raises on Linear's `errors` array, so the two paths are
+    different animals: the exception is a call that failed, this is a call that
+    succeeded and declined.
+    """
     if already_flagged(ln, issue["id"]):
         return "already-flagged"
     try:
-        ln.graphql(COMMENT_CREATE, {"input": {
+        res = ln.graphql(COMMENT_CREATE, {"input": {
             "issueId": issue["id"],
             "body": dormancy_comment(days, threshold),
         }})
     except Exception as exc:
         return f"FAILED ({exc})"
+    if not (((res or {}).get("commentCreate") or {}).get("success")):
+        return "FAILED (commentCreate returned success=false)"
     return "flagged"
 
 
@@ -514,12 +555,21 @@ def main(argv: list) -> int:
                   f"not-attempted={len(dormant) - len(to_flag)}")
 
     hits = breaches(m)
+    alert_failed = False
     if hits and not args.no_notify:
         line = (f"{SELF_MARKER} " + "; ".join(hits) +
                 f". {m['dormant']} dormant >={args.dormant_days}d. "
                 f"Drain is owner:sana -> kipi-dispatch.sh.")
         rc = notify(line)
-        print(f"\nalerted (exit {rc}): {line}")
+        # A NONZERO HERE IS A DELIVERY FAILURE AND MUST REACH THE EXIT CODE.
+        # This printed `alerted (exit 1)` and then returned 0, so a 3am launchd
+        # run recorded success for a breach nobody was told about -- the one
+        # state this script exists to make impossible (Codex major, PR #204).
+        # `notify()` never raises by design, which is exactly why its return
+        # value is the only signal there is.
+        alert_failed = rc != 0
+        verb = "alert FAILED" if alert_failed else "alerted"
+        print(f"\n{verb} (exit {rc}): {line}")
     elif hits:
         print(f"\nwould alert (suppressed by --no-notify): {'; '.join(hits)}")
     else:
@@ -529,6 +579,10 @@ def main(argv: list) -> int:
         print("INCOMPLETE: the issue walk did not finish; numbers are partial.",
               file=sys.stderr)
         return EXIT_INCOMPLETE
+    if alert_failed:
+        print("ALERT FAILED: a threshold was breached and the alert did not send.",
+              file=sys.stderr)
+        return EXIT_ALERT_FAILED
     return EXIT_OK
 
 

--- a/q-system/.q-system/scripts/linear-triage-health.py
+++ b/q-system/.q-system/scripts/linear-triage-health.py
@@ -93,7 +93,6 @@ import json
 import os
 import subprocess
 import sys
-import tempfile
 from datetime import datetime, timezone
 
 EXIT_OK = 0
@@ -459,39 +458,74 @@ def dormancy_comment(days: float, threshold: int) -> str:
 
 
 def apply_lock_path() -> str:
-    """One lock per INSTALLED COPY. AN OPTIMIZATION, NOT THE FLAG-ONCE GUARANTEE.
+    """One lock per MACHINE per Linear team. Still not the flag-once guarantee.
 
     Read this before reasoning about duplicate dormancy comments. The guarantee
     that an issue is flagged once lives in `already_flagged()`, which walks
-    every comment page. This lock only spares a same-host loser a whole sweep
-    of wasted API calls.
+    every comment page. This lock removes the window between that read and the
+    write for every sweep that CAN share a filesystem.
 
-    Keyed on the script's own directory rather than a fixed name so that a copy
-    running out of a tmpdir (the suite does exactly this) cannot contend with
-    the real installation, while two runs of the SAME installation -- the
-    launchd job and a founder's manual run -- resolve to the same path. That
-    keying is also precisely why it can never be the guarantee: two installs,
-    or two hosts, hash to different paths and never contend. Reproduced on the
-    PR head: two install directories produced distinct lock paths and both
-    wrote (Codex major round 4, PR #204). Lives in the system temp dir, not in
-    the repo: `kipi update` rsyncs this tree, and a lock file inside it would
-    be fleet cargo.
+    KEYED ON THE TEAM BEING SWEPT, NOT ON THE INSTALL PATH, and that is the
+    round-5 fix. The old key was `sha256(HERE)`, the directory the running copy
+    lives in, chosen so a tmpdir copy could not contend with the real
+    installation. The cost of that convenience was the thing the lock is for:
+    two checkouts of this repo on ONE machine -- a worktree and the installed
+    copy, or `/opt/kipi-a` and `/opt/kipi-b` -- hashed to two different paths,
+    never contended, and both left a permanent dormancy comment on the same
+    issue. Reproduced on the PR head: outcomes=['flagged','flagged'],
+    permanent_comment_writes=2 (Codex major round 5, PR #204). The install path
+    is an accident of deployment; the Linear team is what two sweeps actually
+    collide over, so that is what the key is made of.
+
+    Lives in `~/.cache/kipi/`, the same place and for the same stated reason as
+    `alert-to-linear.py`'s `_state_dir()`: OUTSIDE any repo checkout. A lock
+    inside this tree would be rsynced as fleet cargo by `kipi update`, and would
+    also be per-checkout again, which is the defect above wearing a new path.
+    The system temp dir would work for the lock alone, but splitting kipi's
+    machine-local state across two roots is how the next reader misses one.
+
+    Isolation for the suite is now EXPLICIT, via `KIPI_TRIAGE_HEALTH_LOCK`,
+    rather than a side effect of where a staged copy happened to sit. A test
+    that forgets to pin it would contend with the real launchd job, so the
+    suite's `_health_env()` sets it by default rather than per test.
     """
     override = os.environ.get("KIPI_TRIAGE_HEALTH_LOCK")
     if override:
         return override
-    key = hashlib.sha256(HERE.encode("utf-8")).hexdigest()[:16]
-    return os.path.join(tempfile.gettempdir(), f"kipi-triage-health-{key}.lock")
+    # The team key reaches a filesystem path, and it comes from an env var, so
+    # it is constrained here rather than trusted. Anything outside the safe set
+    # collapses to a hash of the raw value: still one stable path per team, with
+    # no way to climb out of the directory.
+    safe = "".join(c for c in TEAM_KEY if c.isalnum() or c in "-_")
+    if not safe or safe != TEAM_KEY:
+        safe = "team-" + hashlib.sha256(TEAM_KEY.encode("utf-8")).hexdigest()[:16]
+    return os.path.join(os.path.expanduser("~"), ".cache", "kipi",
+                        "linear-triage-health", f"{safe}.lock")
 
 
 def acquire_apply_lock():
     """Take the exclusive --apply lock, or return None if another run holds it.
 
     BEST-EFFORT, AND DELIBERATELY NOT THE CORRECTNESS STORY. A future reader
-    who finds a duplicate comment must not reach for a bigger lock. A
-    filesystem lock cannot coordinate two installs or two hosts, and this one
-    is keyed on `HERE`, so it does not even try. What makes flag-once hold is
+    who finds a duplicate comment must not reach for a bigger lock. What makes
+    flag-once hold across anything that does NOT share this filesystem is
     `already_flagged()` reading every comment page before the write.
+
+    WHAT THIS LOCK NOW COVERS, AND WHAT IT STILL DOES NOT. Since the key moved
+    from the install path to the team (see `apply_lock_path`), every sweep on
+    ONE machine serialises no matter which checkout, worktree or install
+    directory it runs from. That is the whole realistic population for this
+    fleet: a launchd job plus a founder's manual run plus an agent worktree,
+    all on the same laptop.
+
+    Two different PHYSICAL HOSTS sweeping one Linear team still race, and that
+    is an accepted, documented limitation rather than something this change
+    quietly closed. No filesystem lock can span hosts. Closing it needs
+    idempotency on Linear's side with no read/write gap, and `commentCreate`
+    exposes no idempotency key, so there is nowhere to put the guarantee. If a
+    duplicate ever shows up, check whether two hosts ran before reaching for a
+    wider lock here; a bigger filesystem lock cannot fix a cross-host race and
+    will only make the same window harder to see.
 
     What this DOES buy: the check and the write are not one operation --
     `already_flagged()` reads Linear, then `flag_dormant()` writes, and nothing
@@ -514,18 +548,24 @@ def acquire_apply_lock():
     corpse to break. This lock file is never unlinked, so unlike the ledger's it
     also needs no inode re-check -- nothing can swap the path underneath it.
 
-    HONEST BOUNDARY, AND IT IS NARROW NOW. Two hosts, or two installs on one
-    host, still race inside the window between a completed read and the write,
-    because the only authority that could close that is Linear and
-    `commentCreate` has no idempotency key. What the paginated read removed is
-    the LARGE case: an unbounded, permanent blind spot that fired on any issue
-    past 100 comments, on one host, with nothing concurrent about it. What is
-    left needs two sweeps to overlap on the same issue on the same day. Do not
-    try to close the remainder with a wider filesystem lock; it gets closed at
-    Linear or it stays documented.
+    HONEST BOUNDARY. Two different HOSTS still race inside the window between a
+    completed read and the write, because the only authority that could close
+    that is Linear and `commentCreate` has no idempotency key. Two installs on
+    one host no longer do -- that was the round-5 finding and the team-keyed
+    path above closes it. What the paginated read removed is the LARGE case: an
+    unbounded, permanent blind spot that fired on any issue past 100 comments,
+    on one host, with nothing concurrent about it. What is left needs two
+    sweeps on two machines to overlap on the same issue on the same day. It
+    gets closed at Linear or it stays documented.
     """
     path = apply_lock_path()
     try:
+        # The cache root is created on demand: this is the first run's path on
+        # any new machine, and a missing parent would otherwise surface as
+        # "cannot open the --apply lock" and skip the sweep forever.
+        parent = os.path.dirname(path)
+        if parent:
+            os.makedirs(parent, exist_ok=True)
         handle = open(path, "a")
     except OSError as exc:
         print(f"WARN: cannot open the --apply lock at {path} ({exc})",

--- a/q-system/.q-system/scripts/spillover-promote.py
+++ b/q-system/.q-system/scripts/spillover-promote.py
@@ -446,6 +446,10 @@ def create_issue(ls, args, root: Path, body: str):
         "teamId": tid, "title": args.title, "description": body,
         "priority": args.priority,
         "labelIds": label_ids, "projectId": pid}})
+    # linear-filer: human-in-the-loop -- one confirmed finding per invocation,
+    # and validate_dor refuses to create without a human-authored title and a
+    # Definition of Ready carrying allowed-files + acceptance. A person decided
+    # this issue exists, so needs-triage would mark work that is already routed.
     ident = ((res.get("issueCreate") or {}).get("issue") or {}).get("identifier")
     if not ident:
         sys.stderr.write(f"Linear create failed: {json.dumps(res)[:300]}\n")

--- a/q-system/.q-system/tests/test_alert_to_linear.py
+++ b/q-system/.q-system/tests/test_alert_to_linear.py
@@ -116,6 +116,7 @@ class FakeLinear:
         # a FIELD OF THE PAYLOAD, so the fixture has to keep the payload; a test
         # that only reads the returned identifier cannot see the field at all.
         self.create_input = None
+        self.labels_created = []
         self.projects = [{"id": "proj-kipi", "name": "kipi-system",
                           "description": ""}]
 
@@ -129,6 +130,16 @@ class FakeLinear:
         if "labels(first" in query:
             return {"team": {"labels": {"nodes": [
                 {"id": "lab-1", "name": "owner:sana"}]}}}
+        if "issueLabelCreate" in query:
+            # The team owns `owner:sana` and NOT `needs-triage`, so the healthy
+            # path creates the second one. This branch was missing: the mutation
+            # fell through to `return {}`, `needs-triage` never resolved, and
+            # every "healthy" file in this suite was quietly DEGRADED with no
+            # test able to see it -- the fixture was modelling a broken Linear
+            # and calling it the happy path (found by the round-5 control).
+            self.labels_created.append(variables["input"]["name"])
+            return {"issueLabelCreate": {"issueLabel": {
+                "id": f"lab-new-{len(self.labels_created)}"}}}
         if "projects(first" in query:
             return {"team": {"projects": {"nodes": self.projects}}}
         if "issueCreate" in query:
@@ -228,8 +239,59 @@ def test_label_failure_still_files_the_ticket(isolated_state, monkeypatch):
             return FakeLinear.graphql(self, query, variables)
 
     monkeypatch.setattr(mod, "_load_linear", lambda: NoLabels())
-    code, _ = mod.file_alert(AUTOCOMMIT[0], now=1000.0)
-    assert code == mod.EXIT_OK and _  # filed anyway
+    code, line = mod.file_alert(AUTOCOMMIT[0], now=1000.0)
+    assert code == mod.EXIT_OK and line  # filed anyway
+    # ROUND 5: this test used to stop at "filed anyway", and that weak
+    # assertion is what let the finding through -- it is true of both a
+    # correctly-degraded file and a silently unlabelled one.
+    assert "DEGRADED" in line, line
+
+
+def test_the_label_query_failing_outright_is_reported_degraded(
+        isolated_state, monkeypatch):
+    """ROUND 5 MAJOR. Two failure points, only one of them visible.
+
+    The round-4 fix taught the per-label CREATE path to record an unresolved
+    name, so a create that failed for a real reason reached the caller's
+    `[DEGRADED: ...]` suffix. The earlier point -- the LABELS_QUERY itself
+    raising -- kept a bare `return []` and skipped both out-lists. A labels
+    endpoint timeout therefore filed a ticket with NO labels, exit 0, and a
+    result line indistinguishable from a fully-labelled file, which is the one
+    thing the triage measurement cannot afford to be blind to.
+
+    Reproduced on the PR head: degraded_visible=False, labelIds absent.
+    """
+    class LabelsEndpointDown(FakeLinear):
+        def graphql(self, query, variables):
+            if "labels(first" in query:
+                raise RuntimeError("labels endpoint timeout")
+            return FakeLinear.graphql(self, query, variables)
+
+    fake = LabelsEndpointDown()
+    monkeypatch.setattr(mod, "_load_linear", lambda: fake)
+    code, line = mod.file_alert(AUTOCOMMIT[0], now=1000.0)
+
+    # the alert still lands: a dropped alert is worse than an unlabelled one
+    assert code == mod.EXIT_OK
+    assert fake.created == 1
+    assert "labelIds" not in (fake.create_input or {})
+    # and the run's own summary line says so
+    assert "DEGRADED" in line, line
+    assert mod.TRIAGE_LABEL in line, line
+
+
+def test_a_fully_labelled_file_is_never_marked_degraded(
+        isolated_state, monkeypatch):
+    """The negative control. A suffix that is always present says nothing.
+
+    FakeLinear resolves `owner:sana` from the team and creates `needs-triage`,
+    so this is the healthy path and it must come back clean.
+    """
+    fake = FakeLinear()
+    monkeypatch.setattr(mod, "_load_linear", lambda: fake)
+    code, line = mod.file_alert(AUTOCOMMIT[0], now=1000.0)
+    assert code == mod.EXIT_OK
+    assert "DEGRADED" not in line, line
 
 
 def test_title_is_one_bounded_line():

--- a/q-system/.q-system/tests/test_linear_filer_label_lint.py
+++ b/q-system/.q-system/tests/test_linear_filer_label_lint.py
@@ -1,0 +1,125 @@
+#!/usr/bin/env python3
+"""Tests for linear-filer-label-lint.py (ASK-882).
+
+The cases that matter are the two the brief names -- a compliant filer passes, a
+new filer that skips the label fails -- plus the population check, because this
+gate was nearly shipped in a form that would have been red on 7 of the 8 files
+already in the repo.
+"""
+import importlib.util
+import os
+
+import pytest
+
+HERE = os.path.dirname(os.path.abspath(__file__))
+# normpath, not a raw join. `tests/../scripts/x.py` still CONTAINS "/tests/", so
+# the un-normalized path made is_test_path() true for every production filer and
+# the population check below passed by skipping all of it. A test that passes
+# because its input never reached the code is worse than no test.
+SCRIPTS = os.path.normpath(os.path.join(HERE, "..", "scripts"))
+
+
+def _load(filename: str, modname: str):
+    path = os.path.join(SCRIPTS, filename)
+    spec = importlib.util.spec_from_file_location(modname, path)
+    mod = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(mod)
+    return mod
+
+
+lint = _load("linear-filer-label-lint.py", "linear_filer_label_lint")
+
+FILER = 'MUT = """mutation($input: IssueCreateInput!) { issueCreate(input: $input) }"""'
+
+
+def test_a_compliant_automated_filer_passes():
+    """The positive case: it attaches the triage label, so it declares itself."""
+    text = FILER + '\nTRIAGE_LABEL = "needs-triage"\npayload["labelIds"] = ids\n'
+    assert lint.check_text("scripts/some-filer.py", text)[0] == lint.EXIT_PASS
+
+
+def test_a_new_filer_that_skips_the_label_is_blocked():
+    """The negative case, and the whole reason this gate exists.
+
+    A future script that creates Linear issues and says nothing about who
+    decided they should exist is exactly the drift the rule could not catch.
+    """
+    text = FILER + '\npayload = {"teamId": team, "title": t}\nln.graphql(MUT, payload)\n'
+    assert lint.check_text("scripts/new-filer.py", text)[0] == lint.EXIT_BLOCK
+
+
+def test_a_human_driven_filer_passes_by_declaring_it():
+    """The judgment half is DECLARED, never inferred. A reason is required."""
+    text = FILER + "\n# linear-filer: human-in-the-loop -- founder types each issue\n"
+    assert lint.check_text("scripts/manual.py", text)[0] == lint.EXIT_PASS
+
+
+def test_a_bare_posture_marker_without_a_reason_is_still_blocked():
+    """A mute exemption defeats the point: the marker exists to say something.
+
+    Pinned because the regex is the only thing standing between "declared" and
+    "waved through", and a trailing-empty group is the easy way to get it wrong.
+    """
+    text = FILER + "\n# linear-filer: human-in-the-loop --\n"
+    assert lint.check_text("scripts/mute.py", text)[0] == lint.EXIT_BLOCK
+
+
+def test_a_file_that_never_files_issues_is_untouched():
+    """Scope must match the rule, or the gate runs on every edit in the repo."""
+    assert lint.check_text("scripts/whatever.py",
+                           "def add(a, b):\n    return a + b\n")[0] == lint.EXIT_PASS
+
+
+def test_tests_are_skipped_so_the_reference_suite_stays_writable():
+    """A suite constructs issueCreate in order to assert on it."""
+    assert lint.check_text("q-system/.q-system/tests/test_alert_to_linear.py",
+                           FILER)[0] == lint.EXIT_PASS
+    assert lint.check_text("scripts/test/test-linear-dor.py",
+                           FILER)[0] == lint.EXIT_PASS
+
+
+def test_non_source_files_are_ignored():
+    """A markdown rule QUOTING the mutation must not be gated as a filer."""
+    assert lint.check_text("docs/automated-filer-marking.md",
+                           FILER)[0] == lint.EXIT_PASS
+
+
+def test_the_bypass_marker_releases_one_file():
+    text = FILER + "\n# linear-filer-lint-skip: migration, one-shot\n"
+    assert lint.check_text("scripts/one-shot.py", text)[0] == lint.EXIT_PASS
+
+
+def test_label_constant_matches_the_filer_and_the_health_script():
+    """Three files, one vocabulary. A rename in one silently empties the queue.
+
+    linear-triage-health.py already pins itself to alert-to-linear.py; this
+    extends the same chain to the gate, so the gate cannot drift into checking
+    for a label nothing writes.
+    """
+    health = _load("linear-triage-health.py", "lfl_health_for_labels")
+    alerts = _load("alert-to-linear.py", "lfl_alerts_for_labels")
+    assert lint.TRIAGE_LABEL == health.TRIAGE_LABEL == alerts.TRIAGE_LABEL
+
+
+@pytest.mark.parametrize("name", [
+    "linear-sync.py",
+    "fleet-health-daily.py",
+    "spillover-promote.py",
+    "linear-job-migration.py",
+    "linear-dor-drafter.py",
+    "alert-to-linear.py",
+])
+def test_every_existing_filer_in_this_repo_passes(name):
+    """The gate must be satisfiable by the population it runs on.
+
+    Measured 2026-08-16: 8 files construct `issueCreate` and only ONE referenced
+    `needs-triage`. A gate demanding the label outright would have been red on 7
+    of them the day it landed, and a gate that cannot pass gets switched off.
+    This is the check that would have caught that, so it runs against the real
+    files rather than a fixture of them.
+    """
+    path = os.path.join(SCRIPTS, name)
+    with open(path, "r", encoding="utf-8", errors="replace") as handle:
+        text = handle.read()
+    code, note = lint.check_text(path, text)
+    assert code == lint.EXIT_PASS, f"{name} would be blocked ({note})"

--- a/q-system/.q-system/tests/test_linear_triage_health.py
+++ b/q-system/.q-system/tests/test_linear_triage_health.py
@@ -285,3 +285,38 @@ def test_triage_label_constant_matches_what_health_measures():
     drain that is keeping pace.
     """
     assert alerts.TRIAGE_LABEL == health.TRIAGE_LABEL == "needs-triage"
+
+
+def test_no_limit_makes_every_dormant_issue_writable():
+    """A run with no --limit writes to ALL dormant issues, not the first 20.
+
+    This is the regression pin for a shipped defect, so the fixture is 25 items
+    on purpose: the write and the print used to share one loop over
+    `dormant[:20]`, so --apply flagged 20 and silently skipped the rest while
+    printing "... and N more". Measured on the live board 2026-08-16: 193 dormant
+    at a 7-day threshold, 173 of which would never have been written to. Any
+    reintroduced display bound turns this red.
+    """
+    dormant = [(issue(f"ASK-{n}", project="p"), 30.0) for n in range(25)]
+    assert len(health.select_to_flag(dormant, 0)) == 25
+
+
+def test_limit_caps_the_write_and_keeps_the_oldest_first():
+    """--limit bounds blast radius, and bounds it from the oldest end.
+
+    find_dormant sorts oldest-first, so a capped run must spend its budget on
+    the issues that have been quiet longest rather than an arbitrary slice.
+    """
+    dormant = [(issue(f"ASK-{n}", project="p"), float(50 - n)) for n in range(10)]
+    picked = health.select_to_flag(dormant, 3)
+    assert [i["identifier"] for i, _ in picked] == ["ASK-0", "ASK-1", "ASK-2"]
+
+
+def test_negative_limit_is_refused_rather_than_silently_emptying():
+    """A negative slice would return [] and read as "nothing was dormant".
+
+    Refusing is the point: a silent empty write set is indistinguishable from a
+    clean board, which is the one wrong conclusion this script exists to prevent.
+    """
+    with pytest.raises(ValueError):
+        health.select_to_flag([(issue("ASK-1", project="p"), 30.0)], -1)

--- a/q-system/.q-system/tests/test_linear_triage_health.py
+++ b/q-system/.q-system/tests/test_linear_triage_health.py
@@ -1,0 +1,287 @@
+#!/usr/bin/env python3
+"""Pins linear-triage-health.py and the needs-triage marking in alert-to-linear.py.
+
+The numbers asserted below are LITERAL, never recomputed from the same helper the
+code uses. A baseline captured by calling `measure()` twice cannot see a change
+that moves both sides, which is how a mutant survives a green suite in this repo.
+
+Every fixture here is shaped like a real Linear GraphQL node (the keys the actual
+OPEN_ISSUES_QUERY selects), not like a convenient dict. A fixture I invent tests
+my assumption; this one at least tests the query's own shape.
+"""
+import importlib.util
+import os
+from datetime import datetime, timedelta, timezone
+
+import pytest
+
+HERE = os.path.dirname(os.path.abspath(__file__))
+SCRIPTS = os.path.join(HERE, "..", "scripts")
+
+NOW = datetime(2026, 8, 16, 12, 0, 0, tzinfo=timezone.utc)
+
+
+def _load(filename: str, modname: str):
+    path = os.path.join(SCRIPTS, filename)
+    spec = importlib.util.spec_from_file_location(modname, path)
+    mod = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(mod)
+    return mod
+
+
+health = _load("linear-triage-health.py", "linear_triage_health")
+alerts = _load("alert-to-linear.py", "alert_to_linear_for_labels")
+
+
+def issue(ident, *, project=None, labels=(), days_old=0, state="Backlog",
+          state_type="backlog", title=None):
+    """One issue node in the shape OPEN_ISSUES_QUERY actually returns."""
+    stamp = (NOW - timedelta(days=days_old)).isoformat().replace("+00:00", "Z")
+    return {
+        "id": f"uuid-{ident}",
+        "identifier": ident,
+        "title": title or f"{ident} some work",
+        "createdAt": stamp,
+        "updatedAt": stamp,
+        "state": {"name": state, "type": state_type},
+        "project": {"id": f"p-{project}", "name": project} if project else None,
+        "labels": {"nodes": [{"name": n} for n in labels]},
+    }
+
+
+# --- the three numbers -------------------------------------------------------
+
+def test_unrouted_counts_only_issues_with_no_project():
+    """The 229. An unset project is what makes an issue unreachable."""
+    issues = [
+        issue("ASK-1"),                       # unrouted
+        issue("ASK-2"),                       # unrouted
+        issue("ASK-3", project="kipi-system"),
+        issue("ASK-4", project="cole-gtm"),
+    ]
+    m = health.measure(issues, NOW)
+    assert m["unrouted"] == 2
+    assert m["open"] == 4
+
+
+def test_needs_triage_counted_and_oldest_reported():
+    """A count alone hides the shape, so the oldest is part of the measurement."""
+    issues = [
+        issue("ASK-1", labels=["needs-triage", "owner:sana"], days_old=3),
+        issue("ASK-2", labels=["needs-triage"], days_old=41),
+        issue("ASK-3", labels=["owner:sana"], days_old=99),   # not triage
+    ]
+    m = health.measure(issues, NOW)
+    assert m["needs_triage"] == 2
+    assert m["oldest_triage_id"] == "ASK-2"
+    assert m["oldest_triage_days"] == pytest.approx(41.0, abs=0.1)
+
+
+def test_label_matching_is_case_insensitive():
+    """Linear preserves the case a label was created with; the count must not care."""
+    m = health.measure([issue("ASK-1", labels=["Needs-Triage"])], NOW)
+    assert m["needs_triage"] == 1
+
+
+# --- the self-exclusion ------------------------------------------------------
+
+def test_self_tickets_are_excluded():
+    """slack-notify.sh files a ticket, so this script's alert lands on its own board.
+
+    Without the exclusion a backlog monitor inflates the backlog it reports and
+    then alerts about the number it caused. This is the negative self-test for
+    that: the self ticket is unrouted, so if the filter breaks, unrouted goes to 2.
+    """
+    self_title = f"[kipi-system] {health.SELF_MARKER} 229 unrouted (no project)"
+    issues = [issue("ASK-1"), issue("ASK-2", title=self_title)]
+
+    assert health.is_self_ticket(issues[1]) is True
+    assert health.is_self_ticket(issues[0]) is False
+
+    kept = [i for i in issues if not health.is_self_ticket(i)]
+    assert health.measure(kept, NOW)["unrouted"] == 1
+
+
+# --- open vs closed ----------------------------------------------------------
+
+def test_duplicate_state_is_not_open():
+    """This team carries a Duplicate state. Counting it as open keeps dead issues forever."""
+    assert health.is_open(issue("ASK-1")) is True
+    assert health.is_open(issue("ASK-2", state="Done", state_type="completed")) is False
+    assert health.is_open(issue("ASK-3", state="Canceled", state_type="canceled")) is False
+    assert health.is_open(issue("ASK-4", state="Duplicate", state_type="duplicate")) is False
+
+
+def test_open_is_read_from_type_not_name():
+    """Names are renameable per-team strings; types are Linear's closed set."""
+    renamed = issue("ASK-1", state="Shipped", state_type="completed")
+    assert health.is_open(renamed) is False
+
+
+# --- dormancy ----------------------------------------------------------------
+
+def test_dormant_finds_only_routed_quiet_work():
+    issues = [
+        issue("ASK-1", project="kipi-system", days_old=100),   # dormant
+        issue("ASK-2", project="kipi-system", days_old=10),    # recent
+        issue("ASK-3", days_old=200),                          # unrouted, skipped
+        issue("ASK-4", project="kipi-system", days_old=200,
+              labels=["needs-triage"]),                        # inflow, skipped
+        issue("ASK-5", project="kipi-system", days_old=200,
+              labels=["dormant"]),                             # already flagged
+    ]
+    found = health.find_dormant(issues, NOW, 75)
+    assert [i["identifier"] for i, _ in found] == ["ASK-1"]
+
+
+def test_dormant_threshold_boundary_is_inclusive_and_configurable():
+    """Exactly at the threshold counts; one day under does not."""
+    at = [issue("ASK-1", project="p", days_old=75)]
+    under = [issue("ASK-2", project="p", days_old=74)]
+    assert len(health.find_dormant(at, NOW, 75)) == 1
+    assert len(health.find_dormant(under, NOW, 75)) == 0
+    # configurable, and the 90 case is the one a 75-day default would over-report
+    assert len(health.find_dormant(at, NOW, 90)) == 0
+
+
+def test_dormant_sorted_oldest_first():
+    issues = [
+        issue("ASK-1", project="p", days_old=80),
+        issue("ASK-2", project="p", days_old=300),
+        issue("ASK-3", project="p", days_old=120),
+    ]
+    found = health.find_dormant(issues, NOW, 75)
+    assert [i["identifier"] for i, _ in found] == ["ASK-2", "ASK-3", "ASK-1"]
+
+
+def test_dormancy_comment_flags_and_never_closes():
+    """GitHub's stale-bot warning: a bot that silently closes teaches people the tracker lies."""
+    body = health.dormancy_comment(120.0, 75)
+    assert health.DORMANT_MARKER in body
+    assert "120 days" in body
+    low = body.lower()
+    assert "nothing was closed" in low
+    # the comment must not claim an automatic close is coming
+    assert "will be closed" not in low
+    assert "auto-clos" not in low
+
+
+# --- alerting posture --------------------------------------------------------
+
+def test_quiet_below_every_threshold():
+    """'Still fine' every day is how a channel stops being read."""
+    m = {"unrouted": 3, "needs_triage": 2, "oldest_triage_days": 1.0,
+         "oldest_triage_id": "ASK-1"}
+    assert health.breaches(m) == []
+
+
+def test_each_threshold_can_fire_on_its_own():
+    base = {"unrouted": 0, "needs_triage": 0, "oldest_triage_days": 0.0,
+            "oldest_triage_id": ""}
+
+    only_unrouted = dict(base, unrouted=health.UNROUTED_ALERT_AT)
+    only_triage = dict(base, needs_triage=health.TRIAGE_ALERT_AT)
+    only_old = dict(base, oldest_triage_days=float(health.OLDEST_ALERT_DAYS),
+                    oldest_triage_id="ASK-9")
+
+    assert len(health.breaches(only_unrouted)) == 1
+    assert len(health.breaches(only_triage)) == 1
+    assert len(health.breaches(only_old)) == 1
+    # and one under each boundary stays silent, so the >= is pinned in both directions
+    assert health.breaches(dict(base, unrouted=health.UNROUTED_ALERT_AT - 1)) == []
+    assert health.breaches(dict(base, needs_triage=health.TRIAGE_ALERT_AT - 1)) == []
+
+
+def test_dormancy_default_can_actually_fire_on_this_board():
+    """A threshold the population can never reach reads as protection and is not.
+
+    The board was created 2026-07-25. A 90-day default could not fire until late
+    October; 75 is inside the researched 60-90 band and reachable.
+    """
+    assert health.DEFAULT_DORMANT_DAYS == 75
+    assert 60 <= health.DEFAULT_DORMANT_DAYS <= 90
+
+
+# --- the fixture guard -------------------------------------------------------
+
+def test_main_refuses_under_pytest():
+    """A suite must never be able to comment on a real issue.
+
+    This asserts the chokepoint, not a per-test stub: per-test stubbing only
+    protects tests someone remembered to fix (ASK-879 is the open issue for the
+    non-pytest runners this does NOT cover).
+    """
+    assert os.environ.get("PYTEST_CURRENT_TEST")
+    assert health.main(["linear-triage-health.py"]) == health.EXIT_REFUSED_FIXTURE
+
+
+# --- the filer marking (alert-to-linear.py) ----------------------------------
+
+class FakeLinear:
+    """Records the mutations it was asked to run. No network, no live path."""
+
+    def __init__(self, existing=(), fail_create_for=()):
+        self.existing = list(existing)
+        self.fail_create_for = set(fail_create_for)
+        self.created = []
+
+    def graphql(self, query, variables):
+        if "labels(first" in query:
+            return {"team": {"labels": {"nodes": [
+                {"id": f"id-{n}", "name": n} for n in self.existing]}}}
+        if "issueLabelCreate" in query:
+            name = variables["input"]["name"]
+            if name in self.fail_create_for:
+                raise RuntimeError(f"refused to create {name}")
+            self.created.append(variables["input"])
+            return {"issueLabelCreate": {"success": True,
+                                         "issueLabel": {"id": f"new-{name}"}}}
+        raise AssertionError(f"unexpected query: {query[:60]}")
+
+
+def test_both_labels_resolved_when_both_exist():
+    ln = FakeLinear(existing=["owner:sana", "needs-triage", "Bug"])
+    ids = alerts._label_ids(ln, "team", [alerts.OWNER_LABEL, alerts.TRIAGE_LABEL])
+    assert ids == ["id-owner:sana", "id-needs-triage"]
+    assert ln.created == []
+
+
+def test_missing_triage_label_is_created_with_its_description():
+    """The label explains itself on the board, or nobody knows what it means."""
+    ln = FakeLinear(existing=["owner:sana"])
+    ids = alerts._label_ids(ln, "team", [alerts.OWNER_LABEL, alerts.TRIAGE_LABEL])
+    assert ids == ["id-owner:sana", "new-needs-triage"]
+    assert len(ln.created) == 1
+    assert ln.created[0]["name"] == "needs-triage"
+    assert ln.created[0]["description"] == alerts.TRIAGE_LABEL_DESCRIPTION
+
+
+def test_a_failed_create_keeps_the_label_that_did_resolve():
+    """Losing the mark is a worse board; losing the ticket is a lost alert.
+
+    Negative self-test for the per-name try: with one try around the whole loop,
+    this returns [] and the ticket files with no owner label at all.
+    """
+    ln = FakeLinear(existing=["owner:sana"], fail_create_for=["needs-triage"])
+    ids = alerts._label_ids(ln, "team", [alerts.OWNER_LABEL, alerts.TRIAGE_LABEL])
+    assert ids == ["id-owner:sana"]
+
+
+def test_label_lookup_failure_never_raises():
+    """An alert filed with no label still reaches Sana; a raised exception loses it."""
+
+    class Broken:
+        def graphql(self, query, variables):
+            raise RuntimeError("linear is down")
+
+    assert alerts._label_ids(Broken(), "team", [alerts.OWNER_LABEL]) == []
+
+
+def test_triage_label_constant_matches_what_health_measures():
+    """Two files, one vocabulary. A rename in one is the drift this pins.
+
+    The filer WRITES the label and the health script COUNTS it. If those strings
+    ever diverge the queue reads as permanently empty, which looks exactly like a
+    drain that is keeping pace.
+    """
+    assert alerts.TRIAGE_LABEL == health.TRIAGE_LABEL == "needs-triage"

--- a/q-system/.q-system/tests/test_linear_triage_health.py
+++ b/q-system/.q-system/tests/test_linear_triage_health.py
@@ -15,6 +15,7 @@ import os
 import shutil
 import subprocess
 import sys
+import tempfile
 from datetime import datetime, timedelta, timezone
 
 import pytest
@@ -504,9 +505,24 @@ def _stage_health_copy(tmp_path, fake_sync=FAKE_LINEAR_SYNC):
     return tmp_path / "linear-triage-health.py"
 
 
+# The suite's --apply lock, pinned OUT of the real one.
+#
+# Until round 5 the lock was keyed on the script's own directory, so a staged
+# copy in a tmpdir could not reach the installed job's lock. That isolation was
+# a side effect of the key, and the key was the round-5 blocker: two checkouts
+# on one machine never contended and both wrote a permanent comment. With the
+# key moved to the Linear team, a staged copy resolves to the SAME path as the
+# real launchd sweep, so a test that forgot to pin it would contend with the
+# real job. Isolation is therefore explicit and defaulted here rather than
+# per-test: forgetting it is not an available mistake.
+_SUITE_LOCK_DIR = tempfile.mkdtemp(prefix="kipi-triage-health-suite-")
+
+
 def _health_env(**extra):
     env = dict(os.environ)
     env.pop("PYTEST_CURRENT_TEST", None)
+    env.setdefault("KIPI_TRIAGE_HEALTH_LOCK",
+                   os.path.join(_SUITE_LOCK_DIR, "apply.lock"))
     env.update({k: str(v) for k, v in extra.items()})
     return env
 
@@ -735,15 +751,16 @@ def test_a_marker_past_the_first_page_is_still_found():
     assert ln.pages_served == 2
 
 
-def test_two_installs_flag_one_issue_once_without_ever_sharing_a_lock():
-    """Finding 1, at the level the fix was actually made.
+def test_two_installs_on_one_machine_share_one_lock():
+    """ROUND 5 BLOCKER. This test used to ASSERT the defect.
 
-    Two installed copies hash to two different lock paths and CANNOT contend --
-    that is asserted here rather than fixed, because a filesystem lock cannot
-    represent a shared Linear team and pretending otherwise is the bug. What
-    stops the duplicate is that the second sweep's read finds the first sweep's
-    marker, wherever it landed. The filler pushes that marker onto page 2, so
-    this fails on the PR head for the pagination reason as well.
+    Its previous line was `assert path_a != path_b, "premise of the finding"`,
+    which pinned two install directories to two lock paths and called that
+    settled because "a filesystem lock cannot represent a shared Linear team".
+    A filesystem lock cannot span HOSTS; it represents one machine perfectly
+    well, and two checkouts on one machine is the realistic collision for this
+    fleet -- a worktree plus the installed copy. Keying on the team instead of
+    on `HERE` closes it, so the assertion inverts.
     """
     original_here = health.HERE
     try:
@@ -751,18 +768,138 @@ def test_two_installs_flag_one_issue_once_without_ever_sharing_a_lock():
         path_a = health.apply_lock_path()
         health.HERE = "/opt/kipi-b/scripts"
         path_b = health.apply_lock_path()
-        assert path_a != path_b, "premise of the finding: two installs, two locks"
-
-        shared = PaginatedIssue(_filler(100))
-        issue_node = {"id": "uuid-1", "identifier": "ASK-1"}
-
-        health.HERE = "/opt/kipi-a/scripts"
-        first = health.flag_dormant(shared, issue_node, 120.0, 75)
-        health.HERE = "/opt/kipi-b/scripts"
-        second = health.flag_dormant(shared, issue_node, 120.0, 75)
     finally:
         health.HERE = original_here
+    assert path_a == path_b, "two installs on one machine must contend"
 
+
+class MarkedIssue:
+    """One issue carrying one dormancy marker posted at `marker_at`."""
+
+    def __init__(self, marker_at):
+        self.marker_at = marker_at
+        self.writes = 0
+
+    def graphql(self, query, variables):
+        if "comments(" in query:
+            node = {"body": health.DORMANT_MARKER}
+            if self.marker_at is not None:
+                node["createdAt"] = self.marker_at
+            return {"issue": {"comments": {
+                "nodes": [node],
+                "pageInfo": {"hasNextPage": False, "endCursor": None}}}}
+        self.writes += 1
+        return {"commentCreate": {"success": True}}
+
+
+def test_a_revived_issue_that_goes_quiet_again_is_flagged_again():
+    """ROUND 5 BLOCKER. The marker was a permanent silencer.
+
+    `dormancy_comment()` prints "still wanted -> comment or update it and this
+    clears". Nothing implemented that: `already_flagged()` found the marker
+    forever, so an issue that was flagged, revived by a human, and then went
+    quiet a SECOND time could never be flagged again. A monitor that goes
+    permanently silent on exactly the issues it once identified is worse than
+    one that never ran.
+
+    Timeline: marker 2026-01-15, human touches it 2026-03-01, now 2026-06-01.
+    """
+    issue = {"id": "u1", "identifier": "ASK-1", "title": "real work",
+             "updatedAt": "2026-03-01T00:00:00.000Z", "state": {"type": "backlog"},
+             "project": {"id": "p1"}, "labels": {"nodes": []}}
+    now = datetime(2026, 6, 1, tzinfo=timezone.utc)
+    dormant = health.find_dormant([issue], now, 75)
+    assert dormant, "precondition: the revived issue is dormant again"
+
+    ln = MarkedIssue("2026-01-15T00:00:00.000Z")
+    assert health.flag_dormant(ln, *dormant[0], 75) == "flagged"
+    assert ln.writes == 1
+
+
+def test_an_issue_untouched_since_its_marker_is_not_flagged_twice():
+    """The negative control, and without it the fix above is a comment stack.
+
+    Same marker, same sweep, one field different: nothing touched the issue
+    after the flag. It must stay silent. A version of the fix that always
+    re-flags passes the test above and fails here.
+    """
+    issue = {"id": "u1", "identifier": "ASK-1", "title": "real work",
+             "updatedAt": "2026-01-10T00:00:00.000Z", "state": {"type": "backlog"},
+             "project": {"id": "p1"}, "labels": {"nodes": []}}
+    now = datetime(2026, 6, 1, tzinfo=timezone.utc)
+    dormant = health.find_dormant([issue], now, 75)
+
+    ln = MarkedIssue("2026-01-15T00:00:00.000Z")
+    assert health.flag_dormant(ln, *dormant[0], 75) == "already-flagged"
+    assert ln.writes == 0
+
+
+def test_the_bots_own_comment_does_not_supersede_its_own_marker():
+    """Linear bumps updatedAt on comment creation. Measured, not assumed.
+
+    Sampled 2026-08-17 across 14 ASK issues: in 7 the issue's `updatedAt` equals
+    the newest comment's own `updatedAt` to the exact millisecond, and Linear
+    stamps a comment's `updatedAt` 15-200ms BEFORE its `createdAt`. So the
+    dormancy comment lands with the issue's clock fractionally EARLIER than the
+    marker and cannot invalidate itself on the very next sweep.
+    """
+    marker_at = "2026-01-15T00:00:00.100Z"
+    bumped_to = "2026-01-15T00:00:00.083Z"   # the comment's updatedAt, 17ms earlier
+    assert not health.marker_superseded(marker_at, bumped_to)
+
+
+def test_a_marker_with_no_readable_timestamp_still_silences():
+    """Unknown is not "go ahead and comment again".
+
+    A comment is permanent and has no undo, so an unusable timestamp errs toward
+    silence -- the same posture FlagCheckFailed already takes for a read that
+    did not finish.
+    """
+    for stamp in (None, "", "not-a-date"):
+        ln = MarkedIssue(stamp)
+        assert health.already_flagged(ln, "u1", "2026-06-01T00:00:00.000Z") is True
+
+
+def test_the_newest_marker_decides_not_the_first_one_found():
+    """An issue flagged twice must be judged on its LATEST flag.
+
+    Returning on the first marker found was correct while the only question was
+    "is there a marker". Compared against a clock it inverts: the stale first
+    marker reads as superseded and the sweep re-flags an issue that already
+    holds a current flag.
+    """
+    class TwoMarkers:
+        writes = 0
+
+        def graphql(self, query, variables):
+            if "comments(" in query:
+                return {"issue": {"comments": {"nodes": [
+                    {"body": health.DORMANT_MARKER,
+                     "createdAt": "2026-01-15T00:00:00.000Z"},
+                    {"body": health.DORMANT_MARKER,
+                     "createdAt": "2026-05-01T00:00:00.000Z"}],
+                    "pageInfo": {"hasNextPage": False, "endCursor": None}}}}
+            TwoMarkers.writes += 1
+            return {"commentCreate": {"success": True}}
+
+    # touched between the two markers: stale by the first, current by the second
+    assert health.already_flagged(
+        TwoMarkers(), "u1", "2026-03-01T00:00:00.000Z") is True
+    assert TwoMarkers.writes == 0
+
+
+def test_the_marker_read_still_stops_a_duplicate_without_any_lock():
+    """The lock is an optimisation; the marker read is the guarantee.
+
+    Kept from the round-4 test this replaces, because it covers what a lock
+    never can: two sweeps that do NOT share a filesystem. The filler pushes the
+    marker onto page 2, so this also fails on the round-3 head for the
+    pagination reason.
+    """
+    shared = PaginatedIssue(_filler(100))
+    issue_node = {"id": "uuid-1", "identifier": "ASK-1"}
+    first = health.flag_dormant(shared, issue_node, 120.0, 75)
+    second = health.flag_dormant(shared, issue_node, 120.0, 75)
     assert first == "flagged"
     assert second == "already-flagged"
     assert shared.writes == 1
@@ -1079,6 +1216,69 @@ def test_two_concurrent_apply_runs_comment_once(tmp_path):
     assert codes == [health.EXIT_OK, health.EXIT_LOCKED], codes
 
 
+def test_two_separate_installs_on_one_machine_comment_once(tmp_path):
+    """ROUND 5 BLOCKER, end to end, and the reason the in-process check is thin.
+
+    The reviewer's reproducer varied only `HERE` and then called `flag_dormant`
+    directly. `flag_dormant` sits BELOW the lock -- `main()` takes the lock once
+    per sweep, `_run` refuses without it -- so calling it directly can never
+    observe a lock no matter how it is keyed, and its "2 writes" result was a
+    property of the entry point chosen, not of the lock. This runs the real
+    entry point from two genuinely different install directories, which is the
+    shape the finding describes: a worktree and the installed copy on one
+    machine.
+
+    On the round-4 head the two directories hashed to two lock paths, both runs
+    won, and one issue took two permanent dormancy comments.
+
+    NOT COVERED, and deliberately so: two different HOSTS. No filesystem lock
+    spans machines and `commentCreate` has no idempotency key, so that remains
+    documented rather than fixed. There is no way to write that test here.
+    """
+    install_a = tmp_path / "kipi-a" / "scripts"
+    install_b = tmp_path / "kipi-b" / "scripts"
+    ledger = tmp_path / "writes.log"
+    procs = []
+    for install in (install_a, install_b):
+        install.mkdir(parents=True)
+        script = _stage_health_copy(install, FAKE_SYNC_RACY)
+        env = _health_env(FAKE_WRITE_LEDGER=str(ledger),
+                          KIPI_TRIAGE_HEALTH_LOCK=str(tmp_path / "shared.lock"))
+        procs.append(subprocess.Popen(
+            [sys.executable, str(script), "--apply", "--no-notify",
+             "--dormant-days", "30"],
+            env=env, stdout=subprocess.PIPE, stderr=subprocess.PIPE, text=True))
+    for proc in procs:
+        proc.communicate(timeout=180)
+
+    writes = len([l for l in ledger.read_text().splitlines() if l.strip()]) \
+        if ledger.exists() else 0
+    assert writes == 1, f"two installs left {writes} dormancy comments on one issue"
+    assert sorted(p.returncode for p in procs) == \
+        [health.EXIT_OK, health.EXIT_LOCKED]
+
+
+def test_two_installs_resolve_to_one_lock_without_the_override(tmp_path):
+    """The negative control for the test above, and it is load-bearing.
+
+    That test pins the shared lock path explicitly, so it would still pass if
+    `apply_lock_path()` went back to keying on `HERE` -- the override would be
+    doing all the work and the fix could be reverted invisibly. This asserts the
+    DEFAULT, unpinned path is the same from two install directories, which is
+    the property the override hides.
+    """
+    original_here = health.HERE
+    try:
+        health.HERE = str(tmp_path / "kipi-a" / "scripts")
+        default_a = health.apply_lock_path()
+        health.HERE = str(tmp_path / "kipi-b" / "scripts")
+        default_b = health.apply_lock_path()
+    finally:
+        health.HERE = original_here
+    assert default_a == default_b
+    assert str(tmp_path) not in default_a, "the lock must not live in the install"
+
+
 def test_a_single_apply_run_still_writes(tmp_path):
     """The negative control, and it is load-bearing here.
 
@@ -1109,19 +1309,37 @@ def test_report_only_runs_take_no_lock(tmp_path):
     assert not (tmp_path / "writes.log").exists(), "report-only wrote to Linear"
 
 
-def test_the_apply_lock_is_scoped_to_the_installed_copy(tmp_path):
-    """Two DIFFERENT installations must not block each other.
+def test_the_apply_lock_is_scoped_to_the_team_not_the_install_path(tmp_path):
+    """Every sweep of one team on one machine resolves to ONE path.
 
-    Keyed on the script's own directory, so the suite's tmp copies and the real
-    installation never contend -- while two runs of one installation, the actual
-    collision, resolve to the same path.
+    The inverse of what this file asserted through round 4. The lock key is the
+    Linear team being swept, so where the running copy sits is irrelevant --
+    which is the whole point, because "where the copy sits" was the accident
+    that let two checkouts both comment.
     """
     mine = health.apply_lock_path()
     assert mine.endswith(".lock")
     # not inside the repo: `kipi update` rsyncs this tree and would ship it
     assert not mine.startswith(SCRIPTS)
-    # two runs of ONE installation agree, which is the collision that matters
-    assert health.apply_lock_path() == mine
+    assert health.TEAM_KEY in mine, "the team is the key"
+
+    # moving the install path must NOT move the lock
+    original_here = health.HERE
+    try:
+        health.HERE = "/somewhere/else/entirely"
+        assert health.apply_lock_path() == mine
+    finally:
+        health.HERE = original_here
+
+    # a team key that could climb out of the directory is collapsed to a hash
+    original_team = health.TEAM_KEY
+    try:
+        health.TEAM_KEY = "../../etc"
+        escaped = health.apply_lock_path()
+    finally:
+        health.TEAM_KEY = original_team
+    assert ".." not in escaped
+    assert os.path.dirname(escaped) == os.path.dirname(mine)
 
     # the override wins, so a caller can pin it explicitly
     os.environ["KIPI_TRIAGE_HEALTH_LOCK"] = str(tmp_path / "pinned.lock")

--- a/q-system/.q-system/tests/test_linear_triage_health.py
+++ b/q-system/.q-system/tests/test_linear_triage_health.py
@@ -11,6 +11,9 @@ my assumption; this one at least tests the query's own shape.
 """
 import importlib.util
 import os
+import shutil
+import subprocess
+import sys
 from datetime import datetime, timedelta, timezone
 
 import pytest
@@ -320,3 +323,204 @@ def test_negative_limit_is_refused_rather_than_silently_emptying():
     """
     with pytest.raises(ValueError):
         health.select_to_flag([(issue("ASK-1", project="p"), 30.0)], -1)
+
+
+# --- PR #204 Codex review: the four majors, each with its reproducer ---------
+
+def test_a_routed_ticket_is_no_longer_awaiting_triage():
+    """FINDING 1. The filer sets projectId and needs-triage in ONE payload.
+
+    Nothing anywhere removes the label when a human routes the issue, so a
+    label-only count reported every routed alert ticket as untriaged forever --
+    a permanently growing number, printed by the script whose job is spotting a
+    permanently growing number. Reproduced on the PR head: needs_triage=1 for
+    the routed ticket below.
+
+    Both directions are pinned. Dropping the `is_unrouted` half turns the first
+    assert red; dropping the label half turns the third one red.
+    """
+    routed = issue("ASK-1", project="kipi-system",
+                   labels=["owner:sana", "needs-triage"])
+    unrouted_marked = issue("ASK-2", labels=["owner:sana", "needs-triage"])
+    routed_unmarked = issue("ASK-3", project="kipi-system", labels=["owner:sana"])
+
+    assert health.measure([routed], NOW)["needs_triage"] == 0
+    assert health.measure([unrouted_marked], NOW)["needs_triage"] == 1
+    assert health.measure([routed_unmarked], NOW)["needs_triage"] == 0
+    # and the predicate itself, so a caller added later reads one definition
+    assert health.is_awaiting_triage(routed) is False
+    assert health.is_awaiting_triage(unrouted_marked) is True
+
+
+class CommentLinear:
+    """A Linear that answers commentCreate with whatever `success` it was given.
+
+    Modelled on the real reply shape: COMMENT_CREATE selects `success`, and
+    Linear returns HTTP 200 with success=false rather than raising.
+    """
+
+    def __init__(self, success):
+        self.success = success
+        self.bodies = []
+
+    def graphql(self, query, variables):
+        if "comments(first" in query:
+            return {"issue": {"comments": {"nodes": []}}}
+        if "commentCreate" in query:
+            self.bodies.append(variables["input"]["body"])
+            return {"commentCreate": {"success": self.success}}
+        raise AssertionError(f"unexpected query: {query[:60]}")
+
+
+def test_a_refused_comment_is_not_reported_as_flagged():
+    """FINDING 2. success=false came back through a clean call and read as written.
+
+    The run then counted it in `flagged=N`. A monitoring script that overstates
+    its own writes is the exact failure it exists to catch, one layer up.
+    Reproduced on the PR head: flag_dormant returned 'flagged'.
+    """
+    ln = CommentLinear(success=False)
+    out = health.flag_dormant(ln, {"id": "uuid-1", "identifier": "ASK-1"}, 120.0, 75)
+
+    assert out != "flagged"
+    assert out.startswith("FAILED")
+    # the call really was attempted -- this is a refused write, not a skipped one
+    assert len(ln.bodies) == 1
+
+
+def test_an_accepted_comment_is_still_reported_as_flagged():
+    """The positive control for the test above.
+
+    Without it, `return "FAILED"` unconditionally would pass the success=false
+    case and the suite would be green on a script that can never flag anything.
+    """
+    ln = CommentLinear(success=True)
+    out = health.flag_dormant(ln, {"id": "uuid-1", "identifier": "ASK-1"}, 120.0, 75)
+    assert out == "flagged"
+    assert health.DORMANT_MARKER in ln.bodies[0]
+
+
+def test_a_conflicted_label_create_recovers_the_existing_id():
+    """FINDING 4 (alert-to-linear.py). Losing the create race is not having no label.
+
+    Two filers read the team before either created `needs-triage`; the loser's
+    create fails BECAUSE the label now exists, and the old code dropped the name
+    and filed the ticket unmarked -- invisible to the health script, silently.
+    Reproduced on the PR head: ids came back as ['id-owner:sana'].
+    """
+
+    class Conflict:
+        def __init__(self):
+            self.label_queries = 0
+
+        def graphql(self, query, variables):
+            if "labels(first" in query:
+                self.label_queries += 1
+                # the rival process wins between the first read and the refetch
+                names = (["owner:sana"] if self.label_queries == 1
+                         else ["owner:sana", "needs-triage"])
+                return {"team": {"labels": {"nodes": [
+                    {"id": f"id-{n}", "name": n} for n in names]}}}
+            if "issueLabelCreate" in query:
+                raise RuntimeError('[{"message":"Entity with that name already exists"}]')
+            raise AssertionError(f"unexpected query: {query[:60]}")
+
+    ln = Conflict()
+    ids = alerts._label_ids(ln, "team", [alerts.OWNER_LABEL, alerts.TRIAGE_LABEL])
+
+    assert ids == ["id-owner:sana", "id-needs-triage"]
+    assert ln.label_queries == 2, "the recovery must actually re-read the team"
+
+
+def test_a_create_that_fails_for_another_reason_still_finds_nothing():
+    """The negative control for the recovery above.
+
+    The refetch must not invent an id. A create refused for permissions leaves
+    the label genuinely absent, so this run comes away with only the label it
+    really resolved -- the same posture the pre-existing failed-create test
+    pins, kept honest now that a second lookup happens.
+    """
+    ln = FakeLinear(existing=["owner:sana"], fail_create_for=["needs-triage"])
+    ids = alerts._label_ids(ln, "team", [alerts.OWNER_LABEL, alerts.TRIAGE_LABEL])
+    assert ids == ["id-owner:sana"]
+
+
+# --- FINDING 3: the alert result has to reach the exit code ------------------
+#
+# main() refuses under pytest on purpose, and that chokepoint is worth more than
+# this test is. So this drives a COPY of the script in a subprocess with the
+# guard's env var cleared, beside a fake linear-sync.py and a fake
+# slack-notify.sh. Nothing here can reach the real board: the copy resolves its
+# neighbours from its OWN directory, which is a tmp_path. Clearing the var on
+# the real module in-process would disarm the guard for every test after it.
+
+FAKE_LINEAR_SYNC = '''
+TEAM_QUERY = "query teams"
+
+
+def linear_api_key():
+    return "fake-key-never-sent-anywhere"
+
+
+def graphql(query, variables):
+    if "issues(filter" in query:
+        nodes = [{
+            "id": f"u{n}", "identifier": f"ASK-{n}", "title": f"work {n}",
+            "createdAt": "2026-08-16T00:00:00Z",
+            "updatedAt": "2026-08-16T00:00:00Z",
+            "state": {"name": "Backlog", "type": "backlog"},
+            "project": None,
+            "labels": {"nodes": []},
+        } for n in range(60)]
+        return {"issues": {"nodes": nodes, "pageInfo": {"hasNextPage": False}}}
+    return {"teams": {"nodes": [{"id": "team-1", "key": "ASK"}]}}
+'''
+
+FAKE_NOTIFY = '#!/usr/bin/env bash\nexit "${FAKE_NOTIFY_EXIT:-0}"\n'
+
+
+def _run_health_copy(tmp_path, notify_exit):
+    """Run a copy of the script whose alert path exits `notify_exit`."""
+    shutil.copy(os.path.join(SCRIPTS, "linear-triage-health.py"),
+                tmp_path / "linear-triage-health.py")
+    (tmp_path / "linear-sync.py").write_text(FAKE_LINEAR_SYNC)
+    notify = tmp_path / "slack-notify.sh"
+    notify.write_text(FAKE_NOTIFY)
+    notify.chmod(0o755)
+
+    env = dict(os.environ)
+    env.pop("PYTEST_CURRENT_TEST", None)
+    env["FAKE_NOTIFY_EXIT"] = str(notify_exit)
+    return subprocess.run([sys.executable, str(tmp_path / "linear-triage-health.py")],
+                          capture_output=True, text=True, env=env, timeout=120)
+
+
+def test_a_failed_alert_exits_nonzero(tmp_path):
+    """FINDING 3. `alerted (exit 1)` printed, then `return EXIT_OK`.
+
+    launchd reads the exit code, not stdout, so a 3am run whose alert never
+    reached anyone was recorded as a clean success -- a breach measured, printed
+    into a log nobody opens, and reported as fine. Reproduced on the PR head:
+    main() returned 0 after notify failed.
+
+    The fixture breaches UNROUTED_ALERT_AT (60 unrouted against a 50 threshold),
+    so the alert is genuinely owed rather than skipped.
+    """
+    res = _run_health_copy(tmp_path, notify_exit=1)
+    assert res.returncode == health.EXIT_ALERT_FAILED, res.stdout + res.stderr
+    assert "alert FAILED" in res.stdout
+    # the measurement itself is still printed: the numbers are good, the send failed
+    assert "unrouted (no project) : 60" in res.stdout
+
+
+def test_a_delivered_alert_still_exits_zero(tmp_path):
+    """The negative control. Same breach, same code path, a working alert path.
+
+    Without it, `return EXIT_ALERT_FAILED` unconditionally would satisfy the test
+    above while making every successful run look like a failure -- which on a
+    launchd job is the same bug wearing the other sign.
+    """
+    res = _run_health_copy(tmp_path, notify_exit=0)
+    assert res.returncode == health.EXIT_OK, res.stdout + res.stderr
+    assert "alert FAILED" not in res.stdout
+    assert "alerted (exit 0)" in res.stdout

--- a/q-system/.q-system/tests/test_linear_triage_health.py
+++ b/q-system/.q-system/tests/test_linear_triage_health.py
@@ -9,6 +9,7 @@ Every fixture here is shaped like a real Linear GraphQL node (the keys the actua
 OPEN_ISSUES_QUERY selects), not like a convenient dict. A fixture I invent tests
 my assumption; this one at least tests the query's own shape.
 """
+import argparse
 import importlib.util
 import os
 import shutil
@@ -129,12 +130,19 @@ def test_dormant_finds_only_routed_quiet_work():
         issue("ASK-2", project="kipi-system", days_old=10),    # recent
         issue("ASK-3", days_old=200),                          # unrouted, skipped
         issue("ASK-4", project="kipi-system", days_old=200,
-              labels=["needs-triage"]),                        # inflow, skipped
+              labels=["needs-triage"]),                        # ROUTED, stale label
         issue("ASK-5", project="kipi-system", days_old=200,
               labels=["dormant"]),                             # already flagged
+        issue("ASK-6", days_old=200, labels=["needs-triage"]), # real inflow, skipped
     ]
     found = health.find_dormant(issues, NOW, 75)
-    assert [i["identifier"] for i, _ in found] == ["ASK-1"]
+    # ASK-4 was asserted as "inflow, skipped" until round 2 of the PR #204
+    # review. That was this suite pinning the defect: the issue is ROUTED, so it
+    # is not inflow at all -- nothing removes the label when a human routes an
+    # issue. It counted as neither awaiting-triage nor dormant, at any age.
+    # ASK-6 is the genuine inflow case that exclusion was reaching for, and it
+    # is still skipped. Oldest first, so ASK-4 (200d) precedes ASK-1 (100d).
+    assert [i["identifier"] for i, _ in found] == ["ASK-4", "ASK-1"]
 
 
 def test_dormant_threshold_boundary_is_inclusive_and_configurable():
@@ -479,20 +487,37 @@ def graphql(query, variables):
 FAKE_NOTIFY = '#!/usr/bin/env bash\nexit "${FAKE_NOTIFY_EXIT:-0}"\n'
 
 
-def _run_health_copy(tmp_path, notify_exit):
-    """Run a copy of the script whose alert path exits `notify_exit`."""
+def _stage_health_copy(tmp_path, fake_sync=FAKE_LINEAR_SYNC):
+    """Lay a runnable copy of the script beside fake neighbours. Returns its path.
+
+    The copy resolves `linear-sync.py` and `slack-notify.sh` from its OWN
+    directory, so staging them here is what makes the run unable to reach the
+    real board. It is also what keeps the --apply lock scoped to this tmp_path
+    rather than to the installed script.
+    """
     shutil.copy(os.path.join(SCRIPTS, "linear-triage-health.py"),
                 tmp_path / "linear-triage-health.py")
-    (tmp_path / "linear-sync.py").write_text(FAKE_LINEAR_SYNC)
+    (tmp_path / "linear-sync.py").write_text(fake_sync)
     notify = tmp_path / "slack-notify.sh"
     notify.write_text(FAKE_NOTIFY)
     notify.chmod(0o755)
+    return tmp_path / "linear-triage-health.py"
 
+
+def _health_env(**extra):
     env = dict(os.environ)
     env.pop("PYTEST_CURRENT_TEST", None)
-    env["FAKE_NOTIFY_EXIT"] = str(notify_exit)
-    return subprocess.run([sys.executable, str(tmp_path / "linear-triage-health.py")],
-                          capture_output=True, text=True, env=env, timeout=120)
+    env.update({k: str(v) for k, v in extra.items()})
+    return env
+
+
+def _run_health_copy(tmp_path, notify_exit, *, fake_sync=FAKE_LINEAR_SYNC, args=()):
+    """Run a copy of the script whose alert path exits `notify_exit`."""
+    script = _stage_health_copy(tmp_path, fake_sync)
+    return subprocess.run([sys.executable, str(script)] + list(args),
+                          capture_output=True, text=True,
+                          env=_health_env(FAKE_NOTIFY_EXIT=notify_exit),
+                          timeout=120)
 
 
 def test_a_failed_alert_exits_nonzero(tmp_path):
@@ -524,3 +549,349 @@ def test_a_delivered_alert_still_exits_zero(tmp_path):
     assert res.returncode == health.EXIT_OK, res.stdout + res.stderr
     assert "alert FAILED" not in res.stdout
     assert "alerted (exit 0)" in res.stdout
+
+
+# --- PR #204 Codex review ROUND 2: five findings, each with its reproducer ---
+
+def test_a_routed_issue_with_a_stale_triage_label_can_go_dormant():
+    """ROUND 2 FINDING 1. The issue that fell into NEITHER bucket.
+
+    `is_awaiting_triage()` was narrowed to "label AND unrouted" (round 1), but
+    `find_dormant()` kept excluding on the label alone. A routed issue still
+    carrying a stale `needs-triage` label was therefore not awaiting triage (it
+    has a project) and not dormancy-eligible (it has the label) -- invisible to
+    both readings of the same page, at any age. Reproduced on the PR head: a
+    100-day-old routed issue gave awaiting_triage=False, dormant_matches=0.
+
+    Asserted literally, never against a baseline recomputed from the same
+    helper: a baseline captured from this code cannot see a change moving both
+    sides.
+    """
+    routed_stale = issue("ASK-1", project="kipi-system",
+                         labels=["owner:sana", "needs-triage"], days_old=100)
+
+    found = health.find_dormant([routed_stale], NOW, 75)
+    assert len(found) == 1, "the routed issue with a stale label must be eligible"
+    assert found[0][0]["identifier"] == "ASK-1"
+    # and it really is absent from the other bucket, so this is the only one
+    assert health.measure([routed_stale], NOW)["needs_triage"] == 0
+
+
+def test_dormancy_still_skips_real_inflow_and_the_human_override():
+    """The negative control for the test above.
+
+    Deleting the exclusion entirely would satisfy that test while flagging the
+    unrouted inflow queue -- putting dormancy comments on exactly the noise this
+    system exists to stop filing. Both survivors are pinned here.
+    """
+    unrouted_marked = issue("ASK-2", labels=["owner:sana", "needs-triage"],
+                            days_old=100)
+    routed_overridden = issue("ASK-3", project="kipi-system",
+                              labels=["dormant"], days_old=100)
+
+    # still-unrouted inflow is counted as triage depth, never as stalled work
+    assert health.find_dormant([unrouted_marked], NOW, 75) == []
+    assert health.measure([unrouted_marked], NOW)["needs_triage"] == 1
+    # a human who disagrees applies the label by hand; the sweep honours it
+    assert health.find_dormant([routed_overridden], NOW, 75) == []
+
+
+class BrokenReadLinear:
+    """A Linear whose comments READ raises and whose commentCreate succeeds.
+
+    Both halves matter: the mutation must be able to succeed, so a test that
+    sees no write is seeing a refusal to write rather than a broken fixture.
+    """
+
+    def __init__(self):
+        self.mutations = 0
+
+    def graphql(self, query, variables):
+        if "comments(first" in query:
+            raise RuntimeError("Linear timeout reading comments")
+        if "commentCreate" in query:
+            self.mutations += 1
+            return {"commentCreate": {"success": True}}
+        raise AssertionError(f"unexpected query: {query[:60]}")
+
+
+def test_a_failed_flag_check_is_not_reported_as_already_flagged():
+    """ROUND 2 FINDING 3. An unknown state reported as work someone else did.
+
+    `already_flagged()` returned True on ANY exception, so a Linear timeout
+    reached the operator as `already-flagged` -- a sentence about a comment that
+    exists, produced by a run that learned nothing and wrote nothing. The run
+    then looked complete. Reproduced on the PR head: outcome 'already-flagged',
+    zero mutations attempted.
+    """
+    ln = BrokenReadLinear()
+    out = health.flag_dormant(ln, {"id": "uuid-1", "identifier": "ASK-1"}, 120.0, 75)
+
+    assert out != "already-flagged"
+    assert out.startswith("FAILED")
+    # unknown is not "no": it must not have gambled a write
+    assert ln.mutations == 0
+
+
+def test_a_genuine_already_flagged_issue_is_still_skipped():
+    """The negative control. Returning FAILED on every read would pass the above.
+
+    A real marker present must still produce `already-flagged` and no write, or
+    the nightly sweep grows a comment stack on every dormant issue.
+    """
+
+    class Flagged:
+        def __init__(self):
+            self.mutations = 0
+
+        def graphql(self, query, variables):
+            if "comments(first" in query:
+                return {"issue": {"comments": {"nodes": [
+                    {"body": f"{health.DORMANT_MARKER}\nolder flag"}]}}}
+            self.mutations += 1
+            return {"commentCreate": {"success": True}}
+
+    ln = Flagged()
+    out = health.flag_dormant(ln, {"id": "uuid-1", "identifier": "ASK-1"}, 120.0, 75)
+    assert out == "already-flagged"
+    assert ln.mutations == 0
+
+
+def test_already_flagged_raises_rather_than_answering_on_a_broken_read():
+    """The predicate itself, so a caller added later cannot inherit the old bug.
+
+    A bool return type has no room for "I could not find out", and both of its
+    values are wrong answers. The distinct exception is what makes the unknown
+    impossible to consume by accident.
+    """
+    with pytest.raises(health.FlagCheckFailed):
+        health.already_flagged(BrokenReadLinear(), "uuid-1")
+
+
+# --- ROUND 2 FINDING 2: a refused write has to reach the exit code ----------
+
+FAKE_SYNC_ROUTED_DORMANT = '''
+import os
+TEAM_QUERY = "query teams"
+SUCCESS = os.environ.get("FAKE_COMMENT_SUCCESS", "1") == "1"
+
+
+def linear_api_key():
+    return "fake-key-never-sent-anywhere"
+
+
+def graphql(query, variables):
+    if "issues(filter" in query:
+        nodes = [{
+            "id": f"u{n}", "identifier": f"ASK-{n}", "title": f"work {n}",
+            "createdAt": "2026-01-01T00:00:00Z",
+            "updatedAt": "2026-01-01T00:00:00Z",
+            "state": {"name": "Backlog", "type": "backlog"},
+            "project": {"id": "p-1", "name": "kipi-system"},
+            "labels": {"nodes": []},
+        } for n in range(3)]
+        return {"issues": {"nodes": nodes, "pageInfo": {"hasNextPage": False}}}
+    if "comments(first" in query:
+        return {"issue": {"comments": {"nodes": []}}}
+    if "commentCreate" in query:
+        return {"commentCreate": {"success": SUCCESS}}
+    return {"teams": {"nodes": [{"id": "team-1", "key": "ASK"}]}}
+'''
+
+
+def _run_apply(tmp_path, comment_success):
+    script = _stage_health_copy(tmp_path, FAKE_SYNC_ROUTED_DORMANT)
+    return subprocess.run(
+        [sys.executable, str(script), "--apply", "--no-notify",
+         "--dormant-days", "30"],
+        capture_output=True, text=True, timeout=120,
+        env=_health_env(FAKE_COMMENT_SUCCESS=1 if comment_success else 0))
+
+
+def test_an_apply_run_whose_writes_were_all_refused_exits_nonzero(tmp_path):
+    """ROUND 2 FINDING 2. flag_dormant said FAILED; main() returned 0 anyway.
+
+    Round 1 stopped `flag_dormant()` reporting a declined mutation as "flagged".
+    main() then discarded that per-issue answer when choosing its exit code, so
+    a run where EVERY commentCreate came back success=false still returned 0 --
+    launchd recorded a clean nightly sweep that wrote nothing. The same shape as
+    the alert bug beside it, one layer down. Reproduced on the PR head:
+    failed=3, RETURN_CODE 0.
+    """
+    res = _run_apply(tmp_path, comment_success=False)
+    assert res.returncode == health.EXIT_WRITE_FAILED, res.stdout + res.stderr
+    assert "failed=3" in res.stdout
+    assert "WRITE FAILED" in res.stderr
+
+
+def test_an_apply_run_whose_writes_landed_exits_zero(tmp_path):
+    """The negative control. `return EXIT_WRITE_FAILED` unconditionally would
+    satisfy the test above while making every successful sweep look broken --
+    on a launchd job, the same defect wearing the other sign.
+    """
+    res = _run_apply(tmp_path, comment_success=True)
+    assert res.returncode == health.EXIT_OK, res.stdout + res.stderr
+    assert "flagged=3" in res.stdout
+    assert "WRITE FAILED" not in res.stderr
+
+
+# --- ROUND 2 FINDING 4: check-then-write needs one lock ---------------------
+
+FAKE_SYNC_RACY = '''
+import os, time
+TEAM_QUERY = "query teams"
+LEDGER = os.environ["FAKE_WRITE_LEDGER"]
+
+
+def linear_api_key():
+    return "fake-key-never-sent-anywhere"
+
+
+def graphql(query, variables):
+    if "issues(filter" in query:
+        return {"issues": {"nodes": [{
+            "id": "u1", "identifier": "ASK-1", "title": "routed work",
+            "createdAt": "2026-01-01T00:00:00Z",
+            "updatedAt": "2026-01-01T00:00:00Z",
+            "state": {"name": "Backlog", "type": "backlog"},
+            "project": {"id": "p-1", "name": "kipi-system"},
+            "labels": {"nodes": []},
+        }], "pageInfo": {"hasNextPage": False}}}
+    if "comments(first" in query:
+        try:
+            with open(LEDGER) as fh:
+                n = len([l for l in fh if l.strip()])
+        except OSError:
+            n = 0
+        # Widen the check-to-write window so an unlocked build loses the race
+        # deterministically rather than on timing luck.
+        time.sleep(1.0)
+        return {"issue": {"comments": {"nodes": [
+            {"body": "<!-- kipi-dormancy-flag -->"} for _ in range(n)]}}}
+    if "commentCreate" in query:
+        with open(LEDGER, "a") as fh:
+            fh.write("wrote\\n")
+        return {"commentCreate": {"success": True}}
+    return {"teams": {"nodes": [{"id": "team-1", "key": "ASK"}]}}
+'''
+
+
+def _apply_procs(tmp_path, count):
+    """Launch `count` --apply runs of one staged copy inside the same window."""
+    script = _stage_health_copy(tmp_path, FAKE_SYNC_RACY)
+    ledger = tmp_path / "writes.log"
+    env = _health_env(FAKE_WRITE_LEDGER=str(ledger))
+    cmd = [sys.executable, str(script), "--apply", "--no-notify",
+           "--dormant-days", "30"]
+    procs = [subprocess.Popen(cmd, env=env, stdout=subprocess.PIPE,
+                              stderr=subprocess.PIPE, text=True)
+             for _ in range(count)]
+    for proc in procs:
+        proc.communicate(timeout=180)
+    writes = len([l for l in ledger.read_text().splitlines() if l.strip()]) \
+        if ledger.exists() else 0
+    return writes, sorted(p.returncode for p in procs)
+
+
+def test_two_concurrent_apply_runs_comment_once(tmp_path):
+    """ROUND 2 FINDING 4. Nothing linked the check to the write.
+
+    `already_flagged()` reads, `flag_dormant()` writes, and two concurrent
+    --apply runs (the launchd sweep and a founder's manual run) both read "no
+    marker" and both wrote. A comment is permanent and there is no undo, and a
+    duplicated flag costs trust in every flag. Reproduced on the PR head: 2
+    comment mutations on one issue.
+
+    The loser refuses rather than queueing: this runs daily against a 75-day
+    threshold, so a skipped sweep costs nothing while a launchd job silently
+    waiting on an interactive run looks hung.
+    """
+    writes, codes = _apply_procs(tmp_path, 2)
+    assert writes == 1, f"one issue took {writes} dormancy comments"
+    assert codes == [health.EXIT_OK, health.EXIT_LOCKED], codes
+
+
+def test_a_single_apply_run_still_writes(tmp_path):
+    """The negative control, and it is load-bearing here.
+
+    A lock that never grants would make the test above pass with ZERO writes,
+    turning the nightly sweep into a no-op that reports success. This pins that
+    the uncontended path still comments.
+    """
+    writes, codes = _apply_procs(tmp_path, 1)
+    assert writes == 1
+    assert codes == [health.EXIT_OK]
+
+
+def test_report_only_runs_take_no_lock(tmp_path):
+    """A run that mutates nothing must not serialise against anything.
+
+    Two report-only runs are harmless, so making them queue would be a cost with
+    no buyer -- and would make an interactive check fail while the nightly sweep
+    holds the lock.
+    """
+    script = _stage_health_copy(tmp_path, FAKE_SYNC_RACY)
+    env = _health_env(FAKE_WRITE_LEDGER=str(tmp_path / "writes.log"))
+    cmd = [sys.executable, str(script), "--no-notify", "--dormant-days", "30"]
+    procs = [subprocess.Popen(cmd, env=env, stdout=subprocess.PIPE,
+                              stderr=subprocess.PIPE, text=True) for _ in range(2)]
+    for proc in procs:
+        proc.communicate(timeout=180)
+    assert [p.returncode for p in procs] == [health.EXIT_OK, health.EXIT_OK]
+    assert not (tmp_path / "writes.log").exists(), "report-only wrote to Linear"
+
+
+def test_the_apply_lock_is_scoped_to_the_installed_copy(tmp_path):
+    """Two DIFFERENT installations must not block each other.
+
+    Keyed on the script's own directory, so the suite's tmp copies and the real
+    installation never contend -- while two runs of one installation, the actual
+    collision, resolve to the same path.
+    """
+    mine = health.apply_lock_path()
+    assert mine.endswith(".lock")
+    # not inside the repo: `kipi update` rsyncs this tree and would ship it
+    assert not mine.startswith(SCRIPTS)
+    # two runs of ONE installation agree, which is the collision that matters
+    assert health.apply_lock_path() == mine
+
+    # the override wins, so a caller can pin it explicitly
+    os.environ["KIPI_TRIAGE_HEALTH_LOCK"] = str(tmp_path / "pinned.lock")
+    try:
+        assert health.apply_lock_path() == str(tmp_path / "pinned.lock")
+    finally:
+        os.environ.pop("KIPI_TRIAGE_HEALTH_LOCK", None)
+    assert health.apply_lock_path() == mine
+
+
+def test_the_write_path_refuses_without_the_lock():
+    """Fail closed. `_run` is reachable by a future caller that forgot the lock.
+
+    The guard exists because the alternative is a second write path with no
+    chokepoint, which is the defect this finding already cost once.
+    """
+    args = argparse.Namespace(apply=True, dormant_days=75, no_notify=True,
+                              json=False, limit=0)
+    with pytest.raises(RuntimeError, match="without the --apply lock"):
+        health._run(args, holding_lock=False)
+
+
+# --- ROUND 2 FINDING 5: the promise has to match the mutations --------------
+
+def test_the_module_promises_only_the_mutation_it_makes():
+    """ROUND 2 FINDING 5. The header sold "a comment and a label"; no label
+    mutation existed anywhere in the file.
+
+    Pinned against the PROMISE literal rather than the words, because the
+    corrected docstring QUOTES the old promise in order to explain it -- a text
+    check its own documentation satisfies is broken in the direction that never
+    passes. This also fails if someone adds a label write without saying so.
+    """
+    src = open(os.path.join(SCRIPTS, "linear-triage-health.py")).read()
+    writes_label = "issueUpdate" in src or "labelIds" in src
+
+    assert "gets ONE comment and a label" not in src, "the old promise is back"
+    assert not writes_label, "a label mutation appeared; update the header"
+    assert "gets ONE COMMENT" in src
+    # the label is still READ, and that asymmetry is deliberate, not a leftover
+    assert health.DORMANT_LABEL in src

--- a/q-system/.q-system/tests/test_linear_triage_health.py
+++ b/q-system/.q-system/tests/test_linear_triage_health.py
@@ -668,6 +668,274 @@ def test_already_flagged_raises_rather_than_answering_on_a_broken_read():
         health.already_flagged(BrokenReadLinear(), "uuid-1")
 
 
+# --- ROUND 4 FINDINGS 1+2: the READ is the flag-once guarantee ---------------
+#
+# One cause, two symptoms. The lock was keyed on the installed copy's directory,
+# so two installs never contended; and the idempotency check only read the first
+# 100 comments, so it had a permanent blind spot anyway. These pin the fix at the
+# level it was made: a complete read, not a bigger lock.
+
+
+class PaginatedIssue:
+    """A Linear issue that serves its comments in pages and honours `after`.
+
+    Shaped like the real `comments(first: 100, after: $after)` connection --
+    `nodes` plus a `pageInfo` -- because the defect being pinned is precisely
+    that the old query never asked for the second page. A stub that returns all
+    comments in one bag cannot fail for the reason we care about, and every
+    pre-existing stub in this file is exactly that bag.
+
+    The cursor is a stringified offset. Linear's is opaque, but the only
+    property the code under test may rely on is that it round-trips, and an
+    offset makes an off-by-one visible in the assertion instead of hiding it.
+    """
+
+    PAGE = 100
+
+    def __init__(self, comments=None):
+        self.comments = list(comments or [])
+        self.writes = 0
+        self.pages_served = 0
+
+    def graphql(self, query, variables):
+        if "comments(" in query:
+            start = int(variables.get("after") or 0)
+            chunk = self.comments[start:start + self.PAGE]
+            end = start + len(chunk)
+            self.pages_served += 1
+            return {"issue": {"comments": {
+                "nodes": chunk,
+                "pageInfo": {"hasNextPage": end < len(self.comments),
+                             "endCursor": str(end)},
+            }}}
+        self.writes += 1
+        self.comments.append({"body": variables["input"]["body"]})
+        return {"commentCreate": {"success": True}}
+
+
+def _filler(n):
+    return [{"body": f"unrelated comment {i}"} for i in range(n)]
+
+
+def test_a_marker_past_the_first_page_is_still_found():
+    """The finding-2 reproducer, with a stub that actually paginates.
+
+    Measured on the PR head with this same stub: 1 page fetched, result
+    `flagged`, 1 duplicate mutation. A dormancy comment is permanent and there
+    is no undo, so a second one on an already-flagged issue costs trust in
+    every flag the sweep has ever written.
+    """
+    ln = PaginatedIssue(_filler(100) + [{"body": health.DORMANT_MARKER}])
+    out = health.flag_dormant(ln, {"id": "uuid-1", "identifier": "ASK-1"}, 120.0, 75)
+    assert out == "already-flagged"
+    assert ln.writes == 0
+    # Pins the mechanism, not just the outcome: 2 proves it asked for the page
+    # the old code never asked for. Without this the test would still pass if a
+    # future edit widened `first:` to 200 and re-created the blind spot at 201.
+    assert ln.pages_served == 2
+
+
+def test_two_installs_flag_one_issue_once_without_ever_sharing_a_lock():
+    """Finding 1, at the level the fix was actually made.
+
+    Two installed copies hash to two different lock paths and CANNOT contend --
+    that is asserted here rather than fixed, because a filesystem lock cannot
+    represent a shared Linear team and pretending otherwise is the bug. What
+    stops the duplicate is that the second sweep's read finds the first sweep's
+    marker, wherever it landed. The filler pushes that marker onto page 2, so
+    this fails on the PR head for the pagination reason as well.
+    """
+    original_here = health.HERE
+    try:
+        health.HERE = "/opt/kipi-a/scripts"
+        path_a = health.apply_lock_path()
+        health.HERE = "/opt/kipi-b/scripts"
+        path_b = health.apply_lock_path()
+        assert path_a != path_b, "premise of the finding: two installs, two locks"
+
+        shared = PaginatedIssue(_filler(100))
+        issue_node = {"id": "uuid-1", "identifier": "ASK-1"}
+
+        health.HERE = "/opt/kipi-a/scripts"
+        first = health.flag_dormant(shared, issue_node, 120.0, 75)
+        health.HERE = "/opt/kipi-b/scripts"
+        second = health.flag_dormant(shared, issue_node, 120.0, 75)
+    finally:
+        health.HERE = original_here
+
+    assert first == "flagged"
+    assert second == "already-flagged"
+    assert shared.writes == 1
+
+
+def test_an_unfinishable_comment_walk_is_a_failure_not_a_missing_marker():
+    """A stalled cursor must never be answered as "no marker".
+
+    This is the round-2 lesson (an unknown is not a skip) applied to a SECOND
+    way of not finishing. Returning False here would write a duplicate onto an
+    issue whose marker simply had not been reached yet, which is the original
+    defect wearing a different hat.
+    """
+
+    class StalledCursor:
+        def __init__(self):
+            self.writes = 0
+
+        def graphql(self, query, variables):
+            if "comments(" in query:
+                return {"issue": {"comments": {
+                    "nodes": _filler(100),
+                    "pageInfo": {"hasNextPage": True, "endCursor": None},
+                }}}
+            self.writes += 1
+            return {"commentCreate": {"success": True}}
+
+    ln = StalledCursor()
+    with pytest.raises(health.FlagCheckFailed):
+        health.already_flagged(ln, "uuid-1")
+    # flag_dormant turns that into a reported FAILURE that reaches the exit
+    # code, and writes nothing.
+    out = health.flag_dormant(ln, {"id": "uuid-1", "identifier": "ASK-1"}, 120.0, 75)
+    assert out.startswith("FAILED")
+    assert ln.writes == 0
+
+
+def test_a_never_ending_cursor_hits_the_cap_and_still_refuses_to_write():
+    """The runaway stop is a cap on the LOOP, never a bound on the SEARCH.
+
+    A cap that returned False would be a blind spot at page 51 instead of page
+    2 -- the same defect, moved. So it raises, and the caller reports a failure.
+    """
+
+    class EndlessPages:
+        def __init__(self):
+            self.writes = 0
+            self.pages_served = 0
+
+        def graphql(self, query, variables):
+            if "comments(" in query:
+                self.pages_served += 1
+                cursor = int(variables.get("after") or 0) + 100
+                return {"issue": {"comments": {
+                    "nodes": _filler(100),
+                    "pageInfo": {"hasNextPage": True, "endCursor": str(cursor)},
+                }}}
+            self.writes += 1
+            return {"commentCreate": {"success": True}}
+
+    ln = EndlessPages()
+    with pytest.raises(health.FlagCheckFailed):
+        health.already_flagged(ln, "uuid-1")
+    assert ln.pages_served == health.COMMENT_PAGE_CAP
+    assert ln.writes == 0
+
+
+def test_a_single_page_issue_with_no_marker_is_still_flagged_normally():
+    """The negative control for all of the above.
+
+    Every test in this block asserts something is NOT written. If the paginated
+    walk had a bug that made it raise or return True on ordinary input, they
+    would all still pass while the sweep silently stopped flagging anything.
+    """
+    ln = PaginatedIssue(_filler(3))
+    out = health.flag_dormant(ln, {"id": "uuid-1", "identifier": "ASK-1"}, 120.0, 75)
+    assert out == "flagged"
+    assert ln.writes == 1
+    assert ln.pages_served == 1
+
+
+# --- ROUND 4 FINDING 3: a dropped label must be observable -------------------
+
+
+def _alert_linear(label_create):
+    """A Linear double for the alert filer. `label_create` decides that mutation."""
+
+    class L:
+        def __init__(self):
+            self.created = None
+            self.labels = [{"id": "owner-id", "name": "owner:sana"}]
+
+        def linear_api_key(self):
+            return "k"
+
+        def graphql(self, q, v):
+            if "teams(filter" in q:
+                return {"teams": {"nodes": [{"id": "t"}]}}
+            if "labels(first" in q:
+                return {"team": {"labels": {"nodes": list(self.labels)}}}
+            if "issueLabelCreate" in q:
+                return label_create(self)
+            if "projects(first" in q:
+                return {"team": {"projects": {"nodes": []}}}
+            if "issueCreate" in q:
+                self.created = v["input"]
+                return {"issueCreate": {"issue": {"id": "u9",
+                                                  "identifier": "ASK-9"}}}
+            return {}
+
+    return L()
+
+
+def _file_one_alert(monkeypatch, ln):
+    """Run file_alert against `ln` with state IO stubbed out.
+
+    State is stubbed rather than pointed at a tmp file because this asserts on
+    the returned line and on stderr, not on persistence, and a test that touches
+    the real state path is what the fable-discipline lint exists to stop.
+    """
+    monkeypatch.setattr(alerts, "_load_linear", lambda: ln)
+    monkeypatch.setattr(alerts, "_read_state", lambda fp: {})
+    monkeypatch.setattr(alerts, "_write_state", lambda *a: None)
+    return alerts.file_alert("[kipi-system] detector fired", now=1)
+
+
+def test_a_real_label_failure_is_loud_and_marks_the_file_degraded(monkeypatch, capsys):
+    """A permission error looked exactly like success on the PR head.
+
+    Measured there: `(0, 'filed ASK-9')` with `needs-triage` absent. The alert
+    still has to be filed -- a dropped alert is worse than an unlabelled one,
+    which is this file's standing posture -- but `needs-triage` is the field the
+    whole ASK-882 queue measurement reads, so losing it silently makes the
+    depth quietly wrong instead of loudly broken.
+    """
+
+    def denied(_self):
+        raise RuntimeError("permission denied")
+
+    ln = _alert_linear(denied)
+    code, line = _file_one_alert(monkeypatch, ln)
+
+    assert code == alerts.EXIT_OK, "the alert must still be filed"
+    assert ln.created is not None, "the ticket is created regardless"
+    assert alerts.TRIAGE_LABEL not in ln.created.get("labelIds", [])
+    # The two visibility surfaces, asserted separately. An `or` across them
+    # would pass on whichever half happened to work.
+    assert "DEGRADED" in line and alerts.TRIAGE_LABEL in line
+    assert "permission denied" in capsys.readouterr().err
+
+
+def test_a_lost_create_race_stays_quiet_and_undegraded(monkeypatch, capsys):
+    """The negative control: the loud path must not fire on the benign one.
+
+    Two filers racing means the loser's create fails because the label now
+    EXISTS. That is already handled by the refetch, costs nothing, and must not
+    produce a warning -- a warning on every race would train the operator to
+    ignore the one that matters.
+    """
+
+    def already_exists(self):
+        self.labels.append({"id": "triage-id", "name": alerts.TRIAGE_LABEL})
+        raise RuntimeError("label already exists")
+
+    ln = _alert_linear(already_exists)
+    code, line = _file_one_alert(monkeypatch, ln)
+
+    assert code == alerts.EXIT_OK
+    assert "triage-id" in ln.created.get("labelIds", [])
+    assert "DEGRADED" not in line
+    assert "WARNING" not in capsys.readouterr().err
+
+
 # --- ROUND 2 FINDING 2: a refused write has to reach the exit code ----------
 
 FAKE_SYNC_ROUTED_DORMANT = '''

--- a/settings-template.json
+++ b/settings-template.json
@@ -250,6 +250,10 @@
           },
           {
             "type": "command",
+            "command": "test -f \"$CLAUDE_PROJECT_DIR/q-system/.q-system/scripts/linear-filer-label-lint.py\" && python3 \"$CLAUDE_PROJECT_DIR/q-system/.q-system/scripts/linear-filer-label-lint.py\""
+          },
+          {
+            "type": "command",
             "command": "test -f \"$CLAUDE_PROJECT_DIR/q-system/.q-system/scripts/headline-lint.py\" && python3 \"$CLAUDE_PROJECT_DIR/q-system/.q-system/scripts/headline-lint.py\""
           },
           {


### PR DESCRIPTION
## Summary
- `alert-to-linear.py` now labels every newly-filed (non-suppressed) ticket at creation so it's filterable as needing triage, instead of landing indistinguishable from human-authored backlog. Documented as a standing convention in `.claude/rules/automated-filer-marking.md`.
- Investigated enabling Linear's native Triage feature (the API supports it — `TeamUpdateInput.triageEnabled`) and deliberately did NOT flip it: the existing dispatch drain (`linear-worker.sh`, `linear-dor-drafter.py`) only recognizes `backlog`/`unstarted` state types, so routing into a Triage-type state would make new tickets invisible to the drain entirely — trading a flood for a black hole. Left as a documented, live option with its prerequisite stated, not a silent no.
- New `linear-triage-health.py` + launchd plist: one paginated Linear walk feeding both (a) unrouted/no-project ticket counts and (b) dormancy flagging (75-day default, flags for review, never auto-closes) — no duplicated query logic between the two.
- Correction to a number quoted earlier today: "229 orphaned issues" included closed issues. The real open+unrouted count is 149.
- Found and fixed a self-referential trap: `slack-notify.sh` no longer sends to Slack (files a Linear ticket per a 2026-08-10 founder directive) — a naive backlog monitor routed through it would have counted its own output. Explicitly excluded, covered by a mutation-killed test.

## Test plan
- [x] 19 new tests, 5/5 mutants killed
- [x] Full `q-system/.q-system/tests/` suite — 360 passed
- [x] `validate-separation.py` — 27 PASS, 0 FAIL
- [x] `prd_runner.py gates run` confirmed RED for 30 pre-existing, unrelated blockers — verified zero new blockers from this change (exit code read directly, not through a pipe)

## Known follow-ups (captured, not silent)
- Plist installed and scheduled as part of this PR's rollout (see commit history) — daily 09:00 check.
- Dormancy logic has real Linear-board verification in a follow-up (see companion branch `claude/triage-gate-and-worktree-rule`), since this workspace is too young (22 days) to naturally hit the 75-day threshold yet.
- 3 pre-existing findings surfaced by this repo's spillover ratchet on `alert-to-linear.py`, captured as ASK-879/880/881 (tracked under ASK-882), not bundled into this change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)