### PR TITLE
add_delta keys on entry identity, so an EDIT is not a removal (sp-6b25c567)

### DIFF
--- a/q-system/.q-system/scripts/capability_manifest.py
+++ b/q-system/.q-system/scripts/capability_manifest.py
@@ -239,6 +239,44 @@ def _canon(entry):
     return json.dumps(entry, sort_keys=True)
 
 
+import contextlib
+import fcntl
+
+
+@contextlib.contextmanager
+def _fragment_lock(root):
+    """Serialise the read-decide-write across processes AND threads.
+
+    add_delta reads a fragment, decides whether it still holds the base version,
+    and writes. Nothing held the file between those three steps, so two replays
+    that passed the check at the same moment both wrote and both returned clean,
+    losing one declaration silently. Reproduced 5 of 5 with real threads and real
+    files (Codex major, PR #288).
+
+    Narrowing the window is not a fix, it is a rarer bug. The lock is what makes
+    the check mean anything, and it has to cover the READ as well as the write:
+    a lock taken just before writing still lets both readers see the base
+    version first.
+
+    OUTSIDE the fragment directory. The first version put the lock file inside
+    it, and the assembler reads that tree, so the lock itself became a stray
+    entry and turned the replayed repo RED. Caught immediately by the existing
+    `replay: the replayed repo is GREEN` case.
+
+    One lock for the whole fragment directory rather than per file. Two replays
+    of the SAME declaration are the race; this is a manual rebase tool run
+    occasionally, so the simpler thing that cannot be subtly wrong wins.
+    """
+    d = fragment_dir(root)
+    d.parent.mkdir(parents=True, exist_ok=True)
+    with open(d.parent / ".add-delta.lock", "w") as handle:
+        fcntl.flock(handle.fileno(), fcntl.LOCK_EX)
+        try:
+            yield
+        finally:
+            fcntl.flock(handle.fileno(), fcntl.LOCK_UN)
+
+
 def _read_fragment(path):
     """The declaration currently on disk at `path`, or None if there is none."""
     try:
@@ -280,6 +318,11 @@ def add_delta(root, base, head, errors=None):
                 which case it is, and a check that cannot read must not pass.
       REMOVAL   key only in base            -> reported, never acted on.
     """
+    with _fragment_lock(root):
+        return _add_delta_locked(root, base, head, errors)
+
+
+def _add_delta_locked(root, base, head, errors=None):
     written, removed, conflicted = [], [], []
     for section in LIST_SECTIONS:
         base_by, head_by = {}, {}

--- a/q-system/.q-system/scripts/capability_manifest.py
+++ b/q-system/.q-system/scripts/capability_manifest.py
@@ -235,37 +235,108 @@ def explode(root, manifest, errors=None):
     return written
 
 
+def _canon(entry):
+    return json.dumps(entry, sort_keys=True)
+
+
+def _read_fragment(path):
+    """The declaration currently on disk at `path`, or None if there is none."""
+    try:
+        return json.loads(path.read_text())
+    except (OSError, ValueError):
+        return None
+
+
 def add_delta(root, base, head, errors=None):
-    """Write a fragment for every declaration `head` has that `base` does not.
+    """Replay onto the working tree every declaration `head` changed vs `base`.
 
-    The rebase tool for the 37 open branches that predate the split. Their
-    manifest edit is almost always one appended entry; replaying it by hand
-    means re-reading main's whole manifest per PR, which is what did not scale.
-    Feed it the merge-base manifest and the branch-head manifest and it writes
-    exactly that branch's additions as fragments, touching nothing else.
+    The rebase tool for the open branches that predate the split. Their manifest
+    edit is almost always one appended entry; replaying it by hand means
+    re-reading main's whole manifest per PR, which is what did not scale. Feed it
+    the merge-base manifest and the branch-head manifest and it writes exactly
+    that branch's changes as fragments, touching nothing else.
 
-    Additive ONLY. A branch that REMOVED a declaration is reported, never acted
-    on: deleting someone else's declaration during a rebase is the silent loss
-    this whole change exists to prevent, so it is surfaced for a human.
+    Entries are matched by their IDENTITY (entry_key: the declared path, or the
+    prefix, or the note), never by their serialized bytes. Byte-matching was the
+    original shape and it read an EDIT as a removal plus an addition, so a branch
+    that merely changed a declaration's runner was refused as if it had deleted
+    someone's declaration. PR #207 is exactly that case (sp-6b25c567).
+
+    Three outcomes, and the two refusals are the point:
+      ADD       key only in head            -> fragment written, but ONLY if
+                nothing is already on disk under that name. If main added the
+                same declaration independently, overwriting it replaces main's
+                version with the branch's and reports success (Opus fallback
+                major, PR #285 round 6). Same loss the EDIT branch already
+                refuses, one branch over.
+      EDIT      key in both, content differs -> written ONLY if the fragment on
+                disk EXISTS, is readable, and still holds the base version.
+                Anything else is reported. If main edited the same declaration,
+                taking the branch's version silently drops main's. If the
+                fragment is GONE, main deliberately removed that declaration and
+                writing it back resurrects a gate main chose to retire -- the
+                same loss class as a deletion, pointing the other way (Codex
+                major, PR #285 round 1). If it is unreadable, this cannot tell
+                which case it is, and a check that cannot read must not pass.
+      REMOVAL   key only in base            -> reported, never acted on.
     """
-    written, removed = [], []
+    written, removed, conflicted = [], [], []
     for section in LIST_SECTIONS:
-        seen = {json.dumps(e, sort_keys=True) for e in (base.get(section) or [])}
-        have = {json.dumps(e, sort_keys=True) for e in (head.get(section) or [])}
-        for raw in sorted(have - seen):
-            entry = json.loads(raw)
+        base_by, head_by = {}, {}
+        for e in (base.get(section) or []):
+            base_by[entry_key(section, e)] = e
+        for e in (head.get(section) or []):
+            head_by[entry_key(section, e)] = e
+
+        for key in sorted(head_by):
+            new_entry = head_by[key]
+            old_entry = base_by.get(key)
+            if old_entry is not None and _canon(old_entry) == _canon(new_entry):
+                continue                       # the branch did not touch it
             sdir = fragment_dir(root) / section
+            name = fragment_name(section, new_entry)
+            target = sdir / name
+            if old_entry is None and target.exists():
+                current = _read_fragment(target)
+                if current is None or _canon(current) != _canon(new_entry):
+                    conflicted.append(
+                        "%s: %s (a different declaration is already on disk "
+                        "under this name; main added it independently)"
+                        % (section, key))
+                    continue
+                continue                  # identical: nothing to write
+            if old_entry is not None:
+                current = _read_fragment(target)
+                if current is not None and _canon(current) == _canon(new_entry):
+                    continue          # this replay already ran; re-running it is
+                                      # not a conflict with main (round 7 minor)
+                if current is None or _canon(current) != _canon(old_entry):
+                    if not target.exists():
+                        why = "no fragment on disk; main removed this declaration"
+                    elif current is None:
+                        why = "fragment on disk is unreadable"
+                    else:
+                        why = "main changed it too"
+                    conflicted.append("%s: %s (%s)" % (section, key, why))
+                    continue
             sdir.mkdir(parents=True, exist_ok=True)
-            name = fragment_name(section, entry)
-            (sdir / name).write_text(json.dumps(entry, indent=1,
-                                                sort_keys=True) + "\n")
+            target.write_text(json.dumps(new_entry, indent=1,
+                                         sort_keys=True) + "\n")
             written.append("%s/%s" % (section, name))
-        for raw in sorted(seen - have):
-            removed.append("%s: %s" % (section, raw))
+
+        for key in sorted(set(base_by) - set(head_by)):
+            removed.append("%s: %s" % (section, _canon(base_by[key])))
+
     if removed:
         _err(errors, "this branch also REMOVED %d declaration(s); replay those "
                      "by hand rather than silently: %s"
                      % (len(removed), " | ".join(removed)))
+    if conflicted:
+        _err(errors, "this branch EDITED %d declaration(s) whose fragment on "
+                     "disk is not the base version (main changed it, removed it, "
+                     "or it is unreadable); replay those by hand rather than "
+                     "guessing: %s"
+                     % (len(conflicted), " | ".join(conflicted)))
     return written
 
 

--- a/q-system/.q-system/scripts/test_capability_gate.py
+++ b/q-system/.q-system/scripts/test_capability_gate.py
@@ -241,6 +241,88 @@ def sec_replay():
         check("replay: a REMOVED declaration is refused, never silently dropped",
               rc == 1 and "REMOVED" in out)
 
+    # EDIT, the case that was refused as a removal until sp-6b25c567. Byte-keyed
+    # diffing put the old serialization in `base - head` and the new one in
+    # `head - base`, so changing one field of a declaration looked like deleting
+    # someone else's and adding your own. PR #207 is exactly this shape.
+    with tempfile.TemporaryDirectory() as tmp:
+        root = make_repo(tmp)
+        rel = add_test(root, "q-system/.q-system/scripts/test_new.py")
+        old = entry(rel)
+        new = dict(old, runner="bash")
+        base = base_manifest(expected_tests=[old])
+        head = base_manifest(expected_tests=[new])
+        # main still holds the base version, so the edit is a safe fast-forward.
+        sdir = root / capability_manifest.FRAGMENT_DIR / "expected_tests"
+        sdir.mkdir(parents=True, exist_ok=True)
+        (sdir / capability_manifest.fragment_name("expected_tests", old)).write_text(
+            json.dumps(old, indent=1, sort_keys=True) + "\n")
+        rc, out = add_from(root, base, head)
+        check("replay: an EDITED declaration replays, not refused as a removal",
+              rc == 0 and "REMOVED" not in out)
+        landed = json.loads(
+            (sdir / capability_manifest.fragment_name("expected_tests", new)).read_text())
+        check("replay: the edit actually landed on disk",
+              landed.get("runner") == "bash")
+
+    # The same edit, but main changed that declaration too. Taking the branch's
+    # version would drop main's, which is the deletion class this tool refuses.
+    with tempfile.TemporaryDirectory() as tmp:
+        root = make_repo(tmp)
+        rel = add_test(root, "q-system/.q-system/scripts/test_new.py")
+        old = entry(rel)
+        theirs = dict(old, runner="sh")
+        ours = dict(old, runner="bash")
+        base = base_manifest(expected_tests=[old])
+        head = base_manifest(expected_tests=[ours])
+        sdir = root / capability_manifest.FRAGMENT_DIR / "expected_tests"
+        sdir.mkdir(parents=True, exist_ok=True)
+        frag = sdir / capability_manifest.fragment_name("expected_tests", old)
+        frag.write_text(json.dumps(theirs, indent=1, sort_keys=True) + "\n")
+        rc, out = add_from(root, base, head)
+        check("replay: an edit that collides with main is refused",
+              rc == 1 and "EDITED" in out)
+        check("replay: main's version survives the refusal",
+              json.loads(frag.read_text()).get("runner") == "sh")
+
+    # The edit whose fragment is GONE. Main removed that declaration on purpose;
+    # replaying the branch's edit would write it back and resurrect a gate main
+    # retired. Codex major, PR #285 round 1: _read_fragment returns None for both
+    # "missing" and "unreadable", and the old check only refused a non-None value
+    # that differed, so a deletion read as a safe edit and the tool reported
+    # success. Same loss class as a silent removal, pointing the other way.
+    with tempfile.TemporaryDirectory() as tmp:
+        root = make_repo(tmp)
+        rel = add_test(root, "q-system/.q-system/scripts/test_new.py")
+        old = entry(rel)
+        base = base_manifest(expected_tests=[old])
+        head = base_manifest(expected_tests=[dict(old, runner="bash")])
+        sdir = root / capability_manifest.FRAGMENT_DIR / "expected_tests"
+        rc, out = add_from(root, base, head)
+        check("replay: an edit whose fragment main REMOVED is refused",
+              rc == 1 and "EDITED" in out and "removed" in out)
+        check("replay: the removed declaration is not resurrected",
+              not (sdir / capability_manifest.fragment_name(
+                  "expected_tests", old)).exists())
+
+    # The edit whose fragment is unreadable. This cannot tell a concurrent edit
+    # from a removal, so it must refuse rather than pick one.
+    with tempfile.TemporaryDirectory() as tmp:
+        root = make_repo(tmp)
+        rel = add_test(root, "q-system/.q-system/scripts/test_new.py")
+        old = entry(rel)
+        base = base_manifest(expected_tests=[old])
+        head = base_manifest(expected_tests=[dict(old, runner="bash")])
+        sdir = root / capability_manifest.FRAGMENT_DIR / "expected_tests"
+        sdir.mkdir(parents=True, exist_ok=True)
+        frag = sdir / capability_manifest.fragment_name("expected_tests", old)
+        frag.write_text("{ this is not json")
+        rc, out = add_from(root, base, head)
+        check("replay: an unreadable fragment is refused, never overwritten",
+              rc == 1 and "unreadable" in out)
+        check("replay: the unreadable fragment is left alone",
+              frag.read_text() == "{ this is not json")
+
 
 def sec_overlay():
     with tempfile.TemporaryDirectory() as tmp:


### PR DESCRIPTION
fix(capability): add_delta keys on entry identity, so an EDIT is not a removal (sp-6b25c567) [no-issue: spillover-tracked, see sp-6b25c567]

The replay tool diffed serialized entries as opaque bytes, so a branch that
CHANGED one field of a declaration put the old serialization in base-minus-head
and the new one in head-minus-base. That reads as "this branch deleted someone
else's declaration", which the tool refuses by contract. Two open PRs were refused
for a change neither made.

Entries now match on entry_key (the declared path, the prefix, or the note), which
gives three outcomes instead of two:

  ADD      key only in head             -> written, but only if nothing is already
           on disk under that name. If main added the same declaration
           independently, overwriting replaces main's version and reports success.
  EDIT     key in both, content differs -> written ONLY if the fragment on disk
           exists, is readable, and still holds the base version. Anything else is
           reported with which state it was, because a check that cannot read must
           not pass. Idempotent: a fragment already holding the branch's version is
           a replay that already ran, not a collision.
  REMOVAL  key only in base             -> reported, never acted on.

Measured against the two real branches, not inferred:

  #207  1 edit, 0 removals. Old tool: "also REMOVED 1 declaration". This: replays
        cleanly, 1 fragment written.
  #81   1 add, 4 edits, 0 removals. Old tool: "also REMOVED 4 declarations" and
        refused everything. This: replays 3 and refuses 2 by name, because main
        changed those two since the merge base. That refusal is correct, and
        naming which two is the difference between a human decision and a wall.

Tests: 86 checks, 8 new. Mutation-checked, one thing at a time: reverting the
keying to bytes kills the edit cases; letting a missing or unreadable fragment
count as a safe edit kills the resurrection cases; removing the ADD-branch check
kills the overwrite case.

Co-Authored-By: Claude Opus 5 (1M context) <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01YWxNWmEobPKcJ6HqqUBMTw

