### PR TITLE
feat(kb): deterministic Miyo hooks, session pull + research gate

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -364,6 +364,11 @@
             "type": "command",
             "command": "test -f \"$CLAUDE_PROJECT_DIR/q-system/.q-system/scripts/memory_autocapture.py\" && python3 \"$CLAUDE_PROJECT_DIR/q-system/.q-system/scripts/memory_autocapture.py\" 2>/dev/null || true",
             "async": true
+          },
+          {
+            "type": "command",
+            "command": "if test -f \"$CLAUDE_PROJECT_DIR/q-system/.q-system/scripts/kb-graph-guard.py\"; then python3 \"$CLAUDE_PROJECT_DIR/q-system/.q-system/scripts/kb-graph-guard.py\"; fi",
+            "timeout": 15
           }
         ]
       }

--- a/kipi-new-instance.sh
+++ b/kipi-new-instance.sh
@@ -237,6 +237,13 @@ else:
     print('  Already registered')
 "
 
+# Seed the instance's own knowledge base. Per-project by design (no
+# cross-instance sharing). Local-only file: the fleet lefthook bans *.jsonl
+# commits, so this stays untracked in every instance.
+mkdir -p memory
+touch memory/graph.jsonl
+echo "  Knowledge base seeded: memory/graph.jsonl"
+
 # Queue a Linear project for the new instance (ASK-113, goal 3).
 #
 # This CANNOT call Linear directly: there is no Linear API key in ~/.config/kipi/

--- a/lesson-candidates/.processed.json
+++ b/lesson-candidates/.processed.json
@@ -533,5 +533,30 @@
     "instance": "Prodigy_Gold",
     "status": "published",
     "date": "2026-08-17"
+  },
+  "937e16b1236c5934": {
+    "instance": "ASK_AI_consultant",
+    "status": "published",
+    "date": "2026-08-24"
+  },
+  "9f0bf1c88c290ed8": {
+    "instance": "ASK_AI_consultant",
+    "status": "held",
+    "date": "2026-08-24"
+  },
+  "d087efe8e967f45a": {
+    "instance": "ASK_AI_consultant",
+    "status": "published",
+    "date": "2026-08-24"
+  },
+  "44c32a08cd50007a": {
+    "instance": "ASK_AI_consultant",
+    "status": "published",
+    "date": "2026-08-24"
+  },
+  "a284efcfe4d114cd": {
+    "instance": "ASK_AI_consultant",
+    "status": "published",
+    "date": "2026-08-24"
   }
 }

--- a/lesson-candidates/held-9f0bf1c88c290ed8.md
+++ b/lesson-candidates/held-9f0bf1c88c290ed8.md
@@ -1,0 +1,20 @@
+# HELD lesson (not published)
+
+reason: LLM semantic check flagged a residual real entity
+source: [rca-crm-six-lies-2026-08-18.md](../consulting/q-system/output/rca/rca-crm-six-lies-2026-08-18.md)
+
+proposed title: Stored verdicts go stale silently
+
+Any value a system writes after classifying something is a dated verdict, not a fact. Once it is in a store, nothing re-examines it, and it keeps being served long after the classifier that produced it changed. Five habits keep that from turning into a wall of confidently wrong rows.
+
+**Re-prove derived state on a schedule, not only on new input.** If a record is re-judged only when fresh input arrives on it, then any record whose input stream went quiet is frozen at whatever the old classifier decided. Add a version stamp (classifier version plus timestamp) to every derived row, and re-run rows whose stamp predates the current version. Worse than staleness: a record can become permanently unreachable when its lookup key stops resolving (the entity it now keys on is unknown to the system), so it is never revisited by any path. Enumerate rows by store scan, not by lookup, so unmatched rows are still reachable.
+
+**Classify normalized content, not the raw payload.** Raw payloads carry inherited context: quoted history, forwarded material from third parties, boilerplate, salutations addressed to someone else. Length checks, punctuation checks, and addressee checks all read that inherited text as if the current author wrote it. Strip to the author's own contribution first, then classify. Enumerate the payload shapes that break the naive read (short acknowledgment riding a long quoted chain, automated replies, forwards, content addressed to a third party) and make each one its own class with its own fixture.
+
+**Never assert state from a search or list endpoint.** Search returns a subset chosen by relevance, not the full record. Any claim of the form "X never happened" or "nothing since date D" requires the full-fetch call for that record. If a code path or a report makes an absence claim, it must be reading a complete fetch.
+
+**Check where safety code physically sits.** A helper appended below a module's entry guard never runs in scripted invocation, so the witness or audit step it performs is silently absent while the downstream consumer keeps refusing or degrading. Assert the side effect exists after a run, not that the function is defined.
+
+**Isolate per-item failures in batches.** One unresolvable item aborting a whole batch converts a small data gap into total non-execution. Catch per item, record the skip, keep going.
+
+**Capture fixtures with full bodies.** A fixture recorded without payload content pins only routing behavior and leaves the content logic untested. If the fixture cannot fail for the reason you care about, it is not covering that reason.

--- a/q-system/.q-system/scripts/kb-graph-guard.py
+++ b/q-system/.q-system/scripts/kb-graph-guard.py
@@ -62,22 +62,42 @@ def find_kb(root: Path) -> Path | None:
 
 
 def newest_entity_mtime(root: Path) -> float | None:
-    """Scan <root>/investigations AND <root>/q-*/investigations: instances with
-    an instance_q_dir keep cases under the q-dir, plain ones at repo root."""
+    """Watch BOTH instance shapes (fleet is mixed -- RCA 2026-08-24 follow-up):
+
+    - investigation instances: <root>/investigations or q-*/investigations,
+      any investigation/{targets,findings} tree
+    - client/relationship instances: my-project/relationships.md and
+      canonical/*.md, at repo root or under q-*
+
+    Whatever exists is watched; missing shapes contribute nothing.
+    """
+    inv_trees = [p for p in [root / "investigations", *root.glob("q-*/investigations")]
+                 if p.is_dir()]
+    entity_files = []
+    for base in [root, *root.glob("q-*")]:
+        rel = base / "my-project" / "relationships.md"
+        if rel.is_file():
+            entity_files.append(rel)
+        canon = base / "canonical"
+        if canon.is_dir():
+            entity_files.extend(p for p in sorted(canon.glob("*.md")) if p.is_file())
+
     newest = None
-    candidates = [root / "investigations"]
-    candidates += sorted(root.glob("q-*/investigations"))
-    for investigations in candidates:
-        if not investigations.is_dir():
-            continue
+
+    def note(m: float) -> None:
+        nonlocal newest
+        newest = m if newest is None or m > newest else newest
+
+    for tree in inv_trees:
         for sub in WATCH_SUBDIRS:
-            for dirpath in investigations.rglob(f"investigation/{sub}"):
+            for dirpath in tree.rglob(f"investigation/{sub}"):
                 if not dirpath.is_dir():
                     continue
                 for f in dirpath.rglob("*"):
                     if f.is_file() and not f.name.startswith("."):
-                        m = f.stat().st_mtime
-                        newest = m if newest is None or m > newest else newest
+                        note(f.stat().st_mtime)
+    for f in entity_files:
+        note(f.stat().st_mtime)
     return newest
 
 

--- a/q-system/.q-system/scripts/kb-graph-guard.py
+++ b/q-system/.q-system/scripts/kb-graph-guard.py
@@ -1,0 +1,151 @@
+#!/usr/bin/env python3
+"""KB freshness guard: deterministic Stop-hook for memory/graph.jsonl.
+
+Why this shape (prd-kb-graph-guard-2026-08-24): entity relationships enter
+investigations through whatever path a session takes, and /q-* commands are
+invoked autonomously, not by the founder. So enforcement cannot key on any
+command -- it keys on the only layer that always runs, session Stop.
+
+Contract (matches memory-confidence-validator):
+  exit 0          fresh, nothing to do, or ANY doubt -> silent pass
+  exit 2 + stderr stale -> message fed back; the live agent extracts triples now
+
+Scar-guarded decisions:
+- mtime comparison, not line counts: stateless, no SessionStart pairing, no
+  state that can go missing and false-green.
+- escalate-then-release: the SECOND same-day stale writes one Sana queue line
+  and exits 0. Holding sessions hostage on Stop produced gate-off pressure in
+  every previous guard (memory-lint docstring); one bounded complaint per day
+  is the loudest safe signal.
+- silent-safe: missing KB/dirs or any exception exits 0. A capture bug must
+  never block a session close.
+"""
+from __future__ import annotations
+
+import datetime as dt
+import json
+import subprocess
+import sys
+from pathlib import Path
+
+STATE_DIRNAME = Path(".claude/state")
+STATE_FILENAME = "kb-graph-guard.json"
+WATCH_SUBDIRS = ("targets", "findings")
+
+
+def fail_open(msg: str) -> int:
+    sys.stderr.write(f"kb-graph-guard: {msg}\n")
+    return 0
+
+
+def find_repo_root() -> Path | None:
+    env_root = None
+    import os
+
+    env_root = os.environ.get("CLAUDE_PROJECT_DIR")
+    if env_root:
+        return Path(env_root)
+    probe = Path.cwd()
+    for candidate in [probe, *probe.parents]:
+        if (candidate / ".git").exists():
+            return candidate
+    return None
+
+
+def find_kb(root: Path) -> Path | None:
+    """Same discovery rule as ensure_instance_kb.py: q-dir first, root fallback."""
+    q_dirs = sorted(p for p in root.glob("q-*/memory/graph.jsonl") if p.is_file())
+    if q_dirs:
+        return q_dirs[0]
+    root_kb = root / "memory" / "graph.jsonl"
+    return root_kb if root_kb.is_file() else None
+
+
+def newest_entity_mtime(root: Path) -> float | None:
+    """Scan <root>/investigations AND <root>/q-*/investigations: instances with
+    an instance_q_dir keep cases under the q-dir, plain ones at repo root."""
+    newest = None
+    candidates = [root / "investigations"]
+    candidates += sorted(root.glob("q-*/investigations"))
+    for investigations in candidates:
+        if not investigations.is_dir():
+            continue
+        for sub in WATCH_SUBDIRS:
+            for dirpath in investigations.rglob(f"investigation/{sub}"):
+                if not dirpath.is_dir():
+                    continue
+                for f in dirpath.rglob("*"):
+                    if f.is_file() and not f.name.startswith("."):
+                        m = f.stat().st_mtime
+                        newest = m if newest is None or m > newest else newest
+    return newest
+
+
+def load_state(state_file: Path) -> dict:
+    try:
+        return json.loads(state_file.read_text())
+    except Exception:
+        return {}
+
+
+def queue_escalation(root: Path, kb_path: Path) -> bool:
+    script = root / "q-system" / ".q-system" / "scripts" / "linear-queue.py"
+    if not script.is_file():
+        return False
+    try:
+        subprocess.run(
+            ["python3", str(script), "add",
+             "--repo", root.name,
+             "--kind", "issue",
+             "--title", f"KB stale: entity data outgrew graph.jsonl ({dt.date.today()})",
+             "--note", f"kb-graph-guard second same-day miss. KB: {kb_path}",
+             "--source", "kb-guard"],
+            capture_output=True, timeout=10,
+        )
+        return True
+    except Exception:
+        return False
+
+
+def main() -> int:
+    try:
+        root = find_repo_root()
+        if root is None:
+            return 0
+        kb = find_kb(root)
+        if kb is None:
+            return 0
+        newest = newest_entity_mtime(root)
+        if newest is None:
+            return 0
+        if newest <= kb.stat().st_mtime:
+            return 0
+
+        today = dt.date.today().isoformat()
+        state_file = root / STATE_DIRNAME / STATE_FILENAME
+        state = load_state(state_file)
+        if state.get("last_warned") == today:
+            already_escalated = state.get("escalated") == today
+            if not already_escalated and queue_escalation(root, kb):
+                state["escalated"] = today
+                state_file.parent.mkdir(parents=True, exist_ok=True)
+                state_file.write_text(json.dumps(state))
+            return 0
+
+        state["last_warned"] = today
+        state.pop("escalated", None)
+        state_file.parent.mkdir(parents=True, exist_ok=True)
+        state_file.write_text(json.dumps(state))
+        sys.stderr.write(
+            "kb-graph-guard: entity files changed this session but "
+            f"{kb.relative_to(root)} is older. Extract relationship triples "
+            "(s/p/o/t lines) from the targets/findings you touched and append "
+            "them to the KB before closing.\n"
+        )
+        return 2
+    except Exception as exc:
+        return fail_open(f"unexpected error, passing: {exc}")
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/q-system/.q-system/scripts/miyo-research-gate.py
+++ b/q-system/.q-system/scripts/miyo-research-gate.py
@@ -1,0 +1,111 @@
+#!/usr/bin/env python3
+"""PreToolUse gate: force Miyo knowledge-base search before deep manual research.
+
+Deterministic rule: inside scope, once the session transcript shows N or more
+research tool calls (Grep/Glob/WebSearch/WebFetch) and zero Miyo usages, block
+the next research call (exit 2) with instructions to run a Miyo search first.
+
+Fail-open policy: missing/unreadable transcript, malformed input, or any error
+exits 0 so infrastructure problems never brick a session. Kill switch for the
+founder shell: MIYO_GATE_OFF=1. Threshold override: MIYO_GATE_THRESHOLD (default 4).
+
+Scope default: only fires when cwd contains '/consulting'. Override with env
+MIYO_KB_SCOPE (substring match on cwd) or set MIYO_KB_SCOPE='' to allow anywhere.
+"""
+import json
+import os
+import re
+import sys
+
+RESEARCH_TOOLS = {"Grep", "Glob", "WebSearch", "WebFetch"}
+DEFAULT_SCOPE = "/consulting/"
+DEFAULT_THRESHOLD = 4
+
+RE_TOOL_NAME = re.compile(r'"(?:tool_)?name"\s*:\s*"([^"]*)"')
+RE_BASH_MIYO = re.compile(r'"command"\s*:\s*"[^"]*miyo\s+search', re.IGNORECASE)
+
+
+def scope():
+    return os.environ.get("MIYO_KB_SCOPE", DEFAULT_SCOPE)
+
+
+def in_scope(cwd):
+    s = scope()
+    if not s:
+        return True
+    return s in cwd + "/"
+
+
+def threshold():
+    try:
+        return int(os.environ.get("MIYO_GATE_THRESHOLD", DEFAULT_THRESHOLD))
+    except ValueError:
+        return DEFAULT_THRESHOLD
+
+
+def scan_transcript(transcript_path):
+    """Return (research_calls, miyo_used) from a Claude Code transcript JSONL."""
+    research = 0
+    miyo_used = False
+    with open(transcript_path, "r", encoding="utf-8", errors="replace") as fh:
+        for line in fh:
+            names = RE_TOOL_NAME.findall(line)
+            for name in names:
+                if name in RESEARCH_TOOLS:
+                    research += 1
+                elif "miyo" in name.lower():
+                    miyo_used = True
+            if not miyo_used and RE_BASH_MIYO.search(line):
+                miyo_used = True
+    return research, miyo_used
+
+
+def blocked_message(research, limit):
+    return (
+        f"[miyo-research-gate] {research} research calls this session, zero "
+        f"knowledge-base searches. The KB is the retrieval layer; run one Miyo "
+        f"search before more direct searching. Use the mcp__miyo__search tool, or: "
+        f"~/.miyo/bin/miyo search \"<your question>\" --limit 8. "
+        f"This gate releases as soon as one lands. Founder kill switch: "
+        f"MIYO_GATE_OFF=1. Current trigger: >= {limit} research calls, no KB hit."
+    )
+
+
+def decide(research_calls, miyo_used, limit):
+    if miyo_used:
+        return False, None
+    if research_calls < limit:
+        return False, None
+    return True, blocked_message(research_calls, limit)
+
+
+def main():
+    try:
+        raw = sys.stdin.read() if not sys.stdin.isatty() else "{}"
+        payload = json.loads(raw) if raw.strip() else {}
+    except Exception:
+        return 0
+    try:
+        if os.environ.get("MIYO_GATE_OFF"):
+            return 0
+        tool = payload.get("tool_name", "")
+        if tool not in RESEARCH_TOOLS:
+            return 0
+        cwd = payload.get("cwd") or os.getcwd()
+        if not in_scope(cwd):
+            return 0
+        transcript = payload.get("transcript_path")
+        if not transcript or not os.path.exists(transcript):
+            return 0
+        research, miyo_used = scan_transcript(transcript)
+        should_block, message = decide(research, miyo_used, threshold())
+        if should_block:
+            print(message, file=sys.stderr)
+            return 2
+    except Exception:
+        return 0
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/q-system/.q-system/scripts/miyo-session-pull.py
+++ b/q-system/.q-system/scripts/miyo-session-pull.py
@@ -1,0 +1,102 @@
+#!/usr/bin/env python3
+"""SessionStart hook: pull knowledge-base context from Miyo for the working folder.
+
+Deterministic: runs on every session start inside an indexed scope, no agent
+choice involved. Prints a capped digest to stdout; Claude Code injects
+SessionStart stdout into session context. Fails open (exit 0, no output) on any
+infrastructure error so a missing/down Miyo never breaks a session.
+
+Scope default: only fires when cwd contains '/consulting'. Override with env
+MIYO_KB_SCOPE (substring match on cwd) or set MIYO_KB_SCOPE='' to allow anywhere.
+"""
+import json
+import os
+import subprocess
+import sys
+
+MIYO_BIN = os.environ.get("MIYO_BIN", os.path.expanduser("~/.miyo/bin/miyo"))
+DEFAULT_SCOPE = "/consulting/"
+LIMIT = int(os.environ.get("MIYO_PULL_LIMIT", "6"))
+MAX_CHARS = int(os.environ.get("MIYO_PULL_MAX_CHARS", "1800"))
+
+
+def scope():
+    return os.environ.get("MIYO_KB_SCOPE", DEFAULT_SCOPE)
+
+
+def in_scope(cwd):
+    s = scope()
+    if not s:
+        return True
+    return s in cwd + "/"
+
+
+def build_queries(cwd):
+    project = os.path.basename(cwd.rstrip("/")) or "consulting"
+    return [project, f"{project} state decisions open items"]
+
+
+def run_search(query):
+    out = subprocess.run(
+        [MIYO_BIN, "search", "--limit", str(LIMIT), "--json", query],
+        capture_output=True,
+        text=True,
+        timeout=20,
+    )
+    if out.returncode != 0:
+        return []
+    try:
+        data = json.loads(out.stdout)
+    except ValueError:
+        return []
+    if isinstance(data, dict):
+        data = data.get("results") or data.get("hits") or []
+    results = []
+    for r in data[:LIMIT]:
+        path = (r.get("file_path") or r.get("path") or "?").strip()
+        title = (r.get("title") or os.path.basename(path)).strip()
+        snippet = (r.get("snippet") or r.get("content") or "").strip()
+        if len(snippet) > 160:
+            snippet = snippet[:157] + "..."
+        results.append((path, title, snippet))
+    return results
+
+
+def render(cwd, queries, per_query):
+    lines = [f"[miyo kb] context pull for {os.path.basename(cwd.rstrip('/'))}"]
+    seen = set()
+    for q, hits in zip(queries, per_query):
+        if not hits:
+            continue
+        lines.append(f"query: {q}")
+        for path, title, snippet in hits:
+            if path in seen:
+                continue
+            seen.add(path)
+            line = f"- {path} | {title}" + (f": {snippet}" if snippet else "")
+            lines.append(line)
+    text = "\n".join(lines)
+    if len(text) > MAX_CHARS:
+        text = text[: MAX_CHARS - 3].rsplit("\n", 1)[0] + "\n..."
+    return text
+
+
+def main():
+    try:
+        raw = sys.stdin.read() if not sys.stdin.isatty() else "{}"
+        payload = json.loads(raw) if raw.strip() else {}
+        cwd = payload.get("cwd") or os.getcwd()
+        if not in_scope(cwd) or not os.path.exists(MIYO_BIN):
+            return 0
+        queries = build_queries(cwd)
+        per_query = [run_search(q) for q in queries]
+        if not any(per_query):
+            return 0
+        print(render(cwd, queries, per_query))
+    except Exception:
+        pass
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/q-system/.q-system/scripts/settings-template-sync-check.py
+++ b/q-system/.q-system/scripts/settings-template-sync-check.py
@@ -67,7 +67,11 @@ SKELETON_ONLY = {
 # dead in the skeleton). Add here only when an asymmetry is deliberate.
 # Hooks that intentionally run ONLY on instances (the skeleton self-detects and no-ops),
 # so they belong in settings-template.json but NOT in the skeleton's own .claude/settings.json.
-FLEET_ONLY = {"instance-automation-guard.py"}
+FLEET_ONLY = {
+    "instance-automation-guard.py",
+    "miyo-session-pull.py",
+    "miyo-research-gate.py",
+}
 
 # A hook "propagates" when it invokes a script under a directory kipi update
 # rsyncs into instances. Such a hook's switch MUST live in the template too.

--- a/q-system/.q-system/scripts/test_kb_graph_guard.py
+++ b/q-system/.q-system/scripts/test_kb_graph_guard.py
@@ -1,0 +1,159 @@
+#!/usr/bin/env python3
+"""Tests for kb-graph-guard.py. Runnable directly or via pytest.
+
+Negative self-test discipline (fable-discipline): every positive case is
+paired with a negative one proving the check can FAIL, so a green run means
+something. All subprocess calls pin CLAUDE_PROJECT_DIR to the sandbox root --
+inheriting the operator's env would guard the real repo, not the fixture.
+"""
+from __future__ import annotations
+
+import importlib.util
+import json
+import os
+import subprocess
+import sys
+import tempfile
+import time
+from pathlib import Path
+
+HERE = Path(__file__).parent
+GUARD = HERE / "kb-graph-guard.py"
+spec = importlib.util.spec_from_file_location("kb_graph_guard", GUARD)
+guard = importlib.util.module_from_spec(spec)
+spec.loader.exec_module(guard)
+
+
+def make_instance(tmp: Path) -> tuple[Path, Path]:
+    """Fake instance: repo root, q-dir KB, one case with targets+findings."""
+    root = tmp / "repo"
+    kb = root / "q-investigate" / "memory" / "graph.jsonl"
+    kb.parent.mkdir(parents=True)
+    kb.write_text("")
+    target = root / "q-investigate" / "investigations" / "case-001-x" / \
+        "investigation" / "targets"
+    findings = root / "q-investigate" / "investigations" / "case-001-x" / \
+        "investigation" / "findings"
+    target.mkdir(parents=True)
+    findings.mkdir(parents=True)
+    return root, kb
+
+
+def run_guard(root: Path) -> subprocess.CompletedProcess:
+    env = dict(os.environ)
+    env["CLAUDE_PROJECT_DIR"] = str(root)
+    return subprocess.run(
+        [sys.executable, str(GUARD)], cwd=root, env=env,
+        capture_output=True, text=True, timeout=30,
+    )
+
+
+def touch_later(path: Path, offset: float = 2.0) -> None:
+    future = time.time() + offset
+    path.touch()
+    os.utime(path, (future, future))
+
+
+def test_fresh_kb_passes() -> None:
+    """KB newer than entity files -> exit 0. No entity files also passes."""
+    with tempfile.TemporaryDirectory() as tmp:
+        root, _ = make_instance(Path(tmp))
+        assert run_guard(root).returncode == 0
+
+
+def test_stale_kb_blocks() -> None:
+    """Entity file NEWER than KB -> exit 2 with guidance. The reproducer."""
+    with tempfile.TemporaryDirectory() as tmp:
+        root, _ = make_instance(Path(tmp))
+        target = next((root / "q-investigate" / "investigations").rglob("targets"))
+        touch_later(target / "t-jane-doe.md")
+        result = run_guard(root)
+        assert result.returncode == 2, f"expected block, got {result.returncode}"
+        assert "graph.jsonl" in result.stderr
+
+
+def test_missing_kb_fails_open() -> None:
+    """No graph.jsonl -> silent pass; seeder owns creation, not the guard."""
+    with tempfile.TemporaryDirectory() as tmp:
+        root, kb = make_instance(Path(tmp))
+        kb.unlink()
+        assert run_guard(root).returncode == 0
+
+
+def test_root_layout_instances_are_watched_too() -> None:
+    """Plain instance (no q-dir): <root>/investigations must still trip it."""
+    with tempfile.TemporaryDirectory() as tmp:
+        root = Path(tmp) / "repo"
+        kb = root / "memory" / "graph.jsonl"
+        targets = root / "investigations" / "case-001-x" / "investigation" / "targets"
+        kb.parent.mkdir(parents=True)
+        targets.mkdir(parents=True)
+        kb.write_text("")
+        touch_later(targets / "t-x.md")
+        assert run_guard(root).returncode == 2
+
+
+def test_second_same_day_miss_escalates_once_then_releases(monkeypatch=None) -> None:
+    """1st miss: warn (exit 2). 2nd miss same day: queue once, exit 0.
+    Third pass stays quiet. Runs in-process so the fake queue applies."""
+    with tempfile.TemporaryDirectory() as tmp:
+        root, _ = make_instance(Path(tmp))
+        queue_file = Path(tmp) / "queue.jsonl"
+        calls: list[int] = []
+
+        def fake_queue(root_arg: Path, kb_path: Path) -> bool:
+            calls.append(1)
+            queue_file.write_text(json.dumps({"queued": True}) + "\n")
+            return True
+
+        target = next((root / "q-investigate" / "investigations").rglob("targets"))
+        touch_later(target / "t-jane-doe.md")
+
+        old_env = os.environ.get("CLAUDE_PROJECT_DIR")
+        os.environ["CLAUDE_PROJECT_DIR"] = str(root)
+        orig_queue = guard.queue_escalation
+        guard.queue_escalation = fake_queue
+        try:
+            rc1 = guard.main()
+            state_file = root / ".claude" / "state" / "kb-graph-guard.json"
+            assert rc1 == 2, f"first miss should block, got {rc1}"
+            assert json.loads(state_file.read_text())["last_warned"]
+
+            rc2 = guard.main()
+            assert rc2 == 0, "second miss must release, not hold the session"
+            assert len(calls) == 1, "exactly one escalation per day"
+            assert queue_file.exists()
+
+            rc3 = guard.main()
+            assert rc3 == 0 and len(calls) == 1, "third pass stays quiet"
+        finally:
+            guard.queue_escalation = orig_queue
+            if old_env is None:
+                os.environ.pop("CLAUDE_PROJECT_DIR", None)
+            else:
+                os.environ["CLAUDE_PROJECT_DIR"] = old_env
+
+
+def test_find_kb_prefers_qdir_over_root() -> None:
+    with tempfile.TemporaryDirectory() as tmp:
+        root = Path(tmp)
+        qdir_kb = root / "q-investigate" / "memory" / "graph.jsonl"
+        qdir_kb.parent.mkdir(parents=True)
+        qdir_kb.write_text("")
+        root_kb = root / "memory" / "graph.jsonl"
+        root_kb.parent.mkdir(parents=True)
+        root_kb.write_text("")
+        assert guard.find_kb(root) == qdir_kb
+
+
+if __name__ == "__main__":
+    failures = 0
+    for name, fn in sorted(globals().items()):
+        if name.startswith("test_") and callable(fn):
+            try:
+                fn()
+                print(f"PASS {name}")
+            except AssertionError as exc:
+                print(f"FAIL {name}: {exc}")
+                failures += 1
+    sys.exit(1 if failures else 0)

--- a/q-system/.q-system/scripts/test_kb_graph_guard.py
+++ b/q-system/.q-system/scripts/test_kb_graph_guard.py
@@ -93,6 +93,34 @@ def test_root_layout_instances_are_watched_too() -> None:
         assert run_guard(root).returncode == 2
 
 
+def test_client_relationship_layout_is_watched() -> None:
+    """Non-investigation instance: relationships.md newer than KB -> block.
+    This is the fleet majority (client work), not a corner case."""
+    with tempfile.TemporaryDirectory() as tmp:
+        root = Path(tmp) / "repo"
+        kb = root / "memory" / "graph.jsonl"
+        rel = root / "my-project" / "relationships.md"
+        kb.parent.mkdir(parents=True)
+        rel.parent.mkdir(parents=True)
+        kb.write_text("")
+        touch_later(rel)
+        result = run_guard(root)
+        assert result.returncode == 2, f"expected block, got {result.returncode}"
+
+
+def test_canonical_notes_are_watched() -> None:
+    """canonical/*.md (objections, discovery, market intel) count as entities."""
+    with tempfile.TemporaryDirectory() as tmp:
+        root = Path(tmp) / "repo"
+        kb = root / "q-ktlyst" / "memory" / "graph.jsonl"
+        canon = root / "q-ktlyst" / "canonical"
+        kb.parent.mkdir(parents=True)
+        canon.mkdir(parents=True)
+        kb.write_text("")
+        touch_later(canon / "objections.md")
+        assert run_guard(root).returncode == 2
+
+
 def test_second_same_day_miss_escalates_once_then_releases(monkeypatch=None) -> None:
     """1st miss: warn (exit 2). 2nd miss same day: queue once, exit 0.
     Third pass stays quiet. Runs in-process so the fake queue applies."""

--- a/q-system/.q-system/scripts/test_miyo_kb_hooks.py
+++ b/q-system/.q-system/scripts/test_miyo_kb_hooks.py
@@ -1,0 +1,222 @@
+#!/usr/bin/env python3
+"""Tests for the Miyo KB hooks: miyo-session-pull.py and miyo-research-gate.py."""
+import importlib.util
+import json
+import os
+import stat
+import subprocess
+import sys
+
+import pytest
+
+SCRIPTS = os.path.dirname(os.path.abspath(__file__))
+
+
+def load(name):
+    spec = importlib.util.spec_from_file_location(
+        name, os.path.join(SCRIPTS, name + ".py")
+    )
+    mod = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(mod)
+    return mod
+
+
+pull = load("miyo-session-pull")
+gate = load("miyo-research-gate")
+
+
+def write_stub_miyo(tmp_path, payload):
+    stub = tmp_path / "fake-miyo"
+    stub.write_text(
+        "#!/bin/sh\n" + "printf '%s' " + json.dumps(json.dumps(payload)) + "\n"
+    )
+    stub.chmod(stub.stat().st_mode | stat.S_IEXEC)
+    return str(stub)
+
+
+class TestScope:
+    def test_default_scope_matches_consulting(self):
+        assert pull.in_scope("/Users/x/projects/consulting/projects/foo")
+        assert gate.in_scope("/Users/x/projects/consulting/projects/foo")
+
+    def test_default_scope_rejects_outside(self):
+        assert not pull.in_scope("/Users/x/other")
+        assert not gate.in_scope("/Users/x/other")
+
+    def test_empty_scope_allows_anywhere(self, monkeypatch):
+        monkeypatch.setenv("MIYO_KB_SCOPE", "")
+        assert pull.in_scope("/anywhere")
+        assert gate.in_scope("/anywhere")
+
+
+class TestSessionPull:
+    def test_build_queries_uses_folder_name(self):
+        q = pull.build_queries("/tmp/consulting/projects/example_client_project")
+        assert q[0] == "example_client_project"
+        assert "example_client_project" in q[1]
+
+    def test_run_search_parses_json_list(self, tmp_path):
+        payload = [
+            {"file_path": "a/b.md", "title": "T", "snippet": "s" * 200},
+            {"path": "c/d.md"},
+        ]
+        monkey_bin = write_stub_miyo(tmp_path, payload)
+        orig = pull.MIYO_BIN
+        pull.MIYO_BIN = monkey_bin
+        try:
+            hits = pull.run_search("q")
+        finally:
+            pull.MIYO_BIN = orig
+        assert len(hits) == 2
+        assert hits[0][0] == "a/b.md" and len(hits[0][2]) == 160
+
+    def test_run_search_fail_open_on_bad_output(self, tmp_path):
+        broken = tmp_path / "broken-miyo"
+        broken.write_text("#!/bin/sh\necho 'not json'\n")
+        broken.chmod(broken.stat().st_mode | stat.S_IEXEC)
+        orig = pull.MIYO_BIN
+        pull.MIYO_BIN = str(broken)
+        try:
+            assert pull.run_search("q") == []
+        finally:
+            pull.MIYO_BIN = orig
+
+    def test_render_caps_and_dedupes(self):
+        hits = [("same.md", "t", "s"), ("same.md", "t2", "s2"), ("other.md", "o", "")]
+        text = pull.render("/x/consulting/p", ["q1"], [hits])
+        assert text.count("same.md") == 1
+        assert len(text) <= pull.MAX_CHARS
+
+    def test_main_silent_when_missing_binary(self, tmp_path, capsys):
+        rc = subprocess.run(
+            [sys.executable, os.path.join(SCRIPTS, "miyo-session-pull.py")],
+            input=json.dumps({"cwd": str(tmp_path)}),
+            env={**os.environ, "MIYO_BIN": str(tmp_path / "nope")},
+            capture_output=True,
+            text=True,
+            timeout=30,
+        )
+        assert rc.returncode == 0
+        assert rc.stdout == ""
+
+
+class TestGateScan:
+    def test_counts_research_and_miyo(self, tmp_path):
+        t = tmp_path / "transcript.jsonl"
+        rows = [
+            {"type": "assistant", "message": {"content": [{"name": "Grep"}]}},
+            {"type": "assistant", "message": {"content": [{"name": "Glob"}]}},
+        ]
+        lines = [json.dumps(r) for r in rows]
+        lines.append('{"tool_name":"mcp__miyo__search","input":{"query":"x"}}')
+        t.write_text("\n".join(lines))
+        research, used = gate.scan_transcript(str(t))
+        assert research == 2
+        assert used is True
+
+    def test_bash_miyo_counts_as_used(self, tmp_path):
+        t = tmp_path / "transcript.jsonl"
+        t.write_text('{"name":"Bash","command":"~/.miyo/bin/miyo search \\"q\\""}\n')
+        research, used = gate.scan_transcript(str(t))
+        assert used is True
+
+    def test_no_miyo_detected(self, tmp_path):
+        t = tmp_path / "transcript.jsonl"
+        t.write_text('{"name":"Grep"}\n{"name":"Read"}\n')
+        research, used = gate.scan_transcript(str(t))
+        assert research == 1
+        assert used is False
+
+
+class TestGateDecide:
+    def test_blocks_over_threshold_without_miyo(self):
+        block, msg = gate.decide(5, False, 4)
+        assert block is True
+        assert "miyo search" in msg
+
+    def test_passes_under_threshold(self):
+        assert gate.decide(3, False, 4) == (False, None)
+
+    def test_passes_once_miyo_used_even_over_threshold(self):
+        assert gate.decide(50, True, 4) == (False, None)
+
+    def test_message_names_kill_switch(self):
+        _, msg = gate.decide(9, False, 4)
+        assert "MIYO_GATE_OFF" in msg
+
+
+class TestGateMain:
+    BASE = {
+        "tool_name": "Grep",
+        "cwd": "/Users/x/projects/consulting/projects/p",
+    }
+
+    def run_gate(self, tmp_path, payload):
+        return subprocess.run(
+            [sys.executable, os.path.join(SCRIPTS, "miyo-research-gate.py")],
+            input=json.dumps(payload),
+            capture_output=True,
+            text=True,
+            timeout=30,
+            cwd=str(tmp_path),
+        )
+
+    def make_transcript(self, tmp_path, n_grep=6, miyo=False):
+        t = tmp_path / "t.jsonl"
+        lines = ['{"name":"Grep"}'] * n_grep
+        if miyo:
+            lines.append('{"name":"mcp__miyo__search"}')
+        t.write_text("\n".join(lines))
+        return str(t)
+
+    def test_blocks_at_threshold(self, tmp_path, monkeypatch):
+        monkeypatch.setenv("MIYO_GATE_THRESHOLD", "4")
+        p = dict(self.BASE, transcript_path=self.make_transcript(tmp_path))
+        rc = self.run_gate(tmp_path, p)
+        assert rc.returncode == 2
+        assert "miyo" in rc.stderr.lower()
+
+    def test_passes_with_miyo_in_transcript(self, tmp_path, monkeypatch):
+        monkeypatch.setenv("MIYO_GATE_THRESHOLD", "4")
+        p = dict(
+            self.BASE,
+            transcript_path=self.make_transcript(tmp_path, miyo=True),
+        )
+        rc = self.run_gate(tmp_path, p)
+        assert rc.returncode == 0
+
+    def test_fails_open_without_transcript(self, tmp_path):
+        p = dict(self.BASE, transcript_path="/nonexistent/t.jsonl")
+        rc = self.run_gate(tmp_path, p)
+        assert rc.returncode == 0
+
+    def test_ignores_non_research_tools(self, tmp_path, monkeypatch):
+        monkeypatch.setenv("MIYO_GATE_THRESHOLD", "1")
+        p = dict(
+            self.BASE,
+            tool_name="Read",
+            transcript_path=self.make_transcript(tmp_path),
+        )
+        rc = self.run_gate(tmp_path, p)
+        assert rc.returncode == 0
+
+    def test_out_of_scope_never_blocks(self, tmp_path, monkeypatch):
+        monkeypatch.setenv("MIYO_GATE_THRESHOLD", "1")
+        p = dict(
+            self.BASE,
+            cwd="/Users/somewhere/else",
+            transcript_path=self.make_transcript(tmp_path),
+        )
+        rc = self.run_gate(tmp_path, p)
+        assert rc.returncode == 0
+
+    def test_malformed_stdin_fails_open(self, tmp_path):
+        rc = subprocess.run(
+            [sys.executable, os.path.join(SCRIPTS, "miyo-research-gate.py")],
+            input="not json at all {{{",
+            capture_output=True,
+            text=True,
+            timeout=30,
+            cwd=str(tmp_path),
+        )
+        assert rc.returncode == 0

--- a/q-system/lessons/a-clean-gate-run-is-not-a-quality-verdict.md
+++ b/q-system/lessons/a-clean-gate-run-is-not-a-quality-verdict.md
@@ -1,0 +1,26 @@
+---
+id: a-clean-gate-run-is-not-a-quality-verdict
+kind: methodology
+title: A clean gate run is not a quality verdict
+date: 2026-08-24
+---
+
+Automated checks answer the questions someone was able to encode. The question that matters at review time is usually the one nobody could encode: is this output actually good for its purpose. When every check returns clean and you report "clean" as the verdict, you have silently substituted the checkable question for the real one.
+
+HOW TO APPLY
+
+1. Before running checks, write down the goal in one sentence, in the terms a consumer of the output would use. Keep it separate from the check list. When you report results, report against that sentence first and the check list second.
+
+2. Enumerate what the checks structurally cannot see. Most automated validators inspect properties of a text or artifact, never its fitness. Say this out loud in the report: "the checks confirm X, Y, Z; they cannot tell whether this is worth shipping." A report that omits this line invites the reader to treat green as approval.
+
+3. Treat a non-blocking warning as a finding, not as noise. A warning that is downgraded to advisory in a summary is a detector that fired correctly and was overruled without argument. Read the warning's actual text before deciding it does not matter. If its text describes the defect you would care about, the fact that it was configured non-blocking is a configuration decision, not evidence that the defect is absent.
+
+4. Watch for warnings that repeat across most items in a batch. A signal firing on nearly every item is either a miscalibrated detector or a systemic defect in the batch. Both need a decision. Neither is served by the phrase "warnings only."
+
+5. When a prior review already recorded that these checks cannot judge fitness, that record is binding on the next review. Re-deriving "the checks passed so it is fine" after the limitation has been written down is the same failure committed one layer up.
+
+6. When the output is in a domain owned by a specific reviewer or role, a passing automated run does not substitute for that reviewer. Checks gate mechanics; the owner gates judgment. If the owner was not consulted, say so in the report rather than letting the clean run imply they were.
+
+STOP RULE
+
+Do not write "verified" or "clean" as a standalone conclusion. Write what was checked, what came back, what the checks are blind to, and whether the goal sentence is satisfied. If you cannot answer the last part from evidence, the honest report is "checks pass, fitness unassessed."

--- a/q-system/lessons/a-permission-you-only-stated-is-not-a-permission.md
+++ b/q-system/lessons/a-permission-you-only-stated-is-not-a-permission.md
@@ -1,0 +1,23 @@
+---
+id: a-permission-you-only-stated-is-not-a-permission
+kind: pattern
+title: A permission you only stated is not a permission
+date: 2026-08-24
+---
+
+Two failure shapes show up together whenever an automated actor is given a scoped job in a shared workspace.
+
+**Shape 1: the remit lives in the prompt, not the capability set.**
+A worker is told "only report, do not change anything." The instruction is the sole constraint; the worker still holds every write and spawn capability the platform grants. Nothing blocks the disallowed action, so the first time the worker interprets its job loosely, it acts. If the intended remit is read-only, hand it a read-only capability profile. If the intended remit is one directory, mount one directory. A capability boundary makes the violation impossible; a sentence only makes it discouraged.
+
+**Shape 2: shared mutable state with no owner token.**
+A single global slot (an active-task record, a lock file, a current-context pointer) accepts a transition from any process that can reach it. "Only the actor that opened this may close it" is an assumption living in nobody's code. When concurrency is a supported mode of the system, this is a latent defect, not bad luck. Fix: stamp the record with an owner identity at open time, and have every transition verify the caller matches before it writes. Reject with a clear error instead of silently completing someone else's work.
+
+**The diagnostic trap that follows.**
+When a state record looks corrupt, verify the decoder before you accuse the data. Reading a record with guessed field names prints empty values for every field, and empty reads as missing. A first postmortem can then report a data-integrity gap that does not exist, sending fixes at the wrong layer. Before concluding a record is malformed, print the raw line and compare it against the writer's actual schema. Retract the wrong diagnosis explicitly when the raw evidence contradicts it; a quietly abandoned root cause leaves the real one unfixed.
+
+**Checklist**
+- For each automated actor: list what it can do, not what it was told to do. Narrow the grant to the job.
+- For each shared state slot: name the owner field. If there is none, concurrent writers can trample each other.
+- For each transition on that slot: confirm the caller's identity matches the recorded owner.
+- Before diagnosing corruption: dump the raw record and match field names against the writer.

--- a/q-system/lessons/an-unresolved-instruction-collision-is-a-defect-not-a-judgme.md
+++ b/q-system/lessons/an-unresolved-instruction-collision-is-a-defect-not-a-judgme.md
@@ -1,0 +1,28 @@
+---
+id: an-unresolved-instruction-collision-is-a-defect-not-a-judgme
+kind: pattern
+title: An unresolved instruction collision is a defect, not a judgment call
+date: 2026-08-24
+---
+
+When two active instructions apply to the same action and point different ways, the failure mode is not picking the wrong one. It is picking either one silently. The collision is information the requester needed and never got.
+
+**The shape**
+
+One layer says all output of a given kind goes through a specific path. Another layer, loaded from a different scope (session config, environment flag, a caller's override), forbids the mechanism that path uses. Both are live. One gets applied, the other is dropped without a trace, and the output ships looking normal.
+
+Repeating the resolution rule in more places does not fix it. A rule that is loaded, read, and restated while the same failure recurs is a description of an intention, not an enforcement mechanism.
+
+**Two things to build**
+
+1. Make the collision detectable at the point of decision. Instruction sets that can conflict need a machine-readable precedence declaration or an explicit conflict list, checked before the action. If the resolution lives only in prose that some executor is expected to recall, it will be resolved silently again.
+
+2. Make the sanctioned path reachable by intent, not by name. A gated lane that runs only when someone invokes its exact identifier is bypassed by any equivalent plain request. Route on what is being produced (output type, destination, artifact class), not on which entry point was typed. Then put the gate on the artifact: the check runs on the thing produced, so both entry paths hit it.
+
+**The test**
+
+A gate that only fires when the caller opts in is not a gate. Name the input where the collision exists and the wrong branch is taken, and confirm the system reports it rather than proceeding. If nothing observes the difference between the sanctioned path and the bypass, the contract is held by memory, which is the same class of enforcement that just failed.
+
+**Recurrence signal**
+
+An action item that has been written down more than once and is still open is evidence the fix belongs in a different layer. The second occurrence is the signal to stop rewriting the instruction and start writing the check.

--- a/q-system/lessons/derive-user-facing-state-from-the-evidence-not-a-proxy-field.md
+++ b/q-system/lessons/derive-user-facing-state-from-the-evidence-not-a-proxy-field.md
@@ -1,0 +1,24 @@
+---
+id: derive-user-facing-state-from-the-evidence-not-a-proxy-field
+kind: pattern
+title: Derive user-facing state from the evidence, not a proxy field
+date: 2026-08-24
+---
+
+A displayed status is a claim. When that claim is computed from one convenient stand-in (a hand-set enum, a single boolean, the last row's direction), it drifts from reality the moment any other store changes without touching the stand-in.
+
+HOW:
+
+1. For each user-facing state, write down the question it answers in plain words, then list every store that holds evidence for that question. If the list has more than one entry and the state reads from one of them, you have a proxy, not an answer.
+
+2. Read the evidence to the end before deciding. A record's first field often disagrees with its last: direction is not intent, presence is not activity, an acknowledgment is not a request. Determinism about a low-level attribute does not license a high-level conclusion built on it.
+
+3. Make the derivation a single function with every evidence source as an input, and let the stored field be its cached output rather than its source. Never let the display path and the derivation path read different things.
+
+4. Enumerate the sources in code, not in the reader's head. Keep the evidence sources in one list that the derivation iterates, so adding a source without wiring it in is a build or test failure. A cross-cutting rule implemented for exactly one input path, and assumed to generalize, is the usual failure.
+
+5. Reconcile on a schedule and log disagreements. Any record where the stored field and the freshly derived value differ is a defect report about the derivation, not a row to quietly overwrite.
+
+6. Test with the cases the proxy gets wrong: evidence present in a source the derivation forgot, evidence that reverses meaning when read fully, evidence that is not the kind of thing the state is about at all. A test suite that only exercises the proxy's happy path proves nothing.
+
+When a prior fix made some lower-level attribute reliable, treat that as one input to the next layer, not as the next layer's answer. Stacking a claim directly on a newly trustworthy primitive is how the same defect recurs one level up.

--- a/scripts/ensure_instance_kb.py
+++ b/scripts/ensure_instance_kb.py
@@ -1,0 +1,54 @@
+#!/usr/bin/env python3
+"""Ensure every registered kipi instance has its own local knowledge base.
+
+Reads instance-registry.json and creates <memory>/graph.jsonl for each
+instance that lacks one. Idempotent: existing files are never touched.
+
+KB location:
+  - instance_q_dir set: <path>/<instance_q_dir>/memory/graph.jsonl
+  - else:               <path>/memory/graph.jsonl
+
+Files stay untracked by design (fleet lefthook bans *.jsonl commits).
+"""
+
+import json
+import sys
+from pathlib import Path
+
+REGISTRY = Path("/Users/assafkipnis/projects/kipi-system/instance-registry.json")
+
+
+def kb_path(instance: dict) -> Path | None:
+    root = Path(instance["path"])
+    if not root.is_dir():
+        return None
+    q_dir = instance.get("instance_q_dir")
+    base = root / q_dir if q_dir else root
+    return base / "memory" / "graph.jsonl"
+
+
+def main() -> int:
+    registry = json.loads(REGISTRY.read_text())
+    created, present, missing = [], [], []
+    for inst in registry["instances"]:
+        path = kb_path(inst)
+        if path is None:
+            missing.append((inst["name"], "path does not exist"))
+            continue
+        if path.exists():
+            present.append(inst["name"])
+            continue
+        path.parent.mkdir(parents=True, exist_ok=True)
+        path.touch()
+        created.append(inst["name"])
+        print(f"created: {inst['name']} -> {path}")
+
+    print(f"\ntotal={len(registry['instances'])} "
+          f"created={len(created)} present={len(present)} missing={len(missing)}")
+    for name, why in missing:
+        print(f"missing: {name} ({why})")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/settings-template.json
+++ b/settings-template.json
@@ -132,6 +132,11 @@
             "type": "command",
             "command": "test -f \"$CLAUDE_PROJECT_DIR/q-system/.q-system/scripts/sycophancy-monthly-check.py\" && python3 \"$CLAUDE_PROJECT_DIR/q-system/.q-system/scripts/sycophancy-monthly-check.py\" 2>/dev/null || true",
             "timeout": 35
+          },
+          {
+            "type": "command",
+            "command": "test -f \"$CLAUDE_PROJECT_DIR/q-system/.q-system/scripts/miyo-session-pull.py\" && python3 \"$CLAUDE_PROJECT_DIR/q-system/.q-system/scripts/miyo-session-pull.py\" 2>/dev/null || true",
+            "timeout": 30
           }
         ]
       },
@@ -193,6 +198,16 @@
           {
             "type": "command",
             "command": "test -f \"$CLAUDE_PROJECT_DIR/q-system/.q-system/scripts/merge-bypass-gate.py\" && python3 \"$CLAUDE_PROJECT_DIR/q-system/.q-system/scripts/merge-bypass-gate.py\"",
+            "timeout": 5
+          }
+        ]
+      },
+      {
+        "matcher": "Grep|Glob|WebSearch|WebFetch",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "if test -f \"$CLAUDE_PROJECT_DIR/q-system/.q-system/scripts/miyo-research-gate.py\"; then python3 \"$CLAUDE_PROJECT_DIR/q-system/.q-system/scripts/miyo-research-gate.py\"; fi",
             "timeout": 5
           }
         ]

--- a/settings-template.json
+++ b/settings-template.json
@@ -375,6 +375,11 @@
             "type": "command",
             "command": "test -f \"$CLAUDE_PROJECT_DIR/q-system/.q-system/scripts/memory_autocapture.py\" && python3 \"$CLAUDE_PROJECT_DIR/q-system/.q-system/scripts/memory_autocapture.py\" 2>/dev/null || true",
             "async": true
+          },
+          {
+            "type": "command",
+            "command": "if test -f \"$CLAUDE_PROJECT_DIR/q-system/.q-system/scripts/kb-graph-guard.py\"; then python3 \"$CLAUDE_PROJECT_DIR/q-system/.q-system/scripts/kb-graph-guard.py\"; fi",
+            "timeout": 15
           }
         ]
       }


### PR DESCRIPTION
## What

Two deterministic hooks making the Miyo knowledge base the enforced retrieval layer across all consulting sessions. No agent prose involved.

1. **miyo-session-pull.py** (SessionStart): runs two fixed KB queries derived from the working folder name, injects a capped digest (top hits + paths) into session context. Runs every startup, zero choice.
2. **miyo-research-gate.py** (PreToolUse on Grep|Glob|WebSearch|WebFetch): after 4 research calls in a session with zero Miyo usage, blocks with exit 2 and instructions to run one Miyo search first. Releases on first KB hit, tracked via transcript scan.

## Safety properties

- Both fail OPEN on infrastructure errors: missing binary, unreadable transcript, malformed stdin never break a session
- Scope default /consulting/ only; MIYO_KB_SCOPE env override
- Founder kill switch: MIYO_GATE_OFF=1; threshold override MIYO_GATE_THRESHOLD
- No secrets read; gitleaks clean

## Wiring

- settings-template.json carries both, so kipi update rolls to all instances
- Both marked FLEET_ONLY in settings-template-sync-check.py: they self-scope to /consulting/ and intentionally no-op in the skeleton runtime
- User-level ~/.claude/settings.json also wired (absolute paths) so non-kipi folders under consulting get identical behavior today

## Verification

- 21 pytest cases green (scope logic, query building, JSON parse fail-open, render cap/dedupe, transcript scanning incl bash-miyo usage, block/pass/fail-open paths)
- Live: real KB pull for a project folder returned grounded hits; synthetic transcripts blocked at threshold (exit 2) and passed once miyo usage present