### PR TITLE
fix(spillover): resolve the board project from the instance registry

### DIFF
--- a/q-system/.q-system/scripts/spillover-promote.py
+++ b/q-system/.q-system/scripts/spillover-promote.py
@@ -30,6 +30,7 @@ import fcntl
 import importlib.util
 import json
 import os
+import subprocess
 import sys
 from pathlib import Path
 from types import SimpleNamespace
@@ -408,6 +409,39 @@ def promote_locked(args, root: Path, ledger: Path, rec: dict) -> int:
     return 0
 
 
+def _main_checkout(root: Path) -> str:
+    """The registered checkout path for `root`, resolving a git WORKTREE to it.
+
+    the finding (codex, PR #260): matching realpath(root) against the registry
+    rejected every real worktree. instance-registry.json records ONE path per
+    instance, the main checkout, and a worktree lives somewhere else entirely,
+    often under /private/tmp. No row matched, the derivation fell through to the
+    worktree's basename, and the promotion refused.
+
+    That is precisely the UNATTENDED path: linear-worker.sh does its work in
+    worktrees. The rung would have worked every time a human ran it by hand in
+    the checkout and failed every time the worker ran it. Same by-hand-versus-
+    real split verify.sh hit with the hook environment, one repo over, which is
+    why it was worth taking the finding seriously rather than arguing scope.
+
+    `--git-common-dir` is the resolution: inside a worktree it points at the MAIN
+    repo's .git, whose parent is the registered path. In an ordinary checkout it
+    is that checkout's own .git, so this is a no-op there. Any failure falls back
+    to realpath(root), the previous behaviour.
+    """
+    try:
+        out = subprocess.run(
+            ["git", "-C", str(root), "rev-parse",
+             "--path-format=absolute", "--git-common-dir"],
+            capture_output=True, text=True)
+        common = (out.stdout or "").strip()
+        if out.returncode == 0 and common and os.path.basename(common) == ".git":
+            return os.path.realpath(os.path.dirname(common))
+    except Exception:
+        pass
+    return os.path.realpath(str(root))
+
+
 def registry_project(root: Path) -> str:
     """The board project this checkout maps to, per instance-registry.json.
 
@@ -436,7 +470,7 @@ def registry_project(root: Path) -> str:
         mod = importlib.util.module_from_spec(spec)
         spec.loader.exec_module(mod)
         rows = mod._registry_rows()
-        target = os.path.realpath(str(root))
+        target = _main_checkout(root)
     except Exception:
         return ""
     for row in rows:

--- a/q-system/.q-system/scripts/spillover-promote.py
+++ b/q-system/.q-system/scripts/spillover-promote.py
@@ -408,6 +408,49 @@ def promote_locked(args, root: Path, ledger: Path, rec: dict) -> int:
     return 0
 
 
+def registry_project(root: Path) -> str:
+    """The board project this checkout maps to, per instance-registry.json.
+
+    THE THIRD RUNG. linear-worker.sh has always had it and this script did not,
+    so `project_name` fell through to the checkout basename. On the consulting
+    instance that is "consulting", the board project is "ASK Consulting", and
+    every promotion from that repo was refused with "no Linear project named
+    'consulting'". Measured 2026-08-27 against the live board: 19 projects, no
+    "consulting", and "ASK Consulting" present as 6497f378. The registry row has
+    carried `linear_project: "ASK Consulting"` the whole time. Nothing was
+    missing in Linear; this script was asking for the wrong name.
+
+    The old comment here said replicating the rule would give one decision two
+    writers, which was right, so this IMPORTS the decision instead of copying
+    it. `_linear_project_of` in alert-to-linear.py owns the precedence
+    (explicit `linear_project`, then `name`) and stays the only place that rule
+    is written. What lives here is the path match, which is mechanics.
+
+    Returns "" on any failure, so the derivation falls through to the basename
+    exactly as before. A registry that cannot be read must not invent a project
+    name -- filing into the wrong board is worse than refusing.
+    """
+    try:
+        spec = importlib.util.spec_from_file_location(
+            "a2l", HERE.parent / "alert-to-linear.py")
+        mod = importlib.util.module_from_spec(spec)
+        spec.loader.exec_module(mod)
+        rows = mod._registry_rows()
+        target = os.path.realpath(str(root))
+    except Exception:
+        return ""
+    for row in rows:
+        row_path = row.get("path")
+        if not row_path:
+            continue
+        try:
+            if os.path.realpath(row_path) == target:
+                return mod._linear_project_of(row)
+        except OSError:
+            continue
+    return ""
+
+
 def create_issue(ls, args, root: Path, body: str):
     """The issue, or an int exit code when a required name does not resolve."""
     tid = ls.graphql('query{teams(filter:{key:{eq:"%s"}}){nodes{id}}}' % TEAM_KEY,
@@ -426,20 +469,27 @@ def create_issue(ls, args, root: Path, body: str):
             return 2
         label_ids.append(lid)
 
-    # Same derivation ORDER as linear-worker.sh: explicit env override, then the
-    # checkout basename. The worker has a third step (instance-registry lookup)
-    # that this does not replicate -- duplicating that rule would give one
-    # decision two writers and they would drift. See the spillover item filed
-    # with this change: on the three instances whose project name is not their
-    # basename, set KIPI_LINEAR_PROJECT until the derivation is shared.
-    project_name = os.environ.get("KIPI_LINEAR_PROJECT") or root.name
+    # The SAME THREE RUNGS as linear-worker.sh, in the same order: explicit env
+    # override, then the instance-registry alias, then the checkout basename.
+    # The third rung used to be missing here and that was the whole bug: every
+    # instance whose directory name is not its board name refused every
+    # promotion, which on this fleet is 8 of 25 (measured 2026-08-15, recorded
+    # in _registry_path). sp-421fa27d, sp-08fae4fc and sp-f227a6fd are three
+    # ledger rows describing that one gap.
+    project_name = (os.environ.get("KIPI_LINEAR_PROJECT")
+                    or registry_project(root)
+                    or root.name)
     pid = resolve_one(ls, PROJECT_BY_NAME, project_name, "projects")
     if not pid:
         sys.stderr.write(
             f"refused: no Linear project named '{project_name}'.\n"
             "in_this_repo() treats an unset or foreign project as NOT this repo,\n"
-            "so this issue would never be picked by any worker. Set\n"
-            "KIPI_LINEAR_PROJECT to the project this checkout maps to.\n")
+            "so this issue would never be picked by any worker.\n"
+            f"Tried, in order: KIPI_LINEAR_PROJECT (unset), instance-registry\n"
+            f"alias for {root} ({registry_project(root) or 'no row'}), "
+            f"basename ({root.name}).\n"
+            "Add a `linear_project` to this checkout's instance-registry row, or\n"
+            "set KIPI_LINEAR_PROJECT.\n")
         return 2
 
     res = ls.graphql(ls.ISSUE_CREATE, {"input": {

--- a/q-system/.q-system/scripts/test_spillover_promote_selection.py
+++ b/q-system/.q-system/scripts/test_spillover_promote_selection.py
@@ -717,10 +717,6 @@ class ReadOnlyLockTest(unittest.TestCase):
                           "an unlocked promotion has to say so out loud")
 
 
-if __name__ == "__main__":
-    unittest.main(verbosity=2)
-
-
 class TestProjectComesFromTheInstanceRegistry(unittest.TestCase):
     """The THIRD RUNG: instance-registry alias, between env and basename.
 
@@ -781,6 +777,45 @@ class TestProjectComesFromTheInstanceRegistry(unittest.TestCase):
             self.assertEqual(rc, 0, "env override did not take precedence")
             self.assertEqual(stub.created["projectId"], PROJECT_IDS["kipi-system"])
 
+    def test_a_git_worktree_resolves_to_its_registered_main_checkout(self):
+        """codex major on PR #260. The registry records ONE path per instance,
+        the main checkout. linear-worker.sh works in WORKTREES, which live
+        somewhere else entirely, so matching realpath(root) rejected every
+        unattended run: no row matched, the derivation fell through to the
+        worktree basename, and the promotion refused.
+
+        The rung would have worked whenever a human ran it by hand in the
+        checkout and failed every time the worker ran it, which is the split
+        that makes a bug survive."""
+        import subprocess as sp
+        with tempfile.TemporaryDirectory() as tmp:
+            main = Path(tmp) / "checkout"
+            main.mkdir()
+            for cmd in (["init", "-q", "."], ["config", "user.email", "t@t"],
+                        ["config", "user.name", "t"]):
+                sp.run(["git", "-C", str(main)] + cmd, check=True,
+                       capture_output=True)
+            (main / "f.txt").write_text("x")
+            sp.run(["git", "-C", str(main), "add", "f.txt"], check=True,
+                   capture_output=True)
+            sp.run(["git", "-C", str(main), "commit", "-qm", "init"], check=True,
+                   capture_output=True)
+            wt = Path(tmp) / "wt"
+            sp.run(["git", "-C", str(main), "worktree", "add", "--detach",
+                    str(wt)], check=True, capture_output=True)
+
+            mod = load_promote()
+            # The worktree is a real repo at a different path than the registry row.
+            self.assertEqual(mod._main_checkout(wt), os.path.realpath(str(main)),
+                             "a worktree did not resolve to its main checkout")
+            # NEGATIVE SELF-TEST: without the resolution this is the worktree
+            # itself, which is what made every unattended promotion refuse.
+            self.assertNotEqual(os.path.realpath(str(wt)),
+                                os.path.realpath(str(main)),
+                                "fixture is wrong: worktree and checkout share a path")
+            # An ordinary checkout must be unchanged by the same call.
+            self.assertEqual(mod._main_checkout(main), os.path.realpath(str(main)))
+
     def test_an_unreadable_registry_falls_through_and_never_invents_a_project(self):
         """A registry that cannot be read must not become a guess. Filing into
         the wrong board is worse than refusing."""
@@ -792,3 +827,7 @@ class TestProjectComesFromTheInstanceRegistry(unittest.TestCase):
                 extra_env={"KIPI_INSTANCE_REGISTRY": str(bad)})
             self.assertEqual(rc, 2)
             self.assertIsNone(stub.created)
+
+
+if __name__ == "__main__":
+    unittest.main(verbosity=2)

--- a/q-system/.q-system/scripts/test_spillover_promote_selection.py
+++ b/q-system/.q-system/scripts/test_spillover_promote_selection.py
@@ -719,3 +719,76 @@ class ReadOnlyLockTest(unittest.TestCase):
 
 if __name__ == "__main__":
     unittest.main(verbosity=2)
+
+
+class TestProjectComesFromTheInstanceRegistry(unittest.TestCase):
+    """The THIRD RUNG: instance-registry alias, between env and basename.
+
+    the scar (2026-08-27): this script derived the board project as
+    `KIPI_LINEAR_PROJECT or root.name`. linear-worker.sh has always had a third
+    rung, the instance-registry alias, and the old comment here said replicating
+    it would give one decision two writers. So the rung was simply absent, and
+    every instance whose directory name is not its board name refused every
+    promotion: `refused: no Linear project named 'consulting'` while the board
+    carried 'ASK Consulting' and the registry row carried it too. Three ledger
+    rows (sp-421fa27d, sp-08fae4fc, sp-f227a6fd) described that one gap, and the
+    whole escalation route in no-orphan-findings.md was dead on this instance.
+
+    These tests use a tmpdir root whose basename matches NO project, so the
+    registry rung is the only thing that can make them pass.
+    """
+
+    def _registry(self, root, alias):
+        reg = Path(root) / "registry.json"
+        reg.write_text(json.dumps({
+            "skeleton": {"path": "/nowhere/skeleton",
+                         "linear_project": "skeleton-proj"},
+            "instances": [{"name": "SOME_INSTANCE", "path": str(root),
+                           "linear_project": alias}]}))
+        return {"KIPI_INSTANCE_REGISTRY": str(reg)}
+
+    def test_the_registry_alias_resolves_a_repo_whose_basename_is_not_its_board_name(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            env = self._registry(tmp, "kipi-system")
+            rc, stub, root = run_promote(tmp, repo_project=None, extra_env=env)
+            self.assertEqual(rc, 0, "promotion refused despite a registry alias")
+            self.assertEqual(stub.created["projectId"], PROJECT_IDS["kipi-system"],
+                             "issue filed against the wrong project")
+
+    def test_without_the_registry_row_the_same_promotion_refuses(self):
+        """The negative self-test. Same tmpdir shape, same everything, no row.
+
+        Without this the test above would pass on any change that made the
+        script resolve a project by luck rather than by the alias."""
+        with tempfile.TemporaryDirectory() as tmp:
+            reg = Path(tmp) / "registry.json"
+            reg.write_text(json.dumps({"instances": [
+                {"name": "ELSEWHERE", "path": "/some/other/checkout",
+                 "linear_project": "kipi-system"}]}))
+            rc, stub, _ = run_promote(
+                tmp, repo_project=None,
+                extra_env={"KIPI_INSTANCE_REGISTRY": str(reg)})
+            self.assertEqual(rc, 2, "a checkout with no registry row must refuse")
+            self.assertIsNone(stub.created, "refused run still filed an issue")
+
+    def test_an_explicit_env_override_still_wins_over_the_registry(self):
+        """Rung order, not just rung presence. The env var is the escape hatch
+        people were told to use while this was broken; it must keep working."""
+        with tempfile.TemporaryDirectory() as tmp:
+            env = self._registry(tmp, "not-a-real-project")
+            rc, stub, _ = run_promote(tmp, repo_project="kipi-system",
+                                      extra_env=env)
+            self.assertEqual(rc, 0, "env override did not take precedence")
+            self.assertEqual(stub.created["projectId"], PROJECT_IDS["kipi-system"])
+
+    def test_an_unreadable_registry_falls_through_and_never_invents_a_project(self):
+        """A registry that cannot be read must not become a guess. Filing into
+        the wrong board is worse than refusing."""
+        with tempfile.TemporaryDirectory() as tmp:
+            bad = Path(tmp) / "not-json.json"
+            bad.write_text("{ this is not json")
+            rc, stub, _ = run_promote(
+                tmp, repo_project=None,
+                extra_env={"KIPI_INSTANCE_REGISTRY": str(bad)})
+            self.assertEqual(rc, 2)
+            self.assertIsNone(stub.created)


### PR DESCRIPTION
`spillover-promote.py` derived the Linear project as `KIPI_LINEAR_PROJECT or root.name`. `linear-worker.sh` has always had a **third rung** between those two, the instance-registry alias, and this script did not.

So every instance whose directory name is not its board name refused every promotion:

```
refused: no Linear project named 'consulting'.
```

...while the board carried `ASK Consulting` and the registry row had carried `linear_project: "ASK Consulting"` the whole time.

## Nothing was missing in Linear

Measured against the live board 2026-08-27: 19 projects, no `consulting`, `ASK Consulting` present as `6497f378`. This was never a provisioning gap — the script was asking for the wrong name. Per `_registry_path`'s own measurement, **8 of 25 instances** have a basename that is not their board alias, so this was not one instance being unlucky.

## Why it mattered more than it looks

The entire escalation route in `no-orphan-findings.md` was dead on those instances. A finding could be captured and could never be given an address. That is how a ledger reaches **276 open rows**. Three of those rows (`sp-421fa27d`, `sp-08fae4fc`, `sp-f227a6fd`) are three separate descriptions of this one gap.

## The design question the old comment raised, and the answer

The previous comment said replicating the worker's rule would give one decision two writers and they would drift. That was correct, so this **imports** the decision instead of copying it: `_linear_project_of` in `alert-to-linear.py` still owns the precedence (explicit `linear_project`, then `name`) and stays the only place that rule is written. What lives here is the path match, which is mechanics.

A registry that cannot be read returns `""` and the derivation falls through to the basename exactly as before. A registry failure must not become an invented project name — filing into the wrong board is worse than refusing.

The refusal now prints every rung it tried and what each returned, so the next person hits a diagnosis instead of a dead end.

## Evidence

Four tests, and **only the first discriminates**. Against the pre-fix script it fails with the real production message (`no Linear project named 'tmpd_reeuix'` — the basename fallback). The other three assert refusal and precedence behaviour that was already correct and pass either way, which is the honest split rather than a claim that all four are regression coverage.

```
19 passed   (15 pre-existing + 4)
```

Proven end to end on a **real item, not a fixture**:

```
{"finding": "sp-25c5fa20", "linear": "ASK-1077", "status": "promoted"}
```

`ASK-1077` reads back from Linear as project `ASK Consulting`, labels `['owner:sana']`, state `Backlog` — both halves `linear-worker.sh` `ready()` and `in_this_repo()` require, so the issue is selectable and not merely created.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01BqDQzSHEhzazNQBdNJbZtw
