### PR TITLE
fix(floor): verify.sh --staged needs a real repo and a clean git env

### DIFF
--- a/.github/workflows/verify.yml
+++ b/.github/workflows/verify.yml
@@ -14,6 +14,22 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
+        with:
+          # FULL HISTORY, not the default depth-1 shallow clone.
+          #
+          # why (measured 2026-08-27): the first CI run of this workflow failed
+          # 18 tests that are green locally. Seven of them reproduce EXACTLY in a
+          # real shallow clone:
+          #   git clone --depth 1 ... && pytest q-system/.q-system/tests
+          #   -> 7 failed, 446 passed
+          # They are separation tests that run `git show <sha>:<path>` against
+          # commits that a depth-1 checkout does not have, so git exits 128 and
+          # the test reports a defect that is really a missing object.
+          #
+          # This is declaring the environment the suite needs, not loosening the
+          # gate: with full history those tests grade the same thing they grade
+          # on a developer machine.
+          fetch-depth: 0
       - uses: actions/setup-python@v5
         with:
           python-version: '3.12'

--- a/.github/workflows/verify.yml
+++ b/.github/workflows/verify.yml
@@ -1,0 +1,22 @@
+# GATE 2 OF 2 in this repo (pre-commit is the other). The same verify.sh, so the
+# commit door and the merge door cannot quietly diverge.
+#
+# Added with the lefthook wiring 2026-08-27, after Codex review of PR #259 filed
+# a major: the script shipped here with no caller in any tracked hook or
+# workflow, so merging it added zero enforcement. The finding was correct.
+name: verify
+on:
+  pull_request:
+  push:
+    branches: [main]
+jobs:
+  verify:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-python@v5
+        with:
+          python-version: '3.12'
+      - run: pip install pytest
+      - name: verify.sh --full
+        run: bash q-system/.q-system/verify.sh --full

--- a/.github/workflows/verify.yml
+++ b/.github/workflows/verify.yml
@@ -36,3 +36,12 @@ jobs:
       - run: pip install pytest
       - name: verify.sh --full
         run: bash q-system/.q-system/verify.sh --full
+      # THE HARNESS THAT GUARDS THE GATE NEEDS A CALLER TOO.
+      #
+      # codex, PR #259 round 5, minor: 15 adversarial cases asserting verify.sh's
+      # exit codes existed and NOTHING RAN THEM, so they provided zero regression
+      # protection. That is the same finding as the round-1 major one layer up --
+      # I wired the floor and left its own test suite unwired. A check nobody
+      # invokes is an aspiration, whichever layer it sits on.
+      - name: adversarial suite (the floor's own tests)
+        run: bash q-system/.q-system/test_verify_adversarial.sh q-system/.q-system/verify.sh

--- a/.verify-suites
+++ b/.verify-suites
@@ -1,0 +1,24 @@
+# Directories pytest is invoked FROM, one per line. Read by q-system/.q-system/verify.sh.
+#
+# WHY THIS FILE EXISTS HERE. Without it verify.sh falls back to one root-level
+# pytest, and in this repo that is not a red suite, it is NO suite: measured
+# 2026-08-27, root pytest hits "Interrupted: 109 errors during collection" and
+# runs zero tests. The errors come from vendored and rescued trees (.rescue/,
+# rescued/memory-lifecycle/, .wt-parity/, .pr25rev/) and from worktrees under
+# .claude/worktrees/ -- separate checkouts with their own sys.path, collected
+# only because they happen to sit under this root.
+#
+# A collection error is the dangerous shape: pytest exits non-zero, so the gate
+# does go red, but it goes red for a reason that has nothing to do with your
+# change and cannot be fixed by anyone committing. That is how a gate gets
+# switched off in a day.
+#
+# Both suites below were measured green before being named here:
+#   plugins/prd-os             680 passed, 1 skipped
+#   q-system/.q-system/tests   458 passed
+#
+# plugins/kipi-core is deliberately ABSENT: it collects 84 tests and 1 error,
+# and a manifest naming it would make this gate unsatisfiable. See the spillover
+# item filed with this change. Adding it is a fix, not a config edit.
+plugins/prd-os
+q-system/.q-system/tests

--- a/.verify-suites
+++ b/.verify-suites
@@ -30,6 +30,32 @@
 # make this gate unsatisfiable on arrival, which is how a gate gets switched off
 # in a day. Tracked as spillover sp-97ce989b; fixing that collection error and
 # adding the line here is one piece of work, not a config edit.
+#
+# ROUND 3 of the same finding. Codex filed it twice more after the first fix,
+# each time correctly, because I kept fixing the instance instead of the method.
+# The method now: enumerate every tracked test file, group by directory, MEASURE
+# each candidate, name every one that is green. Do not eyeball the tree.
+#   git ls-files '*test_*.py' 'test_*.py' | sed 's|/[^/]*$||' | sort | uniq -c
+#
+# Measured 2026-08-27, all five named suites green:
+#   plugins/prd-os              680 passed, 1 skipped
+#   plugins/kipi-dsse           110 passed
+#   plugins/kipi-core/voicekit   84 passed
+#   automation                   14 passed
+#   q-system/.q-system/tests    458 passed
+#
+# TWO known-excluded, both blockers rather than choices, both ticketed:
+#   q-system/.q-system/scripts  308 passed but 8 ERRORS (317 collected). This is
+#     the largest single body of untested-by-the-floor code in the repo and it
+#     is tracked; naming it today makes this gate unsatisfiable on arrival.
+#   plugins/kipi-core/kipi-mcp  ModuleNotFoundError: No module named 'kipi_mcp'
+#     at collection. Same class, same reason. sp-97ce989b.
+#
+# An exclusion that is WRITTEN DOWN with its measurement is the remedy here. The
+# finding was never "run everything"; it was that a manifest omitting suites in
+# silence is a false claim of coverage.
 plugins/prd-os
 plugins/kipi-dsse
+plugins/kipi-core/voicekit
+automation
 q-system/.q-system/tests

--- a/.verify-suites
+++ b/.verify-suites
@@ -17,8 +17,19 @@
 #   plugins/prd-os             680 passed, 1 skipped
 #   q-system/.q-system/tests   458 passed
 #
-# plugins/kipi-core is deliberately ABSENT: it collects 84 tests and 1 error,
-# and a manifest naming it would make this gate unsatisfiable. See the spillover
-# item filed with this change. Adding it is a fix, not a config edit.
+# EVERY suite that can be named IS named. Codex review of PR #259 filed a major
+# on the first version of this file: it named two suites and silently left real
+# plugin tests out, so CI would go green having never run them. A manifest is a
+# claim about coverage, and an incomplete one is a false claim.
+#
+# plugins/kipi-dsse was added in response, after measuring it: 110 passed.
+#
+# plugins/kipi-core is the ONE deliberate exclusion and it is not a judgement
+# call, it is a blocker: `cd plugins/kipi-core && python3 -m pytest` reports
+# "Interrupted: 1 error during collection" and runs zero tests. Naming it would
+# make this gate unsatisfiable on arrival, which is how a gate gets switched off
+# in a day. Tracked as spillover sp-97ce989b; fixing that collection error and
+# adding the line here is one piece of work, not a config edit.
 plugins/prd-os
+plugins/kipi-dsse
 q-system/.q-system/tests

--- a/.verify-suites
+++ b/.verify-suites
@@ -54,8 +54,38 @@
 # An exclusion that is WRITTEN DOWN with its measurement is the remedy here. The
 # finding was never "run everything"; it was that a manifest omitting suites in
 # silence is a false claim of coverage.
+#
+# ROUND 4 found 10 tracked test files under no runnable directory. A manifest
+# entry may now be a FILE as well as a directory, so they are named rather than
+# quietly dropped. 48 of those tests were passing and gated by nothing.
+#   rescued/memory-lifecycle  18 passed
+#   the four file entries     48 passed together
+#
+# scripts/test_persona_reorg*.py collect NOTHING from scripts/ and are covered
+# as file entries instead.
+#
+# plugins/kipi-design joins the excluded list: 1 collection error, same class as
+# the two below.
 plugins/prd-os
 plugins/kipi-dsse
 plugins/kipi-core/voicekit
 automation
+rescued/memory-lifecycle
 q-system/.q-system/tests
+test_destructive_op_deny_anchor.py
+test_fleet_unblock.py
+#
+# THE REMAINING FIVE, each measured, none silently dropped.
+#
+# Three of them are NOT PYTEST FILES despite the test_ prefix, which is why no
+# manifest entry can carry them:
+#   scripts/test_persona_reorg.py         standalone script: prints PASS/FAIL and
+#   scripts/test_persona_reorg_detach.py  calls sys.exit() AT MODULE LEVEL, so
+#                                         importing it exits the collector
+#                                         (pytest INTERNALERROR: SystemExit: 0)
+#   q-system/.q-system/test_token_guard_runtime.py   collects zero tests
+# Naming any of them makes this gate fail forever. They need converting to real
+# pytest suites, or renaming so they stop claiming to be tests. Tracked.
+#
+# And one suite, same blocker class as the two below:
+#   plugins/kipi-design   1 error during collection (2 tracked test files)

--- a/lefthook.yml
+++ b/lefthook.yml
@@ -4,6 +4,22 @@
 pre-commit:
   parallel: true
   commands:
+    verify:
+      # GATE 1 OF 3. The floor. The SAME script CI runs, so a commit that passes
+      # here is a commit that passes there.
+      #
+      # WIRED 2026-08-27, and it should have been wired in the commit that added
+      # the script. Codex review of PR #259 filed a major: verify.sh shipped to
+      # this repo with no caller anywhere, and its reproducer was a git grep for
+      # callers that returned empty. It was right. A floor nothing invokes is an
+      # aspiration, which is the exact thing wiring-check.md exists to refuse.
+      #
+      # --staged checks the INDEX, materialised as a real throwaway worktree, so
+      # what is verified is what the commit will contain and not what happens to
+      # be lying in the working tree.
+      run: bash q-system/.q-system/verify.sh --staged
+      fail_text: "verify.sh failed on the STAGED snapshot. The same script runs in CI, so this will not pass later."
+
     gitleaks:
       # ~/.gitleaks.toml extends the defaults with kipi-specific rules (ntn_ etc.).
       # It used to ride a hand-chained .git/hooks/pre-commit; when lefthook took

--- a/q-system/.q-system/test_verify_adversarial.sh
+++ b/q-system/.q-system/test_verify_adversarial.sh
@@ -1,0 +1,97 @@
+#!/usr/bin/env bash
+# Adversarial test for verify.sh: does it actually BLOCK, or only pass tests?
+#
+# Every case builds a FRESH throwaway repo, breaks something real, runs the real
+# script, and asserts the EXIT CODE. No mocks, no stubs, no fixtures.
+#
+# The harness lives OUTSIDE the repos it builds. The first version lived inside
+# one and its own `git clean -fd` deleted it mid-run, which produced two
+# phantom failures that had nothing to do with verify.sh. A test harness that
+# perturbs its own subject is measuring itself.
+VERIFY_SRC="${1:?usage: adversarial.sh /path/to/verify.sh}"
+pass=0; fail=0
+
+newrepo() {
+  local d; d="$(mktemp -d)"
+  git -C "$d" init -q .
+  git -C "$d" config user.email t@t; git -C "$d" config user.name t
+  mkdir -p "$d/q-system/.q-system"
+  cp "$VERIFY_SRC" "$d/q-system/.q-system/verify.sh"
+  printf "print('ok')\n" > "$d/good.py"
+  printf '{"a": 1}\n'    > "$d/good.json"
+  printf 'echo hi\n'     > "$d/good.sh"
+  git -C "$d" add -A; git -C "$d" commit -qm init
+  printf '%s' "$d"
+}
+
+check() {
+  if [ "$2" = "$3" ]; then printf '  PASS  %-38s exit=%s\n' "$1" "$3"; pass=$((pass+1))
+  else printf '  FAIL  %-38s exit=%s want=%s\n' "$1" "$3" "$2"; fail=$((fail+1)); fi
+}
+
+run() { ( cd "$1" && bash q-system/.q-system/verify.sh "$2" >/dev/null 2>&1 ); }
+
+# --- baseline: a clean repo must PASS, or every later result is meaningless ---
+R=$(newrepo); run "$R" --full; check "clean repo, --full" 0 $?; rm -rf "$R"
+
+# --- it blocks on real breakage, at the staged gate ---
+for case in "py:def (:bad.py" "json:{bad:bad.json" "sh:if [ 1 ; then:bad.sh"; do
+  kind="${case%%:*}"; rest="${case#*:}"; body="${rest%:*}"; file="${rest##*:}"
+  R=$(newrepo); printf '%s\n' "$body" > "$R/$file"; git -C "$R" add "$file"
+  run "$R" --staged; check "broken $kind, --staged BLOCKS" 1 $?; rm -rf "$R"
+done
+
+# --- THE STAGED SNAPSHOT IS THE SUBJECT, not the working tree ---
+# This is the entire reason --staged materialises the index into a temp dir.
+R=$(newrepo)
+printf 'def (\n' > "$R/good.py"           # TRACKED file, broken, NOT staged
+printf 'x\n' > "$R/ok.txt"; git -C "$R" add ok.txt
+run "$R" --staged; check "unstaged breakage ignored, --staged" 0 $?
+run "$R" --full;   check "same breakage caught by --full" 1 $?
+rm -rf "$R"
+
+# --full deliberately does NOT see an untracked file. It runs at pre-push and in
+# CI, and an untracked file reaches neither. Asserted so that if someone later
+# widens --full to walk the filesystem, this goes red and they have to argue for
+# it rather than drift into it.
+R=$(newrepo)
+printf 'def (\n' > "$R/never-tracked.py"
+run "$R" --full;   check "untracked file NOT checked by --full" 0 $?
+rm -rf "$R"
+
+# --- a commit cannot smuggle breakage past --staged by leaving it unstaged ---
+# The inverse of the case above: the file IS staged broken while the working
+# tree copy is fine. A hook that checked the working tree would pass this.
+R=$(newrepo)
+printf 'def (\n' > "$R/sneak.py"; git -C "$R" add sneak.py
+printf "print('fine')\n" > "$R/sneak.py"   # working tree now clean, index is not
+run "$R" --staged; check "staged-broken/tree-clean BLOCKS" 1 $?
+rm -rf "$R"
+
+# --- THE ONE THAT MATTERS: nothing to check must FAIL, never pass ---
+# A green exit meaning "I found no linter" is indistinguishable from "your code
+# is fine" at any call site that reads only the exit code.
+E="$(mktemp -d)"; git -C "$E" init -q .
+git -C "$E" config user.email t@t; git -C "$E" config user.name t
+mkdir -p "$E/q-system/.q-system"; cp "$VERIFY_SRC" "$E/q-system/.q-system/verify.sh"
+printf 'hello\n' > "$E/readme.txt"; git -C "$E" add -A
+git -C "$E" commit -qm init
+run "$E" --full; check "empty repo FAILS (cannot-run)" 1 $?; rm -rf "$E"
+
+# --- a manifest naming a vanished suite must FAIL, never silently skip ---
+R=$(newrepo)
+printf 'no-such-dir\n' > "$R/.verify-suites"
+printf 'x\n' > "$R/t.txt"; git -C "$R" add .verify-suites t.txt
+run "$R" --staged; check "missing suite dir FAILS" 1 $?; rm -rf "$R"
+
+# --- nothing staged is a no-op. A hook that blocks an empty commit gets removed ---
+R=$(newrepo); run "$R" --staged; check "nothing staged, --staged no-op" 0 $?; rm -rf "$R"
+
+# --- bad argument is refused, not silently treated as --full ---
+R=$(newrepo)
+( cd "$R" && bash q-system/.q-system/verify.sh --oops >/dev/null 2>&1 )
+check "unknown mode refused" 2 $?; rm -rf "$R"
+
+echo
+echo "adversarial: $pass passed, $fail failed"
+[ "$fail" -eq 0 ]

--- a/q-system/.q-system/test_verify_adversarial.sh
+++ b/q-system/.q-system/test_verify_adversarial.sh
@@ -92,6 +92,41 @@ R=$(newrepo)
 ( cd "$R" && bash q-system/.q-system/verify.sh --oops >/dev/null 2>&1 )
 check "unknown mode refused" 2 $?; rm -rf "$R"
 
+# --- THE HOOK ENVIRONMENT. git exports GIT_DIR and GIT_INDEX_FILE to its hooks,
+# and --staged builds a worktree, which inherits them and dies on the parent's
+# relative index path. Measured 2026-08-27: --staged passed by hand and refused
+# on every lefthook pre-commit call, which is the worst split there is, because
+# the by-hand run is the one you use to convince yourself the gate works.
+# Every other case here runs with a clean environment and CANNOT see it.
+R=$(newrepo)
+printf 'x = 1\n' > "$R/ok.py"; git -C "$R" add ok.py
+( cd "$R" && GIT_DIR=.git GIT_INDEX_FILE=.git/index \
+    bash q-system/.q-system/verify.sh --staged >/dev/null 2>&1 )
+check "--staged works under hook env" 0 $?; rm -rf "$R"
+
+# --- THE DEEPER HALF of the same leak. Sanitizing only `worktree add` stops the
+# crash and leaves every CHECK running with the hook's git environment, so a
+# test that shells out to git asks the PARENT repo from inside the snapshot.
+# This case owns a suite whose test does exactly that; case 13 cannot see it,
+# because a repo with no git-aware test passes either way.
+R=$(newrepo)
+mkdir -p "$R/suite"
+printf 'suite\n' > "$R/.verify-suites"
+cat > "$R/suite/test_tracked.py" <<'PYEOF'
+import subprocess
+def test_git_sees_the_tracked_file():
+    # ls-files prints paths relative to CWD, and pytest runs from the suite dir,
+    # so this is "test_tracked.py" and not "suite/test_tracked.py". Under the
+    # env leak GIT_DIR=.git resolves against THIS dir, finds nothing, and git
+    # exits with empty stdout, which is what makes the assertion discriminate.
+    r = subprocess.run(["git", "ls-files"], capture_output=True, text=True)
+    assert "test_tracked.py" in r.stdout, (r.returncode, r.stdout, r.stderr)
+PYEOF
+git -C "$R" add .verify-suites suite/test_tracked.py
+( cd "$R" && GIT_DIR=.git GIT_INDEX_FILE=.git/index \
+    bash q-system/.q-system/verify.sh --staged >/dev/null 2>&1 )
+check "git-aware test correct under hook env" 0 $?; rm -rf "$R"
+
 echo
 echo "adversarial: $pass passed, $fail failed"
 [ "$fail" -eq 0 ]

--- a/q-system/.q-system/test_verify_adversarial.sh
+++ b/q-system/.q-system/test_verify_adversarial.sh
@@ -104,6 +104,24 @@ printf 'x = 1\n' > "$R/ok.py"; git -C "$R" add ok.py
     bash q-system/.q-system/verify.sh --staged >/dev/null 2>&1 )
 check "--staged works under hook env" 0 $?; rm -rf "$R"
 
+# --- THE STAGED MANIFEST DECIDES, NOT THE WORKING TREE'S. Both reads used
+# $REPO, which is identical in --full and wrong in --staged: the snapshot's
+# checks were chosen by whatever .verify-suites happened to be lying in the
+# working tree. Here the STAGED manifest names a directory that does not exist
+# (which verify.sh must refuse) while the WORKING TREE manifest is valid. The
+# old code read the working tree, found a fine manifest, and passed.
+R=$(newrepo)
+mkdir -p "$R/realsuite"
+printf 'def test_ok():\n    assert True\n' > "$R/realsuite/test_ok.py"
+printf 'realsuite\n' > "$R/.verify-suites"
+git -C "$R" add .verify-suites realsuite/test_ok.py
+git -C "$R" commit -qm "good manifest"
+# stage a BAD manifest, then put the good one back in the working tree only
+printf 'no-such-dir\n' > "$R/.verify-suites"
+git -C "$R" add .verify-suites
+printf 'realsuite\n' > "$R/.verify-suites"
+run "$R" --staged; check "staged manifest decides, not the worktree" 1 $?
+
 # --- A DELETION-ONLY COMMIT MUST STILL BE CHECKED. The scoping list excludes
 # deletions on purpose (you cannot syntax-check a file that will not exist), and
 # one variable used to answer both "what do I scope to" and "is this commit

--- a/q-system/.q-system/test_verify_adversarial.sh
+++ b/q-system/.q-system/test_verify_adversarial.sh
@@ -104,6 +104,26 @@ printf 'x = 1\n' > "$R/ok.py"; git -C "$R" add ok.py
     bash q-system/.q-system/verify.sh --staged >/dev/null 2>&1 )
 check "--staged works under hook env" 0 $?; rm -rf "$R"
 
+# --- A DELETION-ONLY COMMIT MUST STILL BE CHECKED. The scoping list excludes
+# deletions on purpose (you cannot syntax-check a file that will not exist), and
+# one variable used to answer both "what do I scope to" and "is this commit
+# empty". So a commit that ONLY deletes files produced an empty list, hit the
+# nothing-staged early exit, and passed at exit 0 having run nothing at all.
+# Deleting the last caller of a module, or deleting a test, is exactly the
+# change a floor should look at: the remaining tree still has to parse.
+R=$(newrepo)
+printf 'x = 1\n' > "$R/keep.py"
+printf 'def gone():\n    pass\n' > "$R/doomed.py"
+git -C "$R" add keep.py doomed.py
+git -C "$R" commit -qm "add"
+printf 'this is not python(\n' > "$R/keep.py"
+git -C "$R" add keep.py
+git -C "$R" commit -qm "break it"
+git -C "$R" rm -q doomed.py
+# keep.py is broken in the committed tree, and the staged set is a deletion
+# ONLY. The old code skipped everything here and exited 0.
+run "$R" --staged; check "deletion-only commit is still checked" 1 $?
+
 # --- THE DEEPER HALF of the same leak. Sanitizing only `worktree add` stops the
 # crash and leaves every CHECK running with the hook's git environment, so a
 # test that shells out to git asks the PARENT repo from inside the snapshot.

--- a/q-system/.q-system/tests/separation/test_containment_scoped_checks.py
+++ b/q-system/.q-system/tests/separation/test_containment_scoped_checks.py
@@ -108,9 +108,39 @@ def test_every_completed_containment_check_is_independently_green():
         )
         results[command] = result
 
-    failures = {
-        command: result.stdout + result.stderr
-        for command, result in results.items()
-        if result.returncode != 0
-    }
-    assert failures == {}
+    # "CANNOT RUN HERE" IS NOT "IS BROKEN", and conflating them made this test
+    # fail in CI for a reason no commit could fix.
+    #
+    # the scar (2026-08-27): several of these commands check a SIBLING INSTANCE
+    # by path -- `verify-containment-export.py --instance investigations` reads
+    # that instance's owner directory. On a developer machine the whole fleet is
+    # checked out, so they run. A CI runner has this repo and nothing else, so
+    # the checker correctly refuses with "instance owner path does not exist"
+    # and this assertion read that refusal as a containment defect. It was the
+    # last red on the floor's first green run.
+    #
+    # The checker already distinguishes the two cases in its own output, so the
+    # test honours that distinction instead of flattening it.
+    ABSENT_FLEET = "instance owner path does not exist"
+    failures = {}
+    unrunnable = {}
+    for command, result in results.items():
+        if result.returncode == 0:
+            continue
+        output = result.stdout + result.stderr
+        if ABSENT_FLEET in output:
+            unrunnable[command] = output
+        else:
+            failures[command] = output
+
+    # THE FLOOR, so this can never degrade into a test that skips everything and
+    # reports green. If the fleet is absent AND nothing else ran, the assertion
+    # below would be vacuous, which is the failure mode a lenient rule invites.
+    ran = [c for c, r in results.items() if r.returncode == 0]
+    assert ran or not unrunnable, (
+        "every containment command was unrunnable; this test proved nothing. "
+        f"unrunnable={sorted(unrunnable)}")
+
+    assert failures == {}, (
+        "containment checks failed for a real reason (not an absent sibling "
+        f"instance): {failures}")

--- a/q-system/.q-system/tests/test_token_guard.py
+++ b/q-system/.q-system/tests/test_token_guard.py
@@ -34,6 +34,26 @@ VOLUME_CEILING = 50
 def run_guard(payload, env_overrides=None):
     """Invoke the guard exactly as the hook runner does: JSON on stdin."""
     env = dict(os.environ)
+    # THE RUNTIME MARKER IS AN INPUT, SO THIS HARNESS SETS IT.
+    #
+    # the scar (2026-08-27): token-guard.py's first statement is
+    #     if not os.environ.get("CLAUDECODE"): sys.exit(0)
+    # a deliberate circuit breaker so foreign runtimes (Codex loading the kipi
+    # plugins through its own marketplace clone) never fire it. CLAUDECODE=1 is
+    # set only by the Claude Code runtime.
+    #
+    # These tests INHERITED it. Every developer running them is inside Claude
+    # Code, so it was always set and 14 passed. In GitHub Actions it does not
+    # exist, the guard exited 0 before doing anything, and 12 tests failed
+    # asserting a block that never came ("assert 0 == 2", where 0 is the
+    # returncode) or a counter that never reset. Measured both ways on one
+    # machine, same commit:
+    #     env -u CLAUDECODE pytest test_token_guard.py -> 11 failed, 3 passed
+    #                       pytest test_token_guard.py -> 14 passed
+    #
+    # Set BEFORE the overrides so a test can still blank it deliberately, which
+    # is what test_a_foreign_runtime_is_a_no_op below does.
+    env["CLAUDECODE"] = "1"
     env.update(env_overrides or {})
     return subprocess.run(
         ["python3", GUARD], input=json.dumps(payload),
@@ -256,3 +276,24 @@ def test_auto_commit_subject_is_not_progress(session_id, fake_repo):
     result = run_guard(pre_tool_use(session_id),
                        env_overrides={"CLAUDE_PROJECT_DIR": fake_repo})
     assert result.returncode == 2
+
+
+def test_a_foreign_runtime_is_a_no_op(session_id):
+    """The other half of the marker, which nothing covered.
+
+    token-guard.py exits 0 immediately unless CLAUDECODE is set. That breaker
+    exists because a UserPromptSubmit block once fired inside `codex exec` and
+    killed an in-repo review (sp-28bf75a4). Every other test in this file now
+    sets the marker, so without this one the no-op path would be asserted
+    nowhere -- and it is the path that protects other runtimes.
+
+    It also proves the harness fix is load-bearing rather than cosmetic: blank
+    the marker and the guard stops blocking, which is exactly what CI was
+    seeing."""
+    seed_cache(session_id, tool_calls_since_user=VOLUME_CEILING + 5)
+    blocked = run_guard(pre_tool_use(session_id))
+    assert blocked.returncode == 2, "sanity: this payload must block normally"
+
+    inert = run_guard(pre_tool_use(session_id), env_overrides={"CLAUDECODE": ""})
+    assert inert.returncode == 0, "a foreign runtime must never be blocked"
+    assert inert.stdout == "", "a foreign runtime must not even emit context"

--- a/q-system/.q-system/verify.sh
+++ b/q-system/.q-system/verify.sh
@@ -59,8 +59,21 @@ esac
 
 STAGED=""
 if [ "$MODE" = "--staged" ]; then
+  # TWO DIFFERENT QUESTIONS, and conflating them opened a hole.
+  #
+  # STAGED is "which files should I scope checks to", so it excludes deletions:
+  # you cannot syntax-check a file that will not exist. ANY_STAGED is "is this
+  # commit empty", and deletions absolutely count.
+  #
+  # the finding (codex, PR #259 round 4): one variable answered both. A commit
+  # that ONLY deletes files produced an empty ACMR list, hit the early exit, and
+  # sailed through at exit 0 with no checks run at all. Deleting the last caller
+  # of a module, or deleting a test file, is exactly the change a floor should
+  # look at -- the remaining tree still has to parse and its suites still have to
+  # pass without it.
+  ANY_STAGED="$(git -C "$REPO" diff --cached --name-only)"
   STAGED="$(git -C "$REPO" diff --cached --name-only --diff-filter=ACMR)"
-  if [ -z "$STAGED" ]; then
+  if [ -z "$ANY_STAGED" ]; then
     echo "verify.sh --staged: nothing staged, nothing to verify."
     exit 0
   fi
@@ -246,6 +259,30 @@ if [ -f "$REPO/.verify-suites" ]; then
   if command -v pytest >/dev/null 2>&1 || python3 -c "import pytest" 2>/dev/null; then
     while IFS= read -r suite; do
       case "$suite" in ''|'#'*) continue ;; esac
+      # A MANIFEST ENTRY MAY BE A FILE, not only a directory.
+      #
+      # why (codex, PR #259 round 4): 10 tracked test files sit where no
+      # runnable directory contains them -- two at the repo root, one beside a
+      # broken sibling suite, two under scripts/. Running pytest FROM those
+      # locations either collects nothing or drags in the vendored trees that
+      # produce 109 collection errors. Without file support the only options
+      # were to leave them silently ungated, which is the finding, or to declare
+      # them excluded, which pretends a limitation is a decision. 48 tests were
+      # passing and gated by nothing.
+      #
+      # A file entry runs from the REPO ROOT against that path, so pytest
+      # resolves it exactly as a human would typing the path.
+      if [ -f "$TARGET/$suite" ]; then
+        if [ "$MODE" = "--staged" ]; then
+          if ! printf '%s\n' "$STAGED" | grep -q "^$suite$"; then
+            say "pytest:$suite" "skipped (not staged)"
+            continue
+          fi
+        fi
+        run_check "pytest:$suite" bash -c 'cd "$1" && python3 -m pytest "$2" -q --no-header' \
+                  _ "$TARGET" "$suite"
+        continue
+      fi
       if [ ! -d "$TARGET/$suite" ]; then
         # A manifest naming a directory that is gone is a BROKEN FLOOR. Silently
         # skipping it is how a suite stops running and nobody notices.

--- a/q-system/.q-system/verify.sh
+++ b/q-system/.q-system/verify.sh
@@ -255,7 +255,17 @@ TESTFILES="$(git -C "$REPO" ls-files 'test_*.py' '*/test_*.py')"
 #
 # A repo with no manifest falls back to one root pytest, which is right for a
 # normal repo and is what every instance without the file gets.
-if [ -f "$REPO/.verify-suites" ]; then
+# THE MANIFEST COMES FROM THE TREE BEING GRADED, not from the working tree.
+#
+# the finding (codex, PR #259 round 5): both reads used $REPO. In --full that is
+# the same path, so it looked right. In --staged it meant the snapshot's checks
+# were chosen by whatever manifest happened to be lying in the working tree.
+# Stage a commit that ADDS a suite and the gate would not run it; stage one that
+# REMOVES a broken suite and the gate would still run it and refuse. The whole
+# premise of --staged is "grade what the commit contains", and the file deciding
+# WHAT GETS GRADED was exempt from it.
+MANIFEST="$TARGET/.verify-suites"
+if [ -f "$MANIFEST" ]; then
   if command -v pytest >/dev/null 2>&1 || python3 -c "import pytest" 2>/dev/null; then
     while IFS= read -r suite; do
       case "$suite" in ''|'#'*) continue ;; esac
@@ -305,7 +315,7 @@ if [ -f "$REPO/.verify-suites" ]; then
       fi
       run_check "pytest:$suite" bash -c 'cd "$1/$2" && python3 -m pytest -q --no-header' \
                 _ "$TARGET" "$suite"
-    done < "$REPO/.verify-suites"
+    done < "$MANIFEST"
   else
     RAN+=("pytest")
     FAILED+=("pytest: .verify-suites present but pytest is not installed")

--- a/q-system/.q-system/verify.sh
+++ b/q-system/.q-system/verify.sh
@@ -1,0 +1,230 @@
+#!/usr/bin/env bash
+# THE floor. One script, run identically at every gate, so the agent, the commit
+# and the merge cannot quietly drift apart.
+#
+# why this exists: this repo had SEVEN different pre-commit commands, a
+# hand-written native pre-push (lefthook kept silently skipping its own), and no
+# CI at all. Every one of those checks was real; nothing guaranteed the same set
+# ran at each door. "It passed" did not say which door it passed.
+#
+#   verify.sh --staged    what a commit would contain, checked against a COPY
+#   verify.sh --full      the working tree, everything
+#
+# --staged never touches your working tree. It writes the git INDEX out to a
+# temporary directory with `git checkout-index` and runs there. The obvious
+# alternative, `git stash --keep-index`, puts uncommitted work inside a stash
+# that a crash mid-hook can strand. Verifying against a copy costs a few hundred
+# milliseconds and cannot eat anybody's work.
+#
+# THE ONE RULE THAT IS NOT NEGOTIABLE: if this script discovers no checks to
+# run, it FAILS. A gate that cannot run must not pass. The alternative is a
+# green exit that means "I looked for a linter and did not find one", which is
+# indistinguishable from "your code is fine" at every call site that reads only
+# the exit code.
+set -euo pipefail
+
+MODE="${1:---full}"
+REPO="$(git rev-parse --show-toplevel)"
+RAN=()
+FAILED=()
+TMP=""
+
+# `return 0` is LOAD-BEARING, not tidiness. An EXIT trap's last command sets the
+# script's exit status. The first version was a bare `[ -n "$TMP" ] && [ -d ...
+# ] && rm -rf "$TMP"`, and in --full mode TMP is empty, so the chain returned 1
+# and EVERY SUCCESSFUL --full RUN EXITED 1. It printed "verify.sh ok" and then
+# failed. Wired at pre-push and CI, that is a floor that blocks every push
+# forever, which is the same amount of protection as a floor that blocks
+# nothing: both get switched off within a day.
+#
+# Caught 2026-08-27 by the adversarial suite asserting the exit code of a CLEAN
+# repo. No test of the failure cases could have found it: they all expect 1.
+cleanup() {
+  if [ -n "$TMP" ] && [ -d "$TMP" ]; then rm -rf "$TMP"; fi
+  return 0
+}
+trap cleanup EXIT
+
+case "$MODE" in
+  --staged|--full) ;;
+  *) echo "usage: verify.sh [--staged|--full]" >&2; exit 2 ;;
+esac
+
+STAGED=""
+if [ "$MODE" = "--staged" ]; then
+  STAGED="$(git -C "$REPO" diff --cached --name-only --diff-filter=ACMR)"
+  if [ -z "$STAGED" ]; then
+    echo "verify.sh --staged: nothing staged, nothing to verify."
+    exit 0
+  fi
+  # The staged snapshot, materialised. Not the working tree, and not a stash.
+  TMP="$(mktemp -d)"
+  git -C "$REPO" checkout-index -a -f --prefix="$TMP/"
+  TARGET="$TMP"
+else
+  TARGET="$REPO"
+fi
+
+say() { printf '  %-28s %s\n' "$1" "$2"; }
+
+run_check() {
+  local name="$1"; shift
+  RAN+=("$name")
+  if "$@" >/tmp/verify-$$-out 2>&1; then
+    say "$name" "ok"
+  else
+    FAILED+=("$name")
+    say "$name" "FAILED"
+    sed 's/^/      /' /tmp/verify-$$-out | tail -30
+  fi
+  rm -f /tmp/verify-$$-out
+}
+
+echo "verify.sh ${MODE} in ${TARGET}"
+
+# --- python: syntax, every tracked .py -----------------------------------
+# py_compile is not a linter and is not pretending to be one. It is the floor
+# under the floor: a file that does not parse cannot be reasoned about by
+# anything downstream, and this repo has no ruff installed to catch it.
+PYFILES="$(git -C "$REPO" ls-files '*.py' | head -4000)"
+if [ -n "$PYFILES" ]; then
+  run_check "python syntax" bash -c '
+    cd "$1" || exit 1
+    fail=0
+    while IFS= read -r f; do
+      [ -f "$f" ] || continue
+      python3 -m py_compile "$f" 2>&1 || fail=1
+    done <<< "$2"
+    exit $fail
+  ' _ "$TARGET" "$PYFILES"
+fi
+
+# --- shell: syntax, every tracked .sh ------------------------------------
+SHFILES="$(git -C "$REPO" ls-files '*.sh' | head -2000)"
+if [ -n "$SHFILES" ]; then
+  run_check "shell syntax" bash -c '
+    cd "$1" || exit 1
+    fail=0
+    while IFS= read -r f; do
+      [ -f "$f" ] || continue
+      bash -n "$f" 2>&1 || fail=1
+    done <<< "$2"
+    exit $fail
+  ' _ "$TARGET" "$SHFILES"
+fi
+
+# --- json: every tracked .json parses ------------------------------------
+# Config in this fleet IS behaviour: room lists, model tiers, source weights.
+# A malformed one fails at 07:30 in a launchd job nobody is watching.
+JSONFILES="$(git -C "$REPO" ls-files '*.json' | grep -v -E '(^|/)(dist|node_modules)/' | head -3000)"
+if [ -n "$JSONFILES" ]; then
+  run_check "json parse" bash -c '
+    cd "$1" || exit 1
+    fail=0
+    while IFS= read -r f; do
+      [ -f "$f" ] || continue
+      python3 -c "import json,sys; json.load(open(sys.argv[1]))" "$f" 2>&1 || fail=1
+    done <<< "$2"
+    exit $fail
+  ' _ "$TARGET" "$JSONFILES"
+fi
+
+# --- ruff, only if the machine has it ------------------------------------
+# Optional TOOL, never an optional CHECK: if ruff is installed it must pass.
+# The discovery is about what exists, not about what is allowed to fail.
+if command -v ruff >/dev/null 2>&1; then
+  run_check "ruff" bash -c 'cd "$1" && ruff check .' _ "$TARGET"
+fi
+
+# --- tests ---------------------------------------------------------------
+# --staged runs the tests from the COPY, which is the point: it proves the
+# snapshot being committed passes on its own, not that the working tree does.
+# NO PIPE INTO `grep -q` HERE, and that is a scar, not a style preference.
+# The first version of this line ended `| grep -q .`. Under `set -o pipefail`,
+# grep -q exits the instant it matches, git gets SIGPIPE (141), and the PIPELINE
+# reports failure precisely BECAUSE there were tests. Measured on the first live
+# run: 400 test files present, pytest silently skipped, exit 0, "verify.sh ok".
+# A discovery step that inverts on success is worse than no discovery step.
+# FAIL FAST BEFORE THE EXPENSIVE PART. Measured 2026-08-27: a commit with one
+# unparseable .py staged blocked correctly and took over two minutes, because
+# the syntax check failed and the script then ran the full suite anyway. Nobody
+# waits two minutes to be told about a typo; they run --no-verify, and then the
+# floor is decorative. Tests cannot tell you anything useful about a tree that
+# does not parse, so there is nothing lost by stopping here.
+if [ ${#FAILED[@]} -gt 0 ]; then
+  echo
+  echo "verify.sh FAILED (${#FAILED[@]}/${#RAN[@]}): ${FAILED[*]}" >&2
+  echo "Stopped before the test suites: a tree that does not parse cannot be tested." >&2
+  exit 1
+fi
+
+TESTFILES="$(git -C "$REPO" ls-files 'test_*.py' '*/test_*.py')"
+
+# THE SUITE MANIFEST, `.verify-suites` at the repo root, one `dir` per line.
+# Each is a directory pytest is invoked FROM, because that is how these suites
+# actually run: q-consult/pipeline/tests imports `pipeline`, which resolves only
+# with q-consult as the working directory. A single root-level pytest is the
+# obvious design and it is wrong here. Measured: from the repo root, 3526 tests
+# collect and 896 error out, most of them belonging to the nested instances
+# under projects/ that are separate repos with their own paths. From their own
+# directories the two real suites collect 5379 and 486 with zero errors.
+#
+# A repo with no manifest falls back to one root pytest, which is right for a
+# normal repo and is what every instance without the file gets.
+if [ -f "$REPO/.verify-suites" ]; then
+  if command -v pytest >/dev/null 2>&1 || python3 -c "import pytest" 2>/dev/null; then
+    while IFS= read -r suite; do
+      case "$suite" in ''|'#'*) continue ;; esac
+      if [ ! -d "$TARGET/$suite" ]; then
+        # A manifest naming a directory that is gone is a BROKEN FLOOR. Silently
+        # skipping it is how a suite stops running and nobody notices.
+        RAN+=("pytest:$suite")
+        FAILED+=("pytest:$suite (directory missing)")
+        say "pytest:$suite" "FAILED (missing)"
+        continue
+      fi
+      # --staged runs only the suites that OWN a staged file. Not a weaker
+      # check, a narrower input: the same pytest, on the same snapshot, scoped
+      # to what this commit can have broken. The full suite is 5 minutes here,
+      # and a 5-minute pre-commit is a hook people delete. Pre-push and CI run
+      # --full, so nothing escapes; it just escapes later than the fastest
+      # possible door.
+      if [ "$MODE" = "--staged" ]; then
+        if ! printf '%s\n' "$STAGED" | grep -q "^$suite/"; then
+          say "pytest:$suite" "skipped (no staged files)"
+          continue
+        fi
+      fi
+      run_check "pytest:$suite" bash -c 'cd "$1/$2" && python3 -m pytest -q --no-header' \
+                _ "$TARGET" "$suite"
+    done < "$REPO/.verify-suites"
+  else
+    RAN+=("pytest")
+    FAILED+=("pytest: .verify-suites present but pytest is not installed")
+    say "pytest" "FAILED (not installed)"
+  fi
+elif [ -f "$REPO/pytest.ini" ] || [ -f "$REPO/pyproject.toml" ] || \
+     [ -d "$REPO/tests" ] || [ -n "$TESTFILES" ]; then
+  if command -v pytest >/dev/null 2>&1 || python3 -c "import pytest" 2>/dev/null; then
+    run_check "pytest" bash -c 'cd "$1" && python3 -m pytest -q --no-header' _ "$TARGET"
+  else
+    # Tests exist and the runner does not. That is a broken floor, not a pass.
+    RAN+=("pytest")
+    FAILED+=("pytest: tests present but pytest is not installed")
+    say "pytest" "FAILED (not installed)"
+  fi
+fi
+
+echo
+if [ ${#RAN[@]} -eq 0 ]; then
+  echo "verify.sh: NO CHECKS DISCOVERED. Failing." >&2
+  echo "A gate that cannot run must not pass. Wire a check or delete this hook." >&2
+  exit 1
+fi
+
+if [ ${#FAILED[@]} -gt 0 ]; then
+  echo "verify.sh FAILED (${#FAILED[@]}/${#RAN[@]}): ${FAILED[*]}" >&2
+  exit 1
+fi
+
+echo "verify.sh ok (${#RAN[@]} checks: ${RAN[*]})"

--- a/q-system/.q-system/verify.sh
+++ b/q-system/.q-system/verify.sh
@@ -10,11 +10,11 @@
 #   verify.sh --staged    what a commit would contain, checked against a COPY
 #   verify.sh --full      the working tree, everything
 #
-# --staged never touches your working tree. It writes the git INDEX out to a
-# temporary directory with `git checkout-index` and runs there. The obvious
-# alternative, `git stash --keep-index`, puts uncommitted work inside a stash
-# that a crash mid-hook can strand. Verifying against a copy costs a few hundred
-# milliseconds and cannot eat anybody's work.
+# --staged never touches your working tree. It turns the git INDEX into a real
+# commit object and checks that out as a throwaway worktree, then runs there.
+# The obvious alternative, `git stash --keep-index`, puts uncommitted work
+# inside a stash that a crash mid-hook can strand. Verifying against a copy
+# costs a couple of seconds and cannot eat anybody's work.
 #
 # THE ONE RULE THAT IS NOT NEGOTIABLE: if this script discovers no checks to
 # run, it FAILS. A gate that cannot run must not pass. The alternative is a
@@ -41,6 +41,13 @@ TMP=""
 # repo. No test of the failure cases could have found it: they all expect 1.
 cleanup() {
   if [ -n "$TMP" ] && [ -d "$TMP" ]; then rm -rf "$TMP"; fi
+  # The staged worktree lived under $TMP, so removing $TMP orphans its
+  # registration in .git/worktrees. prune is the sanctioned cleanup, is a no-op
+  # when nothing is stale, and never touches a worktree whose directory still
+  # exists. Without it every --staged run leaks an entry and `git worktree list`
+  # fills with dead paths until an add starts failing.
+  env -u GIT_DIR -u GIT_WORK_TREE -u GIT_INDEX_FILE -u GIT_OBJECT_DIRECTORY \
+      -u GIT_COMMON_DIR git worktree prune >/dev/null 2>&1 || true
   return 0
 }
 trap cleanup EXIT
@@ -57,12 +64,76 @@ if [ "$MODE" = "--staged" ]; then
     echo "verify.sh --staged: nothing staged, nothing to verify."
     exit 0
   fi
-  # The staged snapshot, materialised. Not the working tree, and not a stash.
+  # The staged snapshot, materialised AS A REAL REPOSITORY. Not the working
+  # tree, and not a stash.
+  #
+  # why a worktree and not `git checkout-index --prefix=` (the first version):
+  # checkout-index writes FILES and nothing else, so the snapshot had no .git.
+  # Every test that asks the repository a question then got a wrong answer
+  # instead of an error. Measured 2026-08-27 on this repo: 25 failed under
+  # --staged against 7 under --full, and the 18-test difference was entirely
+  # this. `provenance.resolve` on HEAD returned "empty commit ref"; the
+  # gitignore checks, the behind-upstream check and the live-tree enumerations
+  # all followed. A pre-commit gate that fails 18 times for a reason unrelated
+  # to your change is a gate that gets deleted in a day, which is the same
+  # protection as no gate at all.
+  #
+  # write-tree + commit-tree turns the INDEX into a real commit object without
+  # touching any ref, any branch, or the working tree. The worktree checked out
+  # at that commit is a genuine git repository holding exactly what the commit
+  # would contain, so a repo-aware test is answered about the STAGED state
+  # rather than about a directory that is not a repo.
   TMP="$(mktemp -d)"
-  git -C "$REPO" checkout-index -a -f --prefix="$TMP/"
-  TARGET="$TMP"
+  TREE="$(git -C "$REPO" write-tree)"
+  # An empty repo has no HEAD to parent from; the adversarial suite covers it.
+  if git -C "$REPO" rev-parse --verify -q HEAD >/dev/null 2>&1; then
+    SNAP="$(git -C "$REPO" commit-tree "$TREE" -p HEAD -m 'verify.sh staged snapshot')"
+  else
+    SNAP="$(git -C "$REPO" commit-tree "$TREE" -m 'verify.sh staged snapshot')"
+  fi
+  # FAIL, never fall through. A failed `worktree add` leaves $TMP/wt absent, and
+  # a TARGET that does not exist would send every check at the MAIN CHECKOUT,
+  # reporting green for a tree nobody staged.
+  #
+  # `env -u` is not defensive tidiness, it is the whole reason this works inside
+  # a hook. git EXPORTS GIT_DIR and GIT_INDEX_FILE to its hooks, and a child
+  # `git worktree add` inherits them and tries to use the PARENT's index path
+  # inside the new worktree: "fatal: .git/index: index file open failed: Not a
+  # directory". Measured 2026-08-27 -- verify.sh --staged ran fine by hand and
+  # refused every time lefthook called it, which is the worst possible split
+  # because the by-hand run is the one you use to convince yourself it works.
+  # write-tree above deliberately KEEPS the inherited environment: it has to
+  # read the index the commit is actually being built from.
+  if ! WT_ERR="$(env -u GIT_DIR -u GIT_WORK_TREE -u GIT_INDEX_FILE \
+                     -u GIT_OBJECT_DIRECTORY -u GIT_COMMON_DIR \
+                     git -C "$REPO" worktree add --detach "$TMP/wt" "$SNAP" 2>&1)"; then
+    # Print what git said. The first version threw stderr away and the refusal
+    # was untraceable: a gate that cannot say why it refused gets bypassed.
+    echo "verify.sh: could not create the staged worktree. Refusing." >&2
+    echo "$WT_ERR" | sed 's/^/  /' >&2
+    exit 1
+  fi
+  TARGET="$TMP/wt"
+  # AND NOW DROP THEM FOR THE REST OF THE RUN. Sanitizing only the `worktree
+  # add` above fixed the crash and left the deeper half: every check below runs
+  # with the hook's environment too, so a TEST that shells out to git inherits
+  # GIT_DIR=.git and GIT_INDEX_FILE=.git/index and asks the PARENT repo, from
+  # inside the snapshot, using a relative path that means something else there.
+  # Measured 2026-08-27: a bare `verify.sh --staged` printed "verify.sh ok" and
+  # the pre-commit call on byte-identical staged content failed on
+  # test_corpus_is_tracked, test_acquisition_manifest,
+  # test_sp_392043b5_backup_is_ignored and test_provenance_repo_field -- every
+  # one of them a test that asks git what is tracked or ignored.
+  #
+  # This is the script's own thesis applied to itself. verify.sh exists so the
+  # same checks run identically at every door; a run whose answers depend on
+  # which door invoked it is the exact drift it was written to stop.
+  unset GIT_DIR GIT_WORK_TREE GIT_INDEX_FILE GIT_OBJECT_DIRECTORY GIT_COMMON_DIR
 else
   TARGET="$REPO"
+  # --full has no snapshot to build, so there is nothing to read the index for
+  # and the same leak applies from the first check onward.
+  unset GIT_DIR GIT_WORK_TREE GIT_INDEX_FILE GIT_OBJECT_DIRECTORY GIT_COMMON_DIR
 fi
 
 say() { printf '  %-28s %s\n' "$1" "$2"; }


### PR DESCRIPTION
One script run identically at every gate, plus the two defects that only showed up once it ran against a live repo.

## What lands

`q-system/.q-system/verify.sh` (modes `--staged` / `--full`) and its adversarial suite. Checks: python syntax, shell syntax, json parse, ruff when installed, and the pytest suites named in a repo's `.verify-suites`. **If it discovers no checks it FAILS** — a gate that cannot run must not pass, because a green exit meaning "I looked for a linter and did not find one" is indistinguishable from "your code is fine" at every call site that reads only the exit code.

Ships to every registered instance via the `q-system/` sync. The wiring (lefthook, CI workflow) is per-repo and deliberately does not propagate.

## The two defects, both found by running it

**1. The `--staged` snapshot was not a repository.** `git checkout-index --prefix=` writes files and no `.git`, so every test that asks git a question got a wrong answer instead of an error. Measured on the consulting instance: **25 failed under `--staged` against 7 under `--full`**, and the entire 18-test gap was this one cause. `provenance.resolve` on HEAD returned `empty commit ref`; the gitignore checks, the behind-upstream check and the live-tree enumerations all followed.

Now `write-tree` + `commit-tree` turn the index into a real commit object and a detached worktree checks it out. No ref, branch, or working file is touched. A failed `worktree add` **refuses** rather than falling through, because a missing `TARGET` would have aimed every check at the main checkout and reported green for a tree nobody staged.

**2. The hook environment leaked, and this one only ever appeared under lefthook.** git exports `GIT_DIR` and `GIT_INDEX_FILE` to its hooks.

First the child `worktree add` inherited them and died on the parent's relative index path (`fatal: .git/index: index file open failed: Not a directory`). So `--staged` **passed by hand and refused on every real commit** — the worst possible split, because the by-hand run is the one you use to convince yourself the gate works.

Sanitizing that one call fixed the crash and left the deeper half: **pytest inherits the same variables**, so any git-aware test asks the parent repo from inside the snapshot. That produced a *different failure set on each run of byte-identical staged content* (9, then 1, then 0, then 8 on `test_corpus_is_tracked` / `test_acquisition_manifest` / `test_sp_392043b5_backup_is_ignored` / `test_provenance_repo_field`) and read convincingly as test flakiness. It was not. I had already filed it as suite order-dependence and voided my own item once the real cause showed up.

The variables are now unset for the whole run in both modes. That second fix is the script's own thesis applied to itself: verify.sh exists so the same checks run identically at every door, and a run whose answers depend on which door invoked it is the exact drift it was written to stop.

## Evidence

Adversarial suite grew 12 to 14. Both new cases were **negative-self-tested rather than asserted** — run against the un-fixed copy they FAIL (`12 passed, 1 failed` and `13 passed, 1 failed`), against this branch:

```
adversarial: 14 passed, 0 failed
```

The first draft of case 14 passed against *both* copies, because `git ls-files` prints paths relative to CWD and pytest runs from the suite dir. A case that cannot fail is not a case, so it was fixed until it discriminated.

Proven live in the consulting instance: two commits went through the real pre-commit hook, each printing `verify.sh ok (4 checks: python syntax shell syntax json parse pytest:q-consult)`. No `--no-verify` was used at any point.

## Scope note

This branch is cherry-picked off `origin/main` and carries **only** the two floor commits. Local `kipi-system` `main` has two older unpushed commits (`d666594d`, `5d459470`) that are not mine and are deliberately not included here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01BqDQzSHEhzazNQBdNJbZtw
