### PR TITLE
chore(voice-stop-gate): drop the dead hashlib import (ASK-908)

### DIFF
--- a/.prd-os/receipts.jsonl
+++ b/.prd-os/receipts.jsonl
@@ -131,3 +131,4 @@
 {"commit_sha": "53d1b42256ac5b1da930a569e27e458534824089", "issue_id": "ASK-841", "receipts": {"reviewed": "2026-08-15T08:18:54Z"}, "reviewed_at": "2026-08-15T08:18:54Z"}
 {"commit_sha": "d652455f4a1f9d9fe347cba7cc217cba7cb41ec9", "issue_id": "ASK-839", "receipts": {"reviewed": "2026-08-15T10:39:41Z"}, "reviewed_at": "2026-08-15T10:39:41Z"}
 {"commit_sha": "4df16a050d4c08222bde42ab19772bd01046612c", "issue_id": "ASK-860", "receipts": {"reviewed": "2026-08-16T14:38:25Z"}, "reviewed_at": "2026-08-16T14:38:25Z"}
+{"commit_sha": "6686bb2307220279c6a75805363f71a8d03b3872", "issue_id": "ASK-908", "receipts": {"reviewed": "2026-08-19T15:13:50Z"}, "reviewed_at": "2026-08-19T15:13:50Z"}

--- a/q-system/.q-system/scripts/voice-stop-gate.py
+++ b/q-system/.q-system/scripts/voice-stop-gate.py
@@ -28,7 +28,6 @@ Exit codes:
     2 = violation (turn blocked, Claude must re-draft)
 """
 
-import hashlib
 import json
 import os
 import re


### PR DESCRIPTION
Closes ASK-908 (promoted from spillover `sp-5abefa27`, source `codex-pr213-r7`).

## What changed

One line. `import hashlib` at `q-system/.q-system/scripts/voice-stop-gate.py:31`, dead since it landed.

## Reproducer, RED before green

```
$ grep -c hashlib q-system/.q-system/scripts/voice-stop-gate.py
1          # RED -- acceptance wants 0
```

`grep -n hashlib` returned exactly one line (31), so the name appears nowhere else in the file. After the edit:

```
$ grep -c hashlib q-system/.q-system/scripts/voice-stop-gate.py
0          # GREEN
```

## Verification, and why a syntax check was not enough

`ast.parse` cannot prove an import is unused at runtime, so the hook was driven end-to-end through its real Stop-payload entry point on a draft that violates voice rules:

```
$ python3 -c "...subprocess with {'transcript_path': <fixture>, 'stop_hook_active': False}..."
exit 2
voice-stop-gate: assistant final message has voice violations.
voice-lint: 4 violation(s) in /var/folders/.../tmpyqi4b2un.md:
  line 1 [banned-word] banned word: 'leverage'
  line 1 [banned-word] banned word: 'cutting-edge'
  line 1 [banned-word] banned word: 'unlock'
  line 1 [banned-word] banned word: 'innovative'
```

That path runs extraction, the set-off draft trim, and the voice-lint subprocess. No `NameError`. Plus the existing suite:

```
$ python3 -m pytest q-system/.q-system/scripts/test_voice_stop_gate_drain_only.py -q
6 passed, 1 skipped in 0.32s
```

## The other two copies are not hand-edited here, on purpose

The DoR asks that social-voice and consulting end byte-identical to the skeleton. They will, and not by an edit in this PR:

- `kipi-update.sh:2257` rsyncs `$ARCHIVE_TMP/q-system/` into each instance, and that tmp is built from `git archive HEAD`. The instance copies track the skeleton's **committed** state, so they converge once this merges and the next `kipi update` runs.
- Hand-editing them would land one value at three sites by hand and bypass the single-writer propagation chokepoint.
- Running `kipi update` from an unmerged branch would rsync this branch's whole working tree into 20+ instances. Wrong blast radius for a one-line import removal.

**Not verified from here, stated rather than hidden:** this session's sandbox is scoped to the worktree, so `grep -c hashlib` against the two instance copies was refused. The shasum-match half of the acceptance criteria is therefore claimed from the propagation mechanism, not measured. It becomes measurable after merge + `kipi update`.

Two of the three named suites (`test_voice_stop_gate_inline_draft.py`, social-voice's `scripts/test_authorship_reach.py`) do not exist in this repo — they live in the instances, outside the same boundary.

## Not bundled into ASK-902

Deliberate, per the DoR. ASK-902 rewrites the extractor and adds a drain mode in this same file; a dead-import removal riding along would be invisible in that diff.

## Found and captured, not fixed here

- `sp-eb713495` — the instruction-budget ratchet rewrote `instruction-budget-baseline.json` (512 → 511) during a commit that touches **no** always-on instruction file. Reverted rather than bundled; the number is not this change's to move.
- The spillover ratchet surfaced 7 open notes on this file, all sourced `ASK-902`. Already in the ledger, so not orphaned, and addressing them is that issue's scope.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
