### PR TITLE
capability-gate: a declared_inert entry must cite a LIVE spillover decision (ASK-345)

### DIFF
--- a/.prd-os/receipts.jsonl
+++ b/.prd-os/receipts.jsonl
@@ -132,3 +132,4 @@
 {"commit_sha": "d652455f4a1f9d9fe347cba7cc217cba7cb41ec9", "issue_id": "ASK-839", "receipts": {"reviewed": "2026-08-15T10:39:41Z"}, "reviewed_at": "2026-08-15T10:39:41Z"}
 {"commit_sha": "4df16a050d4c08222bde42ab19772bd01046612c", "issue_id": "ASK-860", "receipts": {"reviewed": "2026-08-16T14:38:25Z"}, "reviewed_at": "2026-08-16T14:38:25Z"}
 {"commit_sha": "6686bb2307220279c6a75805363f71a8d03b3872", "issue_id": "ASK-908", "receipts": {"reviewed": "2026-08-19T15:13:50Z"}, "reviewed_at": "2026-08-19T15:13:50Z"}
+{"commit_sha": "267538695b4786577d0ed0b2550cd244848909f0", "issue_id": "ASK-345", "receipts": {"reviewed": "2026-08-19T19:11:06Z"}, "reviewed_at": "2026-08-19T19:11:06Z"}

--- a/q-system/.q-system/capability-manifest.json
+++ b/q-system/.q-system/capability-manifest.json
@@ -67,6 +67,10 @@
       "runner": "bash"
     },
     {
+      "path": "q-system/.q-system/scripts/test/test-capability-gate-inert-spillover.py",
+      "runner": "python3"
+    },
+    {
       "path": "q-system/.q-system/scripts/test/test-capability-map-wiring.py",
       "runner": "python3"
     },
@@ -762,12 +766,12 @@
     {
       "path": "q-system/.q-system/scripts/memory_outcomes.py",
       "reason": "auto-capture referee merged (PR #7) but gated OFF fleet-wide; activates with the held kipi update",
-      "spillover_id": "sp-cac8540c"
+      "spillover_id": "sp-b8eb2928"
     },
     {
       "path": "q-system/.q-system/scripts/memory_reflect.py",
       "reason": "auto-capture referee merged but gated OFF fleet-wide",
-      "spillover_id": "sp-cac8540c"
+      "spillover_id": "sp-b8eb2928"
     },
     {
       "path": "q-system/.q-system/scripts/pdf-extract.py",
@@ -782,7 +786,7 @@
     {
       "path": "q-system/.q-system/scripts/session_recall.py",
       "reason": "auto-capture referee merged but gated OFF fleet-wide",
-      "spillover_id": "sp-cac8540c"
+      "spillover_id": "sp-b8eb2928"
     },
     {
       "path": "q-system/.q-system/scripts/stat-registry-extract.py",

--- a/q-system/.q-system/scripts/capability-gate.py
+++ b/q-system/.q-system/scripts/capability-gate.py
@@ -181,6 +181,93 @@ def validate_manifest(data, errors):
             errors.append(f"unsafe or non-relative path in declared_inert: {entry['path']!r}")
 
 
+def spillover_ledger_path(root):
+    """The ONE spillover ledger for this checkout and all of its worktrees.
+
+    Mirrors prd_runner._ledger_root deliberately rather than importing it: this
+    gate is synced to every instance by `kipi update` and must run where
+    plugins/prd-os is absent. The rule it copies is load-bearing — `*.jsonl` is
+    gitignored, so resolving the ledger from a per-worktree root gives every
+    worktree a private copy, and a gate reading the wrong copy reports a safety
+    it cannot provide (sp-bc42f1d3, 26 private ledgers / 71 invisible findings).
+    `--git-common-dir` is shared across the worktree set, so its parent is the
+    main checkout no matter which worktree calls us.
+
+    Falls back to `root` when git cannot answer. Degraded, never fatal: the
+    caller treats a missing ledger as "not mine to judge".
+    """
+    ledger_root = Path(root)
+    try:
+        out = subprocess.run(["git", "rev-parse", "--git-common-dir"],
+                             cwd=str(root), capture_output=True, text=True, timeout=10)
+        if out.returncode == 0 and out.stdout.strip():
+            common = Path(out.stdout.strip())
+            if not common.is_absolute():
+                common = Path(root) / common
+            parent = common.resolve().parent
+            # Only trust it if it really looks like a checkout root; a bare
+            # repo's parent is an arbitrary directory.
+            if (parent / ".git").exists():
+                ledger_root = parent
+    except (OSError, subprocess.SubprocessError):
+        pass
+    return ledger_root / ".prd-os" / "spillover.jsonl"
+
+
+def check_inert_spillover_live(root, manifest, errors):
+    """A declared_inert entry must cite a spillover id that is still a LIVE
+    decision (ASK-345).
+
+    `validate_manifest` only checked that `spillover_id` is a non-empty string.
+    So the pointer that makes "parked as inert" a tracked wire-or-retire
+    decision could aim at a `resolved` ledger row, and the gate stayed GREEN
+    about a silencer that now silences nothing but itself. Measured on main
+    2026-08-19: memory_outcomes.py, memory_reflect.py and session_recall.py all
+    cited sp-cac8540c, status `resolved`. That is the gate's own silent-absence
+    class turned inward.
+
+    `resolved` is the ONLY terminal status prd_runner writes (both the fixed and
+    the voided paths land there), so it is the only one judged dead. `promoted`
+    stays live on purpose: promotion creates a Linear issue that
+    `spillover promoted-audit` re-reads, so the decision is still open.
+
+    TWO SKIPS, both fleet-safety and not lenience — `kipi update` runs this gate
+    in all 20+ instances:
+      * no ledger file -> skip. An instance without prd-os cannot resolve any id.
+      * id not in THIS ledger -> skip. An instance WITH prd-os has its own ids,
+        so "unknown" means "another ledger's row", not "dead pointer". Judging
+        unknown ids would turn every declared_inert entry RED fleet-wide.
+    """
+    path = spillover_ledger_path(root)
+    if not path.is_file():
+        return
+    status = {}
+    try:
+        text = path.read_text(errors="ignore")
+    except OSError as exc:
+        errors.append(f"spillover ledger unreadable at {path}: {exc}")
+        return
+    for line in text.splitlines():
+        line = line.strip()
+        if not line:
+            continue
+        try:
+            rec = json.loads(line)
+        except json.JSONDecodeError:
+            continue  # append-only log; one corrupt line must not blind the rest
+        if isinstance(rec, dict) and rec.get("id"):
+            status[rec["id"]] = rec.get("status")  # last row wins
+    for entry in manifest.get("declared_inert", []):
+        sid = entry.get("spillover_id")
+        if status.get(sid) != "resolved":
+            continue
+        errors.append(
+            f"declared_inert {entry.get('path')} cites {sid}, which is RESOLVED "
+            "in the spillover ledger: the wire-or-retire decision it points at "
+            "is closed, so nothing tracks this script any more. Repoint it at an "
+            "open item or decide the script.")
+
+
 def validate_quarantine(entry, errors):
     q = entry.get("quarantine")
     if q is None:
@@ -640,6 +727,11 @@ def main():
         report(mode, errors, notes)
         sys.exit(1)
     load_overlay(root, manifest, errors)
+    # Needs the filesystem (the ledger), so it cannot live inside
+    # validate_manifest, which is handed data only. Placed before the
+    # fail-closed exit below: a declared_inert entry pointing at a closed
+    # decision is a structural manifest problem, not a finding about the repo.
+    check_inert_spillover_live(root, manifest, errors)
     # counts note BEFORE the structural early-exit: an expired quarantine is a
     # structural error, and exiting first meant exactly those runs lost the
     # quarantine count the contract promises in EVERY summary (codex,

--- a/q-system/.q-system/scripts/capability-gate.py
+++ b/q-system/.q-system/scripts/capability-gate.py
@@ -214,7 +214,12 @@ def spillover_ledger_path(root):
     return ledger_root / ".prd-os" / "spillover.jsonl"
 
 
-def check_inert_spillover_live(root, manifest, errors):
+# A row present with status None is not the same as an id with no row at all;
+# `status.get(sid)` collapses both to None and would make a real row look absent.
+_ABSENT = object()
+
+
+def check_inert_spillover_live(root, manifest, errors, notes=None, mode="instance"):
     """A declared_inert entry must cite a spillover id that is still a LIVE
     decision (ASK-345).
 
@@ -233,13 +238,35 @@ def check_inert_spillover_live(root, manifest, errors):
 
     TWO SKIPS, both fleet-safety and not lenience — `kipi update` runs this gate
     in all 20+ instances:
-      * no ledger file -> skip. An instance without prd-os cannot resolve any id.
-      * id not in THIS ledger -> skip. An instance WITH prd-os has its own ids,
-        so "unknown" means "another ledger's row", not "dead pointer". Judging
-        unknown ids would turn every declared_inert entry RED fleet-wide.
+      * no ledger file -> skip, and SAY SO in notes (see the blindness note).
+      * id not in THIS ledger -> skip IN INSTANCE MODE ONLY. An instance WITH
+        prd-os has its own ids, so "unknown" means "another ledger's row", not
+        "dead pointer"; judging it would turn every declared_inert entry RED
+        fleet-wide. In SKELETON mode the ledger is this manifest's own ledger,
+        so an unknown id is a typo'd or fabricated pointer and goes RED. All 19
+        real ids resolve in the skeleton ledger today (measured 2026-08-19), so
+        the strict half reds nothing that exists (PR #224 review, minor).
+
+    WHERE THIS IS BLIND, AND WHY THE SKIP IS LOUD (PR #224 review, major):
+    `.gitignore:43` excludes `*.jsonl` and un-ignores only `receipts.jsonl`, so
+    `.prd-os/spillover.jsonl` is never committed. Every `actions/checkout` in
+    `.github/workflows/validate.yml` therefore takes the no-ledger branch, and CI
+    CANNOT catch a dead pointer — do not count that step as coverage. Liveness is
+    enforced wherever a ledger is readable: the founder's skeleton checkout via
+    `kipi check`, any worktree of it (git-common-dir), and any instance carrying
+    prd-os. The skip appends a note rather than returning quietly, because a
+    silent GREEN reads as "checked, clean" when it means "not checked" — the same
+    silent-absence class this whole gate exists to make loud.
     """
     path = spillover_ledger_path(root)
     if not path.is_file():
+        if notes is not None:
+            notes.append(
+                f"inert-spillover-liveness: SKIPPED, no ledger at {path}. "
+                f"{len(manifest.get('declared_inert', []))} declared_inert pointer(s) "
+                "were NOT checked for a closed decision. Expected in CI (*.jsonl is "
+                "gitignored) and in instances without prd-os; this run proves nothing "
+                "about pointer liveness.")
         return
     status = {}
     try:
@@ -259,13 +286,22 @@ def check_inert_spillover_live(root, manifest, errors):
             status[rec["id"]] = rec.get("status")  # last row wins
     for entry in manifest.get("declared_inert", []):
         sid = entry.get("spillover_id")
-        if status.get(sid) != "resolved":
-            continue
-        errors.append(
-            f"declared_inert {entry.get('path')} cites {sid}, which is RESOLVED "
-            "in the spillover ledger: the wire-or-retire decision it points at "
-            "is closed, so nothing tracks this script any more. Repoint it at an "
-            "open item or decide the script.")
+        if not sid:
+            continue  # validate_manifest already owns the empty-string error
+        st = status.get(sid, _ABSENT)
+        if st == "resolved":
+            errors.append(
+                f"declared_inert {entry.get('path')} cites {sid}, which is RESOLVED "
+                "in the spillover ledger: the wire-or-retire decision it points at "
+                "is closed, so nothing tracks this script any more. Repoint it at an "
+                "open item or decide the script.")
+        elif st is _ABSENT and mode == "skeleton":
+            errors.append(
+                f"declared_inert {entry.get('path')} cites {sid}, which matches NO "
+                f"row in {path}. In the skeleton that ledger IS this manifest's "
+                "ledger, so an id it has never heard of is a typo or a fabricated "
+                "pointer, and a pointer nothing can resolve tracks nothing. (An "
+                "INSTANCE skips this: its ledger legitimately holds other ids.)")
 
 
 def validate_quarantine(entry, errors):
@@ -731,7 +767,7 @@ def main():
     # validate_manifest, which is handed data only. Placed before the
     # fail-closed exit below: a declared_inert entry pointing at a closed
     # decision is a structural manifest problem, not a finding about the repo.
-    check_inert_spillover_live(root, manifest, errors)
+    check_inert_spillover_live(root, manifest, errors, notes, mode)
     # counts note BEFORE the structural early-exit: an expired quarantine is a
     # structural error, and exiting first meant exactly those runs lost the
     # quarantine count the contract promises in EVERY summary (codex,

--- a/q-system/.q-system/scripts/test/test-capability-gate-inert-spillover.py
+++ b/q-system/.q-system/scripts/test/test-capability-gate-inert-spillover.py
@@ -21,12 +21,25 @@ away from its caller.
 TWO SKIPS ARE LOAD-BEARING, NOT LENIENCE (fleet blast radius):
  - no `.prd-os/spillover.jsonl` at all -> skip. `kipi update` runs this gate in
    every instance; an instance without a ledger cannot resolve skeleton ids.
- - an id that is not IN this ledger -> skip. An instance that HAS a prd-os
-   ledger has its OWN ids, so "unknown id" means "not my ledger to judge", not
-   "dead pointer". Judging it would turn all 19 entries RED fleet-wide.
+ - an id that is not IN this ledger -> skip IN INSTANCE MODE ONLY. An instance
+   that HAS a prd-os ledger has its OWN ids, so "unknown id" means "not my
+   ledger to judge". In SKELETON mode the ledger is authoritative for the
+   skeleton's own manifest, so an unknown id is a fabricated or typo'd pointer
+   and goes RED (PR #224 review, minor).
+
+WHERE THIS CHECK IS BLIND, STATED SO NOBODY COUNTS IT AS COVERAGE (PR #224
+review, major): `.gitignore:43` excludes `*.jsonl` and un-ignores only
+`receipts.jsonl`, so `.prd-os/spillover.jsonl` is NEVER in a fresh checkout.
+`actions/checkout` in `.github/workflows/validate.yml` therefore takes the
+no-ledger skip every run. CI cannot see a dead pointer. Liveness is enforced
+where a ledger is readable -- the founder's skeleton checkout via `kipi check`,
+and any worktree of it. Cases 8 and 10 pin that the skip is REPORTED rather than
+silent, because a silent skip is the same silent-absence class this gate exists
+to make loud.
 """
 
 import importlib.util
+import inspect
 import json
 import os
 import subprocess
@@ -65,11 +78,14 @@ if not hasattr(capgate, "check_inert_spillover_live"):
 MANIFEST_REL = "q-system/.q-system/capability-manifest.json"
 
 
-def build_repo(tmp, spillover_rows, inert_id="sp-fixture01"):
+def build_repo(tmp, spillover_rows, inert_id="sp-fixture01", skeleton=False):
     """A minimal repo root: manifest + optional ledger. Deliberately NOT a git
-    repo and with no instance-registry.json, so the gate runs in instance mode
-    and the ledger lookup falls back to this root."""
+    repo, so the ledger lookup falls back to this root. `skeleton=True` writes
+    an instance-registry.json, which is the ONLY thing detect_mode() reads to
+    call a checkout the skeleton."""
     root = Path(tmp)
+    if skeleton:
+        (root / "instance-registry.json").write_text(json.dumps({"instances": []}))
     manifest = {
         "schema_version": 1,
         "expected_tests": [],
@@ -90,17 +106,32 @@ def build_repo(tmp, spillover_rows, inert_id="sp-fixture01"):
     return root, manifest
 
 
-def errors_for(spillover_rows, inert_id="sp-fixture01"):
-    with tempfile.TemporaryDirectory() as tmp:
-        root, manifest = build_repo(tmp, spillover_rows, inert_id)
-        errs = []
-        capgate.check_inert_spillover_live(root, manifest, errs)
-        return errs
+_SIG = inspect.signature(capgate.check_inert_spillover_live).parameters
+for _p in ("notes", "mode"):
+    if _p not in _SIG:
+        fail(f"check_inert_spillover_live() takes no {_p!r} argument. Without it the "
+             "check cannot report its own no-ledger skip (silent GREEN in CI, where "
+             "*.jsonl is gitignored) and cannot treat an unknown id as RED in "
+             "skeleton mode, where the ledger IS authoritative. PR #224 review.")
 
 
-def gate_rc(spillover_rows, inert_id="sp-fixture01"):
+def run_check(spillover_rows, inert_id="sp-fixture01", skeleton=False):
+    """Returns (errors, notes) from one direct call against a fixture repo."""
     with tempfile.TemporaryDirectory() as tmp:
-        root, _ = build_repo(tmp, spillover_rows, inert_id)
+        root, manifest = build_repo(tmp, spillover_rows, inert_id, skeleton=skeleton)
+        errs, notes = [], []
+        capgate.check_inert_spillover_live(
+            root, manifest, errs, notes, "skeleton" if skeleton else "instance")
+        return errs, notes
+
+
+def errors_for(spillover_rows, inert_id="sp-fixture01", skeleton=False):
+    return run_check(spillover_rows, inert_id, skeleton)[0]
+
+
+def gate_rc(spillover_rows, inert_id="sp-fixture01", skeleton=False):
+    with tempfile.TemporaryDirectory() as tmp:
+        root, _ = build_repo(tmp, spillover_rows, inert_id, skeleton=skeleton)
         env = dict(os.environ)
         env.pop("PYTHONPATH", None)
         proc = subprocess.run(
@@ -156,12 +187,13 @@ if errors_for([ROW_PROMOTED]):
          "(prd_runner spillover promoted-audit); only `resolved` is terminal")
 ok("declared_inert citing a PROMOTED spillover id stays GREEN (promoted is not terminal)")
 
-# --- case 5: an id absent from THIS ledger is not this ledger's to judge
+# --- case 5: in INSTANCE mode an id absent from THIS ledger is not ours to judge
 if errors_for([ROW_OTHER]):
-    fail(f"an id absent from the ledger was judged: {errors_for([ROW_OTHER])}. "
-         "an instance with its own prd-os ledger holds different ids; judging "
-         "unknown ids turns every declared_inert entry RED fleet-wide")
-ok("a spillover id absent from this ledger is skipped, not judged")
+    fail(f"an id absent from the ledger was judged in instance mode: "
+         f"{errors_for([ROW_OTHER])}. an instance with its own prd-os ledger holds "
+         "different ids; judging unknown ids turns every declared_inert entry RED "
+         "fleet-wide, in 20+ instances at once")
+ok("instance mode: a spillover id absent from this ledger is skipped, not judged")
 
 # --- case 6: last row wins, matching the ledger's own append-only read --------
 if errors_for([ROW_OPEN, ROW_RESOLVED]) == []:
@@ -185,19 +217,71 @@ ok("a malformed ledger line is skipped and the readable rows are still judged")
 
 # --- wiring: main() actually calls this, and the real manifest is clean -------
 src = GATE.read_text()
-if "check_inert_spillover_live(root, manifest, errors)" not in src:
+if "check_inert_spillover_live(root, manifest, errors, notes, mode)" not in src:
     fail("main() no longer calls check_inert_spillover_live; this suite would "
          "be testing dead code")
 subprocess.run([sys.executable, "-c", "import ast,sys; ast.parse(open(sys.argv[1]).read())",
                 str(GATE)], check=True)
 ok("wiring: main() calls check_inert_spillover_live and the gate parses")
 
+# --- case 8: the no-ledger skip must be REPORTED, never silent -----------------
+# This is the CI condition. `.gitignore:43` excludes `*.jsonl`, so a fresh
+# actions/checkout has no spillover ledger and this check cannot fire there. A
+# silent GREEN reads as "checked, clean"; it means "not checked". The gate has to
+# say which.
+errs, notes = run_check(None, skeleton=True)
+if errs:
+    fail(f"a repo with no ledger was judged: {errs}")
+if not any("SKIPPED" in n and "spillover" in n.lower() for n in notes):
+    fail(f"the no-ledger skip emitted no note: {notes}. CI takes this branch on "
+         "EVERY run (*.jsonl is gitignored), so a silent skip lets the gate report "
+         "GREEN on the exact dead-pointer manifest it was written to catch")
+ok("the no-ledger skip is reported as SKIPPED in the gate's notes, not silent")
+
+rc, out = gate_rc(None, skeleton=True)
+if rc != 0:
+    fail(f"gate went RED with no ledger, rc={rc}:\n{out}")
+if "SKIPPED" not in out:
+    fail(f"capability-gate.py --check-only printed no skip line with no ledger:\n{out}")
+ok(f"capability-gate.py --check-only prints the skip and still exits {rc}")
+
+# --- case 9: SKELETON mode, unknown id -> RED (the ledger is authoritative here)
+errs, _ = run_check([ROW_OTHER], skeleton=True)
+if not errs:
+    fail("skeleton mode accepted a spillover_id that is in NO ledger row. In the "
+         "skeleton the ledger IS this manifest's ledger, so an unknown id is a "
+         "typo'd or fabricated pointer, not another ledger's business. All 19 real "
+         "ids resolve today, so this reds zero real entries")
+if "sp-fixture01" not in " ".join(errs):
+    fail(f"the skeleton unknown-id error must name the id: {errs}")
+ok("skeleton mode: a spillover id in NO ledger row is RED and names the id")
+
+# --- case 10: mode is the ONLY difference between cases 5 and 9 ----------------
+# Same fixture ledger, same manifest, different mode. If this pair ever agrees,
+# either the fleet skip is gone (20+ instances RED) or the skeleton hole is back.
+inst_errs, _ = run_check([ROW_OTHER], skeleton=False)
+skel_errs, _ = run_check([ROW_OTHER], skeleton=True)
+if bool(inst_errs) == bool(skel_errs):
+    fail(f"instance and skeleton agree on an unknown id (instance={inst_errs}, "
+         f"skeleton={skel_errs}); one of the two behaviours has been lost")
+ok("unknown-id verdict differs by mode only: instance skips, skeleton reds")
+
+# --- wiring: main() actually calls this, and the real manifest is clean -------
 real_manifest = json.loads((ROOT / MANIFEST_REL).read_text())
-real_errs = []
-capgate.check_inert_spillover_live(ROOT, real_manifest, real_errs)
+real_errs, real_notes = [], []
+capgate.check_inert_spillover_live(ROOT, real_manifest, real_errs, real_notes,
+                                   capgate.detect_mode(ROOT, []))
 if real_errs:
     fail("this repo's own capability-manifest.json has dead inert pointers: "
          + " | ".join(real_errs))
-ok("this repo's capability-manifest.json cites only live spillover ids")
+if any("SKIPPED" in n for n in real_notes):
+    # Do NOT claim the manifest is clean when the ledger was never read. This is
+    # what the assertion did in CI before PR #224 review: it printed "cites only
+    # live spillover ids" while sitting on the three dead pointers.
+    ok("this checkout has no spillover ledger, so manifest liveness was NOT "
+       "checked here (expected in CI; run it where the ledger lives)")
+else:
+    ok("this repo's capability-manifest.json cites only live spillover ids "
+       f"({len(real_manifest.get('declared_inert', []))} entries, ledger read)")
 
 print(f"PASS: {PASS}/{PASS} declared_inert spillover-liveness checks")

--- a/q-system/.q-system/scripts/test/test-capability-gate-inert-spillover.py
+++ b/q-system/.q-system/scripts/test/test-capability-gate-inert-spillover.py
@@ -1,0 +1,203 @@
+#!/usr/bin/env python3
+"""Reproducer + acceptance for the capability gate's declared_inert liveness check (ASK-345).
+
+THE DEFECT IT CLOSES: `validate_manifest` checked only that a `declared_inert`
+entry carries non-empty `path`/`reason`/`spillover_id` strings. It never asked
+whether that id still resolves to a LIVE decision. So the pointer that is
+supposed to make "parked as inert" a tracked wire-or-retire decision could point
+at a `resolved` ledger row and the gate stayed GREEN. Measured on main
+2026-08-19: three entries (`memory_outcomes.py`, `memory_reflect.py`,
+`session_recall.py`) all cited `sp-cac8540c`, whose ledger status is `resolved`.
+A silencer aimed at a closed decision silences forever, which is the same
+silent-absence class the gate itself was built to make loud.
+
+WHY THIS DRIVES THE FUNCTION DIRECTLY AND ALSO RUNS THE CLI: the semantics
+(which status is live, which skips) are unit-drivable in milliseconds against
+fixture ledgers, and case 1 additionally runs the real `capability-gate.py
+--check-only` against a minimal fixture repo so "exits non-zero" is observed and
+not assumed. The wiring block at the bottom is what stops the unit from drifting
+away from its caller.
+
+TWO SKIPS ARE LOAD-BEARING, NOT LENIENCE (fleet blast radius):
+ - no `.prd-os/spillover.jsonl` at all -> skip. `kipi update` runs this gate in
+   every instance; an instance without a ledger cannot resolve skeleton ids.
+ - an id that is not IN this ledger -> skip. An instance that HAS a prd-os
+   ledger has its OWN ids, so "unknown id" means "not my ledger to judge", not
+   "dead pointer". Judging it would turn all 19 entries RED fleet-wide.
+"""
+
+import importlib.util
+import json
+import os
+import subprocess
+import sys
+import tempfile
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[4]
+GATE = ROOT / "q-system/.q-system/scripts/capability-gate.py"
+
+PASS = 0
+
+
+def fail(msg):
+    print(f"FAIL: {msg}", file=sys.stderr)
+    sys.exit(1)
+
+
+def ok(msg):
+    global PASS
+    PASS += 1
+    print(f"  ok: {msg}")
+
+
+if not GATE.is_file():
+    fail(f"capability-gate.py does not exist at {GATE}")
+
+spec = importlib.util.spec_from_file_location("capgate", GATE)
+capgate = importlib.util.module_from_spec(spec)
+spec.loader.exec_module(capgate)
+
+if not hasattr(capgate, "check_inert_spillover_live"):
+    fail("capability-gate.py has no check_inert_spillover_live(); the declared_inert "
+         "liveness check is missing, so a resolved spillover id silences the gate forever")
+
+MANIFEST_REL = "q-system/.q-system/capability-manifest.json"
+
+
+def build_repo(tmp, spillover_rows, inert_id="sp-fixture01"):
+    """A minimal repo root: manifest + optional ledger. Deliberately NOT a git
+    repo and with no instance-registry.json, so the gate runs in instance mode
+    and the ledger lookup falls back to this root."""
+    root = Path(tmp)
+    manifest = {
+        "schema_version": 1,
+        "expected_tests": [],
+        "required_data": [],
+        "skeleton_only": [],
+        "declared_inert": [{
+            "path": "q-system/.q-system/scripts/fixture-engine.py",
+            "reason": "fixture",
+            "spillover_id": inert_id,
+        }],
+    }
+    (root / "q-system/.q-system").mkdir(parents=True, exist_ok=True)
+    (root / MANIFEST_REL).write_text(json.dumps(manifest, indent=2))
+    if spillover_rows is not None:
+        (root / ".prd-os").mkdir(parents=True, exist_ok=True)
+        (root / ".prd-os/spillover.jsonl").write_text(
+            "".join(json.dumps(r) + "\n" for r in spillover_rows))
+    return root, manifest
+
+
+def errors_for(spillover_rows, inert_id="sp-fixture01"):
+    with tempfile.TemporaryDirectory() as tmp:
+        root, manifest = build_repo(tmp, spillover_rows, inert_id)
+        errs = []
+        capgate.check_inert_spillover_live(root, manifest, errs)
+        return errs
+
+
+def gate_rc(spillover_rows, inert_id="sp-fixture01"):
+    with tempfile.TemporaryDirectory() as tmp:
+        root, _ = build_repo(tmp, spillover_rows, inert_id)
+        env = dict(os.environ)
+        env.pop("PYTHONPATH", None)
+        proc = subprocess.run(
+            [sys.executable, str(GATE), "--repo-root", str(root), "--check-only"],
+            capture_output=True, text=True, timeout=120, env=env)
+        return proc.returncode, proc.stdout + proc.stderr
+
+
+ROW_RESOLVED = {"id": "sp-fixture01", "status": "resolved", "desc": "fixture"}
+ROW_OPEN = {"id": "sp-fixture01", "status": "open", "desc": "fixture"}
+ROW_PROMOTED = {"id": "sp-fixture01", "status": "promoted", "desc": "fixture"}
+ROW_OTHER = {"id": "sp-somebodyelse", "status": "open", "desc": "another ledger's item"}
+
+# --- case 1: a resolved id is a dead pointer -> RED, and the CLI exits non-zero
+errs = errors_for([ROW_RESOLVED])
+if not errs:
+    fail("a declared_inert entry citing a RESOLVED spillover id was accepted; "
+         "that is the bug -- the silencer outlives the decision it points at")
+if "sp-fixture01" not in " ".join(errs):
+    fail(f"the error must name the dead id so it is fixable without a hunt: {errs}")
+ok("declared_inert citing a resolved spillover id is RED and names the id")
+
+rc, out = gate_rc([ROW_RESOLVED])
+if rc == 0:
+    fail(f"capability-gate.py --check-only exited 0 on a manifest with a dead "
+         f"pointer; the check is not reached from main().\n{out}")
+if "sp-fixture01" not in out:
+    fail(f"gate output does not name the dead id:\n{out}")
+ok(f"capability-gate.py --check-only exits {rc} (non-zero) and reports the dead pointer")
+
+# --- case 2: an open id is a live decision -> GREEN
+if errors_for([ROW_OPEN]):
+    fail(f"an OPEN spillover id was rejected: {errors_for([ROW_OPEN])}")
+rc, out = gate_rc([ROW_OPEN])
+if rc != 0:
+    fail(f"gate went RED on a live (open) pointer, rc={rc}:\n{out}")
+ok("declared_inert citing an OPEN spillover id stays GREEN, CLI included")
+
+# --- case 3: no ledger at all -> skip, GREEN (the fleet skip)
+if errors_for(None):
+    fail(f"a repo with no .prd-os/spillover.jsonl was judged: {errors_for(None)}. "
+         "kipi update runs this gate in every instance; instances without a "
+         "ledger cannot resolve skeleton ids and must stay GREEN")
+rc, out = gate_rc(None)
+if rc != 0:
+    fail(f"gate went RED in a repo with no spillover ledger, rc={rc}:\n{out}")
+ok("a repo with no .prd-os/spillover.jsonl skips the check and stays GREEN")
+
+# --- case 4: promoted is a live decision, not a closed one
+if errors_for([ROW_PROMOTED]):
+    fail(f"a PROMOTED spillover id was rejected: {errors_for([ROW_PROMOTED])}. "
+         "promoted means an issue exists and is still being audited "
+         "(prd_runner spillover promoted-audit); only `resolved` is terminal")
+ok("declared_inert citing a PROMOTED spillover id stays GREEN (promoted is not terminal)")
+
+# --- case 5: an id absent from THIS ledger is not this ledger's to judge
+if errors_for([ROW_OTHER]):
+    fail(f"an id absent from the ledger was judged: {errors_for([ROW_OTHER])}. "
+         "an instance with its own prd-os ledger holds different ids; judging "
+         "unknown ids turns every declared_inert entry RED fleet-wide")
+ok("a spillover id absent from this ledger is skipped, not judged")
+
+# --- case 6: last row wins, matching the ledger's own append-only read --------
+if errors_for([ROW_OPEN, ROW_RESOLVED]) == []:
+    fail("an id opened then resolved was read as live; the ledger is append-only "
+         "and last-write-wins, so the LAST row for an id is its status")
+if errors_for([ROW_RESOLVED, ROW_OPEN]):
+    fail("an id resolved then re-opened was read as dead; last row wins")
+ok("append-only ledger is read last-row-wins for an id, both directions")
+
+# --- case 7: a malformed ledger line must not crash or silently pass ----------
+with tempfile.TemporaryDirectory() as tmp:
+    root, manifest = build_repo(tmp, [ROW_RESOLVED])
+    p = root / ".prd-os/spillover.jsonl"
+    p.write_text("not json at all\n\n" + p.read_text())
+    errs = []
+    capgate.check_inert_spillover_live(root, manifest, errs)
+    if not errs:
+        fail("a junk line ahead of the real row made the check give up; a "
+             "corrupt line must be skipped, not treated as 'nothing to judge'")
+ok("a malformed ledger line is skipped and the readable rows are still judged")
+
+# --- wiring: main() actually calls this, and the real manifest is clean -------
+src = GATE.read_text()
+if "check_inert_spillover_live(root, manifest, errors)" not in src:
+    fail("main() no longer calls check_inert_spillover_live; this suite would "
+         "be testing dead code")
+subprocess.run([sys.executable, "-c", "import ast,sys; ast.parse(open(sys.argv[1]).read())",
+                str(GATE)], check=True)
+ok("wiring: main() calls check_inert_spillover_live and the gate parses")
+
+real_manifest = json.loads((ROOT / MANIFEST_REL).read_text())
+real_errs = []
+capgate.check_inert_spillover_live(ROOT, real_manifest, real_errs)
+if real_errs:
+    fail("this repo's own capability-manifest.json has dead inert pointers: "
+         + " | ".join(real_errs))
+ok("this repo's capability-manifest.json cites only live spillover ids")
+
+print(f"PASS: {PASS}/{PASS} declared_inert spillover-liveness checks")


### PR DESCRIPTION
Closes the DoR on ASK-345 (redrafted scope: the declared_inert liveness check, not `spillover-merge-orphans.py`).

## The defect

`validate_manifest` checked only that a `declared_inert` entry carried non-empty `path` / `reason` / `spillover_id` strings. It never asked whether that id still resolved to an open decision. So the pointer that makes "parked as inert" a *tracked* wire-or-retire call could aim at a closed ledger row and the gate stayed GREEN.

Measured on `main` 2026-08-19: `memory_outcomes.py`, `memory_reflect.py` and `session_recall.py` all cited `sp-cac8540c`, whose ledger status is `resolved`. A silencer aimed at a closed decision silences forever — the gate's own silent-absence class turned inward.

## The change

`check_inert_spillover_live()` reads the one shared ledger and goes RED when a cited id is `resolved`, the only terminal status `prd_runner` writes (both the fixed and the voided paths land there). `promoted` stays live on purpose: promotion creates a Linear issue that `spillover promoted-audit` re-reads, so that decision is still open.

Ledger resolution mirrors `prd_runner._ledger_root` (`git rev-parse --git-common-dir`) rather than importing it, because this gate syncs to every instance and must run where `plugins/prd-os` is absent.

**Two skips are fleet blast-radius safety, not lenience.** The updater runs this gate in 20+ instances:
- no `.prd-os/spillover.jsonl` -> skip. An instance without prd-os cannot resolve any skeleton id.
- an id absent from *this* ledger -> skip. An instance that *has* a prd-os ledger holds its own ids, so "unknown" means "another ledger's row", not "dead pointer". Judging unknown ids would turn all 19 entries RED fleet-wide.

The 3 dead pointers are repointed at `sp-b8eb2928`, a newly captured item stating the actual decision (activate the auto-capture referee or retire the three scripts). No open item tracked it before — which is exactly why the pointer had gone dead.

## Evidence

Reproducer RED before the fix:

```
$ python3 q-system/.q-system/scripts/test/test-capability-gate-inert-spillover.py
FAIL: capability-gate.py has no check_inert_spillover_live(); the declared_inert
liveness check is missing, so a resolved spillover id silences the gate forever
EXIT=1
```

GREEN after, 10 cases:

```
PASS: 10/10 declared_inert spillover-liveness checks
```

Mutation proof on the real manifest — the DoR's Check, both directions:

```
=== UNREPOINTED (the bug) rc=1
  RED: declared_inert .../memory_outcomes.py cites sp-cac8540c, which is RESOLVED ...
  RED: declared_inert .../memory_reflect.py cites sp-cac8540c, which is RESOLVED ...
  RED: declared_inert .../session_recall.py cites sp-cac8540c, which is RESOLVED ...
  capability-gate: RED (3)
=== REPOINTED rc=0 | capability-gate: GREEN
```

## Scope

Per the DoR's Not-doing: nothing about `spillover-merge-orphans.py` (it does not exist on `main`), no audit of the other 13 `declared_inert` reasons, no change to the `quarantine` path. No rule or `settings.json` change; no hook added.

## Captured, not fixed here

- `sp-b8eb2928` — the auto-capture referee wire-or-retire decision (the new live pointer).
- `sp-7363de79` — `prd_runner.py` defines `SPILLOVER_BLOCKING_SEVERITIES` twice (2021 shadowed by 2488), so `high` silently blocks.
- The spillover-ratchet hook reports 33 open notes already filed against `capability-gate.py`. Already captured; triaging them is its own task.

Do not merge — closeout runs through `/issue-verify` and `/issue-closeout`.