### PR TITLE
canonical_digest returns the right content: nested sections, accumulating fields, retired sources named (ASK-977)

### DIFF
--- a/plugins/kipi-core/.claude-plugin/plugin.json
+++ b/plugins/kipi-core/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "kipi-core",
-  "version": "1.7.19",
+  "version": "1.7.20",
   "description": "Core founder OS \u2014 voice, research, AUDHD, LinkedIn/brand, RCA skills + kipi-mcp server",
   "author": {
     "name": "Assaf Kipnis",

--- a/plugins/kipi-core/kipi-mcp/src/kipi_mcp/morning_init.py
+++ b/plugins/kipi-core/kipi-mcp/src/kipi_mcp/morning_init.py
@@ -174,40 +174,29 @@ def canonical_digest(paths) -> dict:
         "discovery": {},
         "decisions": [],
         "warnings": [],
+        "retired_sources": {},
         "valid": False,
+        "validation_failed": [],
     }
 
-    tt_path = paths.canonical_dir / "talk-tracks.md"
-    if tt_path.exists():
-        digest["talk_tracks"] = _parse_talk_tracks(tt_path.read_text())
-    else:
-        digest["warnings"].append("talk-tracks.md not found")
+    for key, dir_attr, filename, parse in _DIGEST_SOURCES:
+        path = getattr(paths, dir_attr) / filename
+        if not path.exists():
+            digest["warnings"].append(f"{filename} not found")
+            continue
+        content = path.read_text()
+        retirement = _retirement(content)
+        if retirement is not None:
+            # A retired source is NOT parsed into structured fields: its content
+            # is history, and shipping it as current is the ASK-977 defect one
+            # layer up. It is recorded instead, so a consumer can tell
+            # empty-because-retired from empty-because-none. No warning --
+            # warnings stay a missing-file signal.
+            digest["retired_sources"][key] = retirement
+            continue
+        digest[key] = parse(content)
 
-    obj_path = paths.canonical_dir / "objections.md"
-    if obj_path.exists():
-        digest["objections"] = _parse_objections(obj_path.read_text())
-    else:
-        digest["warnings"].append("objections.md not found")
-
-    cs_path = paths.my_project_dir / "current-state.md"
-    if cs_path.exists():
-        digest["current_state"] = _parse_current_state(cs_path.read_text())
-    else:
-        digest["warnings"].append("current-state.md not found")
-
-    disc_path = paths.canonical_dir / "discovery.md"
-    if disc_path.exists():
-        digest["discovery"] = _parse_discovery(disc_path.read_text())
-    else:
-        digest["warnings"].append("discovery.md not found")
-
-    dec_path = paths.canonical_dir / "decisions.md"
-    if dec_path.exists():
-        digest["decisions"] = _parse_decisions(dec_path.read_text())
-    else:
-        digest["warnings"].append("decisions.md not found")
-
-    digest["valid"] = _validate_digest(digest)
+    digest["valid"], digest["validation_failed"] = _validate_digest(digest)
     return digest
 
 
@@ -443,21 +432,85 @@ def _clean_old_bus(bus_dir: Path, days: int = 3):
                 pass
 
 
+_HEADING_RE = re.compile(r"^(#+)[ \t]*(.*)$")
+
+# Only the leading block of a file can retire it. Scanning the whole body would
+# let a canonical file that DISCUSSES a retirement retire itself.
+_RETIREMENT_HEADER_LINES = 15
+_STATUS_SUPERSEDED_RE = re.compile(r"^\s*status\s*:\s*superseded\b", re.IGNORECASE | re.MULTILINE)
+_SUPERSEDED_BANNER_RE = re.compile(r"\bSUPERSEDED\b")  # uppercase: a banner, not prose
+_DECISION_REF_RE = re.compile(r"\bASK-\d+\b")
+
+_ITEM_CAP = 10
+
+
+def _heading_depth(line: str) -> int | None:
+    """Depth of a markdown heading line, or None when the line is not one."""
+    match = _HEADING_RE.match(line)
+    return len(match.group(1)) if match else None
+
+
+def _subtree_end(heads: list[tuple[int, int, str]], index: int) -> int | None:
+    """Line index of the next heading at the same or shallower depth."""
+    depth = heads[index][1]
+    for start, later_depth, _ in heads[index + 1:]:
+        if later_depth <= depth:
+            return start
+    return None
+
+
 def _split_sections(content: str) -> list[tuple[str, str]]:
+    """Split markdown into (heading, body) with child sections NESTED in the parent.
+
+    Scar ASK-977: the old split treated every heading line as a peer, so the
+    live '## Unanswered Questions' -- whose 28 questions all sit under five ###
+    children -- parsed to an empty body and the digest shipped questions=[]. A
+    section's body now runs to the next heading of the SAME OR SHALLOWER depth,
+    which is the ordinary document model. Child heading LINES are dropped from
+    the parent body so list-item and [RULE] extraction see content only. A
+    document whose headings are all one depth splits exactly as it did before.
+    """
+    lines = content.splitlines()
+    heads = [
+        (i, _heading_depth(line), _HEADING_RE.match(line).group(2).strip())
+        for i, line in enumerate(lines)
+        if _heading_depth(line) is not None
+    ]
+
     sections: list[tuple[str, str]] = []
-    heading = ""
-    body: list[str] = []
-    for line in content.splitlines():
-        if line.startswith("#"):
-            if heading or body:
-                sections.append((heading, "\n".join(body)))
-            heading = line.lstrip("#").strip()
-            body = []
-        else:
-            body.append(line)
-    if heading or body:
-        sections.append((heading, "\n".join(body)))
+    preamble = lines[: heads[0][0]] if heads else lines
+    if any(line.strip() for line in preamble):
+        sections.append(("", "\n".join(preamble)))
+
+    for index, (start, _depth, title) in enumerate(heads):
+        end = _subtree_end(heads, index)
+        span = lines[start + 1: len(lines) if end is None else end]
+        sections.append((title, "\n".join(l for l in span if _heading_depth(l) is None)))
     return sections
+
+
+def _retirement(content: str) -> dict | None:
+    """{'decision': 'ASK-nnn'} when the source's header retires it, else None."""
+    header = "\n".join(content.splitlines()[:_RETIREMENT_HEADER_LINES])
+    if not (_STATUS_SUPERSEDED_RE.search(header) or _SUPERSEDED_BANNER_RE.search(header)):
+        return None
+    ref = _DECISION_REF_RE.search(header)
+    return {"decision": ref.group(0) if ref else None}
+
+
+def _accumulate(existing: list[str], items: list[str], cap: int | None = _ITEM_CAP) -> list[str]:
+    """Add items to a field instead of REPLACING it, deduped, capped.
+
+    Scar ASK-977: assignment was last-match-wins, so '## Validation Gaps' (0
+    items) was overwritten by '## Website Positioning Gap' (8 items) and the
+    digest shipped March website notes labelled as validation gaps. Dedup also
+    collapses the parent/child pair that nesting now produces.
+    """
+    merged = list(existing)
+    for item in items:
+        if item not in merged:
+            merged.append(item)
+    return merged if cap is None else merged[:cap]
 
 
 def _extract_list_items(text: str) -> list[str]:
@@ -479,7 +532,9 @@ def _parse_talk_tracks(content: str) -> dict:
         elif "wedge" in hl:
             result["wedge"] = body.strip()[:500]
         elif "banned" in hl:
-            result["banned_phrases"] = _extract_list_items(body)
+            result["banned_phrases"] = _accumulate(
+                result["banned_phrases"], _extract_list_items(body), cap=None
+            )
         elif "detection" in hl or "framing" in hl:
             result["detection_rule"] = body.strip()[:500]
     return result
@@ -501,11 +556,11 @@ def _parse_current_state(content: str) -> dict:
         hl = heading.lower()
         items = _extract_list_items(body)
         if "works" in hl and "today" in hl:
-            result["works_today"] = items
+            result["works_today"] = _accumulate(result["works_today"], items)
         elif "unvalidated" in hl or "not yet" in hl:
-            result["unvalidated"] = items
+            result["unvalidated"] = _accumulate(result["unvalidated"], items)
         elif "validated" in hl:
-            result["validated"] = items
+            result["validated"] = _accumulate(result["validated"], items)
     return result
 
 
@@ -515,30 +570,70 @@ def _parse_discovery(content: str) -> dict:
         hl = heading.lower()
         items = _extract_list_items(body)
         if "gap" in hl:
-            result["gaps"] = items[:10]
+            result["gaps"] = _accumulate(result["gaps"], items)
         elif any(k in hl for k in ("question", "q&a", "top")):
-            result["questions"] = items[:10]
+            result["questions"] = _accumulate(result["questions"], items)
     return result
 
 
 def _parse_decisions(content: str) -> list[dict]:
-    decisions = []
+    decisions: list[dict] = []
+    seen: set[str] = set()
+
+    def _add(rule: str, summary: str):
+        # Nesting means a parent section can now restate a child's rule; dedup
+        # by rule text so one rule never lands twice (ASK-977).
+        if rule and rule not in seen:
+            seen.add(rule)
+            decisions.append({"rule": rule, "summary": summary})
+
     for heading, body in _split_sections(content):
         if "rule" in heading.lower():
-            decisions.append({"rule": heading.strip(), "summary": body.strip()[:300]})
+            _add(heading.strip(), body.strip()[:300])
         for match in re.finditer(r"\[RULE\]\s*(.+?)(?:\n|$)", body):
-            decisions.append({"rule": match.group(1).strip(), "summary": ""})
+            _add(match.group(1).strip(), "")
     return decisions
 
 
-def _validate_digest(digest: dict) -> bool:
-    checks = [
-        bool(digest["talk_tracks"].get("metaphor")),
-        bool(digest["talk_tracks"].get("definition")),
-        len(digest["objections"]) > 0,
-        len(digest["current_state"].get("works_today", [])) > 0,
-        len(digest["discovery"].get("questions", [])) > 0,
-        len(digest["decisions"]) > 0,
-        len(digest["warnings"]) < 3,
+# (source key, KipiPaths attribute, filename, parser)
+_DIGEST_SOURCES = (
+    ("talk_tracks", "canonical_dir", "talk-tracks.md", _parse_talk_tracks),
+    ("objections", "canonical_dir", "objections.md", _parse_objections),
+    ("current_state", "my_project_dir", "current-state.md", _parse_current_state),
+    ("discovery", "canonical_dir", "discovery.md", _parse_discovery),
+    ("decisions", "canonical_dir", "decisions.md", _parse_decisions),
+)
+
+
+def _validity_checks(digest: dict) -> list[tuple[str | None, str, bool]]:
+    """(source key this check depends on, reason if it fails, did it pass)."""
+    return [
+        ("talk_tracks", "talk_tracks: no metaphor", bool(digest["talk_tracks"].get("metaphor"))),
+        ("talk_tracks", "talk_tracks: no definition", bool(digest["talk_tracks"].get("definition"))),
+        ("objections", "objections: none parsed", len(digest["objections"]) > 0),
+        ("current_state", "current_state: no works_today items",
+         len(digest["current_state"].get("works_today", [])) > 0),
+        ("discovery", "discovery: no questions parsed",
+         len(digest["discovery"].get("questions", [])) > 0),
+        ("decisions", "decisions: none parsed", len(digest["decisions"]) > 0),
+        (None, "3 or more canonical files not found", len(digest["warnings"]) < 3),
     ]
-    return sum(checks) >= 5
+
+
+def _validate_digest(digest: dict) -> tuple[bool, list[str]]:
+    """(valid, reasons). Every failure names itself.
+
+    Scar ASK-977: this returned a bare bool from `sum(checks) >= 5`, so a
+    caller saw valid=False with nothing to act on. Worse, three of the seven
+    checks read sources retired under ASK-510 (talk-tracks, current-state):
+    they could never pass, which put the 5-of-7 bar out of reach and made
+    valid=False permanent and meaningless. Checks whose source is retired drop
+    out of the accounting entirely; every check that still APPLIES must pass.
+    """
+    retired = digest.get("retired_sources", {})
+    failed = [
+        reason
+        for source, reason, passed in _validity_checks(digest)
+        if source not in retired and not passed
+    ]
+    return not failed, failed

--- a/plugins/kipi-core/kipi-mcp/tests/test_morning_init.py
+++ b/plugins/kipi-core/kipi-mcp/tests/test_morning_init.py
@@ -218,6 +218,166 @@ class TestCanonicalDigest:
         assert result["valid"] is True
 
 
+# ── Canonical Digest: wrong content (ASK-977) ──
+
+
+# Shapes taken from the live consulting tree as MEASURED and recorded in ASK-977
+# on 2026-08-23 (H2 sections with H3 children; '## Validation Gaps' immediately
+# followed by '## Website Positioning Gap'), not from an author's imagination.
+# This worktree cannot read that tree, so the provenance is the issue's
+# measurement, and these fixtures reproduce its SHAPE, never its content.
+
+DISCOVERY_H3_CHILDREN = """\
+# Discovery
+
+## Unanswered Questions
+
+### Pricing
+- What does a pilot actually cost?
+- Who signs the PO?
+
+### Scope
+- Which data sources are in scope?
+
+## Validation Gaps
+
+### Never tested
+- Nobody has paid for the weekly report yet
+
+## Website Positioning Gap
+
+- askconsulting.io reads as fraud investigation
+"""
+
+
+class TestDigestReturnsRightContent:
+    """ASK-977: canonical_digest returned WRONG content, not merely empty."""
+
+    def test_h3_children_stay_in_their_h2_parent(self, paths):
+        """Mechanism 1: H3 was a peer of H2, so the parent parsed to 0 items."""
+        _create_file(paths.canonical_dir / "discovery.md", DISCOVERY_H3_CHILDREN)
+        questions = canonical_digest(paths)["discovery"]["questions"]
+        assert "What does a pilot actually cost?" in questions
+        assert "Which data sources are in scope?" in questions
+
+    def test_matching_sections_accumulate_instead_of_overwriting(self, paths):
+        """Mechanism 2: last-match-wins shipped website notes AS validation gaps."""
+        _create_file(paths.canonical_dir / "discovery.md", DISCOVERY_H3_CHILDREN)
+        gaps = canonical_digest(paths)["discovery"]["gaps"]
+        assert "Nobody has paid for the weekly report yet" in gaps
+        assert "askconsulting.io reads as fraud investigation" in gaps
+
+    def test_accumulated_items_keep_the_cap_and_dedupe(self, paths):
+        """The cap survives accumulation, and a parent+child pair is not doubled."""
+        gap_sections = "\n\n".join(
+            f"## Gap {n}\n\n### detail\n- gap item {n}" for n in range(14)
+        )
+        _create_file(paths.canonical_dir / "discovery.md", gap_sections)
+        gaps = canonical_digest(paths)["discovery"]["gaps"]
+        assert len(gaps) == 10
+        assert len(set(gaps)) == 10
+
+    def test_flat_h1_documents_still_split_per_heading(self, paths):
+        """Nesting must not merge a document whose headings are all one depth."""
+        _create_file(
+            paths.canonical_dir / "objections.md",
+            "# Too expensive\nWe save time.\n\n# Already have a tool\nDoes it remember?\n",
+        )
+        objections = canonical_digest(paths)["objections"]
+        names = [o["name"] for o in objections]
+        assert names == ["Too expensive", "Already have a tool"]
+        assert objections[0]["response"] == "We save time."
+
+
+SUPERSEDED_TALK_TRACKS = """\
+---
+status: superseded
+superseded_by: ASK-510
+---
+
+# Primary Metaphor
+Your brain externalized.
+"""
+
+SUPERSEDED_CURRENT_STATE = """\
+> **SUPERSEDED** by ASK-510. Kept for history only.
+
+# What Works Today
+- Something that has not been true since March
+"""
+
+
+def _seed_live_sources(paths):
+    _create_file(paths.canonical_dir / "objections.md", "# Obj1\nResponse here.\n")
+    _create_file(paths.canonical_dir / "discovery.md", "# Top Questions\n- Q1\n")
+    _create_file(paths.canonical_dir / "decisions.md", "# [RULE] Test\nDo this.\n")
+
+
+class TestRetiredSources:
+    """A retired source must be distinguishable from an absent one."""
+
+    def test_superseded_frontmatter_is_recorded_not_parsed(self, paths):
+        _create_file(paths.canonical_dir / "talk-tracks.md", SUPERSEDED_TALK_TRACKS)
+        result = canonical_digest(paths)
+        assert result["retired_sources"]["talk_tracks"] == {"decision": "ASK-510"}
+        assert result["talk_tracks"].get("metaphor", "") == ""
+
+    def test_superseded_banner_is_recorded_not_parsed(self, paths):
+        _create_file(paths.my_project_dir / "current-state.md", SUPERSEDED_CURRENT_STATE)
+        result = canonical_digest(paths)
+        assert result["retired_sources"]["current_state"] == {"decision": "ASK-510"}
+        assert result["current_state"].get("works_today", []) == []
+
+    def test_retirement_adds_no_warning(self, paths):
+        """warnings stay a missing-file signal; retirement is not a missing file."""
+        _create_file(paths.canonical_dir / "talk-tracks.md", SUPERSEDED_TALK_TRACKS)
+        _create_file(paths.my_project_dir / "current-state.md", SUPERSEDED_CURRENT_STATE)
+        _seed_live_sources(paths)
+        assert canonical_digest(paths)["warnings"] == []
+
+    def test_a_live_source_is_not_marked_retired(self, paths):
+        """Negative self-test: without a banner the same file parses as before."""
+        _create_file(
+            paths.canonical_dir / "talk-tracks.md",
+            "# Primary Metaphor\nYour brain externalized.\n",
+        )
+        result = canonical_digest(paths)
+        assert result["retired_sources"] == {}
+        assert "externalized" in result["talk_tracks"]["metaphor"]
+
+
+class TestValidityAccounting:
+    def test_retired_source_checks_drop_out_and_valid_is_reachable(self, paths):
+        """ASK-510 retired talk-tracks + current-state; 3 of 7 checks were then
+        structurally unreachable, so valid could never go true honestly."""
+        _create_file(paths.canonical_dir / "talk-tracks.md", SUPERSEDED_TALK_TRACKS)
+        _create_file(paths.my_project_dir / "current-state.md", SUPERSEDED_CURRENT_STATE)
+        _seed_live_sources(paths)
+        result = canonical_digest(paths)
+        assert result["validation_failed"] == []
+        assert result["valid"] is True
+
+    def test_invalid_digest_names_every_reason(self, paths):
+        _create_file(paths.canonical_dir / "talk-tracks.md", "# Primary Metaphor\nX.\n")
+        result = canonical_digest(paths)
+        assert result["valid"] is False
+        assert result["validation_failed"], "valid=False named no reason"
+        joined = " ".join(result["validation_failed"])
+        assert "objections" in joined
+        assert "definition" in joined
+
+    def test_a_failing_check_on_a_live_source_still_invalidates(self, paths):
+        """Negative self-test: retirement drops checks, it does not pass them."""
+        _create_file(paths.canonical_dir / "talk-tracks.md", SUPERSEDED_TALK_TRACKS)
+        _create_file(paths.my_project_dir / "current-state.md", SUPERSEDED_CURRENT_STATE)
+        _create_file(paths.canonical_dir / "discovery.md", "# Top Questions\n- Q1\n")
+        _create_file(paths.canonical_dir / "decisions.md", "# [RULE] Test\nDo this.\n")
+        # objections.md absent -> a LIVE check fails and one warning is raised
+        result = canonical_digest(paths)
+        assert result["valid"] is False
+        assert any("objections" in r for r in result["validation_failed"])
+
+
 # ── Morning Init ──
 
 


### PR DESCRIPTION
Closes the ASK-977 finding: `canonical_digest` returned WRONG content, not merely empty.

## Measured on the live tree (q-consult/canonical), before and after

| | questions | gaps | valid | validation_failed |
|---|---|---|---|---|
| origin/main | 0 | 8 (all website notes) | False | None |
| this branch | 10 | 10 (validation gaps AND website) | True | [] |

## Three mechanisms

1. **H3 children were lost.** `_split_sections` treated H3 as a peer of H2, so `## Unanswered Questions` parsed to an empty body while its 28 real questions sat under five `###` children. A section body now runs to the next heading of the SAME OR SHALLOWER depth. Child heading lines are dropped from the parent body so list-item and `[RULE]` extraction see content only. A document whose headings are all one depth splits exactly as before, so every pre-existing fixture is untouched.

2. **Last-match-wins overwrote.** `## Validation Gaps` (0 items) was overwritten by `## Website Positioning Gap` (8 items), so the digest shipped March website notes labelled as validation gaps and a consumer could not tell. List fields now accumulate, deduped, capped at 10. Dedup also collapses the parent/child duplication that nesting introduces, including in `_parse_decisions`.

3. **Retired sources were indistinguishable from absent ones.** A source carrying a `SUPERSEDED` banner or `status: superseded` frontmatter is no longer parsed into structured fields; it is recorded in `digest['retired_sources']` as `{decision: ASK-nnn}`. Retirement adds no warning (warnings stay a missing-file signal). Only the leading 15 lines can retire a file, so a canonical file that DISCUSSES a retirement cannot retire itself.

## Validity accounting

`_validate_digest` returned a bare bool from `sum(checks) >= 5` and named no reason. Three of its seven checks read sources retired under ASK-510, so the 5-of-7 bar was unreachable and `valid: False` was permanent and meaningless. It now returns `(valid, reasons)`: checks whose source is retired drop out of the accounting, every check that still APPLIES must pass, and `valid=False` always names itself in `digest['validation_failed']`.

## Evidence

Reproducer-first. 9 new cases in `test_morning_init.py` were observed RED against origin/main, then green:

```
9 failed, 36 passed     <- before the fix
121 passed              <- after, across test_morning_init / test_paths /
                           test_bus_verifier / test_validator /
                           test_morning_auditor / test_backup
```

Two of the nine are negative self-tests: a live source is NOT marked retired, and retirement DROPS a check rather than passing it.

`test-canonical-digest-real-values.py --self-test` PASSes against the real `ASK_AI_consultant` tree with both fossil controls still failing, so the live path is proven read and the checker can still go red.

## Notes

- Plugin version 1.7.19 to 1.7.20. The runtime loads a version-keyed clone; without the bump the installed copy keeps serving the broken parser. This is the "clone refresh" half of the DoR's end-to-end criterion, which is only checkable after merge.
- Fixture provenance: this worktree's sandbox refuses reads under `~/projects`, so the synthetic fixtures reproduce the SHAPE recorded in ASK-977's measurement of the live files (H2 with H3 children; Validation Gaps immediately followed by Website Positioning Gap), never invented shapes. The live-tree numbers in the table above came from a script that does have that access.
- 5 test modules in this package cannot be collected in this environment (`ModuleNotFoundError: No module named 'yaml'`). Pre-existing, unrelated to this diff, and untouched by it.

DO NOT MERGE from here; closeout runs through /issue-verify and /issue-closeout.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
