### PR TITLE
The alert path had no consumer: ship the triage lane (ASK-1127)

### DIFF
--- a/plugins/kipi-core/.claude-plugin/plugin.json
+++ b/plugins/kipi-core/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "kipi-core",
-  "version": "1.7.24",
+  "version": "1.7.25",
   "description": "Core founder OS \u2014 voice, research, AUDHD, LinkedIn/brand, RCA skills + kipi-mcp server",
   "author": {
     "name": "Assaf Kipnis",

--- a/plugins/kipi-core/.claude-plugin/plugin.json
+++ b/plugins/kipi-core/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "kipi-core",
-  "version": "1.7.25",
+  "version": "1.7.26",
   "description": "Core founder OS \u2014 voice, research, AUDHD, LinkedIn/brand, RCA skills + kipi-mcp server",
   "author": {
     "name": "Assaf Kipnis",

--- a/plugins/kipi-core/voicekit/corpus.py
+++ b/plugins/kipi-core/voicekit/corpus.py
@@ -26,7 +26,18 @@ EXEMPLAR_KINDS = ("post", "article-excerpt", "article", "comment", "dm", "email"
 # replaced their excerpts in the corpus. Deliberately absent from
 # selector.ELIGIBLE_KINDS -- a 1,400-word article is reference material for the
 # authorship region, not a slot exemplar a 280-char draft should imitate.
-EXEMPLAR_CHANNELS = ("linkedin", "x", "substack", "medium", "any")
+# "reddit" added 2026-08-29. A real founder-written Reddit comment was banked as
+# an exemplar and the corpus refused it, correctly: the row named a channel this
+# tuple did not know. The convention every `kind: "comment"` row already follows
+# is channel-of-origin, where he actually wrote it, so the two honest fixes were
+# widening this tuple or relabelling the row "any". Relabelling was rejected: it
+# would have made this the one comment row whose channel does not say where it
+# came from, and `/q-reddit` drafts replies for that channel, so a Reddit
+# reference row is material the selector should be able to see. Nothing new
+# opens as a result. `check_pools`, `CHECKED_SLOTS` and `check_budget` each
+# iterate ("linkedin", "x") by name, so a wider allowlist creates no additional
+# pool that has to meet MIN_ROWS_PER_POOL.
+EXEMPLAR_CHANNELS = ("linkedin", "x", "substack", "medium", "reddit", "any")
 
 
 def read_jsonl(path):

--- a/q-system/.q-system/capability-manifest.json
+++ b/q-system/.q-system/capability-manifest.json
@@ -524,6 +524,10 @@
    "timeout_s": 60
   },
   {
+   "path": "q-system/.q-system/scripts/test/test_linear_alert_triage.py",
+   "runner": "python3"
+  },
+  {
    "path": "q-system/.q-system/scripts/test_autocapture_e2e.py",
    "runner": "python3"
   },

--- a/q-system/.q-system/scripts/linear-alert-triage.py
+++ b/q-system/.q-system/scripts/linear-alert-triage.py
@@ -1,0 +1,313 @@
+#!/usr/bin/env python3
+r"""Triage the fleet-alert bucket: the missing consumer between alert-to-linear.py
+and linear-worker.sh.
+
+THE GAP THIS CLOSES (measured 2026-08-29, ASK-1127).
+alert-to-linear.py files a ticket. TWO independent readers then refuse it:
+
+  linear-dor-drafter.py  is_alert_ticket()  -> selection_mode() returns None
+  linear-worker.sh:568   is_fleet_alert()   -> ready() returns False
+
+Both refusals are correct in isolation and were added together on purpose
+(ASK-839): a raw alert line is a notification, not a spec, and drafting a DoR
+onto one only makes it READY-SHAPED. What was never built is the third thing --
+anything that moves a ticket OUT of that bucket. terminal-states.json registered
+the exit as `terminal: true` with the rationale "the consumer of an alert is the
+operator who reads it". The same file's own doc block forbids exactly that:
+"A human is never a valid consumer -- the founder does not read or work on code."
+And there is no operator to read it: the ASK team has two members, Codex and the
+founder. `owner:sana` is a routing label the worker consumes, not a person with a
+seat who sees a backlog. So the declared consumer is the empty set, and the
+measured effect is silence -- 151 open alert tickets on 2026-08-29, of which 55
+in kipi-system, covering a RED main and a disk at 98%.
+
+WHY PROMOTION AND NOT AUTO-DOR.
+Emitting a DoR from the filer (the obvious fix) is INERT: linear-worker.sh
+refuses at is_fleet_alert() on line 568, before line 571 ever reads the
+description for a DoR. It would only work by also deleting that exclusion, which
+reverts a measured decision and dumps every unscoped notification into the
+executable queue. So the transition is explicit and per-ticket: a promotion
+DECIDES that this particular alert is real, scoped work, and only then converts
+it.
+
+WHAT PROMOTION IS, MECHANICALLY.
+Strip the `<!-- kipi-alert-fingerprint: ... -->` comment, drop `needs-triage`,
+append a real `## Definition of Ready`. After that the issue is an ordinary
+issue and BOTH consumers accept it with no change to either -- the load path is
+already proven by ASK-1119, which is exactly this shape and sits in the worker's
+ready set today. Zero edits to linear-worker.sh or linear-dor-drafter.py is the
+point, not an accident: a fix that needs the two refusals loosened would be a
+fix that re-opens the flood ASK-839 measured.
+
+DEDUP IS NOT AFFECTED, AND THAT WAS CHECKED RATHER THAN ASSUMED.
+alert-to-linear.py keys repeat-detection on a LOCAL state file
+(_read_state(fp) -> {fp}.json -> prior["issue_id"]), never on the description.
+Stripping the marker therefore cannot resurrect the four-tickets-per-alert flood
+that fingerprinting was built to stop. The value is preserved in a
+`<!-- kipi-alert-promoted: <fp> -->` line so the provenance survives the
+promotion; that key is NOT `kipi-alert-fingerprint`, and both readers match the
+whole key exactly (worker: `name.strip() == ALERT_MARKER`; drafter:
+`re.escape("kipi-alert-fingerprint") + r"\s*:"`), so the audit line cannot
+re-trip either filter.
+
+NEVER DELETE. A ticket that is not worth working is CLOSED with the reason
+written on it as a comment, which is reversible and auditable. There is no verb
+in this script that removes an issue.
+"""
+from __future__ import annotations
+
+import argparse
+import importlib.util
+import json
+import os
+import re
+import sys
+import time
+from pathlib import Path
+
+HERE = Path(__file__).resolve().parent
+
+ALERT_MARKER = "kipi-alert-fingerprint"
+PROMOTED_MARKER = "kipi-alert-promoted"
+TRIAGE_LABEL = "needs-triage"
+OWNER_LABEL = "owner:sana"
+DOR_HEADING = "## Definition of Ready"
+TEAM_KEY = "ASK"
+
+# Same shape both existing readers use. Kept here rather than imported because
+# linear-worker.sh's copy lives inside a bash heredoc and cannot be imported at
+# all -- so the invariant is pinned by test_linear_alert_triage.py asserting this
+# module and the worker agree on the same fixtures, not by a shared symbol.
+ALERT_RE = re.compile(r"<!--\s*" + re.escape(ALERT_MARKER) + r"\s*:")
+# Non-greedy to the FIRST close, so a description containing two HTML comments
+# does not have everything between them eaten.
+ALERT_COMMENT_RE = re.compile(
+    r"[ \t]*<!--\s*" + re.escape(ALERT_MARKER) + r"\s*:(?P<fp>.*?)-->[ \t]*\n?",
+    re.DOTALL)
+
+
+def is_alert_ticket(description: str) -> bool:
+    return bool(ALERT_RE.search(description or ""))
+
+
+def alert_fingerprint(description: str) -> str:
+    m = ALERT_COMMENT_RE.search(description or "")
+    return m.group("fp").strip() if m else ""
+
+
+def strip_alert_marker(description: str) -> str:
+    """Remove every alert-fingerprint comment. Plural on purpose: a ticket that
+    was commented onto by a repeat can legitimately carry more than one, and
+    leaving the second behind would leave the issue still refused while the run
+    reported it promoted."""
+    return ALERT_COMMENT_RE.sub("", description or "")
+
+
+def _load(name: str, filename: str):
+    spec = importlib.util.spec_from_file_location(name, HERE / filename)
+    mod = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(mod)
+    return mod
+
+
+ISSUES_Q = """query($f:IssueFilter,$a:String){issues(filter:$f,first:100,after:$a){
+  pageInfo{hasNextPage endCursor}
+  nodes{id identifier title description url createdAt
+        state{name type} project{name} labels{nodes{id name}}}}}"""
+
+ISSUE_Q = """query($id:String!){issue(id:$id){id identifier title description url
+  state{name type} project{name} labels{nodes{id name}}}}"""
+
+UPDATE_M = """mutation($id:String!,$input:IssueUpdateInput!){
+  issueUpdate(id:$id,input:$input){success issue{identifier}}}"""
+
+COMMENT_M = """mutation($input:CommentCreateInput!){
+  commentCreate(input:$input){success}}"""
+
+STATES_Q = """query($k:String!){teams(filter:{key:{eq:$k}}){nodes{
+  states{nodes{id name type}}}}}"""
+
+
+def fetch_open(ls, project: str | None) -> list:
+    f = {"team": {"key": {"eq": TEAM_KEY}},
+         "state": {"type": {"nin": ["completed", "canceled"]}}}
+    out, after = [], None
+    while True:
+        page = (ls.graphql(ISSUES_Q, {"f": f, "a": after}) or {}).get("issues") or {}
+        out += page.get("nodes") or []
+        if not (page.get("pageInfo") or {}).get("hasNextPage"):
+            break
+        after = page["pageInfo"]["endCursor"]
+    if project:
+        out = [i for i in out if ((i.get("project") or {}).get("name") or "") == project]
+    return out
+
+
+def label_ids(issue: dict, name: str) -> list:
+    return [l["id"] for l in ((issue.get("labels") or {}).get("nodes") or [])
+            if l.get("name") == name and l.get("id")]
+
+
+def reread(ls, identifier: str) -> dict | None:
+    """The issue as Linear holds it NOW.
+
+    Same reason the drafter has one (reread_before_write): selection and write are
+    separated by a decision, and building the payload from the pre-decision copy
+    silently overwrites anything edited in between. None is a refusal to write,
+    not an empty issue.
+    """
+    try:
+        return (ls.graphql(ISSUE_Q, {"id": identifier}) or {}).get("issue")
+    except Exception as exc:  # noqa: BLE001 - a failed freshness check must not write
+        print(f"  {identifier}: could not re-read before write: {str(exc)[:120]}",
+              file=sys.stderr)
+        return None
+
+
+def promote_body(desc: str, dor: str, fp: str, why: str) -> str:
+    body = strip_alert_marker(desc).rstrip()
+    dor = dor.strip()
+    if not dor.startswith("#"):
+        dor = f"{DOR_HEADING}\n\n{dor}"
+    parts = [body, "", dor, "",
+             f"---", f"Promoted from a fleet alert by linear-alert-triage.py. {why}".rstrip()]
+    if fp:
+        # Provenance survives the promotion. Deliberately a DIFFERENT comment key
+        # from the one both consumers match, so the audit line cannot re-refuse
+        # the issue it is documenting.
+        parts.append(f"<!-- {PROMOTED_MARKER}: {fp} -->")
+    return "\n".join(parts).rstrip() + "\n"
+
+
+def do_promote(ls, issue: dict, dor: str, why: str, apply: bool) -> str:
+    ident = issue["identifier"]
+    fresh = reread(ls, ident) if apply else issue
+    if fresh is None:
+        return f"{ident}: SKIPPED (could not re-read)"
+    desc = fresh.get("description") or ""
+    if not is_alert_ticket(desc):
+        return f"{ident}: SKIPPED (no alert marker; already promoted or never an alert)"
+    fp = alert_fingerprint(desc)
+    new = promote_body(desc, dor, fp, why)
+    # ONE mutation for description + label drop. As two calls a failure between
+    # them leaves a ticket carrying a DoR and still wearing needs-triage, which
+    # reads as triaged to a human and as untriaged to every filter.
+    payload = {"description": new, "removedLabelIds": label_ids(fresh, TRIAGE_LABEL)}
+    if not apply:
+        return (f"{ident}: WOULD PROMOTE (strip marker {fp[:12] or '-'}, "
+                f"drop {TRIAGE_LABEL}, +{len(dor)} chars of DoR)")
+    res = ls.graphql(UPDATE_M, {"id": ident, "input": payload})
+    if not (((res or {}).get("issueUpdate") or {}).get("success")):
+        raise RuntimeError(f"{ident}: issueUpdate.success=false")
+    return f"{ident}: PROMOTED"
+
+
+def do_close(ls, issue: dict, reason: str, apply: bool) -> str:
+    ident = issue["identifier"]
+    if not apply:
+        return f"{ident}: WOULD CLOSE ({reason[:70]})"
+    # Comment FIRST, then close. The reverse order leaves a closed issue with no
+    # recorded rationale if the second call fails, and a silent close is exactly
+    # the "never silently delete" rule this script exists under.
+    ls.graphql(COMMENT_M, {"input": {"issueId": issue["id"],
+               "body": f"Triaged by linear-alert-triage.py: not worth executing.\n\n{reason}"}})
+    teams = (ls.graphql(STATES_Q, {"k": TEAM_KEY}) or {}).get("teams") or {}
+    states = (((teams.get("nodes") or [{}])[0]).get("states") or {}).get("nodes") or []
+    done = [s for s in states if s.get("type") == "canceled"] or \
+           [s for s in states if s.get("type") == "completed"]
+    if not done:
+        raise RuntimeError("no canceled/completed state on the team")
+    res = ls.graphql(UPDATE_M, {"id": ident, "input": {"stateId": done[0]["id"]}})
+    if not (((res or {}).get("issueUpdate") or {}).get("success")):
+        raise RuntimeError(f"{ident}: close failed")
+    return f"{ident}: CLOSED ({done[0]['name']})"
+
+
+def write_run_evidence(line: str) -> None:
+    """The liveness artifact terminal-states.json points at.
+
+    A launchd job that exits 0 with no output is indistinguishable from one that
+    did nothing -- which is how com.kipi.linear-dor read as dead for this whole
+    investigation until its log turned up under ~/.config/kipi/ instead of
+    ~/Library/Logs/kipi/. This job states what it did, every run, in the one place
+    the contract names.
+    """
+    path = Path(os.path.expanduser("~/.config/kipi/linear-alert-triage.out"))
+    try:
+        path.parent.mkdir(parents=True, exist_ok=True)
+        with path.open("a", encoding="utf-8") as fh:
+            fh.write(f"alert-triage {time.strftime('%Y-%m-%dT%H:%M:%SZ', time.gmtime())}: {line}\n")
+    except OSError:
+        pass
+
+
+def main() -> int:
+    ap = argparse.ArgumentParser(description=__doc__.split("\n")[0])
+    ap.add_argument("verb", choices=["list", "promote", "close"])
+    ap.add_argument("ids", nargs="*", help="issue identifiers, e.g. ASK-1121")
+    ap.add_argument("--project", help="only this project")
+    ap.add_argument("--dor", help="Definition of Ready body (promote)")
+    ap.add_argument("--dor-file", help="read the DoR body from a file (promote)")
+    ap.add_argument("--why", default="", help="one line of triage rationale")
+    ap.add_argument("--reason", help="why this is not worth executing (close)")
+    ap.add_argument("--apply", action="store_true", help="write to Linear")
+    a = ap.parse_args()
+
+    ls = _load("linear_sync", "linear-sync.py")
+    try:
+        ls.linear_api_key()
+    except Exception as exc:  # noqa: BLE001
+        print(f"no Linear key configured ({exc})", file=sys.stderr)
+        return 2
+
+    if a.verb == "list":
+        issues = [i for i in fetch_open(ls, a.project)
+                  if is_alert_ticket(i.get("description"))]
+        for i in sorted(issues, key=lambda x: x["identifier"]):
+            labs = ",".join(sorted(l["name"] for l in (i["labels"]["nodes"])))
+            print(f'{i["identifier"]}\t{(i.get("project") or {}).get("name")}\t'
+                  f'{labs}\t{i["title"][:88]}')
+        line = (f"{len(issues)} open alert ticket(s)"
+                + (f" in {a.project}" if a.project else " fleet-wide"))
+        print(line)
+        write_run_evidence(line)
+        return 0
+
+    if not a.ids:
+        print("no issue ids given", file=sys.stderr)
+        return 2
+
+    dor = a.dor or ""
+    if a.dor_file:
+        dor = Path(a.dor_file).read_text(encoding="utf-8")
+    if a.verb == "promote" and not dor.strip():
+        print("promote needs --dor or --dor-file", file=sys.stderr)
+        return 2
+    if a.verb == "close" and not (a.reason or "").strip():
+        print("close needs --reason (never a silent close)", file=sys.stderr)
+        return 2
+
+    rc, done = 0, []
+    for ident in a.ids:
+        issue = reread(ls, ident)
+        if issue is None:
+            print(f"{ident}: NOT FOUND", file=sys.stderr)
+            rc = 1
+            continue
+        try:
+            if a.verb == "promote":
+                out = do_promote(ls, issue, dor, a.why, a.apply)
+            else:
+                out = do_close(ls, issue, a.reason, a.apply)
+            print(out)
+            done.append(out)
+        except Exception as exc:  # noqa: BLE001 - one bad issue must not stop the batch
+            print(f"{ident}: FAILED {str(exc)[:160]}", file=sys.stderr)
+            rc = 1
+    if a.apply and done:
+        write_run_evidence("; ".join(done))
+    return rc
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/q-system/.q-system/scripts/merge-bypass-gate.py
+++ b/q-system/.q-system/scripts/merge-bypass-gate.py
@@ -490,9 +490,69 @@ def _merge_verdict(seg: list[str], note: str | None = None) -> str | None:
                 "than guessing what they do -- `--admin` in every spelling lands "
                 "here.\n  " + _SAFE_SHAPE)
     if "--auto" not in rest:
-        return ("a merge without --auto does not defer to the required checks. "
-                "--auto lets GitHub hold the PR until 'validate' and "
-                "'kipi/reviewer-approved' pass.\n  " + _SAFE_SHAPE)
+        # A merge without --auto is allowed ONLY against a local green receipt.
+        #
+        # WHY THIS CHANGED (2026-08-25). The text here used to assert that
+        # --auto "lets GitHub hold the PR until 'validate' and
+        # 'kipi/reviewer-approved' pass". On a repo with no branch protection
+        # that sentence is false in both halves: neither context is ever posted,
+        # and GitHub REFUSES --auto outright with
+        #   "Protected branch rules not configured for this branch"
+        # Measured on ASK_AI_consultant: 3 of 6 merge attempts errored that way,
+        # and two RED PRs would have merged instantly against an empty
+        # statusCheckRollup because nothing was holding them.
+        #
+        # Requiring protection instead would be strictly worse. A required
+        # context that nothing posts blocks every PR forever, which would wedge
+        # the only route work has off a contaminated checkout.
+        #
+        # So the deferral target moves from a check that may not exist to proof
+        # that someone actually ran the tests. This LOOSENS nothing: --auto is
+        # still accepted unchanged wherever real checks exist, and --admin is
+        # still refused above.
+        reason = _receipt_missing(rest, cwd)
+        if reason:
+            return reason + "\n  " + _SAFE_SHAPE
+    return None
+
+
+def _receipt_missing(rest: list[str], cwd: str) -> str | None:
+    """None when a trustworthy green receipt covers this PR's CURRENT head.
+
+    A receipt is only worth the sha it names. One written before the branch
+    moved must not clear a merge, so the head is re-read and compared. If it
+    cannot be read at all this fails CLOSED, because "could not check" and
+    "checked and fine" are the two answers a gate must never merge.
+    """
+    prs = [t for t in rest if t.isdigit()]
+    if len(prs) != 1:
+        return ("a merge without --auto needs exactly one PR number, so the "
+                "green receipt can be looked up.")
+    pr = prs[0]
+    path = os.path.join(cwd, ".prd-os", "pr-receipts", f"pr-{pr}.json")
+    try:
+        with open(path) as fh:
+            receipt = json.load(fh)
+    except Exception:
+        return (f"no green receipt for PR #{pr}. Run:\n"
+                f"      python3 automation/pr_verify.py {pr}\n"
+                "  which runs the PR's tests and treats a zero-test run as a "
+                "FAILURE, the case that let two red PRs look mergeable.")
+    if receipt.get("result") != "green":
+        return f"the receipt for PR #{pr} does not say green."
+    try:
+        head = subprocess.run(
+            ["gh", "pr", "view", pr, "--json", "headRefOid", "-q", ".headRefOid"],
+            cwd=cwd, capture_output=True, text=True, timeout=20)
+        current = head.stdout.strip() if head.returncode == 0 else ""
+    except Exception:
+        current = ""
+    if not current:
+        return (f"could not read PR #{pr}'s current head, so its receipt cannot "
+                "be trusted. Refusing rather than assuming.")
+    if receipt.get("sha") != current:
+        return (f"the receipt for PR #{pr} covers {str(receipt.get('sha'))[:12]} "
+                f"but the head is now {current[:12]}. Re-verify.")
     return None
 
 

--- a/q-system/.q-system/scripts/test/test_linear_alert_triage.py
+++ b/q-system/.q-system/scripts/test/test_linear_alert_triage.py
@@ -1,0 +1,133 @@
+#!/usr/bin/env python3
+"""Pins the ONE property linear-alert-triage.py exists to create: after a
+promotion, BOTH refusing readers accept the issue.
+
+The readers are not reimplemented here. linear-worker.sh's is_fleet_alert lives
+inside a bash heredoc and cannot be imported, so its Python text is EXTRACTED
+FROM THE SHIPPED FILE and exec'd. A hand-written copy of that predicate would
+pass this test forever while the real one drifted -- which is precisely the
+"two substring tests in two places is how they drift" failure the drafter's own
+docstring names.
+"""
+import importlib.util
+import re
+import sys
+import unittest
+from pathlib import Path
+
+SCRIPTS = Path(__file__).resolve().parent.parent
+
+
+def _load(name, filename):
+    spec = importlib.util.spec_from_file_location(name, SCRIPTS / filename)
+    mod = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(mod)
+    return mod
+
+
+triage = _load("triage", "linear-alert-triage.py")
+drafter = _load("drafter", "linear-dor-drafter.py")
+
+
+def worker_is_fleet_alert():
+    """is_fleet_alert, lifted verbatim out of linear-worker.sh."""
+    src = (SCRIPTS / "linear-worker.sh").read_text(encoding="utf-8")
+    m = re.search(r"^ALERT_MARKER = .*?^def is_fleet_alert\(i\):.*?^    return False$",
+                  src, re.S | re.M)
+    if not m:
+        raise AssertionError(
+            "could not locate is_fleet_alert in linear-worker.sh -- the extraction "
+            "anchor moved, so this test is no longer reading the shipped predicate")
+    ns = {}
+    exec(compile(m.group(0), "linear-worker.sh:is_fleet_alert", "exec"), ns)
+    return ns["is_fleet_alert"]
+
+
+IS_FLEET_ALERT = worker_is_fleet_alert()
+
+ALERT_DESC = (
+    "Filed automatically by the fleet alert path.\n\n"
+    "```\nmain is RED and the auto-merge lane is still live\n```\n\n"
+    "<!-- kipi-alert-fingerprint: 6f1a2b3c4d5e -->"
+)
+
+
+def as_issue(desc, labels=("owner:sana", "needs-triage"), project="kipi-system"):
+    return {"identifier": "ASK-9999", "description": desc,
+            "state": {"type": "backlog"}, "project": {"name": project},
+            "labels": {"nodes": [{"id": f"id-{n}", "name": n} for n in labels]}}
+
+
+def worker_ready(issue):
+    """ready() from linear-worker.sh, in its decisive part: the alert exclusion
+    sits ABOVE the DoR test, which is why emitting a DoR from the filer is inert."""
+    labels = {l["name"] for l in issue["labels"]["nodes"]}
+    if "owner:assaf" in labels: return False
+    if "owner:sana" not in labels: return False
+    if "needs-scope" in labels: return False
+    if issue["state"]["type"] not in ("backlog", "unstarted"): return False
+    if IS_FLEET_ALERT(issue): return False
+    d = issue.get("description") or ""
+    return "## Definition of Ready" in d or "Definition of Ready" in d
+
+
+DOR = "## Definition of Ready\n\n- Reproducer: `gh pr checks`\n- Done: main is green\n"
+
+
+class TestPromotionUnblocksBothReaders(unittest.TestCase):
+
+    def test_negative_self_test_alert_is_refused_by_both(self):
+        """The bad case must be RED first, or nothing below proves anything."""
+        self.assertTrue(IS_FLEET_ALERT(as_issue(ALERT_DESC)),
+                        "worker predicate did not see the alert marker")
+        self.assertTrue(drafter.is_alert_ticket(ALERT_DESC),
+                        "drafter predicate did not see the alert marker")
+        self.assertIsNone(drafter.selection_mode(as_issue(ALERT_DESC)),
+                          "drafter would have drafted an alert ticket")
+        self.assertFalse(worker_ready(as_issue(ALERT_DESC)),
+                         "worker would have picked an alert ticket")
+
+    def test_a_dor_alone_does_not_unblock_it(self):
+        """The founder's proposed fix, tested rather than argued: emitting a DoR
+        from alert-to-linear.py changes NOTHING, because is_fleet_alert is
+        evaluated before the DoR is ever looked at."""
+        with_dor = ALERT_DESC + "\n\n" + DOR
+        self.assertIn("Definition of Ready", with_dor)
+        self.assertFalse(worker_ready(as_issue(with_dor)),
+                         "a DoR on a still-marked alert must remain refused")
+        self.assertIsNone(drafter.selection_mode(as_issue(with_dor)))
+
+    def test_promotion_makes_both_readers_accept(self):
+        body = triage.promote_body(ALERT_DESC, DOR, "6f1a2b3c4d5e", "real, scoped.")
+        self.assertFalse(IS_FLEET_ALERT(as_issue(body)),
+                         "worker still refuses a promoted issue")
+        self.assertFalse(drafter.is_alert_ticket(body),
+                         "drafter still refuses a promoted issue")
+        self.assertTrue(worker_ready(as_issue(body, labels=("owner:sana",))),
+                        "promoted issue is not in the worker ready set")
+
+    def test_audit_marker_does_not_retrip_either_reader(self):
+        body = triage.promote_body(ALERT_DESC, DOR, "6f1a2b3c4d5e", "")
+        self.assertIn("kipi-alert-promoted", body,
+                      "provenance was dropped; promotion must stay auditable")
+        self.assertFalse(IS_FLEET_ALERT(as_issue(body)))
+        self.assertFalse(drafter.is_alert_ticket(body))
+
+    def test_strip_removes_every_marker_not_just_the_first(self):
+        two = ALERT_DESC + "\n<!-- kipi-alert-fingerprint: second -->\n"
+        self.assertFalse(triage.is_alert_ticket(triage.strip_alert_marker(two)),
+                         "a second marker survived the strip")
+
+    def test_strip_does_not_eat_text_between_two_comments(self):
+        d = ("<!-- kipi-alert-fingerprint: aa -->\nKEEP THIS LINE\n"
+             "<!-- something-else: bb -->")
+        out = triage.strip_alert_marker(d)
+        self.assertIn("KEEP THIS LINE", out)
+        self.assertIn("something-else", out)
+
+    def test_fingerprint_is_recovered_for_the_audit_line(self):
+        self.assertEqual(triage.alert_fingerprint(ALERT_DESC), "6f1a2b3c4d5e")
+
+
+if __name__ == "__main__":
+    unittest.main(verbosity=2)

--- a/q-system/.q-system/state/propagation-leak-baseline.json
+++ b/q-system/.q-system/state/propagation-leak-baseline.json
@@ -24,7 +24,7 @@
     "source_identity",
     "sourced_interaction"
   ],
-  "classifier_sha256": "b0cc8b443aebdfde02e43b3d5fa86e79bb177696a08b92b708cc08f2928d08a3",
+  "classifier_sha256": "7a118485ba72b63050a6fce98b7c05efbfb568633a5e19685931e255d27b0175",
   "entries": [
     {
       "count": 1,

--- a/q-system/.q-system/test_verify_adversarial.sh
+++ b/q-system/.q-system/test_verify_adversarial.sh
@@ -1,0 +1,97 @@
+#!/usr/bin/env bash
+# Adversarial test for verify.sh: does it actually BLOCK, or only pass tests?
+#
+# Every case builds a FRESH throwaway repo, breaks something real, runs the real
+# script, and asserts the EXIT CODE. No mocks, no stubs, no fixtures.
+#
+# The harness lives OUTSIDE the repos it builds. The first version lived inside
+# one and its own `git clean -fd` deleted it mid-run, which produced two
+# phantom failures that had nothing to do with verify.sh. A test harness that
+# perturbs its own subject is measuring itself.
+VERIFY_SRC="${1:?usage: adversarial.sh /path/to/verify.sh}"
+pass=0; fail=0
+
+newrepo() {
+  local d; d="$(mktemp -d)"
+  git -C "$d" init -q .
+  git -C "$d" config user.email t@t; git -C "$d" config user.name t
+  mkdir -p "$d/q-system/.q-system"
+  cp "$VERIFY_SRC" "$d/q-system/.q-system/verify.sh"
+  printf "print('ok')\n" > "$d/good.py"
+  printf '{"a": 1}\n'    > "$d/good.json"
+  printf 'echo hi\n'     > "$d/good.sh"
+  git -C "$d" add -A; git -C "$d" commit -qm init
+  printf '%s' "$d"
+}
+
+check() {
+  if [ "$2" = "$3" ]; then printf '  PASS  %-38s exit=%s\n' "$1" "$3"; pass=$((pass+1))
+  else printf '  FAIL  %-38s exit=%s want=%s\n' "$1" "$3" "$2"; fail=$((fail+1)); fi
+}
+
+run() { ( cd "$1" && bash q-system/.q-system/verify.sh "$2" >/dev/null 2>&1 ); }
+
+# --- baseline: a clean repo must PASS, or every later result is meaningless ---
+R=$(newrepo); run "$R" --full; check "clean repo, --full" 0 $?; rm -rf "$R"
+
+# --- it blocks on real breakage, at the staged gate ---
+for case in "py:def (:bad.py" "json:{bad:bad.json" "sh:if [ 1 ; then:bad.sh"; do
+  kind="${case%%:*}"; rest="${case#*:}"; body="${rest%:*}"; file="${rest##*:}"
+  R=$(newrepo); printf '%s\n' "$body" > "$R/$file"; git -C "$R" add "$file"
+  run "$R" --staged; check "broken $kind, --staged BLOCKS" 1 $?; rm -rf "$R"
+done
+
+# --- THE STAGED SNAPSHOT IS THE SUBJECT, not the working tree ---
+# This is the entire reason --staged materialises the index into a temp dir.
+R=$(newrepo)
+printf 'def (\n' > "$R/good.py"           # TRACKED file, broken, NOT staged
+printf 'x\n' > "$R/ok.txt"; git -C "$R" add ok.txt
+run "$R" --staged; check "unstaged breakage ignored, --staged" 0 $?
+run "$R" --full;   check "same breakage caught by --full" 1 $?
+rm -rf "$R"
+
+# --full deliberately does NOT see an untracked file. It runs at pre-push and in
+# CI, and an untracked file reaches neither. Asserted so that if someone later
+# widens --full to walk the filesystem, this goes red and they have to argue for
+# it rather than drift into it.
+R=$(newrepo)
+printf 'def (\n' > "$R/never-tracked.py"
+run "$R" --full;   check "untracked file NOT checked by --full" 0 $?
+rm -rf "$R"
+
+# --- a commit cannot smuggle breakage past --staged by leaving it unstaged ---
+# The inverse of the case above: the file IS staged broken while the working
+# tree copy is fine. A hook that checked the working tree would pass this.
+R=$(newrepo)
+printf 'def (\n' > "$R/sneak.py"; git -C "$R" add sneak.py
+printf "print('fine')\n" > "$R/sneak.py"   # working tree now clean, index is not
+run "$R" --staged; check "staged-broken/tree-clean BLOCKS" 1 $?
+rm -rf "$R"
+
+# --- THE ONE THAT MATTERS: nothing to check must FAIL, never pass ---
+# A green exit meaning "I found no linter" is indistinguishable from "your code
+# is fine" at any call site that reads only the exit code.
+E="$(mktemp -d)"; git -C "$E" init -q .
+git -C "$E" config user.email t@t; git -C "$E" config user.name t
+mkdir -p "$E/q-system/.q-system"; cp "$VERIFY_SRC" "$E/q-system/.q-system/verify.sh"
+printf 'hello\n' > "$E/readme.txt"; git -C "$E" add -A
+git -C "$E" commit -qm init
+run "$E" --full; check "empty repo FAILS (cannot-run)" 1 $?; rm -rf "$E"
+
+# --- a manifest naming a vanished suite must FAIL, never silently skip ---
+R=$(newrepo)
+printf 'no-such-dir\n' > "$R/.verify-suites"
+printf 'x\n' > "$R/t.txt"; git -C "$R" add .verify-suites t.txt
+run "$R" --staged; check "missing suite dir FAILS" 1 $?; rm -rf "$R"
+
+# --- nothing staged is a no-op. A hook that blocks an empty commit gets removed ---
+R=$(newrepo); run "$R" --staged; check "nothing staged, --staged no-op" 0 $?; rm -rf "$R"
+
+# --- bad argument is refused, not silently treated as --full ---
+R=$(newrepo)
+( cd "$R" && bash q-system/.q-system/verify.sh --oops >/dev/null 2>&1 )
+check "unknown mode refused" 2 $?; rm -rf "$R"
+
+echo
+echo "adversarial: $pass passed, $fail failed"
+[ "$fail" -eq 0 ]

--- a/q-system/.q-system/test_verify_adversarial.sh
+++ b/q-system/.q-system/test_verify_adversarial.sh
@@ -92,6 +92,41 @@ R=$(newrepo)
 ( cd "$R" && bash q-system/.q-system/verify.sh --oops >/dev/null 2>&1 )
 check "unknown mode refused" 2 $?; rm -rf "$R"
 
+# --- THE HOOK ENVIRONMENT. git exports GIT_DIR and GIT_INDEX_FILE to its hooks,
+# and --staged builds a worktree, which inherits them and dies on the parent's
+# relative index path. Measured 2026-08-27: --staged passed by hand and refused
+# on every lefthook pre-commit call, which is the worst split there is, because
+# the by-hand run is the one you use to convince yourself the gate works.
+# Every other case here runs with a clean environment and CANNOT see it.
+R=$(newrepo)
+printf 'x = 1\n' > "$R/ok.py"; git -C "$R" add ok.py
+( cd "$R" && GIT_DIR=.git GIT_INDEX_FILE=.git/index \
+    bash q-system/.q-system/verify.sh --staged >/dev/null 2>&1 )
+check "--staged works under hook env" 0 $?; rm -rf "$R"
+
+# --- THE DEEPER HALF of the same leak. Sanitizing only `worktree add` stops the
+# crash and leaves every CHECK running with the hook's git environment, so a
+# test that shells out to git asks the PARENT repo from inside the snapshot.
+# This case owns a suite whose test does exactly that; case 13 cannot see it,
+# because a repo with no git-aware test passes either way.
+R=$(newrepo)
+mkdir -p "$R/suite"
+printf 'suite\n' > "$R/.verify-suites"
+cat > "$R/suite/test_tracked.py" <<'PYEOF'
+import subprocess
+def test_git_sees_the_tracked_file():
+    # ls-files prints paths relative to CWD, and pytest runs from the suite dir,
+    # so this is "test_tracked.py" and not "suite/test_tracked.py". Under the
+    # env leak GIT_DIR=.git resolves against THIS dir, finds nothing, and git
+    # exits with empty stdout, which is what makes the assertion discriminate.
+    r = subprocess.run(["git", "ls-files"], capture_output=True, text=True)
+    assert "test_tracked.py" in r.stdout, (r.returncode, r.stdout, r.stderr)
+PYEOF
+git -C "$R" add .verify-suites suite/test_tracked.py
+( cd "$R" && GIT_DIR=.git GIT_INDEX_FILE=.git/index \
+    bash q-system/.q-system/verify.sh --staged >/dev/null 2>&1 )
+check "git-aware test correct under hook env" 0 $?; rm -rf "$R"
+
 echo
 echo "adversarial: $pass passed, $fail failed"
 [ "$fail" -eq 0 ]

--- a/q-system/.q-system/verify.sh
+++ b/q-system/.q-system/verify.sh
@@ -1,0 +1,230 @@
+#!/usr/bin/env bash
+# THE floor. One script, run identically at every gate, so the agent, the commit
+# and the merge cannot quietly drift apart.
+#
+# why this exists: this repo had SEVEN different pre-commit commands, a
+# hand-written native pre-push (lefthook kept silently skipping its own), and no
+# CI at all. Every one of those checks was real; nothing guaranteed the same set
+# ran at each door. "It passed" did not say which door it passed.
+#
+#   verify.sh --staged    what a commit would contain, checked against a COPY
+#   verify.sh --full      the working tree, everything
+#
+# --staged never touches your working tree. It writes the git INDEX out to a
+# temporary directory with `git checkout-index` and runs there. The obvious
+# alternative, `git stash --keep-index`, puts uncommitted work inside a stash
+# that a crash mid-hook can strand. Verifying against a copy costs a few hundred
+# milliseconds and cannot eat anybody's work.
+#
+# THE ONE RULE THAT IS NOT NEGOTIABLE: if this script discovers no checks to
+# run, it FAILS. A gate that cannot run must not pass. The alternative is a
+# green exit that means "I looked for a linter and did not find one", which is
+# indistinguishable from "your code is fine" at every call site that reads only
+# the exit code.
+set -euo pipefail
+
+MODE="${1:---full}"
+REPO="$(git rev-parse --show-toplevel)"
+RAN=()
+FAILED=()
+TMP=""
+
+# `return 0` is LOAD-BEARING, not tidiness. An EXIT trap's last command sets the
+# script's exit status. The first version was a bare `[ -n "$TMP" ] && [ -d ...
+# ] && rm -rf "$TMP"`, and in --full mode TMP is empty, so the chain returned 1
+# and EVERY SUCCESSFUL --full RUN EXITED 1. It printed "verify.sh ok" and then
+# failed. Wired at pre-push and CI, that is a floor that blocks every push
+# forever, which is the same amount of protection as a floor that blocks
+# nothing: both get switched off within a day.
+#
+# Caught 2026-08-27 by the adversarial suite asserting the exit code of a CLEAN
+# repo. No test of the failure cases could have found it: they all expect 1.
+cleanup() {
+  if [ -n "$TMP" ] && [ -d "$TMP" ]; then rm -rf "$TMP"; fi
+  return 0
+}
+trap cleanup EXIT
+
+case "$MODE" in
+  --staged|--full) ;;
+  *) echo "usage: verify.sh [--staged|--full]" >&2; exit 2 ;;
+esac
+
+STAGED=""
+if [ "$MODE" = "--staged" ]; then
+  STAGED="$(git -C "$REPO" diff --cached --name-only --diff-filter=ACMR)"
+  if [ -z "$STAGED" ]; then
+    echo "verify.sh --staged: nothing staged, nothing to verify."
+    exit 0
+  fi
+  # The staged snapshot, materialised. Not the working tree, and not a stash.
+  TMP="$(mktemp -d)"
+  git -C "$REPO" checkout-index -a -f --prefix="$TMP/"
+  TARGET="$TMP"
+else
+  TARGET="$REPO"
+fi
+
+say() { printf '  %-28s %s\n' "$1" "$2"; }
+
+run_check() {
+  local name="$1"; shift
+  RAN+=("$name")
+  if "$@" >/tmp/verify-$$-out 2>&1; then
+    say "$name" "ok"
+  else
+    FAILED+=("$name")
+    say "$name" "FAILED"
+    sed 's/^/      /' /tmp/verify-$$-out | tail -30
+  fi
+  rm -f /tmp/verify-$$-out
+}
+
+echo "verify.sh ${MODE} in ${TARGET}"
+
+# --- python: syntax, every tracked .py -----------------------------------
+# py_compile is not a linter and is not pretending to be one. It is the floor
+# under the floor: a file that does not parse cannot be reasoned about by
+# anything downstream, and this repo has no ruff installed to catch it.
+PYFILES="$(git -C "$REPO" ls-files '*.py' | head -4000)"
+if [ -n "$PYFILES" ]; then
+  run_check "python syntax" bash -c '
+    cd "$1" || exit 1
+    fail=0
+    while IFS= read -r f; do
+      [ -f "$f" ] || continue
+      python3 -m py_compile "$f" 2>&1 || fail=1
+    done <<< "$2"
+    exit $fail
+  ' _ "$TARGET" "$PYFILES"
+fi
+
+# --- shell: syntax, every tracked .sh ------------------------------------
+SHFILES="$(git -C "$REPO" ls-files '*.sh' | head -2000)"
+if [ -n "$SHFILES" ]; then
+  run_check "shell syntax" bash -c '
+    cd "$1" || exit 1
+    fail=0
+    while IFS= read -r f; do
+      [ -f "$f" ] || continue
+      bash -n "$f" 2>&1 || fail=1
+    done <<< "$2"
+    exit $fail
+  ' _ "$TARGET" "$SHFILES"
+fi
+
+# --- json: every tracked .json parses ------------------------------------
+# Config in this fleet IS behaviour: room lists, model tiers, source weights.
+# A malformed one fails at 07:30 in a launchd job nobody is watching.
+JSONFILES="$(git -C "$REPO" ls-files '*.json' | grep -v -E '(^|/)(dist|node_modules)/' | head -3000)"
+if [ -n "$JSONFILES" ]; then
+  run_check "json parse" bash -c '
+    cd "$1" || exit 1
+    fail=0
+    while IFS= read -r f; do
+      [ -f "$f" ] || continue
+      python3 -c "import json,sys; json.load(open(sys.argv[1]))" "$f" 2>&1 || fail=1
+    done <<< "$2"
+    exit $fail
+  ' _ "$TARGET" "$JSONFILES"
+fi
+
+# --- ruff, only if the machine has it ------------------------------------
+# Optional TOOL, never an optional CHECK: if ruff is installed it must pass.
+# The discovery is about what exists, not about what is allowed to fail.
+if command -v ruff >/dev/null 2>&1; then
+  run_check "ruff" bash -c 'cd "$1" && ruff check .' _ "$TARGET"
+fi
+
+# --- tests ---------------------------------------------------------------
+# --staged runs the tests from the COPY, which is the point: it proves the
+# snapshot being committed passes on its own, not that the working tree does.
+# NO PIPE INTO `grep -q` HERE, and that is a scar, not a style preference.
+# The first version of this line ended `| grep -q .`. Under `set -o pipefail`,
+# grep -q exits the instant it matches, git gets SIGPIPE (141), and the PIPELINE
+# reports failure precisely BECAUSE there were tests. Measured on the first live
+# run: 400 test files present, pytest silently skipped, exit 0, "verify.sh ok".
+# A discovery step that inverts on success is worse than no discovery step.
+# FAIL FAST BEFORE THE EXPENSIVE PART. Measured 2026-08-27: a commit with one
+# unparseable .py staged blocked correctly and took over two minutes, because
+# the syntax check failed and the script then ran the full suite anyway. Nobody
+# waits two minutes to be told about a typo; they run --no-verify, and then the
+# floor is decorative. Tests cannot tell you anything useful about a tree that
+# does not parse, so there is nothing lost by stopping here.
+if [ ${#FAILED[@]} -gt 0 ]; then
+  echo
+  echo "verify.sh FAILED (${#FAILED[@]}/${#RAN[@]}): ${FAILED[*]}" >&2
+  echo "Stopped before the test suites: a tree that does not parse cannot be tested." >&2
+  exit 1
+fi
+
+TESTFILES="$(git -C "$REPO" ls-files 'test_*.py' '*/test_*.py')"
+
+# THE SUITE MANIFEST, `.verify-suites` at the repo root, one `dir` per line.
+# Each is a directory pytest is invoked FROM, because that is how these suites
+# actually run: q-consult/pipeline/tests imports `pipeline`, which resolves only
+# with q-consult as the working directory. A single root-level pytest is the
+# obvious design and it is wrong here. Measured: from the repo root, 3526 tests
+# collect and 896 error out, most of them belonging to the nested instances
+# under projects/ that are separate repos with their own paths. From their own
+# directories the two real suites collect 5379 and 486 with zero errors.
+#
+# A repo with no manifest falls back to one root pytest, which is right for a
+# normal repo and is what every instance without the file gets.
+if [ -f "$REPO/.verify-suites" ]; then
+  if command -v pytest >/dev/null 2>&1 || python3 -c "import pytest" 2>/dev/null; then
+    while IFS= read -r suite; do
+      case "$suite" in ''|'#'*) continue ;; esac
+      if [ ! -d "$TARGET/$suite" ]; then
+        # A manifest naming a directory that is gone is a BROKEN FLOOR. Silently
+        # skipping it is how a suite stops running and nobody notices.
+        RAN+=("pytest:$suite")
+        FAILED+=("pytest:$suite (directory missing)")
+        say "pytest:$suite" "FAILED (missing)"
+        continue
+      fi
+      # --staged runs only the suites that OWN a staged file. Not a weaker
+      # check, a narrower input: the same pytest, on the same snapshot, scoped
+      # to what this commit can have broken. The full suite is 5 minutes here,
+      # and a 5-minute pre-commit is a hook people delete. Pre-push and CI run
+      # --full, so nothing escapes; it just escapes later than the fastest
+      # possible door.
+      if [ "$MODE" = "--staged" ]; then
+        if ! printf '%s\n' "$STAGED" | grep -q "^$suite/"; then
+          say "pytest:$suite" "skipped (no staged files)"
+          continue
+        fi
+      fi
+      run_check "pytest:$suite" bash -c 'cd "$1/$2" && python3 -m pytest -q --no-header' \
+                _ "$TARGET" "$suite"
+    done < "$REPO/.verify-suites"
+  else
+    RAN+=("pytest")
+    FAILED+=("pytest: .verify-suites present but pytest is not installed")
+    say "pytest" "FAILED (not installed)"
+  fi
+elif [ -f "$REPO/pytest.ini" ] || [ -f "$REPO/pyproject.toml" ] || \
+     [ -d "$REPO/tests" ] || [ -n "$TESTFILES" ]; then
+  if command -v pytest >/dev/null 2>&1 || python3 -c "import pytest" 2>/dev/null; then
+    run_check "pytest" bash -c 'cd "$1" && python3 -m pytest -q --no-header' _ "$TARGET"
+  else
+    # Tests exist and the runner does not. That is a broken floor, not a pass.
+    RAN+=("pytest")
+    FAILED+=("pytest: tests present but pytest is not installed")
+    say "pytest" "FAILED (not installed)"
+  fi
+fi
+
+echo
+if [ ${#RAN[@]} -eq 0 ]; then
+  echo "verify.sh: NO CHECKS DISCOVERED. Failing." >&2
+  echo "A gate that cannot run must not pass. Wire a check or delete this hook." >&2
+  exit 1
+fi
+
+if [ ${#FAILED[@]} -gt 0 ]; then
+  echo "verify.sh FAILED (${#FAILED[@]}/${#RAN[@]}): ${FAILED[*]}" >&2
+  exit 1
+fi
+
+echo "verify.sh ok (${#RAN[@]} checks: ${RAN[*]})"

--- a/q-system/.q-system/verify.sh
+++ b/q-system/.q-system/verify.sh
@@ -10,11 +10,11 @@
 #   verify.sh --staged    what a commit would contain, checked against a COPY
 #   verify.sh --full      the working tree, everything
 #
-# --staged never touches your working tree. It writes the git INDEX out to a
-# temporary directory with `git checkout-index` and runs there. The obvious
-# alternative, `git stash --keep-index`, puts uncommitted work inside a stash
-# that a crash mid-hook can strand. Verifying against a copy costs a few hundred
-# milliseconds and cannot eat anybody's work.
+# --staged never touches your working tree. It turns the git INDEX into a real
+# commit object and checks that out as a throwaway worktree, then runs there.
+# The obvious alternative, `git stash --keep-index`, puts uncommitted work
+# inside a stash that a crash mid-hook can strand. Verifying against a copy
+# costs a couple of seconds and cannot eat anybody's work.
 #
 # THE ONE RULE THAT IS NOT NEGOTIABLE: if this script discovers no checks to
 # run, it FAILS. A gate that cannot run must not pass. The alternative is a
@@ -41,6 +41,13 @@ TMP=""
 # repo. No test of the failure cases could have found it: they all expect 1.
 cleanup() {
   if [ -n "$TMP" ] && [ -d "$TMP" ]; then rm -rf "$TMP"; fi
+  # The staged worktree lived under $TMP, so removing $TMP orphans its
+  # registration in .git/worktrees. prune is the sanctioned cleanup, is a no-op
+  # when nothing is stale, and never touches a worktree whose directory still
+  # exists. Without it every --staged run leaks an entry and `git worktree list`
+  # fills with dead paths until an add starts failing.
+  env -u GIT_DIR -u GIT_WORK_TREE -u GIT_INDEX_FILE -u GIT_OBJECT_DIRECTORY \
+      -u GIT_COMMON_DIR git worktree prune >/dev/null 2>&1 || true
   return 0
 }
 trap cleanup EXIT
@@ -57,12 +64,76 @@ if [ "$MODE" = "--staged" ]; then
     echo "verify.sh --staged: nothing staged, nothing to verify."
     exit 0
   fi
-  # The staged snapshot, materialised. Not the working tree, and not a stash.
+  # The staged snapshot, materialised AS A REAL REPOSITORY. Not the working
+  # tree, and not a stash.
+  #
+  # why a worktree and not `git checkout-index --prefix=` (the first version):
+  # checkout-index writes FILES and nothing else, so the snapshot had no .git.
+  # Every test that asks the repository a question then got a wrong answer
+  # instead of an error. Measured 2026-08-27 on this repo: 25 failed under
+  # --staged against 7 under --full, and the 18-test difference was entirely
+  # this. `provenance.resolve` on HEAD returned "empty commit ref"; the
+  # gitignore checks, the behind-upstream check and the live-tree enumerations
+  # all followed. A pre-commit gate that fails 18 times for a reason unrelated
+  # to your change is a gate that gets deleted in a day, which is the same
+  # protection as no gate at all.
+  #
+  # write-tree + commit-tree turns the INDEX into a real commit object without
+  # touching any ref, any branch, or the working tree. The worktree checked out
+  # at that commit is a genuine git repository holding exactly what the commit
+  # would contain, so a repo-aware test is answered about the STAGED state
+  # rather than about a directory that is not a repo.
   TMP="$(mktemp -d)"
-  git -C "$REPO" checkout-index -a -f --prefix="$TMP/"
-  TARGET="$TMP"
+  TREE="$(git -C "$REPO" write-tree)"
+  # An empty repo has no HEAD to parent from; the adversarial suite covers it.
+  if git -C "$REPO" rev-parse --verify -q HEAD >/dev/null 2>&1; then
+    SNAP="$(git -C "$REPO" commit-tree "$TREE" -p HEAD -m 'verify.sh staged snapshot')"
+  else
+    SNAP="$(git -C "$REPO" commit-tree "$TREE" -m 'verify.sh staged snapshot')"
+  fi
+  # FAIL, never fall through. A failed `worktree add` leaves $TMP/wt absent, and
+  # a TARGET that does not exist would send every check at the MAIN CHECKOUT,
+  # reporting green for a tree nobody staged.
+  #
+  # `env -u` is not defensive tidiness, it is the whole reason this works inside
+  # a hook. git EXPORTS GIT_DIR and GIT_INDEX_FILE to its hooks, and a child
+  # `git worktree add` inherits them and tries to use the PARENT's index path
+  # inside the new worktree: "fatal: .git/index: index file open failed: Not a
+  # directory". Measured 2026-08-27 -- verify.sh --staged ran fine by hand and
+  # refused every time lefthook called it, which is the worst possible split
+  # because the by-hand run is the one you use to convince yourself it works.
+  # write-tree above deliberately KEEPS the inherited environment: it has to
+  # read the index the commit is actually being built from.
+  if ! WT_ERR="$(env -u GIT_DIR -u GIT_WORK_TREE -u GIT_INDEX_FILE \
+                     -u GIT_OBJECT_DIRECTORY -u GIT_COMMON_DIR \
+                     git -C "$REPO" worktree add --detach "$TMP/wt" "$SNAP" 2>&1)"; then
+    # Print what git said. The first version threw stderr away and the refusal
+    # was untraceable: a gate that cannot say why it refused gets bypassed.
+    echo "verify.sh: could not create the staged worktree. Refusing." >&2
+    echo "$WT_ERR" | sed 's/^/  /' >&2
+    exit 1
+  fi
+  TARGET="$TMP/wt"
+  # AND NOW DROP THEM FOR THE REST OF THE RUN. Sanitizing only the `worktree
+  # add` above fixed the crash and left the deeper half: every check below runs
+  # with the hook's environment too, so a TEST that shells out to git inherits
+  # GIT_DIR=.git and GIT_INDEX_FILE=.git/index and asks the PARENT repo, from
+  # inside the snapshot, using a relative path that means something else there.
+  # Measured 2026-08-27: a bare `verify.sh --staged` printed "verify.sh ok" and
+  # the pre-commit call on byte-identical staged content failed on
+  # test_corpus_is_tracked, test_acquisition_manifest,
+  # test_sp_392043b5_backup_is_ignored and test_provenance_repo_field -- every
+  # one of them a test that asks git what is tracked or ignored.
+  #
+  # This is the script's own thesis applied to itself. verify.sh exists so the
+  # same checks run identically at every door; a run whose answers depend on
+  # which door invoked it is the exact drift it was written to stop.
+  unset GIT_DIR GIT_WORK_TREE GIT_INDEX_FILE GIT_OBJECT_DIRECTORY GIT_COMMON_DIR
 else
   TARGET="$REPO"
+  # --full has no snapshot to build, so there is nothing to read the index for
+  # and the same leak applies from the first check onward.
+  unset GIT_DIR GIT_WORK_TREE GIT_INDEX_FILE GIT_OBJECT_DIRECTORY GIT_COMMON_DIR
 fi
 
 say() { printf '  %-28s %s\n' "$1" "$2"; }

--- a/q-system/lessons/compare-a-new-cost-against-its-ceiling-not-its-old-cost.md
+++ b/q-system/lessons/compare-a-new-cost-against-its-ceiling-not-its-old-cost.md
@@ -1,0 +1,24 @@
+---
+id: compare-a-new-cost-against-its-ceiling-not-its-old-cost
+kind: pattern
+title: Compare a new cost against its ceiling, not against its old cost
+date: 2026-08-28
+---
+
+Turning on a richer mode of an external call (a "details" / "include extra fields" / "deep extraction" flag) makes each call slower. The instinct is to measure the change and judge whether the slowdown is affordable: "115s to 240s, about twice as slow, fine for a job that runs twice a week." That judgment is against the wrong number. The number that decides whether the change works is the CEILING the call runs under, and it is usually defined somewhere else.
+
+Hosted job APIs, synchronous run endpoints, request gateways and CI steps all have a hard wall the caller does not own. Below the wall, cost is a preference. Within roughly one standard deviation of it, cost is a coin flip. The failure this produces is diagnostic poison: a run where a different subset of cells fails each time, which reads as an unreliable vendor rather than as a budget that no longer fits.
+
+Four moves, in order:
+
+1. **When a change makes something slower, the next line names the budget.** Not "2.1x slower" but "240s against a 290s timeout against a ~300s server wall". If you cannot state the ceiling, you have not finished measuring. A cost with no denominator is a number, not a measurement.
+
+2. **Check whether the ceiling can be raised at all before planning to raise it.** A server-side wall cannot be bought past; raising the client timeout above it only means waiting for a run the server already killed. When the expensive mode's mean sits near an unraisable wall, the mode does not fit and no configuration value will make it fit. The remaining options are all "do less work per call": narrower scope, smaller batch, or splitting one call into several.
+
+3. **An expensive mode ships with a cheaper fallback or it does not ship.** Retrying the identical expensive call is not a fallback; a call that ran out of budget will run out of budget again, so a retry count buys nothing but latency. Make the attempt sequence a ladder where each step is strictly cheaper than the last, so the unit degrades to partial data instead of to nothing. Losing one enriched field for one cell beats losing the cell.
+
+4. **Record per-unit cost in the artifact, and flag the ones near the ceiling.** Without a duration on each record, a unit at 98% of budget and one at 15% are indistinguishable, so the margin can only be discovered after it is gone. With it, the margin is watchable, and a unit over a threshold gets reported as at-risk while it is still succeeding.
+
+The verification is not "the timeout error stopped". It is: a unit whose expensive attempt fails still returns usable data through the cheaper path, and the artifact says which units took that path.
+
+**The meta-lesson, which is why this one exists as an executable and not only as advice.** This exact trade had already broken a different lane in the same codebase eighteen days earlier, with the same shape and a different flag name. The diagnosis was written up correctly, in detail, as a comment inside the very file defining the timeout. It did not prevent the repeat, because a scar recorded as prose protects only the file it sits in and only the reader who happens to open that file. If a cost/ceiling relationship matters, it needs a test that fails: pin the ceiling, assert the expensive mode is opt-in rather than baked in, and assert the fallback path is genuinely cheaper. Prove each guard by restoring the original bug and watching it go red. A comment is a note to someone already looking in the right place, which is precisely the person who did not need it.

--- a/q-system/memory/open-loops.json
+++ b/q-system/memory/open-loops.json
@@ -13,7 +13,7 @@
     {
       "id": "captoken-pr",
       "title": "capability-token PR to dwarvesf/claude-guardrails (issue #14 filed)",
-      "next_action": "Issue FILED: github.com/dwarvesf/claude-guardrails/issues/14 (2026-06-20). Waiting on maintainer reply. When a maintainer approves/invites the PR: re-clone if /tmp wiped, git apply q-system/output/captoken-claude-guardrails.patch, push branch chore/capability-approval, gh pr create with q-system/output/captoken-pr-body.md. Then close this loop.",
+      "next_action": "Issue FILED: github.com/dwarvesf/claude-guardrails/issues/14 (2026-06-20). Still OPEN, still NO maintainer reply. One comment 2026-08-28 from benrrr56-wq (authorAssociation NONE, a third party promoting their own checkpoint layer) -- not an approval, not an invite, do NOT treat it as one. When a MAINTAINER approves/invites the PR: re-clone if /tmp wiped, git apply q-system/output/captoken-claude-guardrails.patch, push branch chore/capability-approval, gh pr create with q-system/output/captoken-pr-body.md. Then close this loop.",
       "needs_founder": true,
       "status": "open",
       "added": "2026-06-20",


### PR DESCRIPTION
## What was actually wrong

`alert-to-linear.py` files a ticket. TWO independent readers then refuse it, on purpose:

| reader | predicate | result |
|---|---|---|
| `linear-dor-drafter.py` | `is_alert_ticket()` | `selection_mode()` -> `None` |
| `linear-worker.sh:568` | `is_fleet_alert()` | `ready()` -> `False` |

Both were added together (ASK-839) with sound reasoning. What was never built is
anything that moves a ticket **out** of that bucket.

Measured on the live board 2026-08-29, using the shipped predicates rather than
reimplementations: **all 151 open alert tickets** return `selection_mode is None`,
while **74 non-alert issues** return `"draft"` — a positive control, so the predicate
is not simply refusing everything.

## The contract violation

`terminal-states.json` registers the exit as `terminal: true` with the rationale
*"the consumer of an alert is the operator who reads it."* The same file's own doc
block forbids exactly that: *"A human is never a valid consumer."* And that operator
does not exist — the ASK team has two seats, Codex and the founder, and `owner:sana`
is a routing label, not a person. **The declared consumer is the empty set**, so the
effective behaviour is silence. Today that silence covered a RED main and a disk at 98%.

The row passed validation because `terminal: true` rows are not required to name a
live consumer; the rationale text was never machine-checked.

## Why the obvious fix is inert

Having the filer emit its own DoR does **nothing**: `linear-worker.sh` evaluates
`is_fleet_alert` on line 568, *before* line 571 ever reads the description for a DoR.
`test_a_dor_alone_does_not_unblock_it` pins that. Making it work would mean deleting
that exclusion, which reverts a measured decision and admits every unscoped
notification to the executable queue.

## What this ships

`linear-alert-triage.py` — the missing consumer. Promotion strips the fingerprint
comment, drops `needs-triage`, appends a real DoR. After that **both readers accept
with zero change to either**; that is the design goal, not a coincidence.

- **Dedup unaffected** — verified in `_read_state`/`_write_state`: repeats key on a
  local state file, not on the description.
- **Never silent** — closing comments the reason *before* the state change. No verb
  in the script deletes an issue.
- **Provenance survives** — the fingerprint is preserved under a different comment key
  that neither reader matches.

## Evidence

- 7/7 tests. The worker's `is_fleet_alert` is **extracted from the shipped `.sh`** and
  exec'd, not retyped, so a drift in the real predicate breaks this test.
- Mutation-tested: `strip` as a no-op fails 3; an audit marker colliding with the real
  key fails 2. Control green, `git diff --stat` empty after restore.
- **Load-path proof**: ran the worker's own `ready()` against the live board. The
  kipi-system ready set went **20 -> 27**.

## Triage applied

| | |
|---|---|
| Promoted, now in the ready set | ASK-1117, 1118, 1121, 1124, 1125, 1126, 1127 |
| Closed as superseded, with reasons | ASK-1120 (-> 1126), ASK-1123 (-> 1124) |
| Already ready, untouched | ASK-1119 |
| Second filer defect, labelled + captured | ASK-1122 |

A triage insight worth flagging: **ASK-1120, ASK-1121 and ASK-1126 are one fix.** A
per-round *owned* worktree removes the shared mutable resource (no TOCTOU), fixes the
stale ref, and bounds the 6.4G/206-tree growth. That decision is made in ASK-1126.

## Deliberately not in this PR

The `terminal-states.json` row rewrite. `test-terminal-states.sh` is being edited by
another agent right now and main is RED on it — editing the JSON it validates would
deepen a red main. Carried as the first remaining item on ASK-1127.