### PR TITLE
fix(backlog): UNKNOWN is not "not dirty", and a count of findings is not coverage

### DIFF
--- a/q-system/.q-system/capability/expected_tests/q-system__.q-system__scripts__test_pr_restack_unknown.py.json
+++ b/q-system/.q-system/capability/expected_tests/q-system__.q-system__scripts__test_pr_restack_unknown.py.json
@@ -1,0 +1,4 @@
+{
+ "path": "q-system/.q-system/scripts/test_pr_restack_unknown.py",
+ "runner": "python3"
+}

--- a/q-system/.q-system/scripts/pr-restack.py
+++ b/q-system/.q-system/scripts/pr-restack.py
@@ -35,6 +35,7 @@ import os
 import subprocess
 import sys
 import tempfile
+import time
 
 
 def run(args: list[str], cwd: str | None = None, check: bool = False):
@@ -47,6 +48,11 @@ def gh_json(args: list[str]):
         sys.exit("gh failed: " + (r.stderr or r.stdout).strip())
     return json.loads(r.stdout)
 
+
+# How hard to chase a PR whose mergeability GitHub has not computed yet.
+UNKNOWN_ATTEMPTS = 3
+# Overridable so the paired suite does not spend 20 real seconds sleeping.
+UNKNOWN_WAIT_SECONDS = int(os.environ.get("PR_RESTACK_UNKNOWN_WAIT", "10"))
 
 LEGACY_MANIFEST = "q-system/.q-system/capability-manifest.json"
 FRAGMENT_DIR = "q-system/.q-system/capability"
@@ -208,17 +214,49 @@ def main() -> int:
 
     prs = gh_json(["pr", "list", "--state", "open", "--limit", "200",
                    "--json", "number,headRefName,mergeStateStatus,title"])
+    total_open = len(prs)
     if args.only:
         want = {int(x) for x in args.only.split(",") if x.strip()}
         prs = [p for p in prs if p["number"] in want]
+        unknown = []
     else:
+        # UNKNOWN IS NOT "NOT DIRTY" (measured 2026-08-30). GitHub computes
+        # mergeability lazily, and right after a merge to main a large fraction
+        # of the backlog reports UNKNOWN for a minute or two. The first version
+        # filtered for DIRTY and silently dropped those, so a sweep run moments
+        # after a merge examined 1 PR out of 23 and printed "conflicted 1" --
+        # which reads as "the backlog is nearly clean" and was reported upward
+        # as exactly that. Twenty-two branches were never looked at.
+        #
+        # Asking about a single PR forces GitHub to compute it, so an UNKNOWN is
+        # re-queried rather than assumed. A bounded number of attempts, because
+        # a PR that never settles is a fact to report, not a reason to spin.
+        unknown = [p for p in prs if p["mergeStateStatus"] == "UNKNOWN"]
+        for attempt in range(UNKNOWN_ATTEMPTS):
+            if not unknown:
+                break
+            if attempt:
+                time.sleep(UNKNOWN_WAIT_SECONDS)
+            still = []
+            for p in unknown:
+                r = run(["gh", "pr", "view", str(p["number"]),
+                         "--json", "mergeStateStatus", "-q", ".mergeStateStatus"])
+                state = r.stdout.strip() if r.returncode == 0 else "UNKNOWN"
+                p["mergeStateStatus"] = state
+                if state == "UNKNOWN":
+                    still.append(p)
+            unknown = still
         prs = [p for p in prs if p["mergeStateStatus"] == "DIRTY"]
     prs.sort(key=lambda p: p["number"])
     if args.limit:
         prs = prs[: args.limit]
 
     if not prs:
-        print("nothing to restack")
+        print("nothing to restack: %d open PR(s), none reported DIRTY" % total_open)
+        if unknown:
+            print("  WARNING: %d PR(s) never settled out of UNKNOWN and were NOT "
+                  "examined: %s" % (len(unknown),
+                                    ", ".join("#%d" % p["number"] for p in unknown)))
         return 0
 
     # ONE worktree for the whole sweep, detached so no branch is ever "checked
@@ -392,10 +430,18 @@ def main() -> int:
     for n, ref, why in failed:
         print("  #%-4d %-48s %s" % (n, ref, why))
     ver_landed = sum(1 for n, _, _ in version_fixed if n in restacked_nums)
-    print("\nrestacked %d (%d needed the capability fix, %d a plugin version), "
-          "current %d, conflicted %d, failed %d"
-          % (len(merged), len(resolved), ver_landed, len(already),
-             len(conflicted), len(failed)))
+    # SAY HOW MANY WERE LOOKED AT, not only what was found. A count of findings
+    # alone cannot distinguish "examined everything, found little" from
+    # "examined almost nothing".
+    print("\nexamined %d of %d open PR(s): restacked %d (%d needed the capability "
+          "fix, %d a plugin version), current %d, conflicted %d, failed %d"
+          % (len(prs), total_open, len(merged), len(resolved), ver_landed,
+             len(already), len(conflicted), len(failed)))
+    if unknown:
+        print("  WARNING: %d PR(s) never settled out of UNKNOWN after %d attempts "
+              "and were NOT examined: %s"
+              % (len(unknown), UNKNOWN_ATTEMPTS,
+                 ", ".join("#%d" % p["number"] for p in unknown)))
     if len(version_fixed) != ver_landed:
         print("  (%d further branch(es) had their version line resolved but stay "
               "conflicted on something else)" % (len(version_fixed) - ver_landed))

--- a/q-system/.q-system/scripts/test_pr_restack_unknown.py
+++ b/q-system/.q-system/scripts/test_pr_restack_unknown.py
@@ -1,0 +1,140 @@
+#!/usr/bin/env python3
+"""Self-test: pr-restack.py must not silently skip a PR it could not classify.
+
+THE DEFECT (measured 2026-08-30). GitHub computes PR mergeability lazily. In the
+minute or two after a merge to main a large fraction of the backlog reports
+UNKNOWN, and the first version of the sweeper filtered for DIRTY and dropped
+those without a word. A run moments after a merge examined 1 PR out of 23 and
+printed "conflicted 1", which reads as "the backlog is nearly clean". It was
+reported upward as exactly that. Twenty-two branches were never looked at.
+
+The fix has two halves and this file pins both:
+
+  1. an UNKNOWN is RE-QUERIED (asking about one PR forces GitHub to compute it),
+     bounded, rather than assumed to be fine;
+  2. anything still UNKNOWN at the end is NAMED in the output, and every run
+     reports how many PRs it examined against how many are open -- because a
+     count of findings alone cannot tell "examined everything, found little"
+     from "examined almost nothing".
+
+Hermetic: a stub `gh` on PATH decides what every query returns. No network, and
+the sweeper never reaches a real branch because the stub's PRs have none.
+
+Run: python3 test_pr_restack_unknown.py
+"""
+
+from __future__ import annotations
+
+import os
+import subprocess
+import sys
+import tempfile
+from pathlib import Path
+
+TOOL = Path(__file__).resolve().parent / "pr-restack.py"
+
+FAILURES: list[str] = []
+CHECKS = 0
+
+
+def check(name: str, ok: bool, detail: str = "") -> None:
+    global CHECKS
+    CHECKS += 1
+    if not ok:
+        FAILURES.append("%s\n    %s" % (name, detail))
+
+
+def _stub_gh(bindir: Path, *, settles: bool) -> None:
+    """A `gh` whose `pr list` says UNKNOWN for #901.
+
+    `pr view` then answers DIRTY (settles) or UNKNOWN forever (does not), so the
+    two branches of the retry are chosen by the fixture rather than by timing.
+    """
+    view_answer = "DIRTY" if settles else "UNKNOWN"
+    gh = bindir / "gh"
+    gh.write_text(
+        "#!/usr/bin/env bash\n"
+        'if [ "$1" = "pr" ] && [ "$2" = "list" ]; then\n'
+        "  cat <<'JSON'\n"
+        '[{"number":901,"headRefName":"stub/never-existed",'
+        '"mergeStateStatus":"UNKNOWN","title":"stub"}]\n'
+        "JSON\n"
+        "  exit 0\n"
+        "fi\n"
+        'if [ "$1" = "pr" ] && [ "$2" = "view" ]; then\n'
+        '  printf "%s\\n" "' + view_answer + '"\n'
+        "  exit 0\n"
+        "fi\n"
+        "exit 0\n"
+    )
+    gh.chmod(0o755)
+
+
+def run_tool(bindir: Path, repo: Path):
+    env = dict(os.environ)
+    env["PATH"] = str(bindir) + os.pathsep + env["PATH"]
+    env["PR_RESTACK_UNKNOWN_WAIT"] = "0"      # no real sleeping in a test
+    return subprocess.run([sys.executable, str(TOOL), "--dry-run"],
+                          cwd=str(repo), capture_output=True, text=True,
+                          env=env, timeout=120)
+
+
+def _repo(root: Path) -> Path:
+    repo = root / "r"
+    repo.mkdir(parents=True)
+    for a in (["init", "-q", "-b", "main"], ["config", "user.email", "t@t"],
+              ["config", "user.name", "t"]):
+        subprocess.run(["git", "-C", str(repo), *a], check=True,
+                       capture_output=True)
+    (repo / "f.txt").write_text("x\n")
+    subprocess.run(["git", "-C", str(repo), "add", "-A"], check=True,
+                   capture_output=True)
+    subprocess.run(["git", "-C", str(repo), "commit", "-qm", "seed"], check=True,
+                   capture_output=True)
+    # The sweeper cuts its worktree from origin/main, so the fixture needs that
+    # ref to exist. A local alias is enough: nothing here contacts a remote.
+    subprocess.run(["git", "-C", str(repo), "update-ref",
+                    "refs/remotes/origin/main", "HEAD"], check=True,
+                   capture_output=True)
+    return repo
+
+
+def main() -> int:
+    with tempfile.TemporaryDirectory() as td:
+        root = Path(td)
+
+        # --- it never settles: the run must NAME it, not stay quiet ---
+        bindir = root / "bin_stuck"
+        bindir.mkdir()
+        _stub_gh(bindir, settles=False)
+        r = run_tool(bindir, _repo(root / "a"))
+        out = r.stdout + r.stderr
+        check("an unsettled UNKNOWN is reported, not dropped",
+              "WARNING" in out and "#901" in out, out[-400:])
+        check("and it says how many are open on the nothing-to-do path too",
+              "1 open PR(s), none reported DIRTY" in out, out[-400:])
+
+        # --- it settles to DIRTY on re-query: the PR must be EXAMINED ---
+        bindir2 = root / "bin_settles"
+        bindir2.mkdir()
+        _stub_gh(bindir2, settles=True)
+        r2 = run_tool(bindir2, _repo(root / "b"))
+        out2 = r2.stdout + r2.stderr
+        # It has no real branch, so it lands in `failed` -- which is the proof
+        # it was PICKED UP rather than filtered out at the list step.
+        check("an UNKNOWN that re-queries to DIRTY is examined",
+              "#901" in out2 and "WARNING" not in out2, out2[-400:])
+        check("the examined count reflects it",
+              "examined 1 of 1 open PR" in out2, out2[-400:])
+
+    if FAILURES:
+        print("FAIL %d/%d\n" % (len(FAILURES), CHECKS))
+        for f in FAILURES:
+            print("  " + f + "\n")
+        return 1
+    print("ok  %d/%d checks passed" % (CHECKS, CHECKS))
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())


### PR DESCRIPTION
Found by running the tool I shipped an hour earlier (#282) and reading its output against reality.

## The defect

GitHub computes PR mergeability lazily. In the minute or two after a merge to main, a large fraction of the backlog reports `UNKNOWN`. The sweeper filtered for `DIRTY` and dropped those without a word.

Measured 2026-08-30, immediately after three merges landed:

```
examined 1 PR out of 23  ->  printed "conflicted 1"
```

That reads as *"the backlog is nearly clean"*, and it was reported upward as exactly that. **Twenty-two branches were never looked at.** Re-running two minutes later, once GitHub had caught up, found all 22 — same tool, same repo, same day, an answer twenty-two times larger.

Same failure class as two other findings today: **the silence of a thing that did not run is indistinguishable from the silence of a thing that ran and found nothing.**

## The fix, in two halves — either alone still lies

1. **An UNKNOWN is re-queried.** Asking about a single PR forces GitHub to compute it. Bounded at 3 attempts; a PR that never settles is a fact to report, not a reason to spin.
2. **Every run reports coverage, not just findings.** `examined 3 of 54 open PR(s)` cannot be mistaken for completeness. `conflicted 1` could. Anything still UNKNOWN at the end is named.

## Verified

4 cases, hermetic — a stub `gh` on PATH decides which branch runs, so neither depends on timing:

| case | result |
|---|---|
| never settles | WARNING naming `#901`, open count still printed |
| settles to DIRTY on re-query | the PR is picked up and examined |
| **mutation:** re-query removed, back to the single filter | **3 of 4 fail**, starting with the unsettled PR silently vanishing |
| restored | 4/4 |

The retry wait is env-overridable (`PR_RESTACK_UNKNOWN_WAIT`) purely so the suite does not spend twenty real seconds asleep.

## Note on the numbers I reported from #282

The "18 restacked / 6 restacked" figures from earlier sweeps were real merges, but any sweep run shortly after a merge under-examined the backlog. The corrected tool makes that visible rather than requiring someone to notice.