### PR TITLE
A cap-out the redrives can read, so a given-up issue stops restarting (ASK-871)

### DIFF
--- a/q-system/.q-system/capability-manifest.json
+++ b/q-system/.q-system/capability-manifest.json
@@ -101,6 +101,10 @@
       "timeout_s": 120
     },
     {
+      "path": "q-system/.q-system/scripts/test/test-converge-capout.sh",
+      "runner": "bash"
+    },
+    {
       "path": "q-system/.q-system/scripts/test/test-converge.sh",
       "runner": "bash"
     },

--- a/q-system/.q-system/scripts/attempts-ledger.py
+++ b/q-system/.q-system/scripts/attempts-ledger.py
@@ -289,6 +289,28 @@ def op_clear(d, issue, keys):
     return True
 
 
+def op_capout(d, issue, why, ts):
+    """Record that converge stopped this issue at its round cap.
+
+    KEYED PER ISSUE, and that is the whole point (ASK-871). Every other bound in
+    this loop keys on a PR and a head sha -- deliberately, so a PR that pushes a
+    real fix earns a fresh attempt. Nothing bounded DISPATCHES PER ISSUE, so on
+    2026-08-16 ASK-830 spent six converge rounds and five Opus reviews in one
+    morning: converge capped out at 15:59, the redrive handed the same issue back
+    at 16:14, and each round moved the head, so every per-sha cap read as fresh.
+
+    ALWAYS A WRITE, never a claim. `op_claim` answers False the second time, and
+    a caller reading that as "nothing to do" would leave a stale `capout_why`
+    from an older cap-out sitting next to a newer one. A cap-out that happens
+    twice is two facts, and the later one is the true one.
+    """
+    e = d.setdefault(issue, {})
+    e["capout"] = True
+    e["capout_at"] = ts
+    e["capout_why"] = why
+    return True
+
+
 def op_claim(d, issue, flag):
     """True the FIRST time this flag is claimed, False every time after."""
     e = d.setdefault(issue, {})
@@ -418,6 +440,26 @@ def _run(path, op, rest, ts):
         # so a caller does not have to know the current state to be correct.
         issue, flag = _args(op, rest, 2)
         _mutate(path, lambda d: op_clear(d, issue, (flag,)))
+        return 0
+
+    if op == "record-capout":             # record-capout <issue> <why>
+        # THE MACHINE-READABLE HALF OF A CAP-OUT (ASK-871). converge.sh's exit-2
+        # path used to `say` a log line and Slack the founder and stop, so the
+        # only two consumers that could re-enter the issue -- ci-redrive.py and
+        # review-redrive.py -- had no way to learn its rounds were spent. This
+        # is deliberately the SAME ledger those two already read rather than a
+        # new state file: a second store for one issue's budget is how the four
+        # budgets above ended up racing in the first place.
+        issue, why = _args(op, rest, 2)
+        _mutate(path, lambda d: op_capout(d, issue, why, ts))
+        return 0
+    if op == "clear-capout":              # clear-capout <issue>
+        # THE HUMAN'S WAY OUT, and it ships in the same change as the park on
+        # purpose. A cap-out nobody can clear is a permanent park, and a park
+        # with no exit is a quieter version of the 29-hour outage the redrives
+        # were built to end. The cap-out page names this command.
+        (issue,) = _args(op, rest, 1)
+        _mutate(path, lambda d: op_clear(d, issue, ("capout", "capout_at", "capout_why")))
         return 0
 
     if op == "claim-flag":                # claim-flag <issue> <flag> -> 0 first time, 1 after

--- a/q-system/.q-system/scripts/attempts-ledger.py
+++ b/q-system/.q-system/scripts/attempts-ledger.py
@@ -320,6 +320,42 @@ def op_claim(d, issue, flag):
     return True
 
 
+def op_claim_uncapped(d, issue, flag, outcome):
+    """`op_claim`, refusing outright if this issue is parked (codex on PR #210).
+
+    ONE TRANSACTION, and that is the entire reason this op exists rather than a
+    capout read in front of a claim-flag call. The redrives' cap-out gates sat in
+    the read-only OFFER; the atomic claim that actually spends the attempt asked
+    only whether the flag was free. kipi-dispatch.sh runs a ps snapshot, a
+    converge-live probe and a budget read between those two calls, so a cap-out
+    landing in that window authorized the very dispatch it was written to stop.
+
+    A caller-side check would only narrow the window: two subprocesses cannot be
+    atomic against a third writer. The question is answered here, under the same
+    flock that sets the flag, so there is no interval to lose the race in.
+
+    REFUSING WRITES NOTHING, which is load-bearing. Claiming first and reporting
+    the park afterwards would spend the issue's one attempt on a dispatch that
+    never happened, and `clear-capout` would then release an issue no redrive can
+    pick up -- a permanent stall wearing a cleared park's clothes.
+
+    `outcome` carries the verdict out because _mutate answers only bool(changed),
+    and "already claimed" and "refused, parked" are both False with different
+    exit codes owed to the caller.
+    """
+    e = d.setdefault(issue, {})
+    if e.get("capout"):
+        outcome["result"] = "capped"
+        outcome["why"] = e.get("capout_why") or "no reason recorded"
+        return False
+    if e.get(flag):
+        outcome["result"] = "already"
+        return False
+    e[flag] = True
+    outcome["result"] = "claimed"
+    return True
+
+
 def main(argv):
     if len(argv) < 3:
         print("usage: attempts-ledger.py <ledger-path> <op> [args...]", file=sys.stderr)
@@ -466,6 +502,24 @@ def _run(path, op, rest, ts):
         issue, flag = _args(op, rest, 2)
         claimed = _mutate(path, lambda d: op_claim(d, issue, flag))
         return 0 if claimed else 1
+
+    if op == "claim-flag-uncapped":       # -> 0 claimed, 1 already, 4 parked
+        # 4, and it has to be its OWN code. 1 already means "already claimed,
+        # stay quiet" for six call sites, and 2/3 already mean "nothing was
+        # written" -- a park is neither: nothing was written AND the caller must
+        # say so out loud, because a silently skipped dispatch is the 29-hour
+        # outage the redrives exist to end. See op_claim_uncapped for why the
+        # check cannot live in the caller.
+        issue, flag = _args(op, rest, 2)
+        outcome = {}
+        _mutate(path, lambda d: op_claim_uncapped(d, issue, flag, outcome))
+        if outcome.get("result") == "capped":
+            sys.stderr.write(
+                "attempts-ledger: `%s` refused for %s -- converge already gave up "
+                "on this issue (%s). Nothing was claimed.\n"
+                % (op, issue, outcome.get("why", "no reason recorded")))
+            return 4
+        return 0 if outcome.get("result") == "claimed" else 1
 
     print("unknown op: %s" % op, file=sys.stderr)
     return 2

--- a/q-system/.q-system/scripts/ci-redrive.py
+++ b/q-system/.q-system/scripts/ci-redrive.py
@@ -408,6 +408,23 @@ def _ledger_claim_rc(path, issue, flag):
     return proc.returncode
 
 
+def _ledger_claim_rc_uncapped(path, issue, flag):
+    """Raw rc of `claim-flag-uncapped`: 0 claimed, 1 already, 4 parked, 2/3 unwritten.
+
+    Separate from `_ledger_claim_rc` because the caller must distinguish 4 from
+    the rest; folding it into a bool here would put the park back in the same
+    bucket as "someone else owns it" and lose the operator line that names how to
+    un-park it.
+    """
+    proc = subprocess.run(
+        [sys.executable, LEDGER_SCRIPT, path, "claim-flag-uncapped", issue, flag],
+        capture_output=True, text=True)
+    if proc.returncode not in (0, 1, 4):
+        sys.stderr.write("ci-redrive: ledger refused `%s` for %s: %s\n"
+                         % (flag, issue, (proc.stderr or "").strip()[:200]))
+    return proc.returncode
+
+
 def ledger_claim(path, issue, flag):
     """True the first time this flag is claimed anywhere, False otherwise.
 
@@ -544,6 +561,47 @@ def capout_skip(path, issue, who, pr):
     return True
 
 
+def claim_unless_capped(path, issue, flag, who, pr=""):
+    """The atomic claim, refusing a parked issue in the SAME transaction.
+
+    True only when this run now owns the attempt. Replaces `ledger_claim` at both
+    mark-dispatched call sites (codex on PR #210, major): `capout_skip` guards the
+    read-only OFFER, and the claim that actually spends the attempt asked only
+    whether the flag was free. kipi-dispatch.sh does real work between the two --
+    a ps snapshot, a converge-live probe, a budget read -- so a cap-out landing in
+    that window authorized the dispatch it was written to stop.
+
+    Reading capout here, before calling claim-flag, would only shrink the window.
+    Two subprocesses cannot be atomic against a third writer, so the refusal is
+    delegated to the ledger's `claim-flag-uncapped`, which answers under the same
+    flock that sets the flag. rc 4 is the park; anything else non-zero is the
+    pre-existing "someone else owns it, or nothing was written" answer.
+
+    ONE DEFINITION, TWO CALLERS, like `capout_skip` and `is_reviewer_slot` above
+    and for the same reason: the two redrives must refuse the same parked issue.
+    """
+    rc = _ledger_claim_rc_uncapped(path, issue, flag)
+    if rc == 0:
+        return True
+    if rc == 4:
+        # LOUD, not quiet. A skipped dispatch nobody can see is the silent-park
+        # failure mode; the founder was already paged once by converge's exit-2,
+        # so this line is for whoever reads the dispatch log -- and it carries the
+        # clearing command because a park with no exit is the worse outage.
+        sys.stderr.write(
+            "%s: %s%s -- converge already gave up on this issue (%s). NOT "
+            "dispatching, and the attempt is NOT spent. Clear it with: %s\n"
+            % (who, issue, (" PR #%s" % pr) if pr else "",
+               capout(path, issue) or "no reason recorded",
+               CAPOUT_CLEAR % (path, issue)))
+        return False
+    sys.stderr.write(
+        "%s: the attempt for %s%s was already claimed (or the ledger could not be "
+        "written) -- not dispatching.\n"
+        % (who, issue, (" PR #%s" % pr) if pr else ""))
+    return False
+
+
 def cmd_redrive(cands):
     """READ-ONLY. Offers one pick; the dispatcher spends it via mark-dispatched."""
     path = attempts_path()
@@ -586,10 +644,10 @@ def cmd_redrive(cands):
 def cmd_mark_dispatched(issue, sig, head_sha):
     """The atomic claim. 0 = it is yours to dispatch, 1 = it is not."""
     path = attempts_path()
-    if not ledger_claim(path, issue, "ci_redrive_%s" % sig):
-        sys.stderr.write(
-            "ci-redrive: %s attempt for signature %s was already claimed (or the "
-            "ledger could not be written) -- not dispatching.\n" % (issue, sig))
+    # NOT `ledger_claim`. The park has to be refused inside the claim's own
+    # transaction, not read before it -- see claim_unless_capped.
+    if not claim_unless_capped(path, issue, "ci_redrive_%s" % sig,
+                               "ci-redrive [signature %s]" % sig):
         return 1
     # Order matters: record WHICH head first, then the marker saying a head was
     # recorded at all. The reverse order lets a failure between the two claim

--- a/q-system/.q-system/scripts/ci-redrive.py
+++ b/q-system/.q-system/scripts/ci-redrive.py
@@ -495,6 +495,55 @@ def attempts_path():
     return os.environ.get("KIPI_ATTEMPTS", DEFAULT_ATTEMPTS)
 
 
+# --- the cap-out park, read by BOTH redrives ---------------------------------
+# ONE DEFINITION, TWO CALLERS (ASK-871), for the same reason `is_reviewer_slot`
+# lives here: review-redrive.py imports this module rather than keeping its own
+# copy, and two hand-maintained copies of a refusal rule is how a state ends up
+# owned by both consumers or by neither.
+#
+# THE FACT IT READS: converge.sh stopped this ISSUE at its round cap and wrote it
+# to the ledger. Every other bound in this loop keys on a PR and a head sha,
+# which is deliberate -- a PR that pushes a real fix must earn a fresh attempt --
+# and it is exactly why nothing caught ASK-830 on 2026-08-16: each of its six
+# rounds moved the head, so every per-sha cap read as fresh while the ISSUE had
+# already been given up on. This is the missing axis, not a tightening of that one.
+
+CAPOUT_CLEAR = ("python3 q-system/.q-system/scripts/attempts-ledger.py "
+                "%s clear-capout %s")
+
+
+def capout(path, issue):
+    """The recorded reason converge gave up on this issue, or "" if it has not.
+
+    HONEST BOUNDARY: `ledger_get` answers "" both for "no cap-out" and for a
+    ledger it could not read at all, so a ledger that will not parse reads as
+    "not capped" and the redrive proceeds. That is the pre-existing direction of
+    every budget in this file (the `get` op swallows a read failure and returns
+    the default), not something this gate introduces -- but it means the silence
+    of this function is not proof the issue was never capped.
+    """
+    if not ledger_get(path, issue, "capout"):
+        return ""
+    return ledger_get(path, issue, "capout_why") or "no reason recorded"
+
+
+def capout_skip(path, issue, who, pr):
+    """True if this issue is parked; writes the operator line saying so.
+
+    Says how to UN-park it in the same breath. A refusal a human cannot reverse
+    is a permanent park, and the founder reading this line is the only thing
+    standing between a parked issue and the 29-hour outage.
+    """
+    why = capout(path, issue)
+    if not why:
+        return False
+    sys.stderr.write(
+        "%s: %s PR #%s -- converge already gave up on this issue (%s). Not "
+        "re-entering it until a human clears the cap-out: %s\n"
+        % (who, issue, pr, why, CAPOUT_CLEAR % (path, issue)))
+    return True
+
+
 def cmd_redrive(cands):
     """READ-ONLY. Offers one pick; the dispatcher spends it via mark-dispatched."""
     path = attempts_path()
@@ -510,6 +559,13 @@ def cmd_redrive(cands):
                 "ci-redrive: %s PR #%s is red but a converge for it is already "
                 "live -- not offering it and not escalating it this run\n"
                 % (cand["issue"], cand["pr"]))
+            continue
+        # AND BEFORE THE ESCALATION TOO, same reasoning as the gate above. A
+        # capped-out issue has ALREADY paged the founder from converge.sh's
+        # exit-2 path, with the clearing command in the line; escalating here
+        # would be a second alarm about one unchanged fact 15 minutes later,
+        # which is the cry-wolf failure that trains the reader to skim.
+        if capout_skip(path, cand["issue"], "ci-redrive", cand["pr"]):
             continue
         if ledger_get(path, cand["issue"], redrive_flag(cand)):
             escalate(path, cand)           # machine tier already spent on this

--- a/q-system/.q-system/scripts/converge.sh
+++ b/q-system/.q-system/scripts/converge.sh
@@ -964,6 +964,26 @@ while [ "$ROUND" -lt "$MAX_ROUNDS" ]; do
   say "round $ROUND -> $VERDICT (head $SHA); reworking"
 done
 
-say "STOP exit-2: hit the $MAX_ROUNDS-round cap still at '$LAST_VERDICT'. A cap-out means the reviewer and Sana disagree persistently; read the last review before raising the cap."
-bash "$NOTIFY" "converge $ISSUE: hit $MAX_ROUNDS-round cap, still $LAST_VERDICT" 2>/dev/null || true
+CAPOUT_WHY="hit the $MAX_ROUNDS-round cap still at '$LAST_VERDICT'${PR:+ on PR #$PR}"
+say "STOP exit-2: $CAPOUT_WHY. A cap-out means the reviewer and Sana disagree persistently; read the last review before raising the cap."
+# THE MACHINE-READABLE HALF, AND IT IS THE POINT OF ASK-871. Until this line the
+# cap-out announced itself to a human twice -- the `say` above and the page below
+# -- and to a machine not at all. So ci-redrive.py and review-redrive.py, whose
+# whole job is to re-enter a PR nobody else will, correctly-by-their-own-rules
+# re-entered this one: 2026-08-16, ASK-830 capped out at 15:59:53Z and was handed
+# back at 16:14:01Z, six rounds and five Opus reviews in one morning. Their caps
+# key per PR per head sha and every round moved the head, so nothing they read
+# was stale. Nothing bounded dispatches PER ISSUE. This record is that bound.
+#
+# WRITTEN BEFORE THE PAGE. The page names the command that clears the park, and a
+# page telling the founder to clear a record that was never written is worse than
+# no page. If the ledger refuses (a lock timeout, a read-only disk) the run says
+# so and still pages, because a cap-out the founder never hears about is the
+# 29-hour park with the alarm removed.
+CAPOUT_NOTE=""
+if ! python3 "$LEDGER" "$ATTEMPTS" record-capout "$ISSUE" "$CAPOUT_WHY" 2>>"$LOG"; then
+  CAPOUT_NOTE=" WARNING: the cap-out could NOT be recorded in $ATTEMPTS, so the redrives may re-enter this issue -- check that file."
+  say "WARNING: record-capout failed for $ISSUE; the redrives cannot see this cap-out."
+fi
+bash "$NOTIFY" "converge $ISSUE: hit $MAX_ROUNDS-round cap, still $LAST_VERDICT. Parked -- no redrive will re-enter it until you clear it: python3 q-system/.q-system/scripts/attempts-ledger.py $ATTEMPTS clear-capout $ISSUE$CAPOUT_NOTE" 2>/dev/null || true
 exit 2

--- a/q-system/.q-system/scripts/review-redrive.py
+++ b/q-system/.q-system/scripts/review-redrive.py
@@ -612,8 +612,14 @@ def cmd_select(cands, show_all):
 
 
 def cmd_mark_dispatched(issue, action, pr, head_sha):
+    # THE SAME SHARED CLAIM ci-redrive uses, not `ledger_claim` (codex on PR #210).
+    # `cmd_select`'s capout gate gates the OFFER; this is where the attempt is
+    # spent, and a cap-out recorded between the two used to sail straight through
+    # it. Imported rather than reimplemented for the reason `capout_skip` is: two
+    # copies of one refusal rule is how a state ends up owned by neither.
     cand = {"action": action, "pr": pr, "head_sha": head_sha}
-    return 0 if CI.ledger_claim(CI.attempts_path(), issue, flag(cand)) else 1
+    return 0 if CI.claim_unless_capped(
+        CI.attempts_path(), issue, flag(cand), "review-redrive", pr) else 1
 
 
 def main(argv):

--- a/q-system/.q-system/scripts/review-redrive.py
+++ b/q-system/.q-system/scripts/review-redrive.py
@@ -547,6 +547,18 @@ def cmd_select(cands, show_all):
 
     path = CI.attempts_path()
     for c in cands:
+        # THE CAP-OUT PARK, FIRST (ASK-871). converge.sh stopping this ISSUE at
+        # its round cap is a refusal to touch it at all, so it outranks every
+        # question below -- which action, is anything live, is the attempt spent.
+        #
+        # IMPORTED FROM ci-redrive, NOT REIMPLEMENTED, for the same reason
+        # `is_reviewer_slot` is: both redrives must refuse the same parked issue,
+        # and two copies of one refusal rule is how a state ends up owned by
+        # neither. It reads a fact, writes nothing, and cannot page -- so putting
+        # it ahead of the in-flight gates does not reintroduce the false-page
+        # hazard those gates exist for.
+        if CI.capout_skip(path, c["issue"], "review-redrive", c["pr"]):
+            continue
         # IN-FLIGHT GATES, BOTH ACTIONS, BEFORE THE LEDGER IS READ. Each action
         # launches a different long-running process, so each needs its own
         # liveness question -- but the reason is one reason, and the ledger read

--- a/q-system/.q-system/scripts/test/test-converge-capout.sh
+++ b/q-system/.q-system/scripts/test/test-converge-capout.sh
@@ -1,0 +1,255 @@
+#!/usr/bin/env bash
+# Reproducer + acceptance criteria for ASK-871: a converge cap-out is invisible
+# to the redrives, so a stuck issue restarts forever.
+#
+# THE DEFECT IT CLOSES, measured 2026-08-16. ASK-830 ran six converge rounds and
+# five Opus reviews in one morning and produced nothing mergeable:
+#
+#   15:59:53Z converge[ASK-830] STOP exit-2: hit the 3-round cap still at 'REQUEST CHANGES'
+#   16:14:01Z red-CI redrive: handing ASK-830 back to its agent ahead of the fresh pick
+#
+# Fourteen minutes between "I give up" and "here, do it again". Both bounding
+# mechanisms worked; they did not COMPOSE. converge.sh's cap-out announced itself
+# to a human only -- a `say` line and a Slack ping -- and wrote nothing a machine
+# reads, so the redrives had no way to learn the rounds were already spent.
+#
+# THE PROPERTY UNDER TEST IS THE COMPOSITION, and it is asserted in both
+# directions on purpose. A gate that skips a capped issue is satisfied by a WALL
+# -- code that skips everything -- and a wall converts today's runaway into
+# silent parking, which is the strictly worse failure the issue's blast-radius
+# note names. So every skip case is paired with a byte-identical case whose only
+# difference is the cap-out record, and the un-capped twin must still be offered.
+#
+# BOTH REDRIVES, not just the one the DoR named. The 16:14:01Z line above is
+# kipi-dispatch.sh:1141, which is the ci-redrive.py call site -- so gating only
+# review-redrive.py would leave the measured incident live. Ci-redrive's
+# exclusion of the reviewer verdict slots is untouched (that is the ASK-871
+# not-doing list, and PR #73 is its scar); what is added is one more reason to
+# refuse, read from the same ledger.
+#
+# Isolation: KIPI_STATE_DIR, KIPI_ATTEMPTS, KIPI_CONVERGE_WORKER, KIPI_NOTIFY,
+# KIPI_GH and KIPI_PS all point into a mktemp dir. No real worker, no real gh,
+# no real process table, no live Linear, no Slack.
+set -uo pipefail
+
+ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/../../../.." && pwd)"
+CONV="$ROOT/q-system/.q-system/scripts/converge.sh"
+LEDGER="$ROOT/q-system/.q-system/scripts/attempts-ledger.py"
+REVIEW_REDRIVE="$ROOT/q-system/.q-system/scripts/review-redrive.py"
+CI_REDRIVE="$ROOT/q-system/.q-system/scripts/ci-redrive.py"
+for f in "$CONV" "$LEDGER" "$REVIEW_REDRIVE" "$CI_REDRIVE"; do
+  [ -f "$f" ] || { echo "FATAL: missing $f" >&2; exit 1; }
+done
+
+WORK="$(mktemp -d)"
+trap 'rm -rf "$WORK"' EXIT
+PASS=0; FAIL=0
+ok()  { PASS=$((PASS+1)); echo "  ok   - $1"; }
+bad() { FAIL=$((FAIL+1)); echo "  FAIL - $1"; }
+
+mkdir -p "$WORK/bin" "$WORK/state/pr-reviews" "$WORK/records"
+ATTEMPTS="$WORK/state/linear-worker-attempts.json"
+PAGES="$WORK/pages.txt"; : > "$PAGES"
+
+# The notify sink, stubbed for EVERY case. converge.sh pages on cap-out and both
+# redrives escalate from inside their select paths; with no stub that is the real
+# slack-notify.sh, quiet only because no webhook resolves on this machine.
+# Quiet-because-unconfigured is not isolation.
+cat > "$WORK/bin/notify.sh" <<EOS
+#!/usr/bin/env bash
+printf '%s\n' "\$*" >> "$PAGES"
+EOS
+chmod +x "$WORK/bin/notify.sh"
+
+capout_of() {   # capout_of <issue> <key>
+  python3 "$LEDGER" "$ATTEMPTS" get "$1" "$2" "" 2>/dev/null
+}
+
+echo "== converge cap-out is recorded where a machine reads it =="
+
+# --- the converge half: same fake-worker harness test-converge.sh uses --------
+cat > "$WORK/bin/gh" <<'EOS'
+#!/usr/bin/env bash
+case "${1:-} ${2:-}" in
+  "pr list") cat "$FAKE_PR_FILE" 2>/dev/null ;;
+  "pr view") cat "$FAKE_SHA_FILE" 2>/dev/null ;;
+esac
+exit 0
+EOS
+chmod +x "$WORK/bin/gh"
+
+cat > "$WORK/bin/fakeworker" <<'EOS'
+#!/usr/bin/env bash
+N=$(( $(cat "$FAKE_ROUND_FILE" 2>/dev/null || echo 0) + 1 ))
+echo "$N" > "$FAKE_ROUND_FILE"
+ENTRY="$(echo "$FAKE_SEQ" | cut -d'|' -f"$N")"
+[ -n "$ENTRY" ] || exit 0
+V="${ENTRY%%;*}"; S="${ENTRY##*;}"
+echo "$S" > "$FAKE_SHA_FILE"
+PR="$(cat "$FAKE_PR_FILE")"
+python3 -c "
+import json,sys
+json.dump({'pr':int(sys.argv[1]),'issue':sys.argv[4],'verdict':sys.argv[2],
+           'review':'x','ts':'t'}, open(sys.argv[3],'w'))
+" "$PR" "$V" "$FAKE_STATE/pr-reviews/pr-$PR.verdict.json" "$FAKE_ISSUE"
+exit 0
+EOS
+chmod +x "$WORK/bin/fakeworker"
+
+run_converge() {   # run_converge <issue> <pr> <seq> <max-rounds>
+  echo "$2" > "$WORK/pr"; echo "0" > "$WORK/round"; : > "$WORK/sha"
+  rm -f "$WORK/state/pr-reviews"/*.verdict.json
+  env PATH="$WORK/bin:$PATH" \
+      KIPI_STATE_DIR="$WORK/state" \
+      KIPI_CONVERGE_WORKER="$WORK/bin/fakeworker" \
+      KIPI_NOTIFY="$WORK/bin/notify.sh" \
+      FAKE_STATE="$WORK/state" FAKE_ISSUE="$1" \
+      FAKE_PR_FILE="$WORK/pr" FAKE_SHA_FILE="$WORK/sha" FAKE_ROUND_FILE="$WORK/round" \
+      FAKE_SEQ="$3" \
+    bash "$CONV" --issue "$1" --max-rounds "$4" > "$WORK/conv.out" 2>&1
+  echo $?
+}
+
+RC="$(run_converge ASK-9871 301 "REQUEST CHANGES;s1|REQUEST CHANGES;s2|REQUEST CHANGES;s3|REQUEST CHANGES;s4" 3)"
+[ "$RC" = "2" ] && ok "a never-approving reviewer still hits the round cap (exit 2)" \
+  || bad "cap-out did not exit 2, got rc=$RC: $(cat "$WORK/conv.out")"
+
+[ "$(capout_of ASK-9871 capout)" = "True" ] \
+  && ok "the cap-out is written to the attempts ledger, where a machine reads it" \
+  || bad "no cap-out record for ASK-9871 after exit 2 -- the redrives cannot see it"
+
+CAPOUT_WHY="$(capout_of ASK-9871 capout_why)"
+case "$CAPOUT_WHY" in
+  *"3-round cap"*) ok "the record says WHY: $CAPOUT_WHY" ;;
+  *) bad "capout_why does not name the round cap: '$CAPOUT_WHY'" ;;
+esac
+[ -n "$(capout_of ASK-9871 capout_at)" ] \
+  && ok "the record is timestamped" || bad "capout_at is empty"
+
+# The founder-facing half. The Slack line is the ONE alarm for this fact, and a
+# park a human cannot clear is a permanent park -- so the page has to carry the
+# clearing command, not just the news.
+grep -q "clear-capout" "$PAGES" \
+  && ok "the cap-out page names the command that clears the park" \
+  || bad "the page does not tell the founder how to un-park it: $(cat "$PAGES")"
+
+# THE PAIRED NEGATIVE. Without it, "always record a cap-out" passes every assert
+# above and parks every converged issue on the board.
+RC="$(run_converge ASK-9872 302 "APPROVE;s1" 3)"
+[ "$RC" = "1" ] && [ -z "$(capout_of ASK-9872 capout)" ] \
+  && ok "a converge that reaches its goal records NO cap-out" \
+  || bad "APPROVE run (rc=$RC) left capout='$(capout_of ASK-9872 capout)' -- it parks healthy issues"
+
+echo "== the redrives refuse an issue whose cap-out is uncleared =="
+
+# --- the board, stubbed at the gh seam ---------------------------------------
+cat > "$WORK/bin/gh-board" <<'EOS'
+#!/usr/bin/env bash
+cat "$BOARD"
+EOS
+chmod +x "$WORK/bin/gh-board"
+
+# Two PRs identical in every field that either selector reads, except the issue
+# id -- which is the only thing the ledger is keyed on.
+reviewer_pr() {   # reviewer_pr <number> <issue-lower> <sha>
+  cat <<EOS
+{"number": $1, "headRefName": "sana/$2", "headRefOid": "$3",
+ "url": "https://example.invalid/pr/$1", "title": "work ($(echo "$2" | tr a-z A-Z))",
+ "isDraft": false,
+ "statusCheckRollup": [
+   {"__typename": "StatusContext", "context": "kipi/reviewer-approved", "state": "FAILURE"}
+ ]}
+EOS
+}
+ci_pr() {         # ci_pr <number> <issue-lower> <sha>
+  cat <<EOS
+{"number": $1, "headRefName": "sana/$2", "headRefOid": "$3",
+ "url": "https://example.invalid/pr/$1", "title": "work ($(echo "$2" | tr a-z A-Z))",
+ "isDraft": false,
+ "statusCheckRollup": [
+   {"__typename": "CheckRun", "name": "validate", "status": "COMPLETED", "conclusion": "FAILURE"}
+ ]}
+EOS
+}
+record() {        # record <pr> <issue> <sha>
+  python3 - "$WORK/records/pr-$1.verdict.json" "$1" "$2" "$3" <<'PY'
+import json, sys
+out, pr, issue, sha = sys.argv[1:5]
+json.dump({"pr": int(pr), "issue": issue, "verdict": "REQUEST CHANGES",
+           "stated": "REQUEST CHANGES", "derived": "", "source": "findings",
+           "engine": "codex", "round": 1, "review": "", "head_sha": sha,
+           "usable": True, "ts": "now"}, open(out, "w"), indent=2)
+PY
+}
+
+# KIPI_PS is a table with nothing of ours in it: no converge and no reviewer is
+# live, so neither in-flight gate can be what suppresses an offer.
+select_review() {
+  env BOARD="$WORK/board.json" KIPI_GH="$WORK/bin/gh-board" \
+      KIPI_ATTEMPTS="$ATTEMPTS" KIPI_NOTIFY="$WORK/bin/notify.sh" \
+      KIPI_PS="echo /usr/sbin/syslogd" \
+    python3 "$REVIEW_REDRIVE" --repo-dir "$WORK" --records-dir "$WORK/records" \
+      select 2>"$WORK/rr.err"
+}
+select_ci() {
+  env BOARD="$WORK/board.json" KIPI_GH="$WORK/bin/gh-board" \
+      KIPI_ATTEMPTS="$ATTEMPTS" KIPI_NOTIFY="$WORK/bin/notify.sh" \
+      KIPI_PS="echo /usr/sbin/syslogd" \
+    python3 "$CI_REDRIVE" --repo-dir "$WORK" redrive 2>"$WORK/ci.err"
+}
+
+# --- review-redrive: the capped issue is FIRST on the board ------------------
+# Order matters. The selector offers the first eligible candidate and stops, so
+# putting the capped one first means a missing gate offers ASK-8710 (fail) and a
+# wall offers nothing at all (also fail). Only a real gate yields ASK-8711.
+printf '[%s,%s]\n' "$(reviewer_pr 310 ask-8710 aaaa1111)" \
+                   "$(reviewer_pr 311 ask-8711 bbbb2222)" > "$WORK/board.json"
+record 310 ASK-8710 aaaa1111
+record 311 ASK-8711 bbbb2222
+python3 "$LEDGER" "$ATTEMPTS" record-capout ASK-8710 \
+  "hit the 3-round cap still at 'REQUEST CHANGES' on PR #310" >/dev/null 2>&1
+
+PICK="$(select_review | cut -f2)"
+[ "$PICK" = "ASK-8711" ] \
+  && ok "review-redrive skips the capped issue and still offers its un-capped twin" \
+  || bad "review-redrive offered '$PICK', want ASK-8711 (empty = a wall, ASK-8710 = no gate)"
+grep -q "ASK-8710" "$WORK/rr.err" && grep -q "clear-capout" "$WORK/rr.err" \
+  && ok "review-redrive says WHY it skipped and how to un-park it" \
+  || bad "review-redrive skipped silently: $(cat "$WORK/rr.err")"
+
+# --- ci-redrive: the same pair, red on CI rather than on the verdict slot -----
+printf '[%s,%s]\n' "$(ci_pr 320 ask-8712 cccc3333)" \
+                   "$(ci_pr 321 ask-8713 dddd4444)" > "$WORK/board.json"
+python3 "$LEDGER" "$ATTEMPTS" record-capout ASK-8712 \
+  "hit the 3-round cap still at 'REQUEST CHANGES' on PR #320" >/dev/null 2>&1
+
+PICK="$(select_ci | cut -f1)"
+[ "$PICK" = "ASK-8713" ] \
+  && ok "ci-redrive skips the capped issue and still offers its un-capped twin" \
+  || bad "ci-redrive offered '$PICK', want ASK-8713 -- this is the path that re-entered ASK-830"
+grep -q "ASK-8712" "$WORK/ci.err" && grep -q "clear-capout" "$WORK/ci.err" \
+  && ok "ci-redrive says WHY it skipped and how to un-park it" \
+  || bad "ci-redrive skipped silently: $(cat "$WORK/ci.err")"
+
+echo "== a human clears the park, and only a human =="
+
+# The park must be exitable, or the fix trades a runaway for a permanent stall.
+python3 "$LEDGER" "$ATTEMPTS" clear-capout ASK-8710 >/dev/null 2>&1
+[ -z "$(capout_of ASK-8710 capout)" ] \
+  && ok "clear-capout removes the record" \
+  || bad "capout survived clear-capout: '$(capout_of ASK-8710 capout)'"
+
+printf '[%s]\n' "$(reviewer_pr 310 ask-8710 aaaa1111)" > "$WORK/board.json"
+PICK="$(select_review | cut -f2)"
+[ "$PICK" = "ASK-8710" ] \
+  && ok "once cleared, the issue is redriven again -- the park is not permanent" \
+  || bad "cleared issue was still refused: '$PICK'"
+
+# And clearing is per issue, not a global reset: the OTHER capped issue stays parked.
+printf '[%s]\n' "$(ci_pr 320 ask-8712 cccc3333)" > "$WORK/board.json"
+[ -z "$(select_ci)" ] \
+  && ok "clearing one issue does not un-park the others" \
+  || bad "clear-capout ASK-8710 also released ASK-8712"
+
+echo "  $PASS passed, $FAIL failed"
+[ "$FAIL" -eq 0 ]

--- a/q-system/.q-system/scripts/test/test-converge-capout.sh
+++ b/q-system/.q-system/scripts/test/test-converge-capout.sh
@@ -231,6 +231,94 @@ grep -q "ASK-8712" "$WORK/ci.err" && grep -q "clear-capout" "$WORK/ci.err" \
   && ok "ci-redrive says WHY it skipped and how to un-park it" \
   || bad "ci-redrive skipped silently: $(cat "$WORK/ci.err")"
 
+echo "== the atomic claim refuses a cap-out that landed after the offer =="
+
+# THE WINDOW BETWEEN OFFER AND CLAIM (codex review on PR #210, major). The two
+# gates above sit in the READ-ONLY offer. kipi-dispatch.sh then runs a `ps`
+# snapshot, a converge-live probe and a budget read before it reaches
+# mark-dispatched, which is where the attempt is actually spent -- and THAT call
+# asked only "is this flag unclaimed", never "is this issue parked". So a cap-out
+# recorded inside that window authorized the dispatch it was written to stop:
+# converge exits, `converge_live` goes false, the offer passes the capout check
+# microseconds before op_capout lands, and the claim then says yes.
+#
+# Checking capout in the caller before claiming would only narrow the window, not
+# close it -- two subprocesses cannot be atomic against a third. The question has
+# to be answered INSIDE the transaction that sets the flag, which is the ledger's
+# own flock'd _mutate.
+mark_review() {   # mark_review <issue> <pr> <sha> -> rc, stderr in rr-mark.err
+  env KIPI_ATTEMPTS="$ATTEMPTS" KIPI_NOTIFY="$WORK/bin/notify.sh" \
+    python3 "$REVIEW_REDRIVE" --repo-dir "$WORK" --records-dir "$WORK/records" \
+      mark-dispatched --issue "$1" --action rework --pr "$2" --head-sha "$3" \
+      2>"$WORK/rr-mark.err"
+  echo $?
+}
+mark_ci() {       # mark_ci <issue> <signature> <sha> -> rc, stderr in ci-mark.err
+  env KIPI_ATTEMPTS="$ATTEMPTS" KIPI_NOTIFY="$WORK/bin/notify.sh" \
+    python3 "$CI_REDRIVE" --repo-dir "$WORK" mark-dispatched \
+      --issue "$1" --signature "$2" --head-sha "$3" 2>"$WORK/ci-mark.err"
+  echo $?
+}
+
+python3 "$LEDGER" "$ATTEMPTS" record-capout ASK-8720 \
+  "hit the 3-round cap still at 'REQUEST CHANGES' on PR #330" >/dev/null 2>&1
+
+RC="$(mark_review ASK-8720 330 eeee5555)"
+[ "$RC" != "0" ] \
+  && ok "review-redrive's claim refuses a capped issue (rc=$RC) -- the dispatch is not authorized" \
+  || bad "review-redrive mark-dispatched returned 0 for a parked issue -- it authorizes the dispatch the cap-out exists to stop"
+grep -q "clear-capout" "$WORK/rr-mark.err" \
+  && ok "the refusing claim names the command that clears the park" \
+  || bad "the claim refused without naming clear-capout: $(cat "$WORK/rr-mark.err")"
+
+# THE WALL GUARD, same shape as every pair above: byte-identical call, no cap-out.
+RC="$(mark_review ASK-8721 331 ffff6666)"
+[ "$RC" = "0" ] \
+  && ok "an un-capped issue is still claimed -- the gate is not a wall" \
+  || bad "mark_review refused an UN-capped issue (rc=$RC): $(cat "$WORK/rr-mark.err")"
+
+python3 "$LEDGER" "$ATTEMPTS" record-capout ASK-8722 \
+  "hit the 3-round cap still at 'REQUEST CHANGES' on PR #340" >/dev/null 2>&1
+
+RC="$(mark_ci ASK-8722 sig8722 aaaa7777)"
+[ "$RC" != "0" ] \
+  && ok "ci-redrive's claim refuses a capped issue (rc=$RC) -- this is ASK-830's call site" \
+  || bad "ci-redrive mark-dispatched returned 0 for a parked issue: $(cat "$WORK/ci-mark.err")"
+grep -q "clear-capout" "$WORK/ci-mark.err" \
+  && ok "ci-redrive's refusing claim names the clearing command too" \
+  || bad "ci-redrive claim refused without naming clear-capout: $(cat "$WORK/ci-mark.err")"
+
+RC="$(mark_ci ASK-8723 sig8723 bbbb8888)"
+[ "$RC" = "0" ] \
+  && ok "ci-redrive still claims an un-capped issue -- not a wall" \
+  || bad "mark_ci refused an UN-capped issue (rc=$RC): $(cat "$WORK/ci-mark.err")"
+
+# THE REFUSAL MUST NOT SPEND THE ATTEMPT, and this is the case that separates a
+# real check-and-claim from "claim, then notice". A claim that sets the flag and
+# then reports a park has burned the issue's one attempt on a dispatch that never
+# happened, so clearing the park would release an issue that can no longer be
+# redriven -- a silent permanent stall wearing a cleared park's clothes.
+[ -z "$(capout_of ASK-8720 review_rework_pr330_eeee5555)" ] \
+  && ok "the refused claim left the attempt flag UNSET -- the park is reversible" \
+  || bad "the refusal still claimed review_rework_pr330_eeee5555 -- clearing the park cannot recover it"
+
+python3 "$LEDGER" "$ATTEMPTS" clear-capout ASK-8720 >/dev/null 2>&1
+RC="$(mark_review ASK-8720 330 eeee5555)"
+[ "$RC" = "0" ] \
+  && ok "once the park is cleared the same claim succeeds -- nothing was consumed" \
+  || bad "the attempt was consumed by the refusal (rc=$RC after clear-capout)"
+
+# The ledger op itself, at its own seam: one op, one transaction, a distinct code.
+python3 "$LEDGER" "$ATTEMPTS" record-capout ASK-8724 "capped" >/dev/null 2>&1
+python3 "$LEDGER" "$ATTEMPTS" claim-flag-uncapped ASK-8724 f1 >/dev/null 2>&1
+RC=$?
+[ "$RC" = "4" ] \
+  && ok "claim-flag-uncapped exits 4 on a parked issue -- not 1, which means 'already claimed, stay quiet'" \
+  || bad "claim-flag-uncapped on a capped issue exited $RC, want 4"
+[ -z "$(capout_of ASK-8724 f1)" ] \
+  && ok "and it wrote no flag while refusing" \
+  || bad "claim-flag-uncapped set the flag it refused to claim"
+
 echo "== a human clears the park, and only a human =="
 
 # The park must be exitable, or the fix trades a runaway for a permanent stall.


### PR DESCRIPTION
## The defect (ASK-871)

`converge.sh`'s exit-2 cap-out did exactly two things: `say` a line into the converge log and Slack the founder. Nothing machine-readable. So the two consumers whose whole job is re-entering a stuck PR had no way to learn the rounds were already spent, and re-entered it correctly by their own rules.

Measured 2026-08-16 on ASK-830 -- six converge rounds, five Opus reviews, one morning, nothing mergeable, ~70% of the day's autonomous spend:

```
15:59:53Z converge[ASK-830] STOP exit-2: hit the 3-round cap still at 'REQUEST CHANGES'
16:14:01Z red-CI redrive: handing ASK-830 back to its agent ahead of the fresh pick
```

Both bounding mechanisms worked. They did not compose.

## What changed

| File | Change |
|---|---|
| `attempts-ledger.py` | two ops: `record-capout <issue> <why>`, `clear-capout <issue>` |
| `converge.sh` | exit-2 writes the record, then pages with the clear command in the line |
| `ci-redrive.py` | `capout()` / `capout_skip()` -- the one definition -- and the gate in `cmd_redrive` |
| `review-redrive.py` | imports and calls the same gate, first in `cmd_select` |
| `test/test-converge-capout.sh` | new, registered in `capability-manifest.json` |

**The mechanism choice, per the DoR's "decide deliberately and say why".** The record lives in the attempts ledger, not a new file. `attempts-ledger.py` is already the flock'd single writer that both redrives and the worker read, and a second store for one issue's budget is precisely how the four budgets in that file ended up racing. The two new ops are symmetric with the existing `clear-conflict` / `clear-drift` / `clear-automerge` family.

**The per-SHA keying is untouched.** It is deliberate and correct, and it is why nothing caught this: each of ASK-830's rounds moved the head, so every per-sha cap read as fresh while the *issue* had already been given up on. The missing axis is dispatches per issue. That is what this adds.

## One deviation from the DoR's Files list, stated up front

The DoR named `review-redrive.py` as the reading side. The evidence line it quotes -- `red-CI redrive: handing ASK-830 back` -- is `kipi-dispatch.sh:1141`, which is the **`ci-redrive.py`** call site. Gating only `review-redrive.py` would have left the measured incident live.

So both redrives are gated, through **one** definition in `ci-redrive.py` that `review-redrive.py` imports, exactly as it already imports `is_reviewer_slot` and for the same stated reason: two hand-maintained copies of one refusal rule is how a state ends up owned by neither.

This does not touch anything on the Not-doing list. Ci-redrive's exclusion of the reviewer verdict slots (PR #73's scar) is unchanged; the addition is one more reason to refuse, read from the ledger.

## The clearing path ships in the same change

Per the blast-radius note: a cap-out no human can clear is a permanent park, and a park with no alarm is the 29-hour outage the redrives were built to end. So:

- the founder gets the **same** Slack line, now carrying the exact `clear-capout` command;
- both redrives print that command on every skip;
- a ledger write that fails degrades to a page that **says the record was not written**, rather than to silence.

Only one alarm fires per cap-out, deliberately. The redrives do not escalate a parked issue -- converge already paged 15 minutes earlier with the same unchanged fact, and a second page is the cry-wolf failure that trains the reader to skim.

## Verification

Reproducer written first, **observed RED at 4 passed / 9 failed** -- both selectors offered the capped issue, converge recorded nothing, the page named no clearing command.

Every skip case is paired with a byte-identical un-capped twin that must still be offered, and the capped PR is placed **first** on the board. A missing gate offers the capped issue; a wall (code that skips everything) offers nothing. Only a real gate passes.

```
test-converge-capout.sh        13/13   (was 4/13)
test-review-redrive.sh         30/30
test-review-redrive-absent.py  PASS
test-attempts-ledger.py        13/13
test-converge.sh               21/21
test-ci-redrive.sh             65/65
```

## Captured, not fixed here

- `sp-34cb0b96` -- converge exit-5 (no progress) and exit-7 (no verdict) are the same invisible-terminal shape; ASK-871 scoped only exit-2, so those two still leak.
- `sp-8aa4cbb9` -- `capout()` fails open on an unreadable ledger (`ledger_get` swallows read failures). Pre-existing direction for every budget in that file, documented in the function's own HONEST BOUNDARY.

Also voided two stale notes on `attempts-ledger.py` (`sp-029ef6f9`, `sp-626e9452`) -- both describe the pre-ASK-286 mkdir/token lock, which no longer exists in the file.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
