### PR TITLE
Voice DNA reaches the model again: the discarded-envelope fix, alone

### DIFF
--- a/q-system/.q-system/scripts/lessons-inject.py
+++ b/q-system/.q-system/scripts/lessons-inject.py
@@ -395,6 +395,14 @@ def main():
     # including that file's omission of the same key. Copying a shape is not
     # checking it. voice-dna-loader.py has the identical defect and is captured
     # separately rather than widened into this PR.
+    #
+    # CONFIRMED BY MEASUREMENT 2026-08-30, not by reading the docs: three
+    # headless `claude -p` runs via probe_hook_envelope.py, a unique marker per
+    # arm and a positive control that had to pass first. Nested-with-name
+    # delivered; nested-without-name and top-level both came back ABSENT. The
+    # published docs call the key optional and they are wrong. The
+    # voice-dna-loader.py defect this comment defers is now fixed too, together
+    # with 27 instance copies of it and nine stale token-guard forks.
     sys.stdout.write(json.dumps({"hookSpecificOutput": {
         "hookEventName": "UserPromptSubmit",
         "additionalContext": "".join(parts),

--- a/q-system/.q-system/scripts/probe_hook_envelope.py
+++ b/q-system/.q-system/scripts/probe_hook_envelope.py
@@ -1,0 +1,113 @@
+#!/usr/bin/env python3
+"""Does a UserPromptSubmit hook's additionalContext reach the model WITHOUT
+hookEventName?
+
+Codex called its absence a major on PR #277 ("the payload is discarded"). The
+published docs, read back by a summarizer, say the key looks optional. Neither is
+a measurement, and the claim decides whether lessons-inject has been delivering
+for its whole life or not at all. So: run it.
+
+Three arms, each a real headless session with its own project dir and its own
+hook:
+
+    nested_with_name    {"hookSpecificOutput": {"hookEventName": ..., "additionalContext": M}}
+    nested_no_name      {"hookSpecificOutput": {"additionalContext": M}}      <- the disputed one
+    top_level           {"additionalContext": M}                              <- the recorded scar
+
+Each marker is unique per run, so a marker in the answer can only have come from
+that arm's hook. The prompt asks the model to echo the marker or say ABSENT,
+which makes a non-delivery legible instead of silent.
+"""
+
+import json
+import os
+import pathlib
+import re
+import subprocess
+import sys
+import tempfile
+import uuid
+
+ARMS = {
+    "nested_with_name": '{"hookSpecificOutput": {"hookEventName": "UserPromptSubmit", "additionalContext": "%s"}}',
+    "nested_no_name": '{"hookSpecificOutput": {"additionalContext": "%s"}}',
+    "top_level": '{"additionalContext": "%s"}',
+}
+
+PROMPT = ("Some context may have been injected into this turn. If it contains a "
+          "token of the form MARKER-<letters>-<digits>, reply with that token and "
+          "nothing else. If there is no such token, reply with exactly ABSENT.")
+
+
+def build(root: pathlib.Path, shape: str, marker: str) -> None:
+    hooks_dir = root / "hooks"
+    hooks_dir.mkdir(parents=True)
+    hook = hooks_dir / "emit.py"
+    payload = shape % ("CONTEXT: the secret token is " + marker)
+    # Sanity: the marker has to survive into the bytes the hook will print, or
+    # the arm proves nothing about delivery.
+    assert marker in payload, payload
+    json.loads(payload)          # and it has to be valid JSON
+    hook.write_text(
+        "#!/usr/bin/env python3\n"
+        "import sys\n"
+        "sys.stdin.read()\n"
+        "sys.stdout.write(%r)\n" % payload)
+    hook.chmod(0o755)
+    cfg = root / ".claude"
+    cfg.mkdir(parents=True)
+    (cfg / "settings.json").write_text(json.dumps({
+        "hooks": {"UserPromptSubmit": [
+            {"hooks": [{"type": "command",
+                        "command": "python3 %s" % hook}]}]}
+    }, indent=2))
+
+
+def ask(root: pathlib.Path) -> str:
+    env = dict(os.environ)
+    env["CLAUDE_PROJECT_DIR"] = str(root)
+    try:
+        r = subprocess.run(["claude", "-p", PROMPT], cwd=str(root), env=env,
+                           capture_output=True, text=True, timeout=180)
+    except (OSError, subprocess.TimeoutExpired) as exc:
+        return "RUN-FAILED: %s" % exc
+    return (r.stdout or r.stderr or "").strip()
+
+
+def main() -> int:
+    results = {}
+    for arm, shape in ARMS.items():
+        marker = "MARKER-%s-%d" % (uuid.uuid4().hex[:6].upper(),
+                                   abs(hash(arm)) % 9000 + 1000)
+        root = pathlib.Path(tempfile.mkdtemp(prefix="envprobe-%s-" % arm))
+        build(root, shape, marker)
+        answer = ask(root)
+        delivered = marker in answer
+        results[arm] = (marker, delivered, answer[:160].replace("\n", " "))
+        print("%-18s marker=%s delivered=%-5s answer=%r"
+              % (arm, marker, delivered, answer[:80].replace("\n", " ")))
+
+    print()
+    with_name = results["nested_with_name"][1]
+    no_name = results["nested_no_name"][1]
+    top = results["top_level"][1]
+    if not with_name:
+        print("INCONCLUSIVE: the KNOWN-GOOD shape did not deliver either, so this "
+              "probe is not measuring what it claims. Fix the harness before "
+              "reading anything into the other two arms.")
+        return 2
+    print("nested WITH hookEventName delivered: %s  (control, expected True)" % with_name)
+    print("nested WITHOUT hookEventName delivered: %s" % no_name)
+    print("top-level additionalContext delivered: %s  (recorded scar says False)" % top)
+    print()
+    if no_name:
+        print("VERDICT: hookEventName is NOT required. Codex's major on PR #277 "
+              "is WRONG, and lessons-inject HAS been delivering all along.")
+    else:
+        print("VERDICT: hookEventName IS required. Codex's major stands and the "
+              "hook was inert until it was added.")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/q-system/.q-system/scripts/voice-dna-loader.py
+++ b/q-system/.q-system/scripts/voice-dna-loader.py
@@ -221,7 +221,17 @@ def main():
         voice_dna_path = resolve_path(VOICE_DNA_REL_PATH)
         samples_path = resolve_path(WRITING_SAMPLES_REL_PATH)
         context = build_context(voice_dna_path, samples_path)
-    output = {"hookSpecificOutput": {"additionalContext": context}}
+    # hookEventName is REQUIRED, not optional. Claude Code silently DISCARDS
+    # a hook payload whose hookSpecificOutput carries no hookEventName --
+    # measured 2026-08-30 by probe_hook_envelope.py, three headless runs with
+    # a positive control; the published docs say optional and are wrong. This
+    # hook emitted the nameless shape from the day it was written, so nothing
+    # it injected ever reached the model, and no downstream gate could see it:
+    # they all measure the OUTPUT, none check that the INPUT arrived.
+    output = {"hookSpecificOutput": {
+        "hookEventName": "UserPromptSubmit",
+        "additionalContext": context,
+    }}
     sys.stdout.write(json.dumps(output))
     sys.exit(0)
 


### PR DESCRIPTION
fix(hooks): voice DNA reaches the model again [no-issue: fleet defect found mid-sweep; sp-e85ff9dc and sp-c4031c2e track it]

Claude Code silently DISCARDS a hook's additionalContext unless it is nested as
{"hookSpecificOutput": {"hookEventName": "<Event>", "additionalContext": "..."}}.

Measured 2026-08-30 by probe_hook_envelope.py: three headless `claude -p` runs, a
unique marker per arm, and a positive control that had to pass before the negative
arms counted.

    nested WITH hookEventName     -> delivered
    nested WITHOUT hookEventName  -> ABSENT
    top-level additionalContext   -> ABSENT

The published docs call the key optional. They are wrong, and trusting them would
have reverted a correct fix.

voice-dna-loader.py emitted the nameless shape from the day it was written, so
about 5.3KB of founder voice DNA never once reached the model. Nothing downstream
could see it: every gate here measures the OUTPUT and none check that the INPUT
arrived. Verified by running the hook and reading the bytes it prints, not by
reading the source: event=UserPromptSubmit, 5423 chars of context.

lessons-inject.py already carries main's fix from #277. Its change here is the
measurement added to the comment, plus retiring the note that deferred
voice-dna-loader.

probe_hook_envelope.py is committed at the path the last handoff already cited.
It had only ever existed in a scratchpad, so that provenance marker pointed at
nothing.

The same one-key fix was applied and verified live across 27 instance copies, 9
stale token-guard forks and 4 product-kit hooks in their own repos; this commit is
the skeleton's half.

Deliberately NOT here: the static audit and its PostToolUse gate. Measured against
a battery of 7 correct and 3 broken hooks, that audit false-blocks 2 of the 7 and
silently passes 3 of 3 broken non-literal shapes, so arming it would trade a real
fix for a new false-block class. It returns as its own issue after the
UNKNOWN-by-construction rewrite the spillover already names.

Co-Authored-By: Claude Opus 5 (1M context) <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01YWxNWmEobPKcJ6HqqUBMTw

