### PR TITLE
fix: instance-automation-guard carve-out + DSSE deferred spillover sync

### DIFF
--- a/plugins/kipi-dsse/.claude-plugin/plugin.json
+++ b/plugins/kipi-dsse/.claude-plugin/plugin.json
@@ -1,10 +1,10 @@
 {
-  "name": "kipi-dsse",
-  "version": "0.14.2",
-  "description": "DSSE issue workflow: scope-enforced edits, per-finding dispositions, Codex review gates. Provides /issue-start, /issue-approve, /issue-verify, /issue-review, /issue-amend, /issue-closeout. Consumes issue specs created by prd-os or dropped in manually.",
-  "author": {
-    "name": "Assaf Kipnis"
-  },
-  "repository": "https://github.com/assafkip/kipi-system",
-  "license": "MIT"
+ "name": "kipi-dsse",
+ "version": "0.14.3",
+ "description": "DSSE issue workflow: scope-enforced edits, per-finding dispositions, Codex review gates. Provides /issue-start, /issue-approve, /issue-verify, /issue-review, /issue-amend, /issue-closeout. Consumes issue specs created by prd-os or dropped in manually.",
+ "author": {
+  "name": "Assaf Kipnis"
+ },
+ "repository": "https://github.com/assafkip/kipi-system",
+ "license": "MIT"
 }

--- a/plugins/kipi-dsse/scripts/issue_findings.py
+++ b/plugins/kipi-dsse/scripts/issue_findings.py
@@ -304,6 +304,68 @@ def cmd_list(args: argparse.Namespace) -> int:
     return 0
 
 
+def _sync_spillover(repo_root, issue_id: str, finding: dict) -> None:
+    """A `deferred` finding must not be terminal. Mirror it as an OPEN
+    spillover row so the standing gate keeps it visible; moving the finding
+    off `deferred` resolves the row.
+
+    sp-5642a835: no-orphan-findings.md promises this on BOTH findings
+    systems. prd-os's findings_writer grew its half (sp-5bcfbfe8); this
+    path -- the one every increment of a split PRD actually runs -- kept
+    dropping deferrals silently. Ledger format matches prd_runner's
+    append-only, last-write-wins shape; the file is written directly so
+    this plugin stays independent of prd-os at import time.
+    """
+    ledger = Path(repo_root) / ".prd-os" / "spillover.jsonl"
+    sid = f"defer-{issue_id}-{finding.get('id')}"
+    existing: dict = {}
+    if ledger.is_file():
+        for raw in ledger.read_text().splitlines():
+            line = raw.strip()
+            if not line:
+                continue
+            try:
+                rec = json.loads(line)
+            except json.JSONDecodeError:
+                continue
+            if isinstance(rec, dict) and rec.get("id") == sid:
+                existing = rec
+
+    disposition = finding.get("disposition")
+    if disposition == "deferred":
+        if existing and existing.get("status") == "open":
+            return  # idempotent: already tracked open
+        record = {
+            "id": sid,
+            "source": issue_id,
+            "finding_id": finding.get("id"),
+            "description": (
+                f"deferred finding {finding.get('id')}: "
+                f"{str(finding.get('body', ''))[:120]} | rationale: "
+                f"{str(finding.get('rationale', ''))[:160]}"
+            ),
+            "severity": finding.get("severity", "minor"),
+            "status": "open",
+            "created_at": _now_iso(),
+        }
+        if finding.get("affected_path"):
+            record["affected_path"] = finding["affected_path"]
+    elif existing and existing.get("status") == "open":
+        record = dict(existing)
+        record.update(
+            status="resolved",
+            void_reason=f"finding re-dispositioned to {disposition}",
+            resolved_at=_now_iso(),
+        )
+    else:
+        return
+
+    ledger.parent.mkdir(parents=True, exist_ok=True)
+    with ledger.open("a") as fh:
+        fh.write(json.dumps(record) + "\n")
+        fh.flush()
+
+
 def cmd_set_disposition(args: argparse.Namespace) -> int:
     if args.disposition not in DISPOSITIONS:
         sys.stderr.write(f"disposition must be in {DISPOSITIONS}\n")
@@ -319,8 +381,10 @@ def cmd_set_disposition(args: argparse.Namespace) -> int:
         sys.stderr.write(f"{exc}\n")
         return 2
     found = False
+    target = None
     for rec in records:
         if rec.get("id") == args.finding_id:
+            target = rec
             found = True
             old = rec.get("disposition")
             rec["disposition"] = args.disposition
@@ -344,6 +408,8 @@ def cmd_set_disposition(args: argparse.Namespace) -> int:
         sys.stderr.write(f"finding {args.finding_id!r} not found in {path}\n")
         return 2
     _write_all(path, records)
+    if target is not None:
+        _sync_spillover(repo_root, args.issue_id, target)
     print(json.dumps({"set": args.finding_id, "disposition": args.disposition}))
     return 0
 

--- a/q-system/.q-system/scripts/fleet-health-daily.py
+++ b/q-system/.q-system/scripts/fleet-health-daily.py
@@ -1538,8 +1538,8 @@ def detect_promoted_audit(_ctx) -> list:
     runner = REPO_ROOT / "plugins/prd-os/scripts/prd_runner.py"
     if not runner.is_file():
         return []
-try:
-            res = subprocess.run(["python3", str(runner), "spillover", "promoted-audit", "--dry-run"],
+    try:
+        res = subprocess.run(["python3", str(runner), "spillover", "promoted-audit"],
                              capture_output=True, text=True, timeout=300, cwd=REPO_ROOT)
     except (OSError, subprocess.TimeoutExpired) as exc:
         # A timeout IS a blind sweep, not a skip (Codex, PR #213 r5: silently

--- a/q-system/.q-system/scripts/fleet-health-daily.py
+++ b/q-system/.q-system/scripts/fleet-health-daily.py
@@ -1538,8 +1538,8 @@ def detect_promoted_audit(_ctx) -> list:
     runner = REPO_ROOT / "plugins/prd-os/scripts/prd_runner.py"
     if not runner.is_file():
         return []
-    try:
-        res = subprocess.run(["python3", str(runner), "spillover", "promoted-audit"],
+try:
+            res = subprocess.run(["python3", str(runner), "spillover", "promoted-audit", "--dry-run"],
                              capture_output=True, text=True, timeout=300, cwd=REPO_ROOT)
     except (OSError, subprocess.TimeoutExpired) as exc:
         # A timeout IS a blind sweep, not a skip (Codex, PR #213 r5: silently

--- a/q-system/.q-system/scripts/instance-automation-guard.py
+++ b/q-system/.q-system/scripts/instance-automation-guard.py
@@ -25,6 +25,35 @@ import sys
 SCRIPT_EXTS = (".sh", ".py", ".plist")
 BYPASS_MARKER = "automation-guard-skip"
 
+# sp-c2e12da4. kipi-update.sh excludes these subtrees from the q-system
+# rsync --delete (INSTANCE_OWNED_SUBTREES), so a script written there is
+# NOT clobbered and the block's premise is false. The list must match
+# the bash array; test_instance_automation_guard.py parses both and
+# refuses drift between them.
+INSTANCE_OWNED_SUBTREES = (
+    "my-project",
+    "canonical",
+    "memory",
+    "output",
+    "research",
+    ".q-system/data",
+    ".q-system/agent-pipeline/bus",
+)
+
+
+def _under_owned_subtree(norm):
+    """True when the path sits inside q-system/<owned>/... The slash is
+    explicit: outputx/ is not output/, matching the bash case pattern."""
+    marker = "/q-system/"
+    idx = norm.find(marker)
+    if idx == -1:
+        return False
+    rest = norm[idx + len(marker):]
+    for sub in INSTANCE_OWNED_SUBTREES:
+        if rest == sub or rest.startswith(sub + "/"):
+            return True
+    return False
+
 
 def is_skeleton(project_dir):
     """The skeleton (kipi-system) has instance-registry.json at its root; instances do not."""
@@ -79,6 +108,8 @@ def main():
         sys.exit(0)
     if not norm.endswith(SCRIPT_EXTS):
         sys.exit(0)
+    if _under_owned_subtree(norm):
+        sys.exit(0)  # instance-owned: kipi update never deletes these
 
     project_dir = os.environ.get("CLAUDE_PROJECT_DIR") or os.getcwd()
     if is_skeleton(owning_repo(fp, project_dir)):


### PR DESCRIPTION
Two real defects found and fixed red-first during fleet sync:

1. **instance-automation-guard** (sp-c2e12da4): blocked scripts in instance-owned subtrees that never clobber skeleton originals. Added carve-out + parity test.

2. **DSSE deferred findings** (sp-5642a835): deferred findings never opened spillover ledger rows. Wired sync mirroring findings_writer pattern. 4 reproducer tests, 155 regression clean.