### PR TITLE
fix(capability-gate): refuse an unannounced declaration outside SCAN_ROOTS (ASK-972)

### DIFF
--- a/.prd-os/receipts.jsonl
+++ b/.prd-os/receipts.jsonl
@@ -149,3 +149,4 @@
 {"commit_sha": "b7630d1855c35fc763161239787aabb84b80435f", "issue_id": "ASK-138", "receipts": {"reviewed": "2026-08-21T16:20:31Z"}, "reviewed_at": "2026-08-21T16:20:31Z"}
 {"commit_sha": "dd8a8d32d8e05cf838e98eb1d7d62666946572aa", "issue_id": "ASK-137", "receipts": {"reviewed": "2026-08-21T17:49:06Z"}, "reviewed_at": "2026-08-21T17:49:06Z"}
 {"commit_sha": "ff85eec58630ec72f0816dd585e8e92dbeaa2ab4", "issue_id": "ASK-136", "receipts": {"reviewed": "2026-08-21T20:30:36Z"}, "reviewed_at": "2026-08-21T20:30:36Z"}
+{"commit_sha": "0adb37645d20787c79b781f1734233c5647455ac", "issue_id": "ASK-972", "receipts": {"reviewed": "2026-08-22T20:10:30Z"}, "reviewed_at": "2026-08-22T20:10:30Z"}

--- a/q-system/.q-system/capability-manifest.json
+++ b/q-system/.q-system/capability-manifest.json
@@ -737,7 +737,7 @@
       "runner": "bash"
     },
     {
-      "path": "test_dispatch_pinned.sh",
+      "path": "q-system/.q-system/scripts/test/test-dispatch-pinned.sh",
       "runner": "bash"
     }
   ],
@@ -763,7 +763,7 @@
     "q-system/.q-system/scripts/test/test-token-guard-template-wiring.sh",
     "q-system/.q-system/scripts/test/test-updater-issue-sequence.py",
     "q-system/.q-system/scripts/test_autocapture_wiring.py",
-    "test_dispatch_pinned.sh"
+    "q-system/.q-system/scripts/test/test-dispatch-pinned.sh"
   ],
   "declared_inert": [
     {
@@ -866,5 +866,19 @@
     "plugins/*/tests \u2014 prd-os plugin suite, run by the plugin's own harness; outside v1 scan roots (finding-9 deferred)",
     "repo-root *.sh utilities are wiring surfaces, not test artifacts",
     "stat-registry.json: NOT expressible as required_data in v1 \u2014 the one instance holding it keeps canonical under its own instance_q_dir (not q-system/) and its registry name differs from its dir basename, so a scoped entry could never fire (grounded 2026-07-23). Declared gap; owning decision + instance detail in spillover sp-72b60bff"
+  ],
+  "scope_exempt": [
+    {
+      "prefix": "plugins/",
+      "reason": "plugin trees carry their own harness (see uncovered_known: plugins/*/tests are run by the plugin's own harness). The declared entries here are the subset the gate also runs. Discovery is NOT widened: 83 tracked test-pattern files live under plugins/, and declaring all of them is a fleet-wide design call captured as sp-c3d0f4d3."
+    },
+    {
+      "prefix": "q-system/.q-system/tests/",
+      "reason": "pytest suite tree, collected via pytest.ini rather than by the gate's TEST_PATTERNS discovery. The declared entries are the ones the gate also runs directly; the other 25 are sp-c3d0f4d3."
+    },
+    {
+      "prefix": "q-system/hooks/test/",
+      "reason": "hook-local test dir outside the scripts scan root; one declared entry, kept beside the hook it exercises (sp-c3d0f4d3)."
+    }
   ]
 }

--- a/q-system/.q-system/scripts/capability-gate.py
+++ b/q-system/.q-system/scripts/capability-gate.py
@@ -30,7 +30,7 @@ from pathlib import Path
 SCHEMA_VERSION = 1
 ALLOWED_TOP_KEYS = {
     "schema_version", "expected_tests", "required_data",
-    "skeleton_only", "declared_inert", "uncovered_known",
+    "skeleton_only", "declared_inert", "uncovered_known", "scope_exempt",
 }
 OVERLAY_ALLOWED_KEYS = {"expected_tests", "required_data"}
 TEST_PATTERNS = ("test_*.py", "test-*.py", "test-*.sh")
@@ -117,13 +117,69 @@ def unsafe_path(p):
     return ".." in p.split("/")
 
 
-def validate_test_entry(entry, seen, errors):
+def validate_scope_exempt(data, errors):
+    """Read `scope_exempt` and return the path prefixes it declares.
+
+    This is the ONLY way a declaration may sit outside SCAN_ROOTS, and it exists
+    because the alternative shapes both fail (ASK-972, measured 2026-08-22 on
+    this repo): refusing every unscanned path outright is RED on 15 entries the
+    day it ships, and widening discovery to the repo root surfaces 123
+    undeclared test-pattern files. A gate red on its own population gets
+    switched off, and a gate that is off protects nothing.
+
+    So the boundary is not removed, it is made LEGIBLE: every escape is named
+    with a reason in one reviewable place, counted in the summary of every run,
+    and still subject to the existence check. What it buys is that a NEW escape
+    can no longer happen in silence, which is the whole defect.
+
+    What this deliberately does NOT do is close the undeclared-artifact
+    direction inside an exempt tree; that population and its design call are
+    captured as sp-c3d0f4d3 rather than left as a comment. # spillover-skip
+    """
+    prefixes = []
+    for item in data.get("scope_exempt", []):
+        if not isinstance(item, dict) or not item.get("prefix") or not item.get("reason"):
+            errors.append(f"scope_exempt entry needs prefix+reason: {item!r}")
+            continue
+        if unsafe_path(item["prefix"]):
+            errors.append(f"unsafe or non-relative prefix in scope_exempt: {item['prefix']!r}")
+            continue
+        prefixes.append(item["prefix"])
+    return prefixes
+
+
+def declaration_scope_error(path, exempt_prefixes):
+    """The message for a declaration that neither scan root covers.
+
+    Named separately so the refusal text is written once and both the canonical
+    manifest and the instance overlay refuse with the identical wording.
+    """
+    if any(path.startswith(pref) for pref in exempt_prefixes):
+        return None
+    return (f"declared outside the scan roots and not exempt: {path} — "
+            f"expected_tests paths live under {SCAN_ROOTS[0]}/ or directly in "
+            f"{SCAN_ROOTS[1]}/, because the undeclared-artifact direction of the "
+            "diff can only see what those roots discover. Move it, or add a "
+            "scope_exempt {prefix, reason} entry saying why this tree is not "
+            "scanned.")
+
+
+def validate_test_entry(entry, seen, errors, exempt_prefixes=()):
     """One validator for canonical AND overlay entries (finding: overlay
     entries were appended after validation and never validated themselves)."""
     p = entry.get("path", "")
     if unsafe_path(p):
         errors.append(f"unsafe or non-relative path in expected_tests: {p!r}")
         return
+    if not in_scan_scope(p):
+        # ASK-972: this was the silent escape. `in_scan_scope` was consulted only
+        # by the diff, which then had nothing to compare an unscanned path
+        # against, so such a path skipped the undeclared-artifact direction
+        # entirely and nothing said so. Refusing at DECLARATION time is the
+        # earliest point the two scopes can be held equal.
+        msg = declaration_scope_error(p, exempt_prefixes)
+        if msg:
+            errors.append(msg)
     if entry.get("runner") not in ("python3", "bash"):
         errors.append(f"expected_tests entry needs runner python3|bash: {p}")
     if p in seen:
@@ -161,9 +217,10 @@ def validate_manifest(data, errors):
     unknown = set(data) - ALLOWED_TOP_KEYS
     if unknown:
         errors.append(f"manifest unknown top-level keys: {sorted(unknown)}")
+    exempt = validate_scope_exempt(data, errors)
     seen = set()
     for entry in data.get("expected_tests", []):
-        validate_test_entry(entry, seen, errors)
+        validate_test_entry(entry, seen, errors, exempt)
     for set_name in ("required_data", "skeleton_only", "declared_inert"):
         items = data.get(set_name, [])
         paths = [i if isinstance(i, str) else (i or {}).get("path", "") for i in items]
@@ -338,6 +395,12 @@ def load_overlay(root, manifest, errors):
     if unknown:
         errors.append(f"overlay may only ADD {sorted(OVERLAY_ALLOWED_KEYS)}; found: {sorted(unknown)}")
     canonical = {e.get("path") for e in manifest.get("expected_tests", [])}
+    # The overlay reads the CANONICAL exemptions and cannot declare its own:
+    # `scope_exempt` is absent from OVERLAY_ALLOWED_KEYS on purpose. An overlay
+    # that could mint its own exemption would be a per-instance hatch out of the
+    # scan roots, which is the bypass surface load_overlay exists to refuse.
+    exempt = [i["prefix"] for i in manifest.get("scope_exempt", [])
+              if isinstance(i, dict) and i.get("prefix")]
     seen = set(canonical)
     for entry in data.get("expected_tests", []):
         if entry.get("path") in canonical:
@@ -345,7 +408,7 @@ def load_overlay(root, manifest, errors):
         elif entry.get("quarantine"):
             errors.append(f"overlay may not quarantine: {entry.get('path')}")
         else:
-            validate_test_entry(entry, seen, errors)
+            validate_test_entry(entry, seen, errors, exempt)
             manifest.setdefault("expected_tests", []).append(entry)
     canonical_data = {e.get("path") for e in manifest.get("required_data", [])}
     for entry in data.get("required_data", []):
@@ -777,6 +840,16 @@ def main():
     notes.append(f"declared: {len(expected)} tests ({q_count} quarantined), "
                  f"{len(manifest.get('skeleton_only', []))} skeleton-only, "
                  f"{len(manifest.get('declared_inert', []))} declared-inert")
+    # ASK-972: say the coverage boundary out loud on EVERY run. The escape used
+    # to be a property of the source you had to go read; a GREEN that silently
+    # meant "some of these were only half-checked" is the same silent-absence
+    # class the whole gate exists to make loud.
+    n_exempt = sum(1 for e in expected
+                   if isinstance(e, dict) and e.get("path")
+                   and not in_scan_scope(e["path"]))
+    notes.append(f"scan scope: {len(expected) - n_exempt} declared entries inside "
+                 f"the scan roots (checked BOTH directions), {n_exempt} exempt "
+                 "from undeclared-artifact detection (existence-checked only)")
     if errors:  # fail closed on structural problems before trusting the sets
         report(mode, errors, notes)
         sys.exit(1)

--- a/q-system/.q-system/scripts/test/test-dispatch-pinned.sh
+++ b/q-system/.q-system/scripts/test/test-dispatch-pinned.sh
@@ -12,8 +12,15 @@
 # an assertion that has only ever been green cannot tell "the wrapper refuses to
 # force" from "the test cannot see forcing".
 set -uo pipefail
-HERE="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
-WRAPPER="$HERE/kipi-dispatch-pinned.sh"
+# The subject lives at the REPO ROOT (RULE-2026-06-30-A: instance automation is
+# not written into the synced q-system/ subtree), while this test lives in a
+# capability-gate scan root -- same split as test-kipi-update-safety.sh and its
+# root-level subject. Moved here for ASK-972: at the repo root the declaration
+# sat outside both scan roots, so it was invisible to the undeclared-artifact
+# direction of the gate's diff. Renamed test_ -> test- because discover_tests
+# globs TEST_PATTERNS, and `test_*.sh` matches none of them (scar 18a39135).
+ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/../../../.." && pwd)"
+WRAPPER="$ROOT/kipi-dispatch-pinned.sh"
 fails=0
 ok()   { printf 'ok   %s\n' "$1"; }
 bad()  { printf 'FAIL %s\n     %s\n' "$1" "${2:-}"; fails=$((fails + 1)); }
@@ -167,7 +174,7 @@ PAGE_SINK="$NOTE2" KIPI_NOTIFY="$R4/notify.sh" run_wrapper "$R4" "$STRIPPED" >/d
 # Without this the wrapper is dead code: the scheduler keeps running dispatch out
 # of the shared checkout and merging changes nothing. A test that only exercises
 # the wrapper cannot see that, which is exactly how it was missed.
-PLIST="$HERE/q-system/.q-system/scripts/com.kipi.dispatch.plist"
+PLIST="$ROOT/q-system/.q-system/scripts/com.kipi.dispatch.plist"
 if [ -f "$PLIST" ]; then
   grep -q 'kipi-dispatch-pinned.sh' "$PLIST" \
     && ok "T6 the plist runs the pinned wrapper, so it has a production invoker" \

--- a/q-system/.q-system/scripts/test_capability_gate.py
+++ b/q-system/.q-system/scripts/test_capability_gate.py
@@ -526,20 +526,114 @@ def sec_skeleton_only_absent():
     # the scan roots -- the fleet-RED shape codex named on PR #216. The earlier
     # tests created the file first, so no test could fail when it was missing.
     rel = "test_root_only_absent.sh"
+    # ASK-972: a repo-root declaration now needs a scope_exempt prefix, so the
+    # fixture carries one. That is load-bearing rather than boilerplate — it is
+    # what proves the exemption waives only the SCOPE check: the skeleton case
+    # below still goes RED on the file's absence.
+    ex = [{"prefix": "test_", "reason": "fixture: repo-root skeleton-only artifact"}]
     with tempfile.TemporaryDirectory() as tmp:
         root = make_repo(tmp, skeleton=False)
-        m = base_manifest(expected_tests=[entry(rel, runner="bash")], skeleton_only=[rel])
+        m = base_manifest(expected_tests=[entry(rel, runner="bash")],
+                          skeleton_only=[rel], scope_exempt=ex)
         (root / "q-system/.q-system/capability-manifest.json").write_text(json.dumps(m))
         rc, out = run_gate(root)
         check("skeleton-only-absent: instance is GREEN without the file",
               rc == 0 and "declared-but-missing" not in out)
     with tempfile.TemporaryDirectory() as tmp:
         root = make_repo(tmp)  # skeleton mode: the file MUST exist here
-        m = base_manifest(expected_tests=[entry(rel, runner="bash")], skeleton_only=[rel])
+        m = base_manifest(expected_tests=[entry(rel, runner="bash")],
+                          skeleton_only=[rel], scope_exempt=ex)
         (root / "q-system/.q-system/capability-manifest.json").write_text(json.dumps(m))
         rc, out = run_gate(root)
         check("skeleton-only-absent: skeleton is still RED without the file",
               rc == 1 and "declared-but-missing (outside scan root)" in out)
+
+
+def sec_scan_scope():
+    """ASK-972: a declaration outside SCAN_ROOTS escaped BOTH directions silently.
+
+    The F3 direction (an artifact appearing with no declaration) only ever sees
+    what `discover_tests` walks, so anything declared elsewhere sat in a scope
+    nothing measured -- and nothing SAID so. These cases pin the two halves of
+    the fix: an unannounced escape is refused, an announced one is counted out
+    loud and still has to exist.
+    """
+    stray = "test-stray-probe.sh"
+    # 1. THE REPRODUCER. Declaring a repo-root path is out of both scan roots.
+    #    Before the fix this was accepted in silence and the gate went GREEN.
+    with tempfile.TemporaryDirectory() as tmp:
+        root = make_repo(tmp)
+        add_test(root, stray)
+        m = base_manifest(expected_tests=[entry(stray)])
+        (root / "q-system/.q-system/capability-manifest.json").write_text(json.dumps(m))
+        rc, out = run_gate(root, "--check-only")
+        check("scan-scope: undeclared-exemption escape is RED",
+              rc == 1 and "outside the scan roots" in out)
+        check("scan-scope: the refusal NAMES the scan roots",
+              "q-system/.q-system/scripts" in out)
+
+    # 2. CONTROL. The same artifact inside a scan root is still reported by the
+    #    F3 direction exactly as before -- the fix must not trade one blindness
+    #    for another.
+    with tempfile.TemporaryDirectory() as tmp:
+        root = make_repo(tmp)
+        add_test(root, "q-system/.q-system/scripts/test-stray-probe.sh")
+        rc, out = run_gate(root, "--check-only")
+        check("scan-scope CONTROL: in-scope undeclared still RED",
+              rc == 1 and "present-but-undeclared" in out)
+
+    # 3. An ANNOUNCED escape is accepted -- and the run says how many entries
+    #    are riding it, so the boundary is legible on every run instead of
+    #    being a property you have to go read the source to discover.
+    exempt = [{"prefix": "test-", "reason": "repo-root automation tests"}]
+    with tempfile.TemporaryDirectory() as tmp:
+        root = make_repo(tmp)
+        add_test(root, stray)
+        m = base_manifest(expected_tests=[entry(stray)], scope_exempt=exempt)
+        (root / "q-system/.q-system/capability-manifest.json").write_text(json.dumps(m))
+        rc, out = run_gate(root, "--check-only")
+        check("scan-scope: declared exemption is accepted", rc == 0)
+        check("scan-scope: the run REPORTS the F3-blind count",
+              "1 exempt from undeclared-artifact detection" in out)
+
+    # 4. An exemption waives the SCOPE check, never the EXISTENCE check. If it
+    #    waived both, `scope_exempt` would be a delete-anything hatch.
+    with tempfile.TemporaryDirectory() as tmp:
+        root = make_repo(tmp)
+        m = base_manifest(expected_tests=[entry(stray)], scope_exempt=exempt)
+        (root / "q-system/.q-system/capability-manifest.json").write_text(json.dumps(m))
+        rc, out = run_gate(root, "--check-only")
+        check("scan-scope: exempt-but-vanished is still RED",
+              rc == 1 and "declared-but-missing (outside scan root)" in out)
+
+    # 5. The instance-local overlay runs through the same validator, so it
+    #    cannot be used to smuggle in an escape the canonical manifest refuses.
+    with tempfile.TemporaryDirectory() as tmp:
+        root = make_repo(tmp, skeleton=False)
+        add_test(root, stray)
+        (root / "capability-manifest.local.json").write_text(
+            json.dumps({"expected_tests": [entry(stray)]}))
+        rc, out = run_gate(root, "--check-only")
+        check("scan-scope: overlay cannot smuggle an escape",
+              rc == 1 and "outside the scan roots" in out)
+
+    # 6. The exemption list is itself validated: a reasonless or unsafe prefix
+    #    is a silent hole in the one place that is allowed to make holes.
+    #    The expected message is asserted EXACTLY, and the unknown-top-level-key
+    #    error is asserted ABSENT -- before scope_exempt was a known key these
+    #    same cases went red on "unknown top-level keys", which is a pass for
+    #    entirely the wrong reason.
+    for bad, want, why in (
+        (({"prefix": "test-"},), "scope_exempt entry needs prefix+reason", "reasonless"),
+        (({"prefix": "/etc/", "reason": "x"},),
+         "unsafe or non-relative prefix in scope_exempt", "absolute"),
+        (("test-",), "scope_exempt entry needs prefix+reason", "bare string"),
+    ):
+        with tempfile.TemporaryDirectory() as tmp:
+            root = make_repo(tmp, manifest=base_manifest(scope_exempt=list(bad)))
+            rc, out = run_gate(root, "--check-only")
+            check(f"scan-scope: {why} scope_exempt entry RED",
+                  rc == 1 and want in out and "unknown top-level keys" not in out)
 
 
 SECTIONS = {
@@ -547,6 +641,7 @@ SECTIONS = {
     "wiring": sec_wiring, "runner": sec_runner, "mode": sec_mode,
     "negative-proof": sec_negative_proof,
     "skeleton_only_absent": sec_skeleton_only_absent,
+    "scan-scope": sec_scan_scope,
 }
 
 


### PR DESCRIPTION
Closes the F3 escape in `capability-gate.py`'s declared-vs-actual diff. Linear: ASK-972.

## What the defect was

The gate's docstring claims the diff runs in both directions because "one direction alone would miss F3 (an artifact that appears without a declaration) or mask a vanished test". A declaration whose path started with neither scan root escaped the F3 direction entirely, and nothing said so.

## Where the DoR's premise moved (measured, not assumed)

Measured with the gate's own imported functions:

- **15** declared entries sit outside SCAN_ROOTS, not 1. The DoR's preferred option 1 ("refuse outright") is RED on 15 the day it ships.
- Repo-wide there are **300** tracked test-pattern files against **178** declared, so option 2 ("widen SCAN_ROOTS") surfaces **123** undeclared artifacts.

Both are the gate-red-on-its-own-population shape this repo already names as how a gate gets switched off. So the escape is not removed, it is made legible and impossible to make in silence.

## The fix

- `scope_exempt`: `{prefix, reason}` entries, validated. Reasonless, unsafe, and bare-string entries are RED. Deliberately **absent** from `OVERLAY_ALLOWED_KEYS`, so an instance cannot mint its own hatch out of the scan roots.
- `validate_test_entry` refuses any unexempt declaration outside SCAN_ROOTS, naming them. One validator, one wording, canonical and overlay paths alike.
- The exemption waives the **scope** check only. An exempt-but-vanished entry is still `declared-but-missing (outside scan root)`.
- Every run prints the boundary: `scan scope: 164 declared entries inside the scan roots (checked BOTH directions), 14 exempt from undeclared-artifact detection (existence-checked only)`.
- `test_dispatch_pinned.sh` relocated into a scan root as `q-system/.q-system/scripts/test/test-dispatch-pinned.sh`, renamed `test_` to `test-` because `discover_tests` globs TEST_PATTERNS and `test_*.sh` matches none of them (the 18a39135 scar). Its two `$HERE`-relative lookups now resolve the repo root the way `test-kipi-update-safety.sh` does, since its subject stays at the root per RULE-2026-06-30-A.

## Verification (run, not assumed)

| Command | Result |
|---|---|
| `test_capability_gate.py --only scan-scope` (before) | **6 FAILED** |
| `test_capability_gate.py` (after) | **ALL PASS** |
| mutation: `in_scan_scope` check to `if False` | **3 FAILED** — the new cases can fail for the right reason |
| `capability-gate.py --check-only` | **GREEN**, 164 in scope / 14 exempt |
| `bash .../test-dispatch-pinned.sh` (relocated) | **PASS: dispatch-pinned** |

The three `scope_exempt` validation cases were tightened after the first green: they had passed pre-fix on the `unknown top-level keys` error, which is a pass for entirely the wrong reason. They now assert the exact message and assert the unknown-key error absent.

Full gate with test execution (178 tests) is running; result posted as a comment below.

## Residual, captured not mentioned

`sp-c3d0f4d3`. This does not close the F3 direction *inside* an exempt tree. Whether the other 123 files should be declared, left to their own harness, or excluded by rule is a design call with fleet-wide blast radius (the gate syncs to 20+ instances) and is outside this issue's allowed files.

Do not merge; closeout runs through `/issue-verify` and `/issue-closeout`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)