### PR TITLE
voice-loop C3 + seam fix: the Stop-gate reads an optional instance channel registry

### DIFF
--- a/plugins/kipi-core/.claude-plugin/plugin.json
+++ b/plugins/kipi-core/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "kipi-core",
-  "version": "1.7.31",
+  "version": "1.7.32",
   "description": "Core founder OS \u2014 voice, research, AUDHD, LinkedIn/brand, RCA skills + kipi-mcp server",
   "author": {
     "name": "Assaf Kipnis",

--- a/plugins/kipi-core/.claude-plugin/plugin.json
+++ b/plugins/kipi-core/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "kipi-core",
-  "version": "1.7.28",
+  "version": "1.7.29",
   "description": "Core founder OS \u2014 voice, research, AUDHD, LinkedIn/brand, RCA skills + kipi-mcp server",
   "author": {
     "name": "Assaf Kipnis",

--- a/plugins/kipi-core/.claude-plugin/plugin.json
+++ b/plugins/kipi-core/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "kipi-core",
-  "version": "1.7.30",
+  "version": "1.7.31",
   "description": "Core founder OS \u2014 voice, research, AUDHD, LinkedIn/brand, RCA skills + kipi-mcp server",
   "author": {
     "name": "Assaf Kipnis",

--- a/plugins/kipi-core/.claude-plugin/plugin.json
+++ b/plugins/kipi-core/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "kipi-core",
-  "version": "1.7.29",
+  "version": "1.7.30",
   "description": "Core founder OS \u2014 voice, research, AUDHD, LinkedIn/brand, RCA skills + kipi-mcp server",
   "author": {
     "name": "Assaf Kipnis",

--- a/plugins/kipi-core/voiceloop/channel_registry.py
+++ b/plugins/kipi-core/voiceloop/channel_registry.py
@@ -60,9 +60,9 @@ DEFAULT_ASSEMBLED = ("linkedin", "x")
 # KNOWN_LINT_INPUTS, for the same reason.
 KNOWN_ROLES = ("scope", "assembled")
 
-# Both live under q-system/.q-system/data/, which is in the skeleton sync's
-# INSTANCE_OWNED_SUBTREES, so `kipi update` never overwrites or deletes them
-# (RULE-2026-06-30-A).
+# Both live under q-system/.q-system/data/, which the fleet sync treats as
+# instance-owned, so a sync never overwrites or deletes them. A file placed next
+# to this module instead would be replaced by the next sync.
 REGISTRY_REL = os.path.join("q-system", ".q-system", "data", "voice-channels.json")
 POINTER_REL = os.path.join("q-system", ".q-system", "data", "voice-channels.path")
 
@@ -137,8 +137,9 @@ def load(registry_path):
     to the pre-registry behavior.
 
     A registry with no `channel_vocabulary` key also returns DEFAULT. That is not
-    laziness: cole-gtm's live registry answers the SURFACE question only, and a
-    registry gaining a new consumer must not change what it already answers.
+    laziness: the registries already in the field answer the SURFACE question
+    only, and a registry gaining a new consumer must not change what it already
+    answers to its existing ones.
 
     Raises ChannelRegistryError on a present-but-untrustworthy registry.
     """

--- a/plugins/kipi-core/voiceloop/channel_registry.py
+++ b/plugins/kipi-core/voiceloop/channel_registry.py
@@ -1,0 +1,207 @@
+#!/usr/bin/env python3
+"""The channel vocabulary this engine validates against, and its ONE owner.
+
+WHY THIS FILE EXISTS (sp-6c93d3d8, measured 2026-08-30). `validate.py` restated
+channel membership FOUR times in one file: the correction-scope allowlist, the
+`check_pools` loop, `CHECKED_SLOTS`, and `check_budget`'s default. A founder
+correction scoped to "reddit" was refused by the first of those, and the fleet
+had eighteen hardcoded channel sites for the same reason. Adding "reddit" to the
+allowlist would have made it the nineteenth site and left three more disagreeing
+inside the same file. Shotgun Surgery has a named cure and it is not one more
+literal: derive the value from its owner.
+
+TWO AXES, NOT ONE. Collapsing them is the same defect one level in.
+
+- SCOPE: which channel names a correction may be scoped to. Seven today.
+- ASSEMBLED: which channels the assembler actually builds a prompt for, so which
+  ones must clear the pool floor, the anchor-rotation floor and the char budget.
+  Two today. A channel can be a legal correction scope without owning a pool --
+  reddit is exactly that case, and a registry that could not say so would put
+  reddit into `check_pools` and turn 27 corpora red for a pool nobody assembles.
+
+THE HARD CONSTRAINT, and it outranks the feature. An instance with NO registry
+must behave byte-identically to before this module existed. 27 instances load
+this code and none of them asked for a registry. So `DEFAULT` below is today's
+literals verbatim, `resolve()` returning None is the normal case, and every
+`channels=None` default in validate.py lands here. `test_channel_registry.py`
+pins that with the pre-change literals written out independently, so a future
+edit to DEFAULT is caught by a test that does not import DEFAULT.
+
+RESOLUTION SHAPE IS COPIED, NOT INVENTED. `resolve()` is the same two-source
+shape as `resolve_channel_registry` in q-system/.q-system/scripts/voice-stop-gate.py,
+which itself copied `resolve_reporter` beside it. Same relative paths, same
+pointer-file semantics, same "return the named path even when it is missing" rule.
+sp-52635fa3 tracks collapsing those copies into one importable home; this module
+is that home for everything that can import the voice engine. The Stop-gate's
+copy is deliberately NOT collapsed into it here: that hook is fail-closed on every
+turn of 27 instances, this package's directory name is mid-rename across the
+fleet, and an import that resolved to the old name would hold every turn on every
+instance that has not synced yet. That collapse waits for the rename to land
+and for the schema-conformance fixture sp-52635fa3 asks for.
+
+FAIL-CLOSED, same posture as the rest of this package's validate half. A registry
+that is PRESENT and untrustworthy raises rather than falling back to DEFAULT.
+Falling back would silently grade a corpus against the wrong vocabulary, which is
+the entire defect the registry exists to prevent.
+"""
+from __future__ import annotations
+
+import json
+import os
+
+# Today's literals, lifted verbatim from validate.py before this module existed.
+# These ARE the no-registry behavior. Changing them changes 27 instances.
+DEFAULT_SCOPES = ("linkedin", "x", "substack", "medium", "dm", "email", "comment")
+DEFAULT_ASSEMBLED = ("linkedin", "x")
+
+# A role a channel can hold. Unknown roles fail closed rather than being ignored:
+# a typo'd "assembeled" that silently dropped a channel out of the budget check
+# would read exactly like a healthy corpus. Same rule as the Stop-gate's
+# KNOWN_LINT_INPUTS, for the same reason.
+KNOWN_ROLES = ("scope", "assembled")
+
+# Both live under q-system/.q-system/data/, which is in the skeleton sync's
+# INSTANCE_OWNED_SUBTREES, so `kipi update` never overwrites or deletes them
+# (RULE-2026-06-30-A).
+REGISTRY_REL = os.path.join("q-system", ".q-system", "data", "voice-channels.json")
+POINTER_REL = os.path.join("q-system", ".q-system", "data", "voice-channels.path")
+
+
+class ChannelRegistryError(Exception):
+    """A registry that is present and cannot be trusted. Callers must not fall back."""
+
+
+class Channels:
+    """The vocabulary, one object, two axes. `source` is the file it came from,
+    or None for the built-in default -- so an error message can name the file an
+    operator has to edit instead of saying "unknown scope" and stopping there."""
+
+    __slots__ = ("scopes", "assembled", "source")
+
+    def __init__(self, scopes, assembled, source=None):
+        self.scopes = tuple(scopes)
+        self.assembled = tuple(assembled)
+        self.source = source
+
+    def __repr__(self):                                     # pragma: no cover
+        return (f"Channels(scopes={self.scopes!r}, assembled={self.assembled!r}, "
+                f"source={self.source!r})")
+
+    def __eq__(self, other):
+        if not isinstance(other, Channels):
+            return NotImplemented
+        return (self.scopes == other.scopes
+                and self.assembled == other.assembled
+                and self.source == other.source)
+
+
+DEFAULT = Channels(DEFAULT_SCOPES, DEFAULT_ASSEMBLED, None)
+
+
+def resolve(instance_root):
+    """This instance's registry path, or None. Two sources, in order:
+
+    1. `q-system/.q-system/data/voice-channels.json` in the instance.
+    2. A pointer file beside it naming the real location, because an instance that
+       already owns a registry keeps it beside its own config, and there is no
+       fleet-wide answer to which subtree that is. The pointer is one relative or
+       absolute path; blank lines and `#` comments are ignored.
+
+    Returns the NAMED path even when it does not exist, so `load` can say "the
+    pointer names X, which is missing" instead of "no registry" -- the
+    resolve_reporter scar, where a silent None read as "correctly absent".
+    """
+    if not instance_root:
+        return None
+    local = os.path.join(instance_root, REGISTRY_REL)
+    if os.path.isfile(local):
+        return local
+    pointer = os.path.join(instance_root, POINTER_REL)
+    try:
+        with open(pointer, encoding="utf-8") as handle:
+            named = handle.read()
+    except OSError:
+        return None
+    named = "".join(ln for ln in named.splitlines()
+                    if ln.strip() and not ln.lstrip().startswith("#")).strip()
+    if not named:
+        return None
+    named = os.path.expanduser(named)
+    if not os.path.isabs(named):
+        named = os.path.join(instance_root, named)
+    return os.path.realpath(named)
+
+
+def load(registry_path):
+    """`Channels` for this registry. None (no registry) -> DEFAULT, byte-identical
+    to the pre-registry behavior.
+
+    A registry with no `channel_vocabulary` key also returns DEFAULT. That is not
+    laziness: cole-gtm's live registry answers the SURFACE question only, and a
+    registry gaining a new consumer must not change what it already answers.
+
+    Raises ChannelRegistryError on a present-but-untrustworthy registry.
+    """
+    if registry_path is None:
+        return DEFAULT
+    try:
+        with open(registry_path, encoding="utf-8") as handle:
+            data = json.load(handle)
+    except OSError as exc:
+        raise ChannelRegistryError(
+            f"voice-channels registry named at {registry_path} is unreadable: "
+            f"{exc}") from exc
+    except ValueError as exc:
+        raise ChannelRegistryError(
+            f"voice-channels registry at {registry_path} is malformed: {exc}") from exc
+    if not isinstance(data, dict):
+        raise ChannelRegistryError(
+            f"voice-channels registry at {registry_path} must be an object")
+    vocab = data.get("channel_vocabulary")
+    if vocab is None:
+        return DEFAULT
+    if not isinstance(vocab, dict):
+        raise ChannelRegistryError(
+            f"voice-channels registry at {registry_path}: channel_vocabulary must "
+            f"be an object mapping channel name -> list of roles")
+
+    scopes, assembled = [], []
+    for name, roles in vocab.items():
+        if not isinstance(name, str) or not name.strip():
+            raise ChannelRegistryError(
+                f"voice-channels registry at {registry_path}: a channel_vocabulary "
+                f"key is empty")
+        if not isinstance(roles, (list, tuple)):
+            raise ChannelRegistryError(
+                f"voice-channels registry at {registry_path}: roles for {name!r} "
+                f"must be a list, got {type(roles).__name__}")
+        for role in roles:
+            if role not in KNOWN_ROLES:
+                raise ChannelRegistryError(
+                    f"voice-channels registry at {registry_path}: channel {name!r} "
+                    f"declares unknown role {role!r}; known: {list(KNOWN_ROLES)}")
+        if "scope" in roles:
+            scopes.append(name)
+        if "assembled" in roles:
+            assembled.append(name)
+
+    # An axis declared EMPTY is a check that can never fire, dressed as protection.
+    # Empty scopes refuses every correction; empty assembled makes check_pools,
+    # check_anchor_diversity, check_rotation_headroom and check_budget all iterate
+    # nothing and report a clean corpus they never looked at. Both are worse than
+    # no registry, so both are refused rather than accepted quietly.
+    if not scopes:
+        raise ChannelRegistryError(
+            f"voice-channels registry at {registry_path}: no channel declares the "
+            f"'scope' role, so every correction scope would be refused")
+    if not assembled:
+        raise ChannelRegistryError(
+            f"voice-channels registry at {registry_path}: no channel declares the "
+            f"'assembled' role, so the pool, anchor and budget checks would grade "
+            f"nothing and report healthy")
+    return Channels(scopes, assembled, registry_path)
+
+
+def for_instance(instance_root):
+    """`resolve` then `load`. The one call an instance seam needs."""
+    return load(resolve(instance_root))

--- a/plugins/kipi-core/voiceloop/channel_registry.py
+++ b/plugins/kipi-core/voiceloop/channel_registry.py
@@ -158,9 +158,15 @@ def load(registry_path):
     if not isinstance(data, dict):
         raise ChannelRegistryError(
             f"voice-channels registry at {registry_path} must be an object")
-    vocab = data.get("channel_vocabulary")
-    if vocab is None:
+    # PRESENCE, not falsiness. `.get()` returns None for an ABSENT key and for an
+    # explicit `"channel_vocabulary": null` alike, so the null quietly loaded the
+    # built-in default instead of failing closed. That is the same hole the Stop
+    # gate had one layer up, and the same answer: a registry declaring the field
+    # and getting it wrong is malformed, while a registry that simply does not
+    # declare it is a registry with no vocabulary opinion.
+    if "channel_vocabulary" not in data:
         return DEFAULT
+    vocab = data["channel_vocabulary"]
     if not isinstance(vocab, dict):
         raise ChannelRegistryError(
             f"voice-channels registry at {registry_path}: channel_vocabulary must "

--- a/plugins/kipi-core/voiceloop/channel_registry.py
+++ b/plugins/kipi-core/voiceloop/channel_registry.py
@@ -206,3 +206,49 @@ def load(registry_path):
 def for_instance(instance_root):
     """`resolve` then `load`. The one call an instance seam needs."""
     return load(resolve(instance_root))
+
+
+# How far up to look before giving up. Deep enough for the real fleet shape, an
+# instance corpus dir sitting four levels under its root, and shallow enough that
+# a runaway walk cannot reach a stranger's home directory.
+_MAX_WALK = 12
+
+
+def instance_root_for(start):
+    """The directory at or above `start` that OWNS a channel registry, or None.
+
+    Anchored on the registry's OWN two locations rather than on .git or any other
+    landmark, because that is literally the question being asked: which directory
+    above this one holds voice-channels.json or the pointer beside it. Answering
+    it with a different landmark is how a seam ends up reading a tree that has no
+    registry -- the public mirror and the skeleton disagree about where .git and
+    tests/ live, and a walk keyed on those finds a different answer in each
+    (the same trap test_validate_holds_no_channel_literal's VALIDATE_PY note
+    records for module paths).
+
+    None is a real answer and the common one: 26 instances own no registry and
+    every caller must treat None as "use the built-in default", which is
+    byte-identical to the behavior before this module existed.
+    """
+    current = os.path.abspath(start)
+    for _ in range(_MAX_WALK):
+        for rel in (REGISTRY_REL, POINTER_REL):
+            if os.path.isfile(os.path.join(current, rel)):
+                return current
+        parent = os.path.dirname(current)
+        if parent == current:               # filesystem root
+            break
+        current = parent
+    return None
+
+
+def for_path(start):
+    """The Channels governing `start`, or the built-in default when nothing owns it.
+
+    The whole seam in one call, so a caller cannot wire half of it. A registry
+    that IS present and broken still raises: falling back to the default there
+    would grade a corpus against a vocabulary its instance rejected, which is the
+    wrong-vocabulary bug wearing a fix.
+    """
+    root = instance_root_for(start)
+    return for_instance(root) if root else DEFAULT

--- a/plugins/kipi-core/voiceloop/tests/test_channel_registry.py
+++ b/plugins/kipi-core/voiceloop/tests/test_channel_registry.py
@@ -253,3 +253,60 @@ def test_the_literal_detector_can_fail():
         "for channel in channels.assembled:",
         'for channel in ("linkedin", "x"):', 1)
     assert _channel_literals(mutated) == {"linkedin", "x"}
+
+
+# ------------------------------------------- the seam has to be LOADED, not documented ----
+
+def _instance(tmp_path, with_registry):
+    """An instance tree whose voice dir sits BELOW the registry, as the real one does.
+
+    The registered instance keeps its corpus several levels under its root while
+    the registry lives in the synced data dir, so the validator is handed a path
+    well below the instance root and has to find that root itself. A fixture that
+    put the two side by side would pass against a resolver that never walks.
+    """
+    root = tmp_path / "inst"
+    voice = root / "instance-content" / "voice"
+    voice.mkdir(parents=True)
+    row = {"id": "r-1", "date": "2026-08-30", "instruction": "no CTA here",
+           "class": "interpretive", "status": "active", "scope": ["reddit"]}
+    (voice / corpus.CORRECTIONS).write_text(json.dumps(row) + "\n", encoding="utf-8")
+    if with_registry:
+        _write(os.path.join(str(root), cr.REGISTRY_REL),
+               {"channel_vocabulary": {"linkedin": ["scope", "assembled"],
+                                       "x": ["scope", "assembled"],
+                                       "reddit": ["scope"]}})
+    return str(voice)
+
+
+UNKNOWN_REDDIT = "unknown scope 'reddit'"
+
+
+def test_check_all_loads_the_instance_registry(tmp_path):
+    """Codex MAJOR on PR #291: the registry was never LOADED by the validator.
+
+    `check_all` documented that "an instance seam that owns a registry passes
+    channel_registry.for_instance(<repo root>)" and no caller in this repo ever
+    did. Measured: `for_instance` had exactly one definition and zero non-test
+    callers, so every instance validated its corpus against the built-in
+    vocabulary no matter what its registry declared.
+
+    That is live, not theoretical. The one registered instance declares `reddit`
+    as a scope, in a registry reached through the pointer file beside the synced
+    data dir. Its first reddit-scoped correction would be refused by its own
+    suite as an unknown scope, which is the same wrong-vocabulary failure this whole change exists to
+    end, arriving at suite time instead of runtime.
+    """
+    problems = validate.check_all(_instance(tmp_path, with_registry=True))
+    assert not [p for p in problems if UNKNOWN_REDDIT in p], problems
+
+
+def test_check_all_without_a_registry_still_uses_the_built_in_vocabulary(tmp_path):
+    """The control, and the constraint the fix must not break.
+
+    Without this the test above passes on a `check_all` that accepts every scope.
+    26 instances have no registry and must behave byte-identically to before, so
+    an unregistered `reddit` is still an unknown scope.
+    """
+    problems = validate.check_all(_instance(tmp_path, with_registry=False))
+    assert [p for p in problems if UNKNOWN_REDDIT in p], problems

--- a/plugins/kipi-core/voiceloop/tests/test_channel_registry.py
+++ b/plugins/kipi-core/voiceloop/tests/test_channel_registry.py
@@ -228,8 +228,11 @@ def _channel_literals(source):
     return found
 
 
-VALIDATE_PY = os.path.join(
-    os.path.dirname(os.path.dirname(os.path.abspath(__file__))), "validate.py")
+# From the IMPORTED module, never from this file's path. The public mirror puts
+# tests/ at the repo root while the skeleton puts them inside the package, so a
+# dirname walk finds validate.py in one tree and nothing in the other. Asking the
+# module where it lives also checks the copy that actually got imported.
+VALIDATE_PY = os.path.abspath(validate.__file__)
 
 
 def test_validate_holds_no_channel_literal():

--- a/plugins/kipi-core/voiceloop/tests/test_channel_registry.py
+++ b/plugins/kipi-core/voiceloop/tests/test_channel_registry.py
@@ -310,3 +310,26 @@ def test_check_all_without_a_registry_still_uses_the_built_in_vocabulary(tmp_pat
     """
     problems = validate.check_all(_instance(tmp_path, with_registry=False))
     assert [p for p in problems if UNKNOWN_REDDIT in p], problems
+
+
+def test_an_explicit_null_channel_vocabulary_is_malformed(tmp_path):
+    """Codex MINOR on PR #291 round 4, the same hole one layer down.
+
+    `.get()` returns None for an ABSENT key and for an explicit
+    `"channel_vocabulary": null` alike, so the null quietly loaded the built-in
+    default rather than failing closed. A registry that declares the field and
+    gets it wrong is malformed; one that never declares it has no opinion.
+    """
+    path = os.path.join(str(tmp_path), cr.REGISTRY_REL)
+    _write(path, {"channel_vocabulary": None})
+    with pytest.raises(cr.ChannelRegistryError) as exc:
+        cr.load(path)
+    assert "channel_vocabulary must" in str(exc.value), str(exc.value)
+
+
+def test_a_registry_with_no_vocabulary_key_still_gets_the_default(tmp_path):
+    """The control. Without it the test above passes on a load() that rejects
+    every registry, and the 26 instances that declare no vocabulary would break."""
+    path = os.path.join(str(tmp_path), cr.REGISTRY_REL)
+    _write(path, {"channels": {}})
+    assert cr.load(path) is cr.DEFAULT

--- a/plugins/kipi-core/voiceloop/tests/test_channel_registry.py
+++ b/plugins/kipi-core/voiceloop/tests/test_channel_registry.py
@@ -1,0 +1,252 @@
+#!/usr/bin/env python3
+"""The channel vocabulary has ONE owner, and an instance without one is unchanged.
+
+Every assertion about the no-registry case writes the pre-change literals out by
+hand rather than importing them. A test that reads `DEFAULT` and asserts against
+`DEFAULT` cannot see an edit to DEFAULT, which is the one edit that would silently
+change 27 instances.
+"""
+import json
+import os
+import sys
+
+import pytest
+
+sys.path.insert(0, os.path.dirname(os.path.dirname(os.path.dirname(
+    os.path.abspath(__file__)))))
+
+from voiceloop import channel_registry as cr           # noqa: E402
+from voiceloop import corpus, validate                 # noqa: E402
+
+
+# The literals that lived in validate.py at lines 110 / 120 / 138 / 293 before
+# this module existed. Typed here, imported from nowhere.
+PRE_CHANGE_SCOPES = ("linkedin", "x", "substack", "medium", "dm", "email", "comment")
+PRE_CHANGE_ASSEMBLED = ("linkedin", "x")
+PRE_CHANGE_CHECKED_SLOTS = (("linkedin", "post"), ("linkedin", "comment"),
+                            ("x", "post"), ("x", "comment"))
+
+
+def _write(path, obj):
+    os.makedirs(os.path.dirname(path), exist_ok=True)
+    with open(path, "w", encoding="utf-8") as handle:
+        json.dump(obj, handle)
+    return path
+
+
+def _corrections(tmp_path, scope):
+    """A voice dir holding exactly one correction with this scope."""
+    d = tmp_path / "voice"
+    d.mkdir(exist_ok=True)
+    row = {"id": "r-1", "date": "2026-08-30", "instruction": "no CTA here",
+           "class": "interpretive", "status": "active", "scope": [scope]}
+    (d / corpus.CORRECTIONS).write_text(json.dumps(row) + "\n", encoding="utf-8")
+    return str(d / corpus.CORRECTIONS)
+
+
+# --- the hard constraint: no registry is byte-identical to before -----------------
+
+class TestAnInstanceWithNoRegistry:
+    def test_default_is_the_pre_change_literals(self):
+        assert cr.DEFAULT.scopes == PRE_CHANGE_SCOPES
+        assert cr.DEFAULT.assembled == PRE_CHANGE_ASSEMBLED
+        assert cr.DEFAULT.source is None
+
+    def test_checked_slots_is_the_pre_change_tuple(self):
+        assert validate.checked_slots() == PRE_CHANGE_CHECKED_SLOTS
+        assert validate.CHECKED_SLOTS == PRE_CHANGE_CHECKED_SLOTS
+
+    def test_an_empty_instance_resolves_to_nothing(self, tmp_path):
+        assert cr.resolve(str(tmp_path)) is None
+        assert cr.for_instance(str(tmp_path)) == cr.DEFAULT
+
+    def test_load_of_none_is_the_default(self):
+        assert cr.load(None) is cr.DEFAULT
+
+    def test_reddit_is_still_refused_without_a_registry(self, tmp_path):
+        """The behavior sp-6c93d3d8 recorded, unchanged where no registry exists."""
+        problems = validate.check_corrections(_corrections(tmp_path, "reddit"))
+        assert any("unknown scope 'reddit'" in p for p in problems), problems
+
+
+# --- resolution, the shape copied from the Stop-gate -----------------------------
+
+class TestResolve:
+    def test_the_in_repo_registry_wins(self, tmp_path):
+        p = _write(os.path.join(str(tmp_path), cr.REGISTRY_REL), {})
+        assert cr.resolve(str(tmp_path)) == p
+
+    def test_a_pointer_names_a_registry_outside_the_synced_tree(self, tmp_path):
+        target = _write(os.path.join(str(tmp_path), "config", "voice-channels.json"),
+                        {"channel_vocabulary": {"reddit": ["scope"],
+                                                "linkedin": ["scope", "assembled"]}})
+        pointer = os.path.join(str(tmp_path), cr.POINTER_REL)
+        os.makedirs(os.path.dirname(pointer), exist_ok=True)
+        with open(pointer, "w", encoding="utf-8") as handle:
+            handle.write("# where this instance keeps it\nconfig/voice-channels.json\n")
+        assert cr.resolve(str(tmp_path)) == os.path.realpath(target)
+
+    def test_a_pointer_to_a_missing_file_still_names_it(self, tmp_path):
+        """Not None. The caller must be able to say WHICH file is missing."""
+        pointer = os.path.join(str(tmp_path), cr.POINTER_REL)
+        os.makedirs(os.path.dirname(pointer), exist_ok=True)
+        with open(pointer, "w", encoding="utf-8") as handle:
+            handle.write("config/gone.json\n")
+        named = cr.resolve(str(tmp_path))
+        assert named and named.endswith("gone.json")
+        with pytest.raises(cr.ChannelRegistryError) as exc:
+            cr.load(named)
+        assert "gone.json" in str(exc.value)
+
+    def test_an_empty_pointer_is_no_registry(self, tmp_path):
+        pointer = os.path.join(str(tmp_path), cr.POINTER_REL)
+        os.makedirs(os.path.dirname(pointer), exist_ok=True)
+        with open(pointer, "w", encoding="utf-8") as handle:
+            handle.write("# nothing but a comment\n\n")
+        assert cr.resolve(str(tmp_path)) is None
+
+
+# --- the derivation is BOUND to the registry, not merely equal to it -------------
+
+class TestTheDerivationFollowsTheRegistry:
+    VOCAB = {"linkedin": ["scope", "assembled"], "x": ["scope", "assembled"],
+             "substack": ["scope"], "medium": ["scope"], "dm": ["scope"],
+             "email": ["scope"], "comment": ["scope"], "reddit": ["scope"]}
+
+    def _load(self, tmp_path, vocab):
+        return cr.load(_write(os.path.join(str(tmp_path), cr.REGISTRY_REL),
+                              {"channel_vocabulary": vocab}))
+
+    def test_reddit_becomes_a_legal_scope(self, tmp_path):
+        ch = self._load(tmp_path, self.VOCAB)
+        assert "reddit" in ch.scopes
+        assert "reddit" not in ch.assembled, "reddit owns no pool; it must not"
+        assert validate.check_corrections(_corrections(tmp_path, "reddit"), ch) == []
+
+    @pytest.mark.parametrize("dropped", sorted(set(VOCAB) - {"linkedin"}))
+    def test_dropping_a_channel_drops_it_from_the_derived_set(self, tmp_path, dropped):
+        """Bound, not equal. Every channel in the registry, one at a time, so a
+        derivation that happened to match the literal cannot pass this."""
+        vocab = {k: v for k, v in self.VOCAB.items() if k != dropped}
+        ch = self._load(tmp_path, vocab)
+        assert dropped not in ch.scopes
+        assert dropped not in ch.assembled
+        problems = validate.check_corrections(_corrections(tmp_path, dropped), ch)
+        assert any(f"unknown scope {dropped!r}" in p for p in problems), problems
+
+    def test_adding_an_assembled_channel_reaches_the_pool_and_budget_checks(
+            self, tmp_path):
+        vocab = dict(self.VOCAB, substack=["scope", "assembled"])
+        ch = self._load(tmp_path, vocab)
+        assert ch.assembled == ("linkedin", "x", "substack")
+        assert ("substack", "post") in validate.checked_slots(ch)
+        voice = corpus.load(str(tmp_path / "empty-voice"))
+        assert any(p.startswith("pool (substack") for p in
+                   validate.check_pools(voice, ch))
+
+    def test_a_registry_without_a_vocabulary_changes_nothing(self, tmp_path):
+        """The live surface-only registries must keep answering only what they did."""
+        ch = cr.load(_write(os.path.join(str(tmp_path), cr.REGISTRY_REL),
+                            {"channels": {"reddit": {"lint": "reddit_persona_lint"}}}))
+        assert ch is cr.DEFAULT
+
+
+# --- fail closed -----------------------------------------------------------------
+
+class TestAPresentRegistryThatCannotBeTrusted:
+    def _raises(self, tmp_path, payload, needle):
+        path = os.path.join(str(tmp_path), cr.REGISTRY_REL)
+        os.makedirs(os.path.dirname(path), exist_ok=True)
+        with open(path, "w", encoding="utf-8") as handle:
+            handle.write(payload if isinstance(payload, str) else json.dumps(payload))
+        with pytest.raises(cr.ChannelRegistryError) as exc:
+            cr.load(path)
+        assert needle in str(exc.value), str(exc.value)
+
+    def test_malformed_json(self, tmp_path):
+        self._raises(tmp_path, "{not json", "malformed")
+
+    def test_not_an_object(self, tmp_path):
+        self._raises(tmp_path, ["linkedin"], "must be an object")
+
+    def test_vocabulary_is_not_an_object(self, tmp_path):
+        self._raises(tmp_path, {"channel_vocabulary": ["linkedin"]},
+                     "channel_vocabulary must be an object")
+
+    def test_roles_are_not_a_list(self, tmp_path):
+        self._raises(tmp_path, {"channel_vocabulary": {"linkedin": "scope"}},
+                     "must be a list")
+
+    def test_a_typod_role_is_refused_rather_than_ignored(self, tmp_path):
+        """`assembeled` silently dropping linkedin out of the budget check would
+        read exactly like a healthy corpus."""
+        self._raises(tmp_path,
+                     {"channel_vocabulary": {"linkedin": ["scope", "assembeled"]}},
+                     "unknown role 'assembeled'")
+
+    def test_an_empty_scope_axis_is_refused(self, tmp_path):
+        self._raises(tmp_path, {"channel_vocabulary": {"linkedin": ["assembled"]}},
+                     "every correction scope would be refused")
+
+    def test_an_empty_assembled_axis_is_refused(self, tmp_path):
+        """A guard that grades nothing and reports healthy is worse than no guard."""
+        self._raises(tmp_path, {"channel_vocabulary": {"linkedin": ["scope"]}},
+                     "report healthy")
+
+
+# --- structural: no site may own a private copy again ----------------------------
+
+# Channel names that are ONLY ever channels. "dm" / "comment" / "email" are
+# deliberately absent: they are also `EXEMPLAR_KINDS` and `SLOT_KINDS` values, so
+# matching them would fire on `("post", "comment")`, which is a slot kind and not
+# a channel. A detector that fires on the wrong thing gets deleted, and then
+# nothing checks the real thing.
+UNAMBIGUOUS_CHANNELS = ("linkedin", "x", "substack", "medium", "reddit")
+
+
+def _channel_literals(source):
+    """Channel names appearing as STRING CONSTANTS in code, docstrings and comments
+    excluded. A grep over the raw text always fails here (every one of these names
+    is discussed in a scar comment), so it would be deleted as noise rather than
+    kept as a check."""
+    import ast
+    tree = ast.parse(source)
+    docstrings = set()
+    for node in ast.walk(tree):
+        if isinstance(node, (ast.Module, ast.ClassDef, ast.FunctionDef,
+                             ast.AsyncFunctionDef)):
+            doc = node.body[0] if node.body else None
+            if (isinstance(doc, ast.Expr) and isinstance(doc.value, ast.Constant)
+                    and isinstance(doc.value.value, str)):
+                docstrings.add(id(doc.value))
+    found = set()
+    for node in ast.walk(tree):
+        if (isinstance(node, ast.Constant) and isinstance(node.value, str)
+                and id(node) not in docstrings
+                and node.value in UNAMBIGUOUS_CHANNELS):
+            found.add(node.value)
+    return found
+
+
+VALIDATE_PY = os.path.join(
+    os.path.dirname(os.path.dirname(os.path.abspath(__file__))), "validate.py")
+
+
+def test_validate_holds_no_channel_literal():
+    """The mutation this whole change exists to prevent is someone adding the
+    nineteenth hardcoded site. Four sites in this file each owned the set, so the
+    check is on the SOURCE and not on any one behavior."""
+    found = _channel_literals(open(VALIDATE_PY, encoding="utf-8").read())
+    assert found == set(), (
+        f"validate.py names {sorted(found)} directly; the channel vocabulary "
+        f"belongs to channel_registry")
+
+
+def test_the_literal_detector_can_fail():
+    """Negative self-test. The check above is green on a file that also has every
+    channel name written across its comments, so "it passed" proves nothing until
+    the same detector is shown going red on the exact defect it guards."""
+    mutated = open(VALIDATE_PY, encoding="utf-8").read().replace(
+        "for channel in channels.assembled:",
+        'for channel in ("linkedin", "x"):', 1)
+    assert _channel_literals(mutated) == {"linkedin", "x"}

--- a/plugins/kipi-core/voiceloop/validate.py
+++ b/plugins/kipi-core/voiceloop/validate.py
@@ -14,7 +14,7 @@ import json
 import os
 import re
 
-from . import assemble, corpus, fingerprint, selector
+from . import assemble, channel_registry, corpus, fingerprint, selector
 
 MIN_ROWS_PER_POOL = 3      # below this, selection silently narrows to repetition;
                            # the fix is curation, so the message says so.
@@ -77,9 +77,10 @@ CORRECTION_CLASSES = ("deterministic", "interpretive")
 CORRECTION_STATUSES = ("active", "promoted", "retired")
 
 
-def check_corrections(path):
+def check_corrections(path, channels=None):
     """corrections.jsonl schema health (voice-2 review: the ledger had no
     validator at all, so a malformed or duplicate row passed the gate green)."""
+    channels = channels or channel_registry.DEFAULT
     if not os.path.exists(path):
         return []                      # an absent ledger is a valid empty ledger
     problems = []
@@ -107,17 +108,20 @@ def check_corrections(path):
             if row.get("status") not in CORRECTION_STATUSES:
                 problems.append(f"{rid}: status {row.get('status')!r}")
             for ch in row.get("scope") or []:
-                if ch not in ("linkedin", "x", "substack", "medium", "dm",
-                              "email", "comment"):
-                    problems.append(f"{rid}: unknown scope {ch!r}")
+                if ch not in channels.scopes:
+                    problems.append(
+                        f"{rid}: unknown scope {ch!r}; the channel vocabulary is "
+                        f"{list(channels.scopes)} (from "
+                        f"{channels.source or 'the built-in default, no registry'})")
     return problems
 
 
-def check_pools(voice):
+def check_pools(voice, channels=None):
     """Selection starvation check: every (channel, kind) pool a slot can ask for."""
+    channels = channels or channel_registry.DEFAULT
     problems = []
     rows = voice.active_exemplars()
-    for channel in ("linkedin", "x"):
+    for channel in channels.assembled:
         for kind in ("post",):
             n = sum(1 for r in rows if r.get("kind") == kind
                     and r.get("channel", "any") in (channel, "any"))
@@ -134,12 +138,26 @@ def check_pools(voice):
 # zero anchors while all three checks stayed silent: ELIGIBLE_KINDS maps
 # comment/dm to a ('comment','dm') primary tier that most corpora have no rows
 # for, so it is the slot most likely to be thin and the one nobody looks at.
-CHECKED_SLOTS = tuple((channel, slot_kind)
-                      for channel in ("linkedin", "x")
-                      for slot_kind in ("post", "comment"))
+SLOT_KINDS = ("post", "comment")
 
 
-def _resolved_slots(voice, k):
+def checked_slots(channels=None):
+    """(channel, slot_kind) for every slot a caller can ask for, channels from
+    the registry. The slot KINDS are a property of this engine's selector, not of
+    an instance, so they stay here; the channels are not, so they do not."""
+    channels = channels or channel_registry.DEFAULT
+    return tuple((channel, slot_kind)
+                 for channel in channels.assembled
+                 for slot_kind in SLOT_KINDS)
+
+
+# Kept as a module attribute because reviews and docs reference it by name. It is
+# DERIVED from the one authority, so it is a view of the default vocabulary and
+# not a fifth copy of the channel list.
+CHECKED_SLOTS = checked_slots()
+
+
+def _resolved_slots(voice, k, channels=None):
     """(channel, slot_kind, primary, pool) for each slot, POOL FROM THE SELECTOR.
 
     Both checks below used to count primary-kind rows by hand, which equals the
@@ -150,13 +168,13 @@ def _resolved_slots(voice, k):
     A checker that re-derives the rule it checks is testing its own copy.
     """
     rows = voice.active_exemplars()
-    for channel, slot_kind in CHECKED_SLOTS:
+    for channel, slot_kind in checked_slots(channels):
         primary, _ = selector.eligible(rows, channel, slot_kind)
         yield (channel, slot_kind, primary,
                selector.resolved_pool(rows, channel, slot_kind, k))
 
 
-def check_anchor_diversity(voice, k=selector.DEFAULT_K):
+def check_anchor_diversity(voice, k=selector.DEFAULT_K, channels=None):
     """Anchors must ROTATE within the pool a slot actually draws from.
 
     The pairing this exists for (finding-5, prd-content-engine-sameness-2026-08-09):
@@ -192,7 +210,7 @@ def check_anchor_diversity(voice, k=selector.DEFAULT_K):
     corpus_has_anchors = any(r.get("anchor") for r in voice.active_exemplars())
     if not corpus_has_anchors:
         return problems
-    for channel, slot_kind, _primary, pool in _resolved_slots(voice, k):
+    for channel, slot_kind, _primary, pool in _resolved_slots(voice, k, channels):
         reachable = [r for r in pool if r.get("anchor")]
         if len(reachable) < MIN_ANCHORS_PER_KIND:
             problems.append(
@@ -204,7 +222,7 @@ def check_anchor_diversity(voice, k=selector.DEFAULT_K):
     return problems
 
 
-def check_rotation_headroom(voice, k=selector.DEFAULT_K):
+def check_rotation_headroom(voice, k=selector.DEFAULT_K, channels=None):
     """A pool no larger than k cannot rotate: `select` takes min(k, len(pool)).
 
     Found by adversarial review 2026-08-09, measured over counters 0-29 with k=4
@@ -236,7 +254,7 @@ def check_rotation_headroom(voice, k=selector.DEFAULT_K):
     """
     problems = []
     floor = k + 1
-    for channel, slot_kind, primary, pool in _resolved_slots(voice, k):
+    for channel, slot_kind, primary, pool in _resolved_slots(voice, k, channels):
         if not pool:
             continue                    # an empty pool is check_pools' story
         if len(pool) <= k:
@@ -290,12 +308,13 @@ def check_fingerprint_fresh(voice):
     return problems
 
 
-def check_budget(voice, channels=("linkedin", "x")):
+def check_budget(voice, channels=None):
     """The largest legal assembly must fit the budget. Suite-time, so the daily
     job never needs a runtime cap -- the cap that failed loudly here cannot slice
     silently there."""
+    channels = channels or channel_registry.DEFAULT
     problems = []
-    for channel in channels:
+    for channel in channels.assembled:
         worst = 0
         for counter in range(12):        # one rotation lap is enough to find the max
             text, _ = assemble.voice_section(voice, channel, counter)
@@ -306,16 +325,24 @@ def check_budget(voice, channels=("linkedin", "x")):
     return problems
 
 
-def check_all(voice_dir):
-    """Every check, one list. [] is a healthy corpus."""
+def check_all(voice_dir, channels=None):
+    """Every check, one list. [] is a healthy corpus.
+
+    `channels` is a `channel_registry.Channels`. None means the built-in default,
+    which is what every instance without a registry gets and is byte-identical to
+    the behavior before the registry existed. An instance seam that owns a
+    registry passes `channel_registry.for_instance(<repo root>)`.
+    """
+    channels = channels or channel_registry.DEFAULT
     voice = corpus.load(voice_dir)
     problems = check_exemplars(os.path.join(voice_dir, corpus.EXEMPLARS))
-    problems += check_corrections(os.path.join(voice_dir, corpus.CORRECTIONS))
-    problems += check_pools(voice)
-    problems += check_anchor_diversity(voice)
-    problems += check_rotation_headroom(voice)
+    problems += check_corrections(os.path.join(voice_dir, corpus.CORRECTIONS),
+                                  channels)
+    problems += check_pools(voice, channels)
+    problems += check_anchor_diversity(voice, channels=channels)
+    problems += check_rotation_headroom(voice, channels=channels)
     problems += check_fingerprint_fresh(voice)
-    problems += check_budget(voice)
+    problems += check_budget(voice, channels)
     if voice.skipped_rows:
         problems.append(f"{voice.skipped_rows} corrupt JSONL row(s) skipped by the "
                         f"loader -- fix or remove them")

--- a/plugins/kipi-core/voiceloop/validate.py
+++ b/plugins/kipi-core/voiceloop/validate.py
@@ -328,12 +328,22 @@ def check_budget(voice, channels=None):
 def check_all(voice_dir, channels=None):
     """Every check, one list. [] is a healthy corpus.
 
-    `channels` is a `channel_registry.Channels`. None means the built-in default,
-    which is what every instance without a registry gets and is byte-identical to
-    the behavior before the registry existed. An instance seam that owns a
-    registry passes `channel_registry.for_instance(<repo root>)`.
+    `channels` is a `channel_registry.Channels`. None LOADS the registry that owns
+    `voice_dir`, and falls back to the built-in default when nothing does -- which
+    is what every instance without a registry gets and is byte-identical to the
+    behavior before the registry existed.
+
+    THIS IS THE LOAD PATH AND IT USED TO BE A SENTENCE. The line above said "an
+    instance seam that owns a registry passes for_instance(<repo root>)" and no
+    caller in this repo ever did: measured on PR #291, `for_instance` had one
+    definition and zero non-test callers, so every corpus was graded against the
+    built-in vocabulary no matter what its instance declared. The one instance
+    that owns a registry today declares a scope the built-in default does not
+    carry, so its first correction in that scope would have been refused by its
+    own suite as unknown. Documenting a seam is not wiring one.
     """
-    channels = channels or channel_registry.DEFAULT
+    if channels is None:
+        channels = channel_registry.for_path(voice_dir)
     voice = corpus.load(voice_dir)
     problems = check_exemplars(os.path.join(voice_dir, corpus.EXEMPLARS))
     problems += check_corrections(os.path.join(voice_dir, corpus.CORRECTIONS),

--- a/q-system/.q-system/scripts/voice-stop-gate.py
+++ b/q-system/.q-system/scripts/voice-stop-gate.py
@@ -542,6 +542,15 @@ def channel_surface_lint(registry_path, channel, instance_root):
         raise ChannelRegistryError(
             f"voice-channels registry at {registry_path} must be an object")
     channels = data.get("channels") or {}
+    # Codex MINOR on PR #291: a non-object `channels` reached `.get` and raised an
+    # uncaught AttributeError. main() catches ChannelRegistryError and exits 2;
+    # an AttributeError escapes it, Python exits 1, and a Stop hook exiting 1
+    # does NOT hold the turn. A malformed registry has to fail through the
+    # explicit hold path, not around it.
+    if not isinstance(channels, dict):
+        raise ChannelRegistryError(
+            f"voice-channels registry at {registry_path}: 'channels' must be an "
+            f"object, got {type(channels).__name__}")
     entry = channels.get(channel) if channel else None
     if entry is None:
         entry = data.get("default")

--- a/q-system/.q-system/scripts/voice-stop-gate.py
+++ b/q-system/.q-system/scripts/voice-stop-gate.py
@@ -406,14 +406,168 @@ def report_not_checked(lines, out=None, err=None):
         (err or sys.stderr).write(line + "\n")
 
 
-def run_check(script, file_path):
+# --- the OPTIONAL instance channel registry ----------------------------------
+#
+# The un-shipped half of prd-voice-gate-platform-aware-2026-07-22. That PRD built the
+# instance half (cole-gtm/gtm/scripts/voice_channel_registry.py) and named the constraint
+# on this half in its section 4: this file lives in the SKELETON and reaches 26 instances
+# via `kipi push`, so "the recurrence guard must live where every instance loads it, not
+# in one instance's gtm/". Measured 2026-08-30, thirteen months of drift later:
+# `grep -c "voice_channel_registry\|channel_registry"` against this file returned 0.
+#
+# THE HARD CONSTRAINT, and it outranks the feature: an instance with NO registry must
+# behave exactly as it did before this block existed. 26 instances have no registry and
+# none of them asked for one. So the registry is opt-in, resolved from an INSTANCE-OWNED
+# path, and absent means `channel_surface_lint` returns None and the two assaf lints run
+# with the identical argv they always ran with.
+#
+# WHAT THIS HALF CONSUMES, and what it does not. The registry carries two axes: `voice_ref`
+# (whose voice) and `surface_ref` + `lint` (what surface the channel imposes). This gate
+# has no corpus and no semantic judge -- it runs pattern lints -- so it consumes only the
+# SURFACE axis: `lint_script` (the executable) and `lint_input` (how that executable wants
+# the draft). The voice axis is consumed by the instance's own judge. Saying so here rather
+# than reading `voice_ref` and doing nothing with it, because a field fetched and never
+# read is how a docstring starts making promises the code does not keep.
+#
+# FAIL-CLOSED, same rule as every other check in this file. A registry that is PRESENT and
+# unreadable, or that names a lint_script which is absent, HOLDS the turn. Silently falling
+# back to the assaf lints there would grade a reddit draft on the wrong rulebook, which is
+# the entire defect the registry exists to prevent.
+CHANNEL_REGISTRY_REL = Path("q-system") / ".q-system" / "data" / "voice-channels.json"
+CHANNEL_REGISTRY_POINTER_REL = (
+    Path("q-system") / ".q-system" / "data" / "voice-channels.path")
+
+# How a surface lint wants the draft handed to it. A typo must fail closed, not route a
+# channel to an invocation shape its lint cannot parse and read the exit code as a verdict.
+KNOWN_LINT_INPUTS = {"text_file", "json_body"}
+DEFAULT_LINT_INPUT = "text_file"
+
+# Channels this gate can name from publish framing. Same vocabulary as _PLAT, which the
+# publish-intent matcher already captures and then discards.
+_CHANNEL_RE = re.compile(r"(?i)\b" + _PLAT + r"\b")
+_CHANNEL_ALIASES = {"twitter": "x"}
+
+
+class ChannelRegistryError(Exception):
+    """A registry that is present and cannot be trusted. Callers HOLD the turn."""
+
+
+def resolve_channel_registry(instance_root):
+    """This instance's channel registry path, or None. Shape copied from
+    `resolve_reporter` above rather than invented, for the reason written there.
+
+    Two sources, in order:
+
+    1. `q-system/.q-system/data/voice-channels.json` in the instance.
+    2. A pointer file beside it naming the real location, because an instance that
+       already owns a registry keeps it with its own config (consulting:
+       `q-consult/config/voice-channels.json`; cole-gtm: `gtm/config/voice-channels.json`)
+       and there is no fleet-wide answer to which subtree that is.
+
+    Both live under `q-system/.q-system/data/`, which is in the skeleton sync's
+    INSTANCE_OWNED_SUBTREES, so `kipi update` never overwrites or deletes them
+    (RULE-2026-06-30-A). A file next to this script would be erased by the next sync.
+
+    Returns the NAMED path even when it does not exist, so a caller can say "the pointer
+    names X, which is missing" instead of "no registry" -- the resolve_reporter scar.
+    """
+    local = Path(instance_root) / CHANNEL_REGISTRY_REL
+    if local.is_file():
+        return local
+    pointer = Path(instance_root) / CHANNEL_REGISTRY_POINTER_REL
+    try:
+        named = pointer.read_text(encoding="utf-8")
+    except OSError:
+        return None
+    named = "".join(ln for ln in named.splitlines()
+                    if ln.strip() and not ln.lstrip().startswith("#")).strip()
+    if not named:
+        return None
+    named_path = Path(os.path.expanduser(named))
+    if not named_path.is_absolute():
+        named_path = Path(instance_root) / named_path
+    return named_path.resolve()
+
+
+def detect_channel(text):
+    """The channel this draft is framed for, or ''. First platform named wins.
+
+    `_PLAT` already sits inside `_PUBLISH_MARKER_RE`, which matched to get here and then
+    throws the platform away. This reads the same vocabulary rather than a second one:
+    two lists of channel names is the drift this whole change is about.
+    """
+    match = _CHANNEL_RE.search(text or "")
+    if not match:
+        return ""
+    name = match.group(1).lower()
+    return _CHANNEL_ALIASES.get(name, name)
+
+
+def channel_surface_lint(registry_path, channel, instance_root):
+    """(script Path, input mode) for this channel's SURFACE lint, or None.
+
+    None means "no channel-specific surface": run the assaf lints, which is what every
+    instance without a registry does and what a registered assaf channel does too.
+
+    Raises ChannelRegistryError when the registry is present and untrustworthy.
+    """
+    if registry_path is None:
+        return None
+    try:
+        data = json.loads(Path(registry_path).read_text(encoding="utf-8"))
+    except OSError as exc:
+        raise ChannelRegistryError(
+            f"voice-channels registry named at {registry_path} is unreadable: {exc}") from exc
+    except ValueError as exc:
+        raise ChannelRegistryError(
+            f"voice-channels registry at {registry_path} is malformed: {exc}") from exc
+    if not isinstance(data, dict):
+        raise ChannelRegistryError(
+            f"voice-channels registry at {registry_path} must be an object")
+    channels = data.get("channels") or {}
+    entry = channels.get(channel) if channel else None
+    if entry is None:
+        entry = data.get("default")
+    if entry is None:
+        return None
+    if not isinstance(entry, dict):
+        raise ChannelRegistryError(
+            f"voice-channels entry for {channel!r} must be an object")
+    script = entry.get("lint_script")
+    if not script:
+        return None
+    mode = entry.get("lint_input", DEFAULT_LINT_INPUT)
+    if mode not in KNOWN_LINT_INPUTS:
+        raise ChannelRegistryError(
+            f"voice-channels entry for {channel!r} has unknown lint_input {mode!r}; "
+            f"known: {sorted(KNOWN_LINT_INPUTS)}")
+    script_path = Path(script)
+    if not script_path.is_absolute():
+        script_path = Path(instance_root) / script_path
+    if not script_path.is_file():
+        raise ChannelRegistryError(
+            f"voice-channels entry for {channel!r} names lint_script {script_path}, "
+            f"which does not exist; holding rather than grading on the wrong rulebook")
+    return (script_path, mode)
+
+
+def _lint_argv(script, file_path, mode):
+    """The invocation shape a lint declared. text_file is the shape every skeleton lint
+    has always used, so an instance with no registry produces a byte-identical argv."""
+    if mode == "json_body":
+        return ["python3", str(script), "--file", file_path]
+    return ["python3", str(script), file_path]
+
+
+def run_check(script, file_path, mode=DEFAULT_LINT_INPUT, json_path=None):
     if not script.exists():
         return (NOT_CHECKED,
                 "voice-stop-gate: %s is MISSING at %s, so this draft was NOT "
                 "CHECKED by it. That is not a pass." % (script.name, script))
+    target = json_path if mode == "json_body" else file_path
     try:
         result = subprocess.run(
-            ["python3", str(script), file_path],
+            _lint_argv(script, target, mode),
             capture_output=True,
             text=True,
             timeout=15,
@@ -470,24 +624,48 @@ def main():
         # measurement no longer rides on it.
         authorship_spool(extract_setoff_draft(text), text, request)
         finish_ok()
+    # WHICH RULEBOOK. An instance with no registry resolves to None here and the two
+    # assaf lints below run exactly as they did before this block existed -- the hard
+    # constraint, because 26 instances have no registry. An instance WITH one routes the
+    # channel to its surface lint instead, which is what "a reddit draft was graded on the
+    # wrong rulebook and shipped AI-sounding" (scar 2026-07-22) was waiting for.
+    #
+    # A present-but-broken registry HOLDS. Falling back to the assaf lints there would be
+    # the wrong-rulebook bug wearing a fix.
+    try:
+        surface = channel_surface_lint(
+            resolve_channel_registry(INSTANCE_ROOT), detect_channel(text), INSTANCE_ROOT)
+    except ChannelRegistryError as exc:
+        sys.stderr.write(
+            "voice-stop-gate: channel registry error, holding the turn (fail-closed).\n"
+            f"{exc}\n")
+        sys.exit(2)
+
     with tempfile.NamedTemporaryFile(
         mode="w", suffix=".md", delete=False, encoding="utf-8"
     ) as tmp:
         tmp.write(draft)
         tmp_path = tmp.name
+    # A surface lint may want the draft as JSON rather than a text file (the reddit
+    # persona lint reads {title?,subject?,body}). Written unconditionally so the cleanup
+    # in `finally` has one shape; costs one small tempfile per gated turn.
+    with tempfile.NamedTemporaryFile(
+        mode="w", suffix=".json", delete=False, encoding="utf-8"
+    ) as tmp_json:
+        json.dump({"body": draft}, tmp_json)
+        tmp_json_path = tmp_json.name
     try:
         violations_output = []
         not_checked = []
-        code1, out1 = run_check(VOICE_LINT, tmp_path)
-        if code1 == 2 and out1:
-            violations_output.append(out1)
-        elif code1 == NOT_CHECKED:
-            not_checked.append(out1)
-        code2, out2 = run_check(SUBSTANCE_LINT, tmp_path)
-        if code2 == 2 and out2:
-            violations_output.append(out2)
-        elif code2 == NOT_CHECKED:
-            not_checked.append(out2)
+        checks = ([(surface[0], surface[1])] if surface
+                  else [(VOICE_LINT, DEFAULT_LINT_INPUT),
+                        (SUBSTANCE_LINT, DEFAULT_LINT_INPUT)])
+        for script, mode in checks:
+            code, out = run_check(script, tmp_path, mode, tmp_json_path)
+            if code == 2 and out:
+                violations_output.append(out)
+            elif code == NOT_CHECKED:
+                not_checked.append(out)
         report_not_checked(not_checked)
         if violations_output:
             sys.stderr.write(
@@ -504,10 +682,11 @@ def main():
             # refused, which Claude is about to replace.
             sys.exit(2)
     finally:
-        try:
-            os.unlink(tmp_path)
-        except OSError:
-            pass
+        for path in (tmp_path, tmp_json_path):
+            try:
+                os.unlink(path)
+            except OSError:
+                pass
 
     # THE CLEAN PATH. Score this draft (backgrounded, arrives next turn) and
     # surface whatever a previous turn's worker finished.

--- a/q-system/.q-system/scripts/voice-stop-gate.py
+++ b/q-system/.q-system/scripts/voice-stop-gate.py
@@ -490,17 +490,34 @@ def resolve_channel_registry(instance_root):
 
 
 def detect_channel(text):
-    """The channel this draft is framed for, or ''. First platform named wins.
+    """The channel the draft is FRAMED for, or ''. Read out of the publish marker.
 
     `_PLAT` already sits inside `_PUBLISH_MARKER_RE`, which matched to get here and then
     throws the platform away. This reads the same vocabulary rather than a second one:
     two lists of channel names is the drift this whole change is about.
+
+    IT MUST NOT BE A FREE SCAN OF THE WHOLE RESPONSE, and it was one until Codex found
+    it on PR #291 (sp-9fd6dafd). `_CHANNEL_RE.search(text)` returned the first platform
+    named ANYWHERE, so a response that mentions LinkedIn as comparison or rewrite
+    context and then ships a Reddit draft was graded against the LinkedIn rulebook --
+    the exact "wrong rulebook, shipped AI-sounding" scar (2026-07-22) this registry
+    exists to close, re-entering through the channel picker.
+
+    So the platform is taken from inside a PUBLISH MARKER match. Markers that name no
+    platform ("here's the draft", "ready to paste") are skipped rather than ending the
+    search, which is what keeps "here's the draft for Twitter" resolving to x.
+
+    Returning '' is the SAFE outcome, not a gap: it routes to the assaf lints, which is
+    what all 26 registry-less instances already do. Guessing a channel off unrelated
+    prose is the direction that misroutes, so framing that names no platform yields no
+    channel even when one is named elsewhere in the message.
     """
-    match = _CHANNEL_RE.search(text or "")
-    if not match:
-        return ""
-    name = match.group(1).lower()
-    return _CHANNEL_ALIASES.get(name, name)
+    for marker in _PUBLISH_MARKER_RE.finditer(text or ""):
+        found = _CHANNEL_RE.search(marker.group(0))
+        if found:
+            name = found.group(1).lower()
+            return _CHANNEL_ALIASES.get(name, name)
+    return ""
 
 
 def channel_surface_lint(registry_path, channel, instance_root):
@@ -662,16 +679,42 @@ def main():
     try:
         violations_output = []
         not_checked = []
+        lint_failures = []
         checks = ([(surface[0], surface[1])] if surface
                   else [(VOICE_LINT, DEFAULT_LINT_INPUT),
                         (SUBSTANCE_LINT, DEFAULT_LINT_INPUT)])
+        # EVERY OUTCOME IS CLASSIFIED, and the else-branch is the fix. Codex MAJOR on
+        # PR #291 (sp-5b4b3c35): this handled 2 and NOT_CHECKED and let every other
+        # exit fall through to the clean path. `run_check` returns 1 for a timeout AND
+        # for an ordinary crash, so a lint that graded nothing reported the draft clean
+        # and it shipped. A gate whose checker crashed has not cleared anything.
+        #
+        # The contract is 0 = pass, 2 = block (skill-hook-pairing.md). Anything else is
+        # the gate NOT KNOWING, and not knowing holds the turn. `code == 2` no longer
+        # requires output either: a lint that blocked without printing was read as
+        # clean, which is the same fail-open wearing a different exit code.
         for script, mode in checks:
             code, out = run_check(script, tmp_path, mode, tmp_json_path)
-            if code == 2 and out:
-                violations_output.append(out)
-            elif code == NOT_CHECKED:
+            if code == NOT_CHECKED:
                 not_checked.append(out)
+            elif code == 0:
+                continue
+            elif code == 2:
+                violations_output.append(out or (
+                    "%s exited 2 (block) without saying why." % script.name))
+            else:
+                lint_failures.append(
+                    "%s exited %s instead of grading this draft.\n%s"
+                    % (script.name, code, out.strip() or "(no output)"))
         report_not_checked(not_checked)
+        if lint_failures:
+            sys.stderr.write(
+                "voice-stop-gate: a voice check FAILED TO RUN, so this draft was "
+                "NOT graded. Holding the turn (fail-closed).\n"
+                "Fix the lint, then complete the turn.\n\n"
+            )
+            for output in lint_failures:
+                sys.stderr.write(output + "\n")
         if violations_output:
             sys.stderr.write(
                 "voice-stop-gate: assistant final message has voice violations.\n"
@@ -685,6 +728,10 @@ def main():
             # file is left alone so the next completed turn surfaces it. Spooling
             # here would spend 3s of torch on a draft the voice gates just
             # refused, which Claude is about to replace.
+            sys.exit(2)
+        if lint_failures:
+            # Same reasoning as the violations path above: no drain, no spool. A
+            # draft nothing graded is not a draft to score.
             sys.exit(2)
     finally:
         for path in (tmp_path, tmp_json_path):

--- a/q-system/.q-system/scripts/voice-stop-gate.py
+++ b/q-system/.q-system/scripts/voice-stop-gate.py
@@ -647,13 +647,18 @@ def main():
         tmp.write(draft)
         tmp_path = tmp.name
     # A surface lint may want the draft as JSON rather than a text file (the reddit
-    # persona lint reads {title?,subject?,body}). Written unconditionally so the cleanup
-    # in `finally` has one shape; costs one small tempfile per gated turn.
-    with tempfile.NamedTemporaryFile(
-        mode="w", suffix=".json", delete=False, encoding="utf-8"
-    ) as tmp_json:
-        json.dump({"body": draft}, tmp_json)
-        tmp_json_path = tmp_json.name
+    # persona lint reads {title?,subject?,body}). Written ONLY when a lint asked for that
+    # form. Writing it unconditionally would be simpler and would spend a tempfile per
+    # gated turn on 26 instances that have no registry and get nothing from it -- and it
+    # would make "an instance with no registry behaves exactly as before" false in a way
+    # no test here would have caught, because none of them look at the filesystem.
+    tmp_json_path = None
+    if surface and surface[1] == "json_body":
+        with tempfile.NamedTemporaryFile(
+            mode="w", suffix=".json", delete=False, encoding="utf-8"
+        ) as tmp_json:
+            json.dump({"body": draft}, tmp_json)
+            tmp_json_path = tmp_json.name
     try:
         violations_output = []
         not_checked = []
@@ -683,6 +688,8 @@ def main():
             sys.exit(2)
     finally:
         for path in (tmp_path, tmp_json_path):
+            if path is None:
+                continue
             try:
                 os.unlink(path)
             except OSError:

--- a/q-system/.q-system/scripts/voice-stop-gate.py
+++ b/q-system/.q-system/scripts/voice-stop-gate.py
@@ -494,6 +494,18 @@ def resolve_channel_registry(instance_root):
     return named_path.resolve()
 
 
+def _sentence_at(text, pos):
+    """The sentence (or line) of `text` containing offset `pos`."""
+    start, end = 0, len(text)
+    for bound in _SENTENCE_RE.finditer(text):
+        if bound.end() <= pos:
+            start = bound.end()
+        elif bound.start() >= pos:
+            end = bound.start()
+            break
+    return text[start:end]
+
+
 def detect_channel(text):
     """The channel the draft is FRAMED for, or ''. Read out of the publish marker.
 
@@ -517,27 +529,40 @@ def detect_channel(text):
     prose is the direction that misroutes, so framing that names no platform yields no
     channel even when one is named elsewhere in the message.
     """
-    for chunk in _SENTENCE_RE.split(text or ""):
-        markers = list(_PUBLISH_MARKER_RE.finditer(chunk))
-        if not markers:
-            continue
-        # A platform INSIDE the framing wins, and it has to be checked first.
-        # "I rewrote this from LinkedIn for Reddit." names both in one sentence
-        # and only the framing ("for Reddit") says which one it is FOR.
-        for marker in markers:
-            found = _CHANNEL_RE.search(marker.group(0))
-            if found:
-                name = found.group(1).lower()
-                return _CHANNEL_ALIASES.get(name, name)
-        # Then the rest of the framing's own sentence. Codex MINOR round 3:
-        # "Reddit version, ready to paste" is unmistakable publish framing whose
-        # marker ("ready to paste") carries no platform, and marker-only scoping
-        # sent it to the default lints. The sentence is the window because it is
-        # the smallest one that still holds the framing and its subject together.
-        found = _CHANNEL_RE.search(chunk)
+    text = text or ""
+    markers = list(_PUBLISH_MARKER_RE.finditer(text))
+    if not markers:
+        return ""
+    # NEAREST THE DRAFT WINS, and this is the rule rather than the fourth patch.
+    #
+    # Codex found a counterexample in this function four rounds running, and each
+    # round the previous shape had one: FIRST-anywhere let context outrank the
+    # draft; first-in-the-marker missed framing that names no platform;
+    # first-in-the-sentence let "For LinkedIn context, here's the Reddit post"
+    # route a reddit draft to LinkedIn. Four counterexamples to three heuristics
+    # is a statement about the heuristics, not about the examples.
+    #
+    # What is actually true of this text: publish framing INTRODUCES the draft
+    # that follows it, so of all the framing in a message the piece nearest the
+    # draft is the piece describing it, and everything earlier is context. That
+    # is one rule, it is a property of how the sentences are written rather than
+    # of any example, and every counterexample from all four rounds is in the
+    # parametrized corpus in the test file so a fifth change cannot quietly undo
+    # an earlier one.
+    for marker in reversed(markers):
+        found = _CHANNEL_RE.search(marker.group(0))
         if found:
             name = found.group(1).lower()
             return _CHANNEL_ALIASES.get(name, name)
+    # No framing named a platform at all. Widen to the sentence holding the LAST
+    # piece of framing, which is where "Reddit version, ready to paste" says it.
+    # The sentence, not the message: a platform named two sentences earlier as
+    # context still cannot claim the draft.
+    chunk = _sentence_at(text, markers[-1].start())
+    found = _CHANNEL_RE.search(chunk)
+    if found:
+        name = found.group(1).lower()
+        return _CHANNEL_ALIASES.get(name, name)
     return ""
 
 

--- a/q-system/.q-system/scripts/voice-stop-gate.py
+++ b/q-system/.q-system/scripts/voice-stop-gate.py
@@ -446,6 +446,11 @@ DEFAULT_LINT_INPUT = "text_file"
 # publish-intent matcher already captures and then discards.
 _CHANNEL_RE = re.compile(r"(?i)\b" + _PLAT + r"\b")
 _CHANNEL_ALIASES = {"twitter": "x"}
+# Sentence boundaries, and blank-line/newline boundaries too, because a draft is
+# not one paragraph. This is the window `detect_channel` searches: wide enough to
+# hold framing and subject together, narrow enough that a platform named two
+# sentences earlier as CONTEXT cannot claim the draft.
+_SENTENCE_RE = re.compile(r"(?<=[.!?:])\s+|\n+")
 
 
 class ChannelRegistryError(Exception):
@@ -512,8 +517,24 @@ def detect_channel(text):
     prose is the direction that misroutes, so framing that names no platform yields no
     channel even when one is named elsewhere in the message.
     """
-    for marker in _PUBLISH_MARKER_RE.finditer(text or ""):
-        found = _CHANNEL_RE.search(marker.group(0))
+    for chunk in _SENTENCE_RE.split(text or ""):
+        markers = list(_PUBLISH_MARKER_RE.finditer(chunk))
+        if not markers:
+            continue
+        # A platform INSIDE the framing wins, and it has to be checked first.
+        # "I rewrote this from LinkedIn for Reddit." names both in one sentence
+        # and only the framing ("for Reddit") says which one it is FOR.
+        for marker in markers:
+            found = _CHANNEL_RE.search(marker.group(0))
+            if found:
+                name = found.group(1).lower()
+                return _CHANNEL_ALIASES.get(name, name)
+        # Then the rest of the framing's own sentence. Codex MINOR round 3:
+        # "Reddit version, ready to paste" is unmistakable publish framing whose
+        # marker ("ready to paste") carries no platform, and marker-only scoping
+        # sent it to the default lints. The sentence is the window because it is
+        # the smallest one that still holds the framing and its subject together.
+        found = _CHANNEL_RE.search(chunk)
         if found:
             name = found.group(1).lower()
             return _CHANNEL_ALIASES.get(name, name)
@@ -550,12 +571,20 @@ def channel_surface_lint(registry_path, channel, instance_root):
     # see it, so exactly the malformed registries that look emptiest sailed
     # through to the default lints unvalidated.
     #
-    # Only an ABSENT key is an empty mapping. A present-but-wrong one is a
-    # malformed registry and takes the explicit hold path, because a registry
-    # this gate cannot read must never quietly become "no registry".
-    channels = data.get("channels")
-    if channels is None:
+    # PRESENCE, not falsiness, and not `is None` either. Codex narrowed this
+    # three rounds running and each round the hole was the same shape: a
+    # registry the gate cannot read quietly becoming "no registry". Round 3 was
+    # `"channels": null` -- an explicit null is a present-but-wrong value, but
+    # `.get()` returns None for it and for an ABSENT key alike, so the null
+    # sailed through as an empty mapping.
+    #
+    # `in` is the only test that separates the two, so it is the test used. Only
+    # a key that is genuinely not there means "no channels"; anything present
+    # and not an object is a malformed registry and takes the hold path.
+    if "channels" not in data:
         channels = {}
+    else:
+        channels = data["channels"]
     if not isinstance(channels, dict):
         raise ChannelRegistryError(
             f"voice-channels registry at {registry_path}: 'channels' must be an "

--- a/q-system/.q-system/scripts/voice-stop-gate.py
+++ b/q-system/.q-system/scripts/voice-stop-gate.py
@@ -541,12 +541,21 @@ def channel_surface_lint(registry_path, channel, instance_root):
     if not isinstance(data, dict):
         raise ChannelRegistryError(
             f"voice-channels registry at {registry_path} must be an object")
-    channels = data.get("channels") or {}
-    # Codex MINOR on PR #291: a non-object `channels` reached `.get` and raised an
-    # uncaught AttributeError. main() catches ChannelRegistryError and exits 2;
+    # `.get()` and NOT `.get(...) or {}`, which is the whole point. Codex found
+    # this twice. Round 2: a non-object `channels` reached `.get` and raised an
+    # uncaught AttributeError -- main() catches ChannelRegistryError and exits 2,
     # an AttributeError escapes it, Python exits 1, and a Stop hook exiting 1
-    # does NOT hold the turn. A malformed registry has to fail through the
-    # explicit hold path, not around it.
+    # does NOT hold the turn. Round 3: the `or {}` I added the guard behind
+    # coerced every FALSY non-object ([], "", 0) to {} BEFORE the guard could
+    # see it, so exactly the malformed registries that look emptiest sailed
+    # through to the default lints unvalidated.
+    #
+    # Only an ABSENT key is an empty mapping. A present-but-wrong one is a
+    # malformed registry and takes the explicit hold path, because a registry
+    # this gate cannot read must never quietly become "no registry".
+    channels = data.get("channels")
+    if channels is None:
+        channels = {}
     if not isinstance(channels, dict):
         raise ChannelRegistryError(
             f"voice-channels registry at {registry_path}: 'channels' must be an "

--- a/q-system/.q-system/tests/test_voice_stop_gate_channel_registry.py
+++ b/q-system/.q-system/tests/test_voice_stop_gate_channel_registry.py
@@ -363,3 +363,43 @@ def test_a_non_object_channels_field_holds_rather_than_crashing(tmp_path):
     assert "Traceback" not in result.stderr, (
         "crashed out of the hold path instead of taking it: " + result.stderr)
     assert ASSAF_SPOKE not in result.stderr
+
+
+@pytest.mark.parametrize("bad", [[], "", 0, False])
+def test_an_EMPTY_non_object_channels_field_also_holds(tmp_path, bad):
+    """Codex MINOR round 3, and it is why the guard alone was not enough.
+
+    The guard was added behind `data.get("channels") or {}`, and `or {}` turns
+    every FALSY non-object into an empty mapping BEFORE the guard can see it. So
+    the malformed registries that look emptiest were exactly the ones that
+    sailed through to the default lints unvalidated -- a registry the gate could
+    not read quietly becoming "no registry", which is the wrong-rulebook bug this
+    branch exists to end.
+
+    An ABSENT key is the only thing that means "no channels".
+    """
+    _stub_lints(tmp_path)
+    data_dir = tmp_path / "q-system" / ".q-system" / "data"
+    data_dir.mkdir(parents=True, exist_ok=True)
+    (data_dir / "voice-channels.json").write_text(
+        json.dumps({"channels": bad}), encoding="utf-8")
+    result = _run_gate(tmp_path, DRAFT)
+    assert result.returncode == 2, result.stdout + result.stderr
+    assert "channel registry error" in result.stderr, result.stderr
+    assert ASSAF_SPOKE not in result.stderr, (
+        "a malformed registry silently selected the default lints")
+
+
+def test_a_registry_with_no_channels_key_at_all_is_not_an_error(tmp_path):
+    """The control. `or {}` existed for a reason and the fix must keep it:
+    a registry that declares only a default, with no `channels` key, is
+    well-formed and routes to that default rather than holding the turn."""
+    _stub_lints(tmp_path)
+    data_dir = tmp_path / "q-system" / ".q-system" / "data"
+    data_dir.mkdir(parents=True, exist_ok=True)
+    (data_dir / "voice-channels.json").write_text(
+        json.dumps({"default": {"voice_ref": "voice", "lint": "assaf"}}),
+        encoding="utf-8")
+    result = _run_gate(tmp_path, DRAFT)
+    assert "channel registry error" not in result.stderr, result.stderr
+    assert ASSAF_SPOKE in result.stderr, result.stderr

--- a/q-system/.q-system/tests/test_voice_stop_gate_channel_registry.py
+++ b/q-system/.q-system/tests/test_voice_stop_gate_channel_registry.py
@@ -189,10 +189,16 @@ def test_an_unknown_lint_input_holds(tmp_path):
     # wrong rulebook again, just quieter.
     ("Reddit version, ready to paste:\n\n> draft body", "reddit"),
     ("Medium piece, ready to publish:\n\n> draft body", "medium"),
-    # And the round-1 case still resolves the same way, because a platform named
-    # INSIDE the framing outranks one merely sharing its sentence.
+    # And the round-1 case still resolves the same way, because the framing
+    # NEAREST the draft is the framing that describes it.
     ("I rewrote this from LinkedIn for Reddit. Here is the reddit post, "
      "ready to paste:\n\n> draft body", "reddit"),
+    # Codex MAJOR round 4: context and draft framing in ONE sentence, context
+    # first. Sentence-scoped first-match sent this to the LinkedIn rulebook.
+    ("For LinkedIn context, here's the Reddit post, ready to paste:"
+     "\n\n> body", "reddit"),
+    ("Compared with LinkedIn, here's the Reddit post, ready to paste:"
+     "\n\n> body", "reddit"),
 ])
 def test_detect_channel(text, expected):
     assert gate.detect_channel(text) == expected

--- a/q-system/.q-system/tests/test_voice_stop_gate_channel_registry.py
+++ b/q-system/.q-system/tests/test_voice_stop_gate_channel_registry.py
@@ -168,6 +168,22 @@ def test_an_unknown_lint_input_holds(tmp_path):
     ("here's the LinkedIn post", "linkedin"),
     ("here's the draft for Twitter", "x"),
     ("here's the fix for the parser", ""),
+    # Codex MAJOR on PR #291 (sp-9fd6dafd): the platform must come from the
+    # PUBLISH framing, not from the first platform named anywhere in the
+    # response. Both of these ship a reddit draft while naming LinkedIn first
+    # as comparison or rewrite context, and both used to route to the LinkedIn
+    # rulebook -- the exact "graded on the wrong rulebook and shipped" scar
+    # (2026-07-22) that this registry exists to close.
+    ("Here is the LinkedIn version context. Here is the reddit post, "
+     "ready to paste:\n\n> draft body", "reddit"),
+    ("I rewrote this from LinkedIn for Reddit. Here is the reddit post, "
+     "ready to paste:\n\n> draft body", "reddit"),
+    # Narrowing control: publish framing that names NO platform yields no
+    # channel even though a platform is named in ordinary prose. "" routes to
+    # the assaf lints, which is what all 26 registry-less instances already do
+    # -- the conservative direction. Guessing a channel off unrelated prose is
+    # the direction that misroutes.
+    ("We talked about LinkedIn earlier. Here's the draft:\n\n> body", ""),
 ])
 def test_detect_channel(text, expected):
     assert gate.detect_channel(text) == expected
@@ -266,3 +282,62 @@ def test_a_broken_registry_holds_the_turn_rather_than_grading_on_assaf(tmp_path)
     assert "channel registry error" in result.stderr
     assert ASSAF_SPOKE not in result.stderr
     assert PERSONA_SPOKE not in result.stderr
+
+
+# --------------------------------------------- claim: a check that cannot run holds ----
+
+NOT_GRADED = "voice-stop-gate: a voice check FAILED TO RUN"
+
+
+def test_a_surface_lint_that_crashes_holds_the_turn(tmp_path):
+    """Codex MAJOR on PR #291 (sp-5b4b3c35): the gate was fail-OPEN on a broken lint.
+
+    `run_check` returns exit code 1 for a timeout and for an ordinary crash, and
+    `main` classified only 2 and NOT_CHECKED. Every other exit fell through to the
+    clean path, so a draft that was never graded reported success and shipped.
+
+    A gate whose checker crashed has not cleared anything. The exit-code contract
+    is 0 = pass and 2 = block; ANY other result is the gate not knowing, and not
+    knowing holds.
+    """
+    _stub_lints(tmp_path)
+    (tmp_path / "persona_lint.py").write_text(
+        "import sys\nsys.stderr.write('BOOM: the lint crashed' + chr(10))\n"
+        "sys.exit(1)\n", encoding="utf-8")
+    _registry(tmp_path, {"voice_ref": "voice", "surface_ref": "persona.md",
+                         "lint": "reddit_persona_lint",
+                         "lint_script": "persona_lint.py", "lint_input": "json_body"})
+    result = _run_gate(tmp_path, DRAFT)
+    assert result.returncode == 2, (
+        "a crashed lint reported the draft clean: " + result.stdout + result.stderr)
+    assert NOT_GRADED in result.stderr, result.stderr
+    assert "BOOM: the lint crashed" in result.stderr, (
+        "the lint's own error was swallowed, so nobody can diagnose it")
+    assert ASSAF_SPOKE not in result.stderr, (
+        "a crashed surface lint silently fell back to the assaf rulebook")
+
+
+def test_a_surface_lint_that_exits_2_with_no_output_still_holds(tmp_path):
+    """Same fail-open class, second shape: `code == 2 and out` required OUTPUT,
+    so a lint that blocked without printing was read as clean."""
+    _stub_lints(tmp_path)
+    (tmp_path / "persona_lint.py").write_text(
+        "import sys\nsys.exit(2)\n", encoding="utf-8")
+    _registry(tmp_path, {"voice_ref": "voice", "surface_ref": "persona.md",
+                         "lint": "reddit_persona_lint",
+                         "lint_script": "persona_lint.py", "lint_input": "json_body"})
+    result = _run_gate(tmp_path, DRAFT)
+    assert result.returncode == 2, result.stdout + result.stderr
+
+
+def test_a_violating_lint_is_not_reported_as_a_crash(tmp_path):
+    """The negative control for both tests above, and the one that keeps the fix
+    from degenerating into "always hold". A lint that RAN and found violations
+    must not be described as one that failed to run, and a lint that exits 0
+    (voice-substance-lint here) must not be counted as a failure at all."""
+    _stub_lints(tmp_path)
+    result = _run_gate(tmp_path, DRAFT)
+    assert result.returncode == 2
+    assert ASSAF_SPOKE in result.stderr
+    assert NOT_GRADED not in result.stderr, (
+        "a clean exit 0 or an honest exit 2 was misreported as a crash")

--- a/q-system/.q-system/tests/test_voice_stop_gate_channel_registry.py
+++ b/q-system/.q-system/tests/test_voice_stop_gate_channel_registry.py
@@ -184,6 +184,15 @@ def test_an_unknown_lint_input_holds(tmp_path):
     # -- the conservative direction. Guessing a channel off unrelated prose is
     # the direction that misroutes.
     ("We talked about LinkedIn earlier. Here's the draft:\n\n> body", ""),
+    # Codex MINOR round 3: unmistakable publish framing whose marker carries no
+    # platform. Marker-only scoping sent this to the default lints, which is the
+    # wrong rulebook again, just quieter.
+    ("Reddit version, ready to paste:\n\n> draft body", "reddit"),
+    ("Medium piece, ready to publish:\n\n> draft body", "medium"),
+    # And the round-1 case still resolves the same way, because a platform named
+    # INSIDE the framing outranks one merely sharing its sentence.
+    ("I rewrote this from LinkedIn for Reddit. Here is the reddit post, "
+     "ready to paste:\n\n> draft body", "reddit"),
 ])
 def test_detect_channel(text, expected):
     assert gate.detect_channel(text) == expected
@@ -365,7 +374,7 @@ def test_a_non_object_channels_field_holds_rather_than_crashing(tmp_path):
     assert ASSAF_SPOKE not in result.stderr
 
 
-@pytest.mark.parametrize("bad", [[], "", 0, False])
+@pytest.mark.parametrize("bad", [[], "", 0, False, None])
 def test_an_EMPTY_non_object_channels_field_also_holds(tmp_path, bad):
     """Codex MINOR round 3, and it is why the guard alone was not enough.
 

--- a/q-system/.q-system/tests/test_voice_stop_gate_channel_registry.py
+++ b/q-system/.q-system/tests/test_voice_stop_gate_channel_registry.py
@@ -1,0 +1,268 @@
+"""The skeleton Stop-gate routes a channel through an OPTIONAL instance registry.
+
+The un-shipped half of prd-voice-gate-platform-aware-2026-07-22. The instance half
+(cole-gtm/gtm/scripts/voice_channel_registry.py) shipped 2026-07-22 with tests; this half
+did not, and `grep -c "voice_channel_registry\\|channel_registry"` against the gate
+returned 0 for thirteen months. So consulting never received it and built a second channel
+source of truth of its own, which is the defect the registry exists to prevent, recreated
+one repo over.
+
+TWO CLAIMS, and the second one outranks the first:
+
+1. An instance WITH a registry grades a reddit-framed draft with the persona lint.
+2. An instance with NO registry behaves exactly as it did before the registry existed.
+   26 instances have no registry. A skeleton change that breaks them to add a feature
+   one instance wants is not a feature.
+
+Claim 2 is pinned by argv equality against the literal pre-change shape, not against a
+baseline captured from the same code -- a baseline cannot see a change that moves both
+sides (scar: "same as baseline" is a weak assert).
+"""
+import importlib.util
+import json
+import os
+import subprocess
+import sys
+import tempfile
+
+import pytest
+
+REPO = os.path.abspath(os.path.join(os.path.dirname(__file__), "..", "..", ".."))
+GATE = os.path.join(REPO, "q-system", ".q-system", "scripts", "voice-stop-gate.py")
+
+
+def _load():
+    spec = importlib.util.spec_from_file_location("voice_stop_gate_reg", GATE)
+    mod = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(mod)
+    return mod
+
+
+gate = _load()
+
+
+def _registry(tmp_path, entry, default=None):
+    """An instance tree whose registry lives at the in-repo default location."""
+    data_dir = tmp_path / "q-system" / ".q-system" / "data"
+    data_dir.mkdir(parents=True)
+    reg = data_dir / "voice-channels.json"
+    reg.write_text(json.dumps({
+        "channels": {"reddit": entry},
+        "default": default if default is not None else {"voice_ref": "voice",
+                                                        "lint": "assaf"},
+    }), encoding="utf-8")
+    return reg
+
+
+def _lint_script(tmp_path, name="persona_lint.py"):
+    script = tmp_path / name
+    script.write_text("import sys\nsys.exit(0)\n", encoding="utf-8")
+    return script
+
+
+# ------------------------------------------------------- claim 2: no registry, no change ----
+
+def test_an_instance_with_no_registry_resolves_to_nothing(tmp_path):
+    assert gate.resolve_channel_registry(tmp_path) is None
+
+
+def test_no_registry_means_no_surface_lint(tmp_path):
+    assert gate.channel_surface_lint(None, "reddit", tmp_path) is None
+
+
+def test_the_argv_with_no_registry_is_the_pre_change_literal(tmp_path):
+    """The exact list this file built before the registry existed:
+        ["python3", str(script), file_path]
+    Asserted as a literal on purpose. A baseline captured by calling the same helper
+    twice would move with any change to it and prove nothing."""
+    script = _lint_script(tmp_path, "voice-lint.py")
+    assert gate._lint_argv(script, "/tmp/draft.md", gate.DEFAULT_LINT_INPUT) == [
+        "python3", str(script), "/tmp/draft.md"]
+
+
+def test_a_registered_assaf_channel_still_runs_the_assaf_lints(tmp_path):
+    """A registry that exists but declares no surface lint for the channel is the same
+    answer as no registry: None. Otherwise adding a registry for ONE channel would
+    silently change every other channel in that instance."""
+    reg = _registry(tmp_path, {"voice_ref": "voice", "lint": "assaf"})
+    assert gate.channel_surface_lint(reg, "linkedin", tmp_path) is None
+
+
+# ------------------------------------------------------ claim 1: a registry routes reddit ----
+
+def test_a_registry_routes_reddit_to_its_surface_lint(tmp_path):
+    script = _lint_script(tmp_path)
+    reg = _registry(tmp_path, {
+        "voice_ref": "voice", "surface_ref": "persona.md", "lint": "reddit_persona_lint",
+        "lint_script": "persona_lint.py", "lint_input": "json_body"})
+    resolved = gate.channel_surface_lint(reg, "reddit", tmp_path)
+    assert resolved is not None
+    assert resolved[0] == script
+    assert resolved[1] == "json_body"
+
+
+def test_a_json_body_lint_gets_the_flag_form(tmp_path):
+    script = _lint_script(tmp_path)
+    assert gate._lint_argv(script, "/tmp/d.json", "json_body") == [
+        "python3", str(script), "--file", "/tmp/d.json"]
+
+
+def test_a_pointer_file_finds_a_registry_kept_with_the_instances_own_config(tmp_path):
+    """consulting keeps its registry at q-consult/config/voice-channels.json, cole-gtm at
+    gtm/config/. There is no fleet-wide answer to which subtree that is, which is why the
+    pointer exists."""
+    elsewhere = tmp_path / "q-consult" / "config"
+    elsewhere.mkdir(parents=True)
+    reg = elsewhere / "voice-channels.json"
+    reg.write_text(json.dumps({"channels": {}, "default": {}}), encoding="utf-8")
+    data_dir = tmp_path / "q-system" / ".q-system" / "data"
+    data_dir.mkdir(parents=True)
+    (data_dir / "voice-channels.path").write_text(
+        "# where this instance keeps it\nq-consult/config/voice-channels.json\n",
+        encoding="utf-8")
+    assert gate.resolve_channel_registry(tmp_path) == reg.resolve()
+
+
+def test_a_pointer_naming_a_missing_file_is_returned_not_swallowed(tmp_path):
+    """The resolve_reporter scar: return the NAMED path even when absent, so a reader can
+    say 'the pointer names X, which is missing' instead of 'no registry'."""
+    data_dir = tmp_path / "q-system" / ".q-system" / "data"
+    data_dir.mkdir(parents=True)
+    (data_dir / "voice-channels.path").write_text("nowhere/voice-channels.json\n",
+                                                  encoding="utf-8")
+    named = gate.resolve_channel_registry(tmp_path)
+    assert named is not None
+    assert not named.exists()
+
+
+# --------------------------------------------------------------------- fail-closed ----
+
+def test_a_malformed_registry_holds(tmp_path):
+    data_dir = tmp_path / "q-system" / ".q-system" / "data"
+    data_dir.mkdir(parents=True)
+    reg = data_dir / "voice-channels.json"
+    reg.write_text("{ not json", encoding="utf-8")
+    with pytest.raises(gate.ChannelRegistryError):
+        gate.channel_surface_lint(reg, "reddit", tmp_path)
+
+
+def test_a_named_lint_script_that_is_missing_holds(tmp_path):
+    reg = _registry(tmp_path, {"voice_ref": "voice", "lint": "reddit_persona_lint",
+                               "lint_script": "gone.py"})
+    with pytest.raises(gate.ChannelRegistryError, match="does not exist"):
+        gate.channel_surface_lint(reg, "reddit", tmp_path)
+
+
+def test_an_unknown_lint_input_holds(tmp_path):
+    _lint_script(tmp_path)
+    reg = _registry(tmp_path, {"voice_ref": "voice", "lint": "reddit_persona_lint",
+                               "lint_script": "persona_lint.py", "lint_input": "telepathy"})
+    with pytest.raises(gate.ChannelRegistryError, match="lint_input"):
+        gate.channel_surface_lint(reg, "reddit", tmp_path)
+
+
+# ------------------------------------------------------------------ channel detection ----
+
+@pytest.mark.parametrize("text,expected", [
+    ("here's the reddit post, ready to paste", "reddit"),
+    ("here's the LinkedIn post", "linkedin"),
+    ("here's the draft for Twitter", "x"),
+    ("here's the fix for the parser", ""),
+])
+def test_detect_channel(text, expected):
+    assert gate.detect_channel(text) == expected
+
+
+# ----------------------------------------------------------- end to end, real process ----
+
+def _run_gate(instance_root, message):
+    """Run the gate as the hook runs it: a transcript on stdin, from a tmp instance root.
+
+    The gate resolves INSTANCE_ROOT at import from ITS OWN location, so a subprocess run
+    against the real file always reads the real instance. This copies the script into the
+    tmp tree so the registry under test is the one it finds -- a refuse-path test run from
+    the checkout it asks about proves nothing (scar: guard tests need the caller's shape).
+    """
+    scripts = instance_root / "q-system" / ".q-system" / "scripts"
+    scripts.mkdir(parents=True, exist_ok=True)
+    copy = scripts / "voice-stop-gate.py"
+    copy.write_bytes(open(GATE, "rb").read())
+    transcript = instance_root / "t.jsonl"
+    transcript.write_text(json.dumps({
+        "type": "assistant",
+        "message": {"role": "assistant", "content": [{"type": "text", "text": message}]},
+    }) + "\n", encoding="utf-8")
+    return subprocess.run(
+        [sys.executable, str(copy)],
+        input=json.dumps({"transcript_path": str(transcript)}),
+        capture_output=True, text=True, timeout=60)
+
+
+DRAFT = ("here's the reddit post, ready to paste:\n\n"
+         "> been running this thing for a while now and the onboarding is still rough. "
+         "worked for me, no idea about your setup. took me way too long to figure out "
+         "that the parser was the part nobody looks at.\n")
+
+ASSAF_SPOKE = "ASSAF VOICE LINT SPOKE"
+PERSONA_SPOKE = "REDDIT PERSONA LINT SPOKE"
+
+
+def _stub_lints(tmp_path):
+    """All three lints present in EVERY tree, so the assertion is about which one the
+    gate CHOSE and not about which one happened to be installed. Stubs, not the real
+    lints: this test is about routing, and coupling the control to voice-lint's rule set
+    would make it go red for a reason it does not exist to catch."""
+    scripts = tmp_path / "q-system" / ".q-system" / "scripts"
+    scripts.mkdir(parents=True, exist_ok=True)
+    (scripts / "voice-lint.py").write_text(
+        "import sys\n"
+        "assert sys.argv[1].endswith('.md'), sys.argv\n"
+        f"sys.stderr.write({ASSAF_SPOKE!r} + chr(10))\n"
+        "sys.exit(2)\n", encoding="utf-8")
+    (scripts / "voice-substance-lint.py").write_text(
+        "import sys\nsys.exit(0)\n", encoding="utf-8")
+    persona = tmp_path / "persona_lint.py"
+    persona.write_text(
+        "import json, sys\n"
+        "a = sys.argv\n"
+        "assert '--file' in a, a\n"
+        "body = json.load(open(a[a.index('--file') + 1]))['body']\n"
+        "assert body.strip(), 'lint got an empty body'\n"
+        f"sys.stderr.write({PERSONA_SPOKE!r} + chr(10))\n"
+        "sys.exit(2)\n", encoding="utf-8")
+    return scripts
+
+
+def test_a_reddit_draft_reaches_the_registered_surface_lint(tmp_path):
+    """THE reproducer. The lint the registry names is the one that runs, and the assaf
+    lints -- present in this same tree -- do not."""
+    _stub_lints(tmp_path)
+    _registry(tmp_path, {"voice_ref": "voice", "surface_ref": "persona.md",
+                         "lint": "reddit_persona_lint",
+                         "lint_script": "persona_lint.py", "lint_input": "json_body"})
+    result = _run_gate(tmp_path, DRAFT)
+    assert result.returncode == 2, result.stdout + result.stderr
+    assert PERSONA_SPOKE in result.stderr
+    assert ASSAF_SPOKE not in result.stderr, "reddit was still graded on assaf voice"
+
+
+def test_the_same_draft_with_no_registry_reaches_the_assaf_lints(tmp_path):
+    """The control, and the state the mutation must restore. Same tree, same draft, same
+    stubs; only the registry is gone."""
+    _stub_lints(tmp_path)
+    result = _run_gate(tmp_path, DRAFT)
+    assert result.returncode == 2, result.stdout + result.stderr
+    assert ASSAF_SPOKE in result.stderr
+    assert PERSONA_SPOKE not in result.stderr
+
+
+def test_a_broken_registry_holds_the_turn_rather_than_grading_on_assaf(tmp_path):
+    _stub_lints(tmp_path)
+    data_dir = tmp_path / "q-system" / ".q-system" / "data"
+    data_dir.mkdir(parents=True, exist_ok=True)
+    (data_dir / "voice-channels.json").write_text("{ not json", encoding="utf-8")
+    result = _run_gate(tmp_path, DRAFT)
+    assert result.returncode == 2
+    assert "channel registry error" in result.stderr
+    assert ASSAF_SPOKE not in result.stderr
+    assert PERSONA_SPOKE not in result.stderr

--- a/q-system/.q-system/tests/test_voice_stop_gate_channel_registry.py
+++ b/q-system/.q-system/tests/test_voice_stop_gate_channel_registry.py
@@ -341,3 +341,25 @@ def test_a_violating_lint_is_not_reported_as_a_crash(tmp_path):
     assert ASSAF_SPOKE in result.stderr
     assert NOT_GRADED not in result.stderr, (
         "a clean exit 0 or an honest exit 2 was misreported as a crash")
+
+
+def test_a_non_object_channels_field_holds_rather_than_crashing(tmp_path):
+    """Codex MINOR on PR #291, and it is the fail-open class again.
+
+    `data["channels"]` as a LIST reached `.get` and raised an uncaught
+    AttributeError. main() catches ChannelRegistryError and exits 2; an
+    AttributeError escapes it and Python exits 1, and a Stop hook exiting 1 does
+    not hold the turn. So the one registry shape that crashed was also the one
+    that let the draft through.
+    """
+    _stub_lints(tmp_path)
+    data_dir = tmp_path / "q-system" / ".q-system" / "data"
+    data_dir.mkdir(parents=True, exist_ok=True)
+    (data_dir / "voice-channels.json").write_text(
+        json.dumps({"channels": ["reddit"]}), encoding="utf-8")
+    result = _run_gate(tmp_path, DRAFT)
+    assert result.returncode == 2, result.stdout + result.stderr
+    assert "channel registry error" in result.stderr, result.stderr
+    assert "Traceback" not in result.stderr, (
+        "crashed out of the hold path instead of taking it: " + result.stderr)
+    assert ASSAF_SPOKE not in result.stderr


### PR DESCRIPTION
## Why this is urgent rather than tidy

`plugins/kipi-core/voiceloop/channel_registry.py` does not exist on `origin/main`. Measured:

```
$ git ls-tree -r origin/main --name-only | grep voiceloop
plugins/kipi-core/voiceloop/__init__.py
plugins/kipi-core/voiceloop/assemble.py
plugins/kipi-core/voiceloop/corpus.py
plugins/kipi-core/voiceloop/echo.py
plugins/kipi-core/voiceloop/fingerprint.py
plugins/kipi-core/voiceloop/selector.py
plugins/kipi-core/voiceloop/validate.py
plugins/kipi-core/voiceloop/voice_ref.py
...
```

Every sibling is there. `channel_registry.py` is not.

Consulting imports it at MODULE level, so an absent file is an import error and not a
degraded feature (`consulting/q-consult/pipeline/voice.py:47-48`):

```python
from voicekit import assemble, corpus, echo, fingerprint, validate  # noqa: E402
from voicekit import channel_registry  # noqa: E402
```

The `plugins/` sync runs `rsync --delete` from the skeleton WORKING TREE
(`kipi-update.sh:555`, `config_source_manages` at :1288-1294: "the rsync is --delete, so
it removes instance files the skeleton does not carry"). Measured on disk today:

```
$ ls plugins/kipi-core/voiceloop/channel_registry.py     # skeleton working tree
ls: ...: No such file or directory
$ ls plugins/kipi-core/voicekit/channel_registry.py      # consulting instance
plugins/kipi-core/voicekit/channel_registry.py
```

So a `kipi update` today strands the import. Captured as `sp-885e1df0`. It resolves by
landing, not by a design choice.

## What shipped

Two commits, C3 first because the seam fix copies its resolver.

**C3 (`ed4f5b32`, `18485c98`) - the skeleton Stop-gate reads an OPTIONAL instance channel registry.**
26 instances have no registry and must behave byte-identically to before. An instance
WITH one routes the channel to its surface lint instead. A present-but-BROKEN registry
holds the turn (fail-closed) rather than falling back to the assaf lints, because that
fallback is the wrong-rulebook bug wearing a fix (scar 2026-07-22: a reddit draft graded
on the wrong rulebook and shipped AI-sounding).

**Seam fix (`cb5d8292`, `840eb048`) - the channel set is derived from the registry, not restated four times.**
`channel_registry.py` becomes the single source; `validate.py` locates itself from the
imported module rather than a hardcoded path.

## What the mutations proved

Both mutants were applied to the real file, run, and reverted; the tree was confirmed
clean afterward (`git status --porcelain` empty).

**Mutant 1 - break `resolve`'s local-registry branch** (`channel_registry.py:117-118`,
`return local` -> `return None`):

```
FAILED plugins/kipi-core/voiceloop/tests/test_channel_registry.py::TestResolve::test_the_in_repo_registry_wins
1 failed, 45 passed in 0.18s
```

KILLED.

**Mutant 2 - flip the fail-closed guard to fail-open** (`voice-stop-gate.py:642`,
`sys.exit(2)` -> `surface = None`):

```
E           ASSAF VOICE LINT SPOKE
FAILED q-system/.q-system/tests/test_voice_stop_gate_channel_registry.py::test_a_broken_registry_holds_the_turn_rather_than_grading_on_assaf
1 failed, 17 passed in 0.19s
```

KILLED, and the failure text is the scar reproducing verbatim: with the guard removed,
the assaf voice lint grades a draft that belongs to another channel's rulebook. That is
the exact 2026-07-22 defect, and the test names it.

## Reproducer output (post-fix, tree clean)

```
$ python3 -m pytest plugins/kipi-core/voiceloop/tests/ \
    q-system/.q-system/tests/test_voice_stop_gate_channel_registry.py \
    q-system/.q-system/tests/test_voice_stop_gate_not_checked.py -q
138 passed in 0.29s
```

## Merge order

This PR is upstream of the voiceloop fleet migration by construction: the seam fix's
`channel_registry.py` header states it copies C3's resolver. Land this first, then the
migration, then run `kipi update --dry-run`.

## Spillover

- `sp-885e1df0` (armed `channel_registry.py` deletion) resolves on this merge.
- `sp-79e212a5` stays OPEN: `corpus.EXEMPLAR_CHANNELS` is a THIRD channel axis still
  hardcoded at `plugins/kipi-core/voiceloop/corpus.py:40` after this PR took over the
  scope and assembled axes. Out of scope here, named rather than swept.
