### PR TITLE
fix(audhd): rule 8 says the flag stays verbatim, not just the command (ASK-923)

### DIFF
--- a/.claude/output-styles/audhd.md
+++ b/.claude/output-styles/audhd.md
@@ -110,6 +110,7 @@ Responses are piped into a text-to-speech engine. Format for the ear, not the ey
 - Meaning lives in words, not symbols. No arrow chains (A -> B), no pipes-as-separators, no "w/" or "b/c". Write "leads to," "or," "with," "because."
 - Code, commands, and paths stay exact, but wrap them in a sentence so the audio still parses: "Run kipi update dry-run mode" beats a bare command block.
 - Headers and bold are fine (TTS skips markup). Structure that only works visually is not.
+- Exact means the flag too: the --dry flag stays --dry, never "dry-run mode". The sentence around the command does the audio work, the way rule 3 above writes it: "Run `kipi update --dry`. Reply with output."
 
 ## 9. Debug spiral brake
 

--- a/.prd-os/receipts.jsonl
+++ b/.prd-os/receipts.jsonl
@@ -133,3 +133,4 @@
 {"commit_sha": "4df16a050d4c08222bde42ab19772bd01046612c", "issue_id": "ASK-860", "receipts": {"reviewed": "2026-08-16T14:38:25Z"}, "reviewed_at": "2026-08-16T14:38:25Z"}
 {"commit_sha": "6686bb2307220279c6a75805363f71a8d03b3872", "issue_id": "ASK-908", "receipts": {"reviewed": "2026-08-19T15:13:50Z"}, "reviewed_at": "2026-08-19T15:13:50Z"}
 {"commit_sha": "267538695b4786577d0ed0b2550cd244848909f0", "issue_id": "ASK-345", "receipts": {"reviewed": "2026-08-19T19:11:06Z"}, "reviewed_at": "2026-08-19T19:11:06Z"}
+{"commit_sha": "b02921fa64640454e584bd93f3e0b121fb796f22", "issue_id": "ASK-923", "receipts": {"reviewed": "2026-08-21T14:44:51Z"}, "reviewed_at": "2026-08-21T14:44:51Z"}

--- a/q-system/output/claude-changes/ask923-tts-exact-command.json
+++ b/q-system/output/claude-changes/ask923-tts-exact-command.json
@@ -1,0 +1,19 @@
+{
+  "schema_version": 1,
+  "slug": "ask923-tts-exact-command",
+  "reason": "ASK-923 (from sp-7c696491). Rule 8 of .claude/output-styles/audhd.md says commands stay exact, then its own example replaces the command with prose ('Run kipi update dry-run mode'). That contradicts rule 3 at line 65, which already writes the same command exactly as `kipi update --dry`, and it contradicts the AUDHD copy-paste principle. Additive only: one bullet is added at the end of the rule-8 list stating that the flag stays verbatim and that the surrounding sentence carries the audio. The offending line 111 is NOT rewritten - that needs the replace op, which rule_text_only refuses on output-styles/ by design, and widening that scope is the separate decision its docstring defers. No hook, setting, or template is touched.",
+  "requires": {
+    "files_present": [
+      ".claude/output-styles/audhd.md"
+    ]
+  },
+  "edits": [
+    {
+      "file": ".claude/output-styles/audhd.md",
+      "op": "insert_after",
+      "anchor": "- Headers and bold are fine (TTS skips markup). Structure that only works visually is not.",
+      "insert": "\n- Exact means the flag too: the --dry flag stays --dry, never \"dry-run mode\". The sentence around the command does the audio work, the way rule 3 above writes it: \"Run `kipi update --dry`. Reply with output.\"",
+      "reason": "Remove the ambiguity the line-111 example creates, without rewriting that example. Anchored on the last bullet of the rule-8 list (audhd.md:112) so the new line lands inside rule 8 and the anchor does not depend on the text a future replace op may change."
+    }
+  ]
+}


### PR DESCRIPTION
## What

`.claude/output-styles/audhd.md` rule 8 (TTS-safe output) says commands stay
exact, then its own example replaces the command with prose: `"Run kipi update
dry-run mode" beats a bare command block`. That contradicts rule 3 at line 65,
which already writes the same command exactly as `kipi update --dry`, and it
contradicts the AUDHD copy-paste principle (synthesizer A7).

One additive bullet lands at the end of the rule-8 list:

> - Exact means the flag too: the --dry flag stays --dry, never "dry-run mode". The sentence around the command does the audio work, the way rule 3 above writes it: "Run `kipi update --dry`. Reply with output."

## Evidence (real output, RED observed before green)

```
$ grep -c 'the --dry flag' .claude/output-styles/audhd.md
0                                                          # RED

$ bash q-system/.q-system/scripts/apply-claude-changes.sh --root . \
    q-system/output/claude-changes/ask923-tts-exact-command.json
OK applied ask923-tts-exact-command: 1 edit(s), 1 file(s),
   hooks 46->46, gates held, tripwire updated
EXIT=0

$ grep -c 'the --dry flag' .claude/output-styles/audhd.md
1                                                          # GREEN

$ bash q-system/.q-system/scripts/apply-claude-changes.sh --root . \
    q-system/output/claude-changes/ask923-tts-exact-command.json
OK already-applied ask923-tts-exact-command: no changes needed
EXIT=0                                                     # idempotent

$ git diff --stat
 .claude/output-styles/audhd.md | 1 +
 1 file changed, 1 insertion(+)
```

All four DoR Check conditions pass. Every lefthook pre-commit gate green
(instruction-budget ratchet: 511 vs baseline 511, unchanged).

## Route

Landed through `apply-claude-changes.sh`, not a direct `.claude/` edit. The
additive `insert_after` op reaches `.claude/output-styles/` through
`scoped_path` unchanged; `rule_text_only` is invoked only for `REPLACE_OPS`
(`apply_claude_changes.py:1061`). This is why the re-scoped DoR is executable
where the first draft was not.

## Not doing (binding, from the DoR)

- Line 111's example is **not** rewritten. That needs the `replace` op, which
  `rule_text_only` refuses on `output-styles/` by design; widening that scope
  is the separate decision its own docstring defers. Engine gap held by
  `sp-38ab789e`.
- No lint detector for prose-ified commands in generated output.
- The public `adhd-output-style` mirror repo is untouched.
- `sp-7c696491` is **not** resolved here. `spillover resolve` refuses unless the
  referenced issue is already closed, and closeout runs through
  `/issue-closeout`.

## One wording tension to flag, not paper over

The DoR's **Outcome** says the new line goes "directly after the offending
example" (line 111). Its **Files** line names the anchor explicitly: the literal
text of `audhd.md:112`, `"Headers and bold are fine (TTS skips markup)..."`.
I followed **Files**, because it is the verified operational spec and because an
anchor bound to line 111 would break if the deferred `replace` widening ever
rewrites that line. Result: the new bullet is the last line of the rule-8 list
rather than the line immediately below the example. Substance of the Outcome is
met either way; the placement differs by one line.

## Blast radius

Fleet-wide. `kipi-update.sh:605` syncs `.claude/output-styles/*.md` into every
registered instance, so this ships on the next update. Additive-only, so the
integrity ratchet and auto-revert stay intact. No `.claude/settings.json` or
`settings-template.json` edit, so no pairing gate fires. Hook count 46 -> 46.

Linear: ASK-923 (promoted from `sp-7c696491`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
