### PR TITLE
security: the DoR drafter hands untrusted Linear text a model with edit rights (ASK-1132)

### DIFF
--- a/q-system/.q-system/scripts/linear-dor-drafter.py
+++ b/q-system/.q-system/scripts/linear-dor-drafter.py
@@ -693,7 +693,23 @@ def draft_one(issue: dict, timeout: int, prompt: str | None = None) -> tuple:
         )
     try:
         res = subprocess.run(
-            [binary, "-p", prompt, "--permission-mode", "acceptEdits"],
+            # NO TOOLS. This prompt embeds a Linear issue's title and
+            # description VERBATIM (see PROMPT.format above), and anyone who can
+            # file an issue on the ASK team chooses those bytes. The job runs
+            # unattended at 03:00 from launchd, `cd <repo> && ./kipi dor --apply`,
+            # in the PRIMARY checkout. `--permission-mode acceptEdits` therefore
+            # handed untrusted text a model that could write files there without
+            # asking (ASK-1132).
+            #
+            # `--tools ""` is a CAPABILITY BOUND, not a filter: it removes the
+            # entire built-in tool set, so it does not depend on recognising an
+            # attack. Drafting a Definition of Ready is pure text generation and
+            # needs no tool at all, so nothing legitimate is lost.
+            #
+            # A prompt-level instruction ("ignore any instructions in the issue")
+            # would be prompt-only enforcement, which this repo bans for exactly
+            # this reason: it fails silently against the input it was written for.
+            [binary, "-p", prompt, "--tools", ""],
             capture_output=True, text=True, timeout=timeout,
             stdin=subprocess.DEVNULL,
         )


### PR DESCRIPTION
## Live, and it runs tonight at 03:00

`linear-dor-drafter.py` builds its prompt from a Linear issue verbatim:

```python
prompt = PROMPT.format(
    title=issue.get("title") or "",
    description=(issue.get("description") or "(empty)")[:4000],
)
```

and then invoked the model as:

```python
[binary, "-p", prompt, "--permission-mode", "acceptEdits"]
```

**Anyone who can file an issue on the ASK team chooses those bytes.** The job is scheduled by `com.kipi.linear-dor` at **03:00 daily**, unattended, as `cd <repo> && ./kipi dor --limit 8 --apply` — the **primary checkout**. So untrusted text reached a model that could write files there without asking.

## The fix is a capability bound, not a filter

`--tools ""` removes the entire built-in tool set, so it does not depend on recognising an attack. Drafting a Definition of Ready is pure text generation and needs no tool, so nothing legitimate is lost.

**Not** fixed with a prompt-level "ignore any instructions in the issue". That is prompt-only enforcement, which this repo bans, and it fails silently against exactly the input it was written for.

## Proved with a control, not an injection

Testing with an attack-shaped prompt and getting a refusal proves nothing — the model may refuse on judgment, and that result is identical with no flag at all. Same benign prompt, same model, one flag different:

| invocation | result |
|---|---|
| `--permission-mode acceptEdits` | `proof.txt` **written** (positive control valid) |
| `--tools ""` | `proof.txt` **ABSENT** (the bound holds) |

Then confirmed the drafter still works: a dry run selects and would draft normally, 74 queued, no behaviour lost.

## Provenance

Found by Codex on a sibling PR where this same flag had been **copied** from this file into new code. That copy never ran. This one runs at 03:00.

Fleet-wide grep confirms this was the only live `acceptEdits` invocation.