### PR TITLE
Canonical read path repair: fail-closed resolver, a verifier that can fail, and a digest check that proves it read live data (ASK-965)

### DIFF
--- a/.prd-os/issues/crpr-bus-verifier-can-fail.md
+++ b/.prd-os/issues/crpr-bus-verifier-can-fail.md
@@ -12,10 +12,10 @@ disallowed_files:
   - .claude/**
   - .prd-os/**
 required_checks:
-  - python3 -m pytest -q plugins/kipi-core/kipi-mcp/tests/test_bus_verifier.py
+  - bash -c 'cd plugins/kipi-core/kipi-mcp && PYTHONPATH=src python3 -m pytest -q tests/test_bus_verifier.py'
 required_reviews:
   - runtime-owner
-bypass_check: "python3 -m pytest -q plugins/kipi-core/kipi-mcp/tests/test_bus_verifier.py -k 'reachable or substantive or error_key'"
+bypass_check: "bash -c 'cd plugins/kipi-core/kipi-mcp && PYTHONPATH=src python3 -m pytest -q tests/test_bus_verifier.py -k \"reachable or substantive or error_key or sequencing\"'"
 gate_lifecycle: historical-receipt
 deliverables_count: 1
 ---
@@ -34,4 +34,27 @@ THREE independent defects, THREE independent tests, each shown RED first and eac
 ## Deliverables
 
 <!-- Check each box when it ships; close refuses until checked count equals deliverables_count (locked at issue-start). -->
-- [ ] Make the canonical-digest check reachable, substantive, and error-proof
+- [x] Make the canonical-digest check reachable, substantive, and error-proof
+
+## Evidence
+
+The required_check as originally written COULD NOT RUN. From repo root the bare
+pytest invocation exits 4 on a conftest ImportError (`No module named 'kipi_mcp'`).
+Same defect class as finding-2 / finding-24. Corrected above and re-measured:
+
+    bare   invocation -> rc=4 (conftest ImportError, zero tests collected)
+    scoped invocation -> rc=0, 17 passed
+
+Three defects, three tests, all green; plus the sequencing predicate with BOTH
+branches asserted.
+
+THE SUITE PINNED DEFECT 3. `test_phase1_calendar_with_error_key` was GREEN while
+asserting the buggy behaviour (`warn` on a required file carrying an error key).
+That green test is why the defect survived. It is inverted to assert the verdict
+(`pass is False`), which is part of the fix, not collateral damage.
+
+SUBSTANCE CHECK CALIBRATED AGAINST REAL DATA, not intuition: the live tree yields
+decisions=10, objections=5, warnings=0 and all-empty talk_tracks, so requiring
+talk_tracks would have redded every run against real data. The predicate passes the
+live shape and rejects both the captured all-empty digest and Codex finding-14's
+nonempty placeholder.

--- a/.prd-os/issues/crpr-bus-verifier-can-fail.md
+++ b/.prd-os/issues/crpr-bus-verifier-can-fail.md
@@ -1,0 +1,37 @@
+---
+id: crpr-bus-verifier-can-fail
+title: Make the canonical-digest check reachable, substantive, and error-proof
+status: open
+priority: p0
+parent_prd: prd-canonical-read-path-repair-2026-08-22
+allowed_files:
+  - plugins/kipi-core/kipi-mcp/src/kipi_mcp/bus_verifier.py
+  - plugins/kipi-core/kipi-mcp/tests/test_bus_verifier.py
+disallowed_files:
+  - plugins/kipi-core/kipi-mcp/src/kipi_mcp/paths.py
+  - .claude/**
+  - .prd-os/**
+required_checks:
+  - python3 -m pytest -q plugins/kipi-core/kipi-mcp/tests/test_bus_verifier.py
+required_reviews:
+  - runtime-owner
+bypass_check: "python3 -m pytest -q plugins/kipi-core/kipi-mcp/tests/test_bus_verifier.py -k 'reachable or substantive or error_key'"
+gate_lifecycle: historical-receipt
+deliverables_count: 1
+---
+<!-- generated-by: prd_split.py prd=prd-canonical-read-path-repair-2026-08-22 finding=finding-13 at=2026-08-22T20:07:44Z -->
+
+# Make the canonical-digest check reachable, substantive, and error-proof
+
+## Context
+
+Parent PRD: `.prd-os/prds/prd-canonical-read-path-repair-2026-08-22.md`
+
+## Acceptance
+
+THREE independent defects, THREE independent tests, each shown RED first and each killed by its own mutation. (1) REACHABLE: canonical-digest.json is in phase 1 required; reverting only this must turn a test red. (2) SUBSTANTIVE: the exact empty digest captured 2026-08-22 must be rejected - talk_tracks {}, objections [], current_state {}, discovery {}, decisions [], warnings 5 not-found messages, valid false; reverting only the lambda must turn a DIFFERENT test red. (3) ERROR SHORT-CIRCUIT (finding-13): bus_verifier.py:46-52 tests 'error' in data BEFORE the structure check and emits warn WITHOUT setting all_pass=False, so a required canonical-digest.json of exactly {"error":"canonical digest unavailable"} yields pass:true even after (1) and (2). Assert verify() returns pass False for that input. A required-file failure is a hard fail per bus_verifier.py:42-81, so assert on pass, never on the presence of a warn. SEQUENCING (finding-27): making this file required while canonical_dir still resolves to ~/.kipi-system/instances/<name>/canonical turns every phase-1 run red on 23 instances. Add a precondition test asserting canonical_dir does NOT resolve under the plugin-data base; it fails until srsa lands, which is the intended block.
+
+## Deliverables
+
+<!-- Check each box when it ships; close refuses until checked count equals deliverables_count (locked at issue-start). -->
+- [ ] Make the canonical-digest check reachable, substantive, and error-proof

--- a/.prd-os/issues/crpr-consulting-fossil-cleanup.md
+++ b/.prd-os/issues/crpr-consulting-fossil-cleanup.md
@@ -1,0 +1,36 @@
+---
+id: crpr-consulting-fossil-cleanup
+title: Delete consulting frozen canonical tree and its two council fossils
+status: open
+priority: p1
+parent_prd: prd-canonical-read-path-repair-2026-08-22
+allowed_files:
+  - q-system/.q-system/scripts/test/test-canonical-fossil-absent.sh
+disallowed_files:
+  - .claude/**
+  - plugins/**
+  - .prd-os/**
+required_checks:
+  - bash q-system/.q-system/scripts/test/test-canonical-fossil-absent.sh
+required_reviews:
+  - runtime-owner
+bypass_check: "bash q-system/.q-system/scripts/test/test-canonical-fossil-absent.sh"
+gate_lifecycle: historical-receipt
+deliverables_count: 1
+---
+<!-- generated-by: prd_split.py prd=prd-canonical-read-path-repair-2026-08-22 finding=finding-25 at=2026-08-22T20:07:44Z -->
+
+# Delete consulting frozen canonical tree and its two council fossils
+
+## Context
+
+Parent PRD: `.prd-os/prds/prd-canonical-read-path-repair-2026-08-22.md`
+
+## Acceptance
+
+RUNS LAST, after crpr-unhook-dead-canonical-consumers has shipped. SCOPE LIMIT, stated plainly (finding-1, finding-26): the issue runner receipts paths in THIS repo only, so it cannot authorize or receipt the consulting deletions. The kipi-system deliverable is the checker; the deletions are performed in /Users/assafkipnis/projects/consulting as tracked git rm commits and are PROVED by this checker. The checker must not be able to pass vacuously (finding-25): an exit 0 body must fail its own negative self-test, so it takes the consulting path as an argument, refuses if that path does not exist, asserts the 10 tracked files under q-system/canonical/ are gone, asserts q-consult/canonical/ still has its 22 files, and asserts the two instance-owned council fossils (.claude/skills/council/ SKILL.md plus workflows/quick.md and workflows/debate.md, and the orphaned .claude/skills/workflows/ pair) no longer name the dead tree. Those .claude/skills/ copies are NOT covered by config_source_manages (kipi-update.sh:1279-1296) so they persist untouched; fixing only the plugin copy leaves two live wrong copies. Deleting consulting/q-system/canonical/ is safe from the updater because canonical is in INSTANCE_OWNED_SUBTREES (kipi-update.sh:64). Show the checker RED against consulting BEFORE the deletion. Afterwards run the fleet updater in DRY mode against consulting and confirm no restore and no reversion of skeleton edits.
+
+## Deliverables
+
+<!-- Check each box when it ships; close refuses until checked count equals deliverables_count (locked at issue-start). -->
+- [ ] Delete consulting frozen canonical tree and its two council fossils

--- a/.prd-os/issues/crpr-digest-asserts-real-canonical.md
+++ b/.prd-os/issues/crpr-digest-asserts-real-canonical.md
@@ -1,0 +1,87 @@
+---
+id: crpr-digest-asserts-real-canonical
+title: Prove the digest read the live canonical tree, by named value
+status: open
+priority: p0
+parent_prd: prd-canonical-read-path-repair-2026-08-22
+allowed_files:
+  - q-system/.q-system/scripts/test/test-canonical-digest-real-values.py
+disallowed_files:
+  - plugins/kipi-core/kipi-mcp/src/kipi_mcp/morning_init.py
+  - .claude/**
+  - .prd-os/**
+required_checks:
+  - python3 q-system/.q-system/scripts/test/test-canonical-digest-real-values.py --self-test
+required_reviews:
+  - runtime-owner
+bypass_check: "python3 q-system/.q-system/scripts/test/test-canonical-digest-real-values.py --self-test"
+gate_lifecycle: historical-receipt
+deliverables_count: 1
+---
+<!-- added-by: sana prd=prd-canonical-read-path-repair-2026-08-22 finding=finding-14 at=2026-08-22T21:10:00Z -->
+<!-- Added AFTER the original split. finding-14 (blocker) and finding-9 were deferred
+     because no entry in the original six could close them: all six are fixture-level
+     and structurally cannot prove a live canonical tree was read. This entry exists
+     to make that claim executable rather than deferred. -->
+
+# Prove the digest read the live canonical tree, by named value
+
+## Context
+
+Parent PRD: `.prd-os/prds/prd-canonical-read-path-repair-2026-08-22.md`
+
+Closes Codex finding-14 (blocker) and finding-9 (major), which name the same hole
+from two sides: the PRD claimed every acceptance check asserts a real canonical
+value, while no manifest criterion named a decision id or objection string. Codex's
+counterexample was a digest of
+`{"talk_tracks":{"metaphor":"placeholder"},"objections":[],"decisions":[],...}` --
+nonempty, and therefore accepted by any "some field is set" assertion, while having
+read nothing.
+
+## Acceptance
+
+Calls `canonical_digest` against a REAL instance tree and asserts NAMED values.
+
+- **Never assert `digest["valid"]`.** Measured 2026-08-22, the LIVE tree returns
+  `valid: false` (3 of 7 `_validate_digest` checks) because those files were retired
+  to pointer docs whose headings no longer match the template the parsers target. So
+  `valid` is not a signal in either direction. (Shape mismatch: `sp-8804dee7`.)
+- **Never assert mere non-emptiness.** That is finding-14 verbatim.
+- **Derive the expected value; never hardcode it.** This repo is PUBLIC. An
+  independent reader (raw regex for `RULE-\d{4}-\d{2}-\d{2}` over the instance's own
+  `decisions.md`) produces the expectation; the shipping parser must then return the
+  same id. Two independent implementations agreeing on a value present only in that
+  tree is what proves the tree was read, and it keeps the checker instance-agnostic.
+- **Negative control, wired into `--self-test` so the required_check exercises it.**
+  Measured: the live `decisions.md` carries exactly 1 dated rule id; the fossil
+  `q-system/canonical/decisions.md` carries 0 (only `RULE-XXX` / `RULE-001..003`
+  template scaffolding). The checker MUST pass against live and MUST fail against
+  both a synthetic template tree and the real fossil. `--self-test` exits nonzero if
+  either fossil case passes.
+- **Refuse, never skip,** when no qualifying instance is found. A skip is a false green.
+
+## Deliverables
+
+<!-- Check each box when it ships; close refuses until checked count equals deliverables_count (locked at issue-start). -->
+- [x] Prove the digest read the live canonical tree, by named value
+
+## Evidence
+
+Ran: `python3 q-system/.q-system/scripts/test/test-canonical-digest-real-values.py --self-test` -> rc=0
+
+```
+[load-path] canonical_digest imported from .../plugins/kipi-core/kipi-mcp/src/kipi_mcp/morning_init.py
+[control:synthetic-fossil] ... -> FAIL: no dated RULE-YYYY-MM-DD id (template scaffolding)
+[control:real-fossil]      ... -> FAIL: no dated RULE-YYYY-MM-DD id (template scaffolding)
+[subject:live]             ... -> PASS: both readers agree on ['RULE-2026-08-18-A'] (valid=False, not asserted)
+PASS: live tree proved read by name; both fossil controls correctly failed.
+```
+
+Mutation test (the check must be able to fail for the right reason): replacing
+`_parse_decisions` with a nonempty placeholder -- Codex finding-14's exact shape --
+flips the live case to FAIL via the readers-disagree branch. Control passes, mutant
+killed.
+
+Shown RED first: the initial version resolved `REPO` with `parents[3]` instead of
+`parents[4]`, could not import the digest, and exited 3 (REFUSED) rather than
+passing. The refusal path was therefore exercised before the pass path.

--- a/.prd-os/issues/crpr-one-canonical-resolver.md
+++ b/.prd-os/issues/crpr-one-canonical-resolver.md
@@ -1,0 +1,38 @@
+---
+id: crpr-one-canonical-resolver
+title: One fail-closed resolver for an instance canonical root
+status: open
+priority: p0
+parent_prd: prd-canonical-read-path-repair-2026-08-22
+allowed_files:
+  - q-system/.q-system/scripts/evidence_ledger.py
+  - q-system/.q-system/scripts/test_evidence_ledger.py
+  - instance-registry.json
+disallowed_files:
+  - .claude/**
+  - plugins/**
+  - .prd-os/**
+required_checks:
+  - python3 q-system/.q-system/scripts/test_evidence_ledger.py
+required_reviews:
+  - runtime-owner
+bypass_check: "python3 q-system/.q-system/scripts/test_evidence_ledger.py"
+gate_lifecycle: historical-receipt
+deliverables_count: 1
+---
+<!-- generated-by: prd_split.py prd=prd-canonical-read-path-repair-2026-08-22 finding=finding-16 at=2026-08-22T20:07:44Z -->
+
+# One fail-closed resolver for an instance canonical root
+
+## Context
+
+Parent PRD: `.prd-os/prds/prd-canonical-read-path-repair-2026-08-22.md`
+
+## Acceptance
+
+Write the failing cases FIRST and show them RED. instance_root() must FAIL CLOSED, not guess, on all three measured gaps: (a) two named q-* dirs both containing canonical/ (today sorted()[0] silently wins, finding-17); (b) a resolved directory with no canonical/ subdir, measured on the two instances whose q-system holds no canonical/ (finding-18); (c) registry instance_q_dir disagreeing with the filesystem, the four instances where the registry says null while a real domain dir containing canonical/ exists (finding-16); enumerate them with the --audit-instance-roots command in the PRD rather than hardcoding names, since this repo is public. Fill in those four instance_q_dir values in instance-registry.json (the registry is gitignored-safe to name locally, the PRD is not) so registry and filesystem agree, and make the resolver read the registry as authority with the filesystem as a cross-check that RAISES on mismatch. NOTE the harness convention: this suite is main-based with case_* functions and pytest collects ZERO tests from it (finding-3, finding-29), so the required_check invokes it directly with python3; do NOT convert it to pytest as a way of making a check go green.
+
+## Deliverables
+
+<!-- Check each box when it ships; close refuses until checked count equals deliverables_count (locked at issue-start). -->
+- [ ] One fail-closed resolver for an instance canonical root

--- a/.prd-os/issues/crpr-reconcile-claude-rules.md
+++ b/.prd-os/issues/crpr-reconcile-claude-rules.md
@@ -1,0 +1,35 @@
+---
+id: crpr-reconcile-claude-rules
+title: Reconcile the rules that mandate the dead path, via the sanctioned path
+status: open
+priority: p1
+parent_prd: prd-canonical-read-path-repair-2026-08-22
+allowed_files:
+  - q-system/.q-system/scripts/test/test-claude-rules-canonical-reconciled.sh
+disallowed_files:
+  - plugins/**
+  - .prd-os/**
+required_checks:
+  - bash q-system/.q-system/scripts/test/test-claude-rules-canonical-reconciled.sh
+required_reviews:
+  - runtime-owner
+bypass_check: "bash q-system/.q-system/scripts/test/test-claude-rules-canonical-reconciled.sh"
+gate_lifecycle: historical-receipt
+deliverables_count: 1
+---
+<!-- generated-by: prd_split.py prd=prd-canonical-read-path-repair-2026-08-22 finding=finding-21 at=2026-08-22T20:07:44Z -->
+
+# Reconcile the rules that mandate the dead path, via the sanctioned path
+
+## Context
+
+Parent PRD: `.prd-os/prds/prd-canonical-read-path-repair-2026-08-22.md`
+
+## Acceptance
+
+folder-structure.md:257-264 actively mandates that all scripts MUST resolve QROOT to q-system/, a direct contradiction of this PRD; four skeleton-synced rules carry frontmatter globs on the dead path (md-hygiene.md:4, anti-misclassification.md:4, sycophancy.md:5, folder-structure.md:236). No other entry can touch these: every one disallows .claude/** (finding-21, finding-5). The EDITS go through apply-claude-changes.sh, the sanctioned proposal path enforced by the claude-path-write-guard hook - do NOT write .claude/ directly and do NOT weaken the hook. This entry allowed_files holds only the checker, which asserts the contradiction is gone and the four globs resolve through the resolver. Show it RED first. Also enumerate the ~20 agent-pipeline prompts under q-system/.q-system/agent-pipeline/agents/ that reference the path and report them explicitly; if this entry does not repoint them, say so rather than implying coverage (finding-11).
+
+## Deliverables
+
+<!-- Check each box when it ships; close refuses until checked count equals deliverables_count (locked at issue-start). -->
+- [ ] Reconcile the rules that mandate the dead path, via the sanctioned path

--- a/.prd-os/issues/crpr-skeleton-resolves-live-canonical.md
+++ b/.prd-os/issues/crpr-skeleton-resolves-live-canonical.md
@@ -1,0 +1,39 @@
+---
+id: crpr-skeleton-resolves-live-canonical
+title: Council and wiring-check call the resolver instead of hardcoding a path
+status: open
+priority: p1
+parent_prd: prd-canonical-read-path-repair-2026-08-22
+allowed_files:
+  - plugins/kipi-ops/skills/council/SKILL.md
+  - plugins/kipi-ops/skills/council/workflows/quick.md
+  - plugins/kipi-ops/skills/council/workflows/debate.md
+  - plugins/kipi-core/commands/wiring-check.md
+  - q-system/.q-system/scripts/test/test-council-resolves-canonical.sh
+disallowed_files:
+  - .claude/**
+  - .prd-os/**
+required_checks:
+  - bash q-system/.q-system/scripts/test/test-council-resolves-canonical.sh
+required_reviews:
+  - runtime-owner
+bypass_check: "bash q-system/.q-system/scripts/test/test-council-resolves-canonical.sh"
+gate_lifecycle: historical-receipt
+deliverables_count: 1
+---
+<!-- generated-by: prd_split.py prd=prd-canonical-read-path-repair-2026-08-22 finding=finding-19 at=2026-08-22T20:07:44Z -->
+
+# Council and wiring-check call the resolver instead of hardcoding a path
+
+## Context
+
+Parent PRD: `.prd-os/prds/prd-canonical-read-path-repair-2026-08-22.md`
+
+## Acceptance
+
+THIRTEEN references, not nine (finding-12, finding-30, recounted: SKILL.md 4, quick.md 4, debate.md 4, wiring-check.md 1). The check must assert the resolver is REACHED, not that a substring is absent: a literal negated grep on q-system/canonical/ is a false green because q-system//canonical/ or a concatenated path keeps the dead tree while passing (finding-19). Write test-council-resolves-canonical.sh to (a) assert every one of the 13 sites names the resolver, and (b) run a positive control against a fixture instance whose domain dir is NOT q-system and assert the resolved path is that dir. Show it RED before the edit. NEVER hardcode q-consult/: 8 registered instances have instance_q_dir null. ALSO IN SCOPE (finding-20): council's q-system/my-project/ references (SKILL.md:37,39 relationships.md and competitive-landscape.md) are the same defect in the same files and are left pointing at a fossil if only canonical is fixed.
+
+## Deliverables
+
+<!-- Check each box when it ships; close refuses until checked count equals deliverables_count (locked at issue-start). -->
+- [ ] Council and wiring-check call the resolver instead of hardcoding a path

--- a/.prd-os/issues/crpr-unhook-dead-canonical-consumers.md
+++ b/.prd-os/issues/crpr-unhook-dead-canonical-consumers.md
@@ -1,0 +1,37 @@
+---
+id: crpr-unhook-dead-canonical-consumers
+title: Stop requiring the dead tree, then delete the skeleton's plugin copy
+status: open
+priority: p0
+parent_prd: prd-canonical-read-path-repair-2026-08-22
+allowed_files:
+  - q-system/.q-system/scripts/verify-containment-export.py
+  - q-system/.q-system/scripts/test/test-verify-containment-export.sh
+  - plugins/kipi-core/kipi-mcp/canonical/**
+disallowed_files:
+  - .claude/**
+  - .prd-os/**
+required_checks:
+  - bash q-system/.q-system/scripts/test/test-verify-containment-export.sh
+required_reviews:
+  - runtime-owner
+bypass_check: "bash q-system/.q-system/scripts/test/test-verify-containment-export.sh"
+gate_lifecycle: historical-receipt
+deliverables_count: 1
+---
+<!-- generated-by: prd_split.py prd=prd-canonical-read-path-repair-2026-08-22 finding=finding-22 at=2026-08-22T20:07:44Z -->
+
+# Stop requiring the dead tree, then delete the skeleton's plugin copy
+
+## Context
+
+Parent PRD: `.prd-os/prds/prd-canonical-read-path-repair-2026-08-22.md`
+
+## Acceptance
+
+THREE hardcoded consumers, not two. Beyond EXPECTED_EXPORT_PATHS:24-28, RECEIPT_RELATIVE_PATH:30-32 is q-system/canonical/.containment-receipt.json and is loaded BEFORE any export path is validated, so the deletion breaks it first (finding-22). Define the receipt schema change explicitly (finding-7, finding-23): _validate_file_receipt requires source_path == destination_path AND membership in EXPECTED_EXPORT_PATHS, while the source is read as a git blob from the skeleton commit and the destination from the instance owner root - so repointing both to q-consult makes the source blob absent and repointing one violates the equality check. The spec must state the new source/destination split and bump the receipt schema_version. The required_check is a NEW harness because the bare script cannot run: it requires --instance and exits 2 on argparse (finding-2, finding-24); the harness must invoke it with a real instance and must FAIL if given a default. Prove exit 0 against an instance whose canonical lives outside q-system/. Only after that: git rm the SKELETON plugins/kipi-core/kipi-mcp/canonical/ tree, because plugins/ is mirrored with rsync -a --delete --delete-excluded (kipi-update.sh:2460) and deleting it elsewhere regenerates it.
+
+## Deliverables
+
+<!-- Check each box when it ships; close refuses until checked count equals deliverables_count (locked at issue-start). -->
+- [ ] Stop requiring the dead tree, then delete the skeleton's plugin copy

--- a/.prd-os/issues/srsa-authoritative-path-contract.md
+++ b/.prd-os/issues/srsa-authoritative-path-contract.md
@@ -1,23 +1,24 @@
 ---
 id: srsa-authoritative-path-contract
 title: Implement the authoritative instance and fleet path contract
-status: open
+status: in-progress
 priority: p0
 parent_prd: prd-single-runtime-state-authority-2026-07-24
 allowed_files:
   - plugins/kipi-core/kipi-mcp/src/kipi_mcp/paths.py
   - plugins/kipi-core/kipi-mcp/tests/test_paths.py
   - plugins/kipi-core/kipi-mcp/tests/conftest.py
+  - plugins/kipi-core/.claude-plugin/plugin.json
 disallowed_files:
   - q-system/canonical/**
   - q-system/my-project/**
   - instance-registry.json
   - .prd-os/**
 required_checks:
-  - python3 -m pytest -q plugins/kipi-core/kipi-mcp/tests/test_paths.py
+  - PYTHONPATH=plugins/kipi-core/kipi-mcp/src python3 -m pytest -q plugins/kipi-core/kipi-mcp/tests/test_paths.py
 required_reviews:
   - runtime-owner
-bypass_check: "python3 -m pytest -q plugins/kipi-core/kipi-mcp/tests/test_paths.py -k 'ambiguous or plugin_cache_write'"
+bypass_check: "PYTHONPATH=plugins/kipi-core/kipi-mcp/src python3 -m pytest -q plugins/kipi-core/kipi-mcp/tests/test_paths.py -k 'ambiguous or plugin_cache_write'"
 deliverables_count: 1
 ---
 <!-- generated-by: prd_split.py prd=prd-single-runtime-state-authority-2026-07-24 finding=finding-1 at=2026-07-24T20:54:11Z -->

--- a/.prd-os/issues/srsa-authoritative-path-contract.md
+++ b/.prd-os/issues/srsa-authoritative-path-contract.md
@@ -7,6 +7,7 @@ parent_prd: prd-single-runtime-state-authority-2026-07-24
 allowed_files:
   - plugins/kipi-core/kipi-mcp/src/kipi_mcp/paths.py
   - plugins/kipi-core/kipi-mcp/tests/test_paths.py
+  - plugins/kipi-core/kipi-mcp/tests/conftest.py
 disallowed_files:
   - q-system/canonical/**
   - q-system/my-project/**
@@ -30,6 +31,29 @@ Parent PRD: `.prd-os/prds/prd-single-runtime-state-authority-2026-07-24.md`
 ## Acceptance
 
 Write failing root-resolution and ambiguity tests first. Derive each instance state root from registry path, subtree_prefix, and instance_q_dir, require an explicit standalone mapping, and resolve fleet registry only from KIPI_FLEET_ROOT.
+
+AMENDED 2026-08-22 (prd-canonical-read-path-repair-2026-08-22, finding-10). The
+acceptance above never mentioned `my_project_dir`, so this issue's required_check could
+pass while `current_state` stayed empty. Added, in scope because it is the same property
+table in the same file:
+
+- `my_project_dir` resolves from the instance tree exactly as `canonical_dir` does. It is
+  the identical defect: `morning_init.py:192` reads `current-state.md` from
+  `paths.my_project_dir`, which today points at `~/.kipi-system/instances/<name>/`.
+- Do NOT treat `valid: true` as proof this landed. `_validate_digest` needs 5 of 7 checks
+  and dropping `current_state.works_today` still leaves 6 reachable, so the headline
+  signal goes green with this half broken (finding-28). Assert `current_state` directly.
+- END-TO-END ASSERTION (finding-9, finding-14): call `kipi_canonical_digest` from the
+  consulting instance and assert a REAL value that exists in no template and in no fossil
+  stub -- the heading `RULE-2026-08-18-A` from that instance's live `decisions.md`. The
+  fossil stubs each carry exactly one fenced `### RULE-XXX: [Name]` template heading and
+  `_split_sections` does not skip fences, so asserting on the shape rather than the value
+  is a false green.
+- `ensure_dirs()` (`paths.py:218-221`) mkdirs both properties. Once they are repo-derived,
+  an unset `repo_dir` writes into the real plugin dir; `test_paths.py:136` is the case.
+- `conftest.py` has NO fixture with a non-null `instance_q_dir` (lines 58, 66), so the
+  registry branch would ship untested. Add one. conftest.py is added to allowed_files for
+  exactly this.
 
 ## Deliverables
 

--- a/.prd-os/issues/srsa-authoritative-path-contract.md
+++ b/.prd-os/issues/srsa-authoritative-path-contract.md
@@ -1,24 +1,32 @@
 ---
 id: srsa-authoritative-path-contract
 title: Implement the authoritative instance and fleet path contract
-status: in-progress
+status: open
 priority: p0
 parent_prd: prd-single-runtime-state-authority-2026-07-24
 allowed_files:
   - plugins/kipi-core/kipi-mcp/src/kipi_mcp/paths.py
+  - plugins/kipi-core/kipi-mcp/src/kipi_mcp/morning_init.py
+  - plugins/kipi-core/kipi-mcp/src/kipi_mcp/validator.py
   - plugins/kipi-core/kipi-mcp/tests/test_paths.py
+  - plugins/kipi-core/kipi-mcp/tests/test_backup.py
+  - plugins/kipi-core/kipi-mcp/tests/test_morning_init.py
+  - plugins/kipi-core/kipi-mcp/tests/test_validator.py
+  - plugins/kipi-core/kipi-mcp/tests/test_bus_verifier.py
   - plugins/kipi-core/kipi-mcp/tests/conftest.py
   - plugins/kipi-core/.claude-plugin/plugin.json
 disallowed_files:
   - q-system/canonical/**
   - q-system/my-project/**
+  - q-system/.q-system/scripts/evidence_ledger.py
   - instance-registry.json
   - .prd-os/**
 required_checks:
   - PYTHONPATH=plugins/kipi-core/kipi-mcp/src python3 -m pytest -q plugins/kipi-core/kipi-mcp/tests/test_paths.py
+  - PYTHONPATH=plugins/kipi-core/kipi-mcp/src python3 -m pytest -q plugins/kipi-core/kipi-mcp/tests/test_paths.py plugins/kipi-core/kipi-mcp/tests/test_backup.py plugins/kipi-core/kipi-mcp/tests/test_morning_init.py plugins/kipi-core/kipi-mcp/tests/test_validator.py plugins/kipi-core/kipi-mcp/tests/test_bus_verifier.py
 required_reviews:
   - runtime-owner
-bypass_check: "PYTHONPATH=plugins/kipi-core/kipi-mcp/src python3 -m pytest -q plugins/kipi-core/kipi-mcp/tests/test_paths.py -k 'ambiguous or plugin_cache_write'"
+bypass_check: "PYTHONPATH=plugins/kipi-core/kipi-mcp/src python3 -m pytest -q plugins/kipi-core/kipi-mcp/tests/test_paths.py -k 'fails_closed or resolves_instance_domain_dir'"
 deliverables_count: 1
 ---
 <!-- generated-by: prd_split.py prd=prd-single-runtime-state-authority-2026-07-24 finding=finding-1 at=2026-07-24T20:54:11Z -->
@@ -55,6 +63,102 @@ table in the same file:
 - `conftest.py` has NO fixture with a non-null `instance_q_dir` (lines 58, 66), so the
   registry branch would ship untested. Add one. conftest.py is added to allowed_files for
   exactly this.
+
+## AMENDMENT 2026-08-22b (Sana) -- the spec's own checks could not run
+
+Recorded here rather than via `/issue-amend` on purpose: `active-issue.json` is CLEARED
+(issue_id null) and this spec still claimed `status: in-progress` with zero receipts and
+no receipt chain behind commit 9d8d671e. Loading the issue only to amend it would have
+put a live issue on the board mid-amendment. Status is set back to `open`, which is what
+is actually true. Amend the loaded snapshot with `/issue-amend` at the next `issue-start`.
+
+**1. bypass_check named no test that exists (sp-b82fda60, blocker).**
+The selector was `-k 'ambiguous or plugin_cache_write'`. Neither name appears anywhere in
+`plugins/kipi-core/kipi-mcp/tests/`. Measured:
+
+    pytest ... -k 'ambiguous or plugin_cache_write'   -> rc=5  (no tests collected)
+
+`issue_runner.py` `_close_preflight` calls `prd_runner.gate_register(..., command=bypass_check)`
+at CLOSE and **never runs it**. So closing this issue as written would have written a
+standing gate into `.prd-os/gates.jsonl` that exits 5 forever, and `gates run` is in this
+repo's definition of done. Gates only grow; there is no hand-clear. Replaced with a
+selector that collects 3 real cases and is RED today for the right reason:
+
+    -k 'fails_closed or resolves_instance_domain_dir'  -> collects 3, rc=1 today
+
+It goes green exactly when the resolver lands, which is what a bypass_check is for.
+PROVE IT COLLECTS with `--collect-only` before closing. The runner will not.
+
+**2. allowed_files was short (sp-aaef828d).** The spillover said "short by three"; the
+measured set is larger. Files referencing `canonical_dir` / `my_project_dir` /
+`tmp_kipi_paths`, counted 2026-08-22:
+
+    src : paths.py, morning_init.py, validator.py, bus_verifier.py
+    test: conftest.py(1) test_backup.py(19) test_bus_verifier.py(3)
+          test_morning_init.py(49) test_paths.py(14) test_validator.py(1)
+
+`tmp_kipi_paths` calls `ensure_dirs()`, so a fail-closed resolver reaches every one of
+them. With the old 4-entry list the scope hook would have blocked those edits mid-build.
+Widened above. `bus_verifier.py` is deliberately NOT added -- it is already being changed
+under `crpr-bus-verifier-can-fail` and two issues must not both own one file.
+
+**3. A second required_check pins the collateral.** The single-file check could go green
+while the resolver broke the other suites. Baseline measured 2026-08-22 on the 5 in-scope
+test files: **5 failed (this issue's reproducer), 91 passed**. The 91 is the number that
+must not drop. Note `pytest tests/` as a whole is NOT usable as a check: 5 unrelated
+modules fail collection on `ModuleNotFoundError: No module named 'yaml'`, pre-existing and
+environmental, so a directory-wide check would be red for a reason this issue cannot fix.
+
+**4. Reproducer status: red, and red for the right reason (sp-0cf100b3).**
+Commit 9d8d671e claimed a red reproducer. It ERRORED AT COLLECTION, so none of the 5
+cases ever ran. Three stacked defects, fixed in commit 63248474:
+`PathContractError` imported but never defined (module-level ImportError = collection
+error); `registry_fixture` defined nowhere, repointed at `tmp_registry_with_instances`;
+and `test_ensure_dirs_never_creates_repo_owned_dirs` asserted a sentinel name nothing
+creates, so it PASSED against unfixed code. Now: `--collect-only` prints 20 tests, and
+5 fail on their own assertions. Do not re-verify by re-running only the file -- confirm
+`--collect-only` first, every time.
+
+## ARBITRATION 2026-08-22 (Sana): two p0 issues, one resolver (sp-36677c6f)
+
+`crpr-one-canonical-resolver` builds a registry-backed fail-closed `instance_root()` in
+`q-system/.q-system/scripts/evidence_ledger.py`. This issue builds one in
+`plugins/kipi-core/kipi-mcp/src/kipi_mcp/paths.py`. The parent PRD decided "ONE resolver"
+and that decision is not currently held by either spec.
+
+**They cannot share an implementation as written.** `crpr-one-canonical-resolver` lists
+`disallowed_files: plugins/**`; this issue touches only `plugins/`. The allowed_file sets
+are mutually exclusive, so "just import the other one" is not available to either issue.
+
+Three options, and why the pick:
+
+- (a) `evidence_ledger.py` imports the resolver from `kipi_mcp.paths`. REJECTED. A
+  `q-system/` script ships to 23 instances via `kipi update` rsync, while the plugin RUNS
+  from the marketplace clone at `~/.claude/plugins/marketplaces/`. The import would
+  resolve to the instance's synced `plugins/` copy, which is a different file from the one
+  executing. That is the load-path scar exactly, and it would be correct in this repo and
+  wrong in the deployed layout.
+- (b) `kipi_mcp.paths` imports from `evidence_ledger.py`. REJECTED for the mirror reason:
+  the MCP server has no `q-system/` on its path.
+- (c) **PICKED. One CONTRACT, two thin call sites, one conformance test.** A single
+  executable table of resolution cases (ambiguous two-domain-dir, resolved dir with no
+  `canonical/`, registry disagreeing with the filesystem, unregistered repo) that BOTH
+  implementations are run against by one test. Neither tree imports the other; drift
+  between them is a test failure rather than a discovery months later.
+
+(c) keeps the PRD's intent -- one behaviour, enforced -- without inventing an import that
+crosses a deployment boundary. **Sequencing: this issue lands first** and owns the
+contract table, because it owns the runtime path that `kipi_canonical_digest` actually
+uses; `crpr-one-canonical-resolver` then conforms to the table rather than authoring a
+second one. The conformance test is a deliverable of whichever issue lands SECOND, so it
+cannot be written against only one implementation.
+
+**Duplicate fixtures:** `srsa-registry-state-root-fixtures` claims ownership of the
+`instance_q_dir` / subtree-fallback fixtures that this issue's reproducer already wrote
+into `conftest.py` (`registry_with_domain_dir`) and `test_paths.py`. Those fixtures are
+SHIPPED as of commit 63248474. `srsa-registry-state-root-fixtures` must not re-author
+them; its remaining scope is whatever it needs beyond `registry_with_domain_dir`, and if
+that is nothing it should be closed as delivered-by this issue rather than worked.
 
 ## Deliverables
 

--- a/.prd-os/issues/srsa-authoritative-path-contract.md
+++ b/.prd-os/issues/srsa-authoritative-path-contract.md
@@ -160,6 +160,36 @@ SHIPPED as of commit 63248474. `srsa-registry-state-root-fixtures` must not re-a
 them; its remaining scope is whatever it needs beyond `registry_with_domain_dir`, and if
 that is nothing it should be closed as delivered-by this issue rather than worked.
 
+## SIZING, measured 2026-08-22 by building it and throwing it away
+
+A throwaway resolver was implemented against this spec and MEASURED, then reverted,
+so the cost below is observed rather than estimated. Registry-as-authority keyed on
+instance name, `instance_q_dir or subtree_prefix`, raising PathContractError on an
+unmapped instance:
+
+  the 4 resolution cases          -> PASS
+  test_paths.py overall           -> 3 failed / 17 passed (was 5 / 15)
+  the 5 in-scope test files       -> 8 failed + 50 ERRORS / 38 passed
+                                     (baseline: 5 failed / 91 passed)
+
+So the resolver itself is small; the work is the **53 collateral tests** it breaks.
+Most are collection ERRORS in test_validator.py and test_morning_init.py, because
+`tmp_kipi_paths` builds KipiPaths with an instance name that no registry lists, and
+a fail-closed resolver raises where those fixtures expect a path. That is the real
+deliverable: every fixture that wants canonical/my-project must register its temp
+repo, exactly as the evidence_ledger fixtures had to (commit e469bddc).
+
+Two conflicts to settle while doing it, both already visible in the numbers:
+- `test_ensure_dirs` (test_paths.py:136) asserts canonical_dir IS created. The new
+  `test_ensure_dirs_never_creates_repo_owned_dirs` asserts it is NOT. They cannot
+  both hold; ensure_dirs must stop mkdir-ing the two repo-owned properties and
+  test_ensure_dirs must drop them from its expected list.
+- `test_instance_subdirectories` asserts the plugin-data shape for both properties.
+
+NOT bundled into PR #240 for a measured reason, not a preference: that PR is
+CI-green, and adding 53 collateral failures to a 20-file PR mid-review makes the
+review surface unreadable. This issue has its own parent PRD.
+
 ## Deliverables
 
 <!-- Check each box when it ships; close refuses until checked count equals deliverables_count (locked at issue-start). -->

--- a/.prd-os/judgments-tip.json
+++ b/.prd-os/judgments-tip.json
@@ -1,6 +1,6 @@
 {
-  "count": 35,
-  "last_receipt_id": "jr-2fdf266cc996e03e",
-  "last_receipt_sha256": "c3cb672b22448ae422d8a3b12468462ab01e223f4e2c6b2854d19bee4c49e06a",
-  "updated_at": "2026-08-21T17:22:51Z"
+  "count": 65,
+  "last_receipt_id": "jr-c34933d28f0e1eb8",
+  "last_receipt_sha256": "b69befd01f775c74edae9e820857c2ad5e7d2ddb487cab73cee91c8c64fa56cc",
+  "updated_at": "2026-08-22T20:07:22Z"
 }

--- a/.prd-os/prds/prd-canonical-read-path-repair-2026-08-22.md
+++ b/.prd-os/prds/prd-canonical-read-path-repair-2026-08-22.md
@@ -328,9 +328,9 @@ not held by anything.
       ".prd-os/**"
     ],
     "required_checks": [
-      "python3 -m pytest -q plugins/kipi-core/kipi-mcp/tests/test_bus_verifier.py"
+      "bash -c 'cd plugins/kipi-core/kipi-mcp && PYTHONPATH=src python3 -m pytest -q tests/test_bus_verifier.py'"
     ],
-    "bypass_check": "python3 -m pytest -q plugins/kipi-core/kipi-mcp/tests/test_bus_verifier.py -k 'reachable or substantive or error_key'",
+    "bypass_check": "bash -c 'cd plugins/kipi-core/kipi-mcp && PYTHONPATH=src python3 -m pytest -q tests/test_bus_verifier.py -k \"reachable or substantive or error_key or sequencing\"'",
     "required_reviews": [
       "runtime-owner"
     ],

--- a/.prd-os/prds/prd-canonical-read-path-repair-2026-08-22.md
+++ b/.prd-os/prds/prd-canonical-read-path-repair-2026-08-22.md
@@ -1,12 +1,14 @@
 ---
 id: prd-canonical-read-path-repair-2026-08-22
 title: Canonical Read Path Repair
-status: idea
+status: in-review
 created_at: 2026-08-22T19:37:28Z
-updated_at: 2026-08-22T19:37:28Z
+updated_at: 2026-08-22T19:59:11Z
 owner: sana
 reviewers: []
 findings_path: .prd-os/findings/prd-canonical-read-path-repair-2026-08-22-findings.jsonl
+codex_reviewed_at: 2026-08-22T20:00:02Z
+reviewed_by: codex-adversarial
 ---
 
 # Canonical Read Path Repair

--- a/.prd-os/prds/prd-canonical-read-path-repair-2026-08-22.md
+++ b/.prd-os/prds/prd-canonical-read-path-repair-2026-08-22.md
@@ -13,123 +13,362 @@ findings_path: .prd-os/findings/prd-canonical-read-path-repair-2026-08-22-findin
 
 ## Problem
 
-<!-- What pain is this solving? Concrete, observed, measurable. -->
+Consulting holds three diverged canonical trees with identical filenames, and every
+consumer in the fleet is split cleanly between them: **everything the instance wrote
+points at `q-consult/canonical/`; everything the skeleton shipped points at
+`q-system/canonical/`.**
+
+Measured, not assumed:
+
+- `q-consult/canonical/` is live: 22 files, 4,478 lines, last written 2026-08-20.
+- `q-system/canonical/` in consulting is frozen at 2026-07-01 template stubs. Its
+  `pricing-framework.md` is 27 lines and contains no prices; the live one is 416 lines.
+- `plugins/kipi-core/kipi-mcp/canonical/` is frozen at 2026-06-10.
+- 1,345 founder-typed messages in the consulting transcripts contain 14 "read the
+  canonical files" asks and 7 "you missed it, it's in the file". The same patterns
+  occur **zero** times across 770 founder-typed messages in kipi-system. The defect is
+  consulting-specific, and it is the instance where the trees diverged.
+
+The digest that exists to prevent this is itself pointed at a fourth, empty location.
+`kipi_canonical_digest` resolves `canonical_dir` to
+`~/.kipi-system/instances/{name}/canonical` (`paths.py:130`), which holds zero files.
+It returns every file "not found" and `valid: false`. It exists to save 40-60K tokens
+against reading full canonical; when it returns nothing, agents fall back to raw files
+and pick from three copies.
+
+**Nothing catches any of this.** `digest["valid"]` is read nowhere outside its own unit
+test, and the one verifier check that names `canonical-digest.json`
+(`bus_verifier.py:102`) is unreachable dead code — the file is listed in phase 1's
+`checks` dict while appearing in neither `required` nor `optional`, so the lambda never
+runs. Even if it ran, it is key-presence only (`"talk_tracks" in d`), so the exact empty
+digest observed today would pass it.
+
+File length and wrong-file are one chain: 4,478 lines is *why* a digest exists. Digest
+broken to raw-file fallback to three copies to wrong answer.
 
 ## Goals
 
-- 
+- The verifier can fail on an empty digest, and is reached at all.
+- Every skeleton-shipped reference to canonical resolves the instance's live tree
+  through one tested resolver, never a hardcoded path.
+- The dead trees are gone, and the plugin copy stops regenerating on the next sync.
+- No consumer breaks as a result of the deletions.
 
 ## Non-goals
 
-- 
+- **Part 1, repointing `paths.py` `canonical_dir`, is deliberately NOT in this PRD.**
+  It is already covered by the approved, Codex-reviewed
+  `.prd-os/prds/prd-single-runtime-state-authority-2026-07-24.md` and its open p0 issue
+  `.prd-os/issues/srsa-authoritative-path-contract.md`, whose `allowed_files` is exactly
+  `[paths.py, test_paths.py]` and whose `required_checks` are already defined. Its
+  resolution formula is already decided and reviewed: if `instance_q_dir` is set, use
+  `<path>/<instance_q_dir>`; otherwise `<path>/<subtree_prefix>/q-system`; missing or
+  ambiguous mappings fail closed. `instance-registry.json` already records
+  `"instance_q_dir": "q-consult"` for consulting. Re-specifying it here would duplicate a
+  Codex review already paid for. That issue is EXECUTED alongside this PRD, not inside it.
+- **Part 5, `my_project_dir`, is executed inside that same srsa issue**, not here.
+  `morning_init.py:192` reads `current_state` from `paths.my_project_dir`, which has the
+  identical defect and the identical fossil twin (`q-system/my-project/`, same 2026-07-01
+  commit). It is a one-property change in the same file that srsa already owns. Splitting
+  it out would put two issues in one file. Recorded here because Part 1's own success
+  criterion is unreachable without it: `_validate_digest` (`morning_init.py:534-544`)
+  needs 5 of 7 checks and one of them is `current_state.works_today`.
+- Changing what the canonical files *say*. This is a read-path repair only.
+- Consolidating the three trees into one schema. Only the dead copies are removed.
 
 ## Proposed approach
 
-<!-- How. Keep it scannable. Diagrams go inline as fenced blocks. -->
+Four issues, ordered. The order inside Part 4 is load-bearing: a consumer that hard-codes
+a path must stop requiring it *before* the path is deleted, or the deletion is a runtime
+failure rather than a cleanup.
+
+### Reuse, do not invent
+
+`q-system/.q-system/scripts/evidence_ledger.py:81-93` already implements the resolver,
+and it is tested by `q-system/.q-system/scripts/test_evidence_ledger.py`:
+
+```python
+def instance_root(repo=None) -> Path:
+    repo = Path(repo or os.environ.get("CLAUDE_PROJECT_DIR") or os.getcwd())
+    named = [p for p in sorted(repo.glob("q-*"))
+             if p.is_dir() and p.name != "q-system" and (p / "canonical").is_dir()]
+    return named[0] if named else repo / "q-system"
+```
+
+It resolves to `q-consult/` on consulting and `q-system/` on the skeleton. Precedent it
+cites: `capability-map-gen.py:390`. Skeleton-shipped references use this. They must never
+hardcode `q-consult/`, which is meaningless in the 8 registered instances whose
+`instance_q_dir` is null.
+
+For the MCP side (Part 1, srsa), the registry formula wins over a second glob-based
+resolver: it is the already-reviewed answer, and it fails closed on ambiguity where a
+glob silently picks `sorted()[0]`.
+
+### Part 2 — the verifier can fail
+
+Two steps, in this order, because doing only the second leaves the check unreachable and
+doing only the first arms a check that cannot fail:
+
+1. Wire `canonical-digest.json` into phase 1's `required` list. Semantics at
+   `bus_verifier.py:42-81`: `False` on a **required** file is a hard fail; `False` on an
+   **optional** file is only a warn. A warn is what let this sit.
+2. Replace the key-presence lambda with a substantive assertion: the digest is valid only
+   if it actually carries content, not merely the keys.
+
+Reproducer first. The exact empty digest observed today goes into a pytest case, red
+before the fix:
+
+```json
+{"talk_tracks":{},"objections":[],"current_state":{},"discovery":{},
+ "decisions":[],"warnings":["...5 not-found messages..."],"valid":false}
+```
+
+### Part 3 — skeleton references resolve the live tree
+
+Nine hardcoded `q-system/canonical/` references ship from the skeleton to every instance:
+
+| File | Lines |
+|---|---|
+| `plugins/kipi-ops/skills/council/SKILL.md` | 37, 38, 39, 53 |
+| `plugins/kipi-ops/skills/council/workflows/quick.md` | 15, 16, 17, 77 |
+| `plugins/kipi-ops/skills/council/workflows/debate.md` | 15, 17, 18, 201 |
+| `plugins/kipi-core/commands/wiring-check.md` | 90 |
+
+Council's own `SKILL.md:44` already describes the resulting behaviour without naming the
+cause: "If a canonical file is empty/template, the persona says 'I don't have data to
+ground this'." That is the fossil tree being read, reported as a content problem.
+
+`.claude/rules/folder-structure.md:257-264` must be reconciled in the same change. It
+actively mandates "All scripts MUST resolve QROOT to `q-system/`" — a direct
+counter-precedent. Leaving it makes the rule and the code disagree, which is how the next
+person re-introduces the hardcode and passes review. Editing `.claude/` goes through the
+sanctioned proposal path (`apply-claude-changes.sh`); the `claude-path-write-guard` hook
+blocks anything else, and that is the gate doing its job.
+
+### Part 4 — remove the dead copies, in order
+
+- **(a) FIRST, unhook the consumers.** `verify-containment-export.py:24-28` hard-codes
+  `q-system/canonical/discovery.md` and `pricing-framework.md` as REQUIRED export paths.
+  Deleting before fixing this is a runtime failure, not a warning. Four skeleton-synced
+  rules carry frontmatter globs on the path (`md-hygiene.md:4`,
+  `anti-misclassification.md:4`, `sycophancy.md:5`, `folder-structure.md:236`), plus ~20
+  agent-pipeline prompts under `q-system/.q-system/agent-pipeline/agents/`.
+- **(b) THEN delete `consulting/q-system/canonical/`** (10 tracked files, frozen
+  2026-07-01). Safe from the updater: `canonical` is in `INSTANCE_OWNED_SUBTREES`
+  (`kipi-update.sh:64`), so it is never restored and never `--delete`d.
+- **(c) Delete the plugin canonical copy in the SKELETON**
+  (`kipi-system/plugins/kipi-core/kipi-mcp/canonical/`). Deleting it in consulting does
+  NOT stick: `plugins/` is mirrored by `rsync -a --delete --delete-excluded`
+  (`kipi-update.sh:2460`) with no `canonical` exclude, so it regenerates from the
+  skeleton. The skeleton is the only place the deletion holds.
+- **(d) Consulting's TWO instance-owned council fossils.** `.claude/skills/council/`
+  (`SKILL.md:32-34,48`; `workflows/quick.md:11-13,73`; `workflows/debate.md:11,13,14,197`)
+  and the orphaned `.claude/skills/workflows/` pair. `.claude/skills/` is NOT managed by
+  the syncer — `config_source_manages` (`kipi-update.sh:1279-1296`) covers only
+  `settings.json`, `agents/*.md`, `rules/*.md`, `output-styles/*.md`, `plugins/*/*` — so
+  these persist untouched and currently point at the dead tree. Fixing only the plugin
+  copy leaves two live wrong copies.
+
+Nothing is silently deleted: every deletion is a tracked `git rm` with the reason in the
+commit message, reversible from history.
 
 ## Alternatives considered
 
-<!--
-Options you weighed and rejected. For each: name the option, the tradeoff, and
-the one reason it lost. This is what lets the reviewer tell a deliberately
-rejected path from one you never saw. Empty here reads as "no alternatives
-exist," which is rarely true.
-
-- **<option>** — Rejected: <why>.
--->
+- **Fold Part 1 into this PRD and mark the 2026-07-24 PRD superseded.** Rejected: that
+  PRD is `status: approved` with `codex_reviewed_at: 2026-07-24` and was split into eight
+  p0 issue specs. Re-specifying `paths.py` here throws away a paid Codex review and leaves
+  eight open issues pointing at a superseded parent.
+- **Point the skeleton references at `q-consult/canonical/` directly.** Rejected: these
+  files ship fleet-wide via `kipi update`. 8 of the registered instances have
+  `instance_q_dir: null`, so the path is meaningless there and would break more consumers
+  than it fixes.
+- **Write a second resolver for the skeleton side.** Rejected: `instance_root()` already
+  exists, is tested, and is cited as precedent by `capability-map-gen.py:390`. A second
+  resolver is a second thing to drift.
+- **Delete the dead trees first and fix consumers when they break.** Rejected:
+  `verify-containment-export.py` treats those two paths as required, so the first
+  containment export after the deletion fails closed. Order is the whole point of Part 4.
+- **Leave `bus_verifier.py`'s check optional and just make the lambda substantive.**
+  Rejected: an optional file that fails the structure check only produces a `warn`
+  (`bus_verifier.py:66-81`). A warn is exactly the signal that let an empty digest ship
+  for months.
+- **Make `morning_init` skip fenced code blocks as part of this work.** Rejected as scope
+  creep, captured as spillover instead. It is a real defect (see Scenarios) but it is a
+  parser bug, not a read-path bug, and bundling it would put two causes in one issue.
 
 ## Scenarios
 
-<!--
-Concrete end-to-end walkthroughs of the approach in use. One per distinct path.
-Actor, trigger, steps, outcome. Prove the approach against the real flow, not
-the abstraction.
+- **The council persona that had the data all along.** The founder runs a Quick Council on
+  a pricing question in consulting. `quick.md:16` sends the Investor persona to
+  `q-system/canonical/talk-tracks.md` — the 2026-07-01 stub. The persona reports "I don't
+  have data to ground this" exactly as `SKILL.md:44` predicts, while 416 lines of live
+  pricing sit in `q-consult/canonical/pricing-framework.md`. After Part 3 the same run
+  resolves through `instance_root()` to `q-consult/` and grounds on the live file.
 
-- **<scenario name>.** <actor> does <trigger>; <steps>; <outcome>.
--->
+- **The morning run that reported healthy while reading nothing.** Phase 1 writes
+  `canonical-digest.json` with every field empty and `valid: false`. `bus_verifier`
+  iterates `required` (calendar, gmail, notion), never reaches `canonical-digest.json`
+  because it is in no list, and returns `pass: true`. After Part 2 the same digest lands
+  the file in `required`, the substantive check returns `False`, and the phase hard-fails
+  with a named reason.
 
-## Resolved decisions
+- **The containment export that fails closed after a clean deletion.** Without Part 4(a),
+  an operator deletes `consulting/q-system/canonical/` and the next
+  `verify-containment-export.py` run raises `ContainmentBlocked` on a missing REQUIRED
+  path. With (a) shipped first, the same run resolves through `instance_root()`, finds
+  `q-consult/canonical/discovery.md`, and exits 0.
 
-<!--
-The counterpart to Open questions: decisions now closed, each with its
-rationale. This is the running record of what was settled and why, so it does
-not get re-litigated later.
+- **The plugin copy that comes back.** An operator deletes
+  `consulting/plugins/kipi-core/kipi-mcp/canonical/`. The next fleet sync mirrors
+  `plugins/` with `rsync -a --delete --delete-excluded` and no `canonical` exclude, and the
+  2026-06-10 tree reappears. Part 4(c) deletes it in the skeleton, which is the only copy
+  the mirror reads from.
 
-- **<decision>.** Decided: <choice>. Rationale: <why>.
--->
+- **The false green.** After Parts 1-5 an engineer calls `kipi_canonical_digest` from
+  consulting and sees `valid: true`. This is not sufficient evidence. See Risks.
 
 ## Risks and rollback
 
-<!-- Blast radius, migration cost, how to back out if this ships wrong. -->
+- **A `valid: true` that comes entirely from fence artifacts.** `morning_init`'s markdown
+  parsers (`_split_sections`, `morning_init.py:467-481`) do NOT skip fenced code blocks.
+  The `## Format <!-- pin -->` templates inside the real canonical files contain
+  `### RULE-XXX: [Name]` and `### "[Objection as they say it]"` inside fences, and these
+  parse as real content — `_parse_decisions` matches on `"rule" in heading.lower()`. So a
+  `valid: true` can be produced entirely by template scaffolding. **Every acceptance check
+  in this PRD asserts on a REAL value** — a known decision ID from
+  `q-consult/canonical/decisions.md`, a known objection string — never on `valid` alone. A
+  green nobody has seen go red for the right reason is decoration.
+- **`ensure_dirs()` writing into the repo.** `paths.py:218-221` includes `canonical_dir`
+  and `my_project_dir` in the `mkdir` loop. Once those resolve from the repo rather than
+  plugin-data, an `ensure_dirs()` call with an unset `repo_dir` would create directories
+  inside the real plugin dir. `test_paths.py:136` is the case that exercises this. Handled
+  in srsa, named here because it is this PRD's Part 5 dependency.
+- **Test fixtures with no instance mapping.** `conftest.py:58,66` has NO fixture with a
+  non-null `instance_q_dir`, so the registry branch of the new resolver would ship
+  untested. Adding one is part of srsa's acceptance.
+- **Rollback:** every change is a tracked commit. The deleted trees are frozen content
+  recoverable from git history at any time; nothing is removed from the working tree
+  without a commit that names it.
 
-## Open questions
+## Resolved decisions
 
-- 
+Each decision below names the executable that holds it. A decision recorded only as
+prose here is not held by anything, so it does not belong in this list.
 
-<!--
-## Persona Review (optional, fill in before /prd-review)
-
-Phase 0 of the prd-os planning-personas experiment (PRD prd-planning-personas-2026-05-13).
-For non-trivial PRDs, answer the three Skeptic questions below before invoking /prd-review.
-Brief answers are fine. The goal is to force one round of adversarial thinking before Codex.
-
-### Skeptic
-
-Q1: What is the strongest argument against doing this?
-A1:
-
-Q2: What is the smallest experiment that would disprove the thesis?
-A2:
-
-Q3: What is the cheapest non-build alternative?
-A3:
-
-When done with these questions, uncomment this section and move it to live just before `## Issues` below.
--->
+- **Part 1 stays out of this PRD.** Decided: execute the existing
+  `srsa-authoritative-path-contract` issue instead. Held by that issue's own
+  `required_checks` entry, `pytest -q plugins/kipi-core/kipi-mcp/tests/test_paths.py`,
+  plus its `bypass_check` on the `ambiguous or plugin_cache_write` selector. Rationale:
+  it is approved and Codex-reviewed; re-specifying it here throws that review away.
+- **Part 5 rides in the srsa issue.** Decided: `my_project_dir` is fixed in the same
+  `paths.py` change as `canonical_dir`, under that same pytest check. Rationale: same
+  file, same defect. Part 1's success criterion (`valid: true` from consulting) is
+  unreachable without it, because `_validate_digest` counts `current_state.works_today`.
+- **The skeleton uses `instance_root()`, the MCP uses the registry formula.** Decided:
+  two resolvers, deliberately. Held by the pytest suite
+  `q-system/.q-system/scripts/test_evidence_ledger.py` on the skeleton side and by
+  `test_paths.py` on the MCP side. Rationale: the skeleton side has no registry access at
+  read time; the MCP side has the registry and the reviewed fail-closed formula. Neither
+  hardcodes an instance name.
+- **Order inside Part 4 is (a) consumers, (b) consulting tree, (c) skeleton plugin copy,
+  (d) consulting `.claude/skills` fossils.** Held by the issue runner: the
+  `crpr-consulting-fossil-cleanup` spec cannot pass its `required_checks` script until
+  `crpr-unhook-dead-canonical-consumers` has shipped, because that script asserts the
+  fossil is absent AND `verify-containment-export.py` still exits 0. Rationale: (b)
+  before (a) is a runtime failure; (c) in consulting instead of the skeleton regenerates
+  on the next sync.
+- **Nothing is deleted without a tracked commit.** Decided: `git rm`, never `rm`. Held by
+  the `destructive-op-deny.sh` hook, which blocks `rm -rf` and `git clean -fd`
+  irrespective of any autonomy grant. Rationale: standing rule — never silently delete,
+  keep it reversible and auditable.
 
 ## Issues
 
-<!--
-After review and approval, populate the fenced JSON block below. The manifest is
-read by TWO consumers and every entry must satisfy both:
-  - `prd_split.py` materializes one issue spec per entry (needs `id`).
-  - the approval gate proves every ACCEPTED finding is covered by an entry (needs
-    `finding_id` + a `bypass_check`). One entry per accepted finding.
-
-Required keys per entry (spine-native -- both consumers):
-  - id (kebab-case, unique across the repo)            -- prd_split.py
-  - finding_id (the accepted finding it covers, e.g. "finding-1") -- approval gate
-  - title (non-empty string)
-  - allowed_files (non-empty list of glob patterns)
-  - required_checks (non-empty list, e.g. ["pytest -q"]). The stop-gate checks
-    three receipts (verified, reviewed, findings_triaged); they are meaningless
-    unless the spec documents what must be verified, so an empty list is rejected.
-  - bypass_check (a command proving no bypass remains) OR
-    bypass_exempt: "<reason>"                          -- spine contract
-
-Write bypass_check as an INVARIANT, not a token count. Counting occurrences of
-an identifier looks deterministic and is not: prose in a comment inflates it, a
-refactor that renames or inlines deflates it, and neither fact says anything
-about whether a bypass remains. Prefer "exactly one scan exists", "the byte
-compare lives in one place", "the guard is still present" over
-`grep -c <name> == N`. If a count really is the invariant, exclude comment lines
-(`grep -v '^[[:space:]]*#' | grep -c`) and use `grep -F` for patterns holding
-regex metacharacters such as `$`.
-
-Scar 2026-07-26 (prd-updater-consolidation): three of five bypass_checks were
-grep-count proxies and each needed a mid-issue amendment. One did real damage --
-it demanded three calls to a function, so a redundant dead call was written
-purely to satisfy the number, and adversarial review caught it. A check that
-shapes the code to fit the check is worse than no check.
-
-Optional keys:
-  - priority (default p1)
-  - disallowed_files, required_reviews, acceptance
-
-Authoring a manifest with `id` but no `finding_id` (the pre-spine shape) is
-rejected at approve. The template-vs-runner contract test enforces this list.
--->
-
 ```json
-[]
+[
+  {
+    "id": "crpr-bus-verifier-can-fail",
+    "title": "Make the canonical-digest check reachable and able to fail",
+    "finding_id": "finding-1",
+    "priority": "p0",
+    "allowed_files": [
+      "plugins/kipi-core/kipi-mcp/src/kipi_mcp/bus_verifier.py",
+      "plugins/kipi-core/kipi-mcp/tests/test_bus_verifier.py"
+    ],
+    "disallowed_files": [
+      "plugins/kipi-core/kipi-mcp/src/kipi_mcp/paths.py",
+      "q-system/canonical/**",
+      ".prd-os/**"
+    ],
+    "required_checks": [
+      "python3 -m pytest -q plugins/kipi-core/kipi-mcp/tests/test_bus_verifier.py"
+    ],
+    "required_reviews": ["runtime-owner"],
+    "acceptance": "Write the failing test FIRST, using the exact empty digest captured 2026-08-22: {\"talk_tracks\":{},\"objections\":[],\"current_state\":{},\"discovery\":{},\"decisions\":[],\"warnings\":[5 not-found messages],\"valid\":false}. Show it RED before any fix. Then (1) add canonical-digest.json to phase 1 `required` so the check is reached at all, and (2) replace the key-presence lambda at bus_verifier.py:102 with an assertion on CONTENT. Prove reachability separately from the assertion: a mutation that reverts only step (1) must turn a test red, and a mutation that reverts only step (2) must turn a different test red. A required-file False is a hard fail per bus_verifier.py:42-81; assert `pass` is False, not merely that a warn was emitted."
+  },
+  {
+    "id": "crpr-skeleton-resolves-live-canonical",
+    "title": "Skeleton-shipped references resolve the instance's live canonical tree",
+    "finding_id": "finding-2",
+    "priority": "p1",
+    "allowed_files": [
+      "plugins/kipi-ops/skills/council/SKILL.md",
+      "plugins/kipi-ops/skills/council/workflows/quick.md",
+      "plugins/kipi-ops/skills/council/workflows/debate.md",
+      "plugins/kipi-core/commands/wiring-check.md",
+      "q-system/.q-system/scripts/test_evidence_ledger.py"
+    ],
+    "disallowed_files": [
+      ".claude/rules/**",
+      "q-system/canonical/**",
+      ".prd-os/**"
+    ],
+    "required_checks": [
+      "python3 -m pytest -q q-system/.q-system/scripts/test_evidence_ledger.py",
+      "bash -c '! grep -rn \"q-system/canonical/\" plugins/kipi-ops/skills/council/ plugins/kipi-core/commands/wiring-check.md'"
+    ],
+    "required_reviews": ["runtime-owner"],
+    "acceptance": "All nine hardcoded q-system/canonical/ references (council SKILL.md:37,38,39,53; quick.md:15,16,17,77; debate.md:15,17,18,201; wiring-check.md:90) resolve through instance_root() from evidence_ledger.py:81-93. NEVER a hardcoded q-consult/ - 8 registered instances have instance_q_dir null and that path is meaningless there. Add a test case to test_evidence_ledger.py proving instance_root() resolves a non-q-system domain dir, since that is the case the skeleton's own fixtures never exercise. The grep check is a negative control: it must FAIL on the current tree before the edit."
+  },
+  {
+    "id": "crpr-unhook-dead-canonical-consumers",
+    "title": "Stop requiring the dead tree, then delete the skeleton's plugin copy",
+    "finding_id": "finding-3",
+    "priority": "p0",
+    "allowed_files": [
+      "q-system/.q-system/scripts/verify-containment-export.py",
+      "q-system/.q-system/scripts/test/test-verify-containment-export.sh",
+      "plugins/kipi-core/kipi-mcp/canonical/**"
+    ],
+    "disallowed_files": [
+      ".claude/rules/**",
+      "q-system/canonical/**",
+      ".prd-os/**"
+    ],
+    "required_checks": [
+      "python3 q-system/.q-system/scripts/verify-containment-export.py"
+    ],
+    "required_reviews": ["runtime-owner"],
+    "acceptance": "STEP ORDER IS LOAD-BEARING. First: verify-containment-export.py:24-28 stops hard-coding q-system/canonical/discovery.md and pricing-framework.md as REQUIRED export paths and resolves them through instance_root() instead; prove it by running the script from consulting (where q-system/canonical/ is the fossil) and getting exit 0 against q-consult/canonical/. Only then: git rm the skeleton's plugins/kipi-core/kipi-mcp/canonical/ tree - the skeleton copy, because plugins/ is mirrored with rsync -a --delete --delete-excluded (kipi-update.sh:2460) with no canonical exclude, so deleting it anywhere else regenerates it. Enumerate and report the ~20 agent-pipeline prompts under q-system/.q-system/agent-pipeline/agents/ that reference the path; if any are left pointing at a tree that still exists in the skeleton, say so explicitly rather than implying coverage."
+  },
+  {
+    "id": "crpr-consulting-fossil-cleanup",
+    "title": "Delete consulting's frozen canonical tree and its two council fossils",
+    "finding_id": "finding-4",
+    "priority": "p1",
+    "allowed_files": [
+      "q-system/.q-system/scripts/test/test-canonical-fossil-absent.sh"
+    ],
+    "disallowed_files": [
+      ".claude/rules/**",
+      "plugins/**",
+      ".prd-os/**"
+    ],
+    "required_checks": [
+      "bash q-system/.q-system/scripts/test/test-canonical-fossil-absent.sh"
+    ],
+    "required_reviews": ["runtime-owner"],
+    "acceptance": "Runs LAST, after crpr-unhook-dead-canonical-consumers has shipped. In /Users/assafkipnis/projects/consulting: git rm the 10 tracked files under q-system/canonical/ (frozen 2026-07-01; safe because `canonical` is in INSTANCE_OWNED_SUBTREES at kipi-update.sh:64, so the updater neither restores nor --deletes it), and repoint the TWO instance-owned council fossils under .claude/skills/ - .claude/skills/council/ (SKILL.md:32-34,48; workflows/quick.md:11-13,73; workflows/debate.md:11,13,14,197) and the orphaned .claude/skills/workflows/ pair. .claude/skills/ is NOT covered by config_source_manages (kipi-update.sh:1279-1296), so these persist untouched and fixing only the plugin copy leaves two live wrong copies. The check in this repo is a fossil-absence assertion that must be shown RED against consulting before the deletion. Then re-run the fleet updater in DRY mode against consulting and confirm no restore of the deleted trees and no reversion of the skeleton edits."
+  }
+]
 ```

--- a/.prd-os/prds/prd-canonical-read-path-repair-2026-08-22.md
+++ b/.prd-os/prds/prd-canonical-read-path-repair-2026-08-22.md
@@ -291,6 +291,7 @@ prose here is not held by anything, so it does not belong in this list.
     "title": "Make the canonical-digest check reachable and able to fail",
     "finding_id": "finding-1",
     "priority": "p0",
+    "bypass_check": "python3 -m pytest -q plugins/kipi-core/kipi-mcp/tests/test_bus_verifier.py -k 'empty_digest'",
     "allowed_files": [
       "plugins/kipi-core/kipi-mcp/src/kipi_mcp/bus_verifier.py",
       "plugins/kipi-core/kipi-mcp/tests/test_bus_verifier.py"
@@ -303,7 +304,9 @@ prose here is not held by anything, so it does not belong in this list.
     "required_checks": [
       "python3 -m pytest -q plugins/kipi-core/kipi-mcp/tests/test_bus_verifier.py"
     ],
-    "required_reviews": ["runtime-owner"],
+    "required_reviews": [
+      "runtime-owner"
+    ],
     "acceptance": "Write the failing test FIRST, using the exact empty digest captured 2026-08-22: {\"talk_tracks\":{},\"objections\":[],\"current_state\":{},\"discovery\":{},\"decisions\":[],\"warnings\":[5 not-found messages],\"valid\":false}. Show it RED before any fix. Then (1) add canonical-digest.json to phase 1 `required` so the check is reached at all, and (2) replace the key-presence lambda at bus_verifier.py:102 with an assertion on CONTENT. Prove reachability separately from the assertion: a mutation that reverts only step (1) must turn a test red, and a mutation that reverts only step (2) must turn a different test red. A required-file False is a hard fail per bus_verifier.py:42-81; assert `pass` is False, not merely that a warn was emitted."
   },
   {
@@ -311,6 +314,7 @@ prose here is not held by anything, so it does not belong in this list.
     "title": "Skeleton-shipped references resolve the instance's live canonical tree",
     "finding_id": "finding-2",
     "priority": "p1",
+    "bypass_check": "bash -c '! grep -rn \"q-system/canonical/\" plugins/kipi-ops/skills/council/ plugins/kipi-core/commands/wiring-check.md'",
     "allowed_files": [
       "plugins/kipi-ops/skills/council/SKILL.md",
       "plugins/kipi-ops/skills/council/workflows/quick.md",
@@ -327,7 +331,9 @@ prose here is not held by anything, so it does not belong in this list.
       "python3 -m pytest -q q-system/.q-system/scripts/test_evidence_ledger.py",
       "bash -c '! grep -rn \"q-system/canonical/\" plugins/kipi-ops/skills/council/ plugins/kipi-core/commands/wiring-check.md'"
     ],
-    "required_reviews": ["runtime-owner"],
+    "required_reviews": [
+      "runtime-owner"
+    ],
     "acceptance": "All nine hardcoded q-system/canonical/ references (council SKILL.md:37,38,39,53; quick.md:15,16,17,77; debate.md:15,17,18,201; wiring-check.md:90) resolve through instance_root() from evidence_ledger.py:81-93. NEVER a hardcoded q-consult/ - 8 registered instances have instance_q_dir null and that path is meaningless there. Add a test case to test_evidence_ledger.py proving instance_root() resolves a non-q-system domain dir, since that is the case the skeleton's own fixtures never exercise. The grep check is a negative control: it must FAIL on the current tree before the edit."
   },
   {
@@ -335,6 +341,7 @@ prose here is not held by anything, so it does not belong in this list.
     "title": "Stop requiring the dead tree, then delete the skeleton's plugin copy",
     "finding_id": "finding-3",
     "priority": "p0",
+    "bypass_check": "bash -c '! grep -n \"q-system/canonical/discovery.md\\|q-system/canonical/pricing-framework.md\" q-system/.q-system/scripts/verify-containment-export.py'",
     "allowed_files": [
       "q-system/.q-system/scripts/verify-containment-export.py",
       "q-system/.q-system/scripts/test/test-verify-containment-export.sh",
@@ -348,7 +355,9 @@ prose here is not held by anything, so it does not belong in this list.
     "required_checks": [
       "python3 q-system/.q-system/scripts/verify-containment-export.py"
     ],
-    "required_reviews": ["runtime-owner"],
+    "required_reviews": [
+      "runtime-owner"
+    ],
     "acceptance": "STEP ORDER IS LOAD-BEARING. First: verify-containment-export.py:24-28 stops hard-coding q-system/canonical/discovery.md and pricing-framework.md as REQUIRED export paths and resolves them through instance_root() instead; prove it by running the script from consulting (where q-system/canonical/ is the fossil) and getting exit 0 against q-consult/canonical/. Only then: git rm the skeleton's plugins/kipi-core/kipi-mcp/canonical/ tree - the skeleton copy, because plugins/ is mirrored with rsync -a --delete --delete-excluded (kipi-update.sh:2460) with no canonical exclude, so deleting it anywhere else regenerates it. Enumerate and report the ~20 agent-pipeline prompts under q-system/.q-system/agent-pipeline/agents/ that reference the path; if any are left pointing at a tree that still exists in the skeleton, say so explicitly rather than implying coverage."
   },
   {
@@ -356,6 +365,7 @@ prose here is not held by anything, so it does not belong in this list.
     "title": "Delete consulting's frozen canonical tree and its two council fossils",
     "finding_id": "finding-4",
     "priority": "p1",
+    "bypass_check": "bash q-system/.q-system/scripts/test/test-canonical-fossil-absent.sh",
     "allowed_files": [
       "q-system/.q-system/scripts/test/test-canonical-fossil-absent.sh"
     ],
@@ -367,7 +377,9 @@ prose here is not held by anything, so it does not belong in this list.
     "required_checks": [
       "bash q-system/.q-system/scripts/test/test-canonical-fossil-absent.sh"
     ],
-    "required_reviews": ["runtime-owner"],
+    "required_reviews": [
+      "runtime-owner"
+    ],
     "acceptance": "Runs LAST, after crpr-unhook-dead-canonical-consumers has shipped. In /Users/assafkipnis/projects/consulting: git rm the 10 tracked files under q-system/canonical/ (frozen 2026-07-01; safe because `canonical` is in INSTANCE_OWNED_SUBTREES at kipi-update.sh:64, so the updater neither restores nor --deletes it), and repoint the TWO instance-owned council fossils under .claude/skills/ - .claude/skills/council/ (SKILL.md:32-34,48; workflows/quick.md:11-13,73; workflows/debate.md:11,13,14,197) and the orphaned .claude/skills/workflows/ pair. .claude/skills/ is NOT covered by config_source_manages (kipi-update.sh:1279-1296), so these persist untouched and fixing only the plugin copy leaves two live wrong copies. The check in this repo is a fossil-absence assertion that must be shown RED against consulting before the deletion. Then re-run the fleet updater in DRY mode against consulting and confirm no restore of the deleted trees and no reversion of the skeleton edits."
   }
 ]

--- a/.prd-os/prds/prd-canonical-read-path-repair-2026-08-22.md
+++ b/.prd-os/prds/prd-canonical-read-path-repair-2026-08-22.md
@@ -334,7 +334,29 @@ not held by anything.
     "required_reviews": [
       "runtime-owner"
     ],
-    "acceptance": "THREE independent defects, THREE independent tests, each shown RED first and each killed by its own mutation. (1) REACHABLE: canonical-digest.json is in phase 1 required; reverting only this must turn a test red. (2) SUBSTANTIVE: the exact empty digest captured 2026-08-22 must be rejected - talk_tracks {}, objections [], current_state {}, discovery {}, decisions [], warnings 5 not-found messages, valid false; reverting only the lambda must turn a DIFFERENT test red. (3) ERROR SHORT-CIRCUIT (finding-13): bus_verifier.py:46-52 tests 'error' in data BEFORE the structure check and emits warn WITHOUT setting all_pass=False, so a required canonical-digest.json of exactly {\"error\":\"canonical digest unavailable\"} yields pass:true even after (1) and (2). Assert verify() returns pass False for that input. A required-file failure is a hard fail per bus_verifier.py:42-81, so assert on pass, never on the presence of a warn. SEQUENCING (finding-27): making this file required while canonical_dir still resolves to ~/.kipi-system/instances/<name>/canonical turns every phase-1 run red on 23 instances. Add a precondition test asserting canonical_dir does NOT resolve under the plugin-data base; it fails until srsa lands, which is the intended block."
+    "acceptance": "THREE independent defects, THREE independent tests, each shown RED first and each killed by its own mutation. (1) REACHABLE: canonical-digest.json is in phase 1 required; reverting only this must turn a test red. (2) SUBSTANTIVE: the exact empty digest captured 2026-08-22 must be rejected - talk_tracks {}, objections [], current_state {}, discovery {}, decisions [], warnings 5 not-found messages, valid false; reverting only the lambda must turn a DIFFERENT test red. (3) ERROR SHORT-CIRCUIT (finding-13): bus_verifier.py:46-52 tests 'error' in data BEFORE the structure check and emits warn WITHOUT setting all_pass=False, so a required canonical-digest.json of exactly {\"error\":\"canonical digest unavailable\"} yields pass:true even after (1) and (2). Assert verify() returns pass False for that input. A required-file failure is a hard fail per bus_verifier.py:42-81, so assert on pass, never on the presence of a warn. SEQUENCING (finding-27): making this file required while canonical_dir still resolves to ~/.kipi-system/instances/<name>/canonical turns every phase-1 run red on 23 instances. Add a precondition test asserting canonical_dir does NOT resolve under the plugin-data base; it fails until srsa lands, which is the intended block. (4) NON-EMPTINESS IS NOT SUBSTANCE (finding-14, finding-9): a fixture-level test CANNOT prove the live tree was read, so this entry must not claim it does. The structure check must reject Codex's exact nonempty placeholder {\"talk_tracks\":{\"metaphor\":\"placeholder\"},\"objections\":[],\"current_state\":{},\"discovery\":{},\"decisions\":[],\"warnings\":[],\"valid\":false} -- assert on that literal, not on 'some field is nonempty'. NEVER assert valid alone in either direction: measured 2026-08-22, the LIVE tree also returns valid:false (3 of 7 checks), so valid:true is not the success signal and valid:false is not the failure signal. Proving a real tree was read belongs to crpr-digest-asserts-real-canonical, which owns that assertion end to end. Do NOT loosen any parser in morning_init.py to move valid; that file is not in allowed_files precisely so this cannot happen."
+  },
+  {
+    "id": "crpr-digest-asserts-real-canonical",
+    "title": "Prove the digest read the live canonical tree, by named value",
+    "finding_id": "finding-14",
+    "priority": "p0",
+    "allowed_files": [
+      "q-system/.q-system/scripts/test/test-canonical-digest-real-values.py"
+    ],
+    "disallowed_files": [
+      "plugins/kipi-core/kipi-mcp/src/kipi_mcp/morning_init.py",
+      ".claude/**",
+      ".prd-os/**"
+    ],
+    "required_checks": [
+      "python3 q-system/.q-system/scripts/test/test-canonical-digest-real-values.py --self-test"
+    ],
+    "bypass_check": "python3 q-system/.q-system/scripts/test/test-canonical-digest-real-values.py --self-test",
+    "required_reviews": [
+      "runtime-owner"
+    ],
+    "acceptance": "Closes finding-14 and finding-9, which no other entry can: every other entry is fixture-level and structurally cannot prove a live tree was read. This checker calls canonical_digest against a REAL instance tree and asserts NAMED values. Rules: (a) NEVER assert valid -- measured 2026-08-22 the live tree returns valid:false (3 of 7), so valid is not a signal in either direction; (b) NEVER assert mere non-emptiness -- that is the exact false green finding-14 names. (c) DERIVE the expected value, do not hardcode it: this repo is PUBLIC, so grep the instance's own decisions.md for a dated rule id matching RULE-[0-9]{4}-[0-9]{2}-[0-9]{2} with an INDEPENDENT reader (regex over the raw file), then assert canonical_digest's parsed decisions[] contains that same id. Two independent readers agreeing on a value present in that one tree is what proves the tree was read; it also keeps the checker instance-agnostic and leaks no client content into a public repo. (d) NEGATIVE SELF-TEST, non-optional and wired as --self-test so the required_check exercises it: the FOSSIL tree is the control. Measured: live decisions.md has exactly 1 dated rule id, fossil q-system/canonical/decisions.md has 0 (it carries only RULE-XXX / RULE-001 / RULE-002 / RULE-003 template scaffolding). The checker MUST pass against the live tree and MUST fail against the fossil; --self-test asserts BOTH and exits nonzero if the fossil case passes. A checker that cannot fail against the fossil is the defect this PRD exists to remove. (e) Show it RED first: run it before the resolver work lands and record the failure reason. (f) If the named instance is absent, REFUSE (exit nonzero) rather than skip -- a skip is a false green."
   },
   {
     "id": "crpr-skeleton-resolves-live-canonical",

--- a/.prd-os/prds/prd-canonical-read-path-repair-2026-08-22.md
+++ b/.prd-os/prds/prd-canonical-read-path-repair-2026-08-22.md
@@ -1,9 +1,9 @@
 ---
 id: prd-canonical-read-path-repair-2026-08-22
 title: Canonical Read Path Repair
-status: in-review
+status: approved
 created_at: 2026-08-22T19:37:28Z
-updated_at: 2026-08-22T19:59:11Z
+updated_at: 2026-08-22T20:07:33Z
 owner: sana
 reviewers: []
 findings_path: .prd-os/findings/prd-canonical-read-path-repair-2026-08-22-findings.jsonl

--- a/.prd-os/prds/prd-canonical-read-path-repair-2026-08-22.md
+++ b/.prd-os/prds/prd-canonical-read-path-repair-2026-08-22.md
@@ -140,6 +140,43 @@ values.** `q-consult/canonical/decisions.md:219` carries the real heading
 `RULE-2026-08-18-A`, which exists in no template and in no fossil file. That string is
 the assertion.
 
+### The live tree does NOT yield `valid: true` (measured 2026-08-22, corrects this PRD)
+
+Running `canonical_digest` directly against the live tree
+(`q-consult/canonical/` + `q-consult/my-project/`) returns **`valid: False`**, with all
+five files found and `warnings: []`. Only 3 of the 7 `_validate_digest` checks pass:
+
+| check | live result | why |
+|---|---|---|
+| `talk_tracks.metaphor` | FAIL | talk-tracks.md was retired to a pointer doc; no `metaphor` heading |
+| `talk_tracks.definition` | FAIL | same |
+| `objections` non-empty | pass | 5 headings, all from the retirement note |
+| `current_state.works_today` | FAIL | heading is `What is true now`, not `works today` |
+| `discovery.questions` | FAIL | items sit under `###` children; `## Unanswered Questions` has an empty body |
+| `decisions` non-empty | pass | 10, incl. `RULE-2026-08-18-A` |
+| `warnings < 3` | pass | 0 |
+
+**This corrects the PRD's own premise.** The read-path fix alone cannot make the headline
+signal green, because the parsers were written against the 2026-07-01 template shape and
+the live files no longer have that shape. Three consequences, all load-bearing:
+
+1. **`valid` is unusable as an acceptance signal in either direction.** It was already
+   wrong to assert `valid: true` (finding-14). It is now also wrong to treat `valid:
+   false` as proof the path is broken. Every acceptance criterion asserts named strings.
+2. **Loosening a parser to make `valid` go green is forbidden.** That is precisely the
+   false-green this PRD exists to eliminate, and it would be the easiest way to fake a
+   pass on any criterion below.
+3. **The parser/live-shape mismatch is a real defect and is NOT in this PRD.** Read-path
+   only. Captured as its own spillover item rather than absorbed here.
+
+The discriminator that survives all of this is a **dated** rule id. Measured across both
+trees: the live `decisions.md` has exactly 1 heading matching
+`RULE-\d{4}-\d{2}-\d{2}`; the fossil `q-system/canonical/decisions.md` has **0** (it
+carries `RULE-XXX`, `RULE-001`, `RULE-002`, `RULE-003` -- template scaffolding only).
+The fossil is therefore a genuine negative control: a checker asserting a dated rule id
+passes against the live tree and fails against the fossil, which is the exact distinction
+this PRD is about.
+
 ### Deletions, in order
 
 Unchanged from the first draft and still load-bearing: unhook consumers, then delete

--- a/.prd-os/prds/prd-canonical-read-path-repair-2026-08-22.md
+++ b/.prd-os/prds/prd-canonical-read-path-repair-2026-08-22.md
@@ -22,367 +22,373 @@ points at `q-consult/canonical/`; everything the skeleton shipped points at
 
 Measured, not assumed:
 
-- `q-consult/canonical/` is live: 22 files, 4,478 lines, last written 2026-08-20.
-- `q-system/canonical/` in consulting is frozen at 2026-07-01 template stubs. Its
-  `pricing-framework.md` is 27 lines and contains no prices; the live one is 416 lines.
+- `q-consult/canonical/` is live: 22 markdown files, last written 2026-08-20.
+- `q-system/canonical/` in consulting is frozen at 2026-07-01 template stubs: exactly
+  10 tracked files. Its `pricing-framework.md` is 27 lines and contains no prices; the
+  live one is 416 lines.
 - `plugins/kipi-core/kipi-mcp/canonical/` is frozen at 2026-06-10.
 - 1,345 founder-typed messages in the consulting transcripts contain 14 "read the
   canonical files" asks and 7 "you missed it, it's in the file". The same patterns
-  occur **zero** times across 770 founder-typed messages in kipi-system. The defect is
-  consulting-specific, and it is the instance where the trees diverged.
+  occur **zero** times across 770 founder-typed messages in kipi-system.
 
-The digest that exists to prevent this is itself pointed at a fourth, empty location.
+The digest that exists to prevent this is pointed at a fourth, empty location.
 `kipi_canonical_digest` resolves `canonical_dir` to
 `~/.kipi-system/instances/{name}/canonical` (`paths.py:130`), which holds zero files.
-It returns every file "not found" and `valid: false`. It exists to save 40-60K tokens
-against reading full canonical; when it returns nothing, agents fall back to raw files
-and pick from three copies.
+It returns every file "not found" and `valid: false`.
 
-**Nothing catches any of this.** `digest["valid"]` is read nowhere outside its own unit
-test, and the one verifier check that names `canonical-digest.json`
-(`bus_verifier.py:102`) is unreachable dead code — the file is listed in phase 1's
-`checks` dict while appearing in neither `required` nor `optional`, so the lambda never
-runs. Even if it ran, it is key-presence only (`"talk_tracks" in d`), so the exact empty
-digest observed today would pass it.
-
-File length and wrong-file are one chain: 4,478 lines is *why* a digest exists. Digest
-broken to raw-file fallback to three copies to wrong answer.
+**Nothing catches it.** `digest["valid"]` is read nowhere outside its own unit test, and
+the one verifier check naming `canonical-digest.json` (`bus_verifier.py:102`) is
+unreachable dead code -- the file sits in phase 1's `checks` dict but in neither
+`required` nor `optional`. Even reached, it is key-presence only.
 
 ## Goals
 
-- The verifier can fail on an empty digest, and is reached at all.
-- Every skeleton-shipped reference to canonical resolves the instance's live tree
-  through one tested resolver, never a hardcoded path.
-- The dead trees are gone, and the plugin copy stops regenerating on the next sync.
-- No consumer breaks as a result of the deletions.
+- The canonical-digest check is reached, is substantive, and cannot pass on an empty,
+  scaffold-only, or `error`-bearing digest.
+- Exactly ONE resolver decides where an instance's canonical tree lives, and it fails
+  closed rather than guessing.
+- Every skeleton-shipped reference resolves through that resolver.
+- The dead trees are gone, the plugin copy stops regenerating, and no consumer breaks.
 
 ## Non-goals
 
-- **Part 1, repointing `paths.py` `canonical_dir`, is deliberately NOT in this PRD.**
-  It is already covered by the approved, Codex-reviewed
-  `.prd-os/prds/prd-single-runtime-state-authority-2026-07-24.md` and its open p0 issue
-  `.prd-os/issues/srsa-authoritative-path-contract.md`, whose `allowed_files` is exactly
-  `[paths.py, test_paths.py]` and whose `required_checks` are already defined. Its
-  resolution formula is already decided and reviewed: if `instance_q_dir` is set, use
-  `<path>/<instance_q_dir>`; otherwise `<path>/<subtree_prefix>/q-system`; missing or
-  ambiguous mappings fail closed. `instance-registry.json` already records
-  `"instance_q_dir": "q-consult"` for consulting. Re-specifying it here would duplicate a
-  Codex review already paid for. That issue is EXECUTED alongside this PRD, not inside it.
-- **Part 5, `my_project_dir`, is executed inside that same srsa issue**, not here.
-  `morning_init.py:192` reads `current_state` from `paths.my_project_dir`, which has the
-  identical defect and the identical fossil twin (`q-system/my-project/`, same 2026-07-01
-  commit). It is a one-property change in the same file that srsa already owns. Splitting
-  it out would put two issues in one file. Recorded here because Part 1's own success
-  criterion is unreachable without it: `_validate_digest` (`morning_init.py:534-544`)
-  needs 5 of 7 checks and one of them is `current_state.works_today`.
-- Changing what the canonical files *say*. This is a read-path repair only.
-- Consolidating the three trees into one schema. Only the dead copies are removed.
+- **Part 1 (`paths.py` `canonical_dir`) is NOT in this PRD.** It is covered by the
+  approved, Codex-reviewed `prd-single-runtime-state-authority-2026-07-24` and its open
+  p0 issue `srsa-authoritative-path-contract` (`allowed_files` exactly
+  `[paths.py, test_paths.py]`). That issue is EXECUTED alongside this PRD.
+- **Part 5 (`my_project_dir`) rides in that same srsa issue** -- same file, same defect.
+  **Correction (finding-28, measured):** the earlier claim that `valid: true` is
+  *unreachable* without it was WRONG. `_validate_digest` needs 5 of 7 checks; dropping
+  `current_state.works_today` still leaves 6 available. So Part 5 can stay broken while
+  the headline signal goes green. That is precisely why the acceptance criteria below
+  assert `current_state` explicitly instead of trusting `valid`.
+- Changing what canonical files *say*. Read-path only.
+- Consolidating the three trees into one schema.
 
 ## Proposed approach
 
-Four issues, ordered. The order inside Part 4 is load-bearing: a consumer that hard-codes
-a path must stop requiring it *before* the path is deleted, or the deletion is a runtime
-failure rather than a cleanup.
+### One resolver, not two (finding-16, finding-17, finding-18)
 
-### Reuse, do not invent
+The first draft said "the skeleton uses `instance_root()`, the MCP uses the registry
+formula -- two resolvers, deliberately." **That was wrong, and measuring it proved it.**
+Running both over the 20 registered instances that exist on disk:
 
-`q-system/.q-system/scripts/evidence_ledger.py:81-93` already implements the resolver,
-and it is tested by `q-system/.q-system/scripts/test_evidence_ledger.py`:
+| Instance class | `instance_q_dir` | `instance_root()` | registry formula | agree |
+|---|---|---|---|---|
+| named domain dir, registry agrees | set | that dir | same dir | yes |
+| **named domain dir, registry stale** | `null` | that dir | `q-system` | **NO (4 instances)** |
+| no domain dir | `null` | `q-system` | `q-system` | yes |
+| **`q-system` has no `canonical/`** | `null` | `q-system` | `q-system` | agree, both wrong (2) |
 
-```python
-def instance_root(repo=None) -> Path:
-    repo = Path(repo or os.environ.get("CLAUDE_PROJECT_DIR") or os.getcwd())
-    named = [p for p in sorted(repo.glob("q-*"))
-             if p.is_dir() and p.name != "q-system" and (p / "canonical").is_dir()]
-    return named[0] if named else repo / "q-system"
+Instance names are omitted on purpose: this repo is public and the client-name guard
+blocks them. Enumerate the affected set locally with the resolver itself rather than a
+hand-maintained list (finding-11):
+
+```bash
+python3 q-system/.q-system/scripts/evidence_ledger.py --audit-instance-roots
 ```
 
-It resolves to `q-consult/` on consulting and `q-system/` on the skeleton. Precedent it
-cites: `capability-map-gen.py:390`. Skeleton-shipped references use this. They must never
-hardcode `q-consult/`, which is meaningless in the 8 registered instances whose
-`instance_q_dir` is null.
+**4 of 20 disagree**, and in all four the registry is the stale one: those instances
+have a real domain dir containing `canonical/` while `instance_q_dir` is null. Two
+authorities that disagree on 20% of the fleet is a defect, not a design. Two more
+resolve to a directory with no `canonical/` at all.
 
-For the MCP side (Part 1, srsa), the registry formula wins over a second glob-based
-resolver: it is the already-reviewed answer, and it fails closed on ambiguity where a
-glob silently picks `sorted()[0]`.
+So: one resolver, registry-backed, failing closed. It reconciles by (a) filling in the
+missing `instance_q_dir` values the glob already proves, and (b) refusing rather than
+guessing when the registry and the filesystem still disagree, when two named `q-*` dirs
+both carry `canonical/` (today `sorted()[0]` silently wins -- finding-17), or when the
+resolved directory has no `canonical/` (finding-18).
 
-### Part 2 — the verifier can fail
+### The verifier can fail (finding-13)
 
-Two steps, in this order, because doing only the second leaves the check unreachable and
-doing only the first arms a check that cannot fail:
+Three defects, not one, and each needs its own mutation-sensitive test:
 
-1. Wire `canonical-digest.json` into phase 1's `required` list. Semantics at
-   `bus_verifier.py:42-81`: `False` on a **required** file is a hard fail; `False` on an
-   **optional** file is only a warn. A warn is what let this sit.
-2. Replace the key-presence lambda with a substantive assertion: the digest is valid only
-   if it actually carries content, not merely the keys.
+1. **Unreachable.** `canonical-digest.json` is in no list, so the lambda never runs.
+2. **Not substantive.** Key-presence passes an all-empty digest.
+3. **The `error` short-circuit.** `bus_verifier.py:46-52` checks `"error" in data`
+   BEFORE the structure check and emits `warn` -- without setting `all_pass = False`.
+   So a required file `{"error": "canonical digest unavailable"}` yields `pass: true`
+   today and would still do so after fixes 1 and 2. This is the one the first draft
+   missed entirely.
 
-Reproducer first. The exact empty digest observed today goes into a pytest case, red
-before the fix:
+### Sequencing is a production hazard, not a preference (finding-27)
 
-```json
-{"talk_tracks":{},"objections":[],"current_state":{},"discovery":{},
- "decisions":[],"warnings":["...5 not-found messages..."],"valid":false}
-```
+Making `canonical-digest.json` **required** while `canonical_dir` still points at the
+empty plugin-data path turns **every phase-1 run red fleet-wide**. The bus-verifier work
+therefore must not land before srsa. This is encoded as an executable precondition in
+the issue's own `required_checks`, not as a sentence in this PRD.
 
-### Part 3 — skeleton references resolve the live tree
+### The false-green risk, re-aimed (finding-15, measured)
 
-Nine hardcoded `q-system/canonical/` references ship from the skeleton to every instance:
+The first draft warned that fenced `## Format` templates in "the real canonical files"
+could manufacture a `valid: true`. **Measured, the artifacts are in the FOSSIL tree, not
+the live one:**
 
-| File | Lines |
-|---|---|
-| `plugins/kipi-ops/skills/council/SKILL.md` | 37, 38, 39, 53 |
-| `plugins/kipi-ops/skills/council/workflows/quick.md` | 15, 16, 17, 77 |
-| `plugins/kipi-ops/skills/council/workflows/debate.md` | 15, 17, 18, 201 |
-| `plugins/kipi-core/commands/wiring-check.md` | 90 |
+| Tree | decisions | discovery | objections | talk-tracks |
+|---|---|---|---|---|
+| fossil `q-system/canonical/` | 1 fenced heading | 1 | 1 | 1 |
+| live `q-consult/canonical/` | 0 | 0 | 0 | 0 |
 
-Council's own `SKILL.md:44` already describes the resulting behaviour without naming the
-cause: "If a canonical file is empty/template, the persona says 'I don't have data to
-ground this'." That is the fossil tree being read, reported as a content problem.
+Across all 22 live files there is exactly **one** heading-shaped line inside a fence, in
+`market-intelligence.md`, which the digest does not parse. So the scaffold-green risk is
+a property of reading the fossil -- the state the fix moves away from.
 
-`.claude/rules/folder-structure.md:257-264` must be reconciled in the same change. It
-actively mandates "All scripts MUST resolve QROOT to `q-system/`" — a direct
-counter-precedent. Leaving it makes the rule and the code disagree, which is how the next
-person re-introduces the hardcode and passes review. Editing `.claude/` goes through the
-sanctioned proposal path (`apply-claude-changes.sh`); the `claude-path-write-guard` hook
-blocks anything else, and that is the gate doing its job.
+That does not make the parser safe. `_split_sections` still does not recognize fences,
+`_parse_decisions` matches any heading containing `rule` (so `Starter Rules` counts), and
+`_parse_objections` accepts every non-empty heading. The mitigation stays: **assert real
+values.** `q-consult/canonical/decisions.md:219` carries the real heading
+`RULE-2026-08-18-A`, which exists in no template and in no fossil file. That string is
+the assertion.
 
-### Part 4 — remove the dead copies, in order
+### Deletions, in order
 
-- **(a) FIRST, unhook the consumers.** `verify-containment-export.py:24-28` hard-codes
-  `q-system/canonical/discovery.md` and `pricing-framework.md` as REQUIRED export paths.
-  Deleting before fixing this is a runtime failure, not a warning. Four skeleton-synced
-  rules carry frontmatter globs on the path (`md-hygiene.md:4`,
-  `anti-misclassification.md:4`, `sycophancy.md:5`, `folder-structure.md:236`), plus ~20
-  agent-pipeline prompts under `q-system/.q-system/agent-pipeline/agents/`.
-- **(b) THEN delete `consulting/q-system/canonical/`** (10 tracked files, frozen
-  2026-07-01). Safe from the updater: `canonical` is in `INSTANCE_OWNED_SUBTREES`
-  (`kipi-update.sh:64`), so it is never restored and never `--delete`d.
-- **(c) Delete the plugin canonical copy in the SKELETON**
-  (`kipi-system/plugins/kipi-core/kipi-mcp/canonical/`). Deleting it in consulting does
-  NOT stick: `plugins/` is mirrored by `rsync -a --delete --delete-excluded`
-  (`kipi-update.sh:2460`) with no `canonical` exclude, so it regenerates from the
-  skeleton. The skeleton is the only place the deletion holds.
-- **(d) Consulting's TWO instance-owned council fossils.** `.claude/skills/council/`
-  (`SKILL.md:32-34,48`; `workflows/quick.md:11-13,73`; `workflows/debate.md:11,13,14,197`)
-  and the orphaned `.claude/skills/workflows/` pair. `.claude/skills/` is NOT managed by
-  the syncer — `config_source_manages` (`kipi-update.sh:1279-1296`) covers only
-  `settings.json`, `agents/*.md`, `rules/*.md`, `output-styles/*.md`, `plugins/*/*` — so
-  these persist untouched and currently point at the dead tree. Fixing only the plugin
-  copy leaves two live wrong copies.
+Unchanged from the first draft and still load-bearing: unhook consumers, then delete
+consulting's fossil tree, then delete the plugin copy **in the skeleton** (`plugins/` is
+mirrored by `rsync -a --delete --delete-excluded`, `kipi-update.sh:2460`, with no
+`canonical` exclude, so deleting it anywhere else regenerates it), then the two
+instance-owned council fossils under consulting's `.claude/skills/` (not covered by
+`config_source_manages`, `kipi-update.sh:1279-1296`).
 
-Nothing is silently deleted: every deletion is a tracked `git rm` with the reason in the
-commit message, reversible from history.
+Two consumers the first draft missed:
+
+- `RECEIPT_RELATIVE_PATH = "q-system/canonical/.containment-receipt.json"`
+  (`verify-containment-export.py:30-32`) -- loaded before any export path is checked, so
+  the deletion breaks it first (finding-22).
+- `_validate_file_receipt` enforces `source_path == destination_path` and both must be in
+  `EXPECTED_EXPORT_PATHS`, while the source is read as a git blob from the skeleton
+  commit and the destination from the instance owner root. Repointing both to `q-consult`
+  makes the skeleton source blob absent; repointing one violates the equality check. The
+  receipt schema needs an explicit source/destination split (finding-7, finding-23).
+
+### Cross-repo and `.claude/` work cannot ride an issue's `allowed_files`
+
+Two structural limits the first draft ignored:
+
+- **Cross-repo (finding-1, finding-26).** The issue runner receipts paths in THIS repo.
+  Consulting's deletions cannot be authorized by an `allowed_files` list here. The
+  kipi-system-side deliverable is a checker that inspects consulting and fails when the
+  fossil is present; the deletions themselves are performed in consulting and *proved* by
+  that checker running against a real path (finding-25 -- a checker that is merely
+  `exit 0` must not be able to pass).
+- **`.claude/` (finding-21, finding-5).** Every entry disallows `.claude/rules/**`, so no
+  entry could reconcile `folder-structure.md:257-264` or the four frontmatter globs. That
+  work goes through `apply-claude-changes.sh`, the sanctioned proposal path the
+  `claude-path-write-guard` hook enforces, as its own entry.
 
 ## Alternatives considered
 
-- **Fold Part 1 into this PRD and mark the 2026-07-24 PRD superseded.** Rejected: that
-  PRD is `status: approved` with `codex_reviewed_at: 2026-07-24` and was split into eight
-  p0 issue specs. Re-specifying `paths.py` here throws away a paid Codex review and leaves
-  eight open issues pointing at a superseded parent.
-- **Point the skeleton references at `q-consult/canonical/` directly.** Rejected: these
-  files ship fleet-wide via `kipi update`. 8 of the registered instances have
-  `instance_q_dir: null`, so the path is meaningless there and would break more consumers
-  than it fixes.
-- **Write a second resolver for the skeleton side.** Rejected: `instance_root()` already
-  exists, is tested, and is cited as precedent by `capability-map-gen.py:390`. A second
-  resolver is a second thing to drift.
-- **Delete the dead trees first and fix consumers when they break.** Rejected:
-  `verify-containment-export.py` treats those two paths as required, so the first
-  containment export after the deletion fails closed. Order is the whole point of Part 4.
-- **Leave `bus_verifier.py`'s check optional and just make the lambda substantive.**
-  Rejected: an optional file that fails the structure check only produces a `warn`
-  (`bus_verifier.py:66-81`). A warn is exactly the signal that let an empty digest ship
-  for months.
-- **Make `morning_init` skip fenced code blocks as part of this work.** Rejected as scope
-  creep, captured as spillover instead. It is a real defect (see Scenarios) but it is a
-  parser bug, not a read-path bug, and bundling it would put two causes in one issue.
+- **Fold Part 1 into this PRD.** Rejected: `prd-single-runtime-state-authority` is
+  approved and Codex-reviewed with eight split issues; re-specifying discards that.
+- **Keep two resolvers (the first draft's choice).** Rejected on measurement: they
+  disagree on 4 of 20 instances. Recorded here rather than deleted because the PRD
+  originally shipped this and the reversal is the point.
+- **Point skeleton references at `q-consult/` directly.** Rejected: 8 registered
+  instances have `instance_q_dir: null`; the path is meaningless there.
+- **Delete first, fix consumers when they break.** Rejected: the containment receipt is
+  loaded before anything else, so the first export after deletion fails closed.
+- **Let the fossil-absence checker be a plain script in this repo.** Rejected as a
+  false-green shape: an `exit 0` body would satisfy both its own checks (finding-25).
 
 ## Scenarios
 
-- **The council persona that had the data all along.** The founder runs a Quick Council on
-  a pricing question in consulting. `quick.md:16` sends the Investor persona to
-  `q-system/canonical/talk-tracks.md` — the 2026-07-01 stub. The persona reports "I don't
-  have data to ground this" exactly as `SKILL.md:44` predicts, while 416 lines of live
-  pricing sit in `q-consult/canonical/pricing-framework.md`. After Part 3 the same run
-  resolves through `instance_root()` to `q-consult/` and grounds on the live file.
-
-- **The morning run that reported healthy while reading nothing.** Phase 1 writes
-  `canonical-digest.json` with every field empty and `valid: false`. `bus_verifier`
-  iterates `required` (calendar, gmail, notion), never reaches `canonical-digest.json`
-  because it is in no list, and returns `pass: true`. After Part 2 the same digest lands
-  the file in `required`, the substantive check returns `False`, and the phase hard-fails
-  with a named reason.
-
-- **The containment export that fails closed after a clean deletion.** Without Part 4(a),
-  an operator deletes `consulting/q-system/canonical/` and the next
-  `verify-containment-export.py` run raises `ContainmentBlocked` on a missing REQUIRED
-  path. With (a) shipped first, the same run resolves through `instance_root()`, finds
-  `q-consult/canonical/discovery.md`, and exits 0.
-
-- **The plugin copy that comes back.** An operator deletes
-  `consulting/plugins/kipi-core/kipi-mcp/canonical/`. The next fleet sync mirrors
-  `plugins/` with `rsync -a --delete --delete-excluded` and no `canonical` exclude, and the
-  2026-06-10 tree reappears. Part 4(c) deletes it in the skeleton, which is the only copy
-  the mirror reads from.
-
-- **The false green.** After Parts 1-5 an engineer calls `kipi_canonical_digest` from
-  consulting and sees `valid: true`. This is not sufficient evidence. See Risks.
+- **The council persona that had the data all along.** Quick Council on pricing in
+  consulting; `quick.md:16` reads the 2026-07-01 stub and the persona says "I don't have
+  data to ground this", exactly as `SKILL.md:44` predicts, while 416 lines of live pricing
+  sit one directory over. After the resolver work the same run grounds on `q-consult/`.
+- **The morning run that reported healthy while reading nothing.** Phase 1 writes an
+  all-empty `canonical-digest.json`; `bus_verifier` never reaches the check and returns
+  `pass: true`. Afterwards the same digest hard-fails with a named reason.
+- **The digest that reports an error and still passes.** Phase 1 writes
+  `{"error": "canonical digest unavailable"}`. The `error` branch emits `warn` and leaves
+  `all_pass` untouched, so `pass: true`. This survives the reachability and substance
+  fixes; only the `error`-branch fix catches it.
+- **The fleet outage from a correct fix in the wrong order.** Bus-verifier work lands
+  before srsa. `canonical-digest.json` is now required, `canonical_dir` still resolves to
+  the empty plugin-data path, and every phase-1 run goes red on 23 instances.
+- **The green that proves nothing.** A council file is edited to
+  `q-system//canonical/discovery.md`. The literal-substring bypass check passes; the dead
+  tree is still being read (finding-19).
 
 ## Risks and rollback
 
-- **A `valid: true` that comes entirely from fence artifacts.** `morning_init`'s markdown
-  parsers (`_split_sections`, `morning_init.py:467-481`) do NOT skip fenced code blocks.
-  The `## Format <!-- pin -->` templates inside the real canonical files contain
-  `### RULE-XXX: [Name]` and `### "[Objection as they say it]"` inside fences, and these
-  parse as real content — `_parse_decisions` matches on `"rule" in heading.lower()`. So a
-  `valid: true` can be produced entirely by template scaffolding. **Every acceptance check
-  in this PRD asserts on a REAL value** — a known decision ID from
-  `q-consult/canonical/decisions.md`, a known objection string — never on `valid` alone. A
-  green nobody has seen go red for the right reason is decoration.
-- **`ensure_dirs()` writing into the repo.** `paths.py:218-221` includes `canonical_dir`
-  and `my_project_dir` in the `mkdir` loop. Once those resolve from the repo rather than
-  plugin-data, an `ensure_dirs()` call with an unset `repo_dir` would create directories
-  inside the real plugin dir. `test_paths.py:136` is the case that exercises this. Handled
-  in srsa, named here because it is this PRD's Part 5 dependency.
-- **Test fixtures with no instance mapping.** `conftest.py:58,66` has NO fixture with a
-  non-null `instance_q_dir`, so the registry branch of the new resolver would ship
-  untested. Adding one is part of srsa's acceptance.
-- **Rollback:** every change is a tracked commit. The deleted trees are frozen content
-  recoverable from git history at any time; nothing is removed from the working tree
-  without a commit that names it.
+- **A `valid: true` from scaffolding.** Mitigated by asserting `RULE-2026-08-18-A`, a
+  real value present in no template. Never assert `valid` alone.
+- **A bypass check that matches a string instead of an invariant.** The Part 3 check
+  asserts the resolver is *called* by the council workflows, not merely that a substring
+  is absent.
+- **`ensure_dirs()` writing into the repo.** `paths.py:218-221` mkdirs `canonical_dir`
+  and `my_project_dir`; once repo-derived, an unset `repo_dir` would create directories
+  inside the real plugin dir. `test_paths.py:136` exercises it. Owned by srsa.
+- **`conftest.py:58,66` has no fixture with a non-null `instance_q_dir`**, so the
+  registry branch would ship untested. Owned by srsa.
+- **Rollback:** every change is a tracked commit; the deleted trees stay recoverable from
+  history. Deletions use `git rm`, never `rm`.
 
 ## Resolved decisions
 
-Each decision below names the executable that holds it. A decision recorded only as
-prose here is not held by anything, so it does not belong in this list.
+Each decision names the executable that holds it. A decision held only by prose here is
+not held by anything.
 
-- **Part 1 stays out of this PRD.** Decided: execute the existing
-  `srsa-authoritative-path-contract` issue instead. Held by that issue's own
-  `required_checks` entry, `pytest -q plugins/kipi-core/kipi-mcp/tests/test_paths.py`,
-  plus its `bypass_check` on the `ambiguous or plugin_cache_write` selector. Rationale:
-  it is approved and Codex-reviewed; re-specifying it here throws that review away.
-- **Part 5 rides in the srsa issue.** Decided: `my_project_dir` is fixed in the same
-  `paths.py` change as `canonical_dir`, under that same pytest check. Rationale: same
-  file, same defect. Part 1's success criterion (`valid: true` from consulting) is
-  unreachable without it, because `_validate_digest` counts `current_state.works_today`.
-- **The skeleton uses `instance_root()`, the MCP uses the registry formula.** Decided:
-  two resolvers, deliberately. Held by the pytest suite
-  `q-system/.q-system/scripts/test_evidence_ledger.py` on the skeleton side and by
-  `test_paths.py` on the MCP side. Rationale: the skeleton side has no registry access at
-  read time; the MCP side has the registry and the reviewed fail-closed formula. Neither
-  hardcodes an instance name.
-- **Order inside Part 4 is (a) consumers, (b) consulting tree, (c) skeleton plugin copy,
-  (d) consulting `.claude/skills` fossils.** Held by the issue runner: the
-  `crpr-consulting-fossil-cleanup` spec cannot pass its `required_checks` script until
-  `crpr-unhook-dead-canonical-consumers` has shipped, because that script asserts the
-  fossil is absent AND `verify-containment-export.py` still exits 0. Rationale: (b)
-  before (a) is a runtime failure; (c) in consulting instead of the skeleton regenerates
-  on the next sync.
-- **Nothing is deleted without a tracked commit.** Decided: `git rm`, never `rm`. Held by
-  the `destructive-op-deny.sh` hook, which blocks `rm -rf` and `git clean -fd`
-  irrespective of any autonomy grant. Rationale: standing rule — never silently delete,
-  keep it reversible and auditable.
+- **Part 1 stays out; execute the existing srsa issue.** Held by that issue's own
+  `required_checks` (`pytest -q plugins/kipi-core/kipi-mcp/tests/test_paths.py`) and its
+  `bypass_check`. Rationale: it is approved and Codex-reviewed.
+- **Part 5 rides in srsa, and its success is asserted separately.** Held by the same
+  pytest check plus this PRD's explicit `current_state` assertion. Rationale: finding-28
+  proved `valid: true` alone does not require it.
+- **ONE resolver, registry-backed, fail-closed.** Held by the pytest suite named in
+  `crpr-one-canonical-resolver`. Rationale: measured disagreement on 4 of 20 instances.
+  This reverses the first draft.
+- **Sequencing is executable.** Held by a precondition inside
+  `crpr-bus-verifier-can-fail`'s `required_checks` that refuses while `canonical_dir`
+  still resolves to plugin-data. Rationale: the alternative is a 23-instance outage.
+- **Cross-repo and `.claude/` work get their own entries.** Held by the
+  `claude-path-write-guard` hook (which blocks any unsanctioned `.claude/` write) and by
+  a consulting-inspecting checker script. Rationale: an `allowed_files` list cannot
+  authorize either.
+- **Nothing is deleted without a tracked commit.** Held by the `destructive-op-deny.sh`
+  hook, which blocks `rm -rf` and `git clean -fd` regardless of any autonomy grant.
 
 ## Issues
 
 ```json
 [
   {
-    "id": "crpr-bus-verifier-can-fail",
-    "title": "Make the canonical-digest check reachable and able to fail",
-    "finding_id": "finding-1",
+    "id": "crpr-one-canonical-resolver",
+    "title": "One fail-closed resolver for an instance canonical root",
+    "finding_id": "finding-16",
     "priority": "p0",
-    "bypass_check": "python3 -m pytest -q plugins/kipi-core/kipi-mcp/tests/test_bus_verifier.py -k 'empty_digest'",
+    "allowed_files": [
+      "q-system/.q-system/scripts/evidence_ledger.py",
+      "q-system/.q-system/scripts/test_evidence_ledger.py",
+      "instance-registry.json"
+    ],
+    "disallowed_files": [
+      ".claude/**",
+      "plugins/**",
+      ".prd-os/**"
+    ],
+    "required_checks": [
+      "python3 q-system/.q-system/scripts/test_evidence_ledger.py"
+    ],
+    "bypass_check": "python3 q-system/.q-system/scripts/test_evidence_ledger.py",
+    "required_reviews": [
+      "runtime-owner"
+    ],
+    "acceptance": "Write the failing cases FIRST and show them RED. instance_root() must FAIL CLOSED, not guess, on all three measured gaps: (a) two named q-* dirs both containing canonical/ (today sorted()[0] silently wins, finding-17); (b) a resolved directory with no canonical/ subdir, measured on the two instances whose q-system holds no canonical/ (finding-18); (c) registry instance_q_dir disagreeing with the filesystem, the four instances where the registry says null while a real domain dir containing canonical/ exists (finding-16); enumerate them with the --audit-instance-roots command in the PRD rather than hardcoding names, since this repo is public. Fill in those four instance_q_dir values in instance-registry.json (the registry is gitignored-safe to name locally, the PRD is not) so registry and filesystem agree, and make the resolver read the registry as authority with the filesystem as a cross-check that RAISES on mismatch. NOTE the harness convention: this suite is main-based with case_* functions and pytest collects ZERO tests from it (finding-3, finding-29), so the required_check invokes it directly with python3; do NOT convert it to pytest as a way of making a check go green."
+  },
+  {
+    "id": "crpr-bus-verifier-can-fail",
+    "title": "Make the canonical-digest check reachable, substantive, and error-proof",
+    "finding_id": "finding-13",
+    "priority": "p0",
     "allowed_files": [
       "plugins/kipi-core/kipi-mcp/src/kipi_mcp/bus_verifier.py",
       "plugins/kipi-core/kipi-mcp/tests/test_bus_verifier.py"
     ],
     "disallowed_files": [
       "plugins/kipi-core/kipi-mcp/src/kipi_mcp/paths.py",
-      "q-system/canonical/**",
+      ".claude/**",
       ".prd-os/**"
     ],
     "required_checks": [
       "python3 -m pytest -q plugins/kipi-core/kipi-mcp/tests/test_bus_verifier.py"
     ],
+    "bypass_check": "python3 -m pytest -q plugins/kipi-core/kipi-mcp/tests/test_bus_verifier.py -k 'reachable or substantive or error_key'",
     "required_reviews": [
       "runtime-owner"
     ],
-    "acceptance": "Write the failing test FIRST, using the exact empty digest captured 2026-08-22: {\"talk_tracks\":{},\"objections\":[],\"current_state\":{},\"discovery\":{},\"decisions\":[],\"warnings\":[5 not-found messages],\"valid\":false}. Show it RED before any fix. Then (1) add canonical-digest.json to phase 1 `required` so the check is reached at all, and (2) replace the key-presence lambda at bus_verifier.py:102 with an assertion on CONTENT. Prove reachability separately from the assertion: a mutation that reverts only step (1) must turn a test red, and a mutation that reverts only step (2) must turn a different test red. A required-file False is a hard fail per bus_verifier.py:42-81; assert `pass` is False, not merely that a warn was emitted."
+    "acceptance": "THREE independent defects, THREE independent tests, each shown RED first and each killed by its own mutation. (1) REACHABLE: canonical-digest.json is in phase 1 required; reverting only this must turn a test red. (2) SUBSTANTIVE: the exact empty digest captured 2026-08-22 must be rejected - talk_tracks {}, objections [], current_state {}, discovery {}, decisions [], warnings 5 not-found messages, valid false; reverting only the lambda must turn a DIFFERENT test red. (3) ERROR SHORT-CIRCUIT (finding-13): bus_verifier.py:46-52 tests 'error' in data BEFORE the structure check and emits warn WITHOUT setting all_pass=False, so a required canonical-digest.json of exactly {\"error\":\"canonical digest unavailable\"} yields pass:true even after (1) and (2). Assert verify() returns pass False for that input. A required-file failure is a hard fail per bus_verifier.py:42-81, so assert on pass, never on the presence of a warn. SEQUENCING (finding-27): making this file required while canonical_dir still resolves to ~/.kipi-system/instances/<name>/canonical turns every phase-1 run red on 23 instances. Add a precondition test asserting canonical_dir does NOT resolve under the plugin-data base; it fails until srsa lands, which is the intended block."
   },
   {
     "id": "crpr-skeleton-resolves-live-canonical",
-    "title": "Skeleton-shipped references resolve the instance's live canonical tree",
-    "finding_id": "finding-2",
+    "title": "Council and wiring-check call the resolver instead of hardcoding a path",
+    "finding_id": "finding-19",
     "priority": "p1",
-    "bypass_check": "bash -c '! grep -rn \"q-system/canonical/\" plugins/kipi-ops/skills/council/ plugins/kipi-core/commands/wiring-check.md'",
     "allowed_files": [
       "plugins/kipi-ops/skills/council/SKILL.md",
       "plugins/kipi-ops/skills/council/workflows/quick.md",
       "plugins/kipi-ops/skills/council/workflows/debate.md",
       "plugins/kipi-core/commands/wiring-check.md",
-      "q-system/.q-system/scripts/test_evidence_ledger.py"
+      "q-system/.q-system/scripts/test/test-council-resolves-canonical.sh"
     ],
     "disallowed_files": [
-      ".claude/rules/**",
-      "q-system/canonical/**",
+      ".claude/**",
       ".prd-os/**"
     ],
     "required_checks": [
-      "python3 -m pytest -q q-system/.q-system/scripts/test_evidence_ledger.py",
-      "bash -c '! grep -rn \"q-system/canonical/\" plugins/kipi-ops/skills/council/ plugins/kipi-core/commands/wiring-check.md'"
+      "bash q-system/.q-system/scripts/test/test-council-resolves-canonical.sh"
     ],
+    "bypass_check": "bash q-system/.q-system/scripts/test/test-council-resolves-canonical.sh",
     "required_reviews": [
       "runtime-owner"
     ],
-    "acceptance": "All nine hardcoded q-system/canonical/ references (council SKILL.md:37,38,39,53; quick.md:15,16,17,77; debate.md:15,17,18,201; wiring-check.md:90) resolve through instance_root() from evidence_ledger.py:81-93. NEVER a hardcoded q-consult/ - 8 registered instances have instance_q_dir null and that path is meaningless there. Add a test case to test_evidence_ledger.py proving instance_root() resolves a non-q-system domain dir, since that is the case the skeleton's own fixtures never exercise. The grep check is a negative control: it must FAIL on the current tree before the edit."
+    "acceptance": "THIRTEEN references, not nine (finding-12, finding-30, recounted: SKILL.md 4, quick.md 4, debate.md 4, wiring-check.md 1). The check must assert the resolver is REACHED, not that a substring is absent: a literal negated grep on q-system/canonical/ is a false green because q-system//canonical/ or a concatenated path keeps the dead tree while passing (finding-19). Write test-council-resolves-canonical.sh to (a) assert every one of the 13 sites names the resolver, and (b) run a positive control against a fixture instance whose domain dir is NOT q-system and assert the resolved path is that dir. Show it RED before the edit. NEVER hardcode q-consult/: 8 registered instances have instance_q_dir null. ALSO IN SCOPE (finding-20): council's q-system/my-project/ references (SKILL.md:37,39 relationships.md and competitive-landscape.md) are the same defect in the same files and are left pointing at a fossil if only canonical is fixed."
   },
   {
     "id": "crpr-unhook-dead-canonical-consumers",
     "title": "Stop requiring the dead tree, then delete the skeleton's plugin copy",
-    "finding_id": "finding-3",
+    "finding_id": "finding-22",
     "priority": "p0",
-    "bypass_check": "bash -c '! grep -n \"q-system/canonical/discovery.md\\|q-system/canonical/pricing-framework.md\" q-system/.q-system/scripts/verify-containment-export.py'",
     "allowed_files": [
       "q-system/.q-system/scripts/verify-containment-export.py",
       "q-system/.q-system/scripts/test/test-verify-containment-export.sh",
       "plugins/kipi-core/kipi-mcp/canonical/**"
     ],
     "disallowed_files": [
-      ".claude/rules/**",
-      "q-system/canonical/**",
+      ".claude/**",
       ".prd-os/**"
     ],
     "required_checks": [
-      "python3 q-system/.q-system/scripts/verify-containment-export.py"
+      "bash q-system/.q-system/scripts/test/test-verify-containment-export.sh"
     ],
+    "bypass_check": "bash q-system/.q-system/scripts/test/test-verify-containment-export.sh",
     "required_reviews": [
       "runtime-owner"
     ],
-    "acceptance": "STEP ORDER IS LOAD-BEARING. First: verify-containment-export.py:24-28 stops hard-coding q-system/canonical/discovery.md and pricing-framework.md as REQUIRED export paths and resolves them through instance_root() instead; prove it by running the script from consulting (where q-system/canonical/ is the fossil) and getting exit 0 against q-consult/canonical/. Only then: git rm the skeleton's plugins/kipi-core/kipi-mcp/canonical/ tree - the skeleton copy, because plugins/ is mirrored with rsync -a --delete --delete-excluded (kipi-update.sh:2460) with no canonical exclude, so deleting it anywhere else regenerates it. Enumerate and report the ~20 agent-pipeline prompts under q-system/.q-system/agent-pipeline/agents/ that reference the path; if any are left pointing at a tree that still exists in the skeleton, say so explicitly rather than implying coverage."
+    "acceptance": "THREE hardcoded consumers, not two. Beyond EXPECTED_EXPORT_PATHS:24-28, RECEIPT_RELATIVE_PATH:30-32 is q-system/canonical/.containment-receipt.json and is loaded BEFORE any export path is validated, so the deletion breaks it first (finding-22). Define the receipt schema change explicitly (finding-7, finding-23): _validate_file_receipt requires source_path == destination_path AND membership in EXPECTED_EXPORT_PATHS, while the source is read as a git blob from the skeleton commit and the destination from the instance owner root - so repointing both to q-consult makes the source blob absent and repointing one violates the equality check. The spec must state the new source/destination split and bump the receipt schema_version. The required_check is a NEW harness because the bare script cannot run: it requires --instance and exits 2 on argparse (finding-2, finding-24); the harness must invoke it with a real instance and must FAIL if given a default. Prove exit 0 against an instance whose canonical lives outside q-system/. Only after that: git rm the SKELETON plugins/kipi-core/kipi-mcp/canonical/ tree, because plugins/ is mirrored with rsync -a --delete --delete-excluded (kipi-update.sh:2460) and deleting it elsewhere regenerates it."
+  },
+  {
+    "id": "crpr-reconcile-claude-rules",
+    "title": "Reconcile the rules that mandate the dead path, via the sanctioned path",
+    "finding_id": "finding-21",
+    "priority": "p1",
+    "allowed_files": [
+      "q-system/.q-system/scripts/test/test-claude-rules-canonical-reconciled.sh"
+    ],
+    "disallowed_files": [
+      "plugins/**",
+      ".prd-os/**"
+    ],
+    "required_checks": [
+      "bash q-system/.q-system/scripts/test/test-claude-rules-canonical-reconciled.sh"
+    ],
+    "bypass_check": "bash q-system/.q-system/scripts/test/test-claude-rules-canonical-reconciled.sh",
+    "required_reviews": [
+      "runtime-owner"
+    ],
+    "acceptance": "folder-structure.md:257-264 actively mandates that all scripts MUST resolve QROOT to q-system/, a direct contradiction of this PRD; four skeleton-synced rules carry frontmatter globs on the dead path (md-hygiene.md:4, anti-misclassification.md:4, sycophancy.md:5, folder-structure.md:236). No other entry can touch these: every one disallows .claude/** (finding-21, finding-5). The EDITS go through apply-claude-changes.sh, the sanctioned proposal path enforced by the claude-path-write-guard hook - do NOT write .claude/ directly and do NOT weaken the hook. This entry allowed_files holds only the checker, which asserts the contradiction is gone and the four globs resolve through the resolver. Show it RED first. Also enumerate the ~20 agent-pipeline prompts under q-system/.q-system/agent-pipeline/agents/ that reference the path and report them explicitly; if this entry does not repoint them, say so rather than implying coverage (finding-11)."
   },
   {
     "id": "crpr-consulting-fossil-cleanup",
-    "title": "Delete consulting's frozen canonical tree and its two council fossils",
-    "finding_id": "finding-4",
+    "title": "Delete consulting frozen canonical tree and its two council fossils",
+    "finding_id": "finding-25",
     "priority": "p1",
-    "bypass_check": "bash q-system/.q-system/scripts/test/test-canonical-fossil-absent.sh",
     "allowed_files": [
       "q-system/.q-system/scripts/test/test-canonical-fossil-absent.sh"
     ],
     "disallowed_files": [
-      ".claude/rules/**",
+      ".claude/**",
       "plugins/**",
       ".prd-os/**"
     ],
     "required_checks": [
       "bash q-system/.q-system/scripts/test/test-canonical-fossil-absent.sh"
     ],
+    "bypass_check": "bash q-system/.q-system/scripts/test/test-canonical-fossil-absent.sh",
     "required_reviews": [
       "runtime-owner"
     ],
-    "acceptance": "Runs LAST, after crpr-unhook-dead-canonical-consumers has shipped. In /Users/assafkipnis/projects/consulting: git rm the 10 tracked files under q-system/canonical/ (frozen 2026-07-01; safe because `canonical` is in INSTANCE_OWNED_SUBTREES at kipi-update.sh:64, so the updater neither restores nor --deletes it), and repoint the TWO instance-owned council fossils under .claude/skills/ - .claude/skills/council/ (SKILL.md:32-34,48; workflows/quick.md:11-13,73; workflows/debate.md:11,13,14,197) and the orphaned .claude/skills/workflows/ pair. .claude/skills/ is NOT covered by config_source_manages (kipi-update.sh:1279-1296), so these persist untouched and fixing only the plugin copy leaves two live wrong copies. The check in this repo is a fossil-absence assertion that must be shown RED against consulting before the deletion. Then re-run the fleet updater in DRY mode against consulting and confirm no restore of the deleted trees and no reversion of the skeleton edits."
+    "acceptance": "RUNS LAST, after crpr-unhook-dead-canonical-consumers has shipped. SCOPE LIMIT, stated plainly (finding-1, finding-26): the issue runner receipts paths in THIS repo only, so it cannot authorize or receipt the consulting deletions. The kipi-system deliverable is the checker; the deletions are performed in /Users/assafkipnis/projects/consulting as tracked git rm commits and are PROVED by this checker. The checker must not be able to pass vacuously (finding-25): an exit 0 body must fail its own negative self-test, so it takes the consulting path as an argument, refuses if that path does not exist, asserts the 10 tracked files under q-system/canonical/ are gone, asserts q-consult/canonical/ still has its 22 files, and asserts the two instance-owned council fossils (.claude/skills/council/ SKILL.md plus workflows/quick.md and workflows/debate.md, and the orphaned .claude/skills/workflows/ pair) no longer name the dead tree. Those .claude/skills/ copies are NOT covered by config_source_manages (kipi-update.sh:1279-1296) so they persist untouched; fixing only the plugin copy leaves two live wrong copies. Deleting consulting/q-system/canonical/ is safe from the updater because canonical is in INSTANCE_OWNED_SUBTREES (kipi-update.sh:64). Show the checker RED against consulting BEFORE the deletion. Afterwards run the fleet updater in DRY mode against consulting and confirm no restore and no reversion of skeleton edits."
   }
 ]
 ```

--- a/.prd-os/prds/prd-canonical-read-path-repair-2026-08-22.md
+++ b/.prd-os/prds/prd-canonical-read-path-repair-2026-08-22.md
@@ -1,0 +1,135 @@
+---
+id: prd-canonical-read-path-repair-2026-08-22
+title: Canonical Read Path Repair
+status: idea
+created_at: 2026-08-22T19:37:28Z
+updated_at: 2026-08-22T19:37:28Z
+owner: sana
+reviewers: []
+findings_path: .prd-os/findings/prd-canonical-read-path-repair-2026-08-22-findings.jsonl
+---
+
+# Canonical Read Path Repair
+
+## Problem
+
+<!-- What pain is this solving? Concrete, observed, measurable. -->
+
+## Goals
+
+- 
+
+## Non-goals
+
+- 
+
+## Proposed approach
+
+<!-- How. Keep it scannable. Diagrams go inline as fenced blocks. -->
+
+## Alternatives considered
+
+<!--
+Options you weighed and rejected. For each: name the option, the tradeoff, and
+the one reason it lost. This is what lets the reviewer tell a deliberately
+rejected path from one you never saw. Empty here reads as "no alternatives
+exist," which is rarely true.
+
+- **<option>** — Rejected: <why>.
+-->
+
+## Scenarios
+
+<!--
+Concrete end-to-end walkthroughs of the approach in use. One per distinct path.
+Actor, trigger, steps, outcome. Prove the approach against the real flow, not
+the abstraction.
+
+- **<scenario name>.** <actor> does <trigger>; <steps>; <outcome>.
+-->
+
+## Resolved decisions
+
+<!--
+The counterpart to Open questions: decisions now closed, each with its
+rationale. This is the running record of what was settled and why, so it does
+not get re-litigated later.
+
+- **<decision>.** Decided: <choice>. Rationale: <why>.
+-->
+
+## Risks and rollback
+
+<!-- Blast radius, migration cost, how to back out if this ships wrong. -->
+
+## Open questions
+
+- 
+
+<!--
+## Persona Review (optional, fill in before /prd-review)
+
+Phase 0 of the prd-os planning-personas experiment (PRD prd-planning-personas-2026-05-13).
+For non-trivial PRDs, answer the three Skeptic questions below before invoking /prd-review.
+Brief answers are fine. The goal is to force one round of adversarial thinking before Codex.
+
+### Skeptic
+
+Q1: What is the strongest argument against doing this?
+A1:
+
+Q2: What is the smallest experiment that would disprove the thesis?
+A2:
+
+Q3: What is the cheapest non-build alternative?
+A3:
+
+When done with these questions, uncomment this section and move it to live just before `## Issues` below.
+-->
+
+## Issues
+
+<!--
+After review and approval, populate the fenced JSON block below. The manifest is
+read by TWO consumers and every entry must satisfy both:
+  - `prd_split.py` materializes one issue spec per entry (needs `id`).
+  - the approval gate proves every ACCEPTED finding is covered by an entry (needs
+    `finding_id` + a `bypass_check`). One entry per accepted finding.
+
+Required keys per entry (spine-native -- both consumers):
+  - id (kebab-case, unique across the repo)            -- prd_split.py
+  - finding_id (the accepted finding it covers, e.g. "finding-1") -- approval gate
+  - title (non-empty string)
+  - allowed_files (non-empty list of glob patterns)
+  - required_checks (non-empty list, e.g. ["pytest -q"]). The stop-gate checks
+    three receipts (verified, reviewed, findings_triaged); they are meaningless
+    unless the spec documents what must be verified, so an empty list is rejected.
+  - bypass_check (a command proving no bypass remains) OR
+    bypass_exempt: "<reason>"                          -- spine contract
+
+Write bypass_check as an INVARIANT, not a token count. Counting occurrences of
+an identifier looks deterministic and is not: prose in a comment inflates it, a
+refactor that renames or inlines deflates it, and neither fact says anything
+about whether a bypass remains. Prefer "exactly one scan exists", "the byte
+compare lives in one place", "the guard is still present" over
+`grep -c <name> == N`. If a count really is the invariant, exclude comment lines
+(`grep -v '^[[:space:]]*#' | grep -c`) and use `grep -F` for patterns holding
+regex metacharacters such as `$`.
+
+Scar 2026-07-26 (prd-updater-consolidation): three of five bypass_checks were
+grep-count proxies and each needed a mid-issue amendment. One did real damage --
+it demanded three calls to a function, so a redundant dead call was written
+purely to satisfy the number, and adversarial review caught it. A check that
+shapes the code to fit the check is worse than no check.
+
+Optional keys:
+  - priority (default p1)
+  - disallowed_files, required_reviews, acceptance
+
+Authoring a manifest with `id` but no `finding_id` (the pre-spine shape) is
+rejected at approve. The template-vs-runner contract test enforces this list.
+-->
+
+```json
+[]
+```

--- a/plugins/kipi-core/.claude-plugin/plugin.json
+++ b/plugins/kipi-core/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "kipi-core",
-  "version": "1.7.11",
+  "version": "1.7.12",
   "description": "Core founder OS \u2014 voice, research, AUDHD, LinkedIn/brand, RCA skills + kipi-mcp server",
   "author": {
     "name": "Assaf Kipnis",

--- a/plugins/kipi-core/.claude-plugin/plugin.json
+++ b/plugins/kipi-core/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "kipi-core",
-  "version": "1.7.12",
+  "version": "1.7.13",
   "description": "Core founder OS \u2014 voice, research, AUDHD, LinkedIn/brand, RCA skills + kipi-mcp server",
   "author": {
     "name": "Assaf Kipnis",

--- a/plugins/kipi-core/.claude-plugin/plugin.json
+++ b/plugins/kipi-core/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "kipi-core",
-  "version": "1.7.10",
+  "version": "1.7.11",
   "description": "Core founder OS \u2014 voice, research, AUDHD, LinkedIn/brand, RCA skills + kipi-mcp server",
   "author": {
     "name": "Assaf Kipnis",

--- a/plugins/kipi-core/.claude-plugin/plugin.json
+++ b/plugins/kipi-core/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "kipi-core",
-  "version": "1.7.17",
+  "version": "1.7.18",
   "description": "Core founder OS \u2014 voice, research, AUDHD, LinkedIn/brand, RCA skills + kipi-mcp server",
   "author": {
     "name": "Assaf Kipnis",

--- a/plugins/kipi-core/.claude-plugin/plugin.json
+++ b/plugins/kipi-core/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "kipi-core",
-  "version": "1.7.16",
+  "version": "1.7.17",
   "description": "Core founder OS \u2014 voice, research, AUDHD, LinkedIn/brand, RCA skills + kipi-mcp server",
   "author": {
     "name": "Assaf Kipnis",

--- a/plugins/kipi-core/.claude-plugin/plugin.json
+++ b/plugins/kipi-core/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "kipi-core",
-  "version": "1.7.18",
+  "version": "1.7.19",
   "description": "Core founder OS \u2014 voice, research, AUDHD, LinkedIn/brand, RCA skills + kipi-mcp server",
   "author": {
     "name": "Assaf Kipnis",

--- a/plugins/kipi-core/.claude-plugin/plugin.json
+++ b/plugins/kipi-core/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "kipi-core",
-  "version": "1.7.9",
+  "version": "1.7.10",
   "description": "Core founder OS \u2014 voice, research, AUDHD, LinkedIn/brand, RCA skills + kipi-mcp server",
   "author": {
     "name": "Assaf Kipnis",

--- a/plugins/kipi-core/.claude-plugin/plugin.json
+++ b/plugins/kipi-core/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "kipi-core",
-  "version": "1.7.15",
+  "version": "1.7.16",
   "description": "Core founder OS \u2014 voice, research, AUDHD, LinkedIn/brand, RCA skills + kipi-mcp server",
   "author": {
     "name": "Assaf Kipnis",

--- a/plugins/kipi-core/.claude-plugin/plugin.json
+++ b/plugins/kipi-core/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "kipi-core",
-  "version": "1.7.14",
+  "version": "1.7.15",
   "description": "Core founder OS \u2014 voice, research, AUDHD, LinkedIn/brand, RCA skills + kipi-mcp server",
   "author": {
     "name": "Assaf Kipnis",

--- a/plugins/kipi-core/.claude-plugin/plugin.json
+++ b/plugins/kipi-core/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "kipi-core",
-  "version": "1.7.13",
+  "version": "1.7.14",
   "description": "Core founder OS \u2014 voice, research, AUDHD, LinkedIn/brand, RCA skills + kipi-mcp server",
   "author": {
     "name": "Assaf Kipnis",

--- a/plugins/kipi-core/kipi-mcp/src/kipi_mcp/bus_verifier.py
+++ b/plugins/kipi-core/kipi-mcp/src/kipi_mcp/bus_verifier.py
@@ -1,8 +1,73 @@
 from __future__ import annotations
 
 import json
+import os
 from datetime import datetime
 from pathlib import Path
+
+CANONICAL_DIGEST = "canonical-digest.json"
+
+
+def _canonical_dir_is_plugin_data() -> bool:
+    """True while canonical_dir still resolves under the plugin-data base.
+
+    SEQUENCING GUARD (PRD finding-27). canonical-digest.json must become a REQUIRED
+    phase-1 file, but promoting it while paths.py still resolves canonical_dir to
+    {plugin-data}/instances/<name>/canonical -- a directory measured to hold ZERO
+    files -- turns every phase-1 run red on all 23 instances at once. So the
+    promotion is computed, not typed: optional until the path contract lands
+    (srsa-authoritative-path-contract), required automatically afterwards.
+
+    Fails toward NOT-required. A crash here must not be able to cause the outage
+    this function exists to prevent.
+    """
+    try:
+        from kipi_mcp.paths import KipiPaths
+
+        canonical = KipiPaths().canonical_dir.resolve()
+    except Exception:
+        return True  # cannot tell -> stay optional -> no outage
+
+    base = os.environ.get("KIPI_PLUGIN_DATA")
+    bases = [Path(base)] if base else []
+    bases.append(Path.home() / ".kipi-system")
+    for b in bases:
+        try:
+            canonical.relative_to(b.resolve())
+            return True
+        except (ValueError, OSError):
+            continue
+    return False
+
+
+def canonical_digest_is_required() -> bool:
+    """The promotion predicate. Public so its BOTH branches can be tested; a
+    predicate whose false branch is never exercised reports success by default."""
+    return not _canonical_dir_is_plugin_data()
+
+
+def _canonical_digest_substantive(d: dict) -> bool:
+    """Reject a digest that parsed nothing, without asserting digest["valid"].
+
+    Calibrated against measurement, not intuition (2026-08-22):
+      * the LIVE tree yields decisions=10, objections=5, warnings=0 -> PASSES,
+        even though its valid is False and its talk_tracks are all empty because
+        those files were retired to pointer docs. Requiring talk_tracks here would
+        red every run against real data.
+      * the captured all-empty digest has decisions=[], objections=[], 5 warnings
+        -> FAILS.
+      * Codex finding-14's nonempty placeholder
+        {"talk_tracks":{"metaphor":"placeholder"},"objections":[],"decisions":[],...}
+        -> FAILS. Key-presence and "some field is nonempty" both accept it, which
+        is exactly why neither is used.
+    """
+    if not all(k in d for k in ("talk_tracks", "objections", "decisions")):
+        return False
+    if not isinstance(d.get("decisions"), list) or not d["decisions"]:
+        return False
+    if not isinstance(d.get("objections"), list) or not d["objections"]:
+        return False
+    return len(d.get("warnings") or []) < 3
 
 
 class BusVerifier:
@@ -29,6 +94,13 @@ class BusVerifier:
         optional = list(spec.get("optional", []))
         checks = spec.get("checks", {})
 
+        # REACHABILITY (PRD defect 1). canonical-digest.json sat in phase 1's `checks`
+        # dict but in neither `required` nor `optional`, so its lambda was never once
+        # invoked -- dead code that read as protection. Wire it into a list, promoting
+        # to required only when the path contract makes that survivable.
+        if phase == 1 and CANONICAL_DIGEST not in required and CANONICAL_DIGEST not in optional:
+            (required if canonical_digest_is_required() else optional).append(CANONICAL_DIGEST)
+
         day_name = datetime.strptime(date, "%Y-%m-%d").strftime("%A").lower()
         if phase == 4 and day_name in ("tuesday", "thursday"):
             if "tl-content.json" in optional:
@@ -48,8 +120,15 @@ class BusVerifier:
             try:
                 data = json.loads(path.read_text())
                 if "error" in data:
-                    results.append({"status": "warn", "type": "required", "file": f,
+                    # ERROR SHORT-CIRCUIT (PRD defect 3, the one the first draft missed).
+                    # This branch used to emit `warn` and leave all_pass untouched, so a
+                    # REQUIRED file containing {"error": "..."} produced pass:true -- and
+                    # it survived both the reachability and the substance fix, because it
+                    # returns before either is consulted. A required file that carries an
+                    # error produced nothing; that is a hard fail, same as MISSING.
+                    results.append({"status": "fail", "type": "required", "file": f,
                                     "detail": f"has error key ({data['error']})"})
+                    all_pass = False
                 elif f in checks and not checks[f](data):
                     results.append({"status": "fail", "type": "required", "file": f,
                                     "detail": "structure check failed"})
@@ -99,7 +178,9 @@ class BusVerifier:
                     "calendar.json": lambda d: "today" in d or "this_week" in d,
                     "gmail.json": lambda d: "emails" in d,
                     "notion.json": lambda d: "contacts" in d and "actions" in d,
-                    "canonical-digest.json": lambda d: "talk_tracks" in d and "objections" in d and "decisions" in d,
+                    # SUBSTANCE (PRD defect 2). Was key-presence only, which passes an
+                    # all-empty digest and passes Codex finding-14's nonempty placeholder.
+                    CANONICAL_DIGEST: _canonical_digest_substantive,
                 },
             },
             2: {

--- a/plugins/kipi-core/kipi-mcp/src/kipi_mcp/bus_verifier.py
+++ b/plugins/kipi-core/kipi-mcp/src/kipi_mcp/bus_verifier.py
@@ -8,8 +8,8 @@ from pathlib import Path
 CANONICAL_DIGEST = "canonical-digest.json"
 
 
-def _canonical_dir_is_plugin_data() -> bool:
-    """True while canonical_dir still resolves under the plugin-data base.
+def _canonical_content_present() -> bool:
+    """True when the resolved canonical dir actually holds canonical content.
 
     SEQUENCING GUARD (PRD finding-27). canonical-digest.json must become a REQUIRED
     phase-1 file, but promoting it while paths.py still resolves canonical_dir to
@@ -18,32 +18,40 @@ def _canonical_dir_is_plugin_data() -> bool:
     promotion is computed, not typed: optional until the path contract lands
     (srsa-authoritative-path-contract), required automatically afterwards.
 
-    Fails toward NOT-required. A crash here must not be able to cause the outage
-    this function exists to prevent.
+    SCAR (Codex review of PR #240, blocker). The first version of this guard asked
+    "does canonical_dir resolve under the plugin-data base?" -- and
+    `KipiPaths.canonical_dir` is DEFINED as `{base}/instances/<name>/canonical`
+    where `{base}` is exactly `KIPI_PLUGIN_DATA` or `~/.kipi-system`. The answer
+    was therefore yes for every reachable configuration. It was a tautology
+    wearing a predicate's clothes: the required branch could only be entered by
+    monkeypatching this function, so the digest check shipped permanently optional
+    and the "make it able to fail" fix was inert in production.
+
+    Emptiness is the condition the docstring above actually names, and unlike a
+    path prefix it can be observed BOTH ways through the real code path: an empty
+    tree yields False (no outage today), a populated one yields True. When the
+    path contract repoints canonical_dir at a live tree, the promotion happens on
+    its own with no edit here.
     """
-    try:
-        from kipi_mcp.paths import KipiPaths
+    from kipi_mcp.paths import KipiPaths
 
-        canonical = KipiPaths().canonical_dir.resolve()
-    except Exception:
-        return True  # cannot tell -> stay optional -> no outage
-
-    base = os.environ.get("KIPI_PLUGIN_DATA")
-    bases = [Path(base)] if base else []
-    bases.append(Path.home() / ".kipi-system")
-    for b in bases:
-        try:
-            canonical.relative_to(b.resolve())
-            return True
-        except (ValueError, OSError):
-            continue
-    return False
+    canonical = KipiPaths().canonical_dir
+    if not canonical.is_dir():
+        return False
+    return any(p.is_file() for p in canonical.iterdir())
 
 
 def canonical_digest_is_required() -> bool:
     """The promotion predicate. Public so its BOTH branches can be tested; a
-    predicate whose false branch is never exercised reports success by default."""
-    return not _canonical_dir_is_plugin_data()
+    predicate whose false branch is never exercised reports success by default.
+
+    Fails toward NOT-required. A crash here must not be able to cause the outage
+    the sequencing guard exists to prevent.
+    """
+    try:
+        return _canonical_content_present()
+    except Exception:
+        return False  # cannot tell -> stay optional -> no outage
 
 
 def _canonical_digest_substantive(d: dict) -> bool:

--- a/plugins/kipi-core/kipi-mcp/src/kipi_mcp/bus_verifier.py
+++ b/plugins/kipi-core/kipi-mcp/src/kipi_mcp/bus_verifier.py
@@ -48,10 +48,47 @@ def canonical_digest_is_required() -> bool:
     Fails toward NOT-required. A crash here must not be able to cause the outage
     the sequencing guard exists to prevent.
     """
+    return canonical_digest_requirement()[0]
+
+
+def canonical_digest_requirement() -> tuple[bool, str | None]:
+    """(is_required, resolution_error). THREE states, not two.
+
+    SCAR (Codex review of PR #240, major). This used to be a bare
+    `except Exception: return False`, which cannot tell these apart:
+
+      "the canonical tree is intentionally empty"  -> not required, correct
+      "path resolution CRASHED"                    -> we know nothing
+
+    Both silently selected the optional branch, so phase-1 verification passed
+    with the detector disabled. Measured against the repro the reviewer gave:
+
+      KIPI_REGISTRY=/definitely/missing KIPI_INSTANCE=prod
+      resolver: RAISED PathContractError
+      required: False        <- crash became "optional", quietly
+
+    That is the broad-except-hides-your-own-bug shape, and it got worse the moment
+    the resolver started raising by design. A resolution failure is now RETURNED so
+    the caller can make it an observable verification failure. Still no exception
+    escapes: an unattended verifier must not wedge, it must report.
+    """
+    from kipi_mcp.paths import PathContractError
+
     try:
-        return _canonical_content_present()
-    except Exception:
-        return False  # cannot tell -> stay optional -> no outage
+        return _canonical_content_present(), None
+    except PathContractError as exc:
+        # kind SEPARATES a normal state from a misconfiguration, which is the whole
+        # point of the finding. "unregistered" is what the SKELETON and any fresh
+        # clone look like: there is no instance canonical tree and there is not
+        # supposed to be one, so the detector is legitimately optional and reding a
+        # run over it would wedge every non-instance checkout. Every other kind --
+        # a registry that is missing or unparseable, a duplicate row, a registered
+        # instance whose tree is absent -- means somebody has to fix something.
+        if getattr(exc, "kind", "unknown") == "unregistered":
+            return False, None
+        return False, str(exc)
+    except Exception as exc:  # unknown failure is still reportable, not silent
+        return False, f"{type(exc).__name__}: {exc}"
 
 
 def _canonical_digest_substantive(d: dict) -> bool:
@@ -106,9 +143,6 @@ class BusVerifier:
         # dict but in neither `required` nor `optional`, so its lambda was never once
         # invoked -- dead code that read as protection. Wire it into a list, promoting
         # to required only when the path contract makes that survivable.
-        if phase == 1 and CANONICAL_DIGEST not in required and CANONICAL_DIGEST not in optional:
-            (required if canonical_digest_is_required() else optional).append(CANONICAL_DIGEST)
-
         day_name = datetime.strptime(date, "%Y-%m-%d").strftime("%A").lower()
         if phase == 4 and day_name in ("tuesday", "thursday"):
             if "tl-content.json" in optional:
@@ -118,6 +152,23 @@ class BusVerifier:
 
         results: list[dict] = []
         all_pass = True
+
+        # REACHABILITY (PRD defect 1). canonical-digest.json sat in phase 1's `checks`
+        # dict but in neither `required` nor `optional`, so its lambda was never once
+        # invoked -- dead code that read as protection. Wire it into a list, promoting
+        # to required only when the path contract makes that survivable.
+        # Sits AFTER results/all_pass on purpose: a path-resolution failure has to be
+        # recordable, and before this it could only silently pick `optional`.
+        if phase == 1 and CANONICAL_DIGEST not in required and CANONICAL_DIGEST not in optional:
+            is_required, resolve_error = canonical_digest_requirement()
+            if resolve_error:
+                results.append({
+                    "status": "fail", "type": "required", "file": CANONICAL_DIGEST,
+                    "detail": f"PATH RESOLUTION FAILED: {resolve_error}",
+                })
+                all_pass = False
+            else:
+                (required if is_required else optional).append(CANONICAL_DIGEST)
 
         for f in required:
             path = bus_day / f

--- a/plugins/kipi-core/kipi-mcp/src/kipi_mcp/paths.py
+++ b/plugins/kipi-core/kipi-mcp/src/kipi_mcp/paths.py
@@ -6,6 +6,20 @@ from pathlib import Path
 
 APP_NAME = "kipi-system"
 
+
+class PathContractError(RuntimeError):
+    """An instance state root could not be resolved from the registry.
+
+    Raised, never defaulted. The whole defect class this replaces is a resolver
+    that GUESSES on an unmapped repo and hands back an empty directory, which
+    reads downstream as "no data" instead of "wrong path" -- that is how
+    kipi_canonical_digest returned valid:false fleet-wide while looking healthy.
+
+    Defined ahead of the resolver on purpose: test_paths.py imports it at module
+    level, so while it was missing pytest raised ImportError at COLLECTION and
+    zero tests ran. A red that never executed the case is not a reproducer.
+    """
+
 _SUFFIX_WORDS = [
     "arrow", "blaze", "comet", "delta", "ember", "frost", "ghost", "haven",
     "ion", "jade", "kite", "lunar", "maple", "noble", "orbit", "prism",

--- a/plugins/kipi-core/kipi-mcp/src/kipi_mcp/paths.py
+++ b/plugins/kipi-core/kipi-mcp/src/kipi_mcp/paths.py
@@ -141,8 +141,66 @@ class KipiPaths:
     # --- Per-instance subdirectories ---
 
     @property
+    def _state_root(self) -> Path:
+        """The instance's OWN tree that owns canonical/ and my-project/.
+
+        THE DEFECT THIS FIXES. These two properties used to return
+        `{base}/instances/{name}/...` -- plugin DATA, which holds no repo content.
+        So kipi_canonical_digest read an empty directory and returned
+        all-files-not-found on every instance, and agents fell back to reading raw
+        canonical (40-60K tokens), where one instance has three diverged copies.
+
+        Registry is the authority, keyed by instance name. Formula per
+        prd-single-runtime-state-authority: `instance_q_dir` when set, else
+        `subtree_prefix`, else q-system.
+
+        FAILS CLOSED. An unmapped instance RAISES rather than returning a path to
+        nothing: an empty directory reads downstream as "no data" when the truth is
+        "wrong path", and that misreading is the whole reason this contract exists.
+
+        NOT `<path>/<subtree_prefix>/q-system`. A literal reading of the contract
+        sentence produces q-system/q-system, and those nested shadow trees were
+        deleted fleet-wide on 2026-07-01.
+        """
+        import json as _json
+        reg = self.registry_path
+        if not reg.is_file():
+            raise PathContractError(
+                f"no instance registry at {reg}; cannot resolve a state root for "
+                f"{self.instance!r} without guessing")
+        try:
+            data = _json.loads(reg.read_text(encoding="utf-8"))
+        except Exception as exc:
+            raise PathContractError(f"registry {reg} is unreadable: {exc}")
+
+        matches = [e for e in data.get("instances", [])
+                   if e.get("name") == self.instance]
+        if len(matches) > 1:
+            raise PathContractError(
+                f"{self.instance!r} appears {len(matches)} times in {reg}. Refusing "
+                f"to let the first row silently win.")
+        if matches:
+            entry = matches[0]
+            sub = (entry.get("instance_q_dir")
+                   or entry.get("subtree_prefix")
+                   or "q-system")
+            return Path(entry.get("path", "")) / sub
+
+        skel = data.get("skeleton") or {}
+        if isinstance(skel, dict) and skel.get("path"):
+            try:
+                if Path(skel["path"]).resolve() == Path(self.repo_dir).resolve():
+                    return Path(skel["path"]) / "q-system"
+            except OSError:
+                pass
+
+        raise PathContractError(
+            f"{self.instance!r} is not a registered instance in {reg}. Refusing to "
+            f"resolve canonical/ or my-project/ by guessing.")
+
+    @property
     def canonical_dir(self) -> Path:
-        return self._instance_dir / "canonical"
+        return self._state_root / "canonical"
 
     @property
     def marketing_config_dir(self) -> Path:
@@ -150,7 +208,7 @@ class KipiPaths:
 
     @property
     def my_project_dir(self) -> Path:
-        return self._instance_dir / "my-project"
+        return self._state_root / "my-project"
 
     @property
     def memory_dir(self) -> Path:
@@ -229,10 +287,8 @@ class KipiPaths:
             self.voice_dir,
             self.audhd_dir,
             self._instance_dir,
-            self.canonical_dir,
             self.marketing_config_dir,
             self.marketing_config_dir / "assets",
-            self.my_project_dir,
             self.memory_dir,
             self.memory_dir / "working",
             self.memory_dir / "weekly",

--- a/plugins/kipi-core/kipi-mcp/src/kipi_mcp/paths.py
+++ b/plugins/kipi-core/kipi-mcp/src/kipi_mcp/paths.py
@@ -107,20 +107,38 @@ class KipiPaths:
             or os.environ.get("KIPI_PLUGIN_ROOT")
             or Path(__file__).resolve().parents[3]
         )
-        self.instance = instance or _detect_instance(self._base)
-        # NOTHING tells the deployed server which instance it serves: KIPI_INSTANCE
-        # is unset and {base}/active-instance does not exist, so _detect_instance
-        # returns the "default" sentinel and the registry has no such row. The live
-        # MCP tool therefore fail-closed even once registry_path was fixed.
-        # CLAUDE_PROJECT_DIR is exactly the missing fact -- Claude Code sets it to
-        # the project in use -- and the registry already maps path -> name. Same
-        # match evidence_ledger._registry_q_dir makes. Only consulted when the
-        # caller passed no instance AND nothing was configured, so an explicit
-        # instance and a real active-instance file both still win.
-        if instance is None and self.instance == "default":
-            resolved = self._instance_from_project_dir()
-            if resolved:
-                self.instance = resolved
+        self.instance = instance or self._resolve_instance()
+
+    def _resolve_instance(self) -> str:
+        """Which instance this process serves. ORDER IS THE SECURITY PROPERTY.
+
+        SCAR (Codex review of PR #240, major -- a leak introduced by the fix that
+        exists to prevent leaks). The first version consulted CLAUDE_PROJECT_DIR
+        only when the answer was already the "default" sentinel, so the
+        `{base}/active-instance` marker outranked it. That marker lives in PLUGIN
+        DATA, which is SHARED BY EVERY PROJECT on the machine. Measured:
+
+            CLAUDE_PROJECT_DIR : ~/projects/consulting
+            shared marker says : KTLYST_strategy
+            canonical_dir      : ~/projects/cole-gtm/projects/strategy/q-ktlyst/canonical
+
+        A session in one project read another project's canonical tree. Ordering:
+
+          1. explicit `instance=` argument -- the caller states it outright.
+          2. KIPI_INSTANCE -- per-PROCESS env, deliberate and not shared.
+          3. CLAUDE_PROJECT_DIR matched against the registry -- per-PROJECT and
+             authoritative for "which project is this process actually in".
+          4. the shared active-instance marker -- legacy, and last precisely
+             because one stale write to it would otherwise redirect every project.
+          5. "default".
+        """
+        env = os.environ.get("KIPI_INSTANCE")
+        if env:
+            return env
+        from_project = self._instance_from_project_dir()
+        if from_project:
+            return from_project
+        return _detect_instance(self._base)
 
     def _instance_from_project_dir(self) -> str | None:
         """Registry row whose path IS the current project dir, or None."""
@@ -223,7 +241,21 @@ class KipiPaths:
             sub = (entry.get("instance_q_dir")
                    or entry.get("subtree_prefix")
                    or "q-system")
-            return Path(entry.get("path", "")) / sub
+            root = Path(entry.get("path", "")) / sub
+            # A REGISTERED row is not proof the tree is there. Measured across the
+            # live registry: 4 of 25 instances (registry rows whose q-system/ holds
+            # no canonical/) resolved to a directory that does not exist and were
+            # handed back as authoritative. Returning a path to nothing is the exact
+            # failure this contract exists to remove -- downstream it reads as "no
+            # data" when the truth is "wrong path". Same rule evidence_ledger's
+            # instance_root already applies.
+            if not (root / "canonical").is_dir():
+                raise PathContractError(
+                    f"{self.instance!r} resolves to {root}, which has no canonical/ "
+                    f"subdirectory. There is no canonical tree here; refusing to "
+                    f"return a path to nothing. Fix the registry row or create the "
+                    f"tree.")
+            return root
 
         skel = data.get("skeleton") or {}
         if isinstance(skel, dict) and skel.get("path"):

--- a/plugins/kipi-core/kipi-mcp/src/kipi_mcp/paths.py
+++ b/plugins/kipi-core/kipi-mcp/src/kipi_mcp/paths.py
@@ -8,17 +8,25 @@ APP_NAME = "kipi-system"
 
 
 class PathContractError(RuntimeError):
-    """An instance state root could not be resolved from the registry.
+    """Carries a `kind` so callers can tell a MISCONFIGURATION from a normal state.
 
-    Raised, never defaulted. The whole defect class this replaces is a resolver
-    that GUESSES on an unmapped repo and hands back an empty directory, which
-    reads downstream as "no data" instead of "wrong path" -- that is how
-    kipi_canonical_digest returned valid:false fleet-wide while looking healthy.
+    Not decoration. bus_verifier has to distinguish "this repo simply is not an
+    instance" (the skeleton, a fresh clone -- there is no canonical tree and that
+    is fine) from "the registry is missing or the registered tree is absent"
+    (someone must fix something). Message-matching for that would be fragile, so
+    the kind is set at each raise site:
 
-    Defined ahead of the resolver on purpose: test_paths.py imports it at module
-    level, so while it was missing pytest raised ImportError at COLLECTION and
-    zero tests ran. A red that never executed the case is not a reproducer.
+        no-registry       the registry file does not exist        -> misconfig
+        unreadable        the registry exists but will not parse  -> misconfig
+        duplicate-name    two rows claim one instance name        -> misconfig
+        no-canonical      registered, but the tree is not there   -> misconfig
+        unregistered      this repo is not a registered instance  -> NORMAL
     """
+
+    def __init__(self, message: str, kind: str = "unknown"):
+        super().__init__(message)
+        self.kind = kind
+
 
 _SUFFIX_WORDS = [
     "arrow", "blaze", "comet", "delta", "ember", "frost", "ghost", "haven",
@@ -224,18 +232,18 @@ class KipiPaths:
         if not reg.is_file():
             raise PathContractError(
                 f"no instance registry at {reg}; cannot resolve a state root for "
-                f"{self.instance!r} without guessing")
+                f"{self.instance!r} without guessing", kind="no-registry")
         try:
             data = _json.loads(reg.read_text(encoding="utf-8"))
         except Exception as exc:
-            raise PathContractError(f"registry {reg} is unreadable: {exc}")
+            raise PathContractError(f"registry {reg} is unreadable: {exc}", kind="unreadable")
 
         matches = [e for e in data.get("instances", [])
                    if e.get("name") == self.instance]
         if len(matches) > 1:
             raise PathContractError(
                 f"{self.instance!r} appears {len(matches)} times in {reg}. Refusing "
-                f"to let the first row silently win.")
+                f"to let the first row silently win.", kind="duplicate-name")
         if matches:
             entry = matches[0]
             sub = (entry.get("instance_q_dir")
@@ -254,7 +262,7 @@ class KipiPaths:
                     f"{self.instance!r} resolves to {root}, which has no canonical/ "
                     f"subdirectory. There is no canonical tree here; refusing to "
                     f"return a path to nothing. Fix the registry row or create the "
-                    f"tree.")
+                    f"tree.", kind="no-canonical")
             return root
 
         skel = data.get("skeleton") or {}
@@ -267,7 +275,7 @@ class KipiPaths:
 
         raise PathContractError(
             f"{self.instance!r} is not a registered instance in {reg}. Refusing to "
-            f"resolve canonical/ or my-project/ by guessing.")
+            f"resolve canonical/ or my-project/ by guessing.", kind="unregistered")
 
     @property
     def canonical_dir(self) -> Path:

--- a/plugins/kipi-core/kipi-mcp/src/kipi_mcp/paths.py
+++ b/plugins/kipi-core/kipi-mcp/src/kipi_mcp/paths.py
@@ -162,13 +162,27 @@ class KipiPaths:
             target = Path(project).resolve()
         except (OSError, ValueError):
             return None
+        # Collect ALL matches, never `return` on the first. Duplicate registry
+        # PATHS are the sibling of the duplicate-NAME hazard guarded in
+        # _state_root, and this site had only the name half. Measured with two
+        # rows sharing one path: resolved_instance=alpha, ambiguity_reported=no --
+        # an unattended server binds to whichever row is listed first and reads
+        # that project's canonical data. Refusing is the only safe answer; picking
+        # is what this whole contract exists to stop.
+        matches = []
         for entry in data.get("instances", []):
             try:
                 if Path(entry.get("path", "")).resolve() == target:
-                    return entry.get("name")
+                    matches.append(entry.get("name"))
             except (OSError, ValueError):
                 continue
-        return None
+        if len(matches) > 1:
+            raise PathContractError(
+                f"{project} is claimed by {len(matches)} registry rows "
+                f"({', '.join(sorted(str(m) for m in matches))}). Refusing to let "
+                f"the first row win. Remove the duplicate path from the registry.",
+                kind="duplicate-path")
+        return matches[0] if matches else None
 
     # --- Base directories ---
 

--- a/plugins/kipi-core/kipi-mcp/src/kipi_mcp/paths.py
+++ b/plugins/kipi-core/kipi-mcp/src/kipi_mcp/paths.py
@@ -93,6 +93,10 @@ class KipiPaths:
         repo_dir: Path | None = None,
         instance: str | None = None,
     ):
+        # Whether base_dir was HANDED to us decides how registry_path resolves.
+        # A test that passes base_dir must stay hermetic; the deployed server, which
+        # passes nothing, must be allowed to go find a registry that exists.
+        self._base_explicit = base_dir is not None
         self._base = Path(
             base_dir
             or os.environ.get("KIPI_PLUGIN_DATA")
@@ -104,6 +108,41 @@ class KipiPaths:
             or Path(__file__).resolve().parents[3]
         )
         self.instance = instance or _detect_instance(self._base)
+        # NOTHING tells the deployed server which instance it serves: KIPI_INSTANCE
+        # is unset and {base}/active-instance does not exist, so _detect_instance
+        # returns the "default" sentinel and the registry has no such row. The live
+        # MCP tool therefore fail-closed even once registry_path was fixed.
+        # CLAUDE_PROJECT_DIR is exactly the missing fact -- Claude Code sets it to
+        # the project in use -- and the registry already maps path -> name. Same
+        # match evidence_ledger._registry_q_dir makes. Only consulted when the
+        # caller passed no instance AND nothing was configured, so an explicit
+        # instance and a real active-instance file both still win.
+        if instance is None and self.instance == "default":
+            resolved = self._instance_from_project_dir()
+            if resolved:
+                self.instance = resolved
+
+    def _instance_from_project_dir(self) -> str | None:
+        """Registry row whose path IS the current project dir, or None."""
+        import json as _json
+        project = os.environ.get("CLAUDE_PROJECT_DIR")
+        if not project:
+            return None
+        reg = self.registry_path
+        if not reg.is_file():
+            return None
+        try:
+            data = _json.loads(reg.read_text(encoding="utf-8"))
+            target = Path(project).resolve()
+        except (OSError, ValueError):
+            return None
+        for entry in data.get("instances", []):
+            try:
+                if Path(entry.get("path", "")).resolve() == target:
+                    return entry.get("name")
+            except (OSError, ValueError):
+                continue
+        return None
 
     # --- Base directories ---
 
@@ -258,7 +297,59 @@ class KipiPaths:
 
     @property
     def registry_path(self) -> Path:
-        return self._base / "instance-registry.json"
+        """Where the fleet registry actually is.
+
+        SCAR (2026-08-22): this returned `{base}/instance-registry.json`
+        unconditionally, and in the DEPLOYED server `{base}` is KIPI_PLUGIN_DATA
+        (see plugins/kipi-core/.mcp.json) -- i.e. ~/.kipi-system, which holds no
+        registry and never has. Once canonical_dir became registry-derived, the
+        resolver therefore fail-closed on every live MCP call:
+
+            PathContractError: no instance registry at
+            ~/.kipi-system/instance-registry.json
+
+        Failing closed on an input that can never exist is still a dead tool. The
+        repoint was proved by hand-feeding base_dir, which is a sound UNIT proof of
+        the resolver and says nothing about the configuration the server runs under.
+
+        Resolution order, first hit wins:
+          0. base_dir was passed explicitly -> use it, no search. Keeps every test
+             hermetic and stops a fixture from reaching the real fleet registry.
+          1. $KIPI_REGISTRY -- explicit operator override.
+          2. {base}/instance-registry.json when it really exists.
+          3. walk UP from repo_dir. The plugin runs from the marketplace clone
+             (CLAUDE_PLUGIN_ROOT -> .../marketplaces/kipi/plugins/kipi-core) and that
+             clone is a checkout of this repo, which TRACKS instance-registry.json at
+             its root. Verified present. This is also the dev-checkout answer, so one
+             rule covers both without hardcoding a path.
+          4. $KIPI_FLEET_ROOT (default ~/projects), the convention
+             verify-alert-wiring.sh:16 already uses.
+        """
+        if self._base_explicit:
+            return self._base / "instance-registry.json"
+
+        override = os.environ.get("KIPI_REGISTRY")
+        if override:
+            return Path(override)
+
+        default = self._base / "instance-registry.json"
+        if default.is_file():
+            return default
+
+        repo = Path(self.repo_dir)
+        for d in (repo, *repo.parents):
+            cand = d / "instance-registry.json"
+            if cand.is_file():
+                return cand
+
+        fleet = Path(os.environ.get("KIPI_FLEET_ROOT") or Path.home() / "projects")
+        cand = fleet / APP_NAME / "instance-registry.json"
+        if cand.is_file():
+            return cand
+
+        # Nothing found: return the documented default so the refusal names a
+        # stable path rather than whichever candidate was checked last.
+        return default
 
     @property
     def sources_dir(self) -> Path:

--- a/plugins/kipi-core/kipi-mcp/tests/conftest.py
+++ b/plugins/kipi-core/kipi-mcp/tests/conftest.py
@@ -1,18 +1,73 @@
 import json
+import sys
 import pytest
 from pathlib import Path
+
+# Make this directory importable so helpers below can be reached as
+# `from conftest import write_registry`. pytest loads conftest under its own
+# private module name, so without this a test importing `conftest` gets
+# ModuleNotFoundError. The plain-function helper is needed by _build_skeleton in
+# test_validator.py, which is a helper, not a fixture, and so cannot receive one.
+sys.path.insert(0, str(Path(__file__).resolve().parent))
 
 from kipi_mcp.paths import KipiPaths
 
 
+def write_registry(base: Path, repo: Path, instance: str = "test",
+                   instance_q_dir=None, subtree_prefix: str = "q-system") -> Path:
+    """Register `repo` as `instance` so canonical_dir / my_project_dir resolve.
+
+    Those two properties are repo-derived now and FAIL CLOSED on an unregistered
+    instance, so any test constructing KipiPaths by hand needs this. Also creates
+    the two repo-owned dirs, because ensure_dirs() deliberately no longer does:
+    they are tracked git content, and this stands in for the git tree.
+    """
+    root = repo / (instance_q_dir or subtree_prefix)
+    (root / "canonical").mkdir(parents=True, exist_ok=True)
+    (root / "my-project").mkdir(parents=True, exist_ok=True)
+    base.mkdir(parents=True, exist_ok=True)
+    (base / "instance-registry.json").write_text(json.dumps({
+        "skeleton": {"path": str(repo)},
+        "instances": [{"name": instance, "path": str(repo),
+                       "subtree_prefix": subtree_prefix,
+                       "instance_q_dir": instance_q_dir}],
+        "excluded": [], "eliminated": [],
+    }), encoding="utf-8")
+    return base / "instance-registry.json"
+
+
 @pytest.fixture
 def tmp_kipi_paths(tmp_path):
-    """Create a KipiPaths with all dirs rooted under tmp_path."""
-    paths = KipiPaths(
-        base_dir=tmp_path / "base",
-        repo_dir=tmp_path / "repo",
-        instance="test-instance",
-    )
+    """Create a KipiPaths with all dirs rooted under tmp_path.
+
+    REGISTERED, and the repo-owned dirs are created here rather than by
+    ensure_dirs(). canonical_dir and my_project_dir are now derived from the
+    instance's own tree via the registry (they used to be plugin-data, which is
+    why kipi_canonical_digest read an empty directory fleet-wide). Two consequences
+    every consumer of this fixture depends on:
+
+      1. An unregistered instance FAILS CLOSED, so the registry row below is not
+         decoration -- without it every test touching canonical/ raises.
+      2. ensure_dirs() no longer mkdirs those two, because they are tracked git
+         content, not tool-created state. The fixture stands in for the git tree.
+    """
+    base = tmp_path / "base"
+    repo = tmp_path / "repo"
+    (repo / "q-system" / "canonical").mkdir(parents=True, exist_ok=True)
+    (repo / "q-system" / "my-project").mkdir(parents=True, exist_ok=True)
+    base.mkdir(parents=True, exist_ok=True)
+    (base / "instance-registry.json").write_text(json.dumps({
+        "skeleton": {"path": str(repo)},
+        "instances": [{
+            "name": "test-instance",
+            "path": str(repo),
+            "subtree_prefix": "q-system",
+            "instance_q_dir": None,
+        }],
+        "excluded": [], "eliminated": [],
+    }), encoding="utf-8")
+
+    paths = KipiPaths(base_dir=base, repo_dir=repo, instance="test-instance")
     paths.ensure_dirs()
     return paths
 

--- a/plugins/kipi-core/kipi-mcp/tests/conftest.py
+++ b/plugins/kipi-core/kipi-mcp/tests/conftest.py
@@ -108,3 +108,37 @@ def tmp_sources_dir(tmp_path):
     sources.mkdir()
     (sources / "chrome").mkdir()
     return sources
+
+
+@pytest.fixture
+def registry_with_domain_dir(tmp_path):
+    """A registry whose instance names a domain dir that is NOT q-system.
+
+    Every pre-existing fixture set `instance_q_dir: None`, so the registry branch of the
+    path contract had no test at all and would have shipped unexercised. Mirrors the real
+    shape: a repo holding both `q-system/` (skeleton-synced code) and a named domain dir
+    that actually owns `canonical/`.
+    """
+    repo = tmp_path / "domain-instance"
+    (repo / "q-system").mkdir(parents=True)
+    (repo / "q-domain" / "canonical").mkdir(parents=True)
+    (repo / "q-domain" / "my-project").mkdir(parents=True)
+
+    registry = {
+        "skeleton": {"path": str(tmp_path / "skeleton"), "remote": "https://example.invalid/x.git"},
+        "instances": [
+            {
+                "name": "domain-instance",
+                "path": str(repo),
+                "subtree_prefix": "q-system",
+                "instance_q_dir": "q-domain",
+                "type": "subtree",
+                "has_git": True,
+            }
+        ],
+        "excluded": [],
+        "eliminated": [],
+    }
+    registry_path = tmp_path / "instance-registry.json"
+    registry_path.write_text(json.dumps(registry, indent=2))
+    return registry_path, repo

--- a/plugins/kipi-core/kipi-mcp/tests/conftest.py
+++ b/plugins/kipi-core/kipi-mcp/tests/conftest.py
@@ -92,13 +92,19 @@ def tmp_registry(tmp_path):
 @pytest.fixture
 def tmp_registry_with_instances(tmp_path):
     """Create a registry with sample instances."""
+    # Each instance gets a REAL canonical tree. A registry row is not proof the
+    # tree exists, and the resolver now refuses a root with no canonical/ (4 live
+    # instances were resolving to directories that do not exist). A fixture that
+    # describes an instance without one is describing something that cannot happen.
     inst_path = tmp_path / "test-instance"
     inst_path.mkdir()
-    (inst_path / "q-system").mkdir()
+    (inst_path / "q-system" / "canonical").mkdir(parents=True)
+    (inst_path / "q-system" / "my-project").mkdir(parents=True)
 
     clone_path = tmp_path / "test-clone"
     clone_path.mkdir()
-    (clone_path / "q-system").mkdir()
+    (clone_path / "q-system" / "canonical").mkdir(parents=True)
+    (clone_path / "q-system" / "my-project").mkdir(parents=True)
 
     registry = {
         "skeleton": {

--- a/plugins/kipi-core/kipi-mcp/tests/test_backup.py
+++ b/plugins/kipi-core/kipi-mcp/tests/test_backup.py
@@ -17,12 +17,19 @@ def backup_mgr(tmp_kipi_paths):
     (tmp_kipi_paths.my_project_dir / "current-state.md").write_text("# State")
     (tmp_kipi_paths.memory_dir / "graph.jsonl").write_text('{"s":"a","p":"knows","o":"b"}')
     (tmp_kipi_paths.output_dir / "morning-log-2026-03-27.json").write_text("{}")
+    # NOTE the archive now holds 4 of these 6, not 6. canonical/ and my-project/
+    # are repo-derived since the path-contract repoint, and BackupManager sweeps
+    # global_dir + config_dir (plugin DATA) only -- so talk-tracks.md and
+    # current-state.md are no longer swept. That is deliberate, not an oversight:
+    # those two live in the instance's git tree now, and a restore that wrote into
+    # a git working tree could clobber tracked content. Backup owns tool state;
+    # git owns repo content. Coverage note captured as spillover.
     return BackupManager(tmp_kipi_paths)
 
 
 def test_backup_creates_archive(backup_mgr, tmp_kipi_paths):
     result = backup_mgr.backup()
-    assert result["files_count"] == 6  # 1 global + 5 instance files
+    assert result["files_count"] == 4  # 1 global + 3 instance files (see backup_mgr)
     assert result["size_bytes"] > 0
     assert Path(result["path"]).exists()
     assert "kipi-backup-" in result["path"]
@@ -42,7 +49,7 @@ def test_backup_contains_manifest(backup_mgr):
         assert MANIFEST_NAME in names
         manifest = json.loads(tar.extractfile(MANIFEST_NAME).read())
         assert manifest["version"] == 1
-        assert len(manifest["files"]) == 6
+        assert len(manifest["files"]) == 4
 
 
 def test_backup_archive_structure(backup_mgr):
@@ -78,7 +85,7 @@ def test_restore_dry_run(backup_mgr, tmp_path):
 
     restore_result = new_mgr.restore(Path(result["path"]), dry_run=True)
     assert restore_result["dry_run"] is True
-    assert len(restore_result["restored"]) == 6
+    assert len(restore_result["restored"]) == 4
     assert not (new_paths.config_dir / "founder-profile.md").exists()
 
 
@@ -97,7 +104,7 @@ def test_restore_writes_files(backup_mgr, tmp_path):
 
     restore_result = new_mgr.restore(Path(result["path"]), dry_run=False)
     assert restore_result["dry_run"] is False
-    assert len(restore_result["restored"]) == 6
+    assert len(restore_result["restored"]) == 4
     assert (new_paths.config_dir / "founder-profile.md").read_text() == "# Profile\nName: Test"
     assert (new_paths.my_project_dir / "current-state.md").read_text() == "# State"
 
@@ -151,6 +158,8 @@ def test_roundtrip_preserves_content(backup_mgr, tmp_path):
     """Full roundtrip: backup -> restore to new location -> verify identical."""
     result = backup_mgr.backup()
     from kipi_mcp.paths import KipiPaths
+    from conftest import write_registry
+    write_registry(tmp_path / "rt_base", tmp_path / "repo", instance="rt")
     new_paths = KipiPaths(
         base_dir=tmp_path / "rt_base",
         repo_dir=tmp_path / "repo",
@@ -160,7 +169,9 @@ def test_roundtrip_preserves_content(backup_mgr, tmp_path):
     new_mgr = BackupManager(new_paths)
     new_mgr.restore(Path(result["path"]), dry_run=False)
 
-    assert (new_paths.canonical_dir / "talk-tracks.md").read_text() == "# Talk Tracks"
+    # talk-tracks.md is NOT asserted here any more: it lives in the repo tree since
+    # the path-contract repoint, so the plugin-data archive never carried it. See
+    # backup_mgr. The three below are genuine tool state and must survive intact.
     assert (new_paths.voice_dir / "voice-dna.md").read_text() == "# Voice DNA"
     assert (new_paths.memory_dir / "graph.jsonl").read_text() == '{"s":"a","p":"knows","o":"b"}'
     assert (new_paths.output_dir / "morning-log-2026-03-27.json").read_text() == "{}"

--- a/plugins/kipi-core/kipi-mcp/tests/test_backup.py
+++ b/plugins/kipi-core/kipi-mcp/tests/test_backup.py
@@ -66,6 +66,8 @@ def test_backup_skips_other_backups(backup_mgr, tmp_kipi_paths):
 def test_restore_dry_run(backup_mgr, tmp_path):
     result = backup_mgr.backup()
     from kipi_mcp.paths import KipiPaths
+    from conftest import write_registry
+    write_registry(tmp_path / "new_base", tmp_path / "repo", instance="restored")
     new_paths = KipiPaths(
         base_dir=tmp_path / "new_base",
         repo_dir=tmp_path / "repo",
@@ -83,6 +85,8 @@ def test_restore_dry_run(backup_mgr, tmp_path):
 def test_restore_writes_files(backup_mgr, tmp_path):
     result = backup_mgr.backup()
     from kipi_mcp.paths import KipiPaths
+    from conftest import write_registry
+    write_registry(tmp_path / "restored_base", tmp_path / "repo", instance="restored")
     new_paths = KipiPaths(
         base_dir=tmp_path / "restored_base",
         repo_dir=tmp_path / "repo",

--- a/plugins/kipi-core/kipi-mcp/tests/test_bus_verifier.py
+++ b/plugins/kipi-core/kipi-mcp/tests/test_bus_verifier.py
@@ -48,13 +48,24 @@ def test_phase1_all_required_present(verifier, tmp_path):
 
 
 def test_phase1_calendar_with_error_key(verifier, tmp_path):
+    """A REQUIRED file carrying an error key is a hard fail, not a warning.
+
+    INVERTED 2026-08-22 (prd-canonical-read-path-repair / crpr-bus-verifier-can-fail).
+    This test previously asserted `warn`, which pinned the defect in place: the
+    error branch ran BEFORE the structure check and emitted warn without setting
+    all_pass=False, so any required file containing {"error": ...} produced
+    pass:true while having delivered no data at all. The bug survived because a
+    green test asserted it. Asserting `pass is False` is the fix; the warn/fail
+    status is secondary, so this asserts the verdict, not the label.
+    """
     date = "2026-03-27"
     _write(tmp_path, date, "calendar.json", {"error": "auth failed"})
     _write(tmp_path, date, "gmail.json", {"emails": []})
     _write(tmp_path, date, "notion.json", {"contacts": [], "actions": []})
     result = verifier.verify(date, 1)
-    warn_results = [r for r in result["results"] if r["status"] == "warn"]
-    assert any(r["file"] == "calendar.json" for r in warn_results)
+    assert result["pass"] is False
+    assert any(r["file"] == "calendar.json" and r["status"] == "fail"
+               for r in result["results"])
 
 
 def test_phase3_missing_required(verifier, tmp_path):
@@ -128,3 +139,113 @@ def test_phase0_structure_check_fails(verifier, tmp_path):
     _write(tmp_path, date, "energy.json", {"level": 3})
     result = verifier.verify(date, 0)
     assert result["pass"] is False
+
+
+# --------------------------------------------------------------------------
+# canonical-digest.json: three independent defects, three independent tests.
+# prd-canonical-read-path-repair-2026-08-22 / crpr-bus-verifier-can-fail.
+#
+# Before this work the check existed in phase 1's `checks` dict but in NEITHER
+# `required` nor `optional`, so its lambda was never invoked once. It read as
+# protection while being dead code.
+# --------------------------------------------------------------------------
+
+import kipi_mcp.bus_verifier as BV
+
+# The exact all-empty digest captured from a real run, 2026-08-22.
+EMPTY_DIGEST = {
+    "talk_tracks": {}, "objections": [], "current_state": {}, "discovery": {},
+    "decisions": [], "warnings": [
+        "talk-tracks.md not found", "objections.md not found",
+        "current-state.md not found", "discovery.md not found",
+        "decisions.md not found",
+    ],
+    "valid": False,
+}
+
+# Codex finding-14's counterexample: NONEMPTY, and it must still be rejected.
+PLACEHOLDER_DIGEST = {
+    "talk_tracks": {"metaphor": "placeholder"}, "objections": [], "current_state": {},
+    "discovery": {}, "decisions": [], "warnings": [], "valid": False,
+}
+
+# Shaped like the real live tree: no talk_tracks (retired to pointer docs), but
+# real decisions and objections. This MUST pass or every run against real data reds.
+LIVE_SHAPED_DIGEST = {
+    "talk_tracks": {"metaphor": "", "definition": ""},
+    "objections": [{"name": "Why this was retired rather than rewritten", "response": "x"}],
+    "current_state": {}, "discovery": {},
+    "decisions": [{"rule": "RULE-2026-08-18-A: ...", "summary": "y"}],
+    "warnings": [], "valid": False,
+}
+
+
+def _phase1_baseline(bus_dir, date):
+    _write(bus_dir, date, "calendar.json", {"today": []})
+    _write(bus_dir, date, "gmail.json", {"emails": []})
+    _write(bus_dir, date, "notion.json", {"contacts": [], "actions": []})
+
+
+def test_canonical_digest_check_is_reachable(verifier, tmp_path, monkeypatch):
+    """DEFECT 1: the file was in no list, so the lambda never ran."""
+    monkeypatch.setattr(BV, "canonical_digest_is_required", lambda: True)
+    date = "2026-03-27"
+    _phase1_baseline(tmp_path, date)
+    _write(tmp_path, date, "canonical-digest.json", EMPTY_DIGEST)
+    result = verifier.verify(date, 1)
+    files = [r["file"] for r in result["results"]]
+    assert "canonical-digest.json" in files, "check never reached: file in no list"
+    assert result["pass"] is False
+
+
+def test_canonical_digest_rejects_empty_and_placeholder(verifier, tmp_path, monkeypatch):
+    """DEFECT 2: key-presence passed both of these."""
+    monkeypatch.setattr(BV, "canonical_digest_is_required", lambda: True)
+    for i, digest in enumerate((EMPTY_DIGEST, PLACEHOLDER_DIGEST)):
+        date = f"2026-04-0{i + 1}"
+        _phase1_baseline(tmp_path, date)
+        _write(tmp_path, date, "canonical-digest.json", digest)
+        assert verifier.verify(date, 1)["pass"] is False, f"digest {i} wrongly passed"
+    # ... and the live shape must still pass, or real data reds every run.
+    date = "2026-04-09"
+    _phase1_baseline(tmp_path, date)
+    _write(tmp_path, date, "canonical-digest.json", LIVE_SHAPED_DIGEST)
+    assert verifier.verify(date, 1)["pass"] is True
+
+
+def test_canonical_digest_error_key_is_a_hard_fail(verifier, tmp_path, monkeypatch):
+    """DEFECT 3: the error branch warned and left all_pass untouched, so this
+    passed even after defects 1 and 2 were fixed. Assert on pass, never on warn."""
+    monkeypatch.setattr(BV, "canonical_digest_is_required", lambda: True)
+    date = "2026-03-28"
+    _phase1_baseline(tmp_path, date)
+    _write(tmp_path, date, "canonical-digest.json", {"error": "canonical digest unavailable"})
+    assert verifier.verify(date, 1)["pass"] is False
+
+
+def test_sequencing_both_branches_of_the_promotion_predicate(verifier, tmp_path, monkeypatch):
+    """The promotion must be OPTIONAL while canonical_dir is still plugin-data,
+    or wiring this in reds every phase-1 run on 23 instances at once.
+    Both branches asserted: a predicate whose false branch is never exercised
+    reports success by default."""
+    date = "2026-03-29"
+    _phase1_baseline(tmp_path, date)  # digest deliberately absent
+
+    monkeypatch.setattr(BV, "canonical_digest_is_required", lambda: False)
+    res = verifier.verify(date, 1)
+    assert res["pass"] is True, "optional branch must not red a run with no digest"
+    assert any(r["file"] == "canonical-digest.json" and r["status"] == "skip"
+               for r in res["results"]), "optional branch must still reach the file"
+
+    monkeypatch.setattr(BV, "canonical_digest_is_required", lambda: True)
+    assert verifier.verify(date, 1)["pass"] is False, "required branch must red a missing digest"
+
+
+def test_promotion_predicate_reads_the_real_path_contract(monkeypatch):
+    """PRECONDITION (finding-27). While canonical_dir resolves under the plugin-data
+    base this is False, and that is the intended block: it flips to True only once
+    srsa-authoritative-path-contract lands. Fails toward NOT-required so a crash
+    here cannot cause the outage the predicate exists to prevent."""
+    monkeypatch.setenv("KIPI_PLUGIN_DATA", "/tmp/some-plugin-data")
+    monkeypatch.setattr(BV, "KipiPaths", None, raising=False)
+    assert BV._canonical_dir_is_plugin_data() is True

--- a/plugins/kipi-core/kipi-mcp/tests/test_bus_verifier.py
+++ b/plugins/kipi-core/kipi-mcp/tests/test_bus_verifier.py
@@ -248,10 +248,23 @@ def _real_paths_env(monkeypatch, tmp_path, instance="promo-inst"):
     whole point of these two cases is to drive the production code path.
     """
     base = tmp_path / "plugin-data"
+    repo = tmp_path / "repo"
     monkeypatch.setenv("KIPI_PLUGIN_DATA", str(base))
     monkeypatch.setenv("KIPI_INSTANCE", instance)
-    canonical = base / "instances" / instance / "canonical"
+    # canonical_dir is REGISTRY-derived now, not {base}/instances/<name>/canonical.
+    # That change is exactly what this pair of cases was written to anticipate:
+    # "when the path contract repoints canonical_dir at a live tree, the promotion
+    # happens on its own with no edit here" (bus_verifier docstring). The predicate
+    # is untouched; only where the tree lives moved.
+    canonical = repo / "q-system" / "canonical"
     canonical.mkdir(parents=True, exist_ok=True)
+    base.mkdir(parents=True, exist_ok=True)
+    (base / "instance-registry.json").write_text(json.dumps({
+        "skeleton": {"path": str(repo)},
+        "instances": [{"name": instance, "path": str(repo),
+                       "subtree_prefix": "q-system", "instance_q_dir": None}],
+        "excluded": [], "eliminated": [],
+    }), encoding="utf-8")
     return canonical
 
 

--- a/plugins/kipi-core/kipi-mcp/tests/test_bus_verifier.py
+++ b/plugins/kipi-core/kipi-mcp/tests/test_bus_verifier.py
@@ -241,11 +241,52 @@ def test_sequencing_both_branches_of_the_promotion_predicate(verifier, tmp_path,
     assert verifier.verify(date, 1)["pass"] is False, "required branch must red a missing digest"
 
 
-def test_promotion_predicate_reads_the_real_path_contract(monkeypatch):
-    """PRECONDITION (finding-27). While canonical_dir resolves under the plugin-data
-    base this is False, and that is the intended block: it flips to True only once
-    srsa-authoritative-path-contract lands. Fails toward NOT-required so a crash
-    here cannot cause the outage the predicate exists to prevent."""
-    monkeypatch.setenv("KIPI_PLUGIN_DATA", "/tmp/some-plugin-data")
-    monkeypatch.setattr(BV, "KipiPaths", None, raising=False)
-    assert BV._canonical_dir_is_plugin_data() is True
+def _real_paths_env(monkeypatch, tmp_path, instance="promo-inst"):
+    """Point the REAL KipiPaths at a tmp base and return its canonical dir.
+
+    Deliberately uses no monkeypatch of the predicate and no stub of KipiPaths: the
+    whole point of these two cases is to drive the production code path.
+    """
+    base = tmp_path / "plugin-data"
+    monkeypatch.setenv("KIPI_PLUGIN_DATA", str(base))
+    monkeypatch.setenv("KIPI_INSTANCE", instance)
+    canonical = base / "instances" / instance / "canonical"
+    canonical.mkdir(parents=True, exist_ok=True)
+    return canonical
+
+
+def test_promotion_predicate_true_branch_is_reachable(monkeypatch, tmp_path):
+    """REPRODUCER (Codex PR #240 blocker). The promotion predicate used to ask
+    "is canonical_dir under the plugin-data base?" -- and `KipiPaths.canonical_dir`
+    is DEFINED as `{base}/instances/<name>/canonical` where `{base}` is exactly
+    KIPI_PLUGIN_DATA or ~/.kipi-system. So the answer was yes for every reachable
+    configuration: a tautology, not a sequencing guard. Its true branch could only
+    ever be entered by monkeypatching the predicate itself, which is how three
+    tests above reached the required branch and why the check stayed permanently
+    optional in production.
+
+    This case drives the real code path with a canonical tree that HAS content.
+    """
+    canonical = _real_paths_env(monkeypatch, tmp_path)
+    (canonical / "decisions.md").write_text("### RULE-2026-08-18-A: real content\n")
+    assert BV.canonical_digest_is_required() is True
+
+
+def test_promotion_predicate_false_while_the_canonical_tree_is_empty(monkeypatch, tmp_path):
+    """The other half, same real code path. SEQUENCING (finding-27): the resolved
+    canonical dir holds ZERO files today (measured 2026-08-22, and re-measured on
+    this machine: 1 instance dir, canonical/ present, 0 .md files), so the digest
+    stays OPTIONAL and no phase-1 run reds. It promotes itself the moment the path
+    contract points canonical_dir at a tree that actually holds content."""
+    _real_paths_env(monkeypatch, tmp_path, instance="empty-inst")
+    assert BV.canonical_digest_is_required() is False
+
+
+def test_promotion_predicate_fails_toward_optional_when_it_cannot_tell(monkeypatch):
+    """A crash in the predicate must not be able to cause the outage it exists to
+    prevent, so an unresolvable path contract means NOT required."""
+    def _boom():
+        raise RuntimeError("path contract unresolvable")
+
+    monkeypatch.setattr(BV, "_canonical_content_present", _boom)
+    assert BV.canonical_digest_is_required() is False

--- a/plugins/kipi-core/kipi-mcp/tests/test_bus_verifier.py
+++ b/plugins/kipi-core/kipi-mcp/tests/test_bus_verifier.py
@@ -188,7 +188,7 @@ def _phase1_baseline(bus_dir, date):
 
 def test_canonical_digest_check_is_reachable(verifier, tmp_path, monkeypatch):
     """DEFECT 1: the file was in no list, so the lambda never ran."""
-    monkeypatch.setattr(BV, "canonical_digest_is_required", lambda: True)
+    monkeypatch.setattr(BV, "canonical_digest_requirement", lambda: (True, None))
     date = "2026-03-27"
     _phase1_baseline(tmp_path, date)
     _write(tmp_path, date, "canonical-digest.json", EMPTY_DIGEST)
@@ -200,7 +200,7 @@ def test_canonical_digest_check_is_reachable(verifier, tmp_path, monkeypatch):
 
 def test_canonical_digest_rejects_empty_and_placeholder(verifier, tmp_path, monkeypatch):
     """DEFECT 2: key-presence passed both of these."""
-    monkeypatch.setattr(BV, "canonical_digest_is_required", lambda: True)
+    monkeypatch.setattr(BV, "canonical_digest_requirement", lambda: (True, None))
     for i, digest in enumerate((EMPTY_DIGEST, PLACEHOLDER_DIGEST)):
         date = f"2026-04-0{i + 1}"
         _phase1_baseline(tmp_path, date)
@@ -216,7 +216,7 @@ def test_canonical_digest_rejects_empty_and_placeholder(verifier, tmp_path, monk
 def test_canonical_digest_error_key_is_a_hard_fail(verifier, tmp_path, monkeypatch):
     """DEFECT 3: the error branch warned and left all_pass untouched, so this
     passed even after defects 1 and 2 were fixed. Assert on pass, never on warn."""
-    monkeypatch.setattr(BV, "canonical_digest_is_required", lambda: True)
+    monkeypatch.setattr(BV, "canonical_digest_requirement", lambda: (True, None))
     date = "2026-03-28"
     _phase1_baseline(tmp_path, date)
     _write(tmp_path, date, "canonical-digest.json", {"error": "canonical digest unavailable"})
@@ -231,13 +231,13 @@ def test_sequencing_both_branches_of_the_promotion_predicate(verifier, tmp_path,
     date = "2026-03-29"
     _phase1_baseline(tmp_path, date)  # digest deliberately absent
 
-    monkeypatch.setattr(BV, "canonical_digest_is_required", lambda: False)
+    monkeypatch.setattr(BV, "canonical_digest_requirement", lambda: (False, None))
     res = verifier.verify(date, 1)
     assert res["pass"] is True, "optional branch must not red a run with no digest"
     assert any(r["file"] == "canonical-digest.json" and r["status"] == "skip"
                for r in res["results"]), "optional branch must still reach the file"
 
-    monkeypatch.setattr(BV, "canonical_digest_is_required", lambda: True)
+    monkeypatch.setattr(BV, "canonical_digest_requirement", lambda: (True, None))
     assert verifier.verify(date, 1)["pass"] is False, "required branch must red a missing digest"
 
 
@@ -266,6 +266,35 @@ def _real_paths_env(monkeypatch, tmp_path, instance="promo-inst"):
         "excluded": [], "eliminated": [],
     }), encoding="utf-8")
     return canonical
+
+
+def test_resolution_failure_is_an_observable_verification_failure(monkeypatch, tmp_path):
+    """Codex PR #240 round 2, major. A path-resolution CRASH used to be swallowed by
+    a bare `except Exception: return False`, so phase 1 passed with the canonical
+    detector silently demoted to optional -- indistinguishable from "the canonical
+    tree is intentionally empty".
+
+    Drives the real verifier, not the predicate: the point is that the FAILURE is
+    recorded and the phase does not pass.
+    """
+    monkeypatch.setenv("KIPI_REGISTRY", "/definitely/missing/instance-registry.json")
+    monkeypatch.setenv("KIPI_INSTANCE", "prod")
+    monkeypatch.delenv("CLAUDE_PROJECT_DIR", raising=False)
+
+    date = "2026-03-27"
+    # The bus day dir must exist or verify() returns before the wiring runs -- the
+    # first draft of this case asserted against that early return, which proved
+    # nothing about resolution failures.
+    (tmp_path / date).mkdir(parents=True, exist_ok=True)
+    verifier = BusVerifier(tmp_path)
+    result = verifier.verify(date, 1)
+
+    assert result["pass"] is False, "a resolution crash must not pass phase 1"
+    rows = [r for r in result["results"]
+            if r.get("file") == "canonical-digest.json"
+            and "PATH RESOLUTION FAILED" in str(r.get("detail", ""))]
+    assert rows, f"resolution failure was not reported: {result['results']}"
+    assert rows[0]["status"] == "fail"
 
 
 def test_promotion_predicate_true_branch_is_reachable(monkeypatch, tmp_path):

--- a/plugins/kipi-core/kipi-mcp/tests/test_morning_init.py
+++ b/plugins/kipi-core/kipi-mcp/tests/test_morning_init.py
@@ -440,7 +440,11 @@ class TestAutoBackup:
     @pytest.fixture
     def backup_mgr(self, paths):
         from kipi_mcp.backup import BackupManager
-        _create_file(paths.canonical_dir / "talk-tracks.md", "# TT")
+        # Seed PLUGIN-DATA, not canonical/. canonical_dir is repo-derived since the
+        # path-contract repoint and BackupManager sweeps global_dir + config_dir
+        # only, so a file seeded there produced an archive of 0 files and this
+        # case asserted >= 1 against an empty backup.
+        _create_file(paths.config_dir / "founder-profile.md", "# Profile")
         return BackupManager(paths)
 
     def test_auto_backup_creates_archive(self, backup_mgr):

--- a/plugins/kipi-core/kipi-mcp/tests/test_morning_init.py
+++ b/plugins/kipi-core/kipi-mcp/tests/test_morning_init.py
@@ -22,6 +22,8 @@ from kipi_mcp.morning_init import (
 @pytest.fixture
 def paths(tmp_path):
     from kipi_mcp.paths import KipiPaths
+    from conftest import write_registry
+    write_registry(tmp_path / "base", tmp_path / "repo", instance="test")
     p = KipiPaths(base_dir=tmp_path / "base", repo_dir=tmp_path / "repo", instance="test")
     p.ensure_dirs()
     return p

--- a/plugins/kipi-core/kipi-mcp/tests/test_paths.py
+++ b/plugins/kipi-core/kipi-mcp/tests/test_paths.py
@@ -108,9 +108,11 @@ def test_global_dir(tmp_path):
 def test_instance_subdirectories(tmp_path):
     paths = KipiPaths(base_dir=tmp_path, instance="proj")
     inst = tmp_path / "instances" / "proj"
-    assert paths.canonical_dir == inst / "canonical"
+    # canonical_dir and my_project_dir are DELIBERATELY absent from this list now.
+    # They are repo-derived (see _state_root) because plugin-data held no content,
+    # which is what made kipi_canonical_digest return all-files-not-found. The rest
+    # of the table is genuinely tool-owned state and still lives under plugin data.
     assert paths.marketing_config_dir == inst / "marketing"
-    assert paths.my_project_dir == inst / "my-project"
     assert paths.memory_dir == inst / "memory"
     assert paths.output_dir == inst / "output"
     assert paths.bus_dir == inst / "bus"
@@ -142,10 +144,8 @@ def test_ensure_dirs(tmp_path):
         paths.voice_dir,
         paths.audhd_dir,
         paths.config_dir,
-        paths.canonical_dir,
         paths.marketing_config_dir,
         paths.marketing_config_dir / "assets",
-        paths.my_project_dir,
         paths.memory_dir,
         paths.memory_dir / "working",
         paths.memory_dir / "weekly",
@@ -156,6 +156,13 @@ def test_ensure_dirs(tmp_path):
     ]
     for d in expected:
         assert d.is_dir(), f"{d} was not created"
+
+    # And the two repo-owned dirs must NOT be conjured. They are tracked git
+    # content; ensure_dirs() with an unset repo_dir used to create them inside the
+    # real plugin directory. `instance="test"` is unregistered, so asking for the
+    # path at all is the fail-closed refusal -- which is itself the assertion.
+    with pytest.raises(PathContractError):
+        _ = paths.canonical_dir
 
 
 # --------------------------------------------------------------- path contract (srsa)

--- a/plugins/kipi-core/kipi-mcp/tests/test_paths.py
+++ b/plugins/kipi-core/kipi-mcp/tests/test_paths.py
@@ -1,6 +1,15 @@
 from pathlib import Path
 
-from kipi_mcp.paths import APP_NAME, KipiPaths, _detect_instance, _slugify, generate_instance_name
+import pytest
+
+from kipi_mcp.paths import (
+    APP_NAME,
+    KipiPaths,
+    PathContractError,
+    _detect_instance,
+    _slugify,
+    generate_instance_name,
+)
 
 
 def test_default_resolution():
@@ -147,3 +156,75 @@ def test_ensure_dirs(tmp_path):
     ]
     for d in expected:
         assert d.is_dir(), f"{d} was not created"
+
+
+# --------------------------------------------------------------- path contract (srsa)
+# These pin the defect that made kipi_canonical_digest return valid:false in every
+# instance: canonical_dir and my_project_dir resolved to plugin-data
+# (~/.kipi-system/instances/<name>/), which holds zero files, instead of to the
+# instance's own tree. The digest exists to save 40-60K tokens against reading full
+# canonical; returning nothing sent agents back to raw files, where consulting has THREE
+# diverged copies. Written to fail first -- see the issue's reproducer-first acceptance.
+
+
+def test_canonical_dir_resolves_instance_domain_dir(registry_with_domain_dir, monkeypatch):
+    registry_path, repo = registry_with_domain_dir
+    monkeypatch.setenv("CLAUDE_PROJECT_DIR", str(repo))
+    paths = KipiPaths(base_dir=registry_path.parent, instance="domain-instance")
+    assert paths.canonical_dir == repo / "q-domain" / "canonical"
+
+
+def test_my_project_dir_resolves_instance_domain_dir(registry_with_domain_dir, monkeypatch):
+    """Part 5. Same defect, same file, different property.
+
+    morning_init.py:192 reads current-state.md from my_project_dir, so fixing only
+    canonical leaves current_state empty. Asserted directly and NOT via digest["valid"]:
+    _validate_digest needs 5 of 7 checks and 6 stay reachable without works_today, so
+    valid can go true with this half still broken.
+    """
+    registry_path, repo = registry_with_domain_dir
+    monkeypatch.setenv("CLAUDE_PROJECT_DIR", str(repo))
+    paths = KipiPaths(base_dir=registry_path.parent, instance="domain-instance")
+    assert paths.my_project_dir == repo / "q-domain" / "my-project"
+
+
+def test_null_domain_dir_falls_back_to_subtree_prefix(registry_fixture, tmp_path, monkeypatch):
+    """instance_q_dir null means the state root IS <path>/<subtree_prefix>.
+
+    NOT <path>/<subtree_prefix>/q-system. A literal reading of the contract sentence
+    produces q-system/q-system, and those nested shadow trees were removed fleet-wide on
+    2026-07-01; re-deriving one here would resurrect the thing that flattening deleted.
+    """
+    repo = tmp_path / "test-instance"
+    monkeypatch.setenv("CLAUDE_PROJECT_DIR", str(repo))
+    paths = KipiPaths(base_dir=registry_fixture.parent, instance="test-instance")
+    assert paths.canonical_dir == repo / "q-system" / "canonical"
+
+
+def test_unregistered_repo_fails_closed(tmp_path, registry_fixture, monkeypatch):
+    """An unmapped repo must RAISE, never silently pick a default.
+
+    The whole defect class is a resolver that guesses and returns an empty directory that
+    reads as 'no data' rather than 'wrong path'.
+    """
+    stranger = tmp_path / "not-in-registry"
+    stranger.mkdir()
+    monkeypatch.setenv("CLAUDE_PROJECT_DIR", str(stranger))
+    paths = KipiPaths(base_dir=registry_fixture.parent, instance="nope")
+    with pytest.raises(PathContractError):
+        _ = paths.canonical_dir
+
+
+def test_ensure_dirs_never_creates_repo_owned_dirs(registry_with_domain_dir, monkeypatch):
+    """ensure_dirs() must not mkdir canonical/ or my-project/ once they are repo-derived.
+
+    They are tracked git content, not tool-created state. Before this, ensure_dirs() with
+    an unset repo_dir would happily create them inside the real plugin directory.
+    """
+    registry_path, repo = registry_with_domain_dir
+    monkeypatch.setenv("CLAUDE_PROJECT_DIR", str(repo))
+    paths = KipiPaths(base_dir=registry_path.parent, instance="domain-instance")
+    stray = repo / "q-domain" / "should-not-appear"
+    paths.ensure_dirs()
+    assert not stray.exists()
+    assert paths.bus_dir.is_dir()

--- a/plugins/kipi-core/kipi-mcp/tests/test_paths.py
+++ b/plugins/kipi-core/kipi-mcp/tests/test_paths.py
@@ -188,7 +188,7 @@ def test_my_project_dir_resolves_instance_domain_dir(registry_with_domain_dir, m
     assert paths.my_project_dir == repo / "q-domain" / "my-project"
 
 
-def test_null_domain_dir_falls_back_to_subtree_prefix(registry_fixture, tmp_path, monkeypatch):
+def test_null_domain_dir_falls_back_to_subtree_prefix(tmp_registry_with_instances, tmp_path, monkeypatch):
     """instance_q_dir null means the state root IS <path>/<subtree_prefix>.
 
     NOT <path>/<subtree_prefix>/q-system. A literal reading of the contract sentence
@@ -197,11 +197,11 @@ def test_null_domain_dir_falls_back_to_subtree_prefix(registry_fixture, tmp_path
     """
     repo = tmp_path / "test-instance"
     monkeypatch.setenv("CLAUDE_PROJECT_DIR", str(repo))
-    paths = KipiPaths(base_dir=registry_fixture.parent, instance="test-instance")
+    paths = KipiPaths(base_dir=tmp_registry_with_instances.parent, instance="test-instance")
     assert paths.canonical_dir == repo / "q-system" / "canonical"
 
 
-def test_unregistered_repo_fails_closed(tmp_path, registry_fixture, monkeypatch):
+def test_unregistered_repo_fails_closed(tmp_path, tmp_registry_with_instances, monkeypatch):
     """An unmapped repo must RAISE, never silently pick a default.
 
     The whole defect class is a resolver that guesses and returns an empty directory that
@@ -210,7 +210,7 @@ def test_unregistered_repo_fails_closed(tmp_path, registry_fixture, monkeypatch)
     stranger = tmp_path / "not-in-registry"
     stranger.mkdir()
     monkeypatch.setenv("CLAUDE_PROJECT_DIR", str(stranger))
-    paths = KipiPaths(base_dir=registry_fixture.parent, instance="nope")
+    paths = KipiPaths(base_dir=tmp_registry_with_instances.parent, instance="nope")
     with pytest.raises(PathContractError):
         _ = paths.canonical_dir
 
@@ -224,7 +224,20 @@ def test_ensure_dirs_never_creates_repo_owned_dirs(registry_with_domain_dir, mon
     registry_path, repo = registry_with_domain_dir
     monkeypatch.setenv("CLAUDE_PROJECT_DIR", str(repo))
     paths = KipiPaths(base_dir=registry_path.parent, instance="domain-instance")
-    stray = repo / "q-domain" / "should-not-appear"
+
+    # The fixture pre-creates both, so remove them: the only thing that can bring
+    # them back inside this test is ensure_dirs itself.
+    for d in (repo / "q-domain" / "canonical", repo / "q-domain" / "my-project"):
+        if d.is_dir():
+            d.rmdir()
+
     paths.ensure_dirs()
-    assert not stray.exists()
-    assert paths.bus_dir.is_dir()
+
+    # Assert the RESOLVED properties. The first draft asserted that
+    # `repo/q-domain/should-not-appear` was absent -- nothing anywhere creates that
+    # name, so it held identically against fixed and unfixed code. Measured
+    # 2026-08-22: it was the one new case that PASSED on the reproducer run, which
+    # is how a vacuous test hides. A test that cannot fail is not a test.
+    assert not paths.canonical_dir.exists(), f"ensure_dirs created {paths.canonical_dir}"
+    assert not paths.my_project_dir.exists(), f"ensure_dirs created {paths.my_project_dir}"
+    assert paths.bus_dir.is_dir(), "ensure_dirs must still create tool-owned state"

--- a/plugins/kipi-core/kipi-mcp/tests/test_paths.py
+++ b/plugins/kipi-core/kipi-mcp/tests/test_paths.py
@@ -234,7 +234,9 @@ def test_ensure_dirs_never_creates_repo_owned_dirs(registry_with_domain_dir, mon
 
     # The fixture pre-creates both, so remove them: the only thing that can bring
     # them back inside this test is ensure_dirs itself.
-    for d in (repo / "q-domain" / "canonical", repo / "q-domain" / "my-project"):
+    expected_canon = repo / "q-domain" / "canonical"
+    expected_proj = repo / "q-domain" / "my-project"
+    for d in (expected_canon, expected_proj):
         if d.is_dir():
             d.rmdir()
 
@@ -245,6 +247,8 @@ def test_ensure_dirs_never_creates_repo_owned_dirs(registry_with_domain_dir, mon
     # name, so it held identically against fixed and unfixed code. Measured
     # 2026-08-22: it was the one new case that PASSED on the reproducer run, which
     # is how a vacuous test hides. A test that cannot fail is not a test.
-    assert not paths.canonical_dir.exists(), f"ensure_dirs created {paths.canonical_dir}"
-    assert not paths.my_project_dir.exists(), f"ensure_dirs created {paths.my_project_dir}"
+    # LITERAL paths, not the properties: with the tree deleted the property now
+    # refuses (correctly), and a refusal is not what this case is testing.
+    assert not expected_canon.exists(), f"ensure_dirs created {expected_canon}"
+    assert not expected_proj.exists(), f"ensure_dirs created {expected_proj}"
     assert paths.bus_dir.is_dir(), "ensure_dirs must still create tool-owned state"

--- a/plugins/kipi-core/kipi-mcp/tests/test_paths.py
+++ b/plugins/kipi-core/kipi-mcp/tests/test_paths.py
@@ -208,6 +208,38 @@ def test_null_domain_dir_falls_back_to_subtree_prefix(tmp_registry_with_instance
     assert paths.canonical_dir == repo / "q-system" / "canonical"
 
 
+def test_duplicate_registry_paths_fail_closed(tmp_path, monkeypatch):
+    """Codex PR #240 round 3, major. The NAME axis was guarded in _state_root and
+    the PATH axis was not, so two rows sharing one path let the first silently win:
+
+        resolved_instance=alpha, ambiguity_reported=no
+
+    An unattended server then binds to whichever row is listed first and reads that
+    project's canonical data. Both axes now refuse.
+    """
+    import json
+    repo = tmp_path / "repo"
+    (repo / "q-system" / "canonical").mkdir(parents=True)
+    base = tmp_path / "base"
+    base.mkdir()
+    (base / "instance-registry.json").write_text(json.dumps({
+        "skeleton": {"path": str(tmp_path / "nope")},
+        "instances": [
+            {"name": "alpha", "path": str(repo), "subtree_prefix": "q-system",
+             "instance_q_dir": None},
+            {"name": "beta", "path": str(repo), "subtree_prefix": "q-system",
+             "instance_q_dir": None},
+        ],
+    }), encoding="utf-8")
+    monkeypatch.setenv("CLAUDE_PROJECT_DIR", str(repo))
+    monkeypatch.setenv("KIPI_PLUGIN_DATA", str(base))
+    monkeypatch.delenv("KIPI_INSTANCE", raising=False)
+
+    with pytest.raises(PathContractError) as exc:
+        KipiPaths()
+    assert exc.value.kind == "duplicate-path"
+
+
 def test_unregistered_repo_fails_closed(tmp_path, tmp_registry_with_instances, monkeypatch):
     """An unmapped repo must RAISE, never silently pick a default.
 

--- a/plugins/kipi-core/kipi-mcp/tests/test_validator.py
+++ b/plugins/kipi-core/kipi-mcp/tests/test_validator.py
@@ -34,7 +34,7 @@ def _build_skeleton(tmp_path: Path) -> tuple[KipiPaths, Path]:
 
     # q-system core (repo code)
     q = repo_dir / "q-system"
-    q.mkdir()
+    q.mkdir(exist_ok=True)  # write_registry already made it
     qsys = q / ".q-system"
     qsys.mkdir()
     agents_dir = qsys / "agent-pipeline" / "agents"
@@ -175,7 +175,7 @@ class TestPhase0:
     def test_phase_0_missing_registry(self, tmp_path):
         repo_dir = tmp_path / "empty"
         repo_dir.mkdir()
-        (repo_dir / "q-system").mkdir()
+        (repo_dir / "q-system").mkdir(exist_ok=True)
         paths = KipiPaths(
             base_dir=tmp_path / "base2",
             repo_dir=repo_dir,

--- a/plugins/kipi-core/kipi-mcp/tests/test_validator.py
+++ b/plugins/kipi-core/kipi-mcp/tests/test_validator.py
@@ -23,6 +23,8 @@ def _build_skeleton(tmp_path: Path) -> tuple[KipiPaths, Path]:
     repo_dir = tmp_path / "repo"
     repo_dir.mkdir()
 
+    from conftest import write_registry
+    write_registry(tmp_path / "base", repo_dir, instance="test")
     paths = KipiPaths(
         base_dir=tmp_path / "base",
         repo_dir=repo_dir,

--- a/q-system/.q-system/capability-manifest.json
+++ b/q-system/.q-system/capability-manifest.json
@@ -67,6 +67,10 @@
       "runner": "bash"
     },
     {
+      "path": "q-system/.q-system/scripts/test/test-canonical-digest-real-values.py",
+      "runner": "python3"
+    },
+    {
       "path": "q-system/.q-system/scripts/test/test-capability-gate-inert-spillover.py",
       "runner": "python3"
     },

--- a/q-system/.q-system/scripts/evidence_ledger.py
+++ b/q-system/.q-system/scripts/evidence_ledger.py
@@ -176,6 +176,23 @@ def instance_root(repo=None, strict: bool = True) -> Path:
     q_dir, registered = _registry_q_dir(repo)
     fs_pick = named[0].name if named else None
 
+    # An UNREGISTERED repo has no mapping, and strict mode must not invent one.
+    # SCAR (Codex review of PR #240, major): the `else` arm below fell through to
+    # repo/"q-system" for ANY unregistered checkout whose q-system/ happened to hold
+    # canonical/, and returned it as authoritative -- measured from an isolated review
+    # tree as registered=False, resolved=<tree>/q-system. That is the exact defect
+    # class this resolver exists to remove: guess quietly rather than refuse out loud.
+    # Refused here, at the one place that knows, so both downstream arms are covered
+    # rather than patching the q-system arm alone.
+    # _registry_q_dir already resolves the SKELETON row (returns "q-system", True), so
+    # kipi-system itself stays registered and this does not refuse the skeleton.
+    if not registered:
+        raise ResolutionError(
+            f"{repo}: not a registered instance and not the skeleton. Refusing to "
+            f"resolve a canonical root by guessing. Add it to the registry, or pass "
+            f"strict=False to accept the legacy guess deliberately."
+        )
+
     if registered and q_dir:
         if fs_pick and fs_pick != q_dir:
             raise ResolutionError(

--- a/q-system/.q-system/scripts/evidence_ledger.py
+++ b/q-system/.q-system/scripts/evidence_ledger.py
@@ -136,7 +136,8 @@ def _named_canonical_dirs(repo: Path) -> list[Path]:
             if p.is_dir() and p.name != "q-system" and (p / "canonical").is_dir()]
 
 
-def instance_root(repo=None, strict: bool = True) -> Path:
+def instance_root(repo=None, strict: bool = True,
+                  allow_unregistered: bool = False) -> Path:
     """The dir holding this instance's canonical/ content. FAILS CLOSED.
 
     WHY (scar, measured 2026-08-22 across all 25 registered instances):
@@ -159,6 +160,28 @@ def instance_root(repo=None, strict: bool = True) -> Path:
       mismatch. strict=False restores the old guessing behaviour and exists only
       for callers that must degrade rather than refuse; it is not the default
       because a silently wrong canonical path is the whole reason this PRD exists.
+
+    `allow_unregistered` is the NARROW middle ground, and the distinction is the
+    hazard, not the caller's convenience:
+
+      WRITE callers (ledger_path -> add/append) keep the default and REFUSE. Codex
+      flagged the real danger as an unattended run from a stray clone APPENDING
+      evidence against the wrong tree; that stays refused.
+
+      READ-ONLY callers that must keep running (system_manifest.health, whose own
+      docstring promises it never raises because a Stop hook depends on it) pass
+      allow_unregistered=True. They still get the AMBIGUITY and no-canonical
+      refusals, so this never restores the sorted()[0] guess between two candidate
+      domain dirs -- it only permits the single-tree repo that has exactly one
+      possible answer.
+
+    SCAR 2026-08-22: the first version of this guard refused on `not registered`
+    unconditionally. That is a coarser rule than the hazard, and it broke 11 tests
+    in test_grounding_manifest_health.py plus, worse, made the grounding Stop hook
+    emit "the manifest is unreadable" on a HEALTHY manifest -- a live false alarm
+    on every turn, which is exactly the fleet-wide wedge health() was written to
+    avoid. Blast radius was measured for the paths.py resolver and not for this
+    one; that asymmetry is the actual defect.
     """
     repo = Path(repo or os.environ.get("CLAUDE_PROJECT_DIR") or os.getcwd())
     named = _named_canonical_dirs(repo)
@@ -186,11 +209,12 @@ def instance_root(repo=None, strict: bool = True) -> Path:
     # rather than patching the q-system arm alone.
     # _registry_q_dir already resolves the SKELETON row (returns "q-system", True), so
     # kipi-system itself stays registered and this does not refuse the skeleton.
-    if not registered:
+    if not registered and not allow_unregistered:
         raise ResolutionError(
             f"{repo}: not a registered instance and not the skeleton. Refusing to "
-            f"resolve a canonical root by guessing. Add it to the registry, or pass "
-            f"strict=False to accept the legacy guess deliberately."
+            f"resolve a canonical root by guessing. Add it to the registry, pass "
+            f"allow_unregistered=True if you are a READ-ONLY caller that must "
+            f"degrade, or strict=False for the full legacy guess."
         )
 
     if registered and q_dir:
@@ -242,8 +266,17 @@ def audit_instance_roots(registry=None) -> list[dict]:
     return rows
 
 
-def ledger_path(repo=None) -> Path:
-    return instance_root(repo) / "canonical" / "evidence.jsonl"
+def ledger_path(repo=None, allow_unregistered: bool = True) -> Path:
+    """Where the evidence ledger lives.
+
+    Permissive BY DEFAULT, and that is deliberate. `read`, `check` and
+    `has_ledger` all come through here, so a refusal on this accessor refuses
+    every READER -- which is how one guard took out the grounding Stop hook and
+    the client-output evidence gate in a single change (2026-08-22).
+
+    The write path opts INTO the refusal explicitly; see append_row.
+    """
+    return instance_root(repo, allow_unregistered=allow_unregistered) / "canonical" / "evidence.jsonl"
 
 
 # ---------------------------------------------------------------------- read/write
@@ -282,6 +315,13 @@ def _validate(row: dict) -> list[str]:
 
 def append_row(repo, row: dict) -> dict:
     """The single write path. Every field required; claim_id unique; append only."""
+    # THE REFUSAL LIVES HERE, at the single write path, not on the shared resolver.
+    # Codex's hazard was an unattended run APPENDING evidence against the wrong
+    # canonical tree -- a property of the OPERATION, not of the repository. Guarding
+    # the repository instead swept in every read-only caller; two rounds of
+    # per-caller opt-ins later, the surface was the problem, not the callers.
+    path = ledger_path(repo, allow_unregistered=False)
+
     errs = _validate(row)
     if errs:
         raise LedgerError(
@@ -296,7 +336,6 @@ def append_row(repo, row: dict) -> dict:
             "append-only and single-writer; re-verifying a claim means adding a row "
             "with a new command, not rewriting the old one."
         )
-    path = ledger_path(repo)
     path.parent.mkdir(parents=True, exist_ok=True)
     with path.open("a", encoding="utf-8") as fh:
         fh.write(json.dumps(row, ensure_ascii=False, sort_keys=True) + "\n")

--- a/q-system/.q-system/scripts/evidence_ledger.py
+++ b/q-system/.q-system/scripts/evidence_ledger.py
@@ -78,19 +78,151 @@ class LedgerError(Exception):
 
 # --------------------------------------------------------------------------- paths
 
-def instance_root(repo=None) -> Path:
-    """The dir holding this instance's canonical/ content.
+class ResolutionError(Exception):
+    """The canonical root is ambiguous or contradicted. Refuse rather than guess."""
 
-    Instances name it per-instance (q-consult/, q-prodigy/); the skeleton uses its own
-    q-system/. Prefer a named instance dir, fall back to q-system. One resolver, so no
-    caller re-derives the path. Precedent: capability-map-gen.py:390.
+
+def _registry_path(repo: Path) -> Path:
+    """The fleet registry. Skeleton-local, which is the only copy that exists.
+
+    NOT ~/.kipi-system/instance-registry.json -- paths.py:188 points there and that
+    file does not exist on this machine or any other (sp-b2c21bdc, measured
+    2026-08-22). Fleet root convention matches verify-alert-wiring.sh:16.
+    """
+    env = os.environ.get("KIPI_EVIDENCE_REGISTRY")
+    if env:
+        return Path(env)
+    local = repo / "instance-registry.json"
+    if local.is_file():
+        return local
+    fleet = Path(os.environ.get("KIPI_FLEET_ROOT") or (Path.home() / "projects"))
+    return fleet / "kipi-system" / "instance-registry.json"
+
+
+def _registry_q_dir(repo: Path) -> tuple[str | None, bool]:
+    """(instance_q_dir, found) for this repo, read from the registry.
+
+    found=False means the repo is not a registered instance at all, which is a
+    different thing from a registered instance whose q_dir is null.
+    """
+    reg = _registry_path(repo)
+    if not reg.is_file():
+        return None, False
+    try:
+        data = json.loads(reg.read_text(encoding="utf-8"))
+    except Exception as exc:
+        raise ResolutionError(f"registry {reg} is unreadable: {exc}")
+    target = repo.resolve()
+    for entry in data.get("instances", []):
+        try:
+            if Path(entry.get("path", "")).resolve() == target:
+                return entry.get("instance_q_dir"), True
+        except Exception:
+            continue
+    skel = data.get("skeleton") or {}
+    skel_path = skel.get("path") if isinstance(skel, dict) else None
+    if skel_path:
+        try:
+            if Path(skel_path).resolve() == target:
+                return "q-system", True
+        except Exception:
+            pass
+    return None, False
+
+
+def _named_canonical_dirs(repo: Path) -> list[Path]:
+    """Filesystem evidence: named q-* domain dirs that actually hold canonical/."""
+    return [p for p in sorted(repo.glob("q-*"))
+            if p.is_dir() and p.name != "q-system" and (p / "canonical").is_dir()]
+
+
+def instance_root(repo=None, strict: bool = True) -> Path:
+    """The dir holding this instance's canonical/ content. FAILS CLOSED.
+
+    WHY (scar, measured 2026-08-22 across all 25 registered instances):
+
+      The previous body was `named[0] if named else repo/"q-system"` -- a pure glob
+      with no registry and no cross-check. It could not be wrong out loud. Three
+      measured failure modes, each of which it answered confidently:
+
+        * 6 of 25 instances: registry says instance_q_dir=null while a real named
+          domain dir holding canonical/ exists on disk. Two authorities disagreeing
+          on a quarter of the fleet is a defect, not a design. (PRD said 4 of 20;
+          re-measured at HEAD it is 6 of 25 -- the count decayed, the defect did not.)
+        * 3 of 25: resolve to a directory with NO canonical/ at all, and the caller
+          gets a path to a tree that is not there.
+        * Two named q-* dirs both holding canonical/: sorted()[0] silently wins.
+          ZERO instances hit this today, so it is covered by a synthetic fixture,
+          not by a fleet instance -- the hazard is in the code regardless.
+
+      Registry is authority; the filesystem is a cross-check that RAISES on
+      mismatch. strict=False restores the old guessing behaviour and exists only
+      for callers that must degrade rather than refuse; it is not the default
+      because a silently wrong canonical path is the whole reason this PRD exists.
     """
     repo = Path(repo or os.environ.get("CLAUDE_PROJECT_DIR") or os.getcwd())
-    named = [p for p in sorted(repo.glob("q-*"))
-             if p.is_dir() and p.name != "q-system" and (p / "canonical").is_dir()]
-    if named:
-        return named[0]
-    return repo / "q-system"
+    named = _named_canonical_dirs(repo)
+
+    if not strict:
+        return named[0] if named else repo / "q-system"
+
+    if len(named) > 1:
+        raise ResolutionError(
+            f"{repo}: {len(named)} named q-* dirs hold canonical/ "
+            f"({', '.join(p.name for p in named)}). Refusing to let sorted()[0] pick. "
+            f"Set instance_q_dir in the registry to disambiguate."
+        )
+
+    q_dir, registered = _registry_q_dir(repo)
+    fs_pick = named[0].name if named else None
+
+    if registered and q_dir:
+        if fs_pick and fs_pick != q_dir:
+            raise ResolutionError(
+                f"{repo}: registry says instance_q_dir={q_dir!r} but the filesystem "
+                f"shows {fs_pick!r} holding canonical/. Refusing to guess which is right."
+            )
+        root = repo / q_dir
+    elif fs_pick:
+        if registered:
+            raise ResolutionError(
+                f"{repo}: {fs_pick!r} holds canonical/ but the registry records "
+                f"instance_q_dir=null. Fill it in so the two agree; refusing to "
+                f"let the glob silently outvote the registry."
+            )
+        root = named[0]
+    else:
+        root = repo / "q-system"
+
+    if not (root / "canonical").is_dir():
+        raise ResolutionError(
+            f"{repo}: resolved canonical root {root} has no canonical/ subdirectory. "
+            f"There is no canonical tree here; refusing to return a path to nothing."
+        )
+    return root
+
+
+def audit_instance_roots(registry=None) -> list[dict]:
+    """Enumerate how every registered instance resolves, so no caller hand-maintains
+    a list of affected instance names. This repo is PUBLIC; names stay local."""
+    reg = Path(registry) if registry else _registry_path(Path.cwd())
+    data = json.loads(reg.read_text(encoding="utf-8"))
+    rows = []
+    for entry in data.get("instances", []):
+        name, path = entry.get("name"), Path(entry.get("path", ""))
+        row = {"name": name, "path": str(path), "registry_q_dir": entry.get("instance_q_dir")}
+        if not path.is_dir():
+            row.update(status="absent", resolved=None, detail="path not on disk")
+            rows.append(row)
+            continue
+        row["filesystem_q_dir"] = (_named_canonical_dirs(path)[0].name
+                                   if _named_canonical_dirs(path) else None)
+        try:
+            row.update(status="ok", resolved=str(instance_root(path)), detail="")
+        except ResolutionError as exc:
+            row.update(status="REFUSED", resolved=None, detail=str(exc))
+        rows.append(row)
+    return rows
 
 
 def ledger_path(repo=None) -> Path:
@@ -262,9 +394,33 @@ def resolve_spans(repo, text: str) -> list[str]:
 
 # -------------------------------------------------------------------------- CLI
 
+def _run_audit(argv) -> int:
+    """`--audit-instance-roots` is a flag, not a subcommand, because the PRD and the
+    issue acceptance both name it that way and a checker copies the string verbatim."""
+    reg = None
+    if "--registry" in argv:
+        reg = argv[argv.index("--registry") + 1]
+    rows = audit_instance_roots(reg)
+    if "--json" in argv:
+        print(json.dumps(rows, indent=2))
+    else:
+        for r in rows:
+            print(f"{r['status']:<8} {r['name']:<22} registry={str(r['registry_q_dir']):<14} "
+                  f"fs={str(r.get('filesystem_q_dir')):<14} {r['detail']}")
+        bad = [r for r in rows if r["status"] == "REFUSED"]
+        print(f"\n{len(rows)} registered, {len(bad)} REFUSED by the fail-closed resolver")
+    return 0
+
+
 def main(argv=None) -> int:
+    argv = list(sys.argv[1:] if argv is None else argv)
+    if "--audit-instance-roots" in argv:
+        return _run_audit(argv)
+
     ap = argparse.ArgumentParser(description=__doc__.split("\n")[0])
     ap.add_argument("--repo", default=None, help="repo root (default: CLAUDE_PROJECT_DIR)")
+    ap.add_argument("--audit-instance-roots", action="store_true",
+                    help="report how every registered instance resolves (handled above)")
     sub = ap.add_subparsers(dest="cmd", required=True)
 
     a = sub.add_parser("add", help="append one verified fact")

--- a/q-system/.q-system/scripts/evidence_ledger.py
+++ b/q-system/.q-system/scripts/evidence_ledger.py
@@ -407,8 +407,30 @@ def _run_audit(argv) -> int:
         for r in rows:
             print(f"{r['status']:<8} {r['name']:<22} registry={str(r['registry_q_dir']):<14} "
                   f"fs={str(r.get('filesystem_q_dir')):<14} {r['detail']}")
-        bad = [r for r in rows if r["status"] == "REFUSED"]
+    bad = [r for r in rows if r["status"] == "REFUSED"]
+    if "--json" not in argv:
         print(f"\n{len(rows)} registered, {len(bad)} REFUSED by the fail-closed resolver")
+
+    # SCAR (Codex review of PR #240, major). This returned a hardcoded 0 on every
+    # path, so the one command that enumerates unresolvable instances could not
+    # fail for the reason it exists -- a caller wiring it as a check would get a
+    # green on a fleet where the resolver refuses. Exit 1 when any instance is
+    # REFUSED; exit 2 reserved for the command itself breaking.
+    #
+    # This is non-zero on the live fleet TODAY and that is the correct report, not
+    # a regression: the registry fill that would clear those rows is deliberately
+    # out of this PR (the client-name guard refuses client-derived names in this
+    # PUBLIC repo, sp-71c71288). `--allow-refused` exists for the enumerating
+    # callers that want the rows without the verdict, and it is opt-in per call so
+    # it cannot silently become the default posture.
+    if bad and "--allow-refused" not in argv:
+        sys.stderr.write(
+            f"evidence_ledger: {len(bad)} of {len(rows)} registered instances are "
+            f"REFUSED by the fail-closed resolver. Fill instance_q_dir in the "
+            f"registry so it agrees with the filesystem, or pass --allow-refused "
+            f"to enumerate without failing.\n"
+        )
+        return 1
     return 0
 
 

--- a/q-system/.q-system/scripts/system_manifest.py
+++ b/q-system/.q-system/scripts/system_manifest.py
@@ -47,7 +47,11 @@ MANIFEST_NAME = "system-manifest.json"
 
 
 def manifest_path(repo=None) -> Path:
-    return instance_root(repo) / "canonical" / MANIFEST_NAME
+    # allow_unregistered: this module only ever READS, and health() promises its
+    # unattended Stop-hook caller that it never raises. A hard refusal here surfaced
+    # as "the manifest is unreadable" on a healthy manifest (2026-08-22). Ambiguous
+    # and no-canonical repos are still refused.
+    return instance_root(repo, allow_unregistered=True) / "canonical" / MANIFEST_NAME
 
 
 MANIFEST_OK = "ok"

--- a/q-system/.q-system/scripts/test/test-canonical-digest-real-values.py
+++ b/q-system/.q-system/scripts/test/test-canonical-digest-real-values.py
@@ -212,64 +212,125 @@ def synthetic_fossil() -> Path:
 
 # ------------------------------------------------------------------------- self-test
 
-def self_test() -> int:
+def synthetic_live(rule_id: str = "RULE-2026-01-02-Z") -> Path:
+    """Hermetic POSITIVE control: a tree a correct checker MUST pass.
+
+    WHY THIS EXISTS (scar, measured 2026-08-22): the first version of this file
+    made only the NEGATIVE control runnable off-fleet, so on a machine with no
+    kipi instances -- every CI runner -- the single assertion was "the fossil
+    fails". A checker hardcoded to `return False` passes that. A one-directional
+    control is the false green this PRD exists to remove, so the hermetic pair
+    runs everywhere: fossil must FAIL and live must PASS in the same run.
+
+    The heading is `### RULE-YYYY-MM-DD...`, which is what _parse_decisions keys
+    on ("rule" in heading.lower()), so both readers can see the same id.
+    """
+    tmp = Path(tempfile.mkdtemp(prefix="canon-live-control-"))
+    canon = tmp / "canonical"
+    canon.mkdir()
+    (canon / "decisions.md").write_text(
+        "# Decision Log\n\n"
+        f"### {rule_id}: Hermetic positive control\n\n"
+        "Body text so the section carries a summary.\n",
+        encoding="utf-8",
+    )
+    (tmp / "my-project").mkdir()
+    return tmp
+
+
+def run_checks(require_fleet: bool) -> int:
+    """The whole check. `require_fleet` changes REPORTING, never an assertion.
+
+    bare run -- `python3 <this file>`, which is exactly what capability-gate.py
+        builds at line 617 and it can pass NO arguments at all. require_fleet is
+        False: the hermetic pair still both run and both assert; an unreachable
+        fleet prints what it could not reach and claims nothing about it.
+    --self-test -- operator, on a machine with the fleet checked out.
+        require_fleet is True: an unreachable fleet is a REFUSAL, not a skip.
+
+    Scar: this file originally printed argparse help and returned 2 on a bare
+    invocation. That made it undeclarable in expected_tests (the gate's only
+    bucket that clears present-but-undeclared), so it sat undeclared and turned
+    the capability gate red instead.
+    """
     _, module_file = _load_digest_fn()
     print(f"[load-path] canonical_digest imported from {module_file}")
 
     failures = []
 
-    # --- hermetic negative control: MUST FAIL -------------------------------
+    # --- hermetic pair: ALWAYS runs, on every machine, both directions -------
     tmp = synthetic_fossil()
     syn_canon, syn_proj = tmp / "canonical", tmp / "my-project"
     # Validate the control is really what we think before trusting its verdict.
     raw = (syn_canon / "decisions.md").read_text(encoding="utf-8")
-    assert "RULE-001" in raw and not DATED_RULE_RE.search(raw), "synthetic control malformed"
+    assert "RULE-001" in raw and not DATED_RULE_RE.search(raw), "synthetic fossil control malformed"
     ok, why = check_tree(syn_canon, syn_proj)
     print(f"[control:synthetic-fossil] {syn_canon}\n    -> {'PASS' if ok else 'FAIL'}: {why}")
     if ok:
         failures.append("synthetic fossil PASSED; the checker cannot distinguish a template tree")
 
-    # --- real trees --------------------------------------------------------
-    name, live_canon, live_proj, fossil_canon = find_live_and_fossil()
-    print(f"[instance] {name}")
-
-    ok, why = check_tree(fossil_canon, fossil_canon.parent / "my-project")
-    print(f"[control:real-fossil] {fossil_canon}\n    -> {'PASS' if ok else 'FAIL'}: {why}")
-    if ok:
-        failures.append(f"real fossil {fossil_canon} PASSED; checker does not separate fossil from live")
-
-    ok, why = check_tree(live_canon, live_proj)
-    print(f"[subject:live] {live_canon}\n    -> {'PASS' if ok else 'FAIL'}: {why}")
+    live_tmp = synthetic_live()
+    lv_canon, lv_proj = live_tmp / "canonical", live_tmp / "my-project"
+    raw_live = (lv_canon / "decisions.md").read_text(encoding="utf-8")
+    assert DATED_RULE_RE.search(raw_live), "synthetic live control malformed"
+    ok, why = check_tree(lv_canon, lv_proj)
+    print(f"[control:synthetic-live] {lv_canon}\n    -> {'PASS' if ok else 'FAIL'}: {why}")
     if not ok:
-        failures.append(f"live tree {live_canon} FAILED: {why}")
+        failures.append(f"synthetic LIVE tree FAILED; checker cannot recognise a live tree: {why}")
+
+    # --- real fleet: the only half that can prove a SHIPPED tree is read -----
+    fleet_ran = False
+    try:
+        name, live_canon, live_proj, fossil_canon = find_live_and_fossil()
+    except Refusal as exc:
+        if require_fleet:
+            raise
+        print(f"[fleet] SKIPPED: {exc}")
+        print("[fleet] this run proves NOTHING about any real instance tree; the "
+              "hermetic pair above is everything it checked.")
+    else:
+        fleet_ran = True
+        print(f"[instance] {name}")
+        ok, why = check_tree(fossil_canon, fossil_canon.parent / "my-project")
+        print(f"[control:real-fossil] {fossil_canon}\n    -> {'PASS' if ok else 'FAIL'}: {why}")
+        if ok:
+            failures.append(f"real fossil {fossil_canon} PASSED; checker does not separate fossil from live")
+        ok, why = check_tree(live_canon, live_proj)
+        print(f"[subject:live] {live_canon}\n    -> {'PASS' if ok else 'FAIL'}: {why}")
+        if not ok:
+            failures.append(f"live tree {live_canon} FAILED: {why}")
 
     print()
     if failures:
         for f in failures:
             print(f"FAIL: {f}", file=sys.stderr)
         return 1
-    print("PASS: live tree proved read by name; both fossil controls correctly failed.")
+    tail = "; real instance tree proved read by name." if fleet_ran else " (fleet half not reached)."
+    print(f"PASS: hermetic pair separated fossil from live{tail}")
     return 0
+
+
+def self_test() -> int:
+    """Back-compat alias. The fleet is REQUIRED here."""
+    return run_checks(require_fleet=True)
 
 
 def main() -> int:
     ap = argparse.ArgumentParser(description=__doc__.splitlines()[0])
     ap.add_argument("--self-test", action="store_true",
-                    help="run the live subject AND both fossil negative controls")
+                    help="require the real fleet: an unreachable instance refuses, never skips")
     ap.add_argument("--canonical-dir", type=Path, help="check one tree directly")
     ap.add_argument("--my-project-dir", type=Path)
     args = ap.parse_args()
 
     try:
-        if args.self_test:
-            return self_test()
         if args.canonical_dir:
             proj = args.my_project_dir or args.canonical_dir.parent / "my-project"
             ok, why = check_tree(args.canonical_dir, proj)
             print(f"{'PASS' if ok else 'FAIL'} {args.canonical_dir}: {why}")
             return 0 if ok else 1
-        ap.print_help()
-        return 2
+        # No flag is the RUNNER's invocation and it must be the real check, not help.
+        return run_checks(require_fleet=args.self_test)
     except Refusal as exc:
         print(f"REFUSED: {exc}", file=sys.stderr)
         return 3

--- a/q-system/.q-system/scripts/test/test-canonical-digest-real-values.py
+++ b/q-system/.q-system/scripts/test/test-canonical-digest-real-values.py
@@ -1,0 +1,279 @@
+#!/usr/bin/env python3
+"""Prove canonical_digest actually READ a live canonical tree, by named value.
+
+Pairs with: prd-canonical-read-path-repair-2026-08-22, issue
+crpr-digest-asserts-real-canonical (closes Codex finding-14 / finding-9).
+
+WHY THIS SHAPE (scar, measured 2026-08-22):
+
+  Every other check in this PRD is fixture-level and therefore structurally
+  cannot prove a live tree was read. Codex finding-14 named the exact hole: a
+  digest of {"talk_tracks":{"metaphor":"placeholder"}, ...} satisfies any
+  "some field is nonempty" assertion while having read nothing.
+
+  So this file asserts NAMED values, and it obeys three hard rules:
+
+  1. NEVER assert digest["valid"]. Measured against the real live tree, valid is
+     FALSE (3 of 7 _validate_digest checks pass) because the live files were
+     retired to pointer docs whose headings no longer match the 2026-07-01
+     template the parsers were written for. valid:true is not the success
+     signal and valid:false is not the failure signal. Asserting it in either
+     direction encodes a wrong belief. (Tracked separately as sp-8804dee7 --
+     read-path repair cannot fix a parser/shape mismatch.)
+
+  2. NEVER assert mere non-emptiness. That is finding-14 verbatim.
+
+  3. DERIVE the expected value with an INDEPENDENT reader; never hardcode it.
+     This repo is PUBLIC, so a client's decision text must not be baked in.
+     A raw regex over decisions.md and the digest's own parser are two
+     independent implementations; when they agree on an id that exists only in
+     THAT tree, the tree was read. That also keeps the checker instance-agnostic.
+
+THE NEGATIVE CONTROL IS THE POINT. Measured across consulting's two trees:
+  live   q-consult/canonical/decisions.md : 1 dated RULE-YYYY-MM-DD id
+  fossil q-system/canonical/decisions.md  : 0 (only RULE-XXX / RULE-001/002/003)
+A checker that passes against the fossil is the false green this PRD exists to
+remove, so --self-test asserts the fossil case FAILS and exits nonzero if it
+passes. A check that cannot fail is not a check.
+
+READ-ONLY. This opens canonical files for reading and never writes to any
+instance tree; the only path it writes is a private tmp dir for the hermetic
+synthetic control.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import os
+import re
+import sys
+import tempfile
+from pathlib import Path
+
+# test/ -> scripts/ -> .q-system/ -> q-system/ -> repo root. Five levels, not four:
+# the first draft used parents[3] and silently resolved to q-system/, which made the
+# import REFUSE. It refused rather than passing, which is the contract working.
+REPO = Path(__file__).resolve().parents[4]
+MCP_SRC = REPO / "plugins" / "kipi-core" / "kipi-mcp" / "src"
+
+# A DATED rule id. The template scaffolding that ships in every fresh instance
+# uses RULE-XXX and RULE-001..003, which this deliberately does NOT match --
+# that gap is exactly what separates a live tree from a fossil one.
+DATED_RULE_RE = re.compile(r"\bRULE-\d{4}-\d{2}-\d{2}[A-Za-z0-9-]*")
+
+
+class Refusal(Exception):
+    """The checker cannot answer. Never a pass, never a skip."""
+
+
+def _load_digest_fn():
+    """Import the digest from the repo copy that ships, and say which file it is."""
+    if str(MCP_SRC) not in sys.path:
+        sys.path.insert(0, str(MCP_SRC))
+    try:
+        from kipi_mcp import morning_init  # noqa: WPS433
+    except Exception as exc:  # pragma: no cover - environment failure
+        raise Refusal(f"cannot import kipi_mcp.morning_init from {MCP_SRC}: {exc}")
+    return morning_init.canonical_digest, Path(morning_init.__file__)
+
+
+class _PathsShim:
+    """canonical_digest only ever reads .canonical_dir and .my_project_dir."""
+
+    def __init__(self, canonical_dir: Path, my_project_dir: Path):
+        self.canonical_dir = canonical_dir
+        self.my_project_dir = my_project_dir
+
+
+def independent_dated_rule_ids(canonical_dir: Path) -> set[str]:
+    """Reader #1: a raw regex over the file. Shares no code with the digest parser."""
+    decisions = canonical_dir / "decisions.md"
+    if not decisions.is_file():
+        return set()
+    text = decisions.read_text(encoding="utf-8", errors="ignore")
+    return {m.group(0) for m in DATED_RULE_RE.finditer(text)}
+
+
+def digest_dated_rule_ids(canonical_dir: Path, my_project_dir: Path) -> tuple[set[str], dict]:
+    """Reader #2: the shipping parser, reached through the real public entrypoint."""
+    canonical_digest, _ = _load_digest_fn()
+    digest = canonical_digest(_PathsShim(canonical_dir, my_project_dir))
+    found: set[str] = set()
+    for entry in digest.get("decisions", []):
+        rule = str(entry.get("rule", ""))
+        found.update(m.group(0) for m in DATED_RULE_RE.finditer(rule))
+    return found, digest
+
+
+def check_tree(canonical_dir: Path, my_project_dir: Path) -> tuple[bool, str]:
+    """True only if both independent readers agree on a dated rule id in THIS tree."""
+    if not canonical_dir.is_dir():
+        return False, f"no canonical dir at {canonical_dir}"
+
+    expected = independent_dated_rule_ids(canonical_dir)
+    if not expected:
+        # This is the fossil / fresh-template outcome, and it is a FAILURE, not a skip.
+        return False, (
+            f"independent reader found no dated RULE-YYYY-MM-DD id in "
+            f"{canonical_dir/'decisions.md'} -- this tree is template scaffolding "
+            f"or a fossil, not a live canonical tree"
+        )
+
+    got, digest = digest_dated_rule_ids(canonical_dir, my_project_dir)
+    agreed = expected & got
+    if not agreed:
+        return False, (
+            f"readers DISAGREE: raw file has {sorted(expected)} but "
+            f"canonical_digest parsed {sorted(got)} from decisions[] "
+            f"({len(digest.get('decisions', []))} entries) -- the digest did not "
+            f"read {canonical_dir}"
+        )
+    # Deliberately NOT asserting digest["valid"]; see module docstring rule 1.
+    return True, f"both readers agree on {sorted(agreed)} (valid={digest.get('valid')!r}, not asserted)"
+
+
+# --------------------------------------------------------------- instance discovery
+
+def fleet_root() -> Path:
+    """Same convention as verify-alert-wiring.sh:16."""
+    return Path(os.environ.get("KIPI_FLEET_ROOT") or (Path.home() / "projects"))
+
+
+def registry_instances() -> list[dict]:
+    reg = REPO / "instance-registry.json"
+    if not reg.is_file():
+        raise Refusal(f"no instance registry at {reg}")
+    data = json.loads(reg.read_text(encoding="utf-8"))
+    return list(data.get("instances", []))
+
+
+def _named_live_dir(root: Path) -> Path | None:
+    """A named q-* domain dir holding canonical/ -- never q-system (that is the fossil)."""
+    for child in sorted(root.glob("q-*")):
+        if child.is_dir() and child.name != "q-system" and (child / "canonical").is_dir():
+            return child
+    return None
+
+
+def find_live_and_fossil() -> tuple[str, Path, Path, Path]:
+    """First registered instance carrying BOTH a live dated-rule tree and a fossil tree.
+
+    Refuses rather than skipping. Instance names are printed locally only; this
+    function hardcodes none, which is what keeps the public repo clean.
+    """
+    reasons = []
+    for entry in registry_instances():
+        path = Path(entry.get("path", ""))
+        if not path.is_dir():
+            reasons.append(f"{entry.get('name')}: path absent")
+            continue
+        live = _named_live_dir(path)
+        if live is None:
+            reasons.append(f"{entry.get('name')}: no named q-* dir with canonical/")
+            continue
+        if not independent_dated_rule_ids(live / "canonical"):
+            reasons.append(f"{entry.get('name')}: live tree has no dated rule id")
+            continue
+        fossil = path / "q-system" / "canonical"
+        if not (fossil / "decisions.md").is_file():
+            reasons.append(f"{entry.get('name')}: no fossil decisions.md to control against")
+            continue
+        return str(entry.get("name")), live / "canonical", live / "my-project", fossil
+    raise Refusal(
+        "no registered instance has BOTH a live dated-rule canonical tree and a "
+        "fossil q-system/canonical/decisions.md to control against. Refusing "
+        "rather than skipping: a skip here is a false green.\n  " + "\n  ".join(reasons)
+    )
+
+
+def synthetic_fossil() -> Path:
+    """Hermetic negative control: template scaffolding, exactly as a fresh instance ships.
+
+    Always available, so the negative half of this checker never silently stops
+    running just because a particular machine lacks the real fossil.
+    """
+    tmp = Path(tempfile.mkdtemp(prefix="canon-fossil-control-"))
+    canon = tmp / "canonical"
+    canon.mkdir()
+    (canon / "decisions.md").write_text(
+        "# Decision Log\n\n"
+        "## Format <!-- pin -->\n\n"
+        "### RULE-XXX: [Name]\n\n"
+        "## Starter Rules <!-- pin -->\n\n"
+        "### RULE-001: Warm Intro Beats Cold\n\n"
+        "### RULE-002: Auto-Close Dead Loops\n\n"
+        "### RULE-003: Max 1 Value Drop Per Person Per Week\n",
+        encoding="utf-8",
+    )
+    (tmp / "my-project").mkdir()
+    return tmp
+
+
+# ------------------------------------------------------------------------- self-test
+
+def self_test() -> int:
+    _, module_file = _load_digest_fn()
+    print(f"[load-path] canonical_digest imported from {module_file}")
+
+    failures = []
+
+    # --- hermetic negative control: MUST FAIL -------------------------------
+    tmp = synthetic_fossil()
+    syn_canon, syn_proj = tmp / "canonical", tmp / "my-project"
+    # Validate the control is really what we think before trusting its verdict.
+    raw = (syn_canon / "decisions.md").read_text(encoding="utf-8")
+    assert "RULE-001" in raw and not DATED_RULE_RE.search(raw), "synthetic control malformed"
+    ok, why = check_tree(syn_canon, syn_proj)
+    print(f"[control:synthetic-fossil] {syn_canon}\n    -> {'PASS' if ok else 'FAIL'}: {why}")
+    if ok:
+        failures.append("synthetic fossil PASSED; the checker cannot distinguish a template tree")
+
+    # --- real trees --------------------------------------------------------
+    name, live_canon, live_proj, fossil_canon = find_live_and_fossil()
+    print(f"[instance] {name}")
+
+    ok, why = check_tree(fossil_canon, fossil_canon.parent / "my-project")
+    print(f"[control:real-fossil] {fossil_canon}\n    -> {'PASS' if ok else 'FAIL'}: {why}")
+    if ok:
+        failures.append(f"real fossil {fossil_canon} PASSED; checker does not separate fossil from live")
+
+    ok, why = check_tree(live_canon, live_proj)
+    print(f"[subject:live] {live_canon}\n    -> {'PASS' if ok else 'FAIL'}: {why}")
+    if not ok:
+        failures.append(f"live tree {live_canon} FAILED: {why}")
+
+    print()
+    if failures:
+        for f in failures:
+            print(f"FAIL: {f}", file=sys.stderr)
+        return 1
+    print("PASS: live tree proved read by name; both fossil controls correctly failed.")
+    return 0
+
+
+def main() -> int:
+    ap = argparse.ArgumentParser(description=__doc__.splitlines()[0])
+    ap.add_argument("--self-test", action="store_true",
+                    help="run the live subject AND both fossil negative controls")
+    ap.add_argument("--canonical-dir", type=Path, help="check one tree directly")
+    ap.add_argument("--my-project-dir", type=Path)
+    args = ap.parse_args()
+
+    try:
+        if args.self_test:
+            return self_test()
+        if args.canonical_dir:
+            proj = args.my_project_dir or args.canonical_dir.parent / "my-project"
+            ok, why = check_tree(args.canonical_dir, proj)
+            print(f"{'PASS' if ok else 'FAIL'} {args.canonical_dir}: {why}")
+            return 0 if ok else 1
+        ap.print_help()
+        return 2
+    except Refusal as exc:
+        print(f"REFUSED: {exc}", file=sys.stderr)
+        return 3
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/q-system/.q-system/scripts/test_client_output_evidence_gate.py
+++ b/q-system/.q-system/scripts/test_client_output_evidence_gate.py
@@ -13,6 +13,7 @@ Run: python3 test_client_output_evidence_gate.py
 from __future__ import annotations
 
 import json
+import os
 import subprocess
 import sys
 import tempfile
@@ -29,6 +30,15 @@ def _repo_with_ledger() -> Path:
     """A temp instance carrying one verified fact: the export has 1177 rows."""
     tmp = Path(tempfile.mkdtemp())
     (tmp / "q-thing" / "canonical").mkdir(parents=True)
+    # REGISTERED, because this fixture WRITES via EL.add and the write path refuses
+    # an unregistered repo (an unattended run must not append evidence to the wrong
+    # tree). The env var is picked up by the gate subprocess too. Reads do not need
+    # this; only the write does.
+    _registry = tmp / "registry.json"
+    _registry.write_text(json.dumps({"instances": [
+        {"name": "tmp-instance", "path": str(tmp), "instance_q_dir": "q-thing"}]}),
+        encoding="utf-8")
+    os.environ["KIPI_EVIDENCE_REGISTRY"] = str(_registry)
     EL.add(tmp, claim="Brightspeed export has 1177 rows", source="xlsx",
            command="openpyxl len(rows)", result="1177 rows, 332 hand-typed dates")
     return tmp

--- a/q-system/.q-system/scripts/test_evidence_ledger.py
+++ b/q-system/.q-system/scripts/test_evidence_ledger.py
@@ -21,9 +21,16 @@ import evidence_ledger as EL  # noqa: E402
 
 
 def _root() -> Path:
-    """A temp instance root shaped like a real one: <root>/q-thing/canonical/."""
+    """A temp instance root shaped like a real one: <root>/q-thing/canonical/.
+
+    It is REGISTERED. Before the fail-closed resolver these cases used a bare temp
+    dir and passed only because instance_root() guessed for unregistered repos --
+    the exact hole Codex flagged on PR #240. Registering here makes the fixture
+    match a real instance instead of relying on the guess that was removed.
+    """
     tmp = Path(tempfile.mkdtemp())
     (tmp / "q-thing" / "canonical").mkdir(parents=True)
+    _reg(tmp, [{"name": "tmp-instance", "path": str(tmp), "instance_q_dir": "q-thing"}])
     return tmp
 
 
@@ -117,14 +124,19 @@ def case_ledger_path_prefers_instance_over_skeleton() -> bool:
     """An instance has both q-system/ and q-<name>/. Content lives in q-<name>/."""
     tmp = Path(tempfile.mkdtemp())
     (tmp / "q-system" / "canonical").mkdir(parents=True)
-    (tmp / "q-prodigy" / "canonical").mkdir(parents=True)
-    return EL.ledger_path(tmp).parent.parent.name == "q-prodigy"
+    (tmp / "q-example" / "canonical").mkdir(parents=True)
+    _reg(tmp, [{"name": "example-instance", "path": str(tmp), "instance_q_dir": "q-example"}])
+    return EL.ledger_path(tmp).parent.parent.name == "q-example"
 
 
 def case_ledger_path_falls_back_to_skeleton() -> bool:
     """The skeleton itself has only q-system/. Resolve there, do not crash."""
     tmp = Path(tempfile.mkdtemp())
     (tmp / "q-system" / "canonical").mkdir(parents=True)
+    # Registered AS THE SKELETON, which is what this case is about. _registry_q_dir
+    # maps the skeleton row to "q-system", so this asserts the real skeleton path
+    # rather than the unregistered-repo guess that no longer exists.
+    _reg(tmp, [], skeleton=tmp)
     return EL.ledger_path(tmp).parent.parent.name == "q-system"
 
 
@@ -137,10 +149,13 @@ def case_ledger_path_falls_back_to_skeleton() -> bool:
 # Every case pins KIPI_EVIDENCE_REGISTRY at its own temp registry. Without that the
 # resolver falls back to the REAL fleet registry and the case stops being hermetic.
 
-def _reg(tmp: Path, entries: list[dict]) -> Path:
+def _reg(tmp: Path, entries: list[dict], skeleton: Path | None = None) -> Path:
     import json
     p = tmp / "registry.json"
-    p.write_text(json.dumps({"instances": entries}), encoding="utf-8")
+    doc: dict = {"instances": entries}
+    if skeleton is not None:
+        doc["skeleton"] = {"path": str(skeleton)}
+    p.write_text(json.dumps(doc), encoding="utf-8")
     os.environ["KIPI_EVIDENCE_REGISTRY"] = str(p)
     return p
 
@@ -185,6 +200,23 @@ def case_resolver_refuses_registered_null_against_real_dir() -> bool:
     tmp = Path(tempfile.mkdtemp())
     (tmp / "q-real" / "canonical").mkdir(parents=True)
     _reg(tmp, [{"name": "x", "path": str(tmp), "instance_q_dir": None}])
+    return _raises(lambda: EL.instance_root(tmp))
+
+
+def case_resolver_refuses_unregistered_repo() -> bool:
+    """Codex review of PR #240, major. An UNREGISTERED checkout whose q-system/
+    happens to hold canonical/ fell straight through to `root = repo / "q-system"`
+    and was returned as authoritative.
+
+    Why it survived the existing suite: case_resolver_refuses_root_with_no_canonical
+    is also unregistered, but it raises on the LATER "no canonical/ subdirectory"
+    check, so the fall-through arm was never once exercised with the dir PRESENT.
+    Measured from the reviewer's isolated tree: registered=False,
+    resolved=<tree>/q-system. An unattended run from a stray clone would append
+    evidence against the wrong canonical tree."""
+    tmp = Path(tempfile.mkdtemp())
+    (tmp / "q-system" / "canonical").mkdir(parents=True)
+    _reg(tmp, [])  # a real registry that simply does not list this repo
     return _raises(lambda: EL.instance_root(tmp))
 
 
@@ -249,6 +281,7 @@ CASES = [
     ("resolver refuses a root with no canonical/", case_resolver_refuses_root_with_no_canonical),
     ("resolver refuses registry/filesystem mismatch", case_resolver_refuses_registry_filesystem_mismatch),
     ("resolver refuses registered-null against a real dir", case_resolver_refuses_registered_null_against_real_dir),
+    ("resolver refuses an unregistered repo", case_resolver_refuses_unregistered_repo),
     ("resolver uses the registry as authority", case_resolver_uses_registry_as_authority),
     ("resolver strict=False restores the legacy guess", case_resolver_nonstrict_restores_legacy_guess),
     ("refuses a claim with no command", case_refuses_missing_command),

--- a/q-system/.q-system/scripts/test_evidence_ledger.py
+++ b/q-system/.q-system/scripts/test_evidence_ledger.py
@@ -220,6 +220,46 @@ def case_resolver_refuses_unregistered_repo() -> bool:
     return _raises(lambda: EL.instance_root(tmp))
 
 
+def case_allow_unregistered_still_refuses_ambiguity() -> bool:
+    """allow_unregistered is NOT strict=False. It must keep refusing the guess
+    between two candidate domain dirs -- that is the sorted()[0] hazard this PRD
+    exists to kill, and a READ-ONLY caller has no better claim to it than a writer."""
+    tmp = Path(tempfile.mkdtemp())
+    (tmp / "q-alpha" / "canonical").mkdir(parents=True)
+    (tmp / "q-beta" / "canonical").mkdir(parents=True)
+    _reg(tmp, [])
+    return _raises(lambda: EL.instance_root(tmp, allow_unregistered=True))
+
+
+def case_allow_unregistered_resolves_a_single_tree() -> bool:
+    """The one thing it DOES permit: an unregistered repo with exactly one possible
+    answer. system_manifest.health() depends on this -- a hard refusal here made the
+    grounding Stop hook report a HEALTHY manifest as unreadable on every turn."""
+    tmp = Path(tempfile.mkdtemp())
+    (tmp / "q-system" / "canonical").mkdir(parents=True)
+    _reg(tmp, [])
+    return EL.instance_root(tmp, allow_unregistered=True) == tmp / "q-system"
+
+
+def case_write_refuses_unregistered_but_read_degrades() -> bool:
+    """THE asymmetry, pinned. Codex's hazard is an unattended run APPENDING evidence
+    to the wrong tree -- a property of the OPERATION. Guarding the REPOSITORY instead
+    took out the grounding Stop hook and the client-output evidence gate, because
+    read/check/has_ledger all share ledger_path(). Two rounds of per-caller opt-ins
+    later, the fix was to move the refusal onto append_row, the single write path.
+    If someone widens ledger_path back to strict, this case goes red."""
+    tmp = Path(tempfile.mkdtemp())
+    (tmp / "q-system" / "canonical").mkdir(parents=True)
+    _reg(tmp, [])  # a real registry that does not list this repo
+    wrote = _raises(lambda: EL.add(tmp, claim="c", source="s",
+                                   command="true", result="ok"))
+    try:
+        read_ok = EL.read(tmp) == []
+    except Exception:
+        read_ok = False
+    return wrote and read_ok
+
+
 def case_resolver_uses_registry_as_authority() -> bool:
     tmp = Path(tempfile.mkdtemp())
     (tmp / "q-real" / "canonical").mkdir(parents=True)
@@ -282,6 +322,9 @@ CASES = [
     ("resolver refuses registry/filesystem mismatch", case_resolver_refuses_registry_filesystem_mismatch),
     ("resolver refuses registered-null against a real dir", case_resolver_refuses_registered_null_against_real_dir),
     ("resolver refuses an unregistered repo", case_resolver_refuses_unregistered_repo),
+    ("allow_unregistered still refuses ambiguity", case_allow_unregistered_still_refuses_ambiguity),
+    ("allow_unregistered resolves a single tree", case_allow_unregistered_resolves_a_single_tree),
+    ("write refuses unregistered, read degrades", case_write_refuses_unregistered_but_read_degrades),
     ("resolver uses the registry as authority", case_resolver_uses_registry_as_authority),
     ("resolver strict=False restores the legacy guess", case_resolver_nonstrict_restores_legacy_guess),
     ("refuses a claim with no command", case_refuses_missing_command),

--- a/q-system/.q-system/scripts/test_evidence_ledger.py
+++ b/q-system/.q-system/scripts/test_evidence_ledger.py
@@ -10,6 +10,7 @@ Run: python3 test_evidence_ledger.py
 """
 from __future__ import annotations
 
+import os
 import sys
 import tempfile
 from pathlib import Path
@@ -127,7 +128,89 @@ def case_ledger_path_falls_back_to_skeleton() -> bool:
     return EL.ledger_path(tmp).parent.parent.name == "q-system"
 
 
+# --------------------------------------------------------- fail-closed resolver
+# Pairs with prd-canonical-read-path-repair-2026-08-22 / crpr-one-canonical-resolver.
+# The old instance_root() was `named[0] if named else repo/"q-system"` -- a glob with
+# no registry and no cross-check, structurally unable to be wrong out loud. Each case
+# below is one measured way it answered confidently and wrongly.
+#
+# Every case pins KIPI_EVIDENCE_REGISTRY at its own temp registry. Without that the
+# resolver falls back to the REAL fleet registry and the case stops being hermetic.
+
+def _reg(tmp: Path, entries: list[dict]) -> Path:
+    import json
+    p = tmp / "registry.json"
+    p.write_text(json.dumps({"instances": entries}), encoding="utf-8")
+    os.environ["KIPI_EVIDENCE_REGISTRY"] = str(p)
+    return p
+
+
+def _raises(fn) -> bool:
+    try:
+        fn()
+    except EL.ResolutionError:
+        return True
+    except Exception:
+        return False
+    return False
+
+
+def case_resolver_refuses_two_named_canonical_dirs() -> bool:
+    """sorted()[0] silently won. ZERO fleet instances hit this, so it must be
+    synthetic -- a hazard with no current victim is still a hazard."""
+    tmp = Path(tempfile.mkdtemp())
+    (tmp / "q-alpha" / "canonical").mkdir(parents=True)
+    (tmp / "q-beta" / "canonical").mkdir(parents=True)
+    _reg(tmp, [])
+    return _raises(lambda: EL.instance_root(tmp))
+
+
+def case_resolver_refuses_root_with_no_canonical() -> bool:
+    """Measured on 3 of 25 instances: resolves to a dir holding no canonical/."""
+    tmp = Path(tempfile.mkdtemp())
+    (tmp / "q-system").mkdir(parents=True)
+    _reg(tmp, [])
+    return _raises(lambda: EL.instance_root(tmp))
+
+
+def case_resolver_refuses_registry_filesystem_mismatch() -> bool:
+    tmp = Path(tempfile.mkdtemp())
+    (tmp / "q-real" / "canonical").mkdir(parents=True)
+    _reg(tmp, [{"name": "x", "path": str(tmp), "instance_q_dir": "q-other"}])
+    return _raises(lambda: EL.instance_root(tmp))
+
+
+def case_resolver_refuses_registered_null_against_real_dir() -> bool:
+    """The 6-of-25 case: registry says null, a real domain dir holds canonical/."""
+    tmp = Path(tempfile.mkdtemp())
+    (tmp / "q-real" / "canonical").mkdir(parents=True)
+    _reg(tmp, [{"name": "x", "path": str(tmp), "instance_q_dir": None}])
+    return _raises(lambda: EL.instance_root(tmp))
+
+
+def case_resolver_uses_registry_as_authority() -> bool:
+    tmp = Path(tempfile.mkdtemp())
+    (tmp / "q-real" / "canonical").mkdir(parents=True)
+    _reg(tmp, [{"name": "x", "path": str(tmp), "instance_q_dir": "q-real"}])
+    return EL.instance_root(tmp) == tmp / "q-real"
+
+
+def case_resolver_nonstrict_restores_legacy_guess() -> bool:
+    """The escape hatch must still guess, or callers cannot degrade deliberately."""
+    tmp = Path(tempfile.mkdtemp())
+    (tmp / "q-alpha" / "canonical").mkdir(parents=True)
+    (tmp / "q-beta" / "canonical").mkdir(parents=True)
+    _reg(tmp, [])
+    return EL.instance_root(tmp, strict=False) == tmp / "q-alpha"
+
+
 CASES = [
+    ("resolver refuses two named canonical dirs", case_resolver_refuses_two_named_canonical_dirs),
+    ("resolver refuses a root with no canonical/", case_resolver_refuses_root_with_no_canonical),
+    ("resolver refuses registry/filesystem mismatch", case_resolver_refuses_registry_filesystem_mismatch),
+    ("resolver refuses registered-null against a real dir", case_resolver_refuses_registered_null_against_real_dir),
+    ("resolver uses the registry as authority", case_resolver_uses_registry_as_authority),
+    ("resolver strict=False restores the legacy guess", case_resolver_nonstrict_restores_legacy_guess),
     ("refuses a claim with no command", case_refuses_missing_command),
     ("refuses a claim with no result", case_refuses_missing_result),
     ("refuses a duplicate claim_id", case_refuses_duplicate_claim_id),

--- a/q-system/.q-system/scripts/test_evidence_ledger.py
+++ b/q-system/.q-system/scripts/test_evidence_ledger.py
@@ -204,7 +204,47 @@ def case_resolver_nonstrict_restores_legacy_guess() -> bool:
     return EL.instance_root(tmp, strict=False) == tmp / "q-alpha"
 
 
+# ------------------------------------------------ the audit's exit code can fail
+# SCAR (Codex review of PR #240, major). `_run_audit` ended in a hardcoded
+# `return 0`, so the one command that enumerates unresolvable instances could not
+# fail for the reason it exists. Both branches are asserted here; an exit code
+# that is only ever observed as 0 is a constant, not a verdict.
+
+def _audit_rc(tmp: Path, entries: list[dict], extra: list[str] | None = None) -> int:
+    reg = _reg(tmp, entries)
+    return EL.main(["--audit-instance-roots", "--registry", str(reg)] + (extra or []))
+
+
+def case_audit_exits_nonzero_when_an_instance_is_refused() -> bool:
+    """A registered instance whose registry says null while a real domain dir holds
+    canonical/ -- the 6-of-25 shape. The resolver REFUSES it, so the audit must too."""
+    tmp = Path(tempfile.mkdtemp())
+    inst = tmp / "inst"
+    (inst / "q-real" / "canonical").mkdir(parents=True)
+    return _audit_rc(tmp, [{"name": "x", "path": str(inst), "instance_q_dir": None}]) == 1
+
+
+def case_audit_exits_zero_when_every_instance_resolves() -> bool:
+    """The green branch, or the case above proves only that the command is broken."""
+    tmp = Path(tempfile.mkdtemp())
+    inst = tmp / "inst"
+    (inst / "q-real" / "canonical").mkdir(parents=True)
+    return _audit_rc(tmp, [{"name": "x", "path": str(inst), "instance_q_dir": "q-real"}]) == 0
+
+
+def case_audit_allow_refused_enumerates_without_failing() -> bool:
+    """The opt-in hatch for callers that want the rows, not the verdict."""
+    tmp = Path(tempfile.mkdtemp())
+    inst = tmp / "inst"
+    (inst / "q-real" / "canonical").mkdir(parents=True)
+    entries = [{"name": "x", "path": str(inst), "instance_q_dir": None}]
+    return _audit_rc(tmp, entries, ["--allow-refused"]) == 0
+
+
 CASES = [
+    ("audit exits non-zero on a REFUSED instance", case_audit_exits_nonzero_when_an_instance_is_refused),
+    ("audit exits zero when every instance resolves", case_audit_exits_zero_when_every_instance_resolves),
+    ("audit --allow-refused enumerates without failing", case_audit_allow_refused_enumerates_without_failing),
     ("resolver refuses two named canonical dirs", case_resolver_refuses_two_named_canonical_dirs),
     ("resolver refuses a root with no canonical/", case_resolver_refuses_root_with_no_canonical),
     ("resolver refuses registry/filesystem mismatch", case_resolver_refuses_registry_filesystem_mismatch),


### PR DESCRIPTION
Three p0 issues from `prd-canonical-read-path-repair-2026-08-22`, each with a proof
that was shown able to fail before it was trusted.

## What shipped

**1. `crpr-digest-asserts-real-canonical` (new 7th issue) — closes Codex finding-14 (blocker) + finding-9**

finding-14 was deferred because none of the original six entries could close it: all
six are fixture-level and structurally cannot prove a live canonical tree was read.
New checker requires two *independent* readers to agree on a dated `RULE-YYYY-MM-DD`
id present only in that tree — a raw regex over `decisions.md`, and the shipping
digest parser. Never asserts `valid`, never asserts non-emptiness.

Negative controls wired into `--self-test`: a synthetic template tree and the real
fossil tree must both FAIL; the live tree must PASS.

**2. `crpr-one-canonical-resolver` — fail-closed instance canonical root**

`instance_root()` was `named[0] if named else repo/"q-system"`: a glob with no
registry and no cross-check, structurally unable to be wrong out loud. Registry is
now authority, filesystem is a cross-check that RAISES on mismatch.

**3. `crpr-bus-verifier-can-fail` — three defects, three tests**

Reachability (the check was in no list, so its lambda never ran once), substance
(key-presence passed an all-empty digest), and the `error` short-circuit (a required
file carrying an error key yielded `pass: true` having delivered no data).

## Measurements that corrected the PRD

- **The live tree does NOT yield `valid: true`.** It returns `valid: false` (3 of 7
  checks) with all files found. The parsers were written against the 2026-07-01
  template shape; the live files were retired to pointer docs. So `valid` is not a
  signal in either direction, and loosening a parser to move it would be the exact
  false green this PRD exists to kill. Captured as `sp-8804dee7`, deliberately out of
  scope (read-path only).
- **The fleet numbers had decayed.** PRD said 4 of 20 disagree, 2 with no
  `canonical/`. Actual across all 25 registered instances: 6 disagree, 3 have no
  `canonical/`, and ZERO have two named domain dirs — so that hazard gets a synthetic
  fixture, not a fleet instance.
- **A green test was pinning a defect.** `test_phase1_calendar_with_error_key`
  asserted the buggy `warn` behaviour and passed, which is why the bug survived.
  Inverting it is part of the fix.
- **Two `required_check`s could not run as written** (bare pytest exits 4 on a
  conftest ImportError). Same defect class as finding-2/24. Corrected.

## Gates respected, not worked around

- The **client-name guard** blocked writing client-derived directory names into
  `instance-registry.json`, which is TRACKED in this PUBLIC repo. It is right, and the
  PRD's "the registry is gitignored-safe" premise is false. The registry fill is
  therefore NOT in this PR; the resolver refuses on those instances instead, which is
  the intended fail-closed behaviour. Raised as `sp-71c71288`.
- The **spillover gate** refuses to resolve finding-14 from an unpushed checkout
  ("merge first, then resolve"). Correct; the deferrals stay open until this merges.

## Verification

| check | before | after |
|---|---|---|
| `test-canonical-digest-real-values.py --self-test` | did not exist | rc=0, both fossil controls FAIL, live PASSES |
| `test_evidence_ledger.py` | 11 cases | 17/17, mutation kills 4 of 6 with the pre-fix body restored |
| `test_bus_verifier.py` (scoped) | 16 passed, check unreachable | 17 passed, rc=0 |
| `--audit-instance-roots` | did not exist | 25 registered, 9 REFUSED (was silently guessing on all 9) |

🤖 Generated with [Claude Code](https://claude.com/claude-code)