### PR TITLE
fix(token-discipline): scope the ENFORCED claims to what actually blocks (ASK-139)

### DIFF
--- a/.claude/rules/token-discipline.md
+++ b/.claude/rules/token-discipline.md
@@ -6,9 +6,9 @@ paths:
 
 # Token Discipline
 
-When the token-guard hook blocks you (exit 2 message), follow its instructions exactly.
-Do not attempt to work around the block. The block exists because you are burning
-tokens without results.
+The executable is `q-system/.q-system/token-guard.py`, wired PreToolUse + PostToolUse +
+UserPromptSubmit in BOTH `.claude/settings.json` and `settings-template.json`. Layer 1
+below IS that script. When it blocks you (exit 2), follow it; do not work around it.
 
 Common blocks and what to do:
 - "3 retries": Something is broken. Diagnose the root cause. Tell the founder.
@@ -37,10 +37,10 @@ When doing cleanup, migration, or rename tasks: run TWO grep passes.
 - Pass 1 catches obvious string/symbol hits.
 - Pass 2 catches stale IDs, dead import paths, and embedded references in JSON, HTML, and markdown.
 - State "pass 1 done, starting pass 2" before finishing.
-- Not optional, even on small renames.
+- **Scope of (ENFORCED) above:** only the honest labelling, pinned by `test-token-discipline-rule-wired.sh`. The two passes themselves are not gated -- deciding a task IS a rename is judgment, and "pass 1 done" is your prose, so no hook can see either. Not optional; also not checked.
 
 ## Pre-Action Echo (ENFORCED)
 
 Before the first Edit, Write, or destructive Bash call: if the task touches more than one file OR more than one tool category (Read, Bash, Edit, Web, Agent), echo the plan in 2-3 bullets and wait for OK. No exceptions for "small" tasks. If you find yourself thinking "this is small, I'll just do it," that is the trigger to echo.
 
-**Exception:** Does not apply to agent pipeline sub-agents executing inside `/q-morning`. Pipeline phases run autonomously.
+**Scope of (ENFORCED) above: the labelling only, pinned by `test-token-discipline-rule-wired.sh`. The echo itself is structurally unhookable and that is not a TODO.** A PreToolUse hook receives `tool_name` and `tool_input`, never your prose, so "echoed the plan" is invisible to it; and "wait for OK" needs a user turn, which no unattended `claude -p` run has. A blocking branch would deadlock the first Edit of every autonomous run fleet-wide -- the `/q-morning` carve-out was the first sign of that, and the fleet has many more unattended runners now. Still does not apply to `/q-morning` pipeline sub-agents.

--- a/q-system/.q-system/capability-manifest.json
+++ b/q-system/.q-system/capability-manifest.json
@@ -445,6 +445,10 @@
       "runner": "bash"
     },
     {
+      "path": "q-system/.q-system/scripts/test/test-token-discipline-rule-wired.sh",
+      "runner": "bash"
+    },
+    {
       "path": "q-system/.q-system/scripts/test/test-token-guard-hook-behavior.sh",
       "runner": "bash"
     },

--- a/q-system/.q-system/scripts/test/test-token-discipline-rule-wired.sh
+++ b/q-system/.q-system/scripts/test/test-token-discipline-rule-wired.sh
@@ -11,7 +11,15 @@
 #       BOTH .claude/settings.json and settings-template.json (a script the fleet
 #       template never wires ships every instance a dead switch);
 #   (b) every "(ENFORCED)" heading in the rule names an executable inside its own
-#       section. A section that cannot name one is ADVISORY and must say so.
+#       section, and that executable EXISTS in this repo. A section that cannot name
+#       a real one has to state its scope honestly instead.
+#
+# (b) demands existence, not just a filename, because "name any plausible script" is
+# a check a hallucinated path would pass. The engine that lands .claude/ edits
+# (apply_claude_changes.py) refuses to let an agent delete an (ENFORCED marker at all
+# -- "demoting a rule to advisory is enforcement-weakening whether or not the prose is
+# honest" -- so the sanctioned repair is to correct the SCOPE under the marker, which
+# is what this check measures.
 #
 # Pairs with .claude/rules/token-discipline.md.
 set -euo pipefail
@@ -33,22 +41,38 @@ rule_names_guard() {
 rule_names_guard "$RULE" \
   || fail "token-discipline.md claims ENFORCED but never names $GUARD_NAME"
 
-# --- (b) no ENFORCED heading without an executable in its section ------------
-# Splits the file on markdown headings, keeps the sections whose heading says
-# ENFORCED, and demands a *.py / *.sh filename somewhere in that section's body.
-# This is the check the two prompt-only subsections failed.
+# --- (b) no ENFORCED heading without a REAL executable in its section --------
+# Walks the file, tracks the current heading, and for every heading carrying
+# "(ENFORCED" collects the *.py / *.sh basenames appearing in that section's body.
+# A section passes only if at least one of those names resolves to a file that
+# actually exists in this repo. This is the check the two prompt-only subsections
+# failed: they named nothing at all.
 enforced_sections_without_executable() {
-  awk '
-    /^#{1,6} / {
-      if (heading != "" && enforced && !named) print heading
-      heading = $0
-      enforced = (index(toupper($0), "(ENFORCED)") > 0)
-      named = 0
-      next
-    }
-    { if ($0 ~ /[A-Za-z0-9_-]+\.(py|sh)/) named = 1 }
-    END { if (heading != "" && enforced && !named) print heading }
-  ' "$1"
+  local rule_file="$1" line heading="" enforced=0 satisfied=0 name
+  emit() {
+    [ "$enforced" -eq 1 ] && [ "$satisfied" -eq 0 ] && [ -n "$heading" ] \
+      && printf '%s\n' "$heading"
+    return 0
+  }
+  while IFS= read -r line; do
+    case "$line" in
+      '#'*' '*)
+        emit
+        heading="$line"
+        case "$line" in *'(ENFORCED'*) enforced=1 ;; *) enforced=0 ;; esac
+        satisfied=0
+        continue
+        ;;
+    esac
+    [ "$enforced" -eq 1 ] || continue
+    # Any basename ending .py/.sh on this line; satisfied once one of them is real.
+    for name in $(printf '%s\n' "$line" | grep -oE '[A-Za-z0-9_-]+\.(py|sh)' || true); do
+      if [ -n "$(find "$ROOT" -name "$name" -not -path '*/.git/*' -print -quit)" ]; then
+        satisfied=1
+      fi
+    done
+  done < "$rule_file"
+  emit
 }
 
 orphans="$(enforced_sections_without_executable "$RULE")"
@@ -70,6 +94,15 @@ printf '\n## Synthetic Claim (ENFORCED)\n\nNo executable is named in this sectio
   >> "$TMPDIR_TEST/orphaned.md"
 if [ -z "$(enforced_sections_without_executable "$TMPDIR_TEST/orphaned.md")" ]; then
   fail "negative self-test: the ENFORCED-heading check passed on a copy carrying a scriptless ENFORCED section"
+fi
+
+# ...and a plausible-but-nonexistent filename must NOT satisfy it, or the check
+# degrades into "name any string ending in .py".
+cp "$RULE" "$TMPDIR_TEST/hallucinated.md"
+printf '\n## Synthetic Claim (ENFORCED)\n\nEnforced by `no-such-guard-ask139.py`.\n' \
+  >> "$TMPDIR_TEST/hallucinated.md"
+if [ -z "$(enforced_sections_without_executable "$TMPDIR_TEST/hallucinated.md")" ]; then
+  fail "negative self-test: a nonexistent script name satisfied the ENFORCED-heading check"
 fi
 
 # --- the named executable is real and wired ----------------------------------

--- a/q-system/.q-system/scripts/test/test-token-discipline-rule-wired.sh
+++ b/q-system/.q-system/scripts/test/test-token-discipline-rule-wired.sh
@@ -1,0 +1,86 @@
+#!/usr/bin/env bash
+# ASK-139: .claude/rules/token-discipline.md carried three ENFORCED-shaped claims and
+# named no executable anywhere in the file. Its Layer-1 blocks ARE real (token-guard.py,
+# wired on three events in both settings files), but two subsections -- the
+# Cleanup/Migration two-grep-pass and Pre-Action Echo -- claimed ENFORCED with nothing
+# behind them. `grep -n -i "pre-action\|two grep\|pass 2" token-guard.py` returned
+# nothing while every token-guard test stayed green: green and blind.
+#
+# This test pins both halves so the file cannot drift back:
+#   (a) the rule NAMES its enforcing executable, and that file exists and is wired in
+#       BOTH .claude/settings.json and settings-template.json (a script the fleet
+#       template never wires ships every instance a dead switch);
+#   (b) every "(ENFORCED)" heading in the rule names an executable inside its own
+#       section. A section that cannot name one is ADVISORY and must say so.
+#
+# Pairs with .claude/rules/token-discipline.md.
+set -euo pipefail
+ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/../../../.." && pwd)"
+RULE="$ROOT/.claude/rules/token-discipline.md"
+GUARD_REL="q-system/.q-system/token-guard.py"
+GUARD_NAME="token-guard.py"
+fail() { echo "FAIL: $1" >&2; exit 1; }
+
+[ -f "$RULE" ] || fail "rule file missing at $RULE"
+
+# --- (a) the rule names its enforcing executable -----------------------------
+# Factored so the negative self-test below runs the SAME check against a copy and
+# proves it can go red. A check that cannot fail is decoration.
+rule_names_guard() {
+  grep -qF "$GUARD_NAME" "$1"
+}
+
+rule_names_guard "$RULE" \
+  || fail "token-discipline.md claims ENFORCED but never names $GUARD_NAME"
+
+# --- (b) no ENFORCED heading without an executable in its section ------------
+# Splits the file on markdown headings, keeps the sections whose heading says
+# ENFORCED, and demands a *.py / *.sh filename somewhere in that section's body.
+# This is the check the two prompt-only subsections failed.
+enforced_sections_without_executable() {
+  awk '
+    /^#{1,6} / {
+      if (heading != "" && enforced && !named) print heading
+      heading = $0
+      enforced = (index(toupper($0), "(ENFORCED)") > 0)
+      named = 0
+      next
+    }
+    { if ($0 ~ /[A-Za-z0-9_-]+\.(py|sh)/) named = 1 }
+    END { if (heading != "" && enforced && !named) print heading }
+  ' "$1"
+}
+
+orphans="$(enforced_sections_without_executable "$RULE")"
+[ -z "$orphans" ] || fail "ENFORCED heading(s) in token-discipline.md name no executable:
+$orphans
+Either wire one and name it, or relabel the section ADVISORY."
+
+# --- negative self-tests: both checks must go red on a mutated copy ----------
+TMPDIR_TEST="$(mktemp -d)"
+trap 'rm -rf "$TMPDIR_TEST"' EXIT
+
+sed "s/$GUARD_NAME//g" "$RULE" > "$TMPDIR_TEST/stripped.md"
+if rule_names_guard "$TMPDIR_TEST/stripped.md"; then
+  fail "negative self-test: rule_names_guard passed on a copy with the name stripped"
+fi
+
+cp "$RULE" "$TMPDIR_TEST/orphaned.md"
+printf '\n## Synthetic Claim (ENFORCED)\n\nNo executable is named in this section.\n' \
+  >> "$TMPDIR_TEST/orphaned.md"
+if [ -z "$(enforced_sections_without_executable "$TMPDIR_TEST/orphaned.md")" ]; then
+  fail "negative self-test: the ENFORCED-heading check passed on a copy carrying a scriptless ENFORCED section"
+fi
+
+# --- the named executable is real and wired ----------------------------------
+# Not asserting the exec bit: both settings entries invoke it as `python3 <path>`,
+# so chmod +x is not what makes this wiring live. Asserting -x here would be a
+# check that passes or fails for a reason nobody depends on.
+[ -f "$ROOT/$GUARD_REL" ] || fail "$GUARD_NAME is named by the rule but missing at $GUARD_REL"
+
+grep -qF "$GUARD_REL" "$ROOT/.claude/settings.json" \
+  || fail ".claude/settings.json does not wire $GUARD_NAME"
+grep -qF "$GUARD_REL" "$ROOT/settings-template.json" \
+  || fail "settings-template.json does not wire $GUARD_NAME (fleet would get a dead switch)"
+
+echo "PASS: token-discipline.md names $GUARD_NAME (exists, wired in .claude/settings.json + settings-template.json) and every ENFORCED heading names an executable"


### PR DESCRIPTION
## What

`.claude/rules/token-discipline.md` claimed ENFORCED three times and named no executable anywhere in the file. Its Layer-1 blocks ARE real. Two subsections were not.

- Intro now names `q-system/.q-system/token-guard.py` and its wiring (PreToolUse + PostToolUse + UserPromptSubmit, in BOTH `.claude/settings.json` and `settings-template.json`).
- Cleanup/Migration and Pre-Action Echo keep their `(ENFORCED)` markers and gain a scope line stating what the marker covers: the labelling, pinned by the new test. The behaviours are judgment; no gate sees them.

Line-neutral, 47 to 47. The file is always-on and the instruction-budget ratchet sits at its 511 baseline. `RATCHET PASS: always-on total 511 (baseline 511, target 300)`.

## Reproducer, red then green

New: `q-system/.q-system/scripts/test/test-token-discipline-rule-wired.sh`, modeled on the ASK-140 precedent `test-voice-enforcement-rule-wired.sh`.

Observed RED at 62e11397, before any fix:

```
$ bash q-system/.q-system/scripts/test/test-token-discipline-rule-wired.sh
FAIL: token-discipline.md claims ENFORCED but never names token-guard.py
EXIT=1
```

GREEN at 75f28ffe:

```
$ bash q-system/.q-system/scripts/test/test-token-discipline-rule-wired.sh
PASS: token-discipline.md names token-guard.py (exists, wired in .claude/settings.json + settings-template.json) and every ENFORCED heading names an executable
EXIT=0
```

Two checks, three negative self-tests against mutated copies. Check (b) was strengthened while still red: an ENFORCED section must name a script that EXISTS in the repo, and a negative self-test proves a plausible-but-fake name (`no-such-guard-ask139.py`) does not satisfy it. Naming any string ending in `.py` would have been a check that cannot fail.

The DoR's own blind-check, reproduced:

```
$ grep -n -i "pre-action\|two grep\|pass 2" q-system/.q-system/token-guard.py
grep rc=1   # no match: the two ENFORCED sections had no code
$ bash q-system/.q-system/scripts/test/test-token-guard-hook-behavior.sh
PASS: token-guard hook behavior (...)
```

Green and blind, exactly as the DoR described.

## No regression

```
test-token-guard-hook-behavior.sh      PASS
test-token-guard-template-wiring.sh    PASS (3 wirings on: UserPromptSubmit PreToolUse PostToolUse)
test_token_guard_observation.py        ALL PASS
```

Registered in `capability-manifest.json` under `expected_tests`.

## Two forks worth reviewing

**1. Markers were scoped, not removed. This was not my first choice.**

My first proposal relabelled both headings ADVISORY. `apply_claude_changes.py` refused it:

```
REFUSED: enforcement ratchet: 4 rule_marks entr(ies) would disappear,
first: token-discipline.md|enforced-heading|0
```

Its docstring: *"Demoting a rule to advisory is enforcement-weakening whether or not the prose is honest. If the claim is genuinely false, the fix is to correct the SCOPE."* Correct call by the gate, and the result is better than what I proposed. Both edits landed through the sanctioned `apply-claude-changes.sh` proposal path (`q-system/output/claude-changes/ask139-token-discipline.json`), never a direct write to `.claude/`.

**2. I took the DoR's prose route, not its hook route. Flagging it rather than skipping it.**

The DoR's Outcome names both: *"either backed by a real hook check or downgraded to advisory prose."* Its Check then sketched the hook-route reproducer (a PreToolUse payload asserting exit 2). I took the other named option, for a reason the DoR itself supplies in its Blast radius line.

Pre-Action Echo cannot be a hook, and this is structural rather than unfinished work:

- A PreToolUse hook receives `tool_name` and `tool_input`. It never sees the model's prose, so "echoed the plan in 2-3 bullets" is unobservable.
- "Wait for OK" requires a user turn. No unattended `claude -p` run has one, and the fleet now runs many: `linear-worker.sh`, the morning pipeline, `auto-commit.py`, every autonomous dispatch including the one that produced this PR.

A blocking branch would therefore deadlock the first Edit of every multi-file autonomous run fleet-wide, which is precisely the false positive the DoR warned about. The rule's own pre-existing `/q-morning` carve-out was the first sign of this; the fleet has more unattended runners now than when that exception was written. The reasoning is recorded in the rule so the next reader does not re-propose it.

Same reasoning for the two-grep-pass rule: deciding a task IS a rename is judgment, and "pass 1 done" is prose. Per `skill-hook-pairing.md`'s decision rule, both are the judgment half.

If you disagree and want the hook branch built anyway, that is a separate issue with a fleet-wide blast radius, not a follow-up to this one.

## Noticed, not fixed

`spillover-ratchet.py` surfaced 19 open notes against `capability-manifest.json` when I edited it (the "magnet file" problem, sp-f3a2ad81). All are already captured in the ledger, so nothing is orphaned. Triaging them is not in this issue's scope.

Closes nothing. Closeout runs through /issue-verify and /issue-closeout.
