### PR TITLE
fix(terminal-states): main is red on a healthy dispatcher, because liveness reads the work log (ASK-1146)

### DIFF
--- a/q-system/.q-system/terminal-states.json
+++ b/q-system/.q-system/terminal-states.json
@@ -122,7 +122,7 @@
       "liveness_check": {
         "kind": "launchd",
         "label": "com.kipi.dispatch",
-        "run_evidence": "~/.config/kipi/dispatch.log",
+        "run_evidence": "~/.config/kipi/dispatch-lastbeat",
         "max_age_s": 3600
       },
       "reentry": {
@@ -142,7 +142,7 @@
       "liveness_check": {
         "kind": "launchd",
         "label": "com.kipi.dispatch",
-        "run_evidence": "~/.config/kipi/dispatch.log",
+        "run_evidence": "~/.config/kipi/dispatch-lastbeat",
         "max_age_s": 3600
       },
       "reentry": {
@@ -162,7 +162,7 @@
       "liveness_check": {
         "kind": "launchd",
         "label": "com.kipi.dispatch",
-        "run_evidence": "~/.config/kipi/dispatch.log",
+        "run_evidence": "~/.config/kipi/dispatch-lastbeat",
         "max_age_s": 3600
       },
       "reentry": {
@@ -182,7 +182,7 @@
       "liveness_check": {
         "kind": "launchd",
         "label": "com.kipi.dispatch",
-        "run_evidence": "~/.config/kipi/dispatch.log",
+        "run_evidence": "~/.config/kipi/dispatch-lastbeat",
         "max_age_s": 3600
       },
       "reentry": {
@@ -202,7 +202,7 @@
       "liveness_check": {
         "kind": "launchd",
         "label": "com.kipi.dispatch",
-        "run_evidence": "~/.config/kipi/dispatch.log",
+        "run_evidence": "~/.config/kipi/dispatch-lastbeat",
         "max_age_s": 3600
       },
       "reentry": {
@@ -309,7 +309,7 @@
       "liveness_check": {
         "kind": "launchd",
         "label": "com.kipi.dispatch",
-        "run_evidence": "~/.config/kipi/dispatch.log",
+        "run_evidence": "~/.config/kipi/dispatch-lastbeat",
         "max_age_s": 3600
       },
       "reentry": {
@@ -404,7 +404,7 @@
       "liveness_check": {
         "kind": "launchd",
         "label": "com.kipi.dispatch",
-        "run_evidence": "~/.config/kipi/dispatch.log",
+        "run_evidence": "~/.config/kipi/dispatch-lastbeat",
         "max_age_s": 3600
       },
       "reentry": {
@@ -440,7 +440,7 @@
       "liveness_check": {
         "kind": "launchd",
         "label": "com.kipi.dispatch",
-        "run_evidence": "~/.config/kipi/dispatch.log",
+        "run_evidence": "~/.config/kipi/dispatch-lastbeat",
         "max_age_s": 3600
       },
       "reentry": {
@@ -490,7 +490,7 @@
       "liveness_check": {
         "kind": "launchd",
         "label": "com.kipi.dispatch",
-        "run_evidence": "~/.config/kipi/dispatch.log",
+        "run_evidence": "~/.config/kipi/dispatch-lastbeat",
         "max_age_s": 3600
       },
       "reentry": {
@@ -520,7 +520,7 @@
       "liveness_check": {
         "kind": "launchd",
         "label": "com.kipi.dispatch",
-        "run_evidence": "~/.config/kipi/dispatch.log",
+        "run_evidence": "~/.config/kipi/dispatch-lastbeat",
         "max_age_s": 3600
       },
       "reentry": {
@@ -540,7 +540,7 @@
       "liveness_check": {
         "kind": "launchd",
         "label": "com.kipi.dispatch",
-        "run_evidence": "~/.config/kipi/dispatch.log",
+        "run_evidence": "~/.config/kipi/dispatch-lastbeat",
         "max_age_s": 3600
       },
       "reentry": {
@@ -580,7 +580,7 @@
       "liveness_check": {
         "kind": "launchd",
         "label": "com.kipi.dispatch",
-        "run_evidence": "~/.config/kipi/dispatch.log",
+        "run_evidence": "~/.config/kipi/dispatch-lastbeat",
         "max_age_s": 3600
       },
       "reentry": {
@@ -610,7 +610,7 @@
       "liveness_check": {
         "kind": "launchd",
         "label": "com.kipi.dispatch",
-        "run_evidence": "~/.config/kipi/dispatch.log",
+        "run_evidence": "~/.config/kipi/dispatch-lastbeat",
         "max_age_s": 3600
       },
       "reentry": {
@@ -640,7 +640,7 @@
       "liveness_check": {
         "kind": "launchd",
         "label": "com.kipi.dispatch",
-        "run_evidence": "~/.config/kipi/dispatch.log",
+        "run_evidence": "~/.config/kipi/dispatch-lastbeat",
         "max_age_s": 3600
       },
       "reentry": {
@@ -690,7 +690,7 @@
       "liveness_check": {
         "kind": "launchd",
         "label": "com.kipi.dispatch",
-        "run_evidence": "~/.config/kipi/dispatch.log",
+        "run_evidence": "~/.config/kipi/dispatch-lastbeat",
         "max_age_s": 3600
       },
       "reentry": {
@@ -710,7 +710,7 @@
       "liveness_check": {
         "kind": "launchd",
         "label": "com.kipi.dispatch",
-        "run_evidence": "~/.config/kipi/dispatch.log",
+        "run_evidence": "~/.config/kipi/dispatch-lastbeat",
         "max_age_s": 3600
       },
       "reentry": {
@@ -746,7 +746,7 @@
       "liveness_check": {
         "kind": "launchd",
         "label": "com.kipi.dispatch",
-        "run_evidence": "~/.config/kipi/dispatch.log",
+        "run_evidence": "~/.config/kipi/dispatch-lastbeat",
         "max_age_s": 3600
       },
       "reentry": {
@@ -766,7 +766,7 @@
       "liveness_check": {
         "kind": "launchd",
         "label": "com.kipi.dispatch",
-        "run_evidence": "~/.config/kipi/dispatch.log",
+        "run_evidence": "~/.config/kipi/dispatch-lastbeat",
         "max_age_s": 3600
       },
       "reentry": {


### PR DESCRIPTION
## main is red right now

Measured on a clean checkout of `origin/main` at 7de326b8, not inferred:
`test-terminal-states.sh` reports **37 passed / 2 failed**, and the capability
gate is RED because of it. Both failures were also present on the rebased #272
and #265 trees, which is what made it clear the base was the problem rather than
either PR.

## The verdict was wrong

```
com.kipi.dispatch is loaded but has not run in 21677s (interval allows 3600s)
-- a loaded job that stopped running is a dead consumer
```

The dispatcher was alive the whole time. Its heartbeat file was **30 seconds
old** when this was measured. What it had actually done, from its own log:

```
2026-08-30T00:18:13Z heartbeat: RESUMED after 45m without a beat
2026-08-29T19:17:26Z DAILY CAP: 10/10 issues dispatched for budget day
                     2026-08-29 (lane=production), stopping until 7:00 local
```

Capped and idle by design, and it had already self-healed from the disk-full
episode earlier in the evening.

## Why the check could not see that

`run_evidence` pointed at `~/.config/kipi/dispatch.log`, which only moves when
the dispatcher **does** something. A correctly-capped job is byte-identical to a
dead one for up to fourteen hours, every night. A gate that goes red every
evening on a healthy system is a gate someone switches off, and then it protects
nothing.

`~/.config/kipi/dispatch-lastbeat` is the right evidence and already exists.
`kipi-dispatch.sh` writes it unconditionally at the top of every run:

```bash
printf '%s' "$NOW_EPOCH" > "$BEAT_FILE"
```

That line sits **before** the concurrency skip and before the daily-cap exit, so
it answers the question the check is actually asking: did the job run. 18 rows
repointed.

## Measurement

- 39 passed / 0 failed, confirmed twice for stability rather than once.
- Mutation-tested: pointing the rows back at `dispatch.log` puts both failures
  back (39 → 37 passed, 2 failed). The fix can go red for the reason it exists.

## The shape

Nothing here was a missing check. The check ran, produced a confident verdict,
and was blind to the designed state it was misreading. It also cost real time:
this began as a six-hour outage investigation, including a `launchctl kickstart`
that turned out to be unnecessary, because the check's own wording ("dead
consumer") asserted a diagnosis it had not established.
