### PR TITLE
fix(rca-mode): name the two executables that already enforce it (ASK-137)

### DIFF
--- a/.claude/rules/rca-mode.md
+++ b/.claude/rules/rca-mode.md
@@ -17,18 +17,18 @@ When any of these happen, invoke the rca skill and write the analysis to
 
 ## The deterministic part
 
-The `rca-notify` hook (PostToolUse on Bash) watches command results and taps you
-to open an RCA when a test or run fails (non-zero exit, or FAIL / BLOCKED /
-Traceback in the output). The `rca-lint` hook validates every RCA doc on write.
-Both ship with the rca skill. The model decides; the hooks make sure the moment
-is not missed and the structure holds.
+Two executables hold the label above, both wired PostToolUse in the plugin's
+`hooks.json`. `plugins/kipi-core/skills/rca/scripts/rca-notify.py` (matcher Bash)
+TAPS you on a failed run -- non-zero exit, or FAIL / BLOCKED / Traceback -- and
+always exits 0, so it prompts and never blocks. Only
+`plugins/kipi-core/skills/rca/scripts/rca-lint.py` (Edit|Write) blocks: exit 2 on
+a malformed RCA or premortem doc. Neither gates the trigger; that is a model call.
 
 ## What the skill enforces
 
-Surface vs structural root cause, multi-factor with cause-type tags,
-evidence-backed verification ("ran X, got Y"), checkbox action items with
-owners, and blameless phrasing. Trivial bugs fixed in the same breath that never
-escaped a gate do not need an RCA.
+Surface vs structural root cause, multi-factor cause-type tags, evidence-backed
+verification ("ran X, got Y"), checkbox action items with owners, and blameless
+phrasing. A trivial bug fixed in the same breath, never escaping a gate, needs none.
 
 ## Relationship to other rules
 

--- a/.prd-os/receipts.jsonl
+++ b/.prd-os/receipts.jsonl
@@ -135,3 +135,4 @@
 {"commit_sha": "267538695b4786577d0ed0b2550cd244848909f0", "issue_id": "ASK-345", "receipts": {"reviewed": "2026-08-19T19:11:06Z"}, "reviewed_at": "2026-08-19T19:11:06Z"}
 {"commit_sha": "b02921fa64640454e584bd93f3e0b121fb796f22", "issue_id": "ASK-923", "receipts": {"reviewed": "2026-08-21T14:44:51Z"}, "reviewed_at": "2026-08-21T14:44:51Z"}
 {"commit_sha": "b7630d1855c35fc763161239787aabb84b80435f", "issue_id": "ASK-138", "receipts": {"reviewed": "2026-08-21T16:20:31Z"}, "reviewed_at": "2026-08-21T16:20:31Z"}
+{"commit_sha": "dd8a8d32d8e05cf838e98eb1d7d62666946572aa", "issue_id": "ASK-137", "receipts": {"reviewed": "2026-08-21T17:49:06Z"}, "reviewed_at": "2026-08-21T17:49:06Z"}


### PR DESCRIPTION
Closes ASK-137 (do not merge until /issue-verify and /issue-closeout run).

## The gap

`.claude/rules/rca-mode.md` claimed ENFORCED and named its two hooks by bare name only — `rca-notify`, `rca-lint`, no extension, no route. `capability-map-gen.py:222` matches `[\w\-/]+\.(?:py|sh)\b`, so the rule graded `NEEDS_WORK` / "prompt-only" while both hooks were live the whole time. Prose gap, not an enforcement gap.

## Recon (run, not assumed)

- `plugins/kipi-core/hooks/hooks.json:9` wires `rca-lint.py` PostToolUse on `Edit|Write|MultiEdit`
- `plugins/kipi-core/hooks/hooks.json:18` wires `rca-notify.py` PostToolUse on `Bash`
- Both scripts present and executable under `plugins/kipi-core/skills/rca/scripts/`

Reading the scripts changed what the rule says. The old text described both as "the hooks make sure the moment is not missed and the structure holds", which reads as two blockers. `rca-notify.py` has no exit path other than `sys.exit(0)`: it PROMPTS on a failed run and never blocks. `rca-lint.py` is the only blocker (exit 2), and only on a `.md` whose H1 starts `RCA:`/`Premortem` or that sits under an `output/rca/` dir. The rule now says exactly that, and states that the TRIGGER is ungated — deciding an event earns an RCA stays a model call no hook can see.

## Reproducer, observed RED then GREEN

```
python3 q-system/.q-system/scripts/capability-map-gen.py --root . --repo kipi-system --out /tmp/cap-rca.json && python3 -c "import json;print([ (c['name'],c['status']) for c in json.load(open('/tmp/cap-rca.json'))['capabilities'] if c['name']=='rule rca-mode'])"
```

RED (before):

```
kipi-system: 365 capabilities (BROKEN=1, LIVE=353, NEEDS_WORK=6, UNWIRED=5)
[('rule rca-mode', 'NEEDS_WORK')]
```

GREEN (after):

```
kipi-system: 365 capabilities (BROKEN=1, LIVE=354, NEEDS_WORK=5, UNWIRED=5)
[('rule rca-mode', 'LIVE')]
```

And `python3 q-system/.q-system/scripts/instruction-budget-audit.py --ratchet`:

```
RATCHET PASS: always-on total 511 (baseline 511, target 300)
```

## How it landed

Through `apply-claude-changes.sh`, the sanctioned route. The harness sensitive-path guard refuses the Write tool on `.claude/**`, which is what this issue was labelled `blocked:capability` for on 2026-07-30. It is not a blocker.

```
OK applied ask137-rca-mode-names-its-executables: 2 edit(s), 1 file(s),
hooks 46->46, gates held, tripwire updated                          exit=0
```

Line-neutral by necessity, 37 → 37. Two gates pull opposite ways here (same wedge the ASK-138 sibling hit, `sp-66ac0beb`): `apply_claude_changes.py`'s L2 census refuses any shrink in a rule's line count, and `instruction-budget-audit.py --ratchet` sits exactly at its 511 baseline and refuses any growth. So the deterministic section grows by one line and "What the skill enforces" reflows 4 → 3 to pay for it.

## Not doing (per the DoR)

No RCA enforcement built or rewired (both hooks were already live), the rca skill and its two scripts untouched, and the detector at `capability-map-gen.py:222` untouched — loosening it to accept a bare hook name was the named alternative and regrades every rule in every repo, a wider blast radius than this issue owns. The 5 rules still reading NEEDS_WORK are the same CAP sweep's siblings and already carry their own issues under the ASK-140 parent, so nothing is orphaned.

## Blast radius

Fleet-wide: `.claude/rules/*.md` propagates to every instance via the skeleton updater. One always-on instruction file, line-neutral, no settings / hook / script behavior change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
