### PR TITLE
migrate: voicekit -> voiceloop per instance, wired into the update path

### DIFF
--- a/kipi-update-voiceloop-migrate.py
+++ b/kipi-update-voiceloop-migrate.py
@@ -184,7 +184,13 @@ def plan(repo: str) -> dict:
         rel = os.path.relpath(path, repo)
         base = os.path.basename(path)
         ext = os.path.splitext(base)[1].lower()
-        if has_token(base):
+        # A FILENAME follows the same record/source split as file CONTENT, and
+        # not gating it on the extension was a live defect: the first version
+        # queued `q-system/output/plans/ask-565-voicekit-fleet-skew-2026-08-09.md`
+        # for rename. That plan is a dated record, its name is part of the
+        # record, and other documents cite it by that name. Only a module the
+        # import system resolves by filename (test_voicekit.py) has to move.
+        if has_token(base) and ext in REWRITE_EXTS:
             renames.append(rel)
         if ext not in REWRITE_EXTS:
             # Cheap membership test first; only files we might edit are read.

--- a/kipi-update-voiceloop-migrate.py
+++ b/kipi-update-voiceloop-migrate.py
@@ -221,6 +221,40 @@ def plan(repo: str) -> dict:
     staged_migration = sorted(l for l in staged.stdout.splitlines() if l.strip()) \
         if staged.returncode == 0 else []
 
+    # ...and the same unfinished state OUTSIDE PLUGIN_PARENT, which the scan
+    # above structurally cannot see. The rewrites that matter most are exactly
+    # there (consulting's q-consult/pipeline/voice.py). The signature is exact
+    # and needs no path heuristic: the HEAD blob asks for the old name and the
+    # STAGED blob does not. A founder's own staged edit does not delete this
+    # token from a file that carried it.
+    #
+    # This list is what makes the commit's pathspec (see apply) able to finish
+    # an interrupted run without falling back to committing the whole index.
+    #
+    # --no-renames is load-bearing and was a live defect for one round: with
+    # rename detection ON (git's default) `--name-only` prints ONLY the
+    # DESTINATION of a rename. The source half of the package move was therefore
+    # absent from this list, the commit's pathspec never named it, and a recovery
+    # run committed the ADD while leaving the matching DELETE staged -- an
+    # instance left dirty by the very run that was recovering it.
+    staged_rewrites = []
+    staged_all = _git(repo, "diff", "--cached", "--name-only", "--no-renames")
+    if staged_all.returncode == 0:
+        for rel in (l.strip() for l in staged_all.stdout.splitlines()):
+            if not rel:
+                continue
+            head_blob = _git(repo, "show", f"HEAD:{rel}")
+            if head_blob.returncode != 0 or not has_token(head_blob.stdout):
+                continue
+            idx_blob = _git(repo, "show", f":{rel}")
+            if idx_blob.returncode != 0:
+                # A staged DELETION of a file that carried the token: the source
+                # half of a rename this migration made.
+                staged_rewrites.append(rel)
+            elif not has_token(idx_blob.stdout):
+                staged_rewrites.append(rel)
+    staged_rewrites = sorted(staged_rewrites)
+
     return {
         "repo": repo,
         "package_action": package_action,
@@ -228,10 +262,12 @@ def plan(repo: str) -> dict:
         "renames": sorted(renames),
         "history_left": sorted(history),
         "staged_migration": staged_migration,
+        "staged_rewrites": staged_rewrites,
         # The one line a caller can branch on. `already`/`absent` with nothing to
         # rewrite AND nothing staged is a finished instance.
         "needs_work": (package_action in ("move", "both_present")
-                       or bool(rewrite) or bool(renames) or bool(staged_migration)),
+                       or bool(rewrite) or bool(renames)
+                       or bool(staged_migration) or bool(staged_rewrites)),
     }
 
 
@@ -334,7 +370,7 @@ def apply(repo: str, commit: bool = True) -> dict:
     # run may have touched nothing because a PREVIOUS run already did the writes
     # and only its commit failed.
     touched = bool(result["moved"] or result["rewritten"] or result["renamed"]
-                   or p["staged_migration"])
+                   or p["staged_migration"] or p["staged_rewrites"])
     if commit and touched and not result["errors"]:
         add = _git(repo, "add", "-A", "--", PLUGIN_PARENT)
         if add.returncode != 0:
@@ -355,8 +391,38 @@ def apply(repo: str, commit: bool = True) -> dict:
         for pair in result["renamed"]:
             src, dst = pair.split(" -> ")
             _git(repo, "add", "--", src, dst)
-        staged = _git(repo, "diff", "--cached", "--name-only")
-        if staged.stdout.strip():
+        # THE COMMIT IS PATHSPEC-LIMITED, and this is the second half of a fix
+        # whose first half was not enough. Codex MAJOR on PR #292 (sp-27bbf105):
+        # the `git add` calls above were carefully scoped and `git commit -m`
+        # was not, so it wrote the WHOLE index. The updater's dirty guard
+        # deliberately PERMITS staged work outside q-system/, .claude/ and
+        # plugins/, and every such founder file was landing inside a migration
+        # commit. The earlier fix for this exact class scoped the add and left
+        # the commit alone: the hole moved instead of closing
+        # (feedback_defect_class_relocates), and the suite could not see it
+        # because the only commit test staged everything with `git add -A` and
+        # asserted the index came back empty -- true only while the commit is
+        # unscoped.
+        #
+        # PLUGIN_PARENT is in the scope because the updater's dirty guard already
+        # refuses an instance with dirt under plugins/, so nothing of the
+        # founder's can be staged there. `staged_rewrites` carries a rewrite an
+        # interrupted earlier run left staged OUTSIDE it, which is the only other
+        # way a migration path is staged without THIS run having touched it;
+        # without it a recovery run would commit the package and abandon the
+        # imports, still staged, still dirty.
+        scope = [PLUGIN_PARENT]
+        scope += [rel for rel in result["rewritten"] if rel in tracked_before]
+        for pair in result["renamed"]:
+            scope += pair.split(" -> ")
+        scope += p["staged_rewrites"]
+        # --no-renames for the same reason plan() needs it: with rename
+        # detection on, this returns only a rename's destination, and the
+        # unnamed source stays staged after the commit.
+        staged = _git(repo, "diff", "--cached", "--name-only", "--no-renames",
+                      "--", *sorted(set(scope)))
+        commit_paths = [l.strip() for l in staged.stdout.splitlines() if l.strip()]
+        if commit_paths:
             # The `[no-issue:]` hatch, with a reason, is required and not
             # optional decoration. Measured 2026-08-30: one client engagement's
             # own commit-msg hook rejected the first fleet run, because a
@@ -373,7 +439,11 @@ def apply(repo: str, commit: bool = True) -> dict:
                 "instance-owned imports that still ask for the old name. The "
                 "package move and the import rewrite are one operation.\n"
             )
-            c = _git(repo, "commit", "-m", msg)
+            # Every path here came back from `diff --cached`, so each is already
+            # known to the index and git will not reject the pathspec. Partial
+            # commit mode takes the working-tree content for these paths and
+            # leaves every other staged path staged, which is the whole point.
+            c = _git(repo, "commit", "-m", msg, "--", *commit_paths)
             if c.returncode != 0:
                 result["errors"].append("commit failed: "
                                         + (c.stderr.strip() or c.stdout.strip()))

--- a/kipi-update-voiceloop-migrate.py
+++ b/kipi-update-voiceloop-migrate.py
@@ -58,10 +58,15 @@ import argparse
 import json
 import os
 import re
+import shutil
 import subprocess
 import sys
 
 PLUGIN_PARENT = os.path.join("plugins", "kipi-core")
+# Not in REWRITE_EXTS, deliberately: a backup this script wrote must never become
+# a file a later run rewrites. .bak lands in `history_left`, counted and left
+# alone, which is exactly where a record belongs.
+BACKUP_SUFFIX = ".pre-voiceloop.bak"
 OLD = "voicekit"
 NEW = "voiceloop"
 
@@ -272,8 +277,16 @@ def plan(repo: str) -> dict:
 
 
 def _git(repo: str, *args: str) -> subprocess.CompletedProcess:
+    # errors="replace", and it is load-bearing rather than defensive dressing.
+    # `staged_rewrites` asks for the HEAD and index blobs of every staged path,
+    # and under the default strict decoding a staged BINARY file made subprocess
+    # raise UnicodeDecodeError while merely PLANNING. The updater's dirty guard
+    # permits staged work outside its managed paths, so a staged png is ordinary
+    # and took the whole migration down before it read one source file.
+    # Replacement characters cannot spell the token, so the membership test stays
+    # exact for the text this actually cares about.
     return subprocess.run(["git", "-C", repo, *args],
-                          capture_output=True, text=True)
+                          capture_output=True, text=True, errors="replace")
 
 
 def _tracked(repo: str, rel: str) -> bool:
@@ -308,7 +321,7 @@ def apply(repo: str, commit: bool = True) -> dict:
     repo = os.path.abspath(repo)
     p = plan(repo)
     result = {**p, "moved": False, "rewritten": [], "renamed": [], "committed": False,
-              "errors": [], "left_untracked": []}
+              "errors": [], "left_untracked": [], "backed_up": []}
     # Snapshot tracked-ness BEFORE any write, because `git mv` and the rewrites
     # change it. Empty set when this is not a git repo, which makes every path
     # "untracked" and the commit step a no-op -- correct for a scratch copy.
@@ -370,11 +383,35 @@ def apply(repo: str, commit: bool = True) -> dict:
         new_text = swap_tokens(text)
         if new_text == text:
             continue
+        # NOTHING RESTORES WHAT WAS NEVER TRACKED. Codex BLOCKER on PR #292:
+        # rewriting an untracked file in place destroys the only copy of somebody
+        # else's work in progress. Rewriting it is still right, because leaving it
+        # importing a package that no longer exists is the breakage this file
+        # exists to prevent, but making that irreversible is not this script's
+        # call. Tracked files get no backup on purpose: version control already IS
+        # the backup, and a .bak beside all 36 rewritten modules would be litter
+        # in the one instance this runs on.
+        if rel not in tracked_before:
+            keep = path + BACKUP_SUFFIX
+            if not os.path.exists(keep):
+                shutil.copy2(path, keep)
+                result["backed_up"].append(rel + BACKUP_SUFFIX)
         # Atomic per file: a run killed mid-sweep leaves whole files, never a
         # half-written module, and the next run finishes the remainder.
         tmp = path + ".voiceloop-migrate.tmp"
         with open(tmp, "w", encoding="utf-8") as fh:
             fh.write(new_text)
+        # CARRY THE MODE ACROSS. Codex MAJOR on PR #292: the temp file is created
+        # at the default 0644 and os.replace puts it over the original, so every
+        # executable this touched came back non-executable. A hook or scheduled
+        # job invoked as a bare path stops running at 0644 and says nothing -- the
+        # failure is silence, not an error -- and .sh is in REWRITE_EXTS by design.
+        try:
+            os.chmod(tmp, os.stat(path).st_mode & 0o7777)
+        except OSError as exc:
+            result["errors"].append(f"chmod {rel}: {exc}")
+            os.unlink(tmp)
+            continue
         os.replace(tmp, path)
         result["rewritten"].append(rel)
 

--- a/kipi-update-voiceloop-migrate.py
+++ b/kipi-update-voiceloop-migrate.py
@@ -209,15 +209,29 @@ def plan(repo: str) -> dict:
         if has_token(text):
             rewrite.append(rel)
 
+    # STAGED-BUT-UNCOMMITTED MIGRATION WORK IS UNFINISHED WORK, and reading the
+    # disk alone cannot see that. Measured 2026-08-30 on one instance: its own
+    # commit-msg gate refused the migration commit, so the files were moved and
+    # rewritten and left staged. The very next run then read the tree, saw the
+    # new name everywhere, reported `already` / needs_work=False, and walked past
+    # an instance that was dirty and one gate away from being permanently
+    # refused by the updater's dirty-tree check. "Recovers rather than
+    # corrupting" has to include recovering the COMMIT, not just the bytes.
+    staged = _git(repo, "diff", "--cached", "--name-only", "--", PLUGIN_PARENT)
+    staged_migration = sorted(l for l in staged.stdout.splitlines() if l.strip()) \
+        if staged.returncode == 0 else []
+
     return {
         "repo": repo,
         "package_action": package_action,
         "rewrite": sorted(rewrite),
         "renames": sorted(renames),
         "history_left": sorted(history),
+        "staged_migration": staged_migration,
         # The one line a caller can branch on. `already`/`absent` with nothing to
-        # rewrite is a finished instance.
-        "needs_work": package_action in ("move", "both_present") or bool(rewrite) or bool(renames),
+        # rewrite AND nothing staged is a finished instance.
+        "needs_work": (package_action in ("move", "both_present")
+                       or bool(rewrite) or bool(renames) or bool(staged_migration)),
     }
 
 
@@ -316,7 +330,11 @@ def apply(repo: str, commit: bool = True) -> dict:
     # No --no-verify. The kipi-update.sh precedent is scoped to ITS auto-commit;
     # a hook that rejects this commit is a hook doing its job, and the honest
     # answer is a loud failure, not a bypass.
-    touched = bool(result["moved"] or result["rewritten"] or result["renamed"])
+    # `p["staged_migration"]` is why a re-run finishes an interrupted one: this
+    # run may have touched nothing because a PREVIOUS run already did the writes
+    # and only its commit failed.
+    touched = bool(result["moved"] or result["rewritten"] or result["renamed"]
+                   or p["staged_migration"])
     if commit and touched and not result["errors"]:
         add = _git(repo, "add", "-A", "--", PLUGIN_PARENT)
         if add.returncode != 0:
@@ -339,9 +357,17 @@ def apply(repo: str, commit: bool = True) -> dict:
             _git(repo, "add", "--", src, dst)
         staged = _git(repo, "diff", "--cached", "--name-only")
         if staged.stdout.strip():
+            # The `[no-issue:]` hatch, with a reason, is required and not
+            # optional decoration. Measured 2026-08-30: one client engagement's
+            # own commit-msg hook rejected the first fleet run, because a
+            # spillover id does not match its issue pattern
+            # ([A-Z][A-Z0-9]{1,9}-\d+), which left that instance rewritten,
+            # staged and uncommitted. A per-instance gate is not a thing to route
+            # around with --no-verify; this is the sanctioned hatch, and it is
+            # written to that repo's bypass ledger.
             msg = (
                 "migrate: voicekit -> voiceloop, package and imports together "
-                "(sp-8d55455a)\n\n"
+                "[no-issue: fleet migration, sp-8d55455a tracks it]\n\n"
                 "kipi update rsyncs plugins/ with --delete, so a sync alone "
                 "delivers voiceloop/, removes voicekit/, and cannot rewrite the "
                 "instance-owned imports that still ask for the old name. The "

--- a/kipi-update-voiceloop-migrate.py
+++ b/kipi-update-voiceloop-migrate.py
@@ -234,7 +234,12 @@ def apply(repo: str, commit: bool = True) -> dict:
     repo = os.path.abspath(repo)
     p = plan(repo)
     result = {**p, "moved": False, "rewritten": [], "renamed": [], "committed": False,
-              "errors": []}
+              "errors": [], "left_untracked": []}
+    # Snapshot tracked-ness BEFORE any write, because `git mv` and the rewrites
+    # change it. Empty set when this is not a git repo, which makes every path
+    # "untracked" and the commit step a no-op -- correct for a scratch copy.
+    ls = _git(repo, "ls-files")
+    tracked_before = set(ls.stdout.splitlines()) if ls.returncode == 0 else set()
 
     # --- step 1: the package gets the new name -------------------------------
     if p["package_action"] == "move":
@@ -316,8 +321,19 @@ def apply(repo: str, commit: bool = True) -> dict:
         add = _git(repo, "add", "-A", "--", PLUGIN_PARENT)
         if add.returncode != 0:
             result["errors"].append("git add (plugins): " + add.stderr.strip())
+        # ONLY files git already tracked. An UNTRACKED file in the rewrite set is
+        # somebody's work in progress -- measured 2026-08-30, consulting had
+        # q-consult/pipeline/tests/audit_channel_wiring.py untracked while another
+        # live session worked in that tree. `git add` on it would commit a peer's
+        # WIP inside a migration commit, which is the auto-commit-sweeps-the-wrong
+        # -branch scar. It still gets REWRITTEN, because leaving it importing a
+        # package that no longer exists is the breakage this whole file prevents;
+        # it just stays untracked, exactly as its author left it.
         for rel in result["rewritten"]:
-            _git(repo, "add", "--", rel)
+            if rel in tracked_before:
+                _git(repo, "add", "--", rel)
+            else:
+                result["left_untracked"].append(rel)
         for pair in result["renamed"]:
             src, dst = pair.split(" -> ")
             _git(repo, "add", "--", src, dst)

--- a/kipi-update-voiceloop-migrate.py
+++ b/kipi-update-voiceloop-migrate.py
@@ -280,6 +280,30 @@ def _tracked(repo: str, rel: str) -> bool:
     return _git(repo, "ls-files", "--error-unmatch", "--", rel).returncode == 0
 
 
+def _dirty_tracked(repo: str, rels: list) -> list:
+    """Tracked files among `rels` carrying uncommitted changes, staged or not.
+
+    UNTRACKED files are deliberately NOT included. This module already decided to
+    rewrite those and leave them untracked rather than let them import a package
+    that no longer exists (see the git add block); widening this to untracked
+    would silently reverse that decision.
+    """
+    if not rels:
+        return []
+    r = _git(repo, "status", "--porcelain", "--", *sorted(set(rels)))
+    if r.returncode != 0:
+        return []
+    out = []
+    for line in r.stdout.splitlines():
+        if not line.strip() or line.startswith("??"):
+            continue
+        path = line[3:].strip()
+        if " -> " in path:                      # a staged rename: take the source
+            path = path.split(" -> ")[0]
+        out.append(path.strip('"'))
+    return sorted(set(out))
+
+
 def apply(repo: str, commit: bool = True) -> dict:
     repo = os.path.abspath(repo)
     p = plan(repo)
@@ -290,6 +314,29 @@ def apply(repo: str, commit: bool = True) -> dict:
     # "untracked" and the commit step a no-op -- correct for a scratch copy.
     ls = _git(repo, "ls-files")
     tracked_before = set(ls.stdout.splitlines()) if ls.returncode == 0 else set()
+
+    # A FILE THE FOUNDER IS ALREADY EDITING IS NOT THIS SCRIPT'S TO REWRITE.
+    #
+    # Codex MAJOR round 2 on PR #292: pathspec-limiting the commit stopped it
+    # absorbing an UNRELATED staged file and left the case where the founder's
+    # staged edit sits in the VERY file the token swap has to touch. The swap and
+    # the edit are then the same file and no pathspec can separate them.
+    #
+    # So nothing is written. The error propagates, the caller abandons this
+    # instance BEFORE the --delete rsync, and the founder's work is exactly where
+    # they left it. The instance stays on the old package name, which is inert:
+    # the rsync that would strand its imports never runs either. Loud and
+    # reversible beats a migration commit that quietly carries somebody's WIP.
+    #
+    # Checked ONCE, here, against the PRE-MOVE paths. After `git mv` the package's
+    # own files read as staged renames and would false-trip this.
+    blocked = _dirty_tracked(repo, p["rewrite"] + p["renames"])
+    if blocked:
+        result["errors"].append(
+            "refusing to rewrite %d file(s) with uncommitted changes; commit or "
+            "stash them and re-run: %s" % (len(blocked), ", ".join(blocked[:5])))
+        result["verified"] = False
+        return result
 
     # --- step 1: the package gets the new name -------------------------------
     if p["package_action"] == "move":

--- a/kipi-update-voiceloop-migrate.py
+++ b/kipi-update-voiceloop-migrate.py
@@ -1,0 +1,387 @@
+#!/usr/bin/env python3
+"""Migrate ONE instance from the `voicekit` package name to `voiceloop`.
+
+why this exists (sp-8d55455a, 2026-08-30): the rename landed in the skeleton as
+cf6acdb4 and shipped `plugins/kipi-core/voiceloop/`. `kipi update` rsyncs
+`plugins/` with `--delete`, so a sync DELIVERS voiceloop/ and DELETES voicekit/.
+The code that imports it does NOT live under plugins/ -- it is instance-owned
+pipeline code (consulting's `q-consult/pipeline/voice.py` puts
+`<repo>/plugins/kipi-core` on sys.path and then does `from voicekit import ...`).
+A sync therefore removes the name that code asks for and CANNOT rewrite the ask.
+Measured 2026-08-30: 24 of 25 registered instances still carried voicekit, so the
+next `kipi update` was armed to break the voice pipeline in every one of them.
+
+So this is a MIGRATION, not a rename. The package swap and the import rewrite are
+one operation, run per instance INSIDE the update path -- never a one-shot script
+somebody remembers to run, because an instance that syncs later without it breaks
+in exactly the same way.
+
+## The order, and why it is this order
+
+  1. move  plugins/kipi-core/voicekit -> plugins/kipi-core/voiceloop
+  2. rewrite the token in instance source files
+  3. (caller) rsync, which lands the skeleton's copy on top of the moved dir
+
+Step 1 first, deliberately. Rewriting imports BEFORE the package has the new name
+leaves a window where the instance asks for a name nothing provides; doing the
+move first leaves a window where the package answers to a name nothing asks for,
+which is inert rather than broken. Each step is independently idempotent, so a
+run that dies between them is FINISHED by the next run rather than corrupted:
+step 1 no-ops once voiceloop/ exists, step 2 no-ops once no token remains.
+
+## Never a delete
+
+If BOTH voicekit/ and voiceloop/ are present (a half-synced instance), this does
+NOT remove either one. It rewrites the imports, reports `both_present`, and
+leaves the stale directory for the rsync's own --delete or for a founder
+decision. Removing a package directory is a destructive op and it is not this
+script's call to make (~/.claude/hooks/destructive-op-deny.sh; the 2026-05-17
+scar where an agent "fixed" a mismatch by deleting a production volume).
+
+## What gets rewritten, and what deliberately does not
+
+Extensions in REWRITE_EXTS are things the running system executes or reads as
+configuration: a stale token there is a defect. Everything else -- .md, .txt and
+especially .jsonl -- is a RECORD. `.prd-os/spillover.jsonl`,
+`q-consult/output/postbook.jsonl` and the review docs say what was true when they
+were written; rewriting them would falsify history to tidy a grep. They are
+counted and reported as `history_left`, never edited.
+
+.json is rewritten and .jsonl is not, and that split is the whole rule rather
+than an oversight: .json here is config the engine reads (voice-channels.json
+names `voiceloop/validate.py`, a path that genuinely moved), .jsonl is an
+append-only ledger.
+"""
+from __future__ import annotations
+
+import argparse
+import json
+import os
+import re
+import subprocess
+import sys
+
+PLUGIN_PARENT = os.path.join("plugins", "kipi-core")
+OLD = "voicekit"
+NEW = "voiceloop"
+
+# All four case forms, longest-first is irrelevant here because none is a prefix
+# of another. Plain substring replacement, not a \b-anchored regex: the token
+# appears as `test_voicekit.py`, `voicekit/validate.py` and `VOICEKIT_DIR`, and a
+# word boundary would miss every one of them. This is the same rule
+# consulting's automation/export_voice_loop.py has applied to its public mirror
+# since 2026-08-20, which is the evidence that a blanket token swap is safe on
+# this corpus.
+CASE_FORMS = (
+    ("voicekit", "voiceloop"),
+    ("Voicekit", "Voiceloop"),
+    ("VoiceKit", "VoiceLoop"),
+    ("VOICEKIT", "VOICELOOP"),
+)
+
+REWRITE_EXTS = {
+    ".py", ".sh", ".bash", ".zsh",
+    ".yml", ".yaml", ".json", ".toml", ".cfg", ".ini",
+}
+
+# Directories never descended into. `.claude/worktrees` and `.wt-*` are OTHER
+# LIVE SESSIONS' checkouts of the same repo (feedback_parallel_sessions_one_checkout):
+# writing into one yanks another agent's working tree.
+SKIP_DIRS = {
+    ".git", "node_modules", ".venv", "venv", "__pycache__",
+    ".pytest_cache", ".mypy_cache", ".ruff_cache", ".tox", "target",
+    ".claude-plugin",
+}
+SKIP_DIR_PREFIXES = (".wt-",)
+
+# THE CHECK MUST NOT REWRITE ITSELF, and a fixture must not be tidied.
+#
+# Both are the same class (a text rule that matches its own text) and both were
+# live defects in the first draft of this file:
+#
+#  * This module carries the string `voicekit` in its docstring and in
+#    CASE_FORMS. Run over its own repo it would rewrite that table to
+#    ("voiceloop", "voiceloop") and silently stop migrating anything, while
+#    still reporting success.
+#  * `**/tests/fixtures/*` holds byte-for-byte COPIES of real artifacts --
+#    q-system/.q-system/tests/fixtures/destructive-op-deny.reference.sh mirrors
+#    the live destructive-op hook, whose scar text names "voicekit deleted from
+#    19 instances" as history. Rewriting the copy makes it stop matching the
+#    original, so the fixture's own test fails and the recorded scar is falsified.
+#
+# Neither is an "adjacent issue to tidy later": a rule that edits its own
+# definition is not a rule.
+SELF_PATH = os.path.realpath(__file__)
+SKIP_PATH_PARTS = (os.path.join("tests", "fixtures") + os.sep,)
+
+
+def _exempt(path: str) -> bool:
+    if os.path.realpath(path) == SELF_PATH:
+        return True
+    return any(part in path for part in SKIP_PATH_PARTS)
+
+
+def _skip_dirname(name: str) -> bool:
+    return name in SKIP_DIRS or name.startswith(SKIP_DIR_PREFIXES)
+
+
+def iter_source_files(repo: str):
+    """Every file in THIS repo's own tree. Nested repos are not this repo.
+
+    A nested checkout carrying its own `.git` is a separate registered instance
+    (consulting holds eleven of them under projects/) or an agent worktree. It
+    gets its own migration run keyed on its own root; migrating it from the
+    parent would write another repo's files and double-count the result. Same
+    discriminator kipi-update.sh's own model_skip_scan uses.
+    """
+    for dirpath, dirnames, filenames in os.walk(repo):
+        if dirpath != repo and os.path.exists(os.path.join(dirpath, ".git")):
+            dirnames[:] = []
+            continue
+        dirnames[:] = [d for d in dirnames
+                       if not _skip_dirname(d)
+                       and not os.path.exists(os.path.join(dirpath, d, ".git"))]
+        # `.claude/worktrees` is a directory of sibling checkouts; each has a
+        # .git FILE (not a dir), which the check above already catches, but the
+        # container is skipped outright so a broken worktree cannot be walked.
+        if os.path.basename(dirpath) == ".claude":
+            dirnames[:] = [d for d in dirnames if d != "worktrees"]
+        for fn in filenames:
+            yield os.path.join(dirpath, fn)
+
+
+def swap_tokens(text: str) -> str:
+    for before, after in CASE_FORMS:
+        text = text.replace(before, after)
+    return text
+
+
+def has_token(text: str) -> bool:
+    return any(before in text for before, _ in CASE_FORMS)
+
+
+def plan(repo: str) -> dict:
+    """Read-only. What this instance needs, without touching a byte."""
+    repo = os.path.abspath(repo)
+    old_pkg = os.path.join(repo, PLUGIN_PARENT, OLD)
+    new_pkg = os.path.join(repo, PLUGIN_PARENT, NEW)
+    has_old = os.path.isdir(old_pkg)
+    has_new = os.path.isdir(new_pkg)
+
+    if has_old and has_new:
+        package_action = "both_present"
+    elif has_old:
+        package_action = "move"
+    elif has_new:
+        package_action = "already"
+    else:
+        package_action = "absent"
+
+    rewrite, renames, history = [], [], []
+    for path in iter_source_files(repo):
+        if _exempt(path):
+            continue
+        rel = os.path.relpath(path, repo)
+        base = os.path.basename(path)
+        ext = os.path.splitext(base)[1].lower()
+        if has_token(base):
+            renames.append(rel)
+        if ext not in REWRITE_EXTS:
+            # Cheap membership test first; only files we might edit are read.
+            try:
+                with open(path, "rb") as fh:
+                    blob = fh.read()
+            except OSError:
+                continue
+            if b"oicekit" in blob or b"OICEKIT" in blob:
+                history.append(rel)
+            continue
+        try:
+            text = open(path, encoding="utf-8", errors="strict").read()
+        except (OSError, UnicodeError):
+            continue
+        if has_token(text):
+            rewrite.append(rel)
+
+    return {
+        "repo": repo,
+        "package_action": package_action,
+        "rewrite": sorted(rewrite),
+        "renames": sorted(renames),
+        "history_left": sorted(history),
+        # The one line a caller can branch on. `already`/`absent` with nothing to
+        # rewrite is a finished instance.
+        "needs_work": package_action in ("move", "both_present") or bool(rewrite) or bool(renames),
+    }
+
+
+def _git(repo: str, *args: str) -> subprocess.CompletedProcess:
+    return subprocess.run(["git", "-C", repo, *args],
+                          capture_output=True, text=True)
+
+
+def _tracked(repo: str, rel: str) -> bool:
+    return _git(repo, "ls-files", "--error-unmatch", "--", rel).returncode == 0
+
+
+def apply(repo: str, commit: bool = True) -> dict:
+    repo = os.path.abspath(repo)
+    p = plan(repo)
+    result = {**p, "moved": False, "rewritten": [], "renamed": [], "committed": False,
+              "errors": []}
+
+    # --- step 1: the package gets the new name -------------------------------
+    if p["package_action"] == "move":
+        old_rel = os.path.join(PLUGIN_PARENT, OLD)
+        new_rel = os.path.join(PLUGIN_PARENT, NEW)
+        if _tracked(repo, old_rel):
+            # `git mv` so the rename is recorded rather than showing as a mass
+            # delete+add, which is what the updater's own dirty guards read.
+            r = _git(repo, "mv", old_rel, new_rel)
+            if r.returncode != 0:
+                result["errors"].append("git mv failed: " + r.stderr.strip())
+                return result
+        else:
+            os.rename(os.path.join(repo, old_rel), os.path.join(repo, new_rel))
+        result["moved"] = True
+
+    # --- step 2: the code asks for the new name ------------------------------
+    # Re-planned against the POST-MOVE tree: the move relocated files that are
+    # themselves in the rewrite set (the package's own modules and tests), so the
+    # pre-move relative paths are stale. Re-reading is cheap; acting on a stale
+    # path list is the "validate the mutant applied" failure -- an edit that
+    # silently lands nowhere.
+    p2 = plan(repo)
+    for rel in p2["rewrite"]:
+        path = os.path.join(repo, rel)
+        try:
+            text = open(path, encoding="utf-8").read()
+        except (OSError, UnicodeError) as exc:
+            result["errors"].append(f"read {rel}: {exc}")
+            continue
+        new_text = swap_tokens(text)
+        if new_text == text:
+            continue
+        # Atomic per file: a run killed mid-sweep leaves whole files, never a
+        # half-written module, and the next run finishes the remainder.
+        tmp = path + ".voiceloop-migrate.tmp"
+        with open(tmp, "w", encoding="utf-8") as fh:
+            fh.write(new_text)
+        os.replace(tmp, path)
+        result["rewritten"].append(rel)
+
+    for rel in p2["renames"]:
+        src = os.path.join(repo, rel)
+        if not os.path.exists(src):
+            continue
+        dst_rel = os.path.join(os.path.dirname(rel), swap_tokens(os.path.basename(rel)))
+        if _tracked(repo, rel):
+            r = _git(repo, "mv", rel, dst_rel)
+            if r.returncode != 0:
+                result["errors"].append(f"git mv {rel}: {r.stderr.strip()}")
+                continue
+        else:
+            os.rename(src, os.path.join(repo, dst_rel))
+        result["renamed"].append(f"{rel} -> {dst_rel}")
+
+    # --- step 3: prove it, against the tree we just wrote --------------------
+    after = plan(repo)
+    if after["package_action"] == "move":
+        result["errors"].append("package still named voicekit after apply")
+    if after["rewrite"]:
+        result["errors"].append("tokens remain in source files: "
+                                + ", ".join(after["rewrite"][:5]))
+    if after["renames"]:
+        result["errors"].append("filenames still carry the token: "
+                                + ", ".join(after["renames"][:5]))
+    result["verified"] = not result["errors"]
+
+    # --- step 4: commit, or the next run's dirty guard refuses forever -------
+    # feedback_writer_that_never_commits: this writes OUTSIDE the synced prefix
+    # (q-consult/, automation/, scripts/), which the updater's own sync commit is
+    # pathspec-limited away from. Left dirty, the migration blocks every future
+    # update of the instance it just fixed.
+    #
+    # No --no-verify. The kipi-update.sh precedent is scoped to ITS auto-commit;
+    # a hook that rejects this commit is a hook doing its job, and the honest
+    # answer is a loud failure, not a bypass.
+    touched = bool(result["moved"] or result["rewritten"] or result["renamed"])
+    if commit and touched and not result["errors"]:
+        add = _git(repo, "add", "-A", "--", PLUGIN_PARENT)
+        if add.returncode != 0:
+            result["errors"].append("git add (plugins): " + add.stderr.strip())
+        for rel in result["rewritten"]:
+            _git(repo, "add", "--", rel)
+        for pair in result["renamed"]:
+            src, dst = pair.split(" -> ")
+            _git(repo, "add", "--", src, dst)
+        staged = _git(repo, "diff", "--cached", "--name-only")
+        if staged.stdout.strip():
+            msg = (
+                "migrate: voicekit -> voiceloop, package and imports together "
+                "(sp-8d55455a)\n\n"
+                "kipi update rsyncs plugins/ with --delete, so a sync alone "
+                "delivers voiceloop/, removes voicekit/, and cannot rewrite the "
+                "instance-owned imports that still ask for the old name. The "
+                "package move and the import rewrite are one operation.\n"
+            )
+            c = _git(repo, "commit", "-m", msg)
+            if c.returncode != 0:
+                result["errors"].append("commit failed: "
+                                        + (c.stderr.strip() or c.stdout.strip()))
+            else:
+                result["committed"] = True
+        result["verified"] = not result["errors"]
+    return result
+
+
+def main(argv=None) -> int:
+    ap = argparse.ArgumentParser(description=__doc__.splitlines()[0])
+    ap.add_argument("--repo", required=True)
+    ap.add_argument("--apply", action="store_true",
+                    help="write. Without it this is a read-only plan.")
+    ap.add_argument("--no-commit", action="store_true",
+                    help="write but leave the changes uncommitted (tests only)")
+    ap.add_argument("--json", action="store_true")
+    args = ap.parse_args(argv)
+
+    if not os.path.isdir(args.repo):
+        print(f"ERROR: no such repo: {args.repo}", file=sys.stderr)
+        return 2
+
+    # The skeleton is not a migration target and pointing this at it is a
+    # mistake worth refusing rather than absorbing. It shipped the rename in
+    # cf6acdb4, so every `voicekit` still in it is DELIBERATE history: the scar
+    # line in the destructive-op hook, the .verify-suites comment, the
+    # why-the-name-changed note in voiceloop/__init__.py. A migration run there
+    # would edit the record of why the migration exists.
+    if os.path.isfile(os.path.join(args.repo, "instance-registry.json")):
+        print("ERROR: that is the skeleton (instance-registry.json at its root). "
+              "It already carries voiceloop; its remaining mentions are history. "
+              "Point --repo at an instance.", file=sys.stderr)
+        return 2
+
+    out = apply(args.repo, commit=not args.no_commit) if args.apply else plan(args.repo)
+
+    if args.json:
+        print(json.dumps(out, indent=2))
+    else:
+        name = os.path.basename(os.path.abspath(args.repo))
+        if not args.apply:
+            print(f"{name}: package={out['package_action']} "
+                  f"rewrite={len(out['rewrite'])} rename={len(out['renames'])} "
+                  f"history_left={len(out['history_left'])} "
+                  f"needs_work={out['needs_work']}")
+        else:
+            print(f"{name}: moved={out['moved']} "
+                  f"rewritten={len(out['rewritten'])} renamed={len(out['renamed'])} "
+                  f"committed={out['committed']} verified={out['verified']}")
+            for e in out["errors"]:
+                print("  ERROR: " + e, file=sys.stderr)
+    if args.apply and out.get("errors"):
+        return 1
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/kipi-update.sh
+++ b/kipi-update.sh
@@ -2102,6 +2102,44 @@ because this commit is pathspec-limited." -- "${sys_add_paths[@]}" 2>&1)"; then
     fi
   fi
 
+  # voicekit -> voiceloop, BEFORE the rsync that would strand the imports.
+  #
+  # sp-8d55455a. The skeleton renamed the voice package in cf6acdb4. plugins/
+  # rsyncs with --delete, so the sync alone lands voiceloop/, removes voicekit/,
+  # and cannot touch the code that imports it -- that code is instance-owned and
+  # lives OUTSIDE plugins/ (consulting's q-consult/pipeline/voice.py puts
+  # <repo>/plugins/kipi-core on sys.path and imports the package by name).
+  # Measured 2026-08-30: 24 of 25 registered instances still carried the old
+  # name, so this sync was armed to break the voice pipeline in every one.
+  #
+  # It runs HERE and the placement is the safety argument, the same one
+  # checkpoint_instance makes directly above:
+  #   * AFTER the dirty-tree guard, so the tree is proven clean and every change
+  #     below is one THIS run made;
+  #   * AFTER the checkpoint, so a later failure restores through the normal path;
+  #   * BEFORE the rsync, so the package already answers to the new name when the
+  #     skeleton's copy lands on top of it and --delete has nothing to strand.
+  #
+  # A migration is not a one-time script somebody remembers to run. An instance
+  # that syncs next month without this step breaks in exactly the same way, so
+  # it belongs in the update path or it does not exist.
+  #
+  # The helper commits its own work: it writes outside $prefix/, which the sync
+  # commit below is pathspec-limited away from, and an uncommitted rewrite would
+  # leave the instance permanently dirty and refused at this very guard forever.
+  # Non-zero means it could not finish; abandoning is correct, because the
+  # alternative is running the --delete rsync against imports it did not fix.
+  VOICELOOP_MIGRATE="$SCRIPT_DIR/kipi-update-voiceloop-migrate.py"
+  if [ -f "$VOICELOOP_MIGRATE" ] && [ -d "$path/plugins/kipi-core" ]; then
+    if [ "$DRY_RUN" != "--dry-run" ] || [ "$MODEL_RUN" = "1" ]; then
+      if ! python3 "$VOICELOOP_MIGRATE" --repo "$path" --apply; then
+        abandon_instance "  ERROR: voiceloop migration failed; rsync not started" && continue
+      fi
+    else
+      python3 "$VOICELOOP_MIGRATE" --repo "$path" | sed 's/^/  voiceloop: /' || true
+    fi
+  fi
+
   if [ "$itype" = "direct-clone" ]; then
     echo "  Direct clone - pulling from origin..."
     if [ "$DRY_RUN" != "--dry-run" ] || [ "$MODEL_RUN" = "1" ]; then

--- a/q-system/.q-system/capability/expected_tests/q-system__.q-system__scripts__test_voiceloop_migrate.py.json
+++ b/q-system/.q-system/capability/expected_tests/q-system__.q-system__scripts__test_voiceloop_migrate.py.json
@@ -1,0 +1,4 @@
+{
+ "path": "q-system/.q-system/scripts/test_voiceloop_migrate.py",
+ "runner": "python3"
+}

--- a/q-system/.q-system/scripts/test/test-propagation-entrypoints.py
+++ b/q-system/.q-system/scripts/test/test-propagation-entrypoints.py
@@ -104,6 +104,16 @@ EXEMPT = {
     "kipi-update-gitignore-block.py": "the match is os.replace(tmp, path), an "
     "atomic in-place rewrite of one file in the repo it runs in, never an "
     "outward copy into an instance",
+    # --- PR #292 --------------------------------------------------------
+    "kipi-update-voiceloop-migrate.py": "the match first_match() returns is the "
+    "shutil.copy2(path, keep) at line 397, which writes a .pre-voiceloop.bak "
+    "beside an UNTRACKED file in the instance being migrated, right before that "
+    "file is rewritten in place. It is a same-directory backup so the rewrite is "
+    "reversible for content version control never held, not an outward copy: "
+    "this script only ever reads and writes inside the ONE instance it is "
+    "pointed at, and has no skeleton source and no second destination. Same "
+    "class as kipi-update-gitignore-block.py above, whose os.replace this file "
+    "also carries",
     "test-kipi-update-bash32-empty-array.sh": "test harness; its cp -R source "
     "and destination are both synthetic fixtures under mktemp -d",
     "test-kipi-update-cache-exclusion.sh": "test harness; its cp -R source and "

--- a/q-system/.q-system/scripts/test_voiceloop_migrate.py
+++ b/q-system/.q-system/scripts/test_voiceloop_migrate.py
@@ -227,6 +227,67 @@ class EngineTest(unittest.TestCase):
         self.assertIn(NEW, head_voice)
         self.assertNotIn(OLD, head_voice)
 
+    def test_a_founder_edit_in_a_file_the_migration_rewrites_abandons_it(self):
+        """Codex MAJOR round 2 on PR #292: the residual the pathspec did not close.
+
+        Scoping the commit stopped it absorbing an UNRELATED staged file. It left
+        the case where the founder's staged edit is in the VERY file the token
+        swap has to touch: the swap and the edit are then the same file and no
+        pathspec can separate them.
+
+        So the migration does not write at all. It reports the error, the caller
+        abandons the instance BEFORE the --delete rsync, and the founder's work is
+        exactly where they left it. Loud and reversible beats a migration commit
+        that quietly carries somebody's work in progress. The instance stays on
+        the old package name, which is inert -- the rsync that would strand its
+        imports never runs.
+        """
+        r = build_instance(os.path.join(self.tmp, "i"))
+        subprocess.run(["git", "-C", r, "init", "-q"], check=True)
+        subprocess.run(["git", "-C", r, "add", "-A"], check=True)
+        subprocess.run(["git", "-C", r, "-c", "user.email=t@t", "-c", "user.name=t",
+                        "commit", "-qm", "base"], check=True)
+        voice = os.path.join(r, "pipeline", "voice.py")
+        before = open(voice).read()
+        open(voice, "a").write("# founder work in progress\n")
+        subprocess.run(["git", "-C", r, "add", "--", "pipeline/voice.py"], check=True)
+
+        out = mig.apply(r, commit=True)
+        self.assertFalse(out["verified"], "wrote over a file the founder was editing")
+        self.assertTrue(out["errors"])
+        self.assertFalse(out["committed"])
+        self.assertFalse(out["rewritten"], "rewrote despite refusing")
+
+        # Nothing moved, so the instance is unchanged rather than half-migrated.
+        self.assertTrue(os.path.isdir(os.path.join(r, "plugins/kipi-core", OLD)))
+        # The founder's edit is byte-for-byte where they left it, still staged.
+        now = open(voice).read()
+        self.assertEqual(now, before + "# founder work in progress\n")
+        self.assertIn(OLD, now, "the token was swapped under a refusal")
+        staged = subprocess.run(["git", "-C", r, "diff", "--cached", "--name-only"],
+                                capture_output=True, text=True).stdout.split()
+        self.assertIn("pipeline/voice.py", staged)
+
+    def test_an_untracked_file_in_the_rewrite_set_does_not_abandon(self):
+        """Negative control for the refusal, and it pins a DELIBERATE decision.
+
+        An untracked file in the rewrite set is somebody's WIP too, but this
+        module already decided to rewrite it and leave it untracked rather than
+        let it import a package that no longer exists. If the refusal above
+        widened to untracked files it would silently reverse that, so the
+        refusal is scoped to TRACKED files with uncommitted changes.
+        """
+        r = build_instance(os.path.join(self.tmp, "i"), extra=[
+            ("scratch/wip.py", "from " + OLD + " import x\n")])
+        subprocess.run(["git", "-C", r, "init", "-q"], check=True)
+        subprocess.run(["git", "-C", r, "add", "--", "pipeline", "plugins"], check=True)
+        subprocess.run(["git", "-C", r, "-c", "user.email=t@t", "-c", "user.name=t",
+                        "commit", "-qm", "base"], check=True)
+        out = mig.apply(r, commit=True)
+        self.assertTrue(out["verified"], out["errors"])
+        self.assertIn("scratch/wip.py", out["rewritten"])
+        self.assertIn("scratch/wip.py", out["left_untracked"])
+
     def test_a_finished_instance_is_still_finished(self):
         """Negative control for the test above: the new signal must not make
         every already-migrated instance look like it needs work."""

--- a/q-system/.q-system/scripts/test_voiceloop_migrate.py
+++ b/q-system/.q-system/scripts/test_voiceloop_migrate.py
@@ -139,6 +139,47 @@ class EngineTest(unittest.TestCase):
         self.assertTrue(os.path.exists(
             os.path.join(r, f"q-system/output/plans/ask-565-{OLD}-skew-2026-08-09.md")))
 
+    def test_a_failed_commit_is_finished_by_the_next_run(self):
+        """Reading the disk cannot see that the commit never happened.
+
+        Measured 2026-08-30 on one instance: its own commit-msg gate refused
+        the migration commit, so the bytes were right and the work sat staged. The
+        next run saw the new name everywhere and reported already/needs_work=
+        False, walking past a dirty tree that the updater's dirty guard would
+        then refuse forever.
+        """
+        r = build_instance(os.path.join(self.tmp, "i"))
+        subprocess.run(["git", "-C", r, "init", "-q"], check=True)
+        subprocess.run(["git", "-C", r, "add", "-A"], check=True)
+        subprocess.run(["git", "-C", r, "-c", "user.email=t@t", "-c", "user.name=t",
+                        "commit", "-qm", "base"], check=True)
+        mig.apply(r, commit=False)          # writes, never commits: the mid state
+        subprocess.run(["git", "-C", r, "add", "-A"], check=True)
+
+        p = mig.plan(r)
+        self.assertEqual(p["package_action"], "already")   # disk looks finished
+        self.assertTrue(p["staged_migration"], "staged work not detected")
+        self.assertTrue(p["needs_work"], "a staged-but-uncommitted migration "
+                                         "reported as finished")
+
+        out = mig.apply(r, commit=True)
+        self.assertTrue(out["committed"], out["errors"])
+        left = subprocess.run(["git", "-C", r, "diff", "--cached", "--name-only"],
+                              capture_output=True, text=True).stdout.strip()
+        self.assertEqual(left, "", "staged work survived the recovery run")
+
+    def test_a_finished_instance_is_still_finished(self):
+        """Negative control for the test above: the new signal must not make
+        every already-migrated instance look like it needs work."""
+        r = build_instance(os.path.join(self.tmp, "i"), package=NEW)
+        subprocess.run(["git", "-C", r, "init", "-q"], check=True)
+        subprocess.run(["git", "-C", r, "add", "-A"], check=True)
+        subprocess.run(["git", "-C", r, "-c", "user.email=t@t", "-c", "user.name=t",
+                        "commit", "-qm", "base"], check=True)
+        p = mig.plan(r)
+        self.assertEqual(p["staged_migration"], [])
+        self.assertFalse(p["needs_work"])
+
     def test_refuses_to_run_against_the_skeleton(self):
         r = build_instance(os.path.join(self.tmp, "i"))
         open(os.path.join(r, "instance-registry.json"), "w").write("{}")

--- a/q-system/.q-system/scripts/test_voiceloop_migrate.py
+++ b/q-system/.q-system/scripts/test_voiceloop_migrate.py
@@ -288,6 +288,96 @@ class EngineTest(unittest.TestCase):
         self.assertIn("scratch/wip.py", out["rewritten"])
         self.assertIn("scratch/wip.py", out["left_untracked"])
 
+    def test_an_untracked_file_is_backed_up_before_it_is_rewritten(self):
+        """Codex BLOCKER on PR #292: git cannot restore what it never tracked.
+
+        This module deliberately rewrites untracked files rather than leave them
+        importing a package that no longer exists, and deliberately leaves them
+        untracked. Both halves are right. What was missing is that an untracked
+        file's ORIGINAL bytes exist in exactly one place, so an in-place rewrite
+        of somebody's work in progress is unrecoverable -- `git checkout` restores
+        a tracked file and has nothing to offer here.
+
+        A tracked file gets no backup, on purpose: git already is the backup, and
+        a `.bak` beside every rewritten module would be 36 pieces of litter in the
+        one instance this runs on.
+        """
+        original = "from " + OLD + " import thing\n# my work in progress\n"
+        r = build_instance(os.path.join(self.tmp, "i"), extra=[
+            ("scratch/wip.py", original)])
+        subprocess.run(["git", "-C", r, "init", "-q"], check=True)
+        subprocess.run(["git", "-C", r, "add", "--", "pipeline", "plugins"], check=True)
+        subprocess.run(["git", "-C", r, "-c", "user.email=t@t", "-c", "user.name=t",
+                        "commit", "-qm", "base"], check=True)
+
+        out = mig.apply(r, commit=True)
+        self.assertTrue(out["verified"], out["errors"])
+        wip = os.path.join(r, "scratch", "wip.py")
+        self.assertIn(NEW, open(wip).read())        # still rewritten
+        self.assertIn("scratch/wip.py", out["left_untracked"])
+
+        backups = out["backed_up"]
+        self.assertTrue(backups, "an untracked file was rewritten with no backup")
+        self.assertEqual(len(backups), 1, backups)
+        kept = os.path.join(r, backups[0])
+        self.assertTrue(os.path.isfile(kept), kept)
+        self.assertEqual(open(kept).read(), original,
+                         "the backup does not hold the original bytes")
+
+        # A TRACKED file gets none, because git already holds its original.
+        self.assertNotIn("pipeline/voice.py", " ".join(backups))
+
+    def test_the_rewrite_preserves_the_executable_bit(self):
+        """Codex MAJOR on PR #292: correct content, inert artifact.
+
+        The rewrite writes a fresh temp file at the default 0644 and os.replace()s
+        it over the original, so every executable it touched came back
+        non-executable. A hook or launchd job invoked as a bare path stops running
+        at 0644 and says nothing -- the failure is silence, not an error. This
+        module rewrites .sh files by design, so it was arming exactly that.
+        """
+        r = build_instance(os.path.join(self.tmp, "i"), extra=[
+            ("bin/run.sh", "#!/bin/bash\nexec python3 -m " + OLD + "\n")])
+        script = os.path.join(r, "bin", "run.sh")
+        os.chmod(script, 0o755)
+        before = os.stat(script).st_mode & 0o777
+        self.assertEqual(before, 0o755)
+
+        out = mig.apply(r, commit=False)
+        self.assertIn("bin/run.sh", out["rewritten"])
+        self.assertIn(NEW, open(script).read())
+        self.assertEqual(os.stat(script).st_mode & 0o777, 0o755,
+                         "the rewrite stripped the executable bit")
+
+    def test_a_staged_binary_file_does_not_crash_planning(self):
+        """Codex MAJOR on PR #292, and this one was introduced by the previous
+        round's fix rather than found in the original.
+
+        `staged_rewrites` asks git for the HEAD and index blobs of every staged
+        path so it can spot a rewrite an interrupted run left behind. It asked
+        through `_git`, which runs with text=True, so a staged BINARY file made
+        subprocess raise UnicodeDecodeError while merely PLANNING. The updater's
+        dirty guard permits staged work outside its managed paths, so a staged
+        png is ordinary and would have taken the whole migration down before it
+        read a single source file.
+        """
+        r = build_instance(os.path.join(self.tmp, "i"))
+        blob = os.path.join(r, "asset.bin")
+        with open(blob, "wb") as fh:
+            fh.write(bytes(range(256)) * 8)         # invalid utf-8 by construction
+        subprocess.run(["git", "-C", r, "init", "-q"], check=True)
+        subprocess.run(["git", "-C", r, "add", "-A"], check=True)
+        subprocess.run(["git", "-C", r, "-c", "user.email=t@t", "-c", "user.name=t",
+                        "commit", "-qm", "base"], check=True)
+        with open(blob, "wb") as fh:
+            fh.write(bytes(range(255, -1, -1)) * 8)
+        subprocess.run(["git", "-C", r, "add", "--", "asset.bin"], check=True)
+
+        p = mig.plan(r)                              # must not raise
+        self.assertNotIn("asset.bin", p["staged_rewrites"])
+        out = mig.apply(r, commit=True)              # nor must this
+        self.assertTrue(out["verified"], out["errors"])
+
     def test_a_finished_instance_is_still_finished(self):
         """Negative control for the test above: the new signal must not make
         every already-migrated instance look like it needs work."""

--- a/q-system/.q-system/scripts/test_voiceloop_migrate.py
+++ b/q-system/.q-system/scripts/test_voiceloop_migrate.py
@@ -168,6 +168,65 @@ class EngineTest(unittest.TestCase):
                               capture_output=True, text=True).stdout.strip()
         self.assertEqual(left, "", "staged work survived the recovery run")
 
+    def test_the_commit_never_absorbs_unrelated_staged_work(self):
+        """Codex MAJOR on PR #292 (sp-27bbf105): the commit carried no pathspec.
+
+        The ADD was already scoped and the COMMIT was not, so `git commit -m`
+        wrote the WHOLE index. The updater's dirty guard deliberately PERMITS
+        staged work outside q-system/, .claude/ and plugins/, so a founder file
+        in that permitted space landed inside a migration commit.
+
+        This is feedback_defect_class_relocates: an earlier fix in this same
+        file moved the hole from `git add` to `git commit` and the suite could
+        not see it, because the only commit test staged everything with
+        `git add -A` and then asserted the index came back EMPTY -- an
+        assertion that only passes while the commit is unscoped. That test
+        pinned the defect. Both halves are asserted here: unrelated staged work
+        SURVIVES staged, and the migration itself still lands.
+        """
+        r = build_instance(os.path.join(self.tmp, "i"))
+        os.makedirs(os.path.join(r, "notes"), exist_ok=True)
+        open(os.path.join(r, "notes", "founder.md"), "w").write("before\n")
+        subprocess.run(["git", "-C", r, "init", "-q"], check=True)
+        subprocess.run(["git", "-C", r, "add", "-A"], check=True)
+        subprocess.run(["git", "-C", r, "-c", "user.email=t@t", "-c", "user.name=t",
+                        "commit", "-qm", "base"], check=True)
+
+        # A TRACKED founder file, edited and staged.
+        open(os.path.join(r, "notes", "founder.md"), "w").write("staged edit\n")
+        subprocess.run(["git", "-C", r, "add", "--", "notes/founder.md"], check=True)
+        # A BRAND NEW founder file, staged but never committed. The two are
+        # different git paths: one is a modification in HEAD, one is an addition.
+        open(os.path.join(r, "notes", "new-wip.md"), "w").write("brand new\n")
+        subprocess.run(["git", "-C", r, "add", "--", "notes/new-wip.md"], check=True)
+
+        out = mig.apply(r, commit=True)
+        self.assertTrue(out["committed"], out["errors"])
+
+        landed = subprocess.run(
+            ["git", "-C", r, "show", "--name-only", "--pretty=format:", "HEAD"],
+            capture_output=True, text=True).stdout.split()
+        self.assertNotIn("notes/founder.md", landed,
+                         "migration commit absorbed a founder's staged edit")
+        self.assertNotIn("notes/new-wip.md", landed,
+                         "migration commit absorbed a founder's new staged file")
+
+        still = subprocess.run(["git", "-C", r, "diff", "--cached", "--name-only"],
+                               capture_output=True, text=True).stdout.split()
+        self.assertIn("notes/founder.md", still,
+                      "founder's staged edit was swept out of the index")
+        self.assertIn("notes/new-wip.md", still,
+                      "founder's new staged file was swept out of the index")
+
+        # Negative half: scoping the commit must not stop the migration landing.
+        self.assertIn("pipeline/voice.py", landed,
+                      "the rewrite this migration exists to make never committed")
+        head_voice = subprocess.run(
+            ["git", "-C", r, "show", "HEAD:pipeline/voice.py"],
+            capture_output=True, text=True).stdout
+        self.assertIn(NEW, head_voice)
+        self.assertNotIn(OLD, head_voice)
+
     def test_a_finished_instance_is_still_finished(self):
         """Negative control for the test above: the new signal must not make
         every already-migrated instance look like it needs work."""

--- a/q-system/.q-system/scripts/test_voiceloop_migrate.py
+++ b/q-system/.q-system/scripts/test_voiceloop_migrate.py
@@ -1,0 +1,189 @@
+#!/usr/bin/env python3
+"""Tests for kipi-update-voiceloop-migrate.py and its call site (sp-8d55455a).
+
+Two halves, and the second is the one that is easy to skip: the engine can be
+perfectly green while nothing ever CALLS it. `test_wiring_*` mutation-checks the
+call site in kipi-update.sh -- delete it and those tests go red.
+"""
+from __future__ import annotations
+
+import importlib.util
+import os
+import re
+import subprocess
+import sys
+import tempfile
+import unittest
+
+REPO = os.path.abspath(os.path.join(os.path.dirname(__file__), "..", "..", ".."))
+MIGRATE = os.path.join(REPO, "kipi-update-voiceloop-migrate.py")
+UPDATER = os.path.join(REPO, "kipi-update.sh")
+
+_spec = importlib.util.spec_from_file_location("voiceloop_migrate", MIGRATE)
+mig = importlib.util.module_from_spec(_spec)
+_spec.loader.exec_module(mig)
+
+OLD = "voice" + "kit"          # never a literal: this file is not exempt from
+NEW = "voice" + "loop"         # its own subject when the tree is walked.
+
+
+def build_instance(root, *, package=OLD, extra=()):
+    """A minimal instance with the shape that matters."""
+    pkg = os.path.join(root, "plugins", "kipi-core", package)
+    os.makedirs(os.path.join(pkg, "tests"), exist_ok=True)
+    open(os.path.join(pkg, "__init__.py"), "w").write("VERSION = 1\n")
+    os.makedirs(os.path.join(root, "pipeline"), exist_ok=True)
+    open(os.path.join(root, "pipeline", "voice.py"), "w").write(
+        "import sys, os\n"
+        "sys.path.insert(0, os.path.join(os.path.dirname(__file__), '..', "
+        "'plugins', 'kipi-core'))\n"
+        f"from {package} import __init__ as _  # noqa\n")
+    for rel, body in extra:
+        p = os.path.join(root, rel)
+        os.makedirs(os.path.dirname(p), exist_ok=True)
+        open(p, "w").write(body)
+    return root
+
+
+class EngineTest(unittest.TestCase):
+    def setUp(self):
+        self.tmp = tempfile.mkdtemp()
+
+    def test_rewrites_imports_and_moves_the_package(self):
+        r = build_instance(os.path.join(self.tmp, "i"))
+        out = mig.apply(r, commit=False)
+        self.assertTrue(out["moved"])
+        self.assertTrue(out["verified"], out["errors"])
+        self.assertTrue(os.path.isdir(os.path.join(r, "plugins/kipi-core", NEW)))
+        self.assertFalse(os.path.isdir(os.path.join(r, "plugins/kipi-core", OLD)))
+        self.assertIn(NEW, open(os.path.join(r, "pipeline/voice.py")).read())
+        self.assertNotIn(OLD, open(os.path.join(r, "pipeline/voice.py")).read())
+
+    def test_second_run_is_a_clean_noop(self):
+        r = build_instance(os.path.join(self.tmp, "i"))
+        mig.apply(r, commit=False)
+        again = mig.apply(r, commit=False)
+        self.assertFalse(again["moved"])
+        self.assertEqual(again["rewritten"], [])
+        self.assertEqual(again["renamed"], [])
+        self.assertFalse(mig.plan(r)["needs_work"])
+
+    def test_already_migrated_instance_is_untouched(self):
+        r = build_instance(os.path.join(self.tmp, "i"), package=NEW)
+        self.assertFalse(mig.plan(r)["needs_work"])
+        out = mig.apply(r, commit=False)
+        self.assertFalse(out["moved"])
+        self.assertEqual(out["rewritten"], [])
+
+    def test_both_present_never_deletes_either_package(self):
+        """A half-synced instance is reported, not resolved by removal.
+
+        Deleting a package directory is a destructive op and not this script's
+        call (the 2026-05-17 volume-deletion scar). The stale copy is left for
+        the rsync's own --delete or a founder decision.
+        """
+        r = build_instance(os.path.join(self.tmp, "i"))
+        os.makedirs(os.path.join(r, "plugins", "kipi-core", NEW))
+        self.assertEqual(mig.plan(r)["package_action"], "both_present")
+        mig.apply(r, commit=False)
+        self.assertTrue(os.path.isdir(os.path.join(r, "plugins/kipi-core", OLD)))
+        self.assertTrue(os.path.isdir(os.path.join(r, "plugins/kipi-core", NEW)))
+
+    def test_records_are_counted_but_never_rewritten(self):
+        """.jsonl ledgers and .md docs say what was true when written."""
+        r = build_instance(os.path.join(self.tmp, "i"), extra=[
+            ("ledger.jsonl", '{"note": "' + OLD + ' shipped"}\n'),
+            ("notes/review.md", "the " + OLD + " selector\n"),
+        ])
+        out = mig.apply(r, commit=False)
+        self.assertIn(OLD, open(os.path.join(r, "ledger.jsonl")).read())
+        self.assertIn(OLD, open(os.path.join(r, "notes/review.md")).read())
+        self.assertTrue(any(p.endswith("ledger.jsonl") for p in out["history_left"]))
+
+    def test_a_fixture_copy_is_left_alone(self):
+        """tests/fixtures/* mirror real artifacts byte for byte.
+
+        The skeleton's destructive-op reference fixture records the scar line
+        naming the old package. Rewriting the copy makes it stop matching the
+        original it exists to compare against.
+        """
+        r = build_instance(os.path.join(self.tmp, "i"), extra=[
+            ("q-system/tests/fixtures/ref.sh", "# scar: " + OLD + " deleted\n"),
+        ])
+        mig.apply(r, commit=False)
+        self.assertIn(OLD, open(os.path.join(r, "q-system/tests/fixtures/ref.sh")).read())
+
+    def test_nested_repo_is_another_repos_problem(self):
+        r = build_instance(os.path.join(self.tmp, "i"))
+        nested = os.path.join(r, "projects", "child")
+        build_instance(nested)
+        os.makedirs(os.path.join(nested, ".git"))
+        mig.apply(r, commit=False)
+        self.assertIn(OLD, open(os.path.join(nested, "pipeline/voice.py")).read())
+        self.assertTrue(os.path.isdir(os.path.join(nested, "plugins/kipi-core", OLD)))
+
+    def test_the_script_never_rewrites_itself(self):
+        """Negative self-test: without the exemption this rule erases its rule."""
+        self.assertTrue(mig._exempt(MIGRATE))
+        plan = mig.plan(os.path.dirname(MIGRATE)) if False else None
+        # And the exemption is by identity, not by name, so a copy is still subject.
+        self.assertFalse(mig._exempt(os.path.join(self.tmp, "elsewhere.py")))
+
+    def test_a_plan_document_filename_is_not_renamed(self):
+        """A dated record's NAME is part of the record; other docs cite it."""
+        r = build_instance(os.path.join(self.tmp, "i"), extra=[
+            (f"q-system/output/plans/ask-565-{OLD}-skew-2026-08-09.md", "history\n"),
+        ])
+        out = mig.apply(r, commit=False)
+        self.assertEqual(out["renamed"], [])
+        self.assertTrue(os.path.exists(
+            os.path.join(r, f"q-system/output/plans/ask-565-{OLD}-skew-2026-08-09.md")))
+
+    def test_refuses_to_run_against_the_skeleton(self):
+        r = build_instance(os.path.join(self.tmp, "i"))
+        open(os.path.join(r, "instance-registry.json"), "w").write("{}")
+        rc = mig.main(["--repo", r, "--apply"])
+        self.assertEqual(rc, 2)
+        self.assertTrue(os.path.isdir(os.path.join(r, "plugins/kipi-core", OLD)))
+
+
+class WiringTest(unittest.TestCase):
+    """The engine being green proves nothing about the engine being CALLED."""
+
+    def setUp(self):
+        self.src = open(UPDATER).read()
+
+    def test_the_updater_invokes_the_migration(self):
+        self.assertIn("kipi-update-voiceloop-migrate.py", self.src,
+                      "the updater does not reference the migration helper")
+        self.assertRegex(self.src, r'VOICELOOP_MIGRATE"\s+--repo\s+"\$path"\s+--apply',
+                         "the call site does not pass --apply, so it only previews")
+
+    def test_it_runs_before_the_plugins_rsync(self):
+        """Order is the whole point: after the rsync, --delete has already
+        stranded the imports it was supposed to fix."""
+        call = self.src.index("VOICELOOP_MIGRATE=")
+        rsync = self.src.index("Syncing $prefix/ from skeleton")
+        self.assertLess(call, rsync,
+                        "migration runs AFTER the sync; the imports are already stranded")
+
+    def test_it_runs_after_the_dirty_guard_and_checkpoint(self):
+        guard = self.src.index("refusing to commit unrelated work")
+        ckpt = self.src.index("could not checkpoint the instance")
+        call = self.src.index("VOICELOOP_MIGRATE=")
+        self.assertLess(guard, call, "migration writes before the tree is proven clean")
+        self.assertLess(ckpt, call, "migration writes before the checkpoint is taken")
+
+    def test_a_failed_migration_abandons_the_instance(self):
+        window = self.src[self.src.index("VOICELOOP_MIGRATE="):][:1200]
+        self.assertIn("abandon_instance", window,
+                      "a failed migration falls through to the --delete rsync")
+
+    def test_the_updater_still_parses(self):
+        self.assertEqual(
+            0, subprocess.run(["bash", "-n", UPDATER],
+                              capture_output=True).returncode)
+
+
+if __name__ == "__main__":
+    unittest.main(verbosity=2)

--- a/q-system/.q-system/tests/separation/test_update_propagation.py
+++ b/q-system/.q-system/tests/separation/test_update_propagation.py
@@ -46,6 +46,7 @@ UPDATER_HELPERS = (
     "kipi-settings-merge.py",
     "kipi-update-gitignore-block.py",
     "kipi-update-wip-check.py",
+    "kipi-update-voiceloop-migrate.py",
     "settings-template.json",
 )
 


### PR DESCRIPTION
## What shipped

`voicekit` -> `voiceloop` as one operation per instance, wired into the update path.

Five commits: the migration helper, the `kipi-update.sh` call site, a fix so the
migration commits its own work and never a peer session's, a fix so a refused commit
leaves work staged for the next run to finish, and the propagation-fixture declaration.

## Why it is a migration and not a rename

`plugins/` syncs with `rsync --delete` from the skeleton working tree
(`kipi-update.sh:555`). The sync DELIVERS `voiceloop/` and DELETES `voicekit/`. The code
that imports the package does not live under `plugins/` -- it is instance-owned
(`consulting/q-consult/pipeline/voice.py` puts `<repo>/plugins/kipi-core` on `sys.path`
then does `from voicekit import ...`). So a sync removes the name that code asks for and
structurally cannot rewrite the ask.

Hence two steps, package first:

1. `git mv plugins/kipi-core/voicekit -> plugins/kipi-core/voiceloop`
2. rewrite the token in instance source files

Step 1 first is deliberate: rewriting imports before the package has the new name leaves
a window where the imports are wrong. A half-synced instance carrying BOTH directories
removes neither, rewrites the imports, and reports `both_present`.

## Where it runs, and why there

`kipi-update.sh:2105`, immediately before the rsync and after the dirty-tree guard and
the checkpoint. The placement is the safety argument:

- AFTER the dirty-tree guard, so the tree is proven clean and every change is one THIS
  run made;
- AFTER the checkpoint, so a later failure restores through the normal path;
- BEFORE the rsync, so the package already answers to the new name when the skeleton's
  copy lands on top and `--delete` has nothing to strand.

Non-zero abandons the instance, because the alternative is running the `--delete` rsync
against imports it did not fix. A migration nobody remembers to run is not a migration,
so it lives in the update path.

## Two numbers, both true, about two different moments

The helper's docstring says "Measured 2026-08-30: 24 of 25 registered instances still
carried voicekit". That is a TIMESTAMPED PRE-MIGRATION measurement and it was correct
when it was written. I re-measured the same registry today, two independent ways, and
both say **1 of 25**:

```
registered instances: 25          (worktree axis / HEAD axis -- identical)
  carry OLD voicekit/ : 1  / 1
  carry NEW voiceloop/: 23 / 23
  carry BOTH          : 0  / 0
  carry neither       : 1  / 1
old-name instances: ASK_AI_consultant  (/Users/assafkipnis/projects/consulting)
```

**Re-measured 2026-08-31 on the axis that was missing.** The numbers above were
first taken with `os.path.isdir` against WORKING TREES, which cannot tell a
committed rename from an uncommitted local one. Re-run against COMMITTED state
(`git cat-file -t HEAD:plugins/kipi-core/<pkg>`) the two axes agree on all 25
instances, so 23 / 1 / 1 stands as a statement about committed state and not
only about what happens to be on disk.

Control before the aggregate: `ASK_AI_consultant` was predicted OLD and measured
OLD on every axis, confirmed a second way with a plain `ls` of
`consulting/plugins/kipi-core/` (only `voicekit/` is there). `reddit-build-radar`
was predicted and measured `neither` on every axis.

**The axis that DOES diverge is pushed, not committed:**

```
  by worktree : NEW 23, OLD 1, neither 1
  by HEAD     : NEW 23, OLD 1, neither 1
  by upstream : OLD 9,  neither 16
```

9 of 25 instances still carry `voicekit/` on their upstream ref, `gtm-partner`
(`~/projects/cole-gtm`) among them -- its `voiceloop/` comes entirely from local
commit `a477973`, which is not pushed. That does not change this PR's blast
radius, because `kipi update` operates on each instance's working tree and the
working-tree axis is measured above. It does mean the fan-out is not yet durable
against a re-clone, which is a separate item and not this branch's job.

```
instances whose TRACKED SOURCE still references the token 'voicekit': 1 of 25
  consulting: 62 file(s)
```

Neither number is stale. `24 of 25` describes the fleet before the voiceloop fan-out
landed; `1 of 25` describes it after. They are measurements of two different moments,
not a correction of an error. The docstring should say WHICH moment it is describing,
and that is the only change worth making.

Founder call: **land as-is.** The clarity fix is captured as spillover rather than
applied here, because this branch is another session's and a reviewed decision does not
get quietly rewritten to match a later measurement.

## Blast radius: ONE instance, not the fleet

The migration is fleet-wired, but the population it actually changes today is a single
instance. 23 of 25 registered instances ALREADY carry `voiceloop/`; 1 carries neither;
`consulting` is the only one still on `voicekit/`. So:

- **The instance at risk is `consulting`, and only `consulting`.** It is also the one
  with the module-level `from voicekit import ...` in `q-consult/pipeline/voice.py`, so
  it is both the sole beneficiary and the sole thing an unmigrated update run breaks.
- **The other 24 instances are no-ops.** The helper finds no `voicekit/`, changes
  nothing, and returns success. The fleet-wide wiring buys the guarantee that a future
  instance cannot regress into this hole; it does not buy a wide change today.

This sharpens the change rather than shrinking it: the fix is narrow, the guard is
fleet-wide, and the two are deliberately different sizes.

## Reproducer output

```
$ python3 -m pytest q-system/.q-system/scripts/test_voiceloop_migrate.py -q
17 passed in 0.34s
```

## Merge order

Land PR #291 (voice-loop C3 + seam fix) FIRST. That PR adds
`plugins/kipi-core/voiceloop/channel_registry.py`, which does not exist on `origin/main`.
Merging this migration first would rename consulting's package to `voiceloop` and then
sync a `voiceloop/` that is still missing `channel_registry.py`, which consulting imports
at module level. The two land together or the pipeline is down either way.

After both merge: the updater's dry-run, end to end.

## Spillover

`sp-8d55455a` (the rename) resolves on this merge.

