### PR TITLE
fix(merge-bypass-gate): scope the push deny to protected fleet remotes (ASK-925)

### DIFF
--- a/q-system/.q-system/scripts/merge-bypass-gate.py
+++ b/q-system/.q-system/scripts/merge-bypass-gate.py
@@ -104,6 +104,31 @@ from pathlib import Path
 # These are the two names the fleet actually protects.
 PROTECTED_BRANCHES = {"main", "master"}
 
+# The PUSH deny is scoped to the remotes that actually carry the PR machinery
+# (required checks 'validate' + 'kipi/reviewer-approved'). Measured 2026-08-19
+# (sp-9154c64d): the unscoped form blocked creating `main` on a brand-new
+# personal repo (assafkip/adhd-output-style) that has no checks at all -- a
+# refusal whose remedy ("let the machinery merge it") cannot exist there. A
+# gate that fires where its own remedy is impossible teaches routing around
+# gates. The MERGE side stays global on purpose: `--admin` is never the safe
+# shape anywhere, and --auto costs nothing to type.
+# A GitHub URL whose owner/name cannot be parsed stays protected (fail closed
+# on the weird form). Read per call so the test suites can pin their own set
+# via MERGE_GATE_PROTECTED_REPOS (comma-separated owner/name).
+_DEFAULT_PROTECTED_REPOS = "assafkip/kipi-system"
+_GH_URL_RE = re.compile(r"github\.com[:/]([^/\s]+)/([^/\s]+?)(?:\.git)?/?$")
+
+
+def _protected_repo(url: str) -> bool:
+    m = _GH_URL_RE.search(url or "")
+    if not m:
+        return True  # a github URL this cannot parse stays protected
+    repos = frozenset(
+        r.strip() for r in os.environ.get(
+            "MERGE_GATE_PROTECTED_REPOS", _DEFAULT_PROTECTED_REPOS).split(",")
+        if r.strip())
+    return f"{m.group(1)}/{m.group(2)}" in repos
+
 # Shell separators that start a new command. `|` is included so `foo | git push ...`
 # is examined rather than swallowed as an argument of foo.
 _SEPARATORS = {";", ";;", "&&", "||", "|", "|&", "&", "\n"}
@@ -486,6 +511,11 @@ def _push_verdict(seg: list[str], cwd: str) -> str | None:
     # A URL typed straight on the command line never reaches `remote get-url`.
     url = remote if re.match(r"^(https?://|git@|ssh://)", remote) else _remote_url(repo_dir, remote)
     if not _is_github(url):
+        return None
+    if not _protected_repo(url):
+        # A GitHub repo outside the protected set has no 'validate' /
+        # 'kipi/reviewer-approved' checks to skip; the deny's remedy does not
+        # exist there (sp-9154c64d).
         return None
 
     if refspecs:

--- a/q-system/.q-system/scripts/merge-bypass-gate.py
+++ b/q-system/.q-system/scripts/merge-bypass-gate.py
@@ -151,8 +151,22 @@ def _protected_set() -> frozenset[str] | None:
     return frozenset(valid)
 
 
+def _repo_root(repo_dir: str) -> str:
+    """The worktree root, so the fleet marker is checked where it lives.
+    Checking the push CWD missed `cd <subdir> && git push` on every instance
+    (PR #226 review round 2, major). Unresolvable -> the dir itself, and the
+    remote-set check still applies behind it."""
+    try:
+        r = subprocess.run(["git", "-C", repo_dir, "rev-parse", "--show-toplevel"],
+                           capture_output=True, text=True, timeout=3)
+    except Exception:
+        return repo_dir
+    top = r.stdout.strip()
+    return top if r.returncode == 0 and top else repo_dir
+
+
 def _protected_repo(url: str, repo_dir: str) -> bool:
-    if (Path(repo_dir) / "q-system").is_dir():
+    if (Path(_repo_root(repo_dir)) / "q-system").is_dir():
         return True  # fleet instance: the machinery is right there in the tree
     m = _GH_URL_RE.search((url or "").lower())
     if not m:

--- a/q-system/.q-system/scripts/merge-bypass-gate.py
+++ b/q-system/.q-system/scripts/merge-bypass-gate.py
@@ -28,6 +28,10 @@ route AROUND machinery that already works without a human:
                                     This is the path linear-worker.sh already uses.
     gh pr merge --admin ...  DENY   The only way to defeat kipi/reviewer-approved.
     git push <protected>     DENY   Skips the PR, so skips both required checks.
+                                    Scoped to protected repos: a fleet-marker
+                                    tree (q-system/) or the protected remote
+                                    set. Elsewhere the checks do not exist, so
+                                    the push is not a bypass (sp-9154c64d).
     everything else          ALLOW  not-applicable
 
 The effect is to make the autonomous path the ONLY path, which is what the founder
@@ -104,7 +108,7 @@ from pathlib import Path
 # These are the two names the fleet actually protects.
 PROTECTED_BRANCHES = {"main", "master"}
 
-# The PUSH deny is scoped to the remotes that actually carry the PR machinery
+# The PUSH deny is scoped to repos that actually carry the PR machinery
 # (required checks 'validate' + 'kipi/reviewer-approved'). Measured 2026-08-19
 # (sp-9154c64d): the unscoped form blocked creating `main` on a brand-new
 # personal repo (assafkip/adhd-output-style) that has no checks at all -- a
@@ -112,21 +116,50 @@ PROTECTED_BRANCHES = {"main", "master"}
 # gate that fires where its own remedy is impossible teaches routing around
 # gates. The MERGE side stays global on purpose: `--admin` is never the safe
 # shape anywhere, and --auto costs nothing to type.
-# A GitHub URL whose owner/name cannot be parsed stays protected (fail closed
-# on the weird form). Read per call so the test suites can pin their own set
-# via MERGE_GATE_PROTECTED_REPOS (comma-separated owner/name).
+#
+# TWO protected signals, either one denies (PR #226 review, major):
+#   1. The FLEET MARKER: this hook ships to every kipi instance via
+#      settings-template.json, and every instance carries q-system/ in its
+#      root. A remote allowlist alone turned the deny off on all of them the
+#      day it landed -- including instances with required checks and
+#      enforce_admins:false, the exact scar configuration. The marker is
+#      local, needs no enumeration, and cannot rot as instances are added.
+#   2. The REMOTE SET: owner/name pairs for protected repos with no fleet
+#      marker in the tree. Default assafkip/kipi-system; override via
+#      MERGE_GATE_PROTECTED_REPOS (comma-separated), read per call so the
+#      test suites can pin their own. Matching is case-folded and tolerates
+#      a .git suffix (GitHub treats both as the same repo). An override that
+#      is SET but yields no valid owner/name entry fails CLOSED -- the same
+#      direction as the URL parser beside it.
+# A GitHub URL whose owner/name cannot be parsed stays protected.
 _DEFAULT_PROTECTED_REPOS = "assafkip/kipi-system"
 _GH_URL_RE = re.compile(r"github\.com[:/]([^/\s]+)/([^/\s]+?)(?:\.git)?/?$")
 
 
-def _protected_repo(url: str) -> bool:
-    m = _GH_URL_RE.search(url or "")
+def _protected_set() -> frozenset[str] | None:
+    """Normalized owner/name set, or None when an explicit override is all
+    malformed (the fail-closed sentinel)."""
+    raw = os.environ.get("MERGE_GATE_PROTECTED_REPOS")
+    entries = (raw if raw is not None else _DEFAULT_PROTECTED_REPOS).split(",")
+    valid = set()
+    for entry in entries:
+        e = entry.strip().lower().removesuffix(".git").strip("/")
+        if e.count("/") == 1 and all(e.split("/")):
+            valid.add(e)
+    if raw is not None and not valid:
+        return None
+    return frozenset(valid)
+
+
+def _protected_repo(url: str, repo_dir: str) -> bool:
+    if (Path(repo_dir) / "q-system").is_dir():
+        return True  # fleet instance: the machinery is right there in the tree
+    m = _GH_URL_RE.search((url or "").lower())
     if not m:
         return True  # a github URL this cannot parse stays protected
-    repos = frozenset(
-        r.strip() for r in os.environ.get(
-            "MERGE_GATE_PROTECTED_REPOS", _DEFAULT_PROTECTED_REPOS).split(",")
-        if r.strip())
+    repos = _protected_set()
+    if repos is None:
+        return True  # explicit override, zero valid entries: stay closed
     return f"{m.group(1)}/{m.group(2)}" in repos
 
 # Shell separators that start a new command. `|` is included so `foo | git push ...`
@@ -512,10 +545,10 @@ def _push_verdict(seg: list[str], cwd: str) -> str | None:
     url = remote if re.match(r"^(https?://|git@|ssh://)", remote) else _remote_url(repo_dir, remote)
     if not _is_github(url):
         return None
-    if not _protected_repo(url):
-        # A GitHub repo outside the protected set has no 'validate' /
-        # 'kipi/reviewer-approved' checks to skip; the deny's remedy does not
-        # exist there (sp-9154c64d).
+    if not _protected_repo(url, repo_dir):
+        # No fleet marker in the tree and not in the protected remote set:
+        # there are no 'validate' / 'kipi/reviewer-approved' checks to skip,
+        # so the deny's remedy does not exist there (sp-9154c64d).
         return None
 
     if refspecs:

--- a/q-system/.q-system/scripts/test_merge_bypass_gate.py
+++ b/q-system/.q-system/scripts/test_merge_bypass_gate.py
@@ -151,6 +151,19 @@ def main() -> int:
         # Fleet marker alone denies, remote set not consulted.
         check("push main in a fleet-marker tree with an unlisted remote",
               "git push origin main", gh_fleet, "deny")
+        # The marker lives at the WORKTREE ROOT: a push from a subdirectory
+        # must still see it (PR #226 review round 2, major).
+        (gh_fleet / "sub").mkdir()
+        check("push main from a subdirectory of a fleet-marker tree",
+              "git push origin main", gh_fleet / "sub", "deny")
+        # The shipped default set is load-bearing when no override is set and
+        # no marker is in the tree: mutating it to garbage must kill this.
+        gh_kipi = _make_repo(root, "gh_kipi",
+                             "https://github.com/assafkip/kipi-system.git", "main")
+        saved_env = os.environ.pop("MERGE_GATE_PROTECTED_REPOS")
+        check("default set protects kipi-system with no env override",
+              "git push origin main", gh_kipi, "deny")
+        os.environ["MERGE_GATE_PROTECTED_REPOS"] = saved_env
         # Case-folded, .git-tolerant set matching.
         check("push main under different URL casing of a protected repo",
               "git push origin main", gh_cased, "deny")

--- a/q-system/.q-system/scripts/test_merge_bypass_gate.py
+++ b/q-system/.q-system/scripts/test_merge_bypass_gate.py
@@ -84,6 +84,15 @@ def main() -> int:
         gh_other = _make_repo(root, "gh_other", GH_OTHER, "main")
         # A GitHub URL the owner/name parser cannot read: stays protected.
         gh_weird = _make_repo(root, "gh_weird", GH_WEIRD, "main")
+        # A FLEET INSTANCE: unlisted remote, but q-system/ in the tree. The
+        # hook ships to every instance, so the marker must deny on its own
+        # (PR #226 review, major).
+        gh_fleet = _make_repo(root, "gh_fleet", GH_OTHER, "main")
+        (gh_fleet / "q-system").mkdir()
+        # Same protected repo under different URL casing and a .git suffix:
+        # GitHub treats these as one repo, so must the set.
+        gh_cased = _make_repo(root, "gh_cased",
+                              "https://github.com/EXAMPLE/REPO.git", "main")
 
         # --- the bypass forms: must DENY ---
         check("admin flag last", "gh pr merge 999 --squash --admin", gh_feature, "deny")
@@ -139,6 +148,18 @@ def main() -> int:
         # GitHub URL the parser cannot read: fail closed, still denied.
         check("push main to an unparseable github url",
               "git push origin main", gh_weird, "deny")
+        # Fleet marker alone denies, remote set not consulted.
+        check("push main in a fleet-marker tree with an unlisted remote",
+              "git push origin main", gh_fleet, "deny")
+        # Case-folded, .git-tolerant set matching.
+        check("push main under different URL casing of a protected repo",
+              "git push origin main", gh_cased, "deny")
+        # An explicit override that parses to zero valid entries fails CLOSED,
+        # same direction as the URL parser (PR #226 review, minor).
+        os.environ["MERGE_GATE_PROTECTED_REPOS"] = "  ,garbage,no-slash-here/"
+        check("malformed explicit override fails closed",
+              "git push origin main", gh_other, "deny")
+        os.environ["MERGE_GATE_PROTECTED_REPOS"] = "example/repo"
         check("push main to a local origin via -C",
               f"git -C {local_origin} push origin main", root, "allow")
         # A script-local variable this process never had: unresolvable, so allow

--- a/q-system/.q-system/scripts/test_merge_bypass_gate.py
+++ b/q-system/.q-system/scripts/test_merge_bypass_gate.py
@@ -15,6 +15,7 @@ Run: python3 test_merge_bypass_gate.py
 from __future__ import annotations
 
 import importlib.util
+import os
 import subprocess
 import sys
 import tempfile
@@ -48,6 +49,12 @@ def _make_repo(root: Path, name: str, origin: str, branch: str) -> Path:
 
 
 GH = "https://github.com/example/repo.git"
+# The push deny is scoped to protected remotes (sp-9154c64d). Pin the fixture
+# repo into the set so every existing deny case still exercises the deny path;
+# the scoping itself is tested against GH_OTHER / GH_WEIRD below.
+os.environ["MERGE_GATE_PROTECTED_REPOS"] = "example/repo"
+GH_OTHER = "https://github.com/other/standalone.git"
+GH_WEIRD = "https://github.com/justowner"
 
 FAILURES: list[str] = []
 CHECKS = 0
@@ -72,6 +79,11 @@ def main() -> int:
         gh_main = _make_repo(root, "gh_main", GH, "main")
         # The shape every test script in this repo uses: origin is a local path.
         local_origin = _make_repo(root, "local", str(root / "bare.git"), "main")
+        # A GitHub repo OUTSIDE the protected set (a personal standalone repo):
+        # no required checks exist there, so the push deny must not fire.
+        gh_other = _make_repo(root, "gh_other", GH_OTHER, "main")
+        # A GitHub URL the owner/name parser cannot read: stays protected.
+        gh_weird = _make_repo(root, "gh_weird", GH_WEIRD, "main")
 
         # --- the bypass forms: must DENY ---
         check("admin flag last", "gh pr merge 999 --squash --admin", gh_feature, "deny")
@@ -118,6 +130,15 @@ def main() -> int:
         # origin is not GitHub, so pushing main there is nobody's bypass.
         check("push main to a local origin",
               "git push origin main", local_origin, "allow")
+        # GitHub, but outside the protected set: the checks the deny protects do
+        # not exist there, so the push is allowed (sp-9154c64d).
+        check("push main to an unprotected github repo",
+              "git push origin main", gh_other, "allow")
+        check("push master to an unprotected github repo",
+              "git push origin master", gh_other, "allow")
+        # GitHub URL the parser cannot read: fail closed, still denied.
+        check("push main to an unparseable github url",
+              "git push origin main", gh_weird, "deny")
         check("push main to a local origin via -C",
               f"git -C {local_origin} push origin main", root, "allow")
         # A script-local variable this process never had: unresolvable, so allow


### PR DESCRIPTION
Resolves spillover sp-9154c64d. The unscoped push deny fired on any GitHub remote, blocking main-branch creation on assafkip/adhd-output-style, a personal repo with none of the required checks the deny protects. The gate's own remedy (auto-merge via PR checks) cannot exist where there is no PR machinery.

- Push deny now keys on remote owner/name against a protected set (default assafkip/kipi-system; MERGE_GATE_PROTECTED_REPOS env override, read per call so test suites pin their own).
- Fail closed: a GitHub URL whose owner/name cannot be parsed stays protected.
- Merge side stays global on purpose: the admin flag is never the safe shape anywhere.

Verification: all 5 gate suites green (126 checks incl. 3 new scoping cases). Mutants killed: fail-open on unparseable URL dies on the gh_weird case; scoping removed dies on both gh_other cases.

Linear: ASK-925. Founder-directed 2026-08-19 ("make sure its on main" for the standalone repo).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_012ncaKh6bKNASSMbyK1wTRt
