### PR TITLE
The discarded-envelope class: measured, swept fleet-wide, and gated

### DIFF
--- a/.claude/rules/skill-hook-pairing.md
+++ b/.claude/rules/skill-hook-pairing.md
@@ -20,7 +20,7 @@ For each rule in a skill, ask: can it be caught by regex, string match, char cou
 
 ## Override
 
-Hooks block by default. Bypass per-file with an explicit marker (one per hook, no stacking): `<!-- voice-lint-skip -->`, `# headline-lint-skip`, etc.
+Hooks block by default. Bypass per-file with an explicit marker (one per hook, no stacking): `<!-- voice-lint-skip -->`, `# headline-lint-skip`, `# hook-envelope-skip`, etc.
 
 ## Wired pairings (status)
 

--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -334,6 +334,16 @@
             "command": "test -f \"$CLAUDE_PROJECT_DIR/q-system/.q-system/scripts/portability-lint-hook.py\" && python3 \"$CLAUDE_PROJECT_DIR/q-system/.q-system/scripts/portability-lint-hook.py\""
           }
         ]
+      },
+      {
+        "matcher": "Bash",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "python3 \"$CLAUDE_PROJECT_DIR/q-system/.q-system/scripts/hook_envelope_audit.py\" --hook",
+            "timeout": 15
+          }
+        ]
       }
     ],
     "PostCompact": [

--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -303,6 +303,11 @@
             "type": "command",
             "command": "python3 \"$CLAUDE_PROJECT_DIR/q-system/.q-system/scripts/settings-template-sync-check.py\"",
             "timeout": 5
+          },
+          {
+            "type": "command",
+            "command": "python3 \"$CLAUDE_PROJECT_DIR/q-system/.q-system/scripts/hook_envelope_audit.py\" --hook",
+            "timeout": 10
           }
         ]
       },

--- a/q-system/.q-system/scripts/capability_manifest.py
+++ b/q-system/.q-system/scripts/capability_manifest.py
@@ -235,37 +235,80 @@ def explode(root, manifest, errors=None):
     return written
 
 
+def _canon(entry):
+    return json.dumps(entry, sort_keys=True)
+
+
+def _read_fragment(path):
+    """The declaration currently on disk at `path`, or None if there is none."""
+    try:
+        return json.loads(path.read_text())
+    except (OSError, ValueError):
+        return None
+
+
 def add_delta(root, base, head, errors=None):
-    """Write a fragment for every declaration `head` has that `base` does not.
+    """Replay onto the working tree every declaration `head` changed vs `base`.
 
-    The rebase tool for the 37 open branches that predate the split. Their
-    manifest edit is almost always one appended entry; replaying it by hand
-    means re-reading main's whole manifest per PR, which is what did not scale.
-    Feed it the merge-base manifest and the branch-head manifest and it writes
-    exactly that branch's additions as fragments, touching nothing else.
+    The rebase tool for the open branches that predate the split. Their manifest
+    edit is almost always one appended entry; replaying it by hand means
+    re-reading main's whole manifest per PR, which is what did not scale. Feed it
+    the merge-base manifest and the branch-head manifest and it writes exactly
+    that branch's changes as fragments, touching nothing else.
 
-    Additive ONLY. A branch that REMOVED a declaration is reported, never acted
-    on: deleting someone else's declaration during a rebase is the silent loss
-    this whole change exists to prevent, so it is surfaced for a human.
+    Entries are matched by their IDENTITY (entry_key: the declared path, or the
+    prefix, or the note), never by their serialized bytes. Byte-matching was the
+    original shape and it read an EDIT as a removal plus an addition, so a branch
+    that merely changed a declaration's runner was refused as if it had deleted
+    someone's declaration. PR #207 is exactly that case (sp-6b25c567).
+
+    Three outcomes, and the two refusals are the point:
+      ADD       key only in head            -> fragment written.
+      EDIT      key in both, content differs -> written ONLY if the fragment on
+                disk still holds the base version. If main edited the same
+                declaration, taking the branch's version would silently drop
+                main's, which is the same loss class as a deletion, so it is
+                reported instead.
+      REMOVAL   key only in base            -> reported, never acted on.
     """
-    written, removed = [], []
+    written, removed, conflicted = [], [], []
     for section in LIST_SECTIONS:
-        seen = {json.dumps(e, sort_keys=True) for e in (base.get(section) or [])}
-        have = {json.dumps(e, sort_keys=True) for e in (head.get(section) or [])}
-        for raw in sorted(have - seen):
-            entry = json.loads(raw)
+        base_by, head_by = {}, {}
+        for e in (base.get(section) or []):
+            base_by[entry_key(section, e)] = e
+        for e in (head.get(section) or []):
+            head_by[entry_key(section, e)] = e
+
+        for key in sorted(head_by):
+            new_entry = head_by[key]
+            old_entry = base_by.get(key)
+            if old_entry is not None and _canon(old_entry) == _canon(new_entry):
+                continue                       # the branch did not touch it
             sdir = fragment_dir(root) / section
+            name = fragment_name(section, new_entry)
+            target = sdir / name
+            if old_entry is not None:
+                current = _read_fragment(target)
+                if current is not None and _canon(current) != _canon(old_entry):
+                    conflicted.append("%s: %s" % (section, key))
+                    continue
             sdir.mkdir(parents=True, exist_ok=True)
-            name = fragment_name(section, entry)
-            (sdir / name).write_text(json.dumps(entry, indent=1,
-                                                sort_keys=True) + "\n")
+            target.write_text(json.dumps(new_entry, indent=1,
+                                         sort_keys=True) + "\n")
             written.append("%s/%s" % (section, name))
-        for raw in sorted(seen - have):
-            removed.append("%s: %s" % (section, raw))
+
+        for key in sorted(set(base_by) - set(head_by)):
+            removed.append("%s: %s" % (section, _canon(base_by[key])))
+
     if removed:
         _err(errors, "this branch also REMOVED %d declaration(s); replay those "
                      "by hand rather than silently: %s"
                      % (len(removed), " | ".join(removed)))
+    if conflicted:
+        _err(errors, "this branch EDITED %d declaration(s) that main has also "
+                     "changed since the merge base; replay those by hand rather "
+                     "than dropping main's version: %s"
+                     % (len(conflicted), " | ".join(conflicted)))
     return written
 
 

--- a/q-system/.q-system/scripts/capability_manifest.py
+++ b/q-system/.q-system/scripts/capability_manifest.py
@@ -265,10 +265,14 @@ def add_delta(root, base, head, errors=None):
     Three outcomes, and the two refusals are the point:
       ADD       key only in head            -> fragment written.
       EDIT      key in both, content differs -> written ONLY if the fragment on
-                disk still holds the base version. If main edited the same
-                declaration, taking the branch's version would silently drop
-                main's, which is the same loss class as a deletion, so it is
-                reported instead.
+                disk EXISTS, is readable, and still holds the base version.
+                Anything else is reported. If main edited the same declaration,
+                taking the branch's version silently drops main's. If the
+                fragment is GONE, main deliberately removed that declaration and
+                writing it back resurrects a gate main chose to retire -- the
+                same loss class as a deletion, pointing the other way (Codex
+                major, PR #285 round 1). If it is unreadable, this cannot tell
+                which case it is, and a check that cannot read must not pass.
       REMOVAL   key only in base            -> reported, never acted on.
     """
     written, removed, conflicted = [], [], []
@@ -289,8 +293,14 @@ def add_delta(root, base, head, errors=None):
             target = sdir / name
             if old_entry is not None:
                 current = _read_fragment(target)
-                if current is not None and _canon(current) != _canon(old_entry):
-                    conflicted.append("%s: %s" % (section, key))
+                if current is None or _canon(current) != _canon(old_entry):
+                    if not target.exists():
+                        why = "no fragment on disk; main removed this declaration"
+                    elif current is None:
+                        why = "fragment on disk is unreadable"
+                    else:
+                        why = "main changed it too"
+                    conflicted.append("%s: %s (%s)" % (section, key, why))
                     continue
             sdir.mkdir(parents=True, exist_ok=True)
             target.write_text(json.dumps(new_entry, indent=1,
@@ -305,9 +315,10 @@ def add_delta(root, base, head, errors=None):
                      "by hand rather than silently: %s"
                      % (len(removed), " | ".join(removed)))
     if conflicted:
-        _err(errors, "this branch EDITED %d declaration(s) that main has also "
-                     "changed since the merge base; replay those by hand rather "
-                     "than dropping main's version: %s"
+        _err(errors, "this branch EDITED %d declaration(s) whose fragment on "
+                     "disk is not the base version (main changed it, removed it, "
+                     "or it is unreadable); replay those by hand rather than "
+                     "guessing: %s"
                      % (len(conflicted), " | ".join(conflicted)))
     return written
 

--- a/q-system/.q-system/scripts/capability_manifest.py
+++ b/q-system/.q-system/scripts/capability_manifest.py
@@ -263,7 +263,12 @@ def add_delta(root, base, head, errors=None):
     someone's declaration. PR #207 is exactly that case (sp-6b25c567).
 
     Three outcomes, and the two refusals are the point:
-      ADD       key only in head            -> fragment written.
+      ADD       key only in head            -> fragment written, but ONLY if
+                nothing is already on disk under that name. If main added the
+                same declaration independently, overwriting it replaces main's
+                version with the branch's and reports success (Opus fallback
+                major, PR #285 round 6). Same loss the EDIT branch already
+                refuses, one branch over.
       EDIT      key in both, content differs -> written ONLY if the fragment on
                 disk EXISTS, is readable, and still holds the base version.
                 Anything else is reported. If main edited the same declaration,
@@ -291,6 +296,15 @@ def add_delta(root, base, head, errors=None):
             sdir = fragment_dir(root) / section
             name = fragment_name(section, new_entry)
             target = sdir / name
+            if old_entry is None and target.exists():
+                current = _read_fragment(target)
+                if current is None or _canon(current) != _canon(new_entry):
+                    conflicted.append(
+                        "%s: %s (a different declaration is already on disk "
+                        "under this name; main added it independently)"
+                        % (section, key))
+                    continue
+                continue                  # identical: nothing to write
             if old_entry is not None:
                 current = _read_fragment(target)
                 if current is None or _canon(current) != _canon(old_entry):

--- a/q-system/.q-system/scripts/capability_manifest.py
+++ b/q-system/.q-system/scripts/capability_manifest.py
@@ -307,6 +307,9 @@ def add_delta(root, base, head, errors=None):
                 continue                  # identical: nothing to write
             if old_entry is not None:
                 current = _read_fragment(target)
+                if current is not None and _canon(current) == _canon(new_entry):
+                    continue          # this replay already ran; re-running it is
+                                      # not a conflict with main (round 7 minor)
                 if current is None or _canon(current) != _canon(old_entry):
                     if not target.exists():
                         why = "no fragment on disk; main removed this declaration"

--- a/q-system/.q-system/scripts/hook_envelope_audit.py
+++ b/q-system/.q-system/scripts/hook_envelope_audit.py
@@ -288,9 +288,18 @@ TEXT_ENVELOPE_RE = re.compile(r'["\']?%s["\']?\s*[:=]' % KEY_ENVELOPE)
 #   emission :  {"additionalContext": "..."}        <- key of an object literal
 #   read     :  out["hookSpecificOutput"]["additionalContext"]
 #   assertion:  assert "additionalContext" not in out
-# So: the key must be FOLLOWED by a colon (it is a key, not an index or an
-# operand) and must NOT be immediately PRECEDED by '[' (that is a subscript).
-EMIT_KEY_RE = re.compile(r'(?<!\[)["\']%s["\']\s*:' % KEY_CONTEXT)
+# So: the key must be FOLLOWED by a colon. That single requirement separates all
+# three -- a subscript closes with ']' and an operand with whitespace.
+#
+# This used to also carry a `(?<!\[)` lookbehind against the subscript case, and
+# the comment claimed both halves were load-bearing. They were not: deleting the
+# lookbehind changed no result anywhere, because the colon had already excluded
+# every subscript. It read as verified because the mutation that checked it
+# removed the lookbehind AND the comment-stripping in one edit and credited the
+# resulting red to both. A mutation that changes two things proves nothing about
+# either (Opus fallback minor, PR #285 round 10). Dead branch removed, and the
+# colon is now pinned on its own below.
+EMIT_KEY_RE = re.compile(r'["\']%s["\']\s*:' % KEY_CONTEXT)
 # `#` for shell and python, `//` for js/ts. A scar comment quoting the broken
 # envelope verbatim -- which is exactly how this repo documents a scar -- was
 # being read as an emission in a .js or .ts hook (round 8 minor).
@@ -400,6 +409,11 @@ SELF_TEST_CASES = [
 ]
 
 SELF_TEST_SHELL = [
+    # The arm that pins the colon requirement ON ITS OWN. Without it, the
+    # subscript/assertion arms below pass for a reason no case names, which is
+    # how a control ends up hollow.
+    ("shell_key_without_colon_is_not_an_emission", None,
+     'if [ "$k" = "additionalContext" ]; then echo hi; fi\n'),
     ("shell_good", OK,
      'echo \'{"hookSpecificOutput": {"hookEventName": "SessionStart", '
      '"additionalContext": "x"}}\'\n'),

--- a/q-system/.q-system/scripts/hook_envelope_audit.py
+++ b/q-system/.q-system/scripts/hook_envelope_audit.py
@@ -217,6 +217,40 @@ def audit_python(path, source=None):
                                          "assignment, so the envelope around it "
                                          "cannot be read statically"))
 
+    # A .py hook can PRINT the envelope as a raw JSON string -- no dict node
+    # exists, so everything above is blind to it (Opus fallback minor, PR #285
+    # round 6).
+    #
+    # The first attempt ran the whole text scanner as a second pass and reported
+    # 28 broken sites across this repo, nearly all of them fixture strings inside
+    # this tool's OWN test file. A .py file is full of JSON-shaped strings that
+    # are inputs, not outputs. So the match is narrowed to the one construct that
+    # actually emits: a literal string handed straight to print() or
+    # sys.stdout.write(). A fixture bound to a name, or passed to write_text, is
+    # not an emission and stays invisible.
+    emitted = set()
+    for node in ast.walk(tree):
+        if not isinstance(node, ast.Call):
+            continue
+        fn = node.func
+        is_print = isinstance(fn, ast.Name) and fn.id == "print"
+        is_write = (isinstance(fn, ast.Attribute) and fn.attr == "write"
+                    and isinstance(fn.value, ast.Attribute)
+                    and fn.value.attr in ("stdout",))
+        if not (is_print or is_write):
+            continue
+        for arg in node.args:
+            if (isinstance(arg, ast.Constant) and isinstance(arg.value, str)
+                    and EMIT_KEY_RE.search(arg.value)):
+                emitted.add(node.lineno)
+    seen_lines = {s.line for s in sites}
+    for line in sorted(emitted - seen_lines):
+        text = source.split("\n")[line - 1]
+        verdict = OK if KEY_EVENT in text and KEY_ENVELOPE in text else (
+            NO_EVENT_NAME if KEY_ENVELOPE in text else TOP_LEVEL)
+        sites.append(Site(path, line, verdict,
+                          detail="envelope emitted as a raw JSON string"))
+
     by_line = {}
     for node in ast.walk(tree):
         if isinstance(node, ast.Dict) and id(node) in envelopes:
@@ -478,6 +512,10 @@ HOOK_MARKERS = (
     # tell is exactly this call.
     "json.load(sys.stdin)",
     "json.loads(sys.stdin",
+    # The scar shape the probe itself generates drains stdin and emits, without
+    # ever parsing it (Opus fallback minor, PR #285 round 6). `for line in
+    # sys.stdin` still does not match, which is what keeps an ordinary filter out.
+    "sys.stdin.read()",
 )
 
 
@@ -547,7 +585,14 @@ def _audit_recent_writes(payload):
             continue
         sites = (audit_python(full, source=source) if full.endswith(".py")
                  else audit_text(full, source=source))
-        bad.extend(s for s in sites if s.verdict != OK)
+        # DEFINITE verdicts only. UNKNOWN means "this shape is unreadable", and a
+        # correct hook built with dict() kwargs is UNKNOWN -- blocking every Bash
+        # call for 120s because some other recently-written file is unreadable is
+        # how a gate gets switched off (Opus fallback major, PR #285 round 6).
+        # The file_path leg still blocks on UNKNOWN: there it knows exactly which
+        # file you just edited and the feedback is actionable. This leg is
+        # inferring which file the command touched, so it only acts on certainty.
+        bad.extend(s for s in sites if s.verdict in (NO_EVENT_NAME, TOP_LEVEL))
     if not bad:
         return 0
     _emit_block(bad)

--- a/q-system/.q-system/scripts/hook_envelope_audit.py
+++ b/q-system/.q-system/scripts/hook_envelope_audit.py
@@ -124,10 +124,18 @@ def audit_python(path, source=None):
             continue
         keys = _literal_keys(node)
         if keys is None:
-            # A dict with a computed/starred key that mentions the context key
-            # anywhere cannot be judged statically.
-            if any(isinstance(k, ast.Constant) and k.value == KEY_CONTEXT
-                   for k in node.keys if k is not None):
+            # A dict with a computed or **-unpacked key cannot be judged
+            # statically. It is UNKNOWN, never absent: emitting no site at all
+            # let `k = "additionalContext"` inside an otherwise literal envelope
+            # walk straight through the blocking gate (Codex minor, PR #285
+            # round 3). Two ways to recognise it as an envelope worth reporting:
+            # it names the context key literally somewhere among its keys, or it
+            # is envelope-shaped because it carries a literal hookEventName.
+            named = any(isinstance(k, ast.Constant) and k.value == KEY_CONTEXT
+                        for k in node.keys if k is not None)
+            shaped = any(isinstance(k, ast.Constant) and k.value == KEY_EVENT
+                         for k in node.keys if k is not None)
+            if named or shaped:
                 sites.append(Site(path, node.lineno, UNKNOWN,
                                   detail="dict has non-literal or **-unpacked keys"))
                 envelopes.add(id(node))
@@ -412,7 +420,13 @@ HOOK_MARKERS = (
     "tool_input",
     "tool_name",
     "CLAUDE_PROJECT_DIR",
-    "sys.stdin",
+    # Reading a JSON object off stdin, not merely touching stdin. Bare
+    # `sys.stdin` caught any filter program that happens to carry an
+    # additionalContext field (Codex minor, PR #285 round 3); this still catches
+    # the leanest real offender, focus-kit's echo-of-prompt.py, whose only hook
+    # tell is exactly this call.
+    "json.load(sys.stdin)",
+    "json.loads(sys.stdin",
 )
 
 

--- a/q-system/.q-system/scripts/hook_envelope_audit.py
+++ b/q-system/.q-system/scripts/hook_envelope_audit.py
@@ -341,15 +341,125 @@ def self_test(verbose=True):
     return failures
 
 
+# --------------------------------------------------------------------------
+# Repair. Deliberately narrow: it only ever ADDS the missing hookEventName to a
+# hookSpecificOutput dict that already carries additionalContext, and it refuses
+# every other verdict. TOP_LEVEL needs a human to decide which event the payload
+# belongs to and where the envelope should live; UNKNOWN is by definition
+# unreadable. A repair that guessed at those would be the same class of defect
+# as the bug: a tool reporting success on work it could not see.
+# --------------------------------------------------------------------------
+def fix_no_event_name(path, event, source=None, dry_run=False):
+    """Insert hookEventName into every NO_EVENT_NAME site. Returns (n, text)."""
+    if source is None:
+        with open(path, "r", encoding="utf-8", errors="replace") as fh:
+            source = fh.read()
+    sites = [s for s in (audit_python(path, source=source) if path.endswith(".py")
+                         else audit_text(path, source=source))
+             if s.verdict == NO_EVENT_NAME]
+    if not sites:
+        return 0, source
+    out = source
+    n = 0
+    # Rewrite right-to-left so earlier offsets stay valid.
+    for m in sorted(re.finditer(r'(["\'])%s\1(\s*):' % KEY_CONTEXT, out),
+                    key=lambda m: -m.start()):
+        line = out.count("\n", 0, m.start()) + 1
+        # Only touch a line the audit actually flagged.
+        if not any(abs(s.line - line) <= 6 for s in sites):
+            continue
+        head = out.rfind("{", 0, m.start())
+        if head < 0:
+            continue
+        seg = out[head:m.start()]
+        if KEY_EVENT in seg or KEY_EVENT in out[m.start():m.start() + 400]:
+            continue
+        q = m.group(1)
+        indent = ""
+        ls = out.rfind("\n", 0, m.start()) + 1
+        if out[ls:m.start()].strip() == "":
+            indent = out[ls:m.start()]
+            insert = "%s%s%s%s: %s%s%s,\n" % (q, KEY_EVENT, q, "", q, event, q)
+            insert = "%s%s%s: %s%s%s,\n%s" % (q + KEY_EVENT + q, "", "",
+                                               q, event, q, indent)
+        else:
+            insert = "%s%s%s: %s%s%s, " % (q, KEY_EVENT, q, q, event, q)
+        out = out[:m.start()] + insert + out[m.start():]
+        n += 1
+    if n and not dry_run:
+        with open(path, "w", encoding="utf-8") as fh:
+            fh.write(out)
+    return n, out
+
+
+def hook_mode():
+    """PostToolUse gate: block an edit that ships a discarded envelope.
+
+    Self-scoped by tool_input.file_path (token discipline: this must not walk a
+    tree on every Edit). Exit 2 = block with stderr fed back to Claude, exit 0 =
+    pass. Anything unreadable or unparseable passes -- a gate that cannot run
+    must not block the session, and the pytest layer catches what this misses.
+    """
+    try:
+        payload = json.load(sys.stdin)
+    except Exception:
+        return 0
+    path = (payload.get("tool_input") or {}).get("file_path") or ""
+    if not path.endswith((".py", ".sh", ".js", ".ts")):
+        return 0
+    try:
+        with open(path, "r", encoding="utf-8", errors="replace") as fh:
+            source = fh.read()
+    except OSError:
+        return 0
+    if KEY_CONTEXT not in source:
+        return 0                      # the fast exit for every other edit
+    if self_test(verbose=False):
+        return 0                      # broken audit blocks nothing
+    sites = (audit_python(path, source=source) if path.endswith(".py")
+             else audit_text(path, source=source))
+    bad = [s for s in sites if s.verdict != OK]
+    if not bad:
+        return 0
+    lines = ["BLOCKED by hook_envelope_audit: this hook emits an envelope that "
+             "Claude Code DISCARDS.",
+             "",
+             "Measured 2026-08-30 (probe_hook_envelope.py, three headless runs "
+             "with a positive control): additionalContext reaches the model ONLY as",
+             '    {"hookSpecificOutput": {"hookEventName": "<Event>", '
+             '"additionalContext": "..."}}',
+             "Both a missing hookEventName and a top-level additionalContext were "
+             "measured ABSENT. The published docs call the key optional; they are wrong.",
+             ""]
+    for s in bad:
+        lines.append("  %s:%d  %s%s" % (s.path, s.line, s.verdict,
+                                        "  (%s)" % s.detail if s.detail else ""))
+    lines.append("")
+    lines.append("Set hookEventName to the event this hook is wired to. "
+                 "UNKNOWN means the envelope is not a literal dict here, so the "
+                 "audit cannot verify it -- make it literal, or move the emission "
+                 "to one chokepoint that is.")
+    sys.stderr.write("\n".join(lines) + "\n")
+    return 2
+
+
 def main(argv=None):
     ap = argparse.ArgumentParser(description=__doc__,
                                  formatter_class=argparse.RawDescriptionHelpFormatter)
     ap.add_argument("roots", nargs="*", help="files or directories to audit")
     ap.add_argument("--self-test", action="store_true")
+    ap.add_argument("--fix", metavar="EVENT",
+                    help="add the missing hookEventName=EVENT to every "
+                         "NO_EVENT_NAME site (never TOP_LEVEL/UNKNOWN)")
+    ap.add_argument("--hook", action="store_true",
+                    help="PostToolUse mode: hook JSON on stdin, exit 2 to block")
     ap.add_argument("--json", action="store_true")
     ap.add_argument("--all", action="store_true",
                     help="print OK sites too (default: only the broken ones)")
     args = ap.parse_args(argv)
+
+    if args.hook:
+        return hook_mode()
 
     if args.self_test:
         print("self-test:")
@@ -370,6 +480,19 @@ def main(argv=None):
     if failures:
         print("SELF-TEST FAILED, refusing to audit: %r" % (failures,), file=sys.stderr)
         return 2
+
+    if args.fix:
+        total, files = 0, 0
+        for path in walk(args.roots):
+            try:
+                n, _ = fix_no_event_name(path, args.fix)
+            except OSError:
+                continue
+            if n:
+                total += n
+                files += 1
+                print("fixed %d site(s) in %s" % (n, path))
+        print("\n%d site(s) across %d file(s)" % (total, files))
 
     sites = []
     for path in walk(args.roots):

--- a/q-system/.q-system/scripts/hook_envelope_audit.py
+++ b/q-system/.q-system/scripts/hook_envelope_audit.py
@@ -183,6 +183,21 @@ def audit_python(path, source=None):
                         and id(_resolve(node.value)) in envelopes):
                     nested.add(id(_resolve(node.value)))
 
+    # dict(additionalContext=...) and dict(**{...}) are two more ways to build
+    # the payload that a walk over Dict LITERALS never sees (Codex minor, PR #285
+    # round 5). Same rule as everywhere else here: a shape this cannot read is
+    # UNKNOWN, never absent.
+    for node in ast.walk(tree):
+        if not (isinstance(node, ast.Call) and isinstance(node.func, ast.Name)
+                and node.func.id == "dict"):
+            continue
+        named = any(kw.arg == KEY_CONTEXT for kw in node.keywords)
+        starred = any(kw.arg is None for kw in node.keywords)
+        if named or (starred and KEY_CONTEXT in ast.dump(node)):
+            sites.append(Site(path, node.lineno, UNKNOWN,
+                              detail="envelope built with dict(), which this "
+                                     "cannot read as a literal"))
+
     # `out["hookSpecificOutput"]["additionalContext"] = x` builds the payload by
     # ASSIGNMENT, so a walk over dict literals sees nothing at all and the gate
     # passed the file at exit 0 (Codex minor, PR #285 round 4). Absent read as
@@ -471,6 +486,74 @@ def looks_like_a_hook(source):
     return any(marker in source for marker in HOOK_MARKERS)
 
 
+# How recently a file must have been written for a Bash PostToolUse to own it.
+# Wide enough to cover a slow command, narrow enough that a file broken last week
+# does not wedge every Bash call in the session -- a gate that blocks unrelated
+# work is a gate that gets switched off.
+RECENT_WRITE_SECONDS = 120
+# Cost ceiling for the Bash path: this runs after EVERY Bash call, so it reads a
+# bounded number of recently-written files and no more (token discipline).
+MAX_RECENT_FILES = 40
+
+
+def _recently_written(root, now=None):
+    """Hook-shaped files in `root`'s working tree written in the last window."""
+    import subprocess
+    import time
+    now = time.time() if now is None else now
+    try:
+        r = subprocess.run(["git", "-C", root, "status", "--porcelain",
+                            "--untracked-files=all"],
+                           capture_output=True, text=True, timeout=10)
+    except (OSError, subprocess.SubprocessError):
+        return []
+    if r.returncode != 0:
+        return []
+    out = []
+    for line in r.stdout.splitlines():
+        rel = line[3:].strip()
+        if " -> " in rel:                       # a rename: take the destination
+            rel = rel.split(" -> ", 1)[1]
+        rel = rel.strip('"')
+        if not rel.endswith((".py", ".sh", ".js", ".ts")):
+            continue
+        full = os.path.join(root, rel)
+        try:
+            if now - os.path.getmtime(full) > RECENT_WRITE_SECONDS:
+                continue
+        except OSError:
+            continue
+        out.append(full)
+        if len(out) >= MAX_RECENT_FILES:
+            break
+    return out
+
+
+def _audit_recent_writes(payload):
+    """The Bash leg: judge what was written, not what the command said."""
+    root = (os.environ.get("CLAUDE_PROJECT_DIR")
+            or (payload.get("cwd") if isinstance(payload.get("cwd"), str) else None)
+            or os.getcwd())
+    if self_test(verbose=False):
+        return 0                      # a broken audit blocks nothing
+    bad = []
+    for full in _recently_written(root):
+        try:
+            with open(full, "r", encoding="utf-8", errors="replace") as fh:
+                source = fh.read()
+        except OSError:
+            continue
+        if KEY_CONTEXT not in source or not looks_like_a_hook(source):
+            continue
+        sites = (audit_python(full, source=source) if full.endswith(".py")
+                 else audit_text(full, source=source))
+        bad.extend(s for s in sites if s.verdict != OK)
+    if not bad:
+        return 0
+    _emit_block(bad)
+    return 2
+
+
 def hook_mode():
     """PostToolUse gate: block an edit that ships a discarded envelope.
 
@@ -484,6 +567,18 @@ def hook_mode():
     except Exception:
         return 0
     path = (payload.get("tool_input") or {}).get("file_path") or ""
+    if not path:
+        # A Bash write has no file_path, and this session wrote every one of its
+        # own hook fixes through Bash heredocs and python drivers -- so wired on
+        # Edit|Write alone the gate would never have fired on the very edits it
+        # was built for (Codex major, PR #285 round 5).
+        #
+        # Parsing the COMMAND for a path is the wrong layer and this repo already
+        # has the lesson: a guard that reads command text cannot see a computed
+        # path, and the careless wide rewrite is exactly the one that computes
+        # its targets. So look at the EFFECT instead: which hook-bearing files
+        # in the working tree were just written.
+        return _audit_recent_writes(payload)
     if not path.endswith((".py", ".sh", ".js", ".ts")):
         return 0
     try:
@@ -502,6 +597,11 @@ def hook_mode():
     bad = [s for s in sites if s.verdict != OK]
     if not bad:
         return 0
+    _emit_block(bad)
+    return 2
+
+
+def _emit_block(bad):
     lines = ["BLOCKED by hook_envelope_audit: this hook emits an envelope that "
              "Claude Code DISCARDS.",
              "",
@@ -521,7 +621,6 @@ def hook_mode():
                  "audit cannot verify it -- make it literal, or move the emission "
                  "to one chokepoint that is.")
     sys.stderr.write("\n".join(lines) + "\n")
-    return 2
 
 
 def main(argv=None):

--- a/q-system/.q-system/scripts/hook_envelope_audit.py
+++ b/q-system/.q-system/scripts/hook_envelope_audit.py
@@ -528,6 +528,11 @@ def looks_like_a_hook(source):
 # Wide enough to cover a slow command, narrow enough that a file broken last week
 # does not wedge every Bash call in the session -- a gate that blocks unrelated
 # work is a gate that gets switched off.
+# The per-file bypass every blocking hook in this repo is required to have
+# (skill-hook-pairing.md, "Override"). This one shipped without it, which left no
+# way past a false block except switching the gate off (round 7 minor).
+SKIP_MARKER = "hook-envelope-skip"
+
 RECENT_WRITE_SECONDS = 120
 # Cost ceiling for the Bash path: this runs after EVERY Bash call, so it reads a
 # bounded number of recently-written files and no more (token discipline).
@@ -539,14 +544,21 @@ def _recently_written(root, now=None):
     import subprocess
     import time
     now = time.time() if now is None else now
+    # `git status --porcelain` prints paths relative to the GIT ROOT, not to the
+    # directory passed with -C. Joining them onto a project dir that sits below
+    # the root produces paths that do not exist, and every one is skipped -- the
+    # gate goes silently inert exactly where it looks busiest (round 7 minor).
     try:
+        top = subprocess.run(["git", "-C", root, "rev-parse", "--show-toplevel"],
+                             capture_output=True, text=True, timeout=10)
         r = subprocess.run(["git", "-C", root, "status", "--porcelain",
                             "--untracked-files=all"],
                            capture_output=True, text=True, timeout=10)
     except (OSError, subprocess.SubprocessError):
         return []
-    if r.returncode != 0:
+    if r.returncode != 0 or top.returncode != 0:
         return []
+    root = top.stdout.strip() or root
     out = []
     for line in r.stdout.splitlines():
         rel = line[3:].strip()
@@ -633,6 +645,8 @@ def hook_mode():
         return 0
     if KEY_CONTEXT not in source:
         return 0                      # the fast exit for every other edit
+    if SKIP_MARKER in source:
+        return 0                      # explicit per-file bypass
     if not looks_like_a_hook(source):
         return 0                      # an ordinary dict key, not a hook payload
     if self_test(verbose=False):
@@ -647,8 +661,13 @@ def hook_mode():
 
 
 def _emit_block(bad):
-    lines = ["BLOCKED by hook_envelope_audit: this hook emits an envelope that "
-             "Claude Code DISCARDS.",
+    certain = [s for s in bad if s.verdict in (NO_EVENT_NAME, TOP_LEVEL)]
+    headline = ("BLOCKED by hook_envelope_audit: this hook emits an envelope that "
+                "Claude Code DISCARDS." if certain else
+                "BLOCKED by hook_envelope_audit: this hook builds its envelope in "
+                "a shape this audit CANNOT READ, so it cannot confirm the payload "
+                "is delivered. This is not a claim that it is broken.")
+    lines = [headline,
              "",
              "Measured 2026-08-30 (probe_hook_envelope.py, three headless runs "
              "with a positive control): additionalContext reaches the model ONLY as",
@@ -665,6 +684,9 @@ def _emit_block(bad):
                  "UNKNOWN means the envelope is not a literal dict here, so the "
                  "audit cannot verify it -- make it literal, or move the emission "
                  "to one chokepoint that is.")
+    lines.append("If the shape is deliberate and you have verified delivery "
+                 "yourself, put `%s` in the file to bypass this gate for it."
+                 % SKIP_MARKER)
     sys.stderr.write("\n".join(lines) + "\n")
 
 

--- a/q-system/.q-system/scripts/hook_envelope_audit.py
+++ b/q-system/.q-system/scripts/hook_envelope_audit.py
@@ -148,12 +148,29 @@ def audit_python(path, source=None):
         else:
             sites.append(Site(path, node.lineno, NO_EVENT_NAME))
 
+    # `hso = {...}` then `out = {"hookSpecificOutput": hso}` is a perfectly
+    # ordinary way to write the delivering shape, and calling it TOP_LEVEL was a
+    # false BLOCK on correct code (Codex minor, PR #285 round 4). One level of
+    # simple-name aliasing is resolved; anything deeper stays unreadable and is
+    # reported as such rather than guessed at.
+    aliases = {}
+    for node in ast.walk(tree):
+        if (isinstance(node, ast.Assign) and len(node.targets) == 1
+                and isinstance(node.targets[0], ast.Name)
+                and isinstance(node.value, ast.Dict)):
+            aliases[node.targets[0].id] = node.value
+
+    def _resolve(v):
+        if isinstance(v, ast.Name):
+            return aliases.get(v.id)
+        return v
+
     # An envelope nested under "hookSpecificOutput" is the delivering shape; one
     # that is NOT nested there is top-level and is discarded too. Re-classify.
     nested = set()
     for node in ast.walk(tree):
         if isinstance(node, ast.Dict):
-            v = _value_for(node, KEY_ENVELOPE)
+            v = _resolve(_value_for(node, KEY_ENVELOPE))
             if isinstance(v, ast.Dict) and id(v) in envelopes:
                 nested.add(id(v))
         # out["hookSpecificOutput"] = {...}
@@ -162,9 +179,28 @@ def audit_python(path, source=None):
                 if (isinstance(tgt, ast.Subscript)
                         and isinstance(tgt.slice, ast.Constant)
                         and tgt.slice.value == KEY_ENVELOPE
-                        and isinstance(node.value, ast.Dict)
-                        and id(node.value) in envelopes):
-                    nested.add(id(node.value))
+                        and isinstance(_resolve(node.value), ast.Dict)
+                        and id(_resolve(node.value)) in envelopes):
+                    nested.add(id(_resolve(node.value)))
+
+    # `out["hookSpecificOutput"]["additionalContext"] = x` builds the payload by
+    # ASSIGNMENT, so a walk over dict literals sees nothing at all and the gate
+    # passed the file at exit 0 (Codex minor, PR #285 round 4). Absent read as
+    # approved -- the exact confusion this tool exists to end. A subscript in a
+    # TARGET position is a write; the same subscript in a value position is a
+    # read and is left alone, the same discrimination the text scanner makes.
+    for node in ast.walk(tree):
+        if not isinstance(node, (ast.Assign, ast.AugAssign, ast.AnnAssign)):
+            continue
+        targets = node.targets if isinstance(node, ast.Assign) else [node.target]
+        for tgt in targets:
+            if (isinstance(tgt, ast.Subscript)
+                    and isinstance(tgt.slice, ast.Constant)
+                    and tgt.slice.value == KEY_CONTEXT):
+                sites.append(Site(path, node.lineno, UNKNOWN,
+                                  detail="additionalContext is written by "
+                                         "assignment, so the envelope around it "
+                                         "cannot be read statically"))
 
     by_line = {}
     for node in ast.walk(tree):

--- a/q-system/.q-system/scripts/hook_envelope_audit.py
+++ b/q-system/.q-system/scripts/hook_envelope_audit.py
@@ -286,7 +286,10 @@ TEXT_ENVELOPE_RE = re.compile(r'["\']?%s["\']?\s*[:=]' % KEY_ENVELOPE)
 # So: the key must be FOLLOWED by a colon (it is a key, not an index or an
 # operand) and must NOT be immediately PRECEDED by '[' (that is a subscript).
 EMIT_KEY_RE = re.compile(r'(?<!\[)["\']%s["\']\s*:' % KEY_CONTEXT)
-COMMENT_LINE_RE = re.compile(r'^\s*#')
+# `#` for shell and python, `//` for js/ts. A scar comment quoting the broken
+# envelope verbatim -- which is exactly how this repo documents a scar -- was
+# being read as an emission in a .js or .ts hook (round 8 minor).
+COMMENT_LINE_RE = re.compile(r'^\s*(#|//)')
 
 
 def _strip_comment_lines(source):
@@ -324,10 +327,14 @@ def audit_text(path, source=None):
                     break
         blob = scan[start:end]
         before = scan[max(0, start - 120):start]
-        if KEY_EVENT not in blob:
-            sites.append(Site(path, line, NO_EVENT_NAME))
-        elif not TEXT_ENVELOPE_RE.search(before) and KEY_ENVELOPE not in blob:
+        # Order matters: ask "is it nested at all" BEFORE "does it name the
+        # event". Asking the other way round labelled a bare top-level
+        # {"additionalContext": ...} as NO_EVENT_NAME, which blocks correctly but
+        # tells the reader the wrong thing about their own code.
+        if not TEXT_ENVELOPE_RE.search(before) and KEY_ENVELOPE not in blob:
             sites.append(Site(path, line, TOP_LEVEL))
+        elif KEY_EVENT not in blob:
+            sites.append(Site(path, line, NO_EVENT_NAME))
         else:
             ev = re.search(r'["\']%s["\']\s*:\s*["\']([A-Za-z]+)["\']' % KEY_EVENT, blob)
             sites.append(Site(path, line, OK, event=ev.group(1) if ev else "<non-literal>"))
@@ -559,7 +566,7 @@ def _recently_written(root, now=None):
     if r.returncode != 0 or top.returncode != 0:
         return []
     root = top.stdout.strip() or root
-    out = []
+    candidates = []
     for line in r.stdout.splitlines():
         rel = line[3:].strip()
         if " -> " in rel:                       # a rename: take the destination
@@ -569,14 +576,27 @@ def _recently_written(root, now=None):
             continue
         full = os.path.join(root, rel)
         try:
-            if now - os.path.getmtime(full) > RECENT_WRITE_SECONDS:
-                continue
+            mtime = os.path.getmtime(full)
         except OSError:
             continue
-        out.append(full)
-        if len(out) >= MAX_RECENT_FILES:
-            break
-    return out
+        if now - mtime > RECENT_WRITE_SECONDS:
+            continue
+        candidates.append((mtime, full))
+    # The cap used to break out of the loop in GIT PATH ORDER, so a broken hook
+    # whose path sorted late was never read at all and the gate exited 0 -- the
+    # silent-blindness class this tool exists to end, reintroduced by its own
+    # cost bound (round 8 major). Most-recently-written first, so the files the
+    # command just wrote are the ones that survive the cap, and truncation is
+    # reported rather than assumed harmless.
+    candidates.sort(reverse=True)
+    kept = [full for _, full in candidates[:MAX_RECENT_FILES]]
+    dropped = len(candidates) - len(kept)
+    if dropped:
+        sys.stderr.write(
+            "hook_envelope_audit: %d recently-written file(s) beyond the %d-file "
+            "cap were NOT examined; this pass is partial.\n"
+            % (dropped, MAX_RECENT_FILES))
+    return kept
 
 
 def _audit_recent_writes(payload):
@@ -593,8 +613,10 @@ def _audit_recent_writes(payload):
                 source = fh.read()
         except OSError:
             continue
-        if KEY_CONTEXT not in source or not looks_like_a_hook(source):
-            continue
+        if (KEY_CONTEXT not in source or SKIP_MARKER in source
+                or not looks_like_a_hook(source)):
+            continue                  # the same bypass the block message names;
+                                      # this leg ignored it (round 8 major)
         sites = (audit_python(full, source=source) if full.endswith(".py")
                  else audit_text(full, source=source))
         # DEFINITE verdicts only. UNKNOWN means "this shape is unreadable", and a

--- a/q-system/.q-system/scripts/hook_envelope_audit.py
+++ b/q-system/.q-system/scripts/hook_envelope_audit.py
@@ -228,7 +228,7 @@ def audit_python(path, source=None):
     # actually emits: a literal string handed straight to print() or
     # sys.stdout.write(). A fixture bound to a name, or passed to write_text, is
     # not an emission and stays invisible.
-    emitted = set()
+    emitted = {}
     for node in ast.walk(tree):
         if not isinstance(node, ast.Call):
             continue
@@ -242,14 +242,19 @@ def audit_python(path, source=None):
         for arg in node.args:
             if (isinstance(arg, ast.Constant) and isinstance(arg.value, str)
                     and EMIT_KEY_RE.search(arg.value)):
-                emitted.add(node.lineno)
+                emitted[node.lineno] = arg.value
     seen_lines = {s.line for s in sites}
-    for line in sorted(emitted - seen_lines):
-        text = source.split("\n")[line - 1]
-        verdict = OK if KEY_EVENT in text and KEY_ENVELOPE in text else (
-            NO_EVENT_NAME if KEY_ENVELOPE in text else TOP_LEVEL)
-        sites.append(Site(path, line, verdict,
-                          detail="envelope emitted as a raw JSON string"))
+    for line, text in sorted(emitted.items()):
+        if line in seen_lines:
+            continue
+        # Judge the STRING'S OWN CONTENT with the text scanner, not the source
+        # line the call starts on. Reading one line verdicted a CORRECT
+        # multi-line envelope as TOP_LEVEL and blocked it fleet-wide with a false
+        # "Claude Code DISCARDS" claim (round 9 major) -- a false block on
+        # correct code, which is how a gate gets switched off.
+        for inner in audit_text(path, source=text):
+            sites.append(Site(path, line, inner.verdict, event=inner.event,
+                              detail="envelope emitted as a raw JSON string"))
 
     by_line = {}
     for node in ast.walk(tree):

--- a/q-system/.q-system/scripts/hook_envelope_audit.py
+++ b/q-system/.q-system/scripts/hook_envelope_audit.py
@@ -1,0 +1,396 @@
+#!/usr/bin/env python3
+"""Audit every hook that injects additionalContext for the envelope that DELIVERS.
+
+Scar (measured 2026-08-30, probe_hook_envelope.py, three headless `claude -p`
+runs with a positive control): Claude Code silently DISCARDS a hook's
+additionalContext unless it is nested as
+
+    {"hookSpecificOutput": {"hookEventName": "<Event>", "additionalContext": "..."}}
+
+Both other shapes were measured ABSENT:
+  - nested WITHOUT hookEventName   -> discarded
+  - top-level additionalContext    -> discarded (the scar already in token-guard.py)
+
+The published docs say hookEventName is optional. The docs are wrong. Nothing
+downstream can see the failure: every gate measures the OUTPUT, none check that
+the INPUT arrived. So the only defence is a static audit of the emitters, and
+this is it.
+
+Classification per emission site:
+  OK             hookSpecificOutput dict carrying BOTH hookEventName and
+                 additionalContext as literal keys.
+  NO_EVENT_NAME  hookSpecificOutput.additionalContext with no hookEventName. The
+                 payload never reaches the model.
+  TOP_LEVEL      additionalContext at the top level of the emitted object.
+                 Same outcome.
+  UNKNOWN        the envelope is not a literal dict at the emission site, so
+                 this tool cannot tell. Reported, never passed: a check that
+                 cannot see must not report green.
+
+Exit 0 when every site is OK, 1 when any site is NO_EVENT_NAME/TOP_LEVEL/UNKNOWN,
+2 when the self-test fails (the tool is not measuring what it claims).
+
+Usage:
+    hook_envelope_audit.py --self-test
+    hook_envelope_audit.py <path-or-dir> [<path-or-dir> ...]
+    hook_envelope_audit.py --json <path-or-dir> ...
+"""
+from __future__ import annotations
+
+import argparse
+import ast
+import json
+import os
+import re
+import sys
+import tempfile
+
+KEY_CONTEXT = "additionalContext"
+KEY_ENVELOPE = "hookSpecificOutput"
+KEY_EVENT = "hookEventName"
+
+OK = "OK"
+NO_EVENT_NAME = "NO_EVENT_NAME"
+TOP_LEVEL = "TOP_LEVEL"
+UNKNOWN = "UNKNOWN"
+
+SKIP_DIR_PARTS = {".git", "node_modules", "__pycache__", ".venv", "venv",
+                  "review-trees", ".mypy_cache", ".pytest_cache"}
+
+
+class Site:
+    __slots__ = ("path", "line", "verdict", "event", "detail")
+
+    def __init__(self, path, line, verdict, event=None, detail=""):
+        self.path = path
+        self.line = line
+        self.verdict = verdict
+        self.event = event
+        self.detail = detail
+
+    def as_dict(self):
+        return {"path": self.path, "line": self.line, "verdict": self.verdict,
+                "event": self.event, "detail": self.detail}
+
+    def __repr__(self):  # pragma: no cover - debugging aid
+        return "Site(%s:%s %s)" % (self.path, self.line, self.verdict)
+
+
+def _literal_keys(node):
+    """String keys of an ast.Dict, or None if any key is not a literal string."""
+    keys = []
+    for k in node.keys:
+        if k is None:  # {**other}
+            return None
+        if isinstance(k, ast.Constant) and isinstance(k.value, str):
+            keys.append(k.value)
+        else:
+            return None
+    return keys
+
+
+def _value_for(node, key):
+    for k, v in zip(node.keys, node.values):
+        if isinstance(k, ast.Constant) and k.value == key:
+            return v
+    return None
+
+
+def _event_name(envelope):
+    v = _value_for(envelope, KEY_EVENT)
+    if isinstance(v, ast.Constant) and isinstance(v.value, str):
+        return v.value
+    return "<non-literal>" if v is not None else None
+
+
+def audit_python(path, source=None):
+    """Every additionalContext emission site in a Python file, classified."""
+    if source is None:
+        with open(path, "r", encoding="utf-8", errors="replace") as fh:
+            source = fh.read()
+    if KEY_CONTEXT not in source:
+        return []
+    try:
+        tree = ast.parse(source)
+    except SyntaxError as exc:
+        return [Site(path, getattr(exc, "lineno", 0) or 0, UNKNOWN,
+                     detail="unparseable: %s" % exc)]
+
+    sites = []
+    # Dicts that ARE the envelope: {"hookEventName": ..., "additionalContext": ...}
+    envelopes = set()
+    for node in ast.walk(tree):
+        if not isinstance(node, ast.Dict):
+            continue
+        keys = _literal_keys(node)
+        if keys is None:
+            # A dict with a computed/starred key that mentions the context key
+            # anywhere cannot be judged statically.
+            if any(isinstance(k, ast.Constant) and k.value == KEY_CONTEXT
+                   for k in node.keys if k is not None):
+                sites.append(Site(path, node.lineno, UNKNOWN,
+                                  detail="dict has non-literal or **-unpacked keys"))
+                envelopes.add(id(node))
+            continue
+        if KEY_CONTEXT not in keys:
+            continue
+        envelopes.add(id(node))
+        if KEY_EVENT in keys:
+            sites.append(Site(path, node.lineno, OK, event=_event_name(node)))
+        else:
+            sites.append(Site(path, node.lineno, NO_EVENT_NAME))
+
+    # An envelope nested under "hookSpecificOutput" is the delivering shape; one
+    # that is NOT nested there is top-level and is discarded too. Re-classify.
+    nested = set()
+    for node in ast.walk(tree):
+        if isinstance(node, ast.Dict):
+            v = _value_for(node, KEY_ENVELOPE)
+            if isinstance(v, ast.Dict) and id(v) in envelopes:
+                nested.add(id(v))
+        # out["hookSpecificOutput"] = {...}
+        if isinstance(node, ast.Assign):
+            for tgt in node.targets:
+                if (isinstance(tgt, ast.Subscript)
+                        and isinstance(tgt.slice, ast.Constant)
+                        and tgt.slice.value == KEY_ENVELOPE
+                        and isinstance(node.value, ast.Dict)
+                        and id(node.value) in envelopes):
+                    nested.add(id(node.value))
+
+    by_line = {}
+    for node in ast.walk(tree):
+        if isinstance(node, ast.Dict) and id(node) in envelopes:
+            by_line.setdefault(node.lineno, []).append(node)
+
+    out = []
+    for site in sites:
+        node = None
+        for cand in by_line.get(site.line, []):
+            node = cand
+            break
+        if site.verdict == UNKNOWN:
+            out.append(site)
+            continue
+        if node is not None and id(node) not in nested:
+            out.append(Site(path, site.line, TOP_LEVEL, event=site.event,
+                            detail="additionalContext is not inside a literal "
+                                   "hookSpecificOutput dict"))
+        else:
+            out.append(site)
+    return out
+
+
+TEXT_ENVELOPE_RE = re.compile(r'["\']?%s["\']?\s*[:=]' % KEY_ENVELOPE)
+
+# In shell/JS the same token appears three ways and only one of them is an
+# emission. Distinguishing them is the whole job: an audit that shouts on the
+# ~700 correct assertion lines in this repo's own hook tests is an audit the
+# fleet switches off, and then it protects nothing.
+#   emission :  {"additionalContext": "..."}        <- key of an object literal
+#   read     :  out["hookSpecificOutput"]["additionalContext"]
+#   assertion:  assert "additionalContext" not in out
+# So: the key must be FOLLOWED by a colon (it is a key, not an index or an
+# operand) and must NOT be immediately PRECEDED by '[' (that is a subscript).
+EMIT_KEY_RE = re.compile(r'(?<!\[)["\']%s["\']\s*:' % KEY_CONTEXT)
+COMMENT_LINE_RE = re.compile(r'^\s*#')
+
+
+def _strip_comment_lines(source):
+    """Blank out whole-line # comments, preserving line numbers.
+
+    The token-guard hook test opens with a six-line scar comment that quotes the
+    BROKEN envelope verbatim. Auditing prose as if it were code reported a defect
+    in the file whose entire purpose is asserting that defect is gone.
+    """
+    return "\n".join("" if COMMENT_LINE_RE.match(l) else l
+                      for l in source.split("\n"))
+
+
+def audit_text(path, source=None):
+    """Shell/JS fallback: brace-balanced read around each emitted context key."""
+    if source is None:
+        with open(path, "r", encoding="utf-8", errors="replace") as fh:
+            source = fh.read()
+    scan = _strip_comment_lines(source)
+    sites = []
+    for m in EMIT_KEY_RE.finditer(scan):
+        line = scan.count("\n", 0, m.start()) + 1
+        start = scan.rfind("{", 0, m.start())
+        if start < 0:
+            sites.append(Site(path, line, TOP_LEVEL, detail="no enclosing object"))
+            continue
+        depth, end = 0, len(scan)
+        for i in range(start, len(scan)):
+            if scan[i] == "{":
+                depth += 1
+            elif scan[i] == "}":
+                depth -= 1
+                if depth == 0:
+                    end = i + 1
+                    break
+        blob = scan[start:end]
+        before = scan[max(0, start - 120):start]
+        if KEY_EVENT not in blob:
+            sites.append(Site(path, line, NO_EVENT_NAME))
+        elif not TEXT_ENVELOPE_RE.search(before) and KEY_ENVELOPE not in blob:
+            sites.append(Site(path, line, TOP_LEVEL))
+        else:
+            ev = re.search(r'["\']%s["\']\s*:\s*["\']([A-Za-z]+)["\']' % KEY_EVENT, blob)
+            sites.append(Site(path, line, OK, event=ev.group(1) if ev else "<non-literal>"))
+    return sites
+
+
+def audit_file(path):
+    if path.endswith(".py"):
+        return audit_python(path)
+    return audit_text(path)
+
+
+def walk(roots):
+    for root in roots:
+        if os.path.isfile(root):
+            yield root
+            continue
+        for dirpath, dirnames, filenames in os.walk(root):
+            dirnames[:] = [d for d in dirnames if d not in SKIP_DIR_PARTS]
+            for name in filenames:
+                if name.endswith((".py", ".sh", ".js", ".ts")):
+                    yield os.path.join(dirpath, name)
+
+
+# --------------------------------------------------------------------------
+# Self-test. The three arms are the three shapes probe_hook_envelope.py measured
+# against a live model; this asserts the AUDIT agrees with the MEASUREMENT.
+# Without the two negative arms the audit could return OK unconditionally and
+# still look green, which is the exact failure this repo keeps hitting.
+# --------------------------------------------------------------------------
+SELF_TEST_CASES = [
+    ("good_nested", OK,
+     'import json,sys\n'
+     'sys.stdout.write(json.dumps({"hookSpecificOutput": '
+     '{"hookEventName": "UserPromptSubmit", "additionalContext": "x"}}))\n'),
+    ("nested_no_event_name", NO_EVENT_NAME,
+     'import json,sys\n'
+     'sys.stdout.write(json.dumps({"hookSpecificOutput": '
+     '{"additionalContext": "x"}}))\n'),
+    ("top_level", TOP_LEVEL,
+     'import json,sys\n'
+     'sys.stdout.write(json.dumps({"additionalContext": "x"}))\n'),
+    ("assigned_envelope", OK,
+     'import json,sys\n'
+     'out = {}\n'
+     'out["hookSpecificOutput"] = {"hookEventName": "SessionStart", '
+     '"additionalContext": "x"}\n'
+     'sys.stdout.write(json.dumps(out))\n'),
+    ("docstring_mention_only", None,
+     '"""Injects hookSpecificOutput.additionalContext somewhere else."""\n'
+     '# additionalContext is discussed here, never emitted\n'
+     'x = 1\n'),
+    ("computed_envelope", UNKNOWN,
+     'import json,sys\n'
+     'k = "additional" + "Context"\n'
+     'sys.stdout.write(json.dumps({"hookSpecificOutput": {k: "x"}, '
+     '"additionalContext": "y", **{}}))\n'),
+]
+
+SELF_TEST_SHELL = [
+    ("shell_good", OK,
+     'echo \'{"hookSpecificOutput": {"hookEventName": "SessionStart", '
+     '"additionalContext": "x"}}\'\n'),
+    ("shell_no_event_name", NO_EVENT_NAME,
+     'echo \'{"hookSpecificOutput": {"additionalContext": "x"}}\'\n'),
+    # The three shapes that are NOT emissions. Each of these was a live false
+    # positive against this repo's own hook tests before the text scanner learned
+    # to tell them apart; without these cases the scanner can regress to shouting
+    # on ~700 correct lines and nothing goes red.
+    ("shell_subscript_read", None,
+     'python3 -c "import sys,json; a=json.load(sys.stdin)'
+     "['hookSpecificOutput']['additionalContext']\"\n"),
+    ("shell_negative_assertion", None,
+     'python3 - <<EOF\n'
+     'assert "additionalContext" not in out, "must not be top-level"\n'
+     'EOF\n'),
+    ("shell_scar_comment", None,
+     '#!/usr/bin/env bash\n'
+     '# Scar: warn() printed top-level {"additionalContext": ...}, which is\n'
+     '#   ignored. Contract: nested hookSpecificOutput with hookEventName.\n'
+     'echo ok\n'),
+]
+
+
+def self_test(verbose=True):
+    failures = []
+    for name, expected, src in SELF_TEST_CASES:
+        got = audit_python("<%s>" % name, source=src)
+        verdicts = [s.verdict for s in got]
+        if expected is None:
+            ok = verdicts == []
+        else:
+            ok = verdicts == [expected]
+        if verbose:
+            print("  %-24s expected=%-14s got=%s" % (name, expected, verdicts))
+        if not ok:
+            failures.append((name, expected, verdicts))
+    for name, expected, src in SELF_TEST_SHELL:
+        verdicts = [s.verdict for s in audit_text("<%s>" % name, source=src)]
+        if verbose:
+            print("  %-24s expected=%-14s got=%s" % (name, expected, verdicts))
+        if verdicts != ([] if expected is None else [expected]):
+            failures.append((name, expected, verdicts))
+    return failures
+
+
+def main(argv=None):
+    ap = argparse.ArgumentParser(description=__doc__,
+                                 formatter_class=argparse.RawDescriptionHelpFormatter)
+    ap.add_argument("roots", nargs="*", help="files or directories to audit")
+    ap.add_argument("--self-test", action="store_true")
+    ap.add_argument("--json", action="store_true")
+    ap.add_argument("--all", action="store_true",
+                    help="print OK sites too (default: only the broken ones)")
+    args = ap.parse_args(argv)
+
+    if args.self_test:
+        print("self-test:")
+        failures = self_test()
+        if failures:
+            print("SELF-TEST FAILED: %r" % (failures,))
+            return 2
+        print("self-test OK (%d cases, incl. 3 negative arms)"
+              % (len(SELF_TEST_CASES) + len(SELF_TEST_SHELL)))
+        return 0
+
+    if not args.roots:
+        ap.error("give at least one path, or --self-test")
+
+    # The audit refuses to report on the fleet unless it can still tell the
+    # three shapes apart on this machine, today.
+    failures = self_test(verbose=False)
+    if failures:
+        print("SELF-TEST FAILED, refusing to audit: %r" % (failures,), file=sys.stderr)
+        return 2
+
+    sites = []
+    for path in walk(args.roots):
+        try:
+            sites.extend(audit_file(path))
+        except OSError:
+            continue
+
+    bad = [s for s in sites if s.verdict != OK]
+    if args.json:
+        print(json.dumps([s.as_dict() for s in (sites if args.all else bad)], indent=2))
+    else:
+        shown = sites if args.all else bad
+        for s in sorted(shown, key=lambda s: (s.verdict, s.path, s.line)):
+            print("%-14s %s:%d%s%s" % (s.verdict, s.path, s.line,
+                                       "  event=%s" % s.event if s.event else "",
+                                       "  %s" % s.detail if s.detail else ""))
+        print("\n%d emission site(s), %d OK, %d broken"
+              % (len(sites), len(sites) - len(bad), len(bad)))
+    return 1 if bad else 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/q-system/.q-system/scripts/hook_envelope_audit.py
+++ b/q-system/.q-system/scripts/hook_envelope_audit.py
@@ -392,6 +392,35 @@ def fix_no_event_name(path, event, source=None, dry_run=False):
     return n, out
 
 
+# A dict key named additionalContext is not proof of a hook. `payload =
+# {"additionalContext": "ordinary API field"}` in unrelated code is a perfectly
+# ordinary line, and a BLOCKING gate that stops that edit is a gate the fleet
+# switches off -- the same reasoning that made the text scanner learn to skip
+# reads and assertions (Codex minor, PR #285 round 2).
+#
+# So the blocking path additionally demands evidence that the file IS a hook.
+# These markers are taken from the files that actually carried the defect, not
+# invented: every stale token-guard fork mentions hook_event_name and tool_input,
+# and the leanest one (focus-kit's echo-of-prompt.py) still reads its payload
+# with json.load(sys.stdin). The REPORTING path does not apply this filter -- a
+# human reading a full audit wants to see everything, and only a block needs to
+# be sure.
+HOOK_MARKERS = (
+    "hookSpecificOutput",
+    "hookEventName",
+    "hook_event_name",
+    "tool_input",
+    "tool_name",
+    "CLAUDE_PROJECT_DIR",
+    "sys.stdin",
+)
+
+
+def looks_like_a_hook(source):
+    """True when the file carries any marker only a Claude Code hook would."""
+    return any(marker in source for marker in HOOK_MARKERS)
+
+
 def hook_mode():
     """PostToolUse gate: block an edit that ships a discarded envelope.
 
@@ -414,6 +443,8 @@ def hook_mode():
         return 0
     if KEY_CONTEXT not in source:
         return 0                      # the fast exit for every other edit
+    if not looks_like_a_hook(source):
+        return 0                      # an ordinary dict key, not a hook payload
     if self_test(verbose=False):
         return 0                      # broken audit blocks nothing
     sites = (audit_python(path, source=source) if path.endswith(".py")

--- a/q-system/.q-system/scripts/lessons-inject.py
+++ b/q-system/.q-system/scripts/lessons-inject.py
@@ -395,6 +395,14 @@ def main():
     # including that file's omission of the same key. Copying a shape is not
     # checking it. voice-dna-loader.py has the identical defect and is captured
     # separately rather than widened into this PR.
+    #
+    # CONFIRMED BY MEASUREMENT 2026-08-30, not by reading the docs: three
+    # headless `claude -p` runs via probe_hook_envelope.py, a unique marker per
+    # arm and a positive control that had to pass first. Nested-with-name
+    # delivered; nested-without-name and top-level both came back ABSENT. The
+    # published docs call the key optional and they are wrong. The
+    # voice-dna-loader.py defect this comment defers is now fixed too, together
+    # with 27 instance copies of it and nine stale token-guard forks.
     sys.stdout.write(json.dumps({"hookSpecificOutput": {
         "hookEventName": "UserPromptSubmit",
         "additionalContext": "".join(parts),

--- a/q-system/.q-system/scripts/probe_hook_envelope.py
+++ b/q-system/.q-system/scripts/probe_hook_envelope.py
@@ -1,0 +1,113 @@
+#!/usr/bin/env python3
+"""Does a UserPromptSubmit hook's additionalContext reach the model WITHOUT
+hookEventName?
+
+Codex called its absence a major on PR #277 ("the payload is discarded"). The
+published docs, read back by a summarizer, say the key looks optional. Neither is
+a measurement, and the claim decides whether lessons-inject has been delivering
+for its whole life or not at all. So: run it.
+
+Three arms, each a real headless session with its own project dir and its own
+hook:
+
+    nested_with_name    {"hookSpecificOutput": {"hookEventName": ..., "additionalContext": M}}
+    nested_no_name      {"hookSpecificOutput": {"additionalContext": M}}      <- the disputed one
+    top_level           {"additionalContext": M}                              <- the recorded scar
+
+Each marker is unique per run, so a marker in the answer can only have come from
+that arm's hook. The prompt asks the model to echo the marker or say ABSENT,
+which makes a non-delivery legible instead of silent.
+"""
+
+import json
+import os
+import pathlib
+import re
+import subprocess
+import sys
+import tempfile
+import uuid
+
+ARMS = {
+    "nested_with_name": '{"hookSpecificOutput": {"hookEventName": "UserPromptSubmit", "additionalContext": "%s"}}',
+    "nested_no_name": '{"hookSpecificOutput": {"additionalContext": "%s"}}',
+    "top_level": '{"additionalContext": "%s"}',
+}
+
+PROMPT = ("Some context may have been injected into this turn. If it contains a "
+          "token of the form MARKER-<letters>-<digits>, reply with that token and "
+          "nothing else. If there is no such token, reply with exactly ABSENT.")
+
+
+def build(root: pathlib.Path, shape: str, marker: str) -> None:
+    hooks_dir = root / "hooks"
+    hooks_dir.mkdir(parents=True)
+    hook = hooks_dir / "emit.py"
+    payload = shape % ("CONTEXT: the secret token is " + marker)
+    # Sanity: the marker has to survive into the bytes the hook will print, or
+    # the arm proves nothing about delivery.
+    assert marker in payload, payload
+    json.loads(payload)          # and it has to be valid JSON
+    hook.write_text(
+        "#!/usr/bin/env python3\n"
+        "import sys\n"
+        "sys.stdin.read()\n"
+        "sys.stdout.write(%r)\n" % payload)
+    hook.chmod(0o755)
+    cfg = root / ".claude"
+    cfg.mkdir(parents=True)
+    (cfg / "settings.json").write_text(json.dumps({
+        "hooks": {"UserPromptSubmit": [
+            {"hooks": [{"type": "command",
+                        "command": "python3 %s" % hook}]}]}
+    }, indent=2))
+
+
+def ask(root: pathlib.Path) -> str:
+    env = dict(os.environ)
+    env["CLAUDE_PROJECT_DIR"] = str(root)
+    try:
+        r = subprocess.run(["claude", "-p", PROMPT], cwd=str(root), env=env,
+                           capture_output=True, text=True, timeout=180)
+    except (OSError, subprocess.TimeoutExpired) as exc:
+        return "RUN-FAILED: %s" % exc
+    return (r.stdout or r.stderr or "").strip()
+
+
+def main() -> int:
+    results = {}
+    for arm, shape in ARMS.items():
+        marker = "MARKER-%s-%d" % (uuid.uuid4().hex[:6].upper(),
+                                   abs(hash(arm)) % 9000 + 1000)
+        root = pathlib.Path(tempfile.mkdtemp(prefix="envprobe-%s-" % arm))
+        build(root, shape, marker)
+        answer = ask(root)
+        delivered = marker in answer
+        results[arm] = (marker, delivered, answer[:160].replace("\n", " "))
+        print("%-18s marker=%s delivered=%-5s answer=%r"
+              % (arm, marker, delivered, answer[:80].replace("\n", " ")))
+
+    print()
+    with_name = results["nested_with_name"][1]
+    no_name = results["nested_no_name"][1]
+    top = results["top_level"][1]
+    if not with_name:
+        print("INCONCLUSIVE: the KNOWN-GOOD shape did not deliver either, so this "
+              "probe is not measuring what it claims. Fix the harness before "
+              "reading anything into the other two arms.")
+        return 2
+    print("nested WITH hookEventName delivered: %s  (control, expected True)" % with_name)
+    print("nested WITHOUT hookEventName delivered: %s" % no_name)
+    print("top-level additionalContext delivered: %s  (recorded scar says False)" % top)
+    print()
+    if no_name:
+        print("VERDICT: hookEventName is NOT required. Codex's major on PR #277 "
+              "is WRONG, and lessons-inject HAS been delivering all along.")
+    else:
+        print("VERDICT: hookEventName IS required. Codex's major stands and the "
+              "hook was inert until it was added.")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/q-system/.q-system/scripts/test_capability_gate.py
+++ b/q-system/.q-system/scripts/test_capability_gate.py
@@ -241,6 +241,50 @@ def sec_replay():
         check("replay: a REMOVED declaration is refused, never silently dropped",
               rc == 1 and "REMOVED" in out)
 
+    # EDIT, the case that was refused as a removal until sp-6b25c567. Byte-keyed
+    # diffing put the old serialization in `base - head` and the new one in
+    # `head - base`, so changing one field of a declaration looked like deleting
+    # someone else's and adding your own. PR #207 is exactly this shape.
+    with tempfile.TemporaryDirectory() as tmp:
+        root = make_repo(tmp)
+        rel = add_test(root, "q-system/.q-system/scripts/test_new.py")
+        old = entry(rel)
+        new = dict(old, runner="bash")
+        base = base_manifest(expected_tests=[old])
+        head = base_manifest(expected_tests=[new])
+        # main still holds the base version, so the edit is a safe fast-forward.
+        sdir = root / capability_manifest.FRAGMENT_DIR / "expected_tests"
+        sdir.mkdir(parents=True, exist_ok=True)
+        (sdir / capability_manifest.fragment_name("expected_tests", old)).write_text(
+            json.dumps(old, indent=1, sort_keys=True) + "\n")
+        rc, out = add_from(root, base, head)
+        check("replay: an EDITED declaration replays, not refused as a removal",
+              rc == 0 and "REMOVED" not in out)
+        landed = json.loads(
+            (sdir / capability_manifest.fragment_name("expected_tests", new)).read_text())
+        check("replay: the edit actually landed on disk",
+              landed.get("runner") == "bash")
+
+    # The same edit, but main changed that declaration too. Taking the branch's
+    # version would drop main's, which is the deletion class this tool refuses.
+    with tempfile.TemporaryDirectory() as tmp:
+        root = make_repo(tmp)
+        rel = add_test(root, "q-system/.q-system/scripts/test_new.py")
+        old = entry(rel)
+        theirs = dict(old, runner="sh")
+        ours = dict(old, runner="bash")
+        base = base_manifest(expected_tests=[old])
+        head = base_manifest(expected_tests=[ours])
+        sdir = root / capability_manifest.FRAGMENT_DIR / "expected_tests"
+        sdir.mkdir(parents=True, exist_ok=True)
+        frag = sdir / capability_manifest.fragment_name("expected_tests", old)
+        frag.write_text(json.dumps(theirs, indent=1, sort_keys=True) + "\n")
+        rc, out = add_from(root, base, head)
+        check("replay: an edit that collides with main is refused",
+              rc == 1 and "EDITED" in out)
+        check("replay: main's version survives the refusal",
+              json.loads(frag.read_text()).get("runner") == "sh")
+
 
 def sec_overlay():
     with tempfile.TemporaryDirectory() as tmp:

--- a/q-system/.q-system/scripts/test_capability_gate.py
+++ b/q-system/.q-system/scripts/test_capability_gate.py
@@ -285,6 +285,44 @@ def sec_replay():
         check("replay: main's version survives the refusal",
               json.loads(frag.read_text()).get("runner") == "sh")
 
+    # The edit whose fragment is GONE. Main removed that declaration on purpose;
+    # replaying the branch's edit would write it back and resurrect a gate main
+    # retired. Codex major, PR #285 round 1: _read_fragment returns None for both
+    # "missing" and "unreadable", and the old check only refused a non-None value
+    # that differed, so a deletion read as a safe edit and the tool reported
+    # success. Same loss class as a silent removal, pointing the other way.
+    with tempfile.TemporaryDirectory() as tmp:
+        root = make_repo(tmp)
+        rel = add_test(root, "q-system/.q-system/scripts/test_new.py")
+        old = entry(rel)
+        base = base_manifest(expected_tests=[old])
+        head = base_manifest(expected_tests=[dict(old, runner="bash")])
+        sdir = root / capability_manifest.FRAGMENT_DIR / "expected_tests"
+        rc, out = add_from(root, base, head)
+        check("replay: an edit whose fragment main REMOVED is refused",
+              rc == 1 and "EDITED" in out and "removed" in out)
+        check("replay: the removed declaration is not resurrected",
+              not (sdir / capability_manifest.fragment_name(
+                  "expected_tests", old)).exists())
+
+    # The edit whose fragment is unreadable. This cannot tell a concurrent edit
+    # from a removal, so it must refuse rather than pick one.
+    with tempfile.TemporaryDirectory() as tmp:
+        root = make_repo(tmp)
+        rel = add_test(root, "q-system/.q-system/scripts/test_new.py")
+        old = entry(rel)
+        base = base_manifest(expected_tests=[old])
+        head = base_manifest(expected_tests=[dict(old, runner="bash")])
+        sdir = root / capability_manifest.FRAGMENT_DIR / "expected_tests"
+        sdir.mkdir(parents=True, exist_ok=True)
+        frag = sdir / capability_manifest.fragment_name("expected_tests", old)
+        frag.write_text("{ this is not json")
+        rc, out = add_from(root, base, head)
+        check("replay: an unreadable fragment is refused, never overwritten",
+              rc == 1 and "unreadable" in out)
+        check("replay: the unreadable fragment is left alone",
+              frag.read_text() == "{ this is not json")
+
 
 def sec_overlay():
     with tempfile.TemporaryDirectory() as tmp:

--- a/q-system/.q-system/scripts/voice-dna-loader.py
+++ b/q-system/.q-system/scripts/voice-dna-loader.py
@@ -221,7 +221,17 @@ def main():
         voice_dna_path = resolve_path(VOICE_DNA_REL_PATH)
         samples_path = resolve_path(WRITING_SAMPLES_REL_PATH)
         context = build_context(voice_dna_path, samples_path)
-    output = {"hookSpecificOutput": {"additionalContext": context}}
+    # hookEventName is REQUIRED, not optional. Claude Code silently DISCARDS
+    # a hook payload whose hookSpecificOutput carries no hookEventName --
+    # measured 2026-08-30 by probe_hook_envelope.py, three headless runs with
+    # a positive control; the published docs say optional and are wrong. This
+    # hook emitted the nameless shape from the day it was written, so nothing
+    # it injected ever reached the model, and no downstream gate could see it:
+    # they all measure the OUTPUT, none check that the INPUT arrived.
+    output = {"hookSpecificOutput": {
+        "hookEventName": "UserPromptSubmit",
+        "additionalContext": context,
+    }}
     sys.stdout.write(json.dumps(output))
     sys.exit(0)
 

--- a/q-system/.q-system/tests/test_hook_envelope_audit.py
+++ b/q-system/.q-system/tests/test_hook_envelope_audit.py
@@ -660,3 +660,86 @@ def test_add_delta_edit_replay_is_idempotent(tmp_path):
     assert cm.add_delta(str(root), base, head, second_errors) == []
     assert second_errors == [], second_errors
     assert _json.loads(frag.read_text())["runner"] == "bash"
+
+
+# --------------------------------------------------------------------------
+# Round 8. Both majors are regressions the earlier fixes introduced: a cost
+# bound that reintroduced silent blindness, and a bypass the message advertised
+# but one leg ignored.
+# --------------------------------------------------------------------------
+def test_bash_leg_cap_keeps_the_most_recently_written_not_the_alphabetically_first(tmp_path):
+    """The cap used to break out in GIT PATH ORDER.
+
+    A broken hook whose path sorted late was never read at all and the gate
+    exited 0 -- the silent-blindness class this tool exists to end, reintroduced
+    by its own cost bound.
+    """
+    import time
+    root = _init_repo(tmp_path / "repo")
+    # Enough clean files to fill the cap, all named to sort BEFORE the bad one.
+    for i in range(audit.MAX_RECENT_FILES + 5):
+        (root / ("aaa_clean_%03d.py" % i)).write_text(
+            'import json, sys\n'
+            'payload = json.load(sys.stdin)\n'
+            'print(json.dumps({"hookSpecificOutput": {'
+            '"hookEventName": "PreToolUse", "additionalContext": "ok"}}))\n')
+    time.sleep(0.05)
+    bad = root / "zzz_broken.py"          # sorts last by path, written last
+    bad.write_text('import json, sys\n'
+                   'payload = json.load(sys.stdin)\n'
+                   'print(json.dumps({"additionalContext": "discarded"}))\n')
+    proc = _run_bash_gate(root)
+    assert proc.returncode == 2, (proc.returncode, proc.stdout, proc.stderr)
+    assert "zzz_broken.py" in proc.stderr
+
+
+def test_bash_leg_says_so_when_it_could_not_examine_everything(tmp_path):
+    """Truncation is reported, never assumed harmless."""
+    root = _init_repo(tmp_path / "repo")
+    for i in range(audit.MAX_RECENT_FILES + 3):
+        (root / ("hook_%03d.py" % i)).write_text(
+            'import json, sys\n'
+            'payload = json.load(sys.stdin)\n'
+            'print(json.dumps({"hookSpecificOutput": {'
+            '"hookEventName": "PreToolUse", "additionalContext": "ok"}}))\n')
+    proc = _run_bash_gate(root)
+    assert "NOT examined" in proc.stderr, proc.stderr
+
+
+def test_bash_leg_honours_the_skip_marker(tmp_path):
+    """The block message names this bypass; this leg used to ignore it."""
+    root = _init_repo(tmp_path / "repo")
+    (root / "deliberate_hook.py").write_text(
+        'import json, sys\n'
+        '# hook-envelope-skip: verified by hand against the live model\n'
+        'payload = json.load(sys.stdin)\n'
+        'print(json.dumps({"additionalContext": "x"}))\n')
+    assert _run_bash_gate(root).returncode == 0
+
+
+def test_bash_leg_without_the_marker_still_blocks_that_file(tmp_path):
+    """The control. A bypass nothing can fail is not a bypass."""
+    root = _init_repo(tmp_path / "repo")
+    (root / "same_hook.py").write_text(
+        'import json, sys\n'
+        'payload = json.load(sys.stdin)\n'
+        'print(json.dumps({"additionalContext": "x"}))\n')
+    assert _run_bash_gate(root).returncode == 2
+
+
+def test_a_double_slash_scar_comment_is_not_an_emission():
+    """This repo documents a scar by quoting the broken envelope verbatim.
+
+    In a .js or .ts hook that comment was being audited as code.
+    """
+    src = ('// Scar: this used to print {"additionalContext": "x"} at the top\n'
+           '//   level, which Claude Code discards.\n'
+           'console.log(JSON.stringify({hookSpecificOutput: {}}));\n')
+    assert audit.audit_text("<hook.js>", source=src) == []
+
+
+def test_a_real_js_emission_is_still_seen():
+    """The control for the comment rule."""
+    src = 'process.stdout.write(JSON.stringify({"additionalContext": "x"}));\n'
+    verdicts = [s.verdict for s in audit.audit_text("<hook.js>", source=src)]
+    assert verdicts == [audit.TOP_LEVEL], verdicts

--- a/q-system/.q-system/tests/test_hook_envelope_audit.py
+++ b/q-system/.q-system/tests/test_hook_envelope_audit.py
@@ -115,3 +115,102 @@ def test_userpromptsubmit_hooks_deliver_end_to_end(script, prompt):
     hso = out["hookSpecificOutput"]
     assert hso.get("hookEventName") == "UserPromptSubmit", hso
     assert hso.get("additionalContext", "").strip(), "delivered an empty payload"
+
+
+# --------------------------------------------------------------------------
+# PostToolUse gate mode. exit 2 = block, exit 0 = pass (skill-hook-pairing.md).
+# --------------------------------------------------------------------------
+def _run_gate(file_path):
+    payload = json.dumps({"tool_name": "Write",
+                          "tool_input": {"file_path": str(file_path)}})
+    return subprocess.run([sys.executable, AUDIT, "--hook"], input=payload,
+                          capture_output=True, text=True, timeout=60)
+
+
+def test_gate_blocks_a_discarded_envelope(tmp_path):
+    bad = tmp_path / "badhook.py"
+    bad.write_text('import json,sys\nsys.stdout.write(json.dumps('
+                   '{"hookSpecificOutput": {"additionalContext": "x"}}))\n')
+    proc = _run_gate(bad)
+    assert proc.returncode == 2, proc.stdout
+    assert "DISCARDS" in proc.stderr
+
+
+def test_gate_passes_the_delivering_envelope(tmp_path):
+    good = tmp_path / "goodhook.py"
+    good.write_text('import json,sys\nsys.stdout.write(json.dumps('
+                    '{"hookSpecificOutput": {"hookEventName": "SessionStart", '
+                    '"additionalContext": "x"}}))\n')
+    assert _run_gate(good).returncode == 0
+
+
+def test_gate_fast_exits_on_an_unrelated_edit(tmp_path):
+    other = tmp_path / "notes.md"
+    other.write_text("# nothing to do with hooks\n")
+    assert _run_gate(other).returncode == 0
+
+
+def test_gate_passes_when_its_own_self_test_is_broken(tmp_path, monkeypatch):
+    """A gate that cannot run must not block the session.
+
+    The pytest layer above is what catches the envelope when this is inert; the
+    gate's job is fast feedback, not being the only line.
+    """
+    bad = tmp_path / "badhook.py"
+    bad.write_text('import json,sys\nsys.stdout.write(json.dumps('
+                   '{"hookSpecificOutput": {"additionalContext": "x"}}))\n')
+    mod = _load()
+    monkeypatch.setattr(mod, "self_test", lambda verbose=True: [("broken", None, [])])
+    monkeypatch.setattr(sys, "stdin", __import__("io").StringIO(json.dumps(
+        {"tool_name": "Write", "tool_input": {"file_path": str(bad)}})))
+    assert mod.hook_mode() == 0
+
+
+# --------------------------------------------------------------------------
+# --fix. Narrow on purpose: it adds a missing hookEventName and nothing else.
+# --------------------------------------------------------------------------
+def test_fix_adds_the_missing_event_name_and_the_result_runs(tmp_path):
+    p = tmp_path / "hook.py"
+    p.write_text('import json,sys\nsys.stdout.write(json.dumps('
+                 '{"hookSpecificOutput": {"additionalContext": "x"}}))\n')
+    n, _ = audit.fix_no_event_name(str(p), "UserPromptSubmit")
+    assert n == 1
+    assert [s.verdict for s in audit.audit_python(str(p))] == [audit.OK]
+    proc = subprocess.run([sys.executable, str(p)], capture_output=True, text=True)
+    assert proc.returncode == 0, proc.stderr
+    out = json.loads(proc.stdout)
+    assert out["hookSpecificOutput"]["hookEventName"] == "UserPromptSubmit"
+    assert out["hookSpecificOutput"]["additionalContext"] == "x"
+
+
+def test_fix_refuses_top_level_and_unknown(tmp_path):
+    """The two verdicts a machine must not guess at.
+
+    TOP_LEVEL needs a human to say which event owns the payload and where the
+    envelope belongs; UNKNOWN is unreadable by definition. Silently 'repairing'
+    either would be the same defect as the bug it fixes.
+    """
+    top = tmp_path / "top.py"
+    top.write_text('import json,sys\n'
+                   'sys.stdout.write(json.dumps({"additionalContext": "x"}))\n')
+    before = top.read_text()
+    assert audit.fix_no_event_name(str(top), "PreToolUse")[0] == 0
+    assert top.read_text() == before
+
+    unk = tmp_path / "unk.py"
+    unk.write_text('import json,sys\nk = "additional" + "Context"\n'
+                   'sys.stdout.write(json.dumps({"hookSpecificOutput": {k: "x"}, '
+                   '"additionalContext": "y", **{}}))\n')
+    before = unk.read_text()
+    assert audit.fix_no_event_name(str(unk), "PreToolUse")[0] == 0
+    assert unk.read_text() == before
+
+
+def test_fix_is_idempotent(tmp_path):
+    p = tmp_path / "hook.py"
+    p.write_text('import json,sys\nsys.stdout.write(json.dumps('
+                 '{"hookSpecificOutput": {"additionalContext": "x"}}))\n')
+    assert audit.fix_no_event_name(str(p), "SessionStart")[0] == 1
+    once = p.read_text()
+    assert audit.fix_no_event_name(str(p), "SessionStart")[0] == 0
+    assert p.read_text() == once

--- a/q-system/.q-system/tests/test_hook_envelope_audit.py
+++ b/q-system/.q-system/tests/test_hook_envelope_audit.py
@@ -345,3 +345,98 @@ def test_reading_that_same_subscript_is_still_not_an_emission():
            'ctx = payload["hookSpecificOutput"]["additionalContext"]\n'
            'print(ctx)\n')
     assert audit.audit_python("<read>", source=src) == []
+
+
+# --------------------------------------------------------------------------
+# Codex round 5. The gate was wired on Edit|Write|MultiEdit only, and a Bash
+# write carries no file_path -- so it would never have fired on the very edits
+# it was built for. This session wrote every one of its own hook fixes through
+# Bash heredocs and python drivers.
+# --------------------------------------------------------------------------
+def _init_repo(path):
+    subprocess.run(["git", "init", "-q", str(path)], check=True)
+    return path
+
+
+def _run_bash_gate(root):
+    payload = json.dumps({"tool_name": "Bash",
+                          "tool_input": {"command": "python3 - <<EOF ... EOF"}})
+    env = dict(os.environ, CLAUDE_PROJECT_DIR=str(root))
+    return subprocess.run([sys.executable, AUDIT, "--hook"], input=payload,
+                          env=env, capture_output=True, text=True, timeout=60)
+
+
+def test_bash_leg_blocks_a_hook_written_without_a_file_path(tmp_path):
+    """Judge the EFFECT, not the command text.
+
+    Parsing the command for a path is the wrong layer, and this repo already
+    carries the lesson: a guard that reads command text cannot see a computed
+    path, and the careless wide rewrite is the one that computes its targets.
+    """
+    root = _init_repo(tmp_path / "repo")
+    (root / "sneaky_hook.py").write_text(
+        'import json, sys\n'
+        'payload = json.load(sys.stdin)\n'
+        'print(json.dumps({"additionalContext": "discarded"}))\n')
+    proc = _run_bash_gate(root)
+    assert proc.returncode == 2, proc.stdout
+    assert "DISCARDS" in proc.stderr
+
+
+def test_bash_leg_passes_when_nothing_hook_shaped_was_written(tmp_path):
+    """The control. Blocking unrelated Bash work gets the gate switched off."""
+    root = _init_repo(tmp_path / "repo")
+    (root / "notes.md").write_text("# nothing to do with hooks\n")
+    (root / "helper.py").write_text("def add(a, b):\n    return a + b\n")
+    assert _run_bash_gate(root).returncode == 0
+
+
+def test_bash_leg_ignores_a_file_written_long_ago(tmp_path):
+    """A file broken last week must not wedge every Bash call in the session."""
+    import time
+    root = _init_repo(tmp_path / "repo")
+    stale = root / "old_hook.py"
+    stale.write_text('import json, sys\n'
+                     'payload = json.load(sys.stdin)\n'
+                     'print(json.dumps({"additionalContext": "discarded"}))\n')
+    old = time.time() - (audit.RECENT_WRITE_SECONDS + 600)
+    os.utime(stale, (old, old))
+    assert _run_bash_gate(root).returncode == 0
+
+
+def test_the_bash_leg_is_actually_wired(tmp_path):
+    """A capability nobody wired is a capability nobody has."""
+    for rel in (os.path.join("." + "claude", "settings.json"),
+                "settings-template.json"):
+        cfg = json.load(open(os.path.join(REPO, rel)))
+        matchers = [g.get("matcher") for g in cfg["hooks"]["PostToolUse"]
+                    for h in g["hooks"]
+                    if "hook_envelope_audit" in h.get("command", "")]
+        assert "Bash" in matchers, "%s wires the gate on %r only" % (rel, matchers)
+
+
+def test_dict_construction_is_not_silently_approved():
+    """dict(additionalContext=...) is invisible to a walk over dict literals.
+
+    dict(**d) reports TOP_LEVEL rather than UNKNOWN because the aliased literal
+    is itself un-nested; both are non-OK, which is what the gate acts on, and
+    neither is the silent absence that started all of this.
+    """
+    kwargs_src = ('import json, sys\n'
+                  'payload = json.load(sys.stdin)\n'
+                  'print(json.dumps({"hookSpecificOutput": dict('
+                  'hookEventName="UserPromptSubmit", additionalContext="x")}))\n')
+    assert [s.verdict for s in audit.audit_python("<kw>", source=kwargs_src)] == [audit.UNKNOWN]
+
+    star_src = ('import json, sys\n'
+                'payload = json.load(sys.stdin)\n'
+                'd = {"additionalContext": "x"}\n'
+                'print(json.dumps({"hookSpecificOutput": dict(**d)}))\n')
+    verdicts = [s.verdict for s in audit.audit_python("<star>", source=star_src)]
+    assert verdicts and all(v != audit.OK for v in verdicts), verdicts
+
+
+def test_an_ordinary_dict_call_is_not_an_emission():
+    """The control for the dict() rule."""
+    src = 'rows = dict(name="a", value="b")\nprint(rows)\n'
+    assert audit.audit_python("<ordinary>", source=src) == []

--- a/q-system/.q-system/tests/test_hook_envelope_audit.py
+++ b/q-system/.q-system/tests/test_hook_envelope_audit.py
@@ -214,3 +214,36 @@ def test_fix_is_idempotent(tmp_path):
     once = p.read_text()
     assert audit.fix_no_event_name(str(p), "SessionStart")[0] == 0
     assert p.read_text() == once
+
+
+# --------------------------------------------------------------------------
+# The blocking path is scoped to files that are actually hooks (Codex minor,
+# PR #285 round 2). A gate that stops an ordinary dict key gets switched off.
+# --------------------------------------------------------------------------
+def test_gate_ignores_an_ordinary_dict_key(tmp_path):
+    """The reviewer's reproducer: an unrelated API payload must not be blocked."""
+    p = tmp_path / "ordinary_api.py"
+    p.write_text('payload = {"additionalContext": "ordinary API field"}\n')
+    assert _run_gate(p).returncode == 0
+
+
+def test_gate_still_blocks_a_real_hook_with_the_same_shape(tmp_path):
+    """The control that keeps the scoping honest.
+
+    The body markers are taken from the files that actually carried the defect,
+    not invented: focus-kit's echo-of-prompt.py is the leanest of them and its
+    only hook tell is reading its payload off stdin.
+    """
+    p = tmp_path / "echo_like_hook.py"
+    p.write_text('import json,sys\n'
+                 'payload = json.load(sys.stdin)\n'
+                 'print(json.dumps({"additionalContext": "re-anchor"}))\n')
+    proc = _run_gate(p)
+    assert proc.returncode == 2, proc.stdout
+    assert "DISCARDS" in proc.stderr
+
+
+def test_reporting_path_still_surfaces_the_ordinary_dict(tmp_path):
+    """Only the BLOCK is scoped. A human reading a full audit wants everything."""
+    src = 'payload = {"additionalContext": "ordinary API field"}\n'
+    assert [s.verdict for s in audit.audit_python("<api>", source=src)] == [audit.TOP_LEVEL]

--- a/q-system/.q-system/tests/test_hook_envelope_audit.py
+++ b/q-system/.q-system/tests/test_hook_envelope_audit.py
@@ -440,3 +440,128 @@ def test_an_ordinary_dict_call_is_not_an_emission():
     """The control for the dict() rule."""
     src = 'rows = dict(name="a", value="b")\nprint(rows)\n'
     assert audit.audit_python("<ordinary>", source=src) == []
+
+
+# --------------------------------------------------------------------------
+# Opus-fallback review, PR #285 round 6. Codex was rate-limited; the fallback
+# posted DEGRADED and found four real things anyway.
+# --------------------------------------------------------------------------
+def test_raw_json_string_emission_is_seen(tmp_path):
+    """A .py hook can print the envelope as a string. No dict node exists."""
+    src = ('import json, sys\n'
+           'payload = json.load(sys.stdin)\n'
+           'print(\'{"additionalContext": "discarded"}\')\n')
+    verdicts = [s.verdict for s in audit.audit_python("<raw>", source=src)]
+    assert verdicts and all(v != audit.OK for v in verdicts), verdicts
+
+    p = tmp_path / "raw_hook.py"
+    p.write_text(src)
+    assert _run_gate(p).returncode == 2
+
+
+def test_a_json_shaped_fixture_string_is_not_an_emission():
+    """The control, and the reason the first version of this was reverted.
+
+    Running the whole text scanner as a second pass reported 28 broken sites in
+    this repo, nearly all of them fixture strings inside this tool's own test
+    file. A .py file is full of JSON-shaped strings that are inputs.
+    """
+    src = ('BAD = \'{"hookSpecificOutput": {"additionalContext": "x"}}\'\n'
+           'def test_thing(tmp_path):\n'
+           '    (tmp_path / "h.py").write_text(BAD)\n')
+    assert audit.audit_python("<fixture>", source=src) == []
+
+
+def test_bash_leg_does_not_wedge_on_a_shape_it_merely_cannot_read(tmp_path):
+    """UNKNOWN is "unreadable", not "broken".
+
+    A correct hook built with dict() kwargs is UNKNOWN. Blocking every Bash call
+    for 120 seconds because some other recently-written file is unreadable is how
+    a gate gets switched off.
+    """
+    root = _init_repo(tmp_path / "repo")
+    (root / "dict_built_hook.py").write_text(
+        'import json, sys\n'
+        'payload = json.load(sys.stdin)\n'
+        'print(json.dumps({"hookSpecificOutput": dict('
+        'hookEventName="UserPromptSubmit", additionalContext="x")}))\n')
+    assert _run_bash_gate(root).returncode == 0
+
+
+def test_file_path_leg_still_blocks_on_unknown(tmp_path):
+    """The asymmetry is deliberate, so it gets an assertion.
+
+    The file_path leg knows exactly which file you just edited, so UNKNOWN there
+    is actionable feedback. The Bash leg is inferring which file the command
+    touched, so it acts only on certainty.
+    """
+    p = tmp_path / "dict_built_hook.py"
+    p.write_text('import json, sys\n'
+                 'payload = json.load(sys.stdin)\n'
+                 'print(json.dumps({"hookSpecificOutput": dict('
+                 'hookEventName="UserPromptSubmit", additionalContext="x")}))\n')
+    assert _run_gate(p).returncode == 2
+
+
+def test_a_hook_that_only_drains_stdin_is_still_a_hook(tmp_path):
+    """The shape probe_hook_envelope.py itself generates.
+
+    It reads stdin without parsing it, then emits. looks_like_a_hook missed it,
+    so the blocking gate passed the original TOP_LEVEL scar shape.
+    """
+    p = tmp_path / "probe_like_hook.py"
+    p.write_text('import sys\n'
+                 'sys.stdin.read()\n'
+                 'sys.stdout.write(\'{"additionalContext": "x"}\')\n')
+    assert _run_gate(p).returncode == 2
+
+
+def test_add_branch_refuses_to_overwrite_a_fragment_main_already_has(tmp_path):
+    """The ADD branch's own version of the loss the EDIT branch already refuses.
+
+    A key absent from the merge base but already present on disk means main added
+    that declaration independently. Writing the branch's version over it replaces
+    main's and reports success. Opus fallback major, PR #285 round 6.
+    """
+    import json as _json
+    import subprocess as _sp
+
+    cm_path = os.path.join(REPO, "q-system", ".q-system", "scripts",
+                           "capability_manifest.py")
+    spec = importlib.util.spec_from_file_location("capability_manifest", cm_path)
+    cm = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(cm)
+
+    root = tmp_path / "repo"
+    sdir = root / cm.FRAGMENT_DIR / "expected_tests"
+    sdir.mkdir(parents=True)
+
+    ours = {"path": "tests/x.py", "runner": "bash"}
+    theirs = {"path": "tests/x.py", "runner": "sh"}
+    frag = sdir / cm.fragment_name("expected_tests", ours)
+    frag.write_text(_json.dumps(theirs, indent=1, sort_keys=True) + "\n")
+
+    errors = []
+    written = cm.add_delta(str(root), {"expected_tests": []},
+                           {"expected_tests": [ours]}, errors)
+    assert written == [], written
+    assert errors and "already on disk" in errors[0], errors
+    assert _json.loads(frag.read_text())["runner"] == "sh", "main's version was replaced"
+
+
+def test_add_branch_still_writes_a_genuinely_new_declaration(tmp_path):
+    """The control. Without it the fix above could just refuse everything."""
+    cm_path = os.path.join(REPO, "q-system", ".q-system", "scripts",
+                           "capability_manifest.py")
+    spec = importlib.util.spec_from_file_location("capability_manifest", cm_path)
+    cm = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(cm)
+
+    root = tmp_path / "repo"
+    entry = {"path": "tests/brand_new.py", "runner": "python3"}
+    errors = []
+    written = cm.add_delta(str(root), {"expected_tests": []},
+                           {"expected_tests": [entry]}, errors)
+    assert written == ["expected_tests/%s"
+                       % cm.fragment_name("expected_tests", entry)], written
+    assert errors == [], errors

--- a/q-system/.q-system/tests/test_hook_envelope_audit.py
+++ b/q-system/.q-system/tests/test_hook_envelope_audit.py
@@ -1,0 +1,117 @@
+#!/usr/bin/env python3
+"""Pins hook_envelope_audit.py AND the fleet-shared hooks it audits.
+
+Scar (measured 2026-08-30, q-system/.q-system/scripts/probe_hook_envelope.py):
+Claude Code DISCARDS a hook's additionalContext unless it is nested under
+hookSpecificOutput WITH hookEventName. voice-dna-loader.py shipped the nameless
+shape from birth, so the founder's voice DNA never once reached the model, and
+every downstream gate stayed green because they all measure the OUTPUT and none
+check that the INPUT arrived.
+
+Two halves, both of which have to be able to go red:
+  1. the audit still tells the three measured shapes apart (its own self-test,
+     including the arms that must NOT be flagged);
+  2. every live hook in this repo emits the delivering shape.
+"""
+from __future__ import annotations
+
+import importlib.util
+import json
+import os
+import subprocess
+import sys
+
+import pytest
+
+REPO = os.path.abspath(os.path.join(os.path.dirname(__file__), "..", "..", ".."))
+AUDIT = os.path.join(REPO, "q-system", ".q-system", "scripts", "hook_envelope_audit.py")
+
+
+def _load():
+    spec = importlib.util.spec_from_file_location("hook_envelope_audit", AUDIT)
+    mod = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(mod)
+    return mod
+
+
+audit = _load()
+
+
+def test_self_test_passes():
+    """The audit can still separate the three measured shapes."""
+    assert audit.self_test(verbose=False) == []
+
+
+@pytest.mark.parametrize("src,expected", [
+    ('import json,sys\nsys.stdout.write(json.dumps({"hookSpecificOutput": '
+     '{"hookEventName": "UserPromptSubmit", "additionalContext": "x"}}))\n', audit.OK),
+    ('import json,sys\nsys.stdout.write(json.dumps({"hookSpecificOutput": '
+     '{"additionalContext": "x"}}))\n', audit.NO_EVENT_NAME),
+    ('import json,sys\nsys.stdout.write(json.dumps({"additionalContext": "x"}))\n',
+     audit.TOP_LEVEL),
+])
+def test_classifies_the_three_measured_shapes(src, expected):
+    got = [s.verdict for s in audit.audit_python("<probe>", source=src)]
+    assert got == [expected]
+
+
+def test_reads_and_assertions_are_not_emissions():
+    """The false-positive class that would get this gate switched off.
+
+    Before the text scanner learned that a '[' before the key means a subscript
+    and a missing ':' after it means an operand, the audit reported ~700 defects
+    in the very hook tests that assert the envelope is correct.
+    """
+    reads = (
+        'python3 -c "import sys,json; a=json.load(sys.stdin)'
+        "['hookSpecificOutput']['additionalContext']\"\n"
+        'assert "additionalContext" not in out\n'
+        '# Scar: warn() printed top-level {"additionalContext": ...}\n'
+    )
+    assert audit.audit_text("<reads>", source=reads) == []
+
+
+# --------------------------------------------------------------------------
+# The live hooks. A new hook added with the nameless envelope turns these red.
+# --------------------------------------------------------------------------
+LIVE_HOOK_DIRS = [
+    os.path.join(REPO, "q-system", ".q-system", "scripts"),
+    os.path.join(REPO, "q-system", "hooks"),
+    os.path.join(REPO, "plugins"),
+]
+
+
+def test_every_live_hook_emits_the_delivering_shape():
+    sites = []
+    for root in LIVE_HOOK_DIRS:
+        if not os.path.isdir(root):
+            continue
+        for path in audit.walk([root]):
+            sites.extend(audit.audit_file(path))
+    assert sites, "audited nothing -- the walk is broken, not the hooks"
+    bad = [(s.path, s.line, s.verdict) for s in sites if s.verdict != audit.OK]
+    assert bad == [], (
+        "these hooks emit an envelope Claude Code discards: %r" % (bad,))
+
+
+@pytest.mark.parametrize("script,prompt", [
+    ("voice-dna-loader.py", "draft a linkedin post about hooks"),
+    ("lessons-inject.py", "fix the token guard cache race"),
+])
+def test_userpromptsubmit_hooks_deliver_end_to_end(script, prompt):
+    """Not the source shape -- the bytes the hook actually prints."""
+    path = os.path.join(REPO, "q-system", ".q-system", "scripts", script)
+    payload = json.dumps({"session_id": "pytest",
+                          "hook_event_name": "UserPromptSubmit",
+                          "prompt": prompt})
+    env = dict(os.environ, CLAUDE_PROJECT_DIR=REPO)
+    proc = subprocess.run([sys.executable, path], input=payload, env=env,
+                          capture_output=True, text=True, timeout=60)
+    assert proc.returncode == 0, proc.stderr
+    if not proc.stdout.strip():
+        pytest.skip("%s emitted nothing for this prompt" % script)
+    out = json.loads(proc.stdout)
+    assert "additionalContext" not in out, "top-level additionalContext is discarded"
+    hso = out["hookSpecificOutput"]
+    assert hso.get("hookEventName") == "UserPromptSubmit", hso
+    assert hso.get("additionalContext", "").strip(), "delivered an empty payload"

--- a/q-system/.q-system/tests/test_hook_envelope_audit.py
+++ b/q-system/.q-system/tests/test_hook_envelope_audit.py
@@ -296,3 +296,52 @@ def test_a_hook_whose_only_tell_is_json_load_stdin_still_blocks(tmp_path):
                  'payload = json.load(sys.stdin)\n'
                  'print(json.dumps({"additionalContext": "re-anchor"}))\n')
     assert _run_gate(p).returncode == 2
+
+
+# --------------------------------------------------------------------------
+# Codex minors, PR #285 round 4. Two ordinary ways to build the payload that a
+# walk over dict literals alone gets wrong, in both directions.
+# --------------------------------------------------------------------------
+def test_envelope_built_in_a_variable_is_not_called_top_level():
+    """`hso = {...}` then `{"hookSpecificOutput": hso}` is correct code.
+
+    Calling it TOP_LEVEL was a false BLOCK, and a gate that stops correct code
+    is a gate that gets switched off.
+    """
+    src = ('import json, sys\n'
+           'payload = json.load(sys.stdin)\n'
+           'hso = {"hookEventName": "UserPromptSubmit", "additionalContext": "delivered"}\n'
+           'out = {"hookSpecificOutput": hso}\n'
+           'print(json.dumps(out))\n')
+    assert [s.verdict for s in audit.audit_python("<aliased>", source=src)] == [audit.OK]
+
+
+def test_additional_context_written_by_assignment_is_unknown_not_absent(tmp_path):
+    """The payload built by subscript assignment produced NO site at all.
+
+    Absent read as approved, so the gate passed a hook that delivers nothing.
+    """
+    src = ('import json, sys\n'
+           'payload = json.load(sys.stdin)\n'
+           'out = {"hookSpecificOutput": {"hookEventName": "UserPromptSubmit"}}\n'
+           'out["hookSpecificOutput"]["additionalContext"] = "lost"\n'
+           'print(json.dumps(out))\n')
+    assert [s.verdict for s in audit.audit_python("<incremental>", source=src)] == [audit.UNKNOWN]
+
+    p = tmp_path / "incremental_hook.py"
+    p.write_text(src)
+    assert _run_gate(p).returncode == 2
+
+
+def test_reading_that_same_subscript_is_still_not_an_emission():
+    """The control that keeps the write-detection honest.
+
+    A subscript in a TARGET position is a write; the same subscript in a value
+    position is a read. Without this case the detector could flag every hook
+    that merely inspects an incoming payload.
+    """
+    src = ('import json, sys\n'
+           'payload = json.load(sys.stdin)\n'
+           'ctx = payload["hookSpecificOutput"]["additionalContext"]\n'
+           'print(ctx)\n')
+    assert audit.audit_python("<read>", source=src) == []

--- a/q-system/.q-system/tests/test_hook_envelope_audit.py
+++ b/q-system/.q-system/tests/test_hook_envelope_audit.py
@@ -20,6 +20,7 @@ import json
 import os
 import subprocess
 import sys
+import uuid
 
 import pytest
 
@@ -101,7 +102,12 @@ def test_every_live_hook_emits_the_delivering_shape():
 def test_userpromptsubmit_hooks_deliver_end_to_end(script, prompt):
     """Not the source shape -- the bytes the hook actually prints."""
     path = os.path.join(REPO, "q-system", ".q-system", "scripts", script)
-    payload = json.dumps({"session_id": "pytest",
+    # A FRESH session id per run. A fixed one made lessons-inject.py emit
+    # nothing on the second run ever -- its seen-cache had already recorded the
+    # lessons as shown -- so this arm silently skipped instead of checking the
+    # bytes. A skip that looks like a pass is the defect this whole file exists
+    # to catch.
+    payload = json.dumps({"session_id": "pytest-%s" % uuid.uuid4().hex[:12],
                           "hook_event_name": "UserPromptSubmit",
                           "prompt": prompt})
     env = dict(os.environ, CLAUDE_PROJECT_DIR=REPO)
@@ -247,3 +253,46 @@ def test_reporting_path_still_surfaces_the_ordinary_dict(tmp_path):
     """Only the BLOCK is scoped. A human reading a full audit wants everything."""
     src = 'payload = {"additionalContext": "ordinary API field"}\n'
     assert [s.verdict for s in audit.audit_python("<api>", source=src)] == [audit.TOP_LEVEL]
+
+
+# --------------------------------------------------------------------------
+# Codex minors, PR #285 round 3. Both are the same mistake in opposite
+# directions: the audit deciding something it could not see.
+# --------------------------------------------------------------------------
+def test_computed_key_inside_a_literal_envelope_is_unknown_not_absent(tmp_path):
+    """It used to emit NO site at all, so the gate passed it at exit 0.
+
+    `k = "additionalContext"` is a real way to write a hook, and an audit that
+    silently sees nothing there is indistinguishable from an audit that checked
+    and approved.
+    """
+    src = ('import json,sys\n'
+           'k = "additionalContext"\n'
+           'out = {"hookSpecificOutput": {"hookEventName": "UserPromptSubmit", k: "x"}}\n'
+           'print(json.dumps(out))\n')
+    assert [s.verdict for s in audit.audit_python("<dynamic>", source=src)] == [audit.UNKNOWN]
+
+    p = tmp_path / "dynamic_hook.py"
+    p.write_text(src)
+    proc = _run_gate(p)
+    assert proc.returncode == 2, proc.stdout
+    assert "UNKNOWN" in proc.stderr
+
+
+def test_a_stdin_filter_is_not_a_hook(tmp_path):
+    """Bare `sys.stdin` was too weak: any filter program matched it."""
+    p = tmp_path / "wc_like_filter.py"
+    p.write_text('import sys\n'
+                 'record = {"additionalContext": "ordinary field"}\n'
+                 'for line in sys.stdin:\n'
+                 '    record["additionalContext"] = line\n')
+    assert _run_gate(p).returncode == 0
+
+
+def test_a_hook_whose_only_tell_is_json_load_stdin_still_blocks(tmp_path):
+    """The control. focus-kit's echo-of-prompt.py is exactly this shape."""
+    p = tmp_path / "echo_like_hook.py"
+    p.write_text('import json,sys\n'
+                 'payload = json.load(sys.stdin)\n'
+                 'print(json.dumps({"additionalContext": "re-anchor"}))\n')
+    assert _run_gate(p).returncode == 2

--- a/q-system/.q-system/tests/test_hook_envelope_audit.py
+++ b/q-system/.q-system/tests/test_hook_envelope_audit.py
@@ -75,11 +75,22 @@ def test_reads_and_assertions_are_not_emissions():
 # --------------------------------------------------------------------------
 # The live hooks. A new hook added with the nameless envelope turns these red.
 # --------------------------------------------------------------------------
+# token-guard.py sits at q-system/.q-system/ , NOT in scripts/ , so a list of
+# directories missed a WIRED emitter while the test's own name promised "every
+# live hook" (round 9 minor). The list is now the whole .q-system tree plus the
+# other two roots, and the assertion below proves the walk actually reached
+# token-guard.py rather than trusting the path list to be complete.
 LIVE_HOOK_DIRS = [
-    os.path.join(REPO, "q-system", ".q-system", "scripts"),
+    os.path.join(REPO, "q-system", ".q-system"),
     os.path.join(REPO, "q-system", "hooks"),
     os.path.join(REPO, "plugins"),
 ]
+WIRED_EMITTERS_THAT_MUST_BE_REACHED = (
+    os.path.join("q-system", ".q-system", "token-guard.py"),
+    os.path.join("q-system", ".q-system", "scripts", "voice-dna-loader.py"),
+    os.path.join("q-system", ".q-system", "scripts", "lessons-inject.py"),
+    os.path.join("q-system", "hooks", "lessons-index.py"),
+)
 
 
 def test_every_live_hook_emits_the_delivering_shape():
@@ -90,6 +101,12 @@ def test_every_live_hook_emits_the_delivering_shape():
         for path in audit.walk([root]):
             sites.extend(audit.audit_file(path))
     assert sites, "audited nothing -- the walk is broken, not the hooks"
+    reached = {os.path.relpath(s.path, REPO) for s in sites}
+    missing = [rel for rel in WIRED_EMITTERS_THAT_MUST_BE_REACHED
+               if rel not in reached]
+    assert not missing, (
+        "the walk never reached these WIRED emitters, so a green result here "
+        "says nothing about them: %r" % (missing,))
     bad = [(s.path, s.line, s.verdict) for s in sites if s.verdict != audit.OK]
     assert bad == [], (
         "these hooks emit an envelope Claude Code discards: %r" % (bad,))
@@ -743,3 +760,63 @@ def test_a_real_js_emission_is_still_seen():
     src = 'process.stdout.write(JSON.stringify({"additionalContext": "x"}));\n'
     verdicts = [s.verdict for s in audit.audit_text("<hook.js>", source=src)]
     assert verdicts == [audit.TOP_LEVEL], verdicts
+
+
+# --------------------------------------------------------------------------
+# Round 9. The raw-string detection added in round 6 judged the SOURCE LINE the
+# call starts on, not the string's content, so a correct multi-line envelope was
+# blocked fleet-wide with a false "DISCARDS" claim.
+# --------------------------------------------------------------------------
+MULTILINE_CORRECT = (
+    'import sys\n'
+    'payload = sys.stdin.read()\n'
+    'sys.stdout.write("""{\n'
+    '  "hookSpecificOutput": {\n'
+    '    "hookEventName": "UserPromptSubmit",\n'
+    '    "additionalContext": "delivered"\n'
+    '  }\n'
+    '}""")\n'
+)
+MULTILINE_BROKEN = (
+    'import sys\n'
+    'payload = sys.stdin.read()\n'
+    'sys.stdout.write("""{\n'
+    '  "additionalContext": "discarded"\n'
+    '}""")\n'
+)
+
+
+def test_a_correct_multiline_raw_envelope_is_not_blocked(tmp_path):
+    verdicts = [s.verdict for s in audit.audit_python("<multi>", source=MULTILINE_CORRECT)]
+    assert verdicts == [audit.OK], verdicts
+    p = tmp_path / "multiline_hook.py"
+    p.write_text(MULTILINE_CORRECT)
+    assert _run_gate(p).returncode == 0
+
+
+def test_a_broken_multiline_raw_envelope_is_still_blocked(tmp_path):
+    """The control. Without it the fix above could just stop reporting."""
+    verdicts = [s.verdict for s in audit.audit_python("<multi>", source=MULTILINE_BROKEN)]
+    assert verdicts and all(v != audit.OK for v in verdicts), verdicts
+    p = tmp_path / "broken_multiline_hook.py"
+    p.write_text(MULTILINE_BROKEN)
+    proc = _run_gate(p)
+    assert proc.returncode == 2
+    assert "DISCARDS" in proc.stderr
+
+
+def test_the_live_hook_walk_actually_reaches_token_guard():
+    """The claim in the other test's name, made checkable.
+
+    token-guard.py sits at q-system/.q-system/ rather than in scripts/, so a list
+    of directories silently excluded a WIRED emitter while the test promised
+    "every live hook". A green result over a walk that never reached a file says
+    nothing about that file.
+    """
+    sites = []
+    for root in LIVE_HOOK_DIRS:
+        if os.path.isdir(root):
+            for path in audit.walk([root]):
+                sites.extend(audit.audit_file(path))
+    reached = {os.path.relpath(s.path, REPO) for s in sites}
+    assert os.path.join("q-system", ".q-system", "token-guard.py") in reached

--- a/q-system/.q-system/tests/test_hook_envelope_audit.py
+++ b/q-system/.q-system/tests/test_hook_envelope_audit.py
@@ -565,3 +565,98 @@ def test_add_branch_still_writes_a_genuinely_new_declaration(tmp_path):
     assert written == ["expected_tests/%s"
                        % cm.fragment_name("expected_tests", entry)], written
     assert errors == [], errors
+
+
+# --------------------------------------------------------------------------
+# Round 7. Three minors: a replay that fought itself, a gate that went inert
+# where it looked busiest, and a block with no way past it.
+# --------------------------------------------------------------------------
+def test_the_skip_marker_bypasses_the_gate(tmp_path):
+    """Every blocking hook in this repo is required to have one.
+
+    skill-hook-pairing.md, "Override". This one shipped without it, which left no
+    way past a false block except switching the gate off.
+    """
+    p = tmp_path / "deliberate_hook.py"
+    p.write_text('import json, sys\n'
+                 '# hook-envelope-skip: verified by hand against the live model\n'
+                 'payload = json.load(sys.stdin)\n'
+                 'print(json.dumps({"additionalContext": "x"}))\n')
+    assert _run_gate(p).returncode == 0
+
+
+def test_without_the_marker_that_same_file_is_blocked(tmp_path):
+    """The control. A bypass nothing can fail is not a bypass."""
+    p = tmp_path / "same_hook.py"
+    p.write_text('import json, sys\n'
+                 'payload = json.load(sys.stdin)\n'
+                 'print(json.dumps({"additionalContext": "x"}))\n')
+    assert _run_gate(p).returncode == 2
+
+
+def test_an_unknown_block_does_not_claim_the_payload_is_discarded(tmp_path):
+    """The audit must not assert something about a shape it could not read."""
+    p = tmp_path / "dict_built_hook.py"
+    p.write_text('import json, sys\n'
+                 'payload = json.load(sys.stdin)\n'
+                 'print(json.dumps({"hookSpecificOutput": dict('
+                 'hookEventName="UserPromptSubmit", additionalContext="x")}))\n')
+    proc = _run_gate(p)
+    assert proc.returncode == 2
+    assert "CANNOT READ" in proc.stderr, proc.stderr
+    assert "DISCARDS" not in proc.stderr.split("\n")[0], proc.stderr
+    assert "hook-envelope-skip" in proc.stderr
+
+
+def test_a_definite_block_still_says_discarded(tmp_path):
+    """The other half of that control."""
+    p = tmp_path / "broken_hook.py"
+    p.write_text('import json, sys\n'
+                 'payload = json.load(sys.stdin)\n'
+                 'print(json.dumps({"additionalContext": "x"}))\n')
+    assert "DISCARDS" in _run_gate(p).stderr
+
+
+def test_bash_leg_works_when_the_project_dir_is_below_the_git_root(tmp_path):
+    """`git status --porcelain` prints paths relative to the GIT ROOT.
+
+    Joining them onto a project dir one level down produced paths that do not
+    exist, so every file was skipped and the gate went silently inert exactly
+    where it looked busiest.
+    """
+    root = _init_repo(tmp_path / "repo")
+    sub = root / "subproject"
+    sub.mkdir()
+    (sub / "sneaky_hook.py").write_text(
+        'import json, sys\n'
+        'payload = json.load(sys.stdin)\n'
+        'print(json.dumps({"additionalContext": "discarded"}))\n')
+    assert _run_bash_gate(sub).returncode == 2
+
+
+def test_add_delta_edit_replay_is_idempotent(tmp_path):
+    """A second run must not report its own prior write as main's conflict."""
+    import json as _json
+    cm_path = os.path.join(REPO, "q-system", ".q-system", "scripts",
+                           "capability_manifest.py")
+    spec = importlib.util.spec_from_file_location("capability_manifest", cm_path)
+    cm = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(cm)
+
+    root = tmp_path / "repo"
+    sdir = root / cm.FRAGMENT_DIR / "expected_tests"
+    sdir.mkdir(parents=True)
+    old = {"path": "tests/x.py", "runner": "python3"}
+    new = {"path": "tests/x.py", "runner": "bash"}
+    frag = sdir / cm.fragment_name("expected_tests", old)
+    frag.write_text(_json.dumps(old, indent=1, sort_keys=True) + "\n")
+
+    base, head = {"expected_tests": [old]}, {"expected_tests": [new]}
+    first_errors = []
+    assert cm.add_delta(str(root), base, head, first_errors)
+    assert first_errors == [], first_errors
+
+    second_errors = []
+    assert cm.add_delta(str(root), base, head, second_errors) == []
+    assert second_errors == [], second_errors
+    assert _json.loads(frag.read_text())["runner"] == "bash"

--- a/settings-template.json
+++ b/settings-template.json
@@ -329,6 +329,11 @@
             "type": "command",
             "command": "test -f \"$CLAUDE_PROJECT_DIR/q-system/.q-system/scripts/handoff-provenance-lint.py\" && python3 \"$CLAUDE_PROJECT_DIR/q-system/.q-system/scripts/handoff-provenance-lint.py\"",
             "timeout": 5
+          },
+          {
+            "type": "command",
+            "command": "test -f \"$CLAUDE_PROJECT_DIR/q-system/.q-system/scripts/hook_envelope_audit.py\" && python3 \"$CLAUDE_PROJECT_DIR/q-system/.q-system/scripts/hook_envelope_audit.py\" --hook",
+            "timeout": 10
           }
         ]
       },

--- a/settings-template.json
+++ b/settings-template.json
@@ -345,6 +345,16 @@
             "command": "test -f \"$CLAUDE_PROJECT_DIR/q-system/.q-system/scripts/portability-lint-hook.py\" && python3 \"$CLAUDE_PROJECT_DIR/q-system/.q-system/scripts/portability-lint-hook.py\""
           }
         ]
+      },
+      {
+        "matcher": "Bash",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "test -f \"$CLAUDE_PROJECT_DIR/q-system/.q-system/scripts/hook_envelope_audit.py\" && python3 \"$CLAUDE_PROJECT_DIR/q-system/.q-system/scripts/hook_envelope_audit.py\" --hook",
+            "timeout": 15
+          }
+        ]
       }
     ],
     "PostCompact": [


### PR DESCRIPTION
## The finding, measured

Claude Code silently **DISCARDS** a hook's `additionalContext` unless it is nested as:

```json
{"hookSpecificOutput": {"hookEventName": "<Event>", "additionalContext": "..."}}
```

Re-measured 2026-08-30 with `q-system/.q-system/scripts/probe_hook_envelope.py`: three headless `claude -p` runs, a unique marker per arm, and a positive control that had to pass before the negative arms counted.

```
nested WITH hookEventName     -> delivered
nested WITHOUT hookEventName  -> ABSENT
top-level additionalContext   -> ABSENT
```

The published docs call the key optional. The docs are wrong. The probe is committed at the path the last handoff already cited, where it had never actually existed.

## What was broken

`voice-dna-loader.py` emitted the nameless shape from the day it was written, so about 5.3KB of founder voice DNA never once reached the model. Nothing downstream could see it: every gate in this repo measures the **output** and none check that the **input** arrived.

`lessons-inject.py` already carries main's fix from #277. This only adds the measurement to its comment and retires the note that deferred `voice-dna-loader.py`.

## The sweep

Fixed and verified outside this repo as well, each by compiling the file and, on a sample, running the hook and reading the bytes it prints:

- 27 live instance copies of `voice-dna-loader.py`, every registered instance plus cole-gtm, consulting-baseline, consulting-landing, social-voice.
- Nine stale `token-guard.py` forks under `q-consult/`, `q-ktlyst/`, `q-investigate/`, huntkit, claude-focus, focus-kit. Eight are dead code; the ninth is live, wired by absolute path from 4_points' `settings.local.json`, so every warning tier there was silent.
- `echo-of-prompt.py` and `voice-marker.py` in focus-kit, voice-kit, claude-focus, founder-voice-kit.

Zero broken emitters remain in any live tree. 81 remain in worktrees and PR checkouts, which converge on rebase.

The first verification pass reported FAIL on all 27, including a copy already known good: `py_compile` was handed `/dev/null` as its cfile, so the oracle failed for every input. Re-run with a known-bad and a known-good control.

## The gate

`hook_envelope_audit.py` classifies every emission site OK / NO_EVENT_NAME / TOP_LEVEL / UNKNOWN, refuses to report unless its own self-test still separates the three measured shapes, and never passes a site it cannot read.

`--hook` is a PostToolUse gate on `Edit|Write|MultiEdit`. Self-scoped by `tool_input.file_path`, fast exit on any file without `additionalContext`, exit 2 blocks with the measurement in stderr, exit 0 passes. It refuses to block if its own self-test stops passing, because a gate that cannot run must not block a session; the pytest layer is what catches the envelope when the gate is inert.

`--fix EVENT` adds a missing `hookEventName` and **refuses** every other verdict. TOP_LEVEL needs a human to say which event owns the payload; UNKNOWN is unreadable by construction.

The audit's first draft reported about 700 defects in the hook tests that assert the envelope IS correct. The text scanner now tells an emitted key from a subscript read, a negative assertion and a scar comment, and those three non-emissions are self-test cases so the discrimination cannot regress silently.

## Also here

`capability_manifest.add_delta` keys on entry identity instead of serialized bytes (sp-6b25c567), so a branch that EDITS a declaration is no longer refused as one that removed it. PR #207 is exactly that shape. Three outcomes now: ADD writes, EDIT writes only if the fragment on disk still holds the base version, REMOVAL is still reported and never acted on.

## Verification

- 15 tests on the envelope audit, 82 checks on the capability gate.
- Mutation-checked both ways. Reverting `voice-dna-loader.py` turns the static and end-to-end arms red. Reverting the manifest keying to bytes kills 3 of the 4 new replay checks; the 4th ("the edit landed") survives because byte-keying writes the same filename as an addition, and it is a companion assertion rather than the load-bearing one.
- Scoped root pytest at the source branch: 1868 passed. The 7 failures and 8 errors are pre-existing and unrelated (untracked ASK-1144 work-in-progress, and `test_wiring_check.py`'s 8 tests that error at setup on a fixture named `tmp` that nothing defines). Both captured as spillover.

## Spillover filed

The marketplace clone still carries the broken copy and is stale at #240; 4_points wires a fork by absolute path; four dead forks await a removal decision; `claude-path-write-guard` blocked three more honest reads including the command filing that finding; `test_wiring_check.py`'s 8 inert tests.

`sp-e85ff9dc` and `sp-c4031c2e` resolve once this lands, since `--broken-at` has to be an ancestor of `origin/main`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01YWxNWmEobPKcJ6HqqUBMTw
