### PR TITLE
fix(floor): print every failure line, not the last 30

### DIFF
--- a/q-system/.q-system/verify.sh
+++ b/q-system/.q-system/verify.sh
@@ -159,6 +159,34 @@ run_check() {
   else
     FAILED+=("$name")
     say "$name" "FAILED"
+    # EVERY failure line, THEN the tail for context.
+    #
+    # the scar (2026-08-27): this was `| tail -30` alone. A run with 50 failures
+    # printed the last 30 lines of pytest output, which held 12 of the 50 FAILED
+    # lines, and the other 38 were invisible EVERYWHERE -- the job log, the raw
+    # API log, `gh run view --log` all only ever contain what this line emitted.
+    # I spent three rounds fixing the instances visible in a 12-of-50 sample,
+    # which is precisely the fix-the-instance-not-the-class failure the reviewer
+    # caught on this same PR three times.
+    #
+    # A gate that hides most of what it found is a gate you cannot act on. The
+    # summary lines are the diagnosis, so they are never truncated silently: if
+    # the cap is hit, the count of what was dropped is PRINTED, so the output can
+    # never imply it was complete when it was not.
+    _sum="$(grep -E '^(FAILED|ERROR) ' /tmp/verify-$$-out || true)"
+    if [ -n "$_sum" ]; then
+      _n=$(printf '%s\n' "$_sum" | wc -l | tr -d ' ')
+      printf '%s\n' "$_sum" | head -200 | sed 's/^/      /'
+      # `if`, NOT `[ ... ] && echo`. Under `set -e` a bare test that evaluates
+      # FALSE returns 1 and kills the script mid-check -- which is exactly what
+      # the first version of this block did, silently, before `say` could even
+      # print the failure. Caught by running it against a repo with 40 failing
+      # tests and watching verify.sh stop after "shell syntax ok".
+      if [ "$_n" -gt 200 ]; then
+        echo "      ... and $((_n - 200)) more failure lines (capped)"
+      fi
+      echo "      ---- tail of the run ----"
+    fi
     sed 's/^/      /' /tmp/verify-$$-out | tail -30
   fi
   rm -f /tmp/verify-$$-out


### PR DESCRIPTION
`run_check` ended in `| tail -30`. On a run with 50 failures that printed the last 30 **lines** of pytest output, which held **12 of the 50** `FAILED` lines.

The other 38 were invisible **everywhere**: the job log, `gh run view --log`, and `gh api .../jobs/{id}/logs` all only ever contain what this line emitted. I pulled all three and got the same 12. There was no rawer source to fall back to.

Working from a 12-of-50 sample is how you fix the instance instead of the class — the exact failure the reviewer caught on #259 three times. It cost a wasted round on ASK-1094: I fixed the visible instances, and the next CI run surfaced three **new** failures my own fix had moved.

## Evidence

Against a repo with 40 deliberately failing tests:

```
OLD verify.sh shows 29 lines   (fewer than the 40 real failures)
NEW verify.sh shows 69 lines   (all 40 summary lines + tail context)
```

The summary lines are the diagnosis, so they are no longer truncated silently. If the 200-line cap is hit, the number dropped is **printed**, so the output can never imply completeness it does not have.

## A bug I introduced and caught

The first version used `[ "$_n" -gt 200 ] && echo ...`. Under `set -e` a bare test evaluating false returns 1 and killed the script **mid-check**, before `say` could print the failure — verify.sh stopped after `shell syntax ok` and exited 1 with no diagnosis at all. Strictly worse than the truncation it replaced. Now an `if`.

**The adversarial suite reported 16/16 throughout that bug.** That is a real gap: no case runs a suite that fails with a summary, so nothing exercised this code path. Recorded rather than papered over.

Adversarial: `16 passed, 0 failed`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01BqDQzSHEhzazNQBdNJbZtw