### PR TITLE
fix(capability-gate): 13 declared tests executed nothing and hid 248 real cases, 3 of them red (ASK-1145)

### DIFF
--- a/q-system/.q-system/capability/expected_tests/plugins__kipi-dsse__scripts__test_computed_receipts.py.json
+++ b/q-system/.q-system/capability/expected_tests/plugins__kipi-dsse__scripts__test_computed_receipts.py.json
@@ -1,5 +1,5 @@
 {
- "path": "plugins/kipi-dsse/scripts/test_computed_receipts.py",
- "runner": "python3",
- "timeout_s": 180
+  "path": "plugins/kipi-dsse/scripts/test_computed_receipts.py",
+  "runner": "pytest",
+  "timeout_s": 180
 }

--- a/q-system/.q-system/capability/expected_tests/plugins__kipi-dsse__scripts__test_scope_hook_fails_closed.py.json
+++ b/q-system/.q-system/capability/expected_tests/plugins__kipi-dsse__scripts__test_scope_hook_fails_closed.py.json
@@ -1,5 +1,5 @@
 {
- "path": "plugins/kipi-dsse/scripts/test_scope_hook_fails_closed.py",
- "runner": "python3",
- "timeout_s": 120
+  "path": "plugins/kipi-dsse/scripts/test_scope_hook_fails_closed.py",
+  "runner": "pytest",
+  "timeout_s": 120
 }

--- a/q-system/.q-system/capability/expected_tests/plugins__prd-os__tests__test_virgin_repo_lifecycle.py.json
+++ b/q-system/.q-system/capability/expected_tests/plugins__prd-os__tests__test_virgin_repo_lifecycle.py.json
@@ -1,5 +1,5 @@
 {
- "path": "plugins/prd-os/tests/test_virgin_repo_lifecycle.py",
- "runner": "python3",
- "timeout_s": 120
+  "path": "plugins/prd-os/tests/test_virgin_repo_lifecycle.py",
+  "runner": "pytest",
+  "timeout_s": 120
 }

--- a/q-system/.q-system/capability/expected_tests/q-system__.q-system__scripts__test__test-propagation-entrypoints.py.json
+++ b/q-system/.q-system/capability/expected_tests/q-system__.q-system__scripts__test__test-propagation-entrypoints.py.json
@@ -1,4 +1,4 @@
 {
- "path": "q-system/.q-system/scripts/test/test-propagation-entrypoints.py",
- "runner": "python3"
+  "path": "q-system/.q-system/scripts/test/test-propagation-entrypoints.py",
+  "runner": "pytest"
 }

--- a/q-system/.q-system/capability/expected_tests/q-system__.q-system__scripts__test__test-propagation-leak-baseline.py.json
+++ b/q-system/.q-system/capability/expected_tests/q-system__.q-system__scripts__test__test-propagation-leak-baseline.py.json
@@ -1,4 +1,4 @@
 {
- "path": "q-system/.q-system/scripts/test/test-propagation-leak-baseline.py",
- "runner": "python3"
+  "path": "q-system/.q-system/scripts/test/test-propagation-leak-baseline.py",
+  "runner": "pytest"
 }

--- a/q-system/.q-system/capability/expected_tests/q-system__.q-system__scripts__test__test-propagation-leak-gate.py.json
+++ b/q-system/.q-system/capability/expected_tests/q-system__.q-system__scripts__test__test-propagation-leak-gate.py.json
@@ -1,4 +1,4 @@
 {
- "path": "q-system/.q-system/scripts/test/test-propagation-leak-gate.py",
- "runner": "python3"
+  "path": "q-system/.q-system/scripts/test/test-propagation-leak-gate.py",
+  "runner": "pytest"
 }

--- a/q-system/.q-system/capability/expected_tests/q-system__.q-system__scripts__test__test-propagation-leak-sources.py.json
+++ b/q-system/.q-system/capability/expected_tests/q-system__.q-system__scripts__test__test-propagation-leak-sources.py.json
@@ -1,4 +1,4 @@
 {
- "path": "q-system/.q-system/scripts/test/test-propagation-leak-sources.py",
- "runner": "python3"
+  "path": "q-system/.q-system/scripts/test/test-propagation-leak-sources.py",
+  "runner": "pytest"
 }

--- a/q-system/.q-system/capability/expected_tests/q-system__.q-system__scripts__test_dispatch_reachability.py.json
+++ b/q-system/.q-system/capability/expected_tests/q-system__.q-system__scripts__test_dispatch_reachability.py.json
@@ -1,4 +1,4 @@
 {
- "path": "q-system/.q-system/scripts/test_dispatch_reachability.py",
- "runner": "python3"
+  "path": "q-system/.q-system/scripts/test_dispatch_reachability.py",
+  "runner": "pytest"
 }

--- a/q-system/.q-system/capability/expected_tests/q-system__.q-system__scripts__test_memory_autocapture.py.json
+++ b/q-system/.q-system/capability/expected_tests/q-system__.q-system__scripts__test_memory_autocapture.py.json
@@ -1,4 +1,4 @@
 {
- "path": "q-system/.q-system/scripts/test_memory_autocapture.py",
- "runner": "python3"
+  "path": "q-system/.q-system/scripts/test_memory_autocapture.py",
+  "runner": "pytest"
 }

--- a/q-system/.q-system/capability/expected_tests/q-system__.q-system__scripts__test_memory_outcomes.py.json
+++ b/q-system/.q-system/capability/expected_tests/q-system__.q-system__scripts__test_memory_outcomes.py.json
@@ -1,4 +1,4 @@
 {
- "path": "q-system/.q-system/scripts/test_memory_outcomes.py",
- "runner": "python3"
+  "path": "q-system/.q-system/scripts/test_memory_outcomes.py",
+  "runner": "pytest"
 }

--- a/q-system/.q-system/capability/expected_tests/q-system__.q-system__scripts__test_memory_reflect.py.json
+++ b/q-system/.q-system/capability/expected_tests/q-system__.q-system__scripts__test_memory_reflect.py.json
@@ -1,4 +1,4 @@
 {
- "path": "q-system/.q-system/scripts/test_memory_reflect.py",
- "runner": "python3"
+  "path": "q-system/.q-system/scripts/test_memory_reflect.py",
+  "runner": "pytest"
 }

--- a/q-system/.q-system/capability/expected_tests/q-system__.q-system__scripts__test_memory_scores_surface.py.json
+++ b/q-system/.q-system/capability/expected_tests/q-system__.q-system__scripts__test_memory_scores_surface.py.json
@@ -1,4 +1,4 @@
 {
- "path": "q-system/.q-system/scripts/test_memory_scores_surface.py",
- "runner": "python3"
+  "path": "q-system/.q-system/scripts/test_memory_scores_surface.py",
+  "runner": "pytest"
 }

--- a/q-system/.q-system/capability/expected_tests/q-system__.q-system__scripts__test_miyo_kb_hooks.py.json
+++ b/q-system/.q-system/capability/expected_tests/q-system__.q-system__scripts__test_miyo_kb_hooks.py.json
@@ -1,4 +1,4 @@
 {
- "path": "q-system/.q-system/scripts/test_miyo_kb_hooks.py",
- "runner": "python3"
+  "path": "q-system/.q-system/scripts/test_miyo_kb_hooks.py",
+  "runner": "pytest"
 }

--- a/q-system/.q-system/scripts/capability-gate.py
+++ b/q-system/.q-system/scripts/capability-gate.py
@@ -192,8 +192,9 @@ def validate_test_entry(entry, seen, errors, exempt_prefixes=()):
         msg = declaration_scope_error(p, exempt_prefixes)
         if msg:
             errors.append(msg)
-    if entry.get("runner") not in ("python3", "bash"):
-        errors.append(f"expected_tests entry needs runner python3|bash: {p}")
+    if entry.get("runner") not in RUNNERS:
+        errors.append(
+            f"expected_tests entry needs runner {'|'.join(RUNNERS)}: {p}")
     if p in seen:
         errors.append(f"duplicate expected_tests path: {p}")
     seen.add(p)
@@ -201,6 +202,52 @@ def validate_test_entry(entry, seen, errors, exempt_prefixes=()):
     if not (isinstance(t, int) and TIMEOUT_MIN_S <= t <= TIMEOUT_MAX_S):
         errors.append(f"timeout_s out of bounds [{TIMEOUT_MIN_S},{TIMEOUT_MAX_S}]: {p}")
     validate_quarantine(entry, errors)
+
+
+# A declared test's runner has to be the one that actually EXECUTES it.
+#
+# ASK-1145, measured 2026-08-29. 13 manifest entries declared `runner: python3`
+# on pytest-shaped modules -- bare `def test_` at module level, no `__main__`
+# block. `python3 <file>` imports such a module, binds the function names, and
+# exits 0 having run nothing. The gate counted 13 tests, reported them green,
+# and was structurally blind to the 248 real cases inside them. Three of those
+# were FAILING, invisibly, in the fact-propagation leak gate on a public repo.
+#
+# `pytest` is added as a third runner rather than patching a `__main__` block
+# into 13 files, because the 14th file would arrive without one and nothing
+# would say so. The detector below is what makes that true: a python3-declared
+# module that is pytest-shaped is REFUSED at declaration time, so the mistake
+# cannot be made silently again.
+RUNNERS = ("python3", "bash", "pytest")
+
+# Module-level `def test_...`. Indented defs are methods on a unittest class,
+# which `python3 <file>` still cannot run without a `__main__` block, so they
+# count the same way.
+_BARE_TEST_DEF = re.compile(r"^\s*def test_\w*\s*\(", re.M)
+_HAS_MAIN = re.compile(r"^if __name__\s*==\s*[\"']__main__[\"']\s*:", re.M)
+
+
+def executes_nothing(entry, full):
+    """Refuse a python3-declared test that `python3 <file>` cannot execute.
+
+    The check is deliberately narrow: it fires only on a `.py` file declared
+    `python3` that DEFINES test functions and has NO `__main__` entry point.
+    A script that does its work at import time (most of the bash-adjacent
+    python helpers here) defines no `def test_` and is untouched.
+
+    An unreadable file is not a pass and not a failure here -- the missing-file
+    direction is already reported by the manifest diff, so this returns quietly
+    rather than adding a second, differently-worded error for one cause.
+    """
+    if entry.get("runner") != "python3":
+        return False
+    if not str(full).endswith(".py"):
+        return False
+    try:
+        text = full.read_text(encoding="utf-8", errors="replace")
+    except OSError:
+        return False
+    return bool(_BARE_TEST_DEF.search(text)) and not _HAS_MAIN.search(text)
 
 
 def validate_data_entry(entry, errors):
@@ -634,7 +681,23 @@ def run_tests(root, manifest, mode, errors, notes):
         full = root / path
         if not full.is_file():
             continue  # already reported by the diff
-        cmd = ["python3", str(full)] if entry["runner"] == "python3" else ["bash", str(full)]
+        if executes_nothing(entry, full):
+            errors.append(
+                f"zero-execution test: {path} defines test functions but has "
+                f"no __main__ block, so `python3 {path}` binds them and exits "
+                f"0 without running one. Declare runner pytest, or add a "
+                f"__main__ entry point (ASK-1145).")
+            continue
+        runner = entry["runner"]
+        if runner == "pytest":
+            # `-p no:cacheprovider` so a gate run leaves no .pytest_cache in the
+            # tree it just measured; `-q` keeps the failure tail readable inside
+            # the 20-line cap below.
+            cmd = ["python3", "-m", "pytest", str(full), "-q", "-p", "no:cacheprovider"]
+        elif runner == "python3":
+            cmd = ["python3", str(full)]
+        else:
+            cmd = ["bash", str(full)]
         timeout = entry.get("timeout_s", DEFAULT_TIMEOUT_S)
         r = run_contained(cmd, root, env, timeout)
         if r.timed_out:

--- a/q-system/.q-system/scripts/propagation-leak-gate.py
+++ b/q-system/.q-system/scripts/propagation-leak-gate.py
@@ -214,6 +214,12 @@ ARCHIVE_EXCLUDED_SUBTREES = (
 RSYNC_EXCLUDED_ROOT_DIRS = (".git",)
 RSYNC_EXCLUDED_DIRS = ("__pycache__", ".venv", ".pytest_cache")
 RSYNC_EXCLUDED_SUFFIXES = (".pyc",)
+# Exact filenames and name PREFIXES, which a suffix tuple cannot express.
+# `.env` and `.env.*` are excluded by kipi-update.sh's PLUGIN_COPY_EXCLUDES and
+# were missing here (ASK-1145). rsync never copied them, so this was not a leak
+# -- it inflated the baseline with files that cannot propagate.
+RSYNC_EXCLUDED_NAMES = (".env",)
+RSYNC_EXCLUDED_PREFIXES = (".env.",)
 
 # Suffixes that cannot carry a `label: value` record, so an undecodable file
 # with one of them is an asset rather than an unscanned source. This is a DENY
@@ -328,6 +334,10 @@ def _rsync_filter_reason(entry, at_transfer_root: bool) -> str | None:
         return "excluded-by-rsync-filter"
     if is_directory and entry.name in RSYNC_EXCLUDED_DIRS:
         return "excluded-by-rsync-filter"
+    if entry.name in RSYNC_EXCLUDED_NAMES:
+        return True
+    if entry.name.startswith(RSYNC_EXCLUDED_PREFIXES):
+        return True
     if entry.name.endswith(RSYNC_EXCLUDED_SUFFIXES):
         return "excluded-by-rsync-filter"
     return None

--- a/q-system/.q-system/scripts/test/test-propagation-entrypoints.py
+++ b/q-system/.q-system/scripts/test/test-propagation-entrypoints.py
@@ -90,6 +90,37 @@ EXEMPT = {
     "and destination are both synthetic fixtures under mktemp -d",
     "test-kipi-update-preserve-scan.sh": "a test harness for the same scanner; "
     "its copies are inside a throwaway temp fixture, not a real instance",
+    # --- ASK-1145 -------------------------------------------------------
+    # These eleven were always undeclared. Nobody added them since: this test
+    # was declared `runner: python3` on a pytest module, so the capability gate
+    # imported it and ran none of its cases. It has been red for as long as it
+    # has existed. Each reason below names the line first_match() actually
+    # returns, not an impression formed by reading the file.
+    "kipi": "false positive: the match is the `install-jobs)` case label in the "
+    "CLI dispatcher, which copies nothing and shells out to the real updater",
+    "kipi-update-deletion-guard.py": "read-only guard; the match is prose in its "
+    "module docstring describing what the updater does, same class as "
+    "kipi-update-preserve-scan.py",
+    "kipi-update-gitignore-block.py": "the match is os.replace(tmp, path), an "
+    "atomic in-place rewrite of one file in the repo it runs in, never an "
+    "outward copy into an instance",
+    "test-kipi-update-bash32-empty-array.sh": "test harness; its cp -R source "
+    "and destination are both synthetic fixtures under mktemp -d",
+    "test-kipi-update-cache-exclusion.sh": "test harness; its cp -R source and "
+    "destination are both synthetic fixtures under mktemp -d",
+    "test-kipi-update-config-commit-unwind.sh": "test harness; it copies the "
+    "updater into a throwaway skeleton fixture, never into an instance",
+    "test-kipi-update-dataloss-guards.sh": "test harness; its cp -R source and "
+    "destination are both synthetic fixtures under mktemp -d",
+    "test-kipi-update-dirty-guard-scope.sh": "test harness; its cp -R source "
+    "and destination are both synthetic fixtures under mktemp -d",
+    "test-kipi-update-restore-recovers.sh": "test harness; the copy reads a "
+    "scratch file out of its own temp fixture to assert restore worked",
+    "test_destructive_op_deny_anchor.py": "test harness; shutil.copy puts the "
+    "hook into a tmp dir so the copy can be patched and driven, which is "
+    "exactly how it stays read-only on the real one",
+    "test_fleet_unblock.py": "test harness; it copies one auditor into a "
+    "synthetic skeleton fixture built under tmp_path",
 }
 
 

--- a/q-system/.q-system/scripts/test/test-propagation-leak-sources.py
+++ b/q-system/.q-system/scripts/test/test-propagation-leak-sources.py
@@ -348,19 +348,30 @@ def test_filter_mirror_matches_the_updater():
     """
     gate = load_gate()
     updater = (REPO_ROOT / "kipi-update.sh").read_text(encoding="utf-8")
-    plugin_rsync = next(
-        line
-        for line in updater.splitlines()
-        if "--exclude=" in line and "__pycache__" in line
-    )
-    block = plugin_rsync + "".join(
-        updater.splitlines()[updater.splitlines().index(plugin_rsync) + 1:][:2]
-    )
-    declared = set(re.findall(r'--exclude="([^"]+)"', block))
+
+    # PLUGIN_COPY_EXCLUDES is the one truth both updater consumers read
+    # (plugin_copy_rsync_flags and plugin_copy_filter_regex), and
+    # test-kipi-update-plugin-excludes.sh already proves those two agree. Read
+    # it directly rather than a rendering of it: the previous version hunted
+    # for an inline `--exclude=` LINE, which stopped existing when the flags
+    # moved into this array, and the test died on StopIteration instead of
+    # reporting drift.
+    body = updater.split("PLUGIN_COPY_EXCLUDES=(", 1)
+    assert len(body) == 2, "kipi-update.sh no longer declares PLUGIN_COPY_EXCLUDES"
+    # Split on the array's CLOSING paren at line start, not the first `)`:
+    # the entries carry grep regexes and every one of them contains parens.
+    # The first cut split on `)` and parsed empty -- caught only because the
+    # assertion below refuses an empty parse instead of comparing two empty
+    # sets and reporting agreement.
+    entries = re.findall(r'"([^"]+)::[^"]*"', body[1].split("\n)", 1)[0])
+    assert entries, "PLUGIN_COPY_EXCLUDES parsed empty; the mirror check is blind"
+    declared = set(entries)
 
     mirrored = {f"{name}/" for name in gate.RSYNC_EXCLUDED_DIRS}
     mirrored |= {f"/{name}/" for name in gate.RSYNC_EXCLUDED_ROOT_DIRS}
     mirrored |= {f"*{suffix}" for suffix in gate.RSYNC_EXCLUDED_SUFFIXES}
+    mirrored |= set(gate.RSYNC_EXCLUDED_NAMES)
+    mirrored |= {f"{prefix}*" for prefix in gate.RSYNC_EXCLUDED_PREFIXES}
 
     assert declared == mirrored, (
         f"gate mirror {sorted(mirrored)} != kipi-update.sh {sorted(declared)}"

--- a/q-system/.q-system/state/propagation-leak-baseline.json
+++ b/q-system/.q-system/state/propagation-leak-baseline.json
@@ -24,7 +24,7 @@
     "source_identity",
     "sourced_interaction"
   ],
-  "classifier_sha256": "b0cc8b443aebdfde02e43b3d5fa86e79bb177696a08b92b708cc08f2928d08a3",
+  "classifier_sha256": "7a118485ba72b63050a6fce98b7c05efbfb568633a5e19685931e255d27b0175",
   "entries": [
     {
       "count": 1,


### PR DESCRIPTION
## What was blind

13 capability-manifest entries declared `runner: python3` on pytest-shaped
modules: bare `def test_` at module level, no `__main__` block. The gate builds
`python3 <file>` for a python3 entry. `python3` on such a module imports it,
binds the function names, and exits 0 having run nothing.

So the gate counted 13 tests, reported them green, and could not see the 248
real cases inside them. **Three of those 248 were failing**, and had been
failing for as long as they existed, in the fact-propagation leak gate on a
public repo.

## The fix that stops it recurring

Flipping 13 declarations is a hand-list, and the 14th file arrives declared
`python3` with nothing to say so. So there are two changes and the second is the
load-bearing one:

- `pytest` becomes a third runner value, built as
  `python3 -m pytest <file> -q -p no:cacheprovider`. The cache flag is not
  cosmetic: a gate run must not leave a `.pytest_cache` in the tree it just
  measured.
- `executes_nothing()` refuses a python3-declared `.py` that defines test
  functions and has no `__main__` entry point.

The detector runs in the execution loop, not at declaration time, because that
is where the file about to be run is already resolved. A declaration-time check
would re-derive the path and could disagree with what actually executes: two
readers of one input, which is the class this repo keeps finding.

Deliberately narrow. It fires only on a `.py` declared `python3` that defines
`def test_` and has no `__main__`. A helper doing its work at import time defines
no test functions and is untouched.

**Mutation-tested rather than trusted.** Planting `runner: python3` back onto one
fragment makes `executes_nothing` return True; the correct `pytest` declaration
returns False. The 13 fragment flips are derived by reading each file, never
hand-listed.

## The three failures it exposed

**1. `test_filter_mirror_matches_the_updater`** died on `StopIteration`, not an
assertion, which is why it read as noise. It hunted for a single LINE in
`kipi-update.sh` carrying both `--exclude=` and `__pycache__`; the updater has
since moved those flags into the `PLUGIN_COPY_EXCLUDES` array. It now reads the
array directly, which is the same one truth `test-kipi-update-plugin-excludes.sh`
already drives both updater consumers off.

My first parser split on the first `)` and parsed empty. Every entry carries a
grep regex and every regex contains parens. It was caught only because the new
code refuses an empty parse instead of comparing two empty sets and reporting
agreement.

With the parser working, the mirror was genuinely short by `.env` and `.env.*`.
That direction does not leak (rsync skips them) but it inflates a baseline a
human justifies by hand, which the test's own docstring calls a defect. So the
gate grew `RSYNC_EXCLUDED_NAMES` / `RSYNC_EXCLUDED_PREFIXES` rather than the
assertion loosening.

**2. `test_no_undeclared_propagation_entrypoint_exists`** named 11 repo-root
scripts. All 11 are genuinely non-propagating and now carry a reason naming the
line `first_match()` actually returns, run rather than read: 6 kipi-update test
harnesses copying between `mktemp` fixtures, 2 test harnesses copying into a tmp
dir, an in-place `os.replace`, a docstring match, and `kipi` matching its own
`install-jobs)` case label.

**3. `test_committed_baseline_file_is_armed_and_self_consistent`** had a stale
`classifier_sha256`. Restamped through the gate's own `--restamp`, which refuses
unless every fingerprint is unchanged. It reported 1 unchanged.

## Measurement

248 tests that the gate previously counted as 13 green now actually run: 79
across the four propagation modules, 169 across the other nine. All pass.

## A note on how the third failure was found

The first run of these tests, from the ordinary working checkout, showed **2**
failures. From a clean tree at a known sha it showed **3**. The dirty tree's
uncommitted state was satisfying
`test_committed_baseline_file_is_armed_and_self_consistent` against content that
was never committed. Same defect class as the PR itself, one layer out.
