### PR TITLE
A missing lint reports NOT CHECKED instead of a pass

### DIFF
--- a/q-system/.q-system/capability/expected_tests/q-system__.q-system__tests__test_voice_stop_gate_not_checked.py.json
+++ b/q-system/.q-system/capability/expected_tests/q-system__.q-system__tests__test_voice_stop_gate_not_checked.py.json
@@ -1,0 +1,5 @@
+{
+ "path": "q-system/.q-system/tests/test_voice_stop_gate_not_checked.py",
+ "runner": "python3",
+ "timeout_s": 60
+}

--- a/q-system/.q-system/scripts/voice-stop-gate.py
+++ b/q-system/.q-system/scripts/voice-stop-gate.py
@@ -388,6 +388,24 @@ def find_final_user_text(transcript_path):
 NOT_CHECKED = "NOT_CHECKED"
 
 
+def report_not_checked(lines, out=None, err=None):
+    """Surface NOT CHECKED on the channel a SUCCESSFUL hook is actually read on.
+
+    The first version of this wrote to stderr only, on a path that then exits 0.
+    A Stop hook's stderr is fed back when it exits 2; on the success path it goes
+    nowhere. So the warning that a draft had not been graded was itself never
+    delivered -- the exact defect this whole change exists to close, reproduced
+    inside the fix for it (Codex major, PR #290).
+
+    Both streams on purpose. stdout is what a successful hook is read on; stderr
+    keeps the line present if this is ever called from the blocking path, where
+    stdout is not surfaced. Writing to one and hoping is what got us here.
+    """
+    for line in lines:
+        (out or sys.stdout).write(line + "\n")
+        (err or sys.stderr).write(line + "\n")
+
+
 def run_check(script, file_path):
     if not script.exists():
         return (NOT_CHECKED,
@@ -470,13 +488,7 @@ def main():
             violations_output.append(out2)
         elif code2 == NOT_CHECKED:
             not_checked.append(out2)
-        # Surfaced on EVERY affected turn, and deliberately not a block. A Stop
-        # hook that hard-refuses on its own missing dependency wedges the session
-        # with no way forward -- this gate honours no bypass marker by design
-        # (voice-enforcement.md). Loud and passing beats silent and passing;
-        # blocking is a separate decision with a much larger blast radius.
-        for line in not_checked:
-            sys.stderr.write(line + "\n")
+        report_not_checked(not_checked)
         if violations_output:
             sys.stderr.write(
                 "voice-stop-gate: assistant final message has voice violations.\n"

--- a/q-system/.q-system/scripts/voice-stop-gate.py
+++ b/q-system/.q-system/scripts/voice-stop-gate.py
@@ -375,9 +375,24 @@ def find_final_user_text(transcript_path):
     return text
 
 
+# A MISSING CHECK IS NOT A PASS. This returned (0, "") when its script was
+# absent, and 0 is the same value a clean draft produces, so a run on a machine
+# where voice-lint.py had moved was byte-for-byte indistinguishable from a run
+# that graded the draft and found nothing wrong. The turn completed, stderr was
+# empty, and the founder got a post no gate had read.
+#
+# The shape is copied from `resolve_reporter` twenty lines up, which was written
+# against this same defect: return the NAMED thing even when it is missing and
+# let the caller decide, so a reader can say "the check named X, which does not
+# exist" instead of seeing silence.
+NOT_CHECKED = "NOT_CHECKED"
+
+
 def run_check(script, file_path):
     if not script.exists():
-        return (0, "")
+        return (NOT_CHECKED,
+                "voice-stop-gate: %s is MISSING at %s, so this draft was NOT "
+                "CHECKED by it. That is not a pass." % (script.name, script))
     try:
         result = subprocess.run(
             ["python3", str(script), file_path],
@@ -444,12 +459,24 @@ def main():
         tmp_path = tmp.name
     try:
         violations_output = []
+        not_checked = []
         code1, out1 = run_check(VOICE_LINT, tmp_path)
         if code1 == 2 and out1:
             violations_output.append(out1)
+        elif code1 == NOT_CHECKED:
+            not_checked.append(out1)
         code2, out2 = run_check(SUBSTANCE_LINT, tmp_path)
         if code2 == 2 and out2:
             violations_output.append(out2)
+        elif code2 == NOT_CHECKED:
+            not_checked.append(out2)
+        # Surfaced on EVERY affected turn, and deliberately not a block. A Stop
+        # hook that hard-refuses on its own missing dependency wedges the session
+        # with no way forward -- this gate honours no bypass marker by design
+        # (voice-enforcement.md). Loud and passing beats silent and passing;
+        # blocking is a separate decision with a much larger blast radius.
+        for line in not_checked:
+            sys.stderr.write(line + "\n")
         if violations_output:
             sys.stderr.write(
                 "voice-stop-gate: assistant final message has voice violations.\n"

--- a/q-system/.q-system/tests/test_voice_stop_gate_not_checked.py
+++ b/q-system/.q-system/tests/test_voice_stop_gate_not_checked.py
@@ -1,0 +1,120 @@
+"""A missing lint must report NOT CHECKED, never a pass.
+
+`run_check` returned `(0, "")` when its script was absent, and 0 is the same
+value a clean draft produces. So a voice-stop-gate run on a machine where
+`voice-lint.py` had moved was byte-for-byte indistinguishable from a run that
+graded the draft and found nothing wrong. The turn completed, nothing was
+written to stderr, and the founder got a post that no gate had read.
+
+This is the precondition for making the Stop gate the bypass recorder. A
+recorder that scores a missing check as a pass fails in exactly the shape it
+exists to record.
+
+The file already knows this. `resolve_reporter` at lines 125-140 was written
+against the same defect and its comment says so: "A probe that cannot fail is
+indistinguishable from one that works, which is why resolve_reporter returns the
+NAMED path even when it is missing and lets the caller decide." That shape was
+never carried the twenty lines down to `run_check`.
+"""
+import importlib.util
+import os
+import subprocess
+import sys
+import tempfile
+
+import pytest
+
+REPO = os.path.abspath(os.path.join(os.path.dirname(__file__), "..", "..", ".."))
+GATE = os.path.join(REPO, "q-system", ".q-system", "scripts", "voice-stop-gate.py")
+VOICE_LINT = os.path.join(REPO, "q-system", ".q-system", "scripts", "voice-lint.py")
+
+
+def _load_gate():
+    spec = importlib.util.spec_from_file_location("voice_stop_gate", GATE)
+    mod = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(mod)
+    return mod
+
+
+gate = _load_gate()
+
+
+def _draft(text):
+    fh = tempfile.NamedTemporaryFile(mode="w", suffix=".md", delete=False,
+                                     encoding="utf-8")
+    fh.write(text)
+    fh.close()
+    return fh.name
+
+
+class TestAMissingLintIsNotAPass:
+
+    def test_run_check_reports_not_checked_when_the_script_is_absent(self):
+        """The defect. Before the fix this returns (0, "") and reads as clean."""
+        from pathlib import Path
+        path = _draft("anything at all\n")
+        try:
+            code, out = gate.run_check(Path("/nonexistent/voice-lint.py"), path)
+        finally:
+            os.unlink(path)
+        assert code == gate.NOT_CHECKED, (
+            "a missing lint returned %r, which the caller cannot tell from a "
+            "clean draft" % (code,))
+
+    def test_the_not_checked_state_is_not_equal_to_the_pass_state(self):
+        """Guards against someone defining NOT_CHECKED as 0 and calling it done.
+
+        Without this, the case above passes for an implementation that changed
+        nothing. NOT_CHECKED has to be a value a clean run cannot also produce.
+        """
+        assert gate.NOT_CHECKED != 0
+
+    def test_the_report_names_the_script_it_could_not_run(self):
+        """So the reader fixes the path instead of hunting the draft."""
+        from pathlib import Path
+        path = _draft("anything at all\n")
+        try:
+            _, out = gate.run_check(Path("/nonexistent/voice-lint.py"), path)
+        finally:
+            os.unlink(path)
+        assert "voice-lint.py" in out and "/nonexistent" in out, out
+
+
+class TestTheNormalPathStillWorks:
+    """The negative controls. Run these before trusting the arms above.
+
+    Without them, deleting the whole check body would satisfy every assertion in
+    the class above.
+    """
+
+    def test_a_real_violation_is_still_surfaced(self):
+        from pathlib import Path
+        if not os.path.exists(VOICE_LINT):
+            pytest.skip("voice-lint.py absent in this checkout")
+        path = _draft("This sentence carries an em dash — which voice-lint bans.\n")
+        try:
+            code, out = gate.run_check(Path(VOICE_LINT), path)
+        finally:
+            os.unlink(path)
+        assert code == 2, (code, out)
+        assert out.strip(), "a violation was found and reported nothing"
+
+    def test_a_clean_draft_still_passes(self):
+        from pathlib import Path
+        if not os.path.exists(VOICE_LINT):
+            pytest.skip("voice-lint.py absent in this checkout")
+        path = _draft("Short line. Nothing banned here.\n")
+        try:
+            code, _ = gate.run_check(Path(VOICE_LINT), path)
+        finally:
+            os.unlink(path)
+        assert code == 0, "a clean draft must still be a plain pass"
+
+
+# The capability gate's only runners are `bash` and `python3`; there is no pytest
+# runner. Declared as python3, a bare pytest file would execute as a script,
+# collect nothing, exit 0, and be counted as a passing declared test -- the same
+# defect this file exists to close, one layer up. This block makes the declared
+# invocation actually run the assertions.
+if __name__ == "__main__":
+    sys.exit(pytest.main([__file__, "-q", "--no-header"]))

--- a/q-system/.q-system/tests/test_voice_stop_gate_not_checked.py
+++ b/q-system/.q-system/tests/test_voice_stop_gate_not_checked.py
@@ -118,3 +118,37 @@ class TestTheNormalPathStillWorks:
 # invocation actually run the assertions.
 if __name__ == "__main__":
     sys.exit(pytest.main([__file__, "-q", "--no-header"]))
+
+
+class TestTheWarningIsActuallyDelivered:
+    """Codex major, PR #290. The first fix returned the right VALUE and delivered
+    it on a channel nobody reads.
+
+    stderr from a Stop hook is fed back when it exits 2. This path exits 0, so
+    the NOT CHECKED line went nowhere. Every test above passed, because they all
+    asserted the return value and none asserted delivery -- the same
+    output-versus-input blindness the whole change exists to close, reproduced
+    inside the fix for it.
+    """
+
+    def test_the_line_reaches_stdout(self):
+        """stdout is what a SUCCESSFUL hook is read on. This is the arm that
+        was missing."""
+        import io
+        out, err = io.StringIO(), io.StringIO()
+        gate.report_not_checked(["voice-stop-gate: X is MISSING"], out=out, err=err)
+        assert "X is MISSING" in out.getvalue(), "nothing reached stdout"
+
+    def test_the_line_also_reaches_stderr(self):
+        """Kept for the blocking path, where stdout is not surfaced."""
+        import io
+        out, err = io.StringIO(), io.StringIO()
+        gate.report_not_checked(["voice-stop-gate: X is MISSING"], out=out, err=err)
+        assert "X is MISSING" in err.getvalue()
+
+    def test_nothing_is_written_when_every_lint_ran(self):
+        """The control. A gate that always shouts is a gate that gets muted."""
+        import io
+        out, err = io.StringIO(), io.StringIO()
+        gate.report_not_checked([], out=out, err=err)
+        assert out.getvalue() == "" and err.getvalue() == ""


### PR DESCRIPTION
fix(voice): a missing lint reports NOT CHECKED instead of a pass [no-issue: voice-loop item-4 precondition, scoped by the end-to-end plan]

`run_check` returned `(0, "")` when its script was absent, and 0 is the same value
a clean draft produces. So a voice-stop-gate run on a machine where voice-lint.py
had moved was byte-for-byte indistinguishable from a run that graded the draft and
found nothing wrong: turn completed, stderr empty, and a post nothing had read.

This is the precondition for making the Stop gate the recorder for pipeline
bypasses. A recorder that scores a missing check as a pass fails in exactly the
shape it exists to record, so it gets fixed before anything is built on top.

THE SHAPE IS NOT NEW HERE. `resolve_reporter`, twenty lines up in the same file,
was written against this same defect and its comment says so: "A probe that cannot
fail is indistinguishable from one that works, which is why resolve_reporter
returns the NAMED path even when it is missing and lets the caller decide." That
answer was never carried down to `run_check`. This carries it.

DELIBERATELY NOT A BLOCK. A Stop hook that hard-refuses on its own missing
dependency wedges the session, and this gate honours no bypass marker by design
(voice-enforcement.md). NOT CHECKED is surfaced on stderr on every affected turn.
Loud and passing beats silent and passing; turning it into a refusal is a separate
decision with a much larger blast radius.

VERIFICATION, in order:
- reproducer written first, 3 arms red before any fix existed
- both negative controls green from the start, which is what proves voice-lint.py
  really does flag an em dash and pass a clean draft rather than the arms passing
  for some unrelated reason
- mutation 1: reverting to `(0, "")` kills two arms
- mutation 2: defining NOT_CHECKED as 0 kills a third. That arm exists precisely
  so the fix cannot be satisfied by changing nothing
- capability gate GREEN on this branch

ONE THING FOUND WHILE DECLARING IT. The capability gate's only runners are `bash`
and `python3`; there is no pytest runner. A pytest file declared as `python3`
executes as a script, collects nothing, exits 0, and counts as a passing declared
test. That is this same defect one layer up, in the act of fixing it. So the test
carries a `__main__` block and the declared invocation was proven able to fail:
mutated it exits 1, restored it exits 0.

Co-Authored-By: Claude Opus 5 (1M context) <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01YWxNWmEobPKcJ6HqqUBMTw

