### PR TITLE
Prove dormancy against real data, gate the filer-label convention, document worktree isolation

### DIFF
--- a/.claude/rules/concurrent-session-worktrees.md
+++ b/.claude/rules/concurrent-session-worktrees.md
@@ -1,0 +1,93 @@
+---
+description: Two or more Claude Code sessions active in one repo each get their own git worktree, because sharing the default checkout lets one session move another's HEAD and sweep its files into the wrong commit.
+paths:
+  - "**/scripts/**"
+  - "**/hooks/**"
+  - "**/*.sh"
+---
+
+# Concurrent sessions each get their own worktree (ADVISORY, not enforced)
+
+Read the heading exactly as written. **Nothing in this repo can enforce this**,
+and the file says so up front rather than at the bottom, because this repo has
+been burned by rules claiming ENFORCED while naming no executable.
+
+Paths-scoped on purpose. An earlier draft of this file used `paths: "**/*"`,
+which is always-on, and the `instruction-budget-audit.py` ratchet refused the
+commit outright (512 -> 576 lines against a 300 target). A rule that does not
+have to be always-on must not be. These globs are the surfaces where branch,
+worktree and session work actually happens.
+
+Session launching happens in the harness, outside this repo's code. No hook fires
+before a session picks its working directory, so no script here can observe two
+sessions sharing one checkout, let alone refuse it. Per `skill-hook-pairing.md`'s
+decision rule this is the judgment half: it lives in the instruction, and if it
+drifts, no gate will say so.
+
+| Piece | Status |
+|---|---|
+| The convention below | ADVISORY. Read by a person or an agent, checked by nothing |
+| A hook that detects two sessions in one checkout | DOES NOT EXIST and cannot, at this layer |
+| `git worktree` itself | Real, and the only mechanical part here |
+
+## The rule
+
+When two or more Claude Code sessions are likely to be active in this repo at the
+same time, each session works from its **own** `git worktree`, never the shared
+default checkout.
+
+```bash
+# From the repo root, one per session:
+git worktree add ../kipi-wt-<session-name> -b <branch-name> origin/main
+
+# When the session's work is merged and the tree is clean:
+git worktree remove ../kipi-wt-<session-name>
+git worktree list          # confirm it is gone
+```
+
+Branch off the ref you actually mean. `origin/main` is the default; if the work
+builds on another session's unmerged branch, name that branch instead and say so,
+because a worktree cut from the wrong base is the first incident below.
+
+## The two incidents this comes from (2026-08-16)
+
+Both happened in one day, between this session and a concurrent `social-voice`
+session sharing one working directory.
+
+1. **A branch built on the wrong ancestor.** Two sessions took turns checking out
+   branches in the same tree. A branch created while the other session's checkout
+   was live inherited that state as its base, so it carried commits nobody
+   intended it to carry, and the diff read as work it had not done.
+
+2. **An unattended auto-commit landing a stale-state revert.** A Stop-hook
+   auto-commit swept the working tree while the other session had it in an
+   intermediate state. The commit captured the other session's half-applied
+   files, which read afterward as a deliberate revert of work that was in fact
+   still in progress.
+
+Neither is a merge conflict, and that is the point: git never complained. Both
+sessions were doing legal operations on one tree, and the damage was to history
+rather than to files, which is where it is expensive to see and expensive to undo.
+
+## Why a worktree rather than "coordinate better"
+
+A worktree gives each session its own HEAD, index, and working files against one
+shared object store. That makes the failure mode structurally impossible instead
+of merely discouraged: one session cannot move another's HEAD because they do not
+share one. Coordination is a prompt-level fix for a state-level problem, and
+prompt-level fixes fail on the first tired night.
+
+Cheap, and the tell that you needed it is always retrospective.
+
+## When this does not apply
+
+- A single session in the repo. One checkout is correct; a worktree is overhead.
+- Read-only work (reviews, audits, greps) that never checks out a branch or writes.
+- Sessions in genuinely different repos. This is about one repo, many sessions.
+
+## Cross-references
+
+`skill-hook-pairing.md` (why the judgment half stays interpretive and gets no
+hook) · `wiring-check.md` (load-path proof: a worktree is also how you keep one
+session's edits from being read as another's) · `linear-first.md` (a branch that
+carries the wrong base still has to name its issue).

--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -238,6 +238,11 @@
           },
           {
             "type": "command",
+            "command": "python3 \"$CLAUDE_PROJECT_DIR/q-system/.q-system/scripts/linear-filer-label-lint.py\"",
+            "timeout": 5
+          },
+          {
+            "type": "command",
             "command": "python3 \"$CLAUDE_PROJECT_DIR/q-system/.q-system/scripts/audhd-lint.py\"",
             "timeout": 5
           },

--- a/q-system/.q-system/scripts/fleet-health-daily.py
+++ b/q-system/.q-system/scripts/fleet-health-daily.py
@@ -1871,6 +1871,11 @@ def _create_one(ls, finding: dict, apply: bool, team_id: str, project,
     if project:
         payload["projectId"] = project["id"]
     data = ls.graphql(ls.ISSUE_CREATE, {"input": payload})
+    # linear-filer-lint-skip: AUTOMATED and currently unmarked. A nightly launchd
+    # detector sweep files one issue per finding, so this SHOULD attach
+    # TRIAGE_LABEL. Captured as sp-1306aca4 (see also sp-2ea6e19c, which named the
+    # same five-writer class) rather than changed here -- relabelling live inflow
+    # is a behaviour change, not a lint fix.
     node = (data.get("issueCreate") or {}).get("issue") or {}
     if not node.get("id"):
         # A create that returned no issue is a FAILURE, not a quiet zero. The

--- a/q-system/.q-system/scripts/linear-dor-drafter.py
+++ b/q-system/.q-system/scripts/linear-dor-drafter.py
@@ -1134,6 +1134,10 @@ def report_failures(ls, failures: list, carried: int = 0) -> str:
         if project:
             payload["projectId"] = project["id"]
         node = (ls.graphql(ls.ISSUE_CREATE, {"input": payload})
+                # linear-filer-lint-skip: AUTOMATED and currently unmarked. The
+                # nightly launchd job files its own run-failure report, machine-
+                # authored and nobody asked for it, so this SHOULD attach
+                # TRIAGE_LABEL. Captured as sp-1306aca4 rather than changed here.
                 .get("issueCreate") or {}).get("issue") or {}
         if not node.get("id"):
             print("  failure report refused by Linear", file=sys.stderr)

--- a/q-system/.q-system/scripts/linear-filer-label-lint.py
+++ b/q-system/.q-system/scripts/linear-filer-label-lint.py
@@ -1,0 +1,202 @@
+#!/usr/bin/env python3
+"""Pairs with `.claude/rules/automated-filer-marking.md`: a file that files Linear
+issues must SAY which kind of filer it is (ASK-882).
+
+WHAT THIS GATE ACTUALLY DECIDES, AND WHAT IT REFUSES TO DECIDE
+
+The rule this pairs with originally shipped with an explicit note that no gate
+could exist here, because catching a future filer "would mean statically deciding
+'is this call site creating a Linear issue without a human', which is a judgment
+a regex loses". That reasoning is correct and this script does not overturn it.
+
+So the gate is split along `skill-hook-pairing.md`'s own decision rule:
+
+  DETERMINISTIC (this script)  does this file construct a Linear issueCreate?
+  JUDGMENT      (the author)   is a human deciding that issue should exist?
+
+A regex can see the first perfectly. It cannot see the second, so the second is
+not guessed -- it is DECLARED, once, in the file, by the person who knows. The
+gate's only demand is that the declaration exists. It never infers a posture and
+it never rewrites one.
+
+That is why a compliant file has exactly two ways to pass, and both are explicit:
+
+  1. It references the triage label (`needs-triage`). It marks its own output,
+     which is the reference implementation in `alert-to-linear.py`.
+  2. It carries a posture marker naming itself human-driven, WITH a reason:
+         # linear-filer: human-in-the-loop -- <why a person decides each issue>
+
+WHY A MARKER AND NOT AN ALLOWLIST OF FILENAMES
+
+An allowlist answers "is this file exempt" in a place the next author never
+opens, and it goes stale silently the moment a human-driven script grows a
+scheduled path. The marker sits on the code that does the filing, so a script
+that changes posture has to move its own line to keep passing.
+
+MEASURED BEFORE IT WAS WRITTEN (this is why it is not stricter)
+
+Run across this repo 2026-08-16: 8 files construct `issueCreate`, and only ONE
+referenced `needs-triage`. A gate demanding the label outright would have been
+red on 7 files the day it landed -- unsatisfiable for its own population, which
+is how a gate gets switched off and then protects nothing. Demanding a DECLARED
+posture is satisfiable by every one of them and still blocks the case that
+matters: a NEW filer that thought about neither.
+
+HONEST BOUNDARY -- read this before trusting the gate's silence
+
+- It matches a SHAPE (`issueCreate` in the text), not a behaviour. A filer that
+  reaches Linear through some future helper without that string is invisible here.
+- It cannot verify a posture marker is TRUE. `# linear-filer: human-in-the-loop`
+  on a nightly sweep passes this gate and is a lie the gate cannot see. It
+  removes ambiguity, not the possibility of being wrong.
+- It checks that the label is REFERENCED, never that it is attached to the
+  create payload on every code path. Referencing `needs-triage` while omitting it
+  from one branch passes.
+- Tests and fixtures are skipped on purpose (they construct the mutation to
+  assert on it), so a real filer disguised as a test file is not seen.
+
+Exit codes follow the PostToolUse contract: 2 blocks and feeds stderr back, 0
+passes. Any internal error exits 0 -- a broken linter must never wedge every
+edit in the repo.
+"""
+from __future__ import annotations
+
+import json
+import os
+import re
+import sys
+
+EXIT_PASS = 0
+EXIT_BLOCK = 2
+
+# The label an automated filer attaches. Must equal alert-to-linear.py's
+# TRIAGE_LABEL and linear-triage-health.py's; test_triage_label_constant_matches
+# already pins those two to each other, and this file's test pins it to them.
+TRIAGE_LABEL = "needs-triage"
+
+# The shape that says "this file creates Linear issues". Linear's mutation name
+# is stable API surface, so matching it is matching the thing itself rather than
+# a naming convention someone may rename.
+FILER_PATTERN = re.compile(r"\bissueCreate\b")
+
+# The explicit posture declaration. A reason is REQUIRED -- a bare marker is a
+# mute exemption, and the point of the marker is that it says something.
+# The reason's first character may not itself be a separator. Without that the
+# alternation backtracks: on a bare `-- ` the separator matches ONE dash and the
+# SECOND dash satisfies "a non-space reason", so a mute marker passed. Caught by
+# test_a_bare_posture_marker_without_a_reason_is_still_blocked before it shipped.
+HUMAN_MARKER = re.compile(
+    r"linear-filer:\s*human-in-the-loop\s*[-:]+\s*([^\s\-:].*)", re.IGNORECASE)
+
+# Last-resort per-file bypass, one marker, no stacking (skill-hook-pairing.md).
+SKIP_MARKER = "linear-filer-lint-skip"
+
+SCANNED_SUFFIXES = (".py", ".sh")
+
+# Test files construct the mutation in order to ASSERT on it. Gating them would
+# make the reference implementation's own suite unwritable.
+TEST_HINTS = ("/tests/", "/test/", "test_", "test-", "_test.", "-test.")
+
+
+def is_test_path(path: str) -> bool:
+    """True for a fixture/suite path, which this gate deliberately ignores."""
+    norm = path.replace(os.sep, "/")
+    base = norm.rsplit("/", 1)[-1]
+    if any(hint in norm for hint in ("/tests/", "/test/")):
+        return True
+    return any(base.startswith(h) or h in base
+               for h in ("test_", "test-", "_test.", "-test."))
+
+
+def in_scope(path: str) -> bool:
+    """Only source files this repo actually writes filers in."""
+    return bool(path) and path.endswith(SCANNED_SUFFIXES) and not is_test_path(path)
+
+
+def creates_linear_issues(text: str) -> bool:
+    """Does this file construct a Linear issue-create mutation?"""
+    return bool(FILER_PATTERN.search(text))
+
+
+def declares_posture(text: str) -> tuple:
+    """(ok, how). The two accepted declarations, checked in no priority order.
+
+    Returns the reason string for a human-in-the-loop marker so a caller can
+    show it; an empty reason is treated as no declaration at all.
+    """
+    if SKIP_MARKER in text:
+        return True, "bypass marker"
+    match = HUMAN_MARKER.search(text)
+    if match and match.group(1).strip():
+        return True, "human-in-the-loop: " + match.group(1).strip()[:60]
+    if TRIAGE_LABEL in text:
+        return True, "marks its output with " + TRIAGE_LABEL
+    return False, ""
+
+
+def message(path: str) -> str:
+    """The block text. It teaches the fix, because a gate that only says no
+    gets worked around rather than satisfied."""
+    return (
+        f"linear-filer-label-lint: {path} creates Linear issues "
+        f"(constructs `issueCreate`) but never declares whether a human decides "
+        f"they should exist.\n\n"
+        f"Automated inflow has to be a filterable set -- inflow here is automated "
+        f"and outflow is manual, so an unmarked filer is indistinguishable from "
+        f"backlog nobody can drain. Pick ONE and put it in the file:\n\n"
+        f"  1. It files WITHOUT a human deciding each issue -> attach the label:\n"
+        f"       label_ids = _label_ids(ln, team_id, [OWNER_LABEL, TRIAGE_LABEL])\n"
+        f"       if label_ids:\n"
+        f"           payload[\"labelIds\"] = label_ids\n"
+        f"     (worked reference: q-system/.q-system/scripts/alert-to-linear.py)\n\n"
+        f"  2. A human decides each issue -> declare it, with a reason:\n"
+        f"       # linear-filer: human-in-the-loop -- <why a person decides each one>\n\n"
+        f"Rule: .claude/rules/automated-filer-marking.md\n"
+        f"Last resort, one file only: {SKIP_MARKER}"
+    )
+
+
+def check_text(path: str, text: str) -> tuple:
+    """(exit_code, note). Pure, so the test drives this and not argv."""
+    if not in_scope(path):
+        return EXIT_PASS, "not a scanned path"
+    if not creates_linear_issues(text):
+        return EXIT_PASS, "not a filer"
+    ok, how = declares_posture(text)
+    if ok:
+        return EXIT_PASS, how
+    return EXIT_BLOCK, "undeclared filer"
+
+
+def main() -> int:
+    try:
+        payload = json.load(sys.stdin)
+    except Exception:
+        # No parsable hook payload is not a violation. Fail open.
+        return EXIT_PASS
+
+    path = (payload.get("tool_input") or {}).get("file_path") or ""
+    if not in_scope(path):
+        return EXIT_PASS
+
+    try:
+        with open(path, "r", encoding="utf-8", errors="replace") as handle:
+            text = handle.read()
+    except OSError:
+        # The file may have been moved between the write and this hook. Not a
+        # violation, and a linter must never block on its own read failure.
+        return EXIT_PASS
+
+    code, _ = check_text(path, text)
+    if code == EXIT_BLOCK:
+        print(message(path), file=sys.stderr)
+    return code
+
+
+if __name__ == "__main__":
+    try:
+        sys.exit(main())
+    except Exception as exc:  # never wedge every edit in the repo
+        print(f"linear-filer-label-lint: internal error, passing ({exc})",
+              file=sys.stderr)
+        sys.exit(EXIT_PASS)

--- a/q-system/.q-system/scripts/linear-job-migration.py
+++ b/q-system/.q-system/scripts/linear-job-migration.py
@@ -205,6 +205,10 @@ def main() -> int:
         if project:
             payload["projectId"] = project["id"]
         data = ls.graphql(ls.ISSUE_CREATE, {"input": payload})
+        # linear-filer-lint-skip: AUTOMATED and currently unmarked. inventory()
+        # enumerates every plist and files one templated issue per discovered
+        # job, so this SHOULD attach TRIAGE_LABEL. Captured as sp-1306aca4
+        # rather than changed here -- a behaviour change to live inflow.
         node = (data.get("issueCreate") or {}).get("issue") or {}
         if not node.get("id"):
             print(f"BLOCK: create returned nothing for {issue['key']}", file=sys.stderr)

--- a/q-system/.q-system/scripts/linear-sync.py
+++ b/q-system/.q-system/scripts/linear-sync.py
@@ -422,6 +422,12 @@ mutation($input: ProjectCreateInput!) {
 }
 """
 
+# linear-filer-lint-skip: AUTOMATED and currently unmarked. cmd_create bulk-files
+# from a scanner-generated CAPABILITY-MAP.json, so a human triggers the run but
+# nobody decides the N issues individually -- this SHOULD attach TRIAGE_LABEL.
+# Captured as sp-1306aca4 rather than changed here: adding a label to four live
+# filers is a behaviour change to production inflow, not a lint fix, and it earns
+# its own issue. The marker is an address for that item, never an exemption.
 ISSUE_CREATE = """
 mutation($input: IssueCreateInput!) {
   issueCreate(input: $input) { success issue { id identifier } }

--- a/q-system/.q-system/scripts/linear-triage-health.py
+++ b/q-system/.q-system/scripts/linear-triage-health.py
@@ -348,6 +348,24 @@ def flag_dormant(ln, issue: dict, days: float, threshold: int) -> str:
     return "flagged"
 
 
+def select_to_flag(dormant: list, limit: int) -> list:
+    """Which dormant issues this run may WRITE to. Never a display concern.
+
+    Split out of main() so it is testable, because the defect it replaces was
+    invisible exactly where it lived. The write and the print used to share one
+    loop over `dormant[:20]`, so --apply flagged 20 and skipped the rest while
+    printing "... and N more" -- a display sentence that read as a work report.
+    Measured 2026-08-16: 193 dormant at a 7-day threshold, 173 silently skipped.
+
+    limit 0 means no cap: every dormant issue is eligible. A caller that wants a
+    bounded first run passes --limit N explicitly rather than inheriting a
+    number that happened to be a print width.
+    """
+    if limit < 0:
+        raise ValueError("limit must be >= 0")
+    return dormant[:limit] if limit else list(dormant)
+
+
 def breaches(m: dict) -> list:
     """Which thresholds this measurement crosses. Empty means stay quiet."""
     out = []
@@ -394,10 +412,17 @@ def main(argv: list) -> int:
     ap.add_argument("--no-notify", action="store_true",
                     help="never call the alert path")
     ap.add_argument("--json", action="store_true", help="print the measurement as JSON")
+    ap.add_argument("--limit", type=int, default=0, metavar="N",
+                    help="write at most N dormancy comments this run (0 = no cap). "
+                         "Bounds the blast radius of a first live --apply.")
     args = ap.parse_args(argv[1:])
 
     if args.dormant_days < 1:
         print("--dormant-days must be >= 1", file=sys.stderr)
+        return EXIT_USAGE
+
+    if args.limit < 0:
+        print("--limit must be >= 0", file=sys.stderr)
         return EXIT_USAGE
 
     # FIXTURE GUARD, the same chokepoint alert-to-linear.py uses. A suite written
@@ -449,14 +474,44 @@ def main(argv: list) -> int:
         print(f"  dormant (>={args.dormant_days}d)      : {m['dormant']}")
 
     if dormant:
-        print(f"\nDORMANT ({'APPLY' if args.apply else 'report only, writes nothing'}):")
+        # The WRITE loop is separate from the DISPLAY loop on purpose, and this
+        # separation is the fix for a real defect, not a style preference. Both
+        # used to be one loop over `dormant[:20]`, so --apply silently flagged
+        # only the first 20 and skipped the rest while printing "... and N more"
+        # -- a line about DISPLAY that read as a line about work done. Measured
+        # 2026-08-16: 193 dormant at a 7-day threshold, so 173 would have been
+        # silently skipped. A display bound must never decide what gets written.
+        to_flag = select_to_flag(dormant, args.limit)
+        outcomes = {}
+        if args.apply:
+            for issue, days in to_flag:
+                outcomes[issue["identifier"]] = flag_dormant(
+                    ln, issue, days, args.dormant_days)
+
+        if args.apply:
+            capped = f", capped at {args.limit}" if args.limit else ""
+            header = f"APPLY: wrote to {len(to_flag)} of {len(dormant)}{capped}"
+        else:
+            header = "report only, writes nothing"
+        print(f"\nDORMANT ({header}):")
+
         for issue, days in dormant[:20]:
             line = f"  {issue['identifier']:<10} {days:6.0f}d  {issue['title'][:58]}"
+            outcome = outcomes.get(issue["identifier"])
             if args.apply:
-                line += "  [" + flag_dormant(ln, issue, days, args.dormant_days) + "]"
+                # "not-attempted" is said out loud rather than left blank: a blank
+                # next to a listed issue is what made the old cap invisible.
+                line += "  [" + (outcome or "not-attempted (over --limit)") + "]"
             print(line)
         if len(dormant) > 20:
-            print(f"  ... and {len(dormant) - 20} more")
+            print(f"  ... and {len(dormant) - 20} more (display cap, not a write cap)")
+
+        if args.apply:
+            wrote = sum(1 for v in outcomes.values() if v == "flagged")
+            print(f"  flagged={wrote} already-flagged="
+                  f"{sum(1 for v in outcomes.values() if v == 'already-flagged')} "
+                  f"failed={sum(1 for v in outcomes.values() if v.startswith('FAILED'))} "
+                  f"not-attempted={len(dormant) - len(to_flag)}")
 
     hits = breaches(m)
     if hits and not args.no_notify:

--- a/q-system/.q-system/scripts/spillover-promote.py
+++ b/q-system/.q-system/scripts/spillover-promote.py
@@ -446,6 +446,10 @@ def create_issue(ls, args, root: Path, body: str):
         "teamId": tid, "title": args.title, "description": body,
         "priority": args.priority,
         "labelIds": label_ids, "projectId": pid}})
+    # linear-filer: human-in-the-loop -- one confirmed finding per invocation,
+    # and validate_dor refuses to create without a human-authored title and a
+    # Definition of Ready carrying allowed-files + acceptance. A person decided
+    # this issue exists, so needs-triage would mark work that is already routed.
     ident = ((res.get("issueCreate") or {}).get("issue") or {}).get("identifier")
     if not ident:
         sys.stderr.write(f"Linear create failed: {json.dumps(res)[:300]}\n")

--- a/q-system/.q-system/tests/test_linear_filer_label_lint.py
+++ b/q-system/.q-system/tests/test_linear_filer_label_lint.py
@@ -1,0 +1,125 @@
+#!/usr/bin/env python3
+"""Tests for linear-filer-label-lint.py (ASK-882).
+
+The cases that matter are the two the brief names -- a compliant filer passes, a
+new filer that skips the label fails -- plus the population check, because this
+gate was nearly shipped in a form that would have been red on 7 of the 8 files
+already in the repo.
+"""
+import importlib.util
+import os
+
+import pytest
+
+HERE = os.path.dirname(os.path.abspath(__file__))
+# normpath, not a raw join. `tests/../scripts/x.py` still CONTAINS "/tests/", so
+# the un-normalized path made is_test_path() true for every production filer and
+# the population check below passed by skipping all of it. A test that passes
+# because its input never reached the code is worse than no test.
+SCRIPTS = os.path.normpath(os.path.join(HERE, "..", "scripts"))
+
+
+def _load(filename: str, modname: str):
+    path = os.path.join(SCRIPTS, filename)
+    spec = importlib.util.spec_from_file_location(modname, path)
+    mod = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(mod)
+    return mod
+
+
+lint = _load("linear-filer-label-lint.py", "linear_filer_label_lint")
+
+FILER = 'MUT = """mutation($input: IssueCreateInput!) { issueCreate(input: $input) }"""'
+
+
+def test_a_compliant_automated_filer_passes():
+    """The positive case: it attaches the triage label, so it declares itself."""
+    text = FILER + '\nTRIAGE_LABEL = "needs-triage"\npayload["labelIds"] = ids\n'
+    assert lint.check_text("scripts/some-filer.py", text)[0] == lint.EXIT_PASS
+
+
+def test_a_new_filer_that_skips_the_label_is_blocked():
+    """The negative case, and the whole reason this gate exists.
+
+    A future script that creates Linear issues and says nothing about who
+    decided they should exist is exactly the drift the rule could not catch.
+    """
+    text = FILER + '\npayload = {"teamId": team, "title": t}\nln.graphql(MUT, payload)\n'
+    assert lint.check_text("scripts/new-filer.py", text)[0] == lint.EXIT_BLOCK
+
+
+def test_a_human_driven_filer_passes_by_declaring_it():
+    """The judgment half is DECLARED, never inferred. A reason is required."""
+    text = FILER + "\n# linear-filer: human-in-the-loop -- founder types each issue\n"
+    assert lint.check_text("scripts/manual.py", text)[0] == lint.EXIT_PASS
+
+
+def test_a_bare_posture_marker_without_a_reason_is_still_blocked():
+    """A mute exemption defeats the point: the marker exists to say something.
+
+    Pinned because the regex is the only thing standing between "declared" and
+    "waved through", and a trailing-empty group is the easy way to get it wrong.
+    """
+    text = FILER + "\n# linear-filer: human-in-the-loop --\n"
+    assert lint.check_text("scripts/mute.py", text)[0] == lint.EXIT_BLOCK
+
+
+def test_a_file_that_never_files_issues_is_untouched():
+    """Scope must match the rule, or the gate runs on every edit in the repo."""
+    assert lint.check_text("scripts/whatever.py",
+                           "def add(a, b):\n    return a + b\n")[0] == lint.EXIT_PASS
+
+
+def test_tests_are_skipped_so_the_reference_suite_stays_writable():
+    """A suite constructs issueCreate in order to assert on it."""
+    assert lint.check_text("q-system/.q-system/tests/test_alert_to_linear.py",
+                           FILER)[0] == lint.EXIT_PASS
+    assert lint.check_text("scripts/test/test-linear-dor.py",
+                           FILER)[0] == lint.EXIT_PASS
+
+
+def test_non_source_files_are_ignored():
+    """A markdown rule QUOTING the mutation must not be gated as a filer."""
+    assert lint.check_text("docs/automated-filer-marking.md",
+                           FILER)[0] == lint.EXIT_PASS
+
+
+def test_the_bypass_marker_releases_one_file():
+    text = FILER + "\n# linear-filer-lint-skip: migration, one-shot\n"
+    assert lint.check_text("scripts/one-shot.py", text)[0] == lint.EXIT_PASS
+
+
+def test_label_constant_matches_the_filer_and_the_health_script():
+    """Three files, one vocabulary. A rename in one silently empties the queue.
+
+    linear-triage-health.py already pins itself to alert-to-linear.py; this
+    extends the same chain to the gate, so the gate cannot drift into checking
+    for a label nothing writes.
+    """
+    health = _load("linear-triage-health.py", "lfl_health_for_labels")
+    alerts = _load("alert-to-linear.py", "lfl_alerts_for_labels")
+    assert lint.TRIAGE_LABEL == health.TRIAGE_LABEL == alerts.TRIAGE_LABEL
+
+
+@pytest.mark.parametrize("name", [
+    "linear-sync.py",
+    "fleet-health-daily.py",
+    "spillover-promote.py",
+    "linear-job-migration.py",
+    "linear-dor-drafter.py",
+    "alert-to-linear.py",
+])
+def test_every_existing_filer_in_this_repo_passes(name):
+    """The gate must be satisfiable by the population it runs on.
+
+    Measured 2026-08-16: 8 files construct `issueCreate` and only ONE referenced
+    `needs-triage`. A gate demanding the label outright would have been red on 7
+    of them the day it landed, and a gate that cannot pass gets switched off.
+    This is the check that would have caught that, so it runs against the real
+    files rather than a fixture of them.
+    """
+    path = os.path.join(SCRIPTS, name)
+    with open(path, "r", encoding="utf-8", errors="replace") as handle:
+        text = handle.read()
+    code, note = lint.check_text(path, text)
+    assert code == lint.EXIT_PASS, f"{name} would be blocked ({note})"

--- a/q-system/.q-system/tests/test_linear_triage_health.py
+++ b/q-system/.q-system/tests/test_linear_triage_health.py
@@ -285,3 +285,38 @@ def test_triage_label_constant_matches_what_health_measures():
     drain that is keeping pace.
     """
     assert alerts.TRIAGE_LABEL == health.TRIAGE_LABEL == "needs-triage"
+
+
+def test_no_limit_makes_every_dormant_issue_writable():
+    """A run with no --limit writes to ALL dormant issues, not the first 20.
+
+    This is the regression pin for a shipped defect, so the fixture is 25 items
+    on purpose: the write and the print used to share one loop over
+    `dormant[:20]`, so --apply flagged 20 and silently skipped the rest while
+    printing "... and N more". Measured on the live board 2026-08-16: 193 dormant
+    at a 7-day threshold, 173 of which would never have been written to. Any
+    reintroduced display bound turns this red.
+    """
+    dormant = [(issue(f"ASK-{n}", project="p"), 30.0) for n in range(25)]
+    assert len(health.select_to_flag(dormant, 0)) == 25
+
+
+def test_limit_caps_the_write_and_keeps_the_oldest_first():
+    """--limit bounds blast radius, and bounds it from the oldest end.
+
+    find_dormant sorts oldest-first, so a capped run must spend its budget on
+    the issues that have been quiet longest rather than an arbitrary slice.
+    """
+    dormant = [(issue(f"ASK-{n}", project="p"), float(50 - n)) for n in range(10)]
+    picked = health.select_to_flag(dormant, 3)
+    assert [i["identifier"] for i, _ in picked] == ["ASK-0", "ASK-1", "ASK-2"]
+
+
+def test_negative_limit_is_refused_rather_than_silently_emptying():
+    """A negative slice would return [] and read as "nothing was dormant".
+
+    Refusing is the point: a silent empty write set is indistinguishable from a
+    clean board, which is the one wrong conclusion this script exists to prevent.
+    """
+    with pytest.raises(ValueError):
+        health.select_to_flag([(issue("ASK-1", project="p"), 30.0)], -1)

--- a/settings-template.json
+++ b/settings-template.json
@@ -250,6 +250,10 @@
           },
           {
             "type": "command",
+            "command": "test -f \"$CLAUDE_PROJECT_DIR/q-system/.q-system/scripts/linear-filer-label-lint.py\" && python3 \"$CLAUDE_PROJECT_DIR/q-system/.q-system/scripts/linear-filer-label-lint.py\""
+          },
+          {
+            "type": "command",
             "command": "test -f \"$CLAUDE_PROJECT_DIR/q-system/.q-system/scripts/headline-lint.py\" && python3 \"$CLAUDE_PROJECT_DIR/q-system/.q-system/scripts/headline-lint.py\""
           },
           {


### PR DESCRIPTION
## Summary
Builds on #204 (branches off it — this PR's diff is only its own delta; base can move to `main` once #204 merges).

- **Dormancy proven against production**, not just fixtures: 193 issues idle at 7 days, 53 at 20 days, on the real ASK_Consulting board. Verified two flagged issues (ASK-99, ASK-86) are genuinely real and idle via direct Linear read. Write path (`--apply`) tested live and reverted.
- **Found and fixed a real defect while proving it**: `--apply` was writing inside the `dormant[:20]` *display* loop, so a real run would silently flag only the first 20 of 193 dormant issues while printing "...and 173 more" as if that were cosmetic. Split display from write, added `--limit`, added a negative self-test pinned to this exact regression.
- **Built the label-enforcement gate as a "declared posture" check, not a blind requirement.** Measured first: 8 files construct `issueCreate`, only 1 already carried the `needs-triage` label. A gate demanding the label outright would fail 7 files on day one. Instead: a filer must either carry the label or an explicit `# linear-filer: human-in-the-loop -- <reason>` marker. The other 4 automated filers that should get the label are captured as a follow-up (`sp-1306aca4`), not silently changed mid-task.
- **Worktree-per-concurrent-session documented as an explicit ADVISORY rule** (`.claude/rules/concurrent-session-worktrees.md`) — states plainly that session-launching lives outside this repo's code, so no hook can enforce it. Documents both real incidents from today that motivated it.

## Test plan
- [x] 378 tests passing
- [x] Dormancy write-path proven live against production Linear data and reverted
- [x] Label-lint gate: 15 test cases, including 2 defects the tests themselves caught before ship (a posture-regex gap, a path-normalization bug that made the population test pass for the wrong reason)
- [x] Hook wired in both `.claude/settings.json` and `settings-template.json`
- [x] `gates run` confirmed RED for 30 pre-existing, unrelated blockers only

## Known follow-ups (captured, not silent)
- `sp-1306aca4`: 4 automated filers should carry the `needs-triage` label but don't yet (behavior change, deferred from this PR on purpose)
- Hook is armed for next session — could not prove it blocks a live Write this session since `.claude/settings.json` loads at session start; proved by payload instead (undeclared filer → exit 2, compliant filer → exit 0)
- Pre-existing spillover backlog surfaced (not introduced) on 4 unrelated filer scripts, left untriaged

🤖 Generated with [Claude Code](https://claude.com/claude-code)