### PR TITLE
The morning board becomes a consulting board, mirroring the state card

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -18,7 +18,7 @@
 - All product/system changes use the PRD template at `q-system/marketing/templates/prd.md`
 
 ## Commands
-- `/q-morning` - The day brief: one Slack message with today's calendar, mail needing an answer, what is owed today, and which overnight jobs failed. Runs itself at 07:40 (`com.kipi.morning-brief`); the command just runs it early. A section that could not be read says COULD NOT READ, never "nothing". If no brief lands by 09:00 a separate job (`com.kipi.morning-brief-deadman`) says so. The 9-phase agent pipeline it replaced is RETIRED (decisions.md RULE-2026-08-30-A)
+- `/q-morning` - The day brief: one Slack message with today's calendar, the mail needing an answer, and his consulting board. What is owed today and which overnight jobs failed are still COLLECTED and no longer reach him: they are engineering signal and route to Sana's Linear triage (`founder-notifications.md`, 2026-08-10). Runs itself at 07:40 (`com.kipi.morning-brief`); the command just runs it early. A section that could not be read says COULD NOT READ, never "nothing". If no brief lands by 09:00 a separate job (`com.kipi.morning-brief-deadman`) says so. The 9-phase agent pipeline it replaced is RETIRED (decisions.md RULE-2026-08-30-A)
 - `/q-debrief` - Post-conversation extraction (highest priority)
 - `/q-calibrate` - Update canonical files
 - `/q-create` - Generate specific output (talk tracks, emails, slides, decks)

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -18,7 +18,7 @@
 - All product/system changes use the PRD template at `q-system/marketing/templates/prd.md`
 
 ## Commands
-- `/q-morning` - The day brief: one Slack message with today's calendar, mail needing an answer, what is owed today, and which overnight jobs failed. Runs itself at 07:00 (`com.kipi.morning-brief`); the command just runs it early. A section that could not be read says COULD NOT READ, never "nothing". If no brief lands by 09:00 a separate job (`com.kipi.morning-brief-deadman`) says so. The 9-phase agent pipeline it replaced is RETIRED (decisions.md RULE-2026-08-30-A)
+- `/q-morning` - The day brief: one Slack message with today's calendar, mail needing an answer, what is owed today, and which overnight jobs failed. Runs itself at 07:40 (`com.kipi.morning-brief`); the command just runs it early. A section that could not be read says COULD NOT READ, never "nothing". If no brief lands by 09:00 a separate job (`com.kipi.morning-brief-deadman`) says so. The 9-phase agent pipeline it replaced is RETIRED (decisions.md RULE-2026-08-30-A)
 - `/q-debrief` - Post-conversation extraction (highest priority)
 - `/q-calibrate` - Update canonical files
 - `/q-create` - Generate specific output (talk tracks, emails, slides, decks)

--- a/pytest.ini
+++ b/pytest.ini
@@ -1,4 +1,18 @@
 [pytest]
+# CODEX'S REVIEWS COULD NOT RUN THE TESTS. PR #296 round 4, 2026-09-03: the
+# reviewer's own `pytest -q ...` exited 1 in 243ms with a traceback ending in
+# `_pytest/capture.py:170 capman.start_global_capturing()`. Not one test ran, so
+# that review's findings came from READING the diff alone -- and nothing in the
+# output said so. A reviewer that silently loses its ability to execute is worse
+# than one that fails loudly: its verdict still arrives looking complete.
+#
+# `--capture=fd` (pytest's default) dups the real file descriptors 1 and 2. In a
+# sandboxed exec with no usable fds that dup raises before collection. `sys`
+# capture replaces sys.stdout/sys.stderr at the Python level instead and needs no
+# fd, so it cannot fail that way. Verified no test in this repo uses the `capfd`
+# fixture, which is the only thing that needs fd-level capture; `capsys` is
+# unaffected. Same failure family as the `stdin=DEVNULL` rule in morning-brief.py.
+addopts = --capture=sys
 # ASK-634. `q-system/.q-system/` is a HIDDEN directory, and pytest's DEFAULT
 # norecursedirs contains `.*`, so every directory-based invocation collected
 # ZERO tests from it. Measured 2026-08-10 before this file existed:

--- a/q-system/.q-system/scripts/board_rows.py
+++ b/q-system/.q-system/scripts/board_rows.py
@@ -287,12 +287,17 @@ def _live_bucket_of(page) -> str:
 WRITE_RESERVE_S = 2.0
 
 
+class _Unreadable:
+    """Sentinel for a property shape this module cannot flatten."""
+    __slots__ = ()
+
+
 def _prop_value(prop):
     """One Notion property flattened to something comparable. Unknown shapes -> None,
     which never compares equal, so an unrecognised property means "write it" rather
     than "assume it matches"."""
     if not isinstance(prop, dict):
-        return None
+        return _Unreadable()
     if "title" in prop or "rich_text" in prop:
         parts = prop.get("title") or prop.get("rich_text") or []
         out = []
@@ -306,7 +311,11 @@ def _prop_value(prop):
         return ((prop.get("select") or {}).get("name") or "") or None
     if "multi_select" in prop:
         return tuple(sorted((o.get("name") or "") for o in prop.get("multi_select") or []))
-    return None
+    # A DISTINCT OBJECT, never None (round 13, minor). The docstring below promised
+    # that an unreadable property compares unequal and fails toward writing, while
+    # None == None made two unreadable shapes compare EQUAL and skip the write, so a
+    # row kept stale text forever. A fresh object is equal to nothing but itself.
+    return _Unreadable()
 
 
 def _already_holds(page, props) -> bool:

--- a/q-system/.q-system/scripts/board_rows.py
+++ b/q-system/.q-system/scripts/board_rows.py
@@ -98,18 +98,38 @@ def _request(token, method, path, body=None, opener=None):
 def item_id(bucket_key: str, item: dict) -> str:
     """Stable across mornings for the same underlying thing.
 
-    Hashed from the TITLE only, never the detail: the commitment text he owes a given
-    client is stable, while its "(due ...)" suffix and reply counts change daily.
-    Hashing the detail too would make every morning a new row and the board would grow
-    by seven rows a day.
+    Hashed from `item["key"]`, which carries the client name or the GTM step id and
+    NOTHING that changes day to day. Not the detail (its "(due ...)" suffix and reply
+    counts move every morning) and, since a Codex finding on 2026-09-03, NOT the title
+    either: the title embeds the health dot, so a client going red to green minted a new
+    id, and the next unattended paint archived the row he had DRAGGED and created a
+    replacement in a computed bucket. That silently reversed his move, which is the one
+    thing this module promises never to do.
+
+    Also NOT the bucket_key, for the same reason: a row moving from Top of Mind to This
+    Week as its health improves is the same row.
+
+    An item with no `key` is REFUSED rather than falling back to the title. A fallback
+    here is how the defect comes back: it would work, quietly, with an unstable id.
     """
-    key = f"{bucket_key}|{item.get('title', '')}".encode("utf-8")
-    return OWNED_PREFIX + hashlib.sha1(key).hexdigest()[:16]
+    key = item.get("key")
+    if not key:
+        raise ValueError(
+            f"item {item.get('title')!r} carries no stable `key`. Every producer must "
+            "supply one; falling back to the title is what made ids move with the "
+            "health dot (Codex finding 2026-09-03)."
+        )
+    return OWNED_PREFIX + hashlib.sha1(str(key).encode("utf-8")).hexdigest()[:16]
 
 
-def existing_rows(token, db, opener=None) -> dict:
-    """{item_id: page} for the rows this module owns. One query, paged."""
+def existing_rows(token, db, opener=None, dupes_out=None) -> dict:
+    """{item_id: page} for the rows this module owns. One query, paged.
+
+    Pass `dupes_out` to learn about ids that appear more than once; see the comment
+    at the collision branch for why they are not silently collapsed.
+    """
     out, cursor = {}, None
+    dupes = {} if dupes_out is None else dupes_out
     while True:
         body = {"page_size": 100, "filter": {"property": "Item id", "rich_text":
                                              {"starts_with": OWNED_PREFIX}}}
@@ -119,8 +139,19 @@ def existing_rows(token, db, opener=None) -> dict:
         for page in data.get("results", []):
             prop = (page.get("properties") or {}).get("Item id") or {}
             text = "".join(t.get("plain_text", "") for t in prop.get("rich_text", []))
-            if text:
-                out[text] = page
+            if not text:
+                continue
+            if text in out:
+                # DUPLICATES ARE COUNTED, NOT COLLAPSED. Codex finding (major),
+                # 2026-09-03: this dict silently kept the last page for an id, so two
+                # painters racing could create two rows for one item and the read-back
+                # count still matched `wanted`, reporting "ok" over a board with
+                # doubles on it. A proof that cannot see the defect it exists to catch
+                # is not a proof.
+                dupes.setdefault(text, 1)
+                dupes[text] += 1
+                continue
+            out[text] = page
         if not data.get("has_more"):
             return out
         cursor = data.get("next_cursor")
@@ -206,10 +237,15 @@ def collect(now, sources: dict, opener=None, token_file=None, db_file=None):
         return [], f"board not written: {buckets['error']}"
     try:
         counts = paint(buckets, token, db, opener)
-        seen = read_back(token, db, opener)
+        dupes = {}
+        seen = len(existing_rows(token, db, opener, dupes_out=dupes))
     except (urllib.error.URLError, urllib.error.HTTPError, OSError, ValueError) as exc:
         return [], f"board write failed: {type(exc).__name__}: {exc}"
 
+    if dupes:
+        return [], (f"duplicate board rows for {len(dupes)} item(s): "
+                    f"{', '.join(sorted(dupes))}. Two painters have run; the board "
+                    "holds doubles and this run's counts cannot be trusted")
     if seen != counts["wanted"]:
         # The write-only-integration scar: a PATCH that returns 200 is not proof the
         # board holds what we think. The read-back is the proof.

--- a/q-system/.q-system/scripts/board_rows.py
+++ b/q-system/.q-system/scripts/board_rows.py
@@ -1,0 +1,219 @@
+#!/usr/bin/env python3
+"""Paint the Kipi backlog ROWS from the consulting state. The board's row writer.
+
+Founder, 2026-09-03: *"copy it but everyting needs to be actually connected fully and is
+automated so its not done by hand"*.
+
+## Rows, not bullets, and that is measured rather than preferred
+
+The Morning board page holds four `child_database` blocks, read live 2026-09-03:
+heading_2, paragraph, child_database, four times. Its three founder sections are FILTERED
+VIEWS of one database, "Kipi backlog", split by the `Bucket` select. So a writer that
+appends bullets under the "Top of mind" heading puts loose text between that heading and
+its database, and the board's own views never see it.
+
+The ids cost an hour and are recorded so nobody re-derives them:
+
+  page               ~/.config/kipi/notion-board-page
+  Kipi backlog DB    0a09bd16-b12e-49bf-a792-fad15e008ed0   <- writes go here
+  data source        3017ad50-...   404s on /v1/databases; it is not an API database id
+  the page's blocks  3cfbf98c-...   LINKED VIEWS, queryable, not the source of truth
+
+## HIS DRAG ALWAYS WINS. This module never moves a row he moved.
+
+`Item id` carries "stable id the brief uses so a hand-moved item is never re-added". So:
+create a row that does not exist, refresh the Notes and Source of one that does, and
+NEVER write `Bucket` on an existing row. That is `gtm_board.record_paint`'s posture
+(painting is not deciding) and DEC-8/DEC-13's one-writer rule. The computed state is
+authoritative about WHAT is owed; he is authoritative about where it sits on his board.
+
+## Rows leave when the work does
+
+An owned row whose id is no longer in the computed set is ARCHIVED, not deleted, and only
+if we own its id prefix. Without this the board only ever grows, which is how the last
+board became 4 stale rows nobody trusted. A row he created by hand carries no owned
+prefix and is never touched.
+
+## A stale source writes NOTHING
+
+OFF switch: a missing `~/.config/kipi/notion-token`. `collect` returns None and no board
+section renders. `~/.config/kipi/notion-backlog-db` overrides the database id without a
+code change; its absence falls back to DEFAULT_DB rather than switching the module off,
+because a token with no db file is a configured board, not an unconfigured one.
+
+## A stale source writes NOTHING
+
+If `consulting_board.buckets` reports an error (the state card is yesterday's, or the
+07:30 job crashed), this writes no rows at all and returns that error. Mirroring a stale
+source onto a board that looks fresh is the one failure that would make him act on a
+wrong number.
+"""
+from __future__ import annotations
+
+import hashlib
+import json
+import os
+import urllib.error
+import urllib.request
+from pathlib import Path
+
+import consulting_board
+
+API = "https://api.notion.com/v1"
+VERSION = "2022-06-28"
+STATE_DIR = Path.home() / ".config" / "kipi"
+TOKEN_FILE = STATE_DIR / "notion-token"
+DB_FILE = STATE_DIR / "notion-backlog-db"
+#: The database the founder's three board views read. Overridable by the file above so a
+#: moved board is a config change, never an edit here.
+DEFAULT_DB = "0a09bd16-b12e-49bf-a792-fad15e008ed0"
+
+#: Every row this module owns starts with it. A row without it is the founder's and is
+#: never updated, moved or archived.
+OWNED_PREFIX = "cb:"
+BUDGET_ROWS = 40
+TIMEOUT_S = 10.0
+
+BUCKET_OF = {"top_of_mind": "Top of Mind", "this_week": "This Week", "inbox": "Inbox"}
+
+
+def _credentials(token_file=None, db_file=None):
+    tf = Path(token_file) if token_file else TOKEN_FILE
+    df = Path(db_file) if db_file else DB_FILE
+    token = tf.read_text(encoding="utf-8").strip() if tf.exists() else None
+    db = df.read_text(encoding="utf-8").strip() if df.exists() else DEFAULT_DB
+    return token, db
+
+
+def _request(token, method, path, body=None, opener=None):
+    req = urllib.request.Request(f"{API}{path}", method=method,
+                                 data=json.dumps(body).encode() if body is not None else None)
+    req.add_header("Authorization", f"Bearer {token}")
+    req.add_header("Notion-Version", VERSION)
+    req.add_header("Content-Type", "application/json")
+    with (opener or urllib.request.urlopen)(req, timeout=TIMEOUT_S) as fh:
+        return json.load(fh)
+
+
+def item_id(bucket_key: str, item: dict) -> str:
+    """Stable across mornings for the same underlying thing.
+
+    Hashed from the TITLE only, never the detail: the commitment text he owes a given
+    client is stable, while its "(due ...)" suffix and reply counts change daily.
+    Hashing the detail too would make every morning a new row and the board would grow
+    by seven rows a day.
+    """
+    key = f"{bucket_key}|{item.get('title', '')}".encode("utf-8")
+    return OWNED_PREFIX + hashlib.sha1(key).hexdigest()[:16]
+
+
+def existing_rows(token, db, opener=None) -> dict:
+    """{item_id: page} for the rows this module owns. One query, paged."""
+    out, cursor = {}, None
+    while True:
+        body = {"page_size": 100, "filter": {"property": "Item id", "rich_text":
+                                             {"starts_with": OWNED_PREFIX}}}
+        if cursor:
+            body["start_cursor"] = cursor
+        data = _request(token, "POST", f"/databases/{db}/query", body, opener)
+        for page in data.get("results", []):
+            prop = (page.get("properties") or {}).get("Item id") or {}
+            text = "".join(t.get("plain_text", "") for t in prop.get("rich_text", []))
+            if text:
+                out[text] = page
+        if not data.get("has_more"):
+            return out
+        cursor = data.get("next_cursor")
+
+
+def _properties(item, bucket, iid, include_bucket: bool):
+    props = {
+        "Task": {"title": [{"text": {"content": (item.get("title") or "(untitled)")[:200]}}]},
+        "Item id": {"rich_text": [{"text": {"content": iid}}]},
+        "Notes": {"rich_text": [{"text": {"content": (item.get("detail") or "")[:1800]}}]},
+        "Domain": {"multi_select": [{"name": "Consulting"}]},
+    }
+    source = item.get("source")
+    if source:
+        # Notion creates a missing select option on write, so "State card" and
+        # "GroupMe" do not need to be added to the schema by hand first.
+        props["Source"] = {"select": {"name": source[:100]}}
+    if include_bucket:
+        # ONLY on create. On an existing row his drag is the truth.
+        props["Bucket"] = {"select": {"name": bucket}}
+        props["Status"] = {"select": {"name": "Not started"}}
+    return props
+
+
+def paint(buckets: dict, token, db, opener=None) -> dict:
+    """Create, refresh and archive. Returns a counts dict. Never moves a row."""
+    if buckets.get("error"):
+        raise ValueError(buckets["error"])
+
+    wanted = {}
+    for key, bucket in BUCKET_OF.items():
+        for item in (buckets.get(key) or [])[:BUDGET_ROWS]:
+            wanted[item_id(key, item)] = (item, bucket)
+
+    have = existing_rows(token, db, opener)
+    created = updated = archived = 0
+
+    for iid, (item, bucket) in wanted.items():
+        page = have.get(iid)
+        if page is None:
+            _request(token, "POST", "/pages",
+                     {"parent": {"database_id": db},
+                      "properties": _properties(item, bucket, iid, include_bucket=True)},
+                     opener)
+            created += 1
+        else:
+            _request(token, "PATCH", f"/pages/{page['id']}",
+                     {"properties": _properties(item, bucket, iid, include_bucket=False)},
+                     opener)
+            updated += 1
+
+    for iid, page in have.items():
+        if iid not in wanted:
+            _request(token, "PATCH", f"/pages/{page['id']}", {"archived": True}, opener)
+            archived += 1
+
+    return {"created": created, "updated": updated, "archived": archived,
+            "wanted": len(wanted)}
+
+
+def read_back(token, db, opener=None) -> int:
+    return len(existing_rows(token, db, opener))
+
+
+def collect(now, sources: dict, opener=None, token_file=None, db_file=None):
+    """Registry contract: (rows, error), or None when the board is OFF."""
+    token, db = _credentials(token_file, db_file)
+    if not token:
+        return None                       # OFF, not broken
+    if opener is None and os.environ.get("PYTEST_CURRENT_TEST"):
+        return [], "refused: running under pytest; the live board is never written by a test"
+    if opener is None and os.environ.get("KIPI_BRIEF_DRY_RUN"):
+        # MEASURED, not anticipated. The first end-to-end `--dry-run` printed
+        # "nothing sent, no receipt written" and had already created 12 rows on his
+        # live board. A dry run that writes is not a dry run, and the flag's promise
+        # was only ever about the Slack send because that was the only write the brief
+        # had before this module. An optional section can write, so the flag has to
+        # reach the sections.
+        return [], "dry-run: board not written"
+
+    buckets = consulting_board.buckets(now, sources)
+    if buckets.get("error"):
+        return [], f"board not written: {buckets['error']}"
+    try:
+        counts = paint(buckets, token, db, opener)
+        seen = read_back(token, db, opener)
+    except (urllib.error.URLError, urllib.error.HTTPError, OSError, ValueError) as exc:
+        return [], f"board write failed: {type(exc).__name__}: {exc}"
+
+    if seen != counts["wanted"]:
+        # The write-only-integration scar: a PATCH that returns 200 is not proof the
+        # board holds what we think. The read-back is the proof.
+        return [], (f"read-back mismatch: wrote {counts['wanted']} row(s), "
+                    f"board shows {seen}")
+    return [f"board: {counts['created']} new, {counts['updated']} refreshed, "
+            f"{counts['archived']} cleared, read-back ok"], None

--- a/q-system/.q-system/scripts/board_rows.py
+++ b/q-system/.q-system/scripts/board_rows.py
@@ -324,11 +324,17 @@ def collect(now, sources: dict, opener=None, token_file=None, db_file=None):
         return [], (f"duplicate board rows for {len(dupes)} item(s): "
                     f"{', '.join(sorted(dupes))}. Two painters have run; the board "
                     "holds doubles and this run's counts cannot be trusted")
-    if seen != counts["wanted"]:
+    # `kept` rows belong to a source that could not answer this run: they are on the
+    # board and deliberately not in `wanted`. Round 3 (major): comparing `seen` to
+    # `wanted` alone made every quiet source report a false read-back mismatch and mark
+    # the whole brief degraded, which would have trained him to ignore the word.
+    expected = counts["wanted"] + counts["kept"]
+    if seen != expected:
         # The write-only-integration scar: a PATCH that returns 200 is not proof the
         # board holds what we think. The read-back is the proof.
-        return [], (f"read-back mismatch: wrote {counts['wanted']} row(s), "
-                    f"board shows {seen}")
+        return [], (f"read-back mismatch: expected {expected} row(s) "
+                    f"({counts['wanted']} written + {counts['kept']} kept from a quiet "
+                    f"source), board shows {seen}")
     return [f"board: {counts['created']} new, {counts['updated']} refreshed, "
             f"{counts['archived']} cleared, {counts['kept']} kept (source quiet), "
             "read-back ok"], None

--- a/q-system/.q-system/scripts/board_rows.py
+++ b/q-system/.q-system/scripts/board_rows.py
@@ -195,14 +195,26 @@ def _scope_of(page) -> str:
 
 
 def _properties(item, bucket, iid, include_bucket: bool):
+    # The done signal leads the note, because it is the line that makes the row
+    # actionable; `scope=` is machinery the painter reads back and belongs last.
+    done = (item.get("done") or "").strip()
+    note = ""
+    if done:
+        note += f"Done signal: {done}\n"
+    note += f"{(item.get('detail') or '')[:1500]}\n{SCOPE_PREFIX}{item.get('scope') or 'card'}"
+
     props = {
         "Task": {"title": [{"text": {"content": (item.get("title") or "(untitled)")[:200]}}]},
         "Item id": {"rich_text": [{"text": {"content": iid}}]},
-        "Notes": {"rich_text": [{"text": {"content":
-            f"{SCOPE_PREFIX}{item.get('scope') or 'card'}\n"
-            f"{(item.get('detail') or '')[:1700]}"}}]},
-        "Domain": {"multi_select": [{"name": "Consulting"}]},
+        "Notes": {"rich_text": [{"text": {"content": note[:1900]}}]},
+        # The producer's own domain. Hardcoding "Consulting" put a GTM step and a
+        # broken-source alarm under the client label, so the column could not be
+        # filtered on -- which is the only thing a domain column is for.
+        "Domain": {"multi_select": [{"name": item.get("domain") or "Consulting"}]},
     }
+    priority = item.get("priority")
+    if priority:
+        props["Priority"] = {"select": {"name": priority}}
     source = item.get("source")
     if source:
         # Notion creates a missing select option on write, so "State card" and

--- a/q-system/.q-system/scripts/board_rows.py
+++ b/q-system/.q-system/scripts/board_rows.py
@@ -19,13 +19,29 @@ The ids cost an hour and are recorded so nobody re-derives them:
   data source        3017ad50-...   404s on /v1/databases; it is not an API database id
   the page's blocks  3cfbf98c-...   LINKED VIEWS, queryable, not the source of truth
 
-## HIS DRAG ALWAYS WINS. This module never moves a row he moved.
+## HIS DRAG ALWAYS WINS. This module never moves a row HE moved.
 
 `Item id` carries "stable id the brief uses so a hand-moved item is never re-added". So:
 create a row that does not exist, refresh the Notes and Source of one that does, and
-NEVER write `Bucket` on an existing row. That is `gtm_board.record_paint`'s posture
+never move a row a human put somewhere. That is `gtm_board.record_paint`'s posture
 (painting is not deciding) and DEC-8/DEC-13's one-writer rule. The computed state is
 authoritative about WHAT is owed; he is authoritative about where it sits on his board.
+
+The first cut of that read "NEVER write `Bucket` on an existing row", which is a wider
+rule than the promise and Codex round 6 (major) is what it cost: a client going red ->
+green kept its old bucket forever and a human had to reconcile the board by hand. A
+stale value the MACHINE painted is not his drag.
+
+The two are told apart the way `gtm_board.apply_board_moves` does it: every write
+records `bucket=` in the row's own Notes, which is what this module last painted there.
+Nothing else writes that column, so a live value differing from the record is a human.
+
+One deliberate divergence from gtm_board, and it is the whole design: there a drag is
+applied back through `set_state`, so the computed state BECOMES his choice and adopting
+the live value as the next baseline is right. Here health is computed from the state
+card and no drag can change it, so adopting would make the record agree next morning and
+move his row back one run later. A row he has moved is therefore PINNED (`pinned=1` in
+the same note) and this module never sets its bucket again.
 
 ## Rows leave when the work does
 
@@ -176,6 +192,30 @@ def existing_rows(token, db, opener=None, dupes_out=None, budget=None) -> dict:
 
 
 SCOPE_PREFIX = "scope="
+#: What this module last PAINTED into the row's Bucket. See the module docstring.
+BUCKET_PREFIX = "bucket="
+#: A human moved this row. From then on the machine refreshes its text and never its
+#: bucket. One flag rather than an inference, because the inference is what would
+#: silently expire (see `_bucket_decision`).
+PINNED_LINE = "pinned=1"
+#: The note's machinery lines are short and fixed; the free text is capped so they
+#: always fit. Before this the whole note was truncated at the end, so a long detail
+#: could push `scope=` off and the row read back as an unknown scope: kept forever,
+#: with no error anywhere.
+NOTE_CAP = 1900
+
+
+def _note_of(page) -> str:
+    prop = (page.get("properties") or {}).get("Notes") or {}
+    return "".join(t.get("plain_text", "") for t in prop.get("rich_text", []))
+
+
+def _note_field(page, prefix: str) -> str:
+    """A `<prefix>value` line off the row's own Notes, or "" when it carries none."""
+    for part in _note_of(page).split("\n"):
+        if part.startswith(prefix):
+            return part[len(prefix):].strip()
+    return ""
 
 
 def _scope_of(page) -> str:
@@ -186,27 +226,76 @@ def _scope_of(page) -> str:
     for. Unknown scope is treated as UNHEALTHY by the caller, which fails safe: an
     unrecognised row is kept, never archived.
     """
-    prop = (page.get("properties") or {}).get("Notes") or {}
-    text = "".join(t.get("plain_text", "") for t in prop.get("rich_text", []))
-    for part in text.split("\n"):
-        if part.startswith(SCOPE_PREFIX):
-            return part[len(SCOPE_PREFIX):].strip()
-    return ""
+    return _note_field(page, SCOPE_PREFIX)
 
 
-def _properties(item, bucket, iid, include_bucket: bool):
+def _live_bucket_of(page) -> str:
+    """The bucket the row sits in RIGHT NOW, whoever put it there."""
+    prop = (page.get("properties") or {}).get("Bucket") or {}
+    return ((prop.get("select") or {}).get("name") or "").strip()
+
+
+def _bucket_decision(page, computed: str):
+    """(write_bucket, bucket_to_record, pinned) for an EXISTING row.
+
+    The whole of "his drag always wins" lives in these five branches, so each one says
+    what it is protecting.
+    """
+    if PINNED_LINE in _note_of(page).split("\n"):
+        return False, _live_bucket_of(page), True      # decided; never revisited
+    live = _live_bucket_of(page)
+    painted = _note_field(page, BUCKET_PREFIX)
+    if not live:
+        # His three board views all filter on Bucket, so a row in none of them is on no
+        # view at all. Leaving it invisible forever is worse than placing it.
+        return True, computed, False
+    if not painted:
+        # COLD START: a row written before this module recorded anything, which on the
+        # morning this ships is every row on the board. Nothing on disk can tell his
+        # drag from our own stale paint here, so this is a one-time bet and it is made
+        # toward the REVERSIBLE side. Moving a row he had dragged costs him one drag,
+        # and that drag pins the row for good. Pinning a row he never touched is
+        # silent, permanent, and leaves the board wrong with no lever to fix it, which
+        # is the round-6 finding wearing a fail-safe's coat.
+        return True, computed, False
+    if live != painted:
+        return False, live, True                       # nothing but a human writes this
+    if live == computed:
+        return False, live, False
+    return True, computed, False
+
+
+def _properties(item, bucket, iid, include_bucket: bool, *, status=None,
+                record_bucket=None, pinned=False):
+    """The row's Notion properties.
+
+    `include_bucket` writes `Bucket`; `status` writes `Status` when given (create only,
+    because he marks rows done and a refresh must never reset that). `record_bucket` is
+    what the row's Bucket will hold AFTER this write and defaults to `bucket`; a caller
+    DECLINING to move a row passes the live value instead, so the note never claims a
+    paint that did not happen.
+    """
     # The done signal leads the note, because it is the line that makes the row
-    # actionable; `scope=` is machinery the painter reads back and belongs last.
+    # actionable; `scope=` and `bucket=` are machinery the painter reads back and
+    # belong last.
     done = (item.get("done") or "").strip()
     note = ""
     if done:
         note += f"Done signal: {done}\n"
-    note += f"{(item.get('detail') or '')[:1500]}\n{SCOPE_PREFIX}{item.get('scope') or 'card'}"
+    note += (item.get("detail") or "")[:1500]
+    tail = f"{SCOPE_PREFIX}{item.get('scope') or 'card'}"
+    tail += f"\n{BUCKET_PREFIX}{record_bucket if record_bucket is not None else bucket}"
+    if pinned:
+        tail += f"\n{PINNED_LINE}"
+    # The FREE TEXT is what gets cut, never the machinery. Truncating the whole note
+    # from the end drops `scope=` first, and an unknown scope is kept forever with no
+    # error: a silent leak wearing a fail-safe's coat.
+    note = f"{note[:max(0, NOTE_CAP - len(tail) - 1)]}\n{tail}"
 
     props = {
         "Task": {"title": [{"text": {"content": (item.get("title") or "(untitled)")[:200]}}]},
         "Item id": {"rich_text": [{"text": {"content": iid}}]},
-        "Notes": {"rich_text": [{"text": {"content": note[:1900]}}]},
+        "Notes": {"rich_text": [{"text": {"content": note}}]},
         # The producer's own domain. Hardcoding "Consulting" put a GTM step and a
         # broken-source alarm under the client label, so the column could not be
         # filtered on -- which is the only thing a domain column is for.
@@ -221,9 +310,11 @@ def _properties(item, bucket, iid, include_bucket: bool):
         # "GroupMe" do not need to be added to the schema by hand first.
         props["Source"] = {"select": {"name": source[:100]}}
     if include_bucket:
-        # ONLY on create. On an existing row his drag is the truth.
         props["Bucket"] = {"select": {"name": bucket}}
-        props["Status"] = {"select": {"name": "Not started"}}
+    if status:
+        # Create only. He marks rows done on the board; a morning refresh that reset
+        # this to "Not started" would undo that every day.
+        props["Status"] = {"select": {"name": status}}
     return props
 
 
@@ -285,21 +376,30 @@ def paint(buckets: dict, token, db, opener=None, budget=None) -> dict:
         )
 
     have = existing_rows(token, db, opener, budget=budget)
-    created = updated = archived = 0
+    created = updated = archived = moved = pinned = 0
 
     for iid, (item, bucket) in wanted.items():
         page = have.get(iid)
         if page is None:
             _request(token, "POST", "/pages",
                      {"parent": {"database_id": db},
-                      "properties": _properties(item, bucket, iid, include_bucket=True)},
+                      "properties": _properties(item, bucket, iid, include_bucket=True,
+                                                status="Not started")},
                      opener, budget)
             created += 1
         else:
+            # Codex round 6 (major): this passed include_bucket=False unconditionally,
+            # so a row's bucket was frozen at whatever its FIRST morning computed. See
+            # `_bucket_decision` and the module docstring for how his drag is told from
+            # our own stale paint.
+            write, record, pin = _bucket_decision(page, bucket)
             _request(token, "PATCH", f"/pages/{page['id']}",
-                     {"properties": _properties(item, bucket, iid, include_bucket=False)},
+                     {"properties": _properties(item, record, iid, include_bucket=write,
+                                                record_bucket=record, pinned=pin)},
                      opener, budget)
             updated += 1
+            moved += 1 if write else 0
+            pinned += 1 if pin else 0
 
     kept = 0
     for iid, page in have.items():
@@ -312,7 +412,7 @@ def paint(buckets: dict, token, db, opener=None, budget=None) -> dict:
         archived += 1
 
     return {"created": created, "updated": updated, "archived": archived,
-            "kept": kept, "wanted": len(wanted)}
+            "kept": kept, "wanted": len(wanted), "moved": moved, "pinned": pinned}
 
 
 def read_back(token, db, opener=None, budget=None) -> int:
@@ -376,5 +476,6 @@ def collect(now, sources: dict, opener=None, token_file=None, db_file=None,
                     f"({counts['wanted']} written + {counts['kept']} kept from a quiet "
                     f"source), board shows {seen}")
     return [f"board: {counts['created']} new, {counts['updated']} refreshed, "
-            f"{counts['archived']} cleared, {counts['kept']} kept (source quiet), "
+            f"{counts['moved']} rebucketed, {counts['archived']} cleared, "
+            f"{counts['kept']} kept (source quiet), {counts['pinned']} yours (untouched), "
             "read-back ok"], None

--- a/q-system/.q-system/scripts/board_rows.py
+++ b/q-system/.q-system/scripts/board_rows.py
@@ -50,6 +50,8 @@ wrong number.
 """
 from __future__ import annotations
 
+import contextlib
+import fcntl
 import hashlib
 import json
 import os
@@ -157,11 +159,32 @@ def existing_rows(token, db, opener=None, dupes_out=None) -> dict:
         cursor = data.get("next_cursor")
 
 
+SCOPE_PREFIX = "scope="
+
+
+def _scope_of(page) -> str:
+    """The scope a row was written under, read back off the row itself.
+
+    Stored in Notes rather than a new Notion property so the board's schema does not
+    change: a select option added by a writer is a schema edit the founder did not ask
+    for. Unknown scope is treated as UNHEALTHY by the caller, which fails safe: an
+    unrecognised row is kept, never archived.
+    """
+    prop = (page.get("properties") or {}).get("Notes") or {}
+    text = "".join(t.get("plain_text", "") for t in prop.get("rich_text", []))
+    for part in text.split("\n"):
+        if part.startswith(SCOPE_PREFIX):
+            return part[len(SCOPE_PREFIX):].strip()
+    return ""
+
+
 def _properties(item, bucket, iid, include_bucket: bool):
     props = {
         "Task": {"title": [{"text": {"content": (item.get("title") or "(untitled)")[:200]}}]},
         "Item id": {"rich_text": [{"text": {"content": iid}}]},
-        "Notes": {"rich_text": [{"text": {"content": (item.get("detail") or "")[:1800]}}]},
+        "Notes": {"rich_text": [{"text": {"content":
+            f"{SCOPE_PREFIX}{item.get('scope') or 'card'}\n"
+            f"{(item.get('detail') or '')[:1700]}"}}]},
         "Domain": {"multi_select": [{"name": "Consulting"}]},
     }
     source = item.get("source")
@@ -176,15 +199,62 @@ def _properties(item, bucket, iid, include_bucket: bool):
     return props
 
 
+LOCK_FILE = STATE_DIR / "board-rows.lock"
+
+
+@contextlib.contextmanager
+def exclusive(lock_path=None):
+    """One painter at a time. Codex round 2 (major): paint() queries then creates, so
+    two simultaneous runs both see "absent" and both create, leaving permanent
+    duplicates. The round-1 fix only DETECTED duplicates after the fact, which reports
+    a mess rather than preventing one.
+
+    flock on a local file, non-blocking: a second painter refuses immediately rather
+    than queueing behind a 07:40 job. The board is machine-local state and both writers
+    would be on this machine, which is exactly what flock covers.
+    """
+    path = Path(lock_path) if lock_path else LOCK_FILE
+    path.parent.mkdir(parents=True, exist_ok=True)
+    handle = open(path, "w", encoding="utf-8")
+    try:
+        try:
+            fcntl.flock(handle, fcntl.LOCK_EX | fcntl.LOCK_NB)
+        except OSError as exc:
+            raise BoardBusy("another painter holds the board lock") from exc
+        yield
+    finally:
+        with contextlib.suppress(OSError):
+            fcntl.flock(handle, fcntl.LOCK_UN)
+        handle.close()
+
+
+class BoardBusy(RuntimeError):
+    """A second painter tried to run. Not a failure of this one."""
+
+
 def paint(buckets: dict, token, db, opener=None) -> dict:
     """Create, refresh and archive. Returns a counts dict. Never moves a row."""
     if buckets.get("error"):
         raise ValueError(buckets["error"])
 
-    wanted = {}
+    wanted, scopes = {}, {}
     for key, bucket in BUCKET_OF.items():
         for item in (buckets.get(key) or [])[:BUDGET_ROWS]:
-            wanted[item_id(key, item)] = (item, bucket)
+            iid = item_id(key, item)
+            wanted[iid] = (item, bucket)
+            scopes[iid] = item.get("scope") or "card"
+
+    # ARCHIVE ONLY INSIDE A HEALTHY SCOPE. Codex round 2 (major): a transient Gmail
+    # error replaced that source's rows with one error row, so every previously
+    # positioned inbox row fell out of `wanted` and the painter archived the lot. A
+    # source that could not answer this morning has said NOTHING about its rows, and
+    # nothing is not "they are gone".
+    healthy = buckets.get("healthy_scopes")
+    if healthy is None:
+        raise ValueError(
+            "buckets carries no `healthy_scopes`. Archiving without it would delete "
+            "rows on any transient source failure (Codex round 2)."
+        )
 
     have = existing_rows(token, db, opener)
     created = updated = archived = 0
@@ -203,13 +273,18 @@ def paint(buckets: dict, token, db, opener=None) -> dict:
                      opener)
             updated += 1
 
+    kept = 0
     for iid, page in have.items():
-        if iid not in wanted:
-            _request(token, "PATCH", f"/pages/{page['id']}", {"archived": True}, opener)
-            archived += 1
+        if iid in wanted:
+            continue
+        if _scope_of(page) not in healthy:
+            kept += 1                      # its source could not answer; leave it alone
+            continue
+        _request(token, "PATCH", f"/pages/{page['id']}", {"archived": True}, opener)
+        archived += 1
 
     return {"created": created, "updated": updated, "archived": archived,
-            "wanted": len(wanted)}
+            "kept": kept, "wanted": len(wanted)}
 
 
 def read_back(token, db, opener=None) -> int:
@@ -236,9 +311,12 @@ def collect(now, sources: dict, opener=None, token_file=None, db_file=None):
     if buckets.get("error"):
         return [], f"board not written: {buckets['error']}"
     try:
-        counts = paint(buckets, token, db, opener)
+        with exclusive():
+            counts = paint(buckets, token, db, opener)
         dupes = {}
         seen = len(existing_rows(token, db, opener, dupes_out=dupes))
+    except BoardBusy as exc:
+        return [], f"board not written: {exc}"
     except (urllib.error.URLError, urllib.error.HTTPError, OSError, ValueError) as exc:
         return [], f"board write failed: {type(exc).__name__}: {exc}"
 
@@ -252,4 +330,5 @@ def collect(now, sources: dict, opener=None, token_file=None, db_file=None):
         return [], (f"read-back mismatch: wrote {counts['wanted']} row(s), "
                     f"board shows {seen}")
     return [f"board: {counts['created']} new, {counts['updated']} refreshed, "
-            f"{counts['archived']} cleared, read-back ok"], None
+            f"{counts['archived']} cleared, {counts['kept']} kept (source quiet), "
+            "read-back ok"], None

--- a/q-system/.q-system/scripts/board_rows.py
+++ b/q-system/.q-system/scripts/board_rows.py
@@ -453,6 +453,49 @@ class BoardBusy(RuntimeError):
     """A second painter tried to run. Not a failure of this one."""
 
 
+def _fair_share(rows, budget):
+    """`rows` reordered so the write budget is shared across SCOPES, round robin.
+
+    ## Why this exists: the two findings that produced it are opposites
+
+    A producer-side cap on mail was removed because trimming DATA meant a still
+    unanswered thread never entered `wanted`, and the archive loop then deleted its
+    live page inside a healthy scope -- a dragged, pinned row gone because a
+    sixteenth thread arrived.
+
+    Uncapped mail then took the whole 40-row budget in source order, so every
+    GroupMe row fell past it. Those rows are protected from archiving by `capped`,
+    which is round 11's rule working, but protected is not updated: they sit on his
+    board unchanged forever while the source that starved them refreshes daily. A
+    channel he asked for, permanently frozen, with nothing saying so.
+
+    Capping the producer brings back defect one. Not capping it is defect two. So
+    neither is the answer: what was wrong is that a single source could spend the
+    whole budget. Each scope now takes one row in turn, so a busy inbox delays the
+    tail of its OWN source rather than deleting another source's channel.
+
+    Order within a scope is preserved (the mail prompt sorts oldest first, and that
+    ordering is a judgement this function must not re-make). Rows past the budget
+    still land in `capped` at the call site and are kept, never archived.
+    """
+    by_scope, order = {}, []
+    for item in rows:
+        scope = item.get("scope") or "card"
+        if scope not in by_scope:
+            by_scope[scope] = []
+            order.append(scope)
+        by_scope[scope].append(item)
+    if len(order) < 2:
+        return list(rows)          # one source cannot starve anybody
+    out = []
+    while len(out) < len(rows):
+        for scope in order:
+            queue = by_scope[scope]
+            if queue:
+                out.append(queue.pop(0))
+    return out
+
+
 def paint(buckets: dict, token, db, opener=None, budget=None) -> dict:
     """Create, refresh and archive. Returns a counts dict. Never moves a row."""
     if buckets.get("error"):
@@ -468,7 +511,7 @@ def paint(buckets: dict, token, db, opener=None, budget=None) -> dict:
         # beside the other counts. Not an overflow ROW: a synthetic row needs a stable
         # id and a scope, and inventing a scope the painter itself declares healthy
         # would make it a writer of the archive authority it consumes.
-        rows_here = buckets.get(key) or []
+        rows_here = _fair_share(buckets.get(key) or [], BUDGET_ROWS)
         over_cap += max(0, len(rows_here) - BUDGET_ROWS)
         for item in rows_here[BUDGET_ROWS:]:
             # A CAPPED ROW IS NOT AN ABSENT ROW (round 11, major). Trimmed rows never

--- a/q-system/.q-system/scripts/board_rows.py
+++ b/q-system/.q-system/scripts/board_rows.py
@@ -281,6 +281,53 @@ def _live_bucket_of(page) -> str:
     return ((prop.get("select") or {}).get("name") or "").strip()
 
 
+#: Seconds of the budget held back so the read-back that PROVES the paint can run. A
+#: painter that spends its last millisecond on one more write has no way to say whether
+#: the board holds what it thinks, which is the write-only-integration scar.
+WRITE_RESERVE_S = 2.0
+
+
+def _prop_value(prop):
+    """One Notion property flattened to something comparable. Unknown shapes -> None,
+    which never compares equal, so an unrecognised property means "write it" rather
+    than "assume it matches"."""
+    if not isinstance(prop, dict):
+        return None
+    if "title" in prop or "rich_text" in prop:
+        parts = prop.get("title") or prop.get("rich_text") or []
+        out = []
+        for part in parts:
+            if "plain_text" in part:
+                out.append(part["plain_text"])
+            elif isinstance(part.get("text"), dict):
+                out.append(part["text"].get("content", ""))
+        return "".join(out)
+    if "select" in prop:
+        return ((prop.get("select") or {}).get("name") or "") or None
+    if "multi_select" in prop:
+        return tuple(sorted((o.get("name") or "") for o in prop.get("multi_select") or []))
+    return None
+
+
+def _already_holds(page, props) -> bool:
+    """True when the row already carries every value this run would write.
+
+    Round 9 (major): the painter PATCHed every wanted row every run, so a steady
+    morning cost one mutation per row against an API documented at roughly three
+    requests a second. Almost none of those writes changed anything: the detail and the
+    `bucket=`/`pinned=` machinery are the only volatile parts, and on most mornings
+    they are identical to what is already there. Comparing against the page we have
+    ALREADY read costs nothing and removes the mutation entirely.
+
+    Fails toward writing: any property this cannot read back compares unequal.
+    """
+    have = page.get("properties") or {}
+    for name, want in props.items():
+        if _prop_value(have.get(name)) != _prop_value(want):
+            return False
+    return True
+
+
 def _bucket_decision(page, computed: str):
     """(write_bucket, bucket_to_record, pinned) for an EXISTING row.
 
@@ -431,11 +478,28 @@ def paint(buckets: dict, token, db, opener=None, budget=None) -> dict:
         )
 
     have = existing_rows(token, db, opener, budget=budget)
-    created = updated = archived = moved = pinned = 0
+    created = updated = archived = moved = pinned = unchanged = deferred = 0
+    deferred_new = 0
+
+    def out_of_write_budget() -> bool:
+        """Stop issuing NEW mutations while there is still time to prove the paint.
+
+        Round 9 (major): BUDGET_ROWS is per BUCKET, so a full paint could ask for 120
+        sequential mutations inside a 15-second budget it cannot finish. The cap is not
+        raised or replaced by a second invented number -- the real constraint is the
+        clock, so the clock is what stops it. With `_already_holds` above, a steady
+        morning issues a handful of writes, which is what keeps the deferred tail from
+        starving: the next run has almost nothing else to do.
+        """
+        return budget is not None and budget.check() <= WRITE_RESERVE_S
 
     for iid, (item, bucket) in wanted.items():
         page = have.get(iid)
         if page is None:
+            if out_of_write_budget():
+                deferred += 1
+                deferred_new += 1
+                continue
             _request(token, "POST", "/pages",
                      {"parent": {"database_id": db},
                       "properties": _properties(item, bucket, iid, include_bucket=True,
@@ -448,13 +512,19 @@ def paint(buckets: dict, token, db, opener=None, budget=None) -> dict:
             # `_bucket_decision` and the module docstring for how his drag is told from
             # our own stale paint.
             write, record, pin = _bucket_decision(page, bucket)
-            _request(token, "PATCH", f"/pages/{page['id']}",
-                     {"properties": _properties(item, record, iid, include_bucket=write,
-                                                record_bucket=record, pinned=pin)},
+            props = _properties(item, record, iid, include_bucket=write,
+                                record_bucket=record, pinned=pin)
+            pinned += 1 if pin else 0
+            if _already_holds(page, props):
+                unchanged += 1
+                continue
+            if out_of_write_budget():
+                deferred += 1
+                continue
+            _request(token, "PATCH", f"/pages/{page['id']}", {"properties": props},
                      opener, budget)
             updated += 1
             moved += 1 if write else 0
-            pinned += 1 if pin else 0
 
     kept = 0
     for iid, page in have.items():
@@ -463,16 +533,21 @@ def paint(buckets: dict, token, db, opener=None, budget=None) -> dict:
         if _scope_of(page) not in healthy:
             kept += 1                      # its source could not answer; leave it alone
             continue
+        if out_of_write_budget():
+            # An unarchived row is on the board, so it counts as kept for the read-back
+            # or the proof would report a mismatch about a row we deliberately left.
+            kept += 1
+            deferred += 1
+            continue
         _request(token, "PATCH", f"/pages/{page['id']}", {"archived": True}, opener, budget)
         archived += 1
 
     return {"created": created, "updated": updated, "archived": archived,
             "kept": kept, "wanted": len(wanted), "moved": moved, "pinned": pinned,
-            "over_cap": over_cap}
-
-
-def read_back(token, db, opener=None, budget=None) -> int:
-    return len(existing_rows(token, db, opener, budget=budget))
+            "over_cap": over_cap, "unchanged": unchanged, "deferred": deferred,
+            # Rows we WANTED but never created: they are not on the board, so the
+            # read-back must not expect them or a deferred write reads as a mismatch.
+            "deferred_new": deferred_new}
 
 
 def collect(now, sources: dict, opener=None, token_file=None, db_file=None,
@@ -495,6 +570,13 @@ def collect(now, sources: dict, opener=None, token_file=None, db_file=None,
     buckets = consulting_board.buckets(now, sources)
     if buckets.get("error"):
         return [], f"board not written: {buckets['error']}"
+    # A CARD PROBLEM IS NOT A REASON TO WRITE NOTHING (round 9, major). This used to
+    # refuse the whole paint, so a late 07:30 state card also kept Gmail and GroupMe
+    # rows off the board -- sources that answered. The stale scope writes nothing, the
+    # board carries an alarm row saying the book could not be read, and the line below
+    # says it too. Not an `error` return: the job did its work, and an exit code that
+    # calls this hour broken is the wolf-cry that costs the real alert later.
+    card_error = buckets.get("card_error")
     def work(budget):
         # The lock is held INSIDE the budget: a painter that runs out of time also
         # lets go, so the 07:40 job is not refused by a worker the brief abandoned.
@@ -524,7 +606,7 @@ def collect(now, sources: dict, opener=None, token_file=None, db_file=None,
     # board and deliberately not in `wanted`. Round 3 (major): comparing `seen` to
     # `wanted` alone made every quiet source report a false read-back mismatch and mark
     # the whole brief degraded, which would have trained him to ignore the word.
-    expected = counts["wanted"] + counts["kept"]
+    expected = counts["wanted"] + counts["kept"] - counts["deferred_new"]
     if seen != expected:
         # The write-only-integration scar: a PATCH that returns 200 is not proof the
         # board holds what we think. The read-back is the proof.
@@ -532,9 +614,15 @@ def collect(now, sources: dict, opener=None, token_file=None, db_file=None,
                     f"({counts['wanted']} written + {counts['kept']} kept from a quiet "
                     f"source), board shows {seen}")
     line = (f"board: {counts['created']} new, {counts['updated']} refreshed, "
+            f"{counts['unchanged']} unchanged, "
             f"{counts['moved']} rebucketed, {counts['archived']} cleared, "
             f"{counts['kept']} kept (source quiet), {counts['pinned']} yours (untouched), "
             "read-back ok")
     if counts["over_cap"]:
         line += f"; {counts['over_cap']} row(s) over the {BUDGET_ROWS}-row cap, not written"
+    if counts["deferred"]:
+        line += (f"; {counts['deferred']} row(s) deferred to the next run "
+                 "(write budget spent)")
+    if card_error:
+        line = f"board: your book could not be read ({card_error}); " + line[len("board: "):]
     return [line], None

--- a/q-system/.q-system/scripts/board_rows.py
+++ b/q-system/.q-system/scripts/board_rows.py
@@ -71,6 +71,7 @@ import fcntl
 import hashlib
 import json
 import os
+import time
 import urllib.error
 import urllib.request
 from pathlib import Path
@@ -116,17 +117,62 @@ def _credentials(token_file=None, db_file=None):
     return token, db
 
 
+#: Codex round 8 (major): Notion documents roughly three requests per second and asks
+#: clients to honour `Retry-After` on a 429. This painter sends one query plus up to 40
+#: sequential mutations with no pacing, so an ordinary morning could be rejected
+#: part-way and report the whole brief degraded. Retried, not paced: a blanket sleep
+#: between every write would spend the 15-second budget on waiting even when nothing is
+#: rate limited, and the next paint reconciles a partial board anyway, so the cost of a
+#: 429 is alert noise rather than a wrong board.
+RATE_LIMIT_RETRIES = 2
+#: 502/503 join 429 because they are the same shape: the server saying "not now".
+RETRYABLE_STATUS = (429, 502, 503)
+#: What the header is allowed to ask for. A server asking for a minute is not something
+#: a 15-second budget can honour, and pretending to wait it out is worse than refusing.
+RETRY_WAIT_CAP_S = 5.0
+RETRY_WAIT_DEFAULT_S = 1.0
+
+
+def _retry_after(exc) -> float:
+    """Seconds the server asked us to wait, clamped. Never trusts the header blindly."""
+    raw = None
+    headers = getattr(exc, "headers", None)
+    if headers is not None:
+        try:
+            raw = headers.get("Retry-After")
+        except AttributeError:
+            raw = None
+    try:
+        wait = float(raw)
+    except (TypeError, ValueError):
+        wait = RETRY_WAIT_DEFAULT_S
+    return max(0.0, min(RETRY_WAIT_CAP_S, wait))
+
+
 def _request(token, method, path, body=None, opener=None, budget=None):
-    timeout = TIMEOUT_S
-    if budget is not None:
-        timeout = min(TIMEOUT_S, max(0.001, budget.check()))   # raises Cancelled when spent
-    req = urllib.request.Request(f"{API}{path}", method=method,
-                                 data=json.dumps(body).encode() if body is not None else None)
-    req.add_header("Authorization", f"Bearer {token}")
-    req.add_header("Notion-Version", VERSION)
-    req.add_header("Content-Type", "application/json")
-    with (opener or urllib.request.urlopen)(req, timeout=timeout) as fh:
-        return json.load(fh)
+    for attempt in range(RATE_LIMIT_RETRIES + 1):
+        timeout = TIMEOUT_S
+        if budget is not None:
+            timeout = min(TIMEOUT_S, max(0.001, budget.check()))  # raises Cancelled when spent
+        req = urllib.request.Request(
+            f"{API}{path}", method=method,
+            data=json.dumps(body).encode() if body is not None else None)
+        req.add_header("Authorization", f"Bearer {token}")
+        req.add_header("Notion-Version", VERSION)
+        req.add_header("Content-Type", "application/json")
+        try:
+            with (opener or urllib.request.urlopen)(req, timeout=timeout) as fh:
+                return json.load(fh)
+        except urllib.error.HTTPError as exc:
+            if exc.code not in RETRYABLE_STATUS or attempt == RATE_LIMIT_RETRIES:
+                raise
+            wait = _retry_after(exc)
+            # SLEEPING PAST THE BUDGET IS THE ROUND-4 DEFECT WEARING A RETRY'S COAT.
+            # A worker the brief has already abandoned must not still be waiting to
+            # write. If the wait does not fit in what is left, this call fails now.
+            if budget is not None and wait >= budget.check():
+                raise
+            time.sleep(wait)
 
 
 def item_id(bucket_key: str, item: dict) -> str:

--- a/q-system/.q-system/scripts/board_rows.py
+++ b/q-system/.q-system/scripts/board_rows.py
@@ -238,8 +238,8 @@ def _live_bucket_of(page) -> str:
 def _bucket_decision(page, computed: str):
     """(write_bucket, bucket_to_record, pinned) for an EXISTING row.
 
-    The whole of "his drag always wins" lives in these five branches, so each one says
-    what it is protecting.
+    The whole of "his drag always wins" lives in the branches below, so each one says
+    what it is protecting rather than what it does.
     """
     if PINNED_LINE in _note_of(page).split("\n"):
         return False, _live_bucket_of(page), True      # decided; never revisited

--- a/q-system/.q-system/scripts/board_rows.py
+++ b/q-system/.q-system/scripts/board_rows.py
@@ -449,7 +449,7 @@ def paint(buckets: dict, token, db, opener=None, budget=None) -> dict:
     if buckets.get("error"):
         raise ValueError(buckets["error"])
 
-    wanted, scopes, over_cap = {}, {}, 0
+    wanted, scopes, over_cap, capped = {}, {}, 0, set()
     for key, bucket in BUCKET_OF.items():
         # Round 7 (minor): this truncation was SILENT, and the read-back cannot see it
         # because `wanted` has already lost the row before the count is taken. The
@@ -459,8 +459,17 @@ def paint(buckets: dict, token, db, opener=None, budget=None) -> dict:
         # beside the other counts. Not an overflow ROW: a synthetic row needs a stable
         # id and a scope, and inventing a scope the painter itself declares healthy
         # would make it a writer of the archive authority it consumes.
-        over_cap += max(0, len(buckets.get(key) or []) - BUDGET_ROWS)
-        for item in (buckets.get(key) or [])[:BUDGET_ROWS]:
+        rows_here = buckets.get(key) or []
+        over_cap += max(0, len(rows_here) - BUDGET_ROWS)
+        for item in rows_here[BUDGET_ROWS:]:
+            # A CAPPED ROW IS NOT AN ABSENT ROW (round 11, major). Trimmed rows never
+            # entered `wanted`, so the archive loop below saw their live page inside a
+            # HEALTHY scope and archived it -- destroying a row he may have dragged and
+            # pinned, because the producer emitted one row too many. The cap is a write
+            # budget, not a statement that the work is finished.
+            with contextlib.suppress(ValueError):
+                capped.add(item_id(key, item))
+        for item in rows_here[:BUDGET_ROWS]:
             iid = item_id(key, item)
             wanted[iid] = (item, bucket)
             scopes[iid] = item.get("scope") or "card"
@@ -529,6 +538,9 @@ def paint(buckets: dict, token, db, opener=None, budget=None) -> dict:
     kept = 0
     for iid, page in have.items():
         if iid in wanted:
+            continue
+        if iid in capped:
+            kept += 1                      # over the write cap this run, not gone
             continue
         if _scope_of(page) not in healthy:
             kept += 1                      # its source could not answer; leave it alone

--- a/q-system/.q-system/scripts/board_rows.py
+++ b/q-system/.q-system/scripts/board_rows.py
@@ -356,8 +356,17 @@ def paint(buckets: dict, token, db, opener=None, budget=None) -> dict:
     if buckets.get("error"):
         raise ValueError(buckets["error"])
 
-    wanted, scopes = {}, {}
+    wanted, scopes, over_cap = {}, {}, 0
     for key, bucket in BUCKET_OF.items():
+        # Round 7 (minor): this truncation was SILENT, and the read-back cannot see it
+        # because `wanted` has already lost the row before the count is taken. The
+        # inbox alone can produce 41 (mail 15 + its overflow row + GroupMe 25), so the
+        # 41st vanished with nothing said anywhere. The cap stays -- it bounds the
+        # Notion writes -- and what changes is that the loss is now counted and printed
+        # beside the other counts. Not an overflow ROW: a synthetic row needs a stable
+        # id and a scope, and inventing a scope the painter itself declares healthy
+        # would make it a writer of the archive authority it consumes.
+        over_cap += max(0, len(buckets.get(key) or []) - BUDGET_ROWS)
         for item in (buckets.get(key) or [])[:BUDGET_ROWS]:
             iid = item_id(key, item)
             wanted[iid] = (item, bucket)
@@ -412,7 +421,8 @@ def paint(buckets: dict, token, db, opener=None, budget=None) -> dict:
         archived += 1
 
     return {"created": created, "updated": updated, "archived": archived,
-            "kept": kept, "wanted": len(wanted), "moved": moved, "pinned": pinned}
+            "kept": kept, "wanted": len(wanted), "moved": moved, "pinned": pinned,
+            "over_cap": over_cap}
 
 
 def read_back(token, db, opener=None, budget=None) -> int:
@@ -475,7 +485,10 @@ def collect(now, sources: dict, opener=None, token_file=None, db_file=None,
         return [], (f"read-back mismatch: expected {expected} row(s) "
                     f"({counts['wanted']} written + {counts['kept']} kept from a quiet "
                     f"source), board shows {seen}")
-    return [f"board: {counts['created']} new, {counts['updated']} refreshed, "
+    line = (f"board: {counts['created']} new, {counts['updated']} refreshed, "
             f"{counts['moved']} rebucketed, {counts['archived']} cleared, "
             f"{counts['kept']} kept (source quiet), {counts['pinned']} yours (untouched), "
-            "read-back ok"], None
+            "read-back ok")
+    if counts["over_cap"]:
+        line += f"; {counts['over_cap']} row(s) over the {BUDGET_ROWS}-row cap, not written"
+    return [line], None

--- a/q-system/.q-system/scripts/board_rows.py
+++ b/q-system/.q-system/scripts/board_rows.py
@@ -60,6 +60,10 @@ import urllib.request
 from pathlib import Path
 
 import consulting_board
+# ONE budget class, shared with the old bullet writer rather than copied from it.
+# notion_board is unregistered as a section (see morning-brief.OPTIONAL_SECTIONS) and
+# stays on disk as a library; its `_Budget` is the interlock both painters need.
+from notion_board import Cancelled, _Budget, _bounded
 
 API = "https://api.notion.com/v1"
 VERSION = "2022-06-28"
@@ -75,6 +79,15 @@ DEFAULT_DB = "0a09bd16-b12e-49bf-a792-fad15e008ed0"
 OWNED_PREFIX = "cb:"
 BUDGET_ROWS = 40
 TIMEOUT_S = 10.0
+#: The board's OWN deadline, held by the worker and checked before every Notion call.
+#: Codex round 4 (major): morning-brief's `_guarded` abandons a collector on timeout,
+#: which bounds the WAIT and not the WRITES. This painter kept creating, refreshing and
+#: archiving rows after the brief had already reported it timed out, with no read-back
+#: behind those writes. Now a spent or cancelled budget refuses the next request and
+#: caps the one in flight, so nothing outlives it. Deliberately BELOW the brief's
+#: COLLECT_BUDGET_S so this cancel fires first and the guard is the backstop;
+#: test_consulting_board pins the ordering.
+BUDGET_S = 15.0
 
 BUCKET_OF = {"top_of_mind": "Top of Mind", "this_week": "This Week", "inbox": "Inbox"}
 
@@ -87,13 +100,16 @@ def _credentials(token_file=None, db_file=None):
     return token, db
 
 
-def _request(token, method, path, body=None, opener=None):
+def _request(token, method, path, body=None, opener=None, budget=None):
+    timeout = TIMEOUT_S
+    if budget is not None:
+        timeout = min(TIMEOUT_S, max(0.001, budget.check()))   # raises Cancelled when spent
     req = urllib.request.Request(f"{API}{path}", method=method,
                                  data=json.dumps(body).encode() if body is not None else None)
     req.add_header("Authorization", f"Bearer {token}")
     req.add_header("Notion-Version", VERSION)
     req.add_header("Content-Type", "application/json")
-    with (opener or urllib.request.urlopen)(req, timeout=TIMEOUT_S) as fh:
+    with (opener or urllib.request.urlopen)(req, timeout=timeout) as fh:
         return json.load(fh)
 
 
@@ -124,7 +140,7 @@ def item_id(bucket_key: str, item: dict) -> str:
     return OWNED_PREFIX + hashlib.sha1(str(key).encode("utf-8")).hexdigest()[:16]
 
 
-def existing_rows(token, db, opener=None, dupes_out=None) -> dict:
+def existing_rows(token, db, opener=None, dupes_out=None, budget=None) -> dict:
     """{item_id: page} for the rows this module owns. One query, paged.
 
     Pass `dupes_out` to learn about ids that appear more than once; see the comment
@@ -137,7 +153,7 @@ def existing_rows(token, db, opener=None, dupes_out=None) -> dict:
                                              {"starts_with": OWNED_PREFIX}}}
         if cursor:
             body["start_cursor"] = cursor
-        data = _request(token, "POST", f"/databases/{db}/query", body, opener)
+        data = _request(token, "POST", f"/databases/{db}/query", body, opener, budget)
         for page in data.get("results", []):
             prop = (page.get("properties") or {}).get("Item id") or {}
             text = "".join(t.get("plain_text", "") for t in prop.get("rich_text", []))
@@ -232,7 +248,7 @@ class BoardBusy(RuntimeError):
     """A second painter tried to run. Not a failure of this one."""
 
 
-def paint(buckets: dict, token, db, opener=None) -> dict:
+def paint(buckets: dict, token, db, opener=None, budget=None) -> dict:
     """Create, refresh and archive. Returns a counts dict. Never moves a row."""
     if buckets.get("error"):
         raise ValueError(buckets["error"])
@@ -256,7 +272,7 @@ def paint(buckets: dict, token, db, opener=None) -> dict:
             "rows on any transient source failure (Codex round 2)."
         )
 
-    have = existing_rows(token, db, opener)
+    have = existing_rows(token, db, opener, budget=budget)
     created = updated = archived = 0
 
     for iid, (item, bucket) in wanted.items():
@@ -265,12 +281,12 @@ def paint(buckets: dict, token, db, opener=None) -> dict:
             _request(token, "POST", "/pages",
                      {"parent": {"database_id": db},
                       "properties": _properties(item, bucket, iid, include_bucket=True)},
-                     opener)
+                     opener, budget)
             created += 1
         else:
             _request(token, "PATCH", f"/pages/{page['id']}",
                      {"properties": _properties(item, bucket, iid, include_bucket=False)},
-                     opener)
+                     opener, budget)
             updated += 1
 
     kept = 0
@@ -280,18 +296,19 @@ def paint(buckets: dict, token, db, opener=None) -> dict:
         if _scope_of(page) not in healthy:
             kept += 1                      # its source could not answer; leave it alone
             continue
-        _request(token, "PATCH", f"/pages/{page['id']}", {"archived": True}, opener)
+        _request(token, "PATCH", f"/pages/{page['id']}", {"archived": True}, opener, budget)
         archived += 1
 
     return {"created": created, "updated": updated, "archived": archived,
             "kept": kept, "wanted": len(wanted)}
 
 
-def read_back(token, db, opener=None) -> int:
-    return len(existing_rows(token, db, opener))
+def read_back(token, db, opener=None, budget=None) -> int:
+    return len(existing_rows(token, db, opener, budget=budget))
 
 
-def collect(now, sources: dict, opener=None, token_file=None, db_file=None):
+def collect(now, sources: dict, opener=None, token_file=None, db_file=None,
+            budget_s: float = BUDGET_S):
     """Registry contract: (rows, error), or None when the board is OFF."""
     token, db = _credentials(token_file, db_file)
     if not token:
@@ -310,13 +327,24 @@ def collect(now, sources: dict, opener=None, token_file=None, db_file=None):
     buckets = consulting_board.buckets(now, sources)
     if buckets.get("error"):
         return [], f"board not written: {buckets['error']}"
-    try:
+    def work(budget):
+        # The lock is held INSIDE the budget: a painter that runs out of time also
+        # lets go, so the 07:40 job is not refused by a worker the brief abandoned.
         with exclusive():
-            counts = paint(buckets, token, db, opener)
+            counts = paint(buckets, token, db, opener, budget)
         dupes = {}
-        seen = len(existing_rows(token, db, opener, dupes_out=dupes))
+        seen = len(existing_rows(token, db, opener, dupes_out=dupes, budget=budget))
+        return counts, dupes, seen
+
+    try:
+        counts, dupes, seen = _bounded(work, budget_s)
     except BoardBusy as exc:
         return [], f"board not written: {exc}"
+    except (TimeoutError, Cancelled) as exc:
+        # The budget is cancelled before this line runs, so the worker's next Notion
+        # call refuses. Partial writes up to that point are ordinary rows the next
+        # paint reconciles; what cannot happen is a write after the brief moved on.
+        return [], f"board write timed out: {exc}; no further write lands"
     except (urllib.error.URLError, urllib.error.HTTPError, OSError, ValueError) as exc:
         return [], f"board write failed: {type(exc).__name__}: {exc}"
 

--- a/q-system/.q-system/scripts/com.kipi.morning-brief.plist
+++ b/q-system/.q-system/scripts/com.kipi.morning-brief.plist
@@ -46,7 +46,12 @@
   </array>
   <!-- Local 07:00. launchd calendar intervals are LOCAL time, so this tracks
        PST/PDT without a DST table. -->
-  <key>StartCalendarInterval</key><dict><key>Hour</key><integer>7</integer><key>Minute</key><integer>0</integer></dict>
+  <!-- 07:40, not 07:00 (2026-09-03). The consulting state card is written at 07:30 by
+       io.askconsulting.ask-crm-state-card, and this brief MIRRORS that card rather than
+       recomputing it. At 07:00 it mirrored yesterday. A second job at 07:40 was the
+       alternative and was rejected: two jobs racing one board is how two writers start.
+       Moving this one keeps a single schedule and a single writer. -->
+  <key>StartCalendarInterval</key><dict><key>Hour</key><integer>7</integer><key>Minute</key><integer>40</integer></dict>
   <key>RunAtLoad</key><false/>
   <key>StandardOutPath</key><string>__HOME__/.config/kipi/logs/morning-brief.out.log</string>
   <key>StandardErrorPath</key><string>__HOME__/.config/kipi/logs/morning-brief.err.log</string>

--- a/q-system/.q-system/scripts/com.kipi.morning-brief.plist
+++ b/q-system/.q-system/scripts/com.kipi.morning-brief.plist
@@ -44,8 +44,10 @@
     <string>/usr/bin/python3</string>
     <string>__KIPI_REPO__/q-system/.q-system/scripts/morning-brief.py</string>
   </array>
-  <!-- Local 07:00. launchd calendar intervals are LOCAL time, so this tracks
-       PST/PDT without a DST table. -->
+  <!-- launchd calendar intervals are LOCAL time, so this tracks PST/PDT without a
+       DST table. The hour itself is on the next comment; this one said 07:00 for a
+       day after the schedule moved, which is the doc-vs-code split Codex round 6
+       charged for two lines further down the same file. -->
   <!-- 07:40, not 07:00 (2026-09-03). The consulting state card is written at 07:30 by
        io.askconsulting.ask-crm-state-card, and this brief MIRRORS that card rather than
        recomputing it. At 07:00 it mirrored yesterday. A second job at 07:40 was the

--- a/q-system/.q-system/scripts/com.kipi.morning-inbox.plist
+++ b/q-system/.q-system/scripts/com.kipi.morning-inbox.plist
@@ -59,24 +59,27 @@
        DST table. The two comments that stood here described the BRIEF's single daily
        slot and were copy-pasted onto an hourly array, which is how the first slot
        below kept the brief's old 07:00 reasoning while the brief itself had moved. -->
-  <!-- Hourly at :05 through the waking day, and the FIRST slot is 07:45 rather than
-       07:05. Codex round 7 (major): the board MIRRORS the consulting state card, which
-       io.askconsulting.ask-crm-state-card writes at 07:30, and `read_heartbeat`
-       withholds a card stamped yesterday. A 07:05 run could therefore only ever see
-       yesterday's: it spent a headless Opus mail call, discarded it, refused the board
-       write and exited 1, which the launchd watchdog reads as a broken hour. Not
-       broken, early, every morning.
+  <!-- Hourly at :05 through the waking day, starting at 08:05. There is NO morning
+       slot before that, and the absence is the decision.
 
-       07:45 and not 07:40: the brief paints the same board at 07:40 and the painter
-       takes an exclusive flock, so sharing the minute would make one of the two refuse
-       with BoardBusy. Five minutes is the gap, not a race.
+       Round 7 (major): the first slot was 07:05, which is before the 07:30 state card
+       this board mirrors. `read_heartbeat` withholds a card stamped yesterday, so the
+       07:05 run could only ever see yesterday's: it spent a headless Opus mail call,
+       discarded it, refused the board write and exited 1, which the launchd watchdog
+       reads as a broken hour. Not broken. Early, every morning.
+
+       That was first fixed by moving the slot to 07:45, and round 9 (minor) charged
+       for the fix: the brief itself paints this same board at 07:40, so 07:45 repeated
+       the whole inbox collection five minutes later and 08:05 did it again twenty
+       minutes after that. The brief covers its own hour. Deleting the slot is what
+       makes the morning read once, and it is cheaper than a plist that has to know
+       what another plist is doing.
 
        WAKING HOURS ONLY: an inbox repainted at 03:00 is a model call and a Notion
        write nobody looks at before morning, and the brief covers the overnight gap.
        `test_no_hourly_slot_fires_before_the_card_it_mirrors` holds the ordering. -->
   <key>StartCalendarInterval</key>
   <array>
-    <dict><key>Hour</key><integer>7</integer><key>Minute</key><integer>45</integer></dict>
     <dict><key>Hour</key><integer>8</integer><key>Minute</key><integer>5</integer></dict>
     <dict><key>Hour</key><integer>9</integer><key>Minute</key><integer>5</integer></dict>
     <dict><key>Hour</key><integer>10</integer><key>Minute</key><integer>5</integer></dict>

--- a/q-system/.q-system/scripts/com.kipi.morning-inbox.plist
+++ b/q-system/.q-system/scripts/com.kipi.morning-inbox.plist
@@ -19,7 +19,7 @@
      with a hardcoded home is unusable on any other machine and invisible to
      validate-separation (the b2df00e / ASK-113 scar).
 
-     Install: bash q-system/.q-system/scripts/install-plist.sh com.kipi.morning-brief
+     Install: bash q-system/.q-system/scripts/install-plist.sh com.kipi.morning-inbox
 
      WHY EnvironmentVariables AND NOT a login shell. Measured 2026-08-30 on this
      Mac: `env -i HOME=... PATH=/usr/bin:/bin /bin/bash -lc 'which claude'` finds
@@ -55,19 +55,28 @@
     <string>__KIPI_REPO__/q-system/.q-system/scripts/morning-brief.py</string>
     <string>--inbox-only</string>
   </array>
-  <!-- Local 07:00. launchd calendar intervals are LOCAL time, so this tracks
-       PST/PDT without a DST table. -->
-  <!-- 07:40, not 07:00 (2026-09-03). The consulting state card is written at 07:30 by
-       io.askconsulting.ask-crm-state-card, and this brief MIRRORS that card rather than
-       recomputing it. At 07:00 it mirrored yesterday. A second job at 07:40 was the
-       alternative and was rejected: two jobs racing one board is how two writers start.
-       Moving this one keeps a single schedule and a single writer. -->
-  <!-- :05 every hour, 07:05 to 19:05. WAKING HOURS ONLY: an inbox repainted at
-       03:00 is a model call and a Notion write nobody looks at before 07:00, and
-       the 07:00 brief covers the overnight gap. -->
+  <!-- launchd calendar intervals are LOCAL time, so this tracks PST/PDT without a
+       DST table. The two comments that stood here described the BRIEF's single daily
+       slot and were copy-pasted onto an hourly array, which is how the first slot
+       below kept the brief's old 07:00 reasoning while the brief itself had moved. -->
+  <!-- Hourly at :05 through the waking day, and the FIRST slot is 07:45 rather than
+       07:05. Codex round 7 (major): the board MIRRORS the consulting state card, which
+       io.askconsulting.ask-crm-state-card writes at 07:30, and `read_heartbeat`
+       withholds a card stamped yesterday. A 07:05 run could therefore only ever see
+       yesterday's: it spent a headless Opus mail call, discarded it, refused the board
+       write and exited 1, which the launchd watchdog reads as a broken hour. Not
+       broken, early, every morning.
+
+       07:45 and not 07:40: the brief paints the same board at 07:40 and the painter
+       takes an exclusive flock, so sharing the minute would make one of the two refuse
+       with BoardBusy. Five minutes is the gap, not a race.
+
+       WAKING HOURS ONLY: an inbox repainted at 03:00 is a model call and a Notion
+       write nobody looks at before morning, and the brief covers the overnight gap.
+       `test_no_hourly_slot_fires_before_the_card_it_mirrors` holds the ordering. -->
   <key>StartCalendarInterval</key>
   <array>
-    <dict><key>Hour</key><integer>7</integer><key>Minute</key><integer>5</integer></dict>
+    <dict><key>Hour</key><integer>7</integer><key>Minute</key><integer>45</integer></dict>
     <dict><key>Hour</key><integer>8</integer><key>Minute</key><integer>5</integer></dict>
     <dict><key>Hour</key><integer>9</integer><key>Minute</key><integer>5</integer></dict>
     <dict><key>Hour</key><integer>10</integer><key>Minute</key><integer>5</integer></dict>

--- a/q-system/.q-system/scripts/com.kipi.morning-inbox.plist
+++ b/q-system/.q-system/scripts/com.kipi.morning-inbox.plist
@@ -1,0 +1,88 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<!-- THE HOURLY INBOX. Founder-directed 2026-09-03: "the email and groupme should be once an hour." Runs the brief in inbox-only mode at :05 from 07:05 to 19:05.
+
+     It sends NO Slack message. It repaints the Notion board's Inbox and nothing else.
+     Twelve Slack messages a day is how a channel gets muted, and the 07:00 brief still
+     carries the one daily read.
+
+     Waking hours only. An inbox repainted at 03:00 is a model call and a Notion write
+     nobody will look at before 07:00, and the 07:00 brief covers the overnight gap.
+
+     Separate label from com.kipi.morning-brief on purpose: one job failing must not
+     take the other down, and launchctl column 2 has to say WHICH one broke.
+     Founder-directed 2026-08-30. Replaces the 37-agent /q-morning pipeline,
+     which produced its last artifact on 2026-04-04 and was never automated.
+
+     TEMPLATE, not a loadable plist. __KIPI_REPO__ and __HOME__ are materialized
+     by install-plist.sh; a plist written straight into ~/Library/LaunchAgents
+     with a hardcoded home is unusable on any other machine and invisible to
+     validate-separation (the b2df00e / ASK-113 scar).
+
+     Install: bash q-system/.q-system/scripts/install-plist.sh com.kipi.morning-brief
+
+     WHY EnvironmentVariables AND NOT a login shell. Measured 2026-08-30 on this
+     Mac: `env -i HOME=... PATH=/usr/bin:/bin /bin/bash -lc 'which claude'` finds
+     NOTHING. The claude CLI lives at ~/.local/bin, which is put on PATH by the
+     INTERACTIVE dotfile, and a login shell under launchd never reads it. A brief
+     scheduled through `bash -lc` alone would fail every morning with "claude:
+     command not found" and its two connector-backed sections would print COULD
+     NOT READ forever. Same class as the launchd job that brake-refused for 24h
+     because .zshrc is interactive-only.
+
+     USER and LOGNAME are set for the same reason: with them absent the CLI
+     answers "Not logged in - please run /login" because the keychain lookup
+     needs them. Measured the same day: identical command, USER set, returned a
+     real calendar answer.
+-->
+<plist version="1.0">
+<dict>
+  <key>Label</key><string>com.kipi.morning-inbox</string>
+  <key>EnvironmentVariables</key>
+  <dict>
+    <key>HOME</key><string>__HOME__</string>
+    <key>USER</key><string>__USER__</string>
+    <key>LOGNAME</key><string>__USER__</string>
+    <key>PATH</key><string>__HOME__/.local/bin:/opt/homebrew/bin:/usr/local/bin:/usr/bin:/bin:/usr/sbin:/sbin</string>
+    <!-- Pinned. An unpinned headless claude -p job rides the default model; a
+         previous fleet-wide instance of that burned 3% of a weekly budget in
+         one hour. -->
+    <key>ANTHROPIC_MODEL</key><string>claude-opus-5</string>
+  </dict>
+  <key>ProgramArguments</key>
+  <array>
+    <string>/usr/bin/python3</string>
+    <string>__KIPI_REPO__/q-system/.q-system/scripts/morning-brief.py</string>
+    <string>--inbox-only</string>
+  </array>
+  <!-- Local 07:00. launchd calendar intervals are LOCAL time, so this tracks
+       PST/PDT without a DST table. -->
+  <!-- 07:40, not 07:00 (2026-09-03). The consulting state card is written at 07:30 by
+       io.askconsulting.ask-crm-state-card, and this brief MIRRORS that card rather than
+       recomputing it. At 07:00 it mirrored yesterday. A second job at 07:40 was the
+       alternative and was rejected: two jobs racing one board is how two writers start.
+       Moving this one keeps a single schedule and a single writer. -->
+  <!-- :05 every hour, 07:05 to 19:05. WAKING HOURS ONLY: an inbox repainted at
+       03:00 is a model call and a Notion write nobody looks at before 07:00, and
+       the 07:00 brief covers the overnight gap. -->
+  <key>StartCalendarInterval</key>
+  <array>
+    <dict><key>Hour</key><integer>7</integer><key>Minute</key><integer>5</integer></dict>
+    <dict><key>Hour</key><integer>8</integer><key>Minute</key><integer>5</integer></dict>
+    <dict><key>Hour</key><integer>9</integer><key>Minute</key><integer>5</integer></dict>
+    <dict><key>Hour</key><integer>10</integer><key>Minute</key><integer>5</integer></dict>
+    <dict><key>Hour</key><integer>11</integer><key>Minute</key><integer>5</integer></dict>
+    <dict><key>Hour</key><integer>12</integer><key>Minute</key><integer>5</integer></dict>
+    <dict><key>Hour</key><integer>13</integer><key>Minute</key><integer>5</integer></dict>
+    <dict><key>Hour</key><integer>14</integer><key>Minute</key><integer>5</integer></dict>
+    <dict><key>Hour</key><integer>15</integer><key>Minute</key><integer>5</integer></dict>
+    <dict><key>Hour</key><integer>16</integer><key>Minute</key><integer>5</integer></dict>
+    <dict><key>Hour</key><integer>17</integer><key>Minute</key><integer>5</integer></dict>
+    <dict><key>Hour</key><integer>18</integer><key>Minute</key><integer>5</integer></dict>
+    <dict><key>Hour</key><integer>19</integer><key>Minute</key><integer>5</integer></dict>
+  </array>
+  <key>RunAtLoad</key><false/>
+  <key>StandardOutPath</key><string>__HOME__/.config/kipi/logs/morning-inbox.out.log</string>
+  <key>StandardErrorPath</key><string>__HOME__/.config/kipi/logs/morning-inbox.err.log</string>
+</dict>
+</plist>

--- a/q-system/.q-system/scripts/consulting_board.py
+++ b/q-system/.q-system/scripts/consulting_board.py
@@ -203,6 +203,8 @@ def read_my_side(now: dt.datetime, paths=None) -> tuple[dict, str | None]:
             entry = {"last_touch": c.get("last_touch"), "slug": slug}
             by_name[str(c.get("name") or "").strip().lower()] = entry
             out[slug] = dict(entry)
+    except FileNotFoundError:
+        pass                     # no registry on this machine; see the note below
     except (OSError, ValueError) as exc:
         errors.append(f"registry unreadable ({type(exc).__name__})")
 
@@ -226,6 +228,13 @@ def read_my_side(now: dt.datetime, paths=None) -> tuple[dict, str | None]:
             if not prior or str(said)[:10] < str(prior)[:10]:
                 rec["said_on"] = said        # the OLDEST open promise is the exposure
                 rec["due"] = row.get("due")
+    # A file that is ABSENT is not a file that is BROKEN. A machine with no commitment
+    # book has no promises to report, which is a fact; a book that exists and cannot be
+    # parsed or read is a failure that must be said out loud. Collapsing the two either
+    # makes a bare checkout look broken every morning or hides a real read failure.
+    # Same posture as groupme_inbox returning None with no token: OFF, not broken.
+    except FileNotFoundError:
+        pass
     except OSError as exc:
         errors.append(f"commitment book unreadable ({type(exc).__name__})")
 
@@ -309,6 +318,104 @@ def read_gtm(paths=None) -> tuple[dict | None, str | None]:
     return live[0], None
 
 
+#: How far ahead "coming up" reaches. A week, because the section is called This Week
+#: and a due date further out is not this week's problem. Not a tuning knob: widening
+#: it turns the section into a second Top of Mind.
+WEEK_DAYS = 7
+
+
+def read_week(now: dt.datetime, paths=None) -> tuple[list[dict], str | None]:
+    """This Week: the GTM moves waiting on him, and deliverables coming due.
+
+    Founder, 2026-09-03: *"This week should be this week's GTM moves and deliverables
+    that are coming up."* Before this the section had NO source at all. It carried a
+    description copied off a reference board describing a Sunday planning ritual he
+    does not have, so it would have stayed empty forever while claiming to be "the
+    plan".
+
+    Two sources, both already on disk:
+
+    - The GTM queue's founder-performer steps that are ready. `read_gtm` takes the
+      top-ranked one for Top of Mind; this takes THE REST, so a step is never on the
+      board twice. Measured 2026-09-03: 5 of 57 rows qualify, so this is a short list
+      and not the whole plan dumped onto a second surface.
+    - Open commitments whose due date lands inside the next `WEEK_DAYS`. An OVERDUE
+      one is deliberately excluded: it is already red in Top of Mind, and showing it
+      in both places teaches him the two sections mean the same thing.
+    """
+    paths = paths or _paths()
+    out, errors = [], []
+
+    lead, gtm_err = read_gtm(paths)
+    if gtm_err:
+        errors.append(gtm_err)
+    else:
+        try:
+            data = json.loads(paths["gtm"].read_text(encoding="utf-8"))
+            rows = data.get("rows") if isinstance(data, dict) else data
+            rows = list(rows.values()) if isinstance(rows, dict) else (rows or [])
+            lead_id = (lead or {}).get("id")
+            rest = [r for r in rows
+                    if isinstance(r, dict)
+                    and r.get("performer") == "founder"
+                    and r.get("state") in ("ready", "surfaced", "blocked")
+                    and r.get("id") != lead_id]
+            rest.sort(key=lambda r: (r.get("rank") if isinstance(r.get("rank"), (int, float))
+                                     else 10**6))
+            for r in rest:
+                out.append({
+                    "title": r.get("action") or r.get("id"),
+                    "key": f"gtm:{r.get('id')}",
+                    "detail": r.get("done_looks_like") or "",
+                    "source": "GTM queue", "scope": "week:gtm",
+                    "priority": "P1" if r.get("state") == "ready" else "P2",
+                    "domain": "GTM",
+                    "done": r.get("done_looks_like") or DONE_GTM_FALLBACK,
+                    "bucket_reason": "gtm-week"})
+        except (OSError, ValueError) as exc:
+            errors.append(f"GTM queue unreadable ({type(exc).__name__})")
+
+    horizon = now.date() + dt.timedelta(days=WEEK_DAYS)
+    try:
+        for line in paths["commitments"].read_text(encoding="utf-8").splitlines():
+            line = line.strip()
+            if not line:
+                continue
+            try:
+                row = json.loads(line)
+            except ValueError:
+                continue
+            if row.get("state") != "open" or not row.get("due"):
+                continue
+            try:
+                due = dt.date.fromisoformat(str(row["due"])[:10])
+            except ValueError:
+                continue          # a junk due date is not a deliverable this week
+            if not (now.date() <= due <= horizon):
+                continue          # overdue is Top of Mind's; further out is not this week
+            left = (due - now.date()).days
+            out.append({
+                "title": f"{row.get('slug')}: {str(row.get('promise'))[:120]}",
+                "key": f"due:{row.get('id') or row.get('slug')}",
+                "detail": f"due {due.isoformat()} ({left}d)",
+                "source": "State card", "scope": "week:due",
+                "priority": "P0" if left <= 2 else "P1",
+                "domain": "Consulting",
+                "done": "you delivered it, or you moved the date with them",
+                "bucket_reason": "due-this-week"})
+    # A file that is ABSENT is not a file that is BROKEN. A machine with no commitment
+    # book has no promises to report, which is a fact; a book that exists and cannot be
+    # parsed or read is a failure that must be said out loud. Collapsing the two either
+    # makes a bare checkout look broken every morning or hides a real read failure.
+    # Same posture as groupme_inbox returning None with no token: OFF, not broken.
+    except FileNotFoundError:
+        pass
+    except OSError as exc:
+        errors.append(f"commitment book unreadable ({type(exc).__name__})")
+
+    return out, ("; ".join(errors) if errors else None)
+
+
 def collect(now: dt.datetime, sources: dict, paths=None):
     """(rows, error) for the brief's consulting section. The registered entry point."""
     paths = paths or _paths()
@@ -334,7 +441,6 @@ def collect(now: dt.datetime, sources: dict, paths=None):
     if withheld:
         # Never a silent trim. The count is the founder's cue that the board has more.
         rows.append(f"...and {withheld} more on the board")
-
     move, gtm_err = read_gtm(paths)
     if gtm_err:
         # A missing GTM move does not void the clients. It is named and the section
@@ -472,6 +578,15 @@ def buckets(now: dt.datetime, sources: dict, paths=None) -> dict:
                     "priority": "P1", "domain": "Fleet",
                     "done": "the commitment book and registry read again",
                     "bucket_reason": "error"})
+
+    week_rows, week_err = read_week(now, paths)
+    week.extend(week_rows)
+    if week_err:
+        week.append({"title": "This Week: COULD NOT READ", "key": "week:error",
+                     "detail": week_err, "source": "GTM queue", "scope": "week",
+                     "priority": "P1", "domain": "Fleet",
+                     "done": "the GTM queue and commitment book read again",
+                     "bucket_reason": "error"})
 
     move, gtm_err = read_gtm(paths)
     if not gtm_err:

--- a/q-system/.q-system/scripts/consulting_board.py
+++ b/q-system/.q-system/scripts/consulting_board.py
@@ -250,8 +250,14 @@ def collect(now: dt.datetime, sources: dict, paths=None):
 #: rendered row, so "2h ago" -> "3h ago" minted a new id, archived the row he had
 #: positioned and created a replacement in the default bucket. Same defect class as the
 #: health dot in round 1, at a call site the round-1 fix did not reach.
-_VOLATILE = re.compile(r"\b\d+\s*(?:[smhd]|min|mins|hour|hours|day|days|ago)\b"
-                       r"|\b\d{1,2}:\d{2}\b|\b\d{4}-\d{2}-\d{2}\b|\d+", re.I)
+#: Round 3 (minor): the trailing `|\d+` stripped EVERY digit run, so "invoice 4021"
+#: and "invoice 4022" collapsed to one board row. Only digits bound to a time unit, a
+#: clock time or a date are volatile; a bare number is usually the identifying part.
+_VOLATILE = re.compile(r"\b\d+\s*(?:secs?|mins?|hours?|days?|weeks?)\b"
+                       r"|\b\d+\s*[smhdw]\s+ago\b"
+                       r"|\b\d{1,2}:\d{2}\b"
+                       r"|\b\d{4}-\d{2}-\d{2}\b"
+                       r"|\bago\b", re.I)
 
 
 def _stable(text: str) -> str:
@@ -277,6 +283,10 @@ def buckets(now: dt.datetime, sources: dict, paths=None) -> dict:
         return {"error": card_err, "top_of_mind": [], "this_week": [], "inbox": [],
                 "healthy_scopes": set()}
 
+    # Scopes that produced a set worth ARCHIVING AGAINST this run. Declared HERE, above
+    # every producer, because each one adds itself only after it answered cleanly.
+    # "card" is unconditional: a card failure returns early, above this line.
+    healthy = {"card"}
     top, week = [], []
     for row in card_rows:
         # `key` is what the row id is hashed from and it carries NO health dot.
@@ -285,7 +295,13 @@ def buckets(now: dt.datetime, sources: dict, paths=None) -> dict:
         # unattended paint then archived the row he had dragged and created a
         # replacement in a computed bucket, silently undoing his move. The whole
         # "his drag always wins" promise depended on an id that does not move.
-        item = {"title": f"{row['health']} {row['name']}", "key": row["name"],
+        # KIND-NAMESPACED. Round 3 (major): both a client row and a reach-out row are
+        # named for the person, so keying on the name alone made them one row -- the
+        # reach-out action was silently dropped and read-back still said ok, because
+        # `wanted` had already collapsed them before the count was taken. Two different
+        # things about one person are two rows.
+        item = {"title": f"{row['health']} {row['name']}",
+                "key": f"{row['kind']}:{row['name']}",
                 "detail": row["detail"], "source": "State card", "scope": "card",
                 "bucket_reason": row["health"]}
         # 🔴 and 📞 are today. Everything else is this week. The split is the card's
@@ -293,6 +309,12 @@ def buckets(now: dt.datetime, sources: dict, paths=None) -> dict:
         (top if row["health"] in ("🔴", "📞") else week).append(item)
 
     move, gtm_err = read_gtm(paths)
+    if not gtm_err:
+        # Round 3 (major): "gtm" was unconditionally healthy, so an unreadable
+        # gtm-queue.json still authorised archiving inside that scope -- the painter
+        # deleted the GTM row he had positioned and recreated it in a computed bucket.
+        # The same reasoning the inbox scopes already had; it just was not applied here.
+        healthy.add("gtm")
     if move:
         top.append({"title": move.get("action") or move.get("id"),
                     "key": f"gtm:{move.get('id')}",   # the step id, stable across rewordings
@@ -304,10 +326,6 @@ def buckets(now: dt.datetime, sources: dict, paths=None) -> dict:
                     "detail": gtm_err, "source": "GTM queue", "bucket_reason": "error"})
 
     inbox = []
-    #: Scopes that produced a set worth ARCHIVING AGAINST this run. "card" and "gtm"
-    #: are here because a failure in either returns early above; an inbox source only
-    #: joins after it answered without an error.
-    healthy = {"card", "gtm"}
     # Gmail and GroupMe only. Codex finding (major), 2026-09-03: this asked for a
     # "slack" source too, and `collect_all` registers no Slack producer, so that
     # channel was silently absent forever while the docs claimed three. An unwired

--- a/q-system/.q-system/scripts/consulting_board.py
+++ b/q-system/.q-system/scripts/consulting_board.py
@@ -77,6 +77,8 @@ def _paths(root: Path | None = None) -> dict:
         "card": q / "output" / "today-card.md",
         "heartbeat": q / "output" / "ask-crm-state-card-heartbeat.json",
         "gtm": q / "my-project" / "gtm-queue.json",
+        "commitments": q / "my-project" / "commitments.jsonl",
+        "clients": q / "my-project" / "clients.json",
     }
 
 
@@ -150,6 +152,105 @@ def read_card(paths=None) -> tuple[list[dict], str | None]:
         return [], (f"{path.name} parsed to zero client lines; the card format changed "
                     "and this reader did not")
     return rows, None
+
+
+def _days(then: str, now: dt.datetime):
+    """Whole days from an ISO date/timestamp to `now`, or None if unparseable.
+    A bad date returns None and the caller omits the phrase; it never renders 0,
+    which would read as "today" and be a lie about how long he has been waiting."""
+    try:
+        d = dt.date.fromisoformat(str(then)[:10])
+    except (TypeError, ValueError):
+        return None
+    return (now.date() - d).days
+
+
+def read_my_side(now: dt.datetime, paths=None) -> tuple[dict, str | None]:
+    """Per slug: WHEN he said the thing, what was due, and when he last touched them.
+
+    ## Why this reader exists (founder, 2026-09-03)
+
+    *"This is a learning from the [a retainer client] fiasco -- they said I wasn't doing
+    things and I've actually been waiting on deliverables for weeks. So it needs to
+    say when was the last thing delivered and what am I still waiting for and how
+    long."* Scoped by him one message later to HIS side only.
+
+    The card renders a promise but no DATE, so a row said "you said X -- not sent"
+    with no way to tell a promise made yesterday from one made in July. A board that
+    cannot say WHEN cannot settle an argument about whether he was slow.
+
+    ## Facts, not a second verdict
+
+    This reads two files the card also reads, and that is deliberate and is NOT the
+    dual-derivation this module's docstring forbids. The forbidden thing is a second
+    opinion about SEVERITY -- red/yellow/reach stays the card's call, and nothing here
+    touches it. A date is a fact with one value; reading it twice cannot disagree.
+
+    `clients.json` is read as a LOOKUP keyed by the names the card already chose,
+    never enumerated: it is 162 rows of which ~150 are cold prospects, and walking it
+    would put them all on the board.
+    """
+    paths = paths or _paths()
+    out, errors = {}, []
+
+    by_name = {}
+    try:
+        reg = json.loads(paths["clients"].read_text(encoding="utf-8"))
+        for c in reg.get("clients") or []:
+            slug = c.get("slug")
+            if not slug:
+                continue
+            entry = {"last_touch": c.get("last_touch"), "slug": slug}
+            by_name[str(c.get("name") or "").strip().lower()] = entry
+            out[slug] = dict(entry)
+    except (OSError, ValueError) as exc:
+        errors.append(f"registry unreadable ({type(exc).__name__})")
+
+    try:
+        for line in paths["commitments"].read_text(encoding="utf-8").splitlines():
+            line = line.strip()
+            if not line:
+                continue
+            try:
+                row = json.loads(line)
+            except ValueError:
+                continue          # one bad line never voids the book
+            # OPEN only. A resolved promise is not something he still owes, and
+            # showing it would recreate the "you did not do this" claim he is
+            # defending against.
+            if row.get("state") != "open" or not row.get("slug"):
+                continue
+            rec = out.setdefault(row["slug"], {"slug": row["slug"], "last_touch": None})
+            said = row.get("extracted_at")
+            prior = rec.get("said_on")
+            if not prior or str(said)[:10] < str(prior)[:10]:
+                rec["said_on"] = said        # the OLDEST open promise is the exposure
+                rec["due"] = row.get("due")
+    except OSError as exc:
+        errors.append(f"commitment book unreadable ({type(exc).__name__})")
+
+    out["_by_name"] = by_name
+    return out, ("; ".join(errors) if errors else None)
+
+
+def my_side_phrase(rec: dict, now: dt.datetime) -> str:
+    """"said 2026-08-18 (16d ago) - due 2026-08-31 - last touch 2026-08-22".
+
+    Every part is omitted when its date is missing rather than rendered as unknown:
+    a board line is read in two seconds and "due: none" costs a second for nothing.
+    """
+    bits = []
+    said = rec.get("said_on")
+    if said:
+        n = _days(said, now)
+        bits.append(f"said {str(said)[:10]}" + (f" ({n}d ago)" if n is not None else ""))
+    if rec.get("due"):
+        bits.append(f"due {str(rec['due'])[:10]}")
+    touch = rec.get("last_touch")
+    if touch:
+        n = _days(touch, now)
+        bits.append(f"last touch {str(touch)[:10]}" + (f" ({n}d)" if n is not None else ""))
+    return " · ".join(bits)
 
 
 def read_heartbeat(now: dt.datetime, paths=None) -> tuple[dict, str | None]:
@@ -324,6 +425,9 @@ def buckets(now: dt.datetime, sources: dict, paths=None) -> dict:
     # every producer, because each one adds itself only after it answered cleanly.
     # "card" is unconditional: a card failure returns early, above this line.
     healthy = {"card"}
+    my_side, my_side_err = read_my_side(now, paths)
+    by_name = my_side.pop("_by_name", {})
+
     top, week = [], []
 
     for row in card_rows:
@@ -345,9 +449,29 @@ def buckets(now: dt.datetime, sources: dict, paths=None) -> dict:
                 "domain": "Consulting",
                 "done": DONE_BY_KIND.get(row["kind"], DONE_DEFAULT),
                 "bucket_reason": row["health"]}
+        # The dates his side of the story needs. Appended to the detail, never
+        # replacing the promise: the promise in his own words is the evidence and
+        # the dates are what make it an alibi.
+        reg = by_name.get(row["name"].strip().lower())
+        rec = dict(my_side.get(reg["slug"], {})) if reg else {}
+        if reg:
+            rec.setdefault("last_touch", reg.get("last_touch"))
+        phrase = my_side_phrase(rec, now) if rec else ""
+        if phrase:
+            item["detail"] = f"{item['detail']}\n{phrase}" if item["detail"] else phrase
         # 🔴 and 📞 are today. Everything else is this week. The split is the card's
         # own health verdict, not a rule invented here.
         (top if row["health"] in ("🔴", "📞") else week).append(item)
+
+    # The dates failing is reported ONCE, as its own row, never as a line stapled to
+    # every client. A test proves this module still delivers with no registry in the
+    # tree at all, and per-row noise would make that delivery look broken.
+    if my_side_err:
+        top.append({"title": "Promise dates: COULD NOT READ", "key": "myside:error",
+                    "detail": my_side_err, "source": "State card", "scope": "myside",
+                    "priority": "P1", "domain": "Fleet",
+                    "done": "the commitment book and registry read again",
+                    "bucket_reason": "error"})
 
     move, gtm_err = read_gtm(paths)
     if not gtm_err:

--- a/q-system/.q-system/scripts/consulting_board.py
+++ b/q-system/.q-system/scripts/consulting_board.py
@@ -245,30 +245,20 @@ def collect(now: dt.datetime, sources: dict, paths=None):
     return rows, None
 
 
-#: Tokens that change while the THING does not: ages, counts, times, dates. Stripped
-#: before an inbox row's identity is hashed. Codex round 2 (major): the id was the
-#: rendered row, so "2h ago" -> "3h ago" minted a new id, archived the row he had
-#: positioned and created a replacement in the default bucket. Same defect class as the
-#: health dot in round 1, at a call site the round-1 fix did not reach.
-#: Round 3 (minor): the trailing `|\d+` stripped EVERY digit run, so "invoice 4021"
-#: and "invoice 4022" collapsed to one board row. Only digits bound to a time unit, a
-#: clock time or a date are volatile; a bare number is usually the identifying part.
-#: Round 4 (major, the first real Codex read after two rounds on the Opus fallback):
-#: the REAL mail producer, morning-brief.collect_mail, renders an age as `[2h]`, a
-#: bracketed unit with no "ago". None of the forms below matched it, so the round-2
-#: fix held for the fixture and not for the producer. The test now drives the producer.
-_VOLATILE = re.compile(r"\b\d+\s*(?:secs?|mins?|hours?|days?|weeks?)\b"
-                       r"|\b\d+\s*[smhdw]\s+ago\b"
-                       r"|\[\s*\d+\s*[smhdw]\s*\]"
-                       r"|\b\d{1,2}:\d{2}\b"
-                       r"|\b\d{4}-\d{2}-\d{2}\b"
-                       r"|\bago\b", re.I)
-
-
-def _stable(text: str) -> str:
-    """`text` with every volatile token removed, for use as an identity."""
-    return " ".join(_VOLATILE.sub("", text or "").split()).lower()[:160]
-
+# `_VOLATILE` / `_stable` LIVED HERE AND ARE DELETED (PR #296, 2026-09-03).
+#
+# They scrubbed volatile tokens out of a rendered line so the line could be hashed
+# into a board-row identity. Four Codex rounds each added one more pattern -- the
+# health dot, "2h ago", a bare digit run that collapsed "invoice 4021" and
+# "invoice 4022" into one row, and finally the `[2h]` the real mail producer emits,
+# which the round-2 fix had never seen because the test drove a fixture instead.
+#
+# Every one of those is the same defect: an identity derived from PRESENTATION.
+# Rendering changes, so the regex could only ever chase it, and each fix bought one
+# round. Producers now emit `morning-brief.Row(line, key)` carrying the id they
+# already had -- a Gmail thread id, a GroupMe conversation id -- and `buckets` refuses
+# a row without one. `test_no_identity_is_derived_from_rendered_text` fails if this
+# file ever grows a text-scrubbing identity again.
 
 def buckets(now: dt.datetime, sources: dict, paths=None) -> dict:
     """The board's three buckets, for notion_board.py's row writer.
@@ -349,7 +339,25 @@ def buckets(now: dt.datetime, sources: dict, paths=None) -> dict:
         healthy.add(f"inbox:{label}")
         for row in rows:
             text = str(row)[:180]
-            inbox.append({"title": text, "key": f"{label}:{_stable(text)}", "detail": "",
+            # THE END OF THE FOUR-ROUND LOOP. The key is the producer's own id
+            # (morning-brief.Row.key: a Gmail thread id, a GroupMe conversation id),
+            # never the rendered line. Rounds 1-4 of PR #296 were four patches to a
+            # regex that scrubbed volatile tokens out of that line -- the health dot,
+            # "2h ago", a digit run that collapsed two invoice numbers, the `[2h]` the
+            # real producer emits -- and a fifth form was guaranteed because rendering
+            # keeps changing and a regex can only chase it.
+            #
+            # An UNKEYED row is refused, loudly, rather than falling back to the text.
+            # A fallback would be indistinguishable from the old behaviour on the day a
+            # new producer forgets, which is exactly how this defect survived three
+            # fixes: each one held for the fixture and not for the producer.
+            key = getattr(row, "key", None)
+            if not key:
+                raise TypeError(
+                    f"{label} produced an inbox row with no stable key: {text!r}. "
+                    "Every inbox producer must emit morning-brief.Row(line, key); "
+                    "keying on the rendered line is the PR #296 rounds 1-4 defect.")
+            inbox.append({"title": text, "key": key, "detail": "",
                           "source": label, "scope": f"inbox:{label}",
                           "bucket_reason": "inbox"})
 

--- a/q-system/.q-system/scripts/consulting_board.py
+++ b/q-system/.q-system/scripts/consulting_board.py
@@ -617,7 +617,14 @@ def buckets(now: dt.datetime, sources: dict, paths=None) -> dict:
 
     my_side, my_side_err = ({}, None) if card_problem else read_my_side(now, paths)
     by_name = my_side.pop("_by_name", {})
-    if not card_problem:
+    if not card_problem and card_rows:
+        # ZERO ROWS NEVER AUTHORISES ARCHIVING (round 14, major, against round 12's
+        # own fix). Treating a quiet morning as healthy meant a format change that
+        # happened to keep the `*Your book today*` header parsed to nothing, declared
+        # the scope healthy, and archived EVERY client row on the board including the
+        # ones he had pinned. Quiet and drifted look identical from here, so the board
+        # keeps what it has and the reader says nothing either way: no alarm row on a
+        # genuinely quiet day, no destruction on a drifted one.
         healthy.add("card")
 
     for row in card_rows:

--- a/q-system/.q-system/scripts/consulting_board.py
+++ b/q-system/.q-system/scripts/consulting_board.py
@@ -363,6 +363,13 @@ def read_gtm(paths=None) -> tuple[dict | None, str | None]:
 WEEK_DAYS = 7
 
 
+def _norm_key(text) -> str:
+    """A promise reduced to a stable identity fragment: whitespace collapsed, cased
+    down, bounded. Not a hash, so a key stays readable in the Notion row and a human
+    can see which promise it belongs to."""
+    return " ".join(str(text or "").split()).lower()[:80]
+
+
 def read_week(now: dt.datetime, paths=None) -> tuple[list[dict], str | None, set]:
     """This Week: the GTM moves waiting on him, and deliverables coming due.
 
@@ -455,7 +462,20 @@ def read_week(now: dt.datetime, paths=None) -> tuple[list[dict], str | None, set
             left = (due - now.date()).days
             out.append({
                 "title": f"{row.get('slug')}: {str(row.get('promise'))[:120]}",
-                "key": f"due:{row.get('id') or row.get('slug')}",
+                # The commitment's own id when it has one; otherwise the slug AND
+                # the promise, because the slug alone is not an identity. Two open
+                # deliverables for one client with no id both keyed `due:<slug>`,
+                # so the second overwrote the first in `wanted` and the read-back
+                # still reported ok -- it counts what it wrote, and the row was
+                # already gone before the count. Same class as the inbox rows: an
+                # id derived from too little is a collision, and a collision is a
+                # silent deletion.
+                #
+                # `_norm_key` is NOT the rendered line. The detail carries a
+                # countdown in days that changes every morning, and keying on it
+                # would mint a new row daily. The promise text is what is stable.
+                "key": (f"due:{row['id']}" if row.get("id")
+                        else f"due:{row.get('slug')}:{_norm_key(row.get('promise'))}"),
                 "detail": f"due {due.isoformat()} ({left}d)",
                 "source": "State card", "scope": "week:due",
                 "priority": "P0" if left <= 2 else "P1",

--- a/q-system/.q-system/scripts/consulting_board.py
+++ b/q-system/.q-system/scripts/consulting_board.py
@@ -111,6 +111,9 @@ _THEN_SEP = "·"
 #: The producer's own tail on that line: "+3 more, lowest-scoring, on the board".
 _MORE_SUMMARY = re.compile(r"^\+\s*\d+\s+more\b")
 #: "— 🔥 Portant (fire, v1 CRM: ...)" -- the person, out of the reach-out header's tail.
+#: A mail key built from sender+subject rather than a thread id. `collect_mail` uses
+#: "<sender>|<subject>" only when the model returned no id; a real id carries none.
+_FALLBACK_KEY = re.compile(r"^[^|]+\|")
 #: `build_card`'s first line, always present. See `read_card` for why it decides.
 _BOOK_HEADER = re.compile(r"\*Your book today\*")
 _REACH_WHO = re.compile(r"^[^A-Za-z0-9]*(?P<who>[A-Za-z0-9][^(:]*?)\s*(?:\(|:|$)")
@@ -730,7 +733,14 @@ def buckets(now: dt.datetime, sources: dict, paths=None) -> dict:
                           "done": f"{label} reads again",
                           "bucket_reason": "error"})
             continue                      # scope deliberately NOT marked healthy
-        healthy.add(f"inbox:{label}")
+        # AN ID-LESS ANSWER DOES NOT AUTHORISE ARCHIVING (round 13, major). When the
+        # model returns thread ids the key is the id; when it does not, the key falls
+        # back to sender+subject. Both are stable in themselves, but they are DIFFERENT
+        # ids for one thread, so a day where the model stops returning ids archives the
+        # row he pinned and recreates it at "Not started". The rows still paint; what
+        # is withheld is the authority to call the old ones gone.
+        if not any(_FALLBACK_KEY.match(getattr(r, "key", "") or "") for r in rows):
+            healthy.add(f"inbox:{label}")
         for row in rows:
             text = str(row)[:180]
             # THE END OF THE FOUR-ROUND LOOP. The key is the producer's own id

--- a/q-system/.q-system/scripts/consulting_board.py
+++ b/q-system/.q-system/scripts/consulting_board.py
@@ -407,6 +407,7 @@ def read_week(now: dt.datetime, paths=None) -> tuple[list[dict], str | None, set
             errors.append(f"GTM queue unreadable ({type(exc).__name__})")
 
     horizon = now.date() + dt.timedelta(days=WEEK_DAYS)
+    unreadable_lines = 0
     try:
         for line in paths["commitments"].read_text(encoding="utf-8").splitlines():
             line = line.strip()
@@ -415,6 +416,11 @@ def read_week(now: dt.datetime, paths=None) -> tuple[list[dict], str | None, set
             try:
                 row = json.loads(line)
             except ValueError:
+                # ROUND 10 (major): this skipped the line and the scope was still
+                # declared healthy below, which AUTHORISED the painter to archive the
+                # row for the very deliverable the corrupt line described. A book we
+                # could not read start to finish has not said those rows are gone.
+                unreadable_lines += 1
                 continue
             if row.get("state") != "open" or not row.get("due"):
                 continue
@@ -434,7 +440,11 @@ def read_week(now: dt.datetime, paths=None) -> tuple[list[dict], str | None, set
                 "domain": "Consulting",
                 "done": "you delivered it, or you moved the date with them",
                 "bucket_reason": "due-this-week"})
-        healthy.add("week:due")           # the book was read start to finish
+        if unreadable_lines:
+            errors.append(f"{unreadable_lines} unreadable line(s) in the commitment "
+                          "book; deliverable rows are kept rather than archived")
+        else:
+            healthy.add("week:due")       # the book was read start to finish
     # A file that is ABSENT is not a file that is BROKEN. A machine with no commitment
     # book has no promises to report, which is a fact; a book that exists and cannot be
     # parsed or read is a failure that must be said out loud. Collapsing the two either

--- a/q-system/.q-system/scripts/consulting_board.py
+++ b/q-system/.q-system/scripts/consulting_board.py
@@ -507,6 +507,10 @@ def collect(now: dt.datetime, sources: dict, paths=None):
 #: design exists to avoid (DEC-8/DEC-13, and the v1 CRM that died of hand-feeding).
 #: So this is a TRANSLATION table, not a scoring rule: his card's dot, in Bloom's
 #: P0-P3 vocabulary.
+#: The scope carrying the "your book could not be read" row. Always healthy, because
+#: this module always knows whether the alarm belongs; see `buckets`.
+CARD_ALARM = "card:alarm"
+
 PRIORITY_BY_HEALTH = {
     "🔴": "P0",    # do today: a promise he made, past due
     "🟠": "P0",    # answer them: a person is waiting on a reply
@@ -549,24 +553,40 @@ def buckets(now: dt.datetime, sources: dict, paths=None) -> dict:
     and neither one recomputes the other's verdict.
     """
     paths = paths or _paths()
-    beat, beat_err = read_heartbeat(now, paths)
-    if beat_err:
-        return {"error": beat_err, "top_of_mind": [], "this_week": [], "inbox": [],
-                "healthy_scopes": set()}
-
-    card_rows, card_err = read_card(paths)
-    if card_err:
-        return {"error": card_err, "top_of_mind": [], "this_week": [], "inbox": [],
-                "healthy_scopes": set()}
-
-    # Scopes that produced a set worth ARCHIVING AGAINST this run. Declared HERE, above
-    # every producer, because each one adds itself only after it answered cleanly.
-    # "card" is unconditional: a card failure returns early, above this line.
-    healthy = {"card"}
-    my_side, my_side_err = read_my_side(now, paths)
-    by_name = my_side.pop("_by_name", {})
-
+    # Scopes that produced a set worth ARCHIVING AGAINST this run. Each adds itself only
+    # after it answered cleanly. CARD_ALARM is the exception and is always healthy: this
+    # function always reaches a verdict about the card, so it can always decide whether
+    # the alarm row belongs, and a stuck alarm nobody can clear is its own defect.
+    healthy = {CARD_ALARM}
     top, week = [], []
+
+    beat, beat_err = read_heartbeat(now, paths)
+    card_rows, card_err = ([], None) if beat_err else read_card(paths)
+    card_problem = beat_err or card_err
+
+    # A STALE CARD NO LONGER SILENCES THE SOURCES THAT DID ANSWER (round 9, major).
+    #
+    # The rule this is often mistaken for is round 2's, and that one stands: a source
+    # that could not answer writes NOTHING, and its rows are neither refreshed nor
+    # archived. What was wrong was the RADIUS. `collect` refused the whole paint on a
+    # card problem, so a late 07:30 job also stopped Gmail and GroupMe rows -- sources
+    # that answered perfectly well -- from reaching the board.
+    #
+    # And the abort was not even protecting him from stale client rows. Nothing
+    # archives or overwrites them either way, so the board showed yesterday's clients
+    # WITH no fresh mail. Per-scope gives him yesterday's clients, an alarm row saying
+    # so, and today's mail.
+    if card_problem:
+        top.append({"title": "Your book: COULD NOT READ", "key": "card:error",
+                    "detail": card_problem, "source": "State card", "scope": CARD_ALARM,
+                    "priority": "P0", "domain": "Fleet",
+                    "done": "the 07:30 state card writes a fresh one",
+                    "bucket_reason": "error"})
+
+    my_side, my_side_err = ({}, None) if card_problem else read_my_side(now, paths)
+    by_name = my_side.pop("_by_name", {})
+    if not card_problem:
+        healthy.add("card")
 
     for row in card_rows:
         # `key` is what the row id is hashed from and it carries NO health dot.
@@ -611,7 +631,7 @@ def buckets(now: dt.datetime, sources: dict, paths=None) -> dict:
     # The dates failing is reported ONCE, as its own row, never as a line stapled to
     # every client. A test proves this module still delivers with no registry in the
     # tree at all, and per-row noise would make that delivery look broken.
-    if not my_side_err:
+    if not my_side_err and not card_problem:
         # The apology row below is scoped `myside`, and until round 6 that scope was
         # never healthy, so the row outlived the outage it reported and nothing could
         # clear it. A source that recovered is what authorises clearing its own alarm.
@@ -713,7 +733,12 @@ def buckets(now: dt.datetime, sources: dict, paths=None) -> dict:
                           "done": DONE_BY_SOURCE.get(label, DONE_DEFAULT),
                           "bucket_reason": "inbox"})
 
-    return {"error": None, "top_of_mind": top, "this_week": week, "inbox": inbox,
+    return {"error": None,
+            # NOT `error`. `error` means the painter must not write at all; a card
+            # problem means one SCOPE has nothing to say. Callers report this, the
+            # board carries the alarm row, and every other scope paints.
+            "card_error": card_problem,
+            "top_of_mind": top, "this_week": week, "inbox": inbox,
             # Which scopes produced a TRUSTWORTHY set this run. The painter archives
             # only inside these; see board_rows.paint. Codex round 2 (major): a
             # transient Gmail error replaced its rows with a single error row, and the

--- a/q-system/.q-system/scripts/consulting_board.py
+++ b/q-system/.q-system/scripts/consulting_board.py
@@ -1,0 +1,268 @@
+#!/usr/bin/env python3
+"""The consulting half of the morning brief: clients, the GTM move, the inbox.
+
+Founder, 2026-09-03, on finding the board full of builds and Sana's Linear queue:
+*"This isn't -- I'm not looking for this to be a build dashboard, but a consulting
+dashboard."* Then, on how to get there: *"copy it but everyting needs to be actually
+connected fully and is automated so its not done by hand"*.
+
+## MIRROR, never a second derivation. This is the whole design.
+
+`consulting/q-consult/pipeline/state_card.py` already computes what he asked for, every
+morning at 07:30 PT: which clients are red, what he promised each of them in his own
+words, who to reach out to. `gtm-queue.json` already carries the one GTM move. This
+module READS those OUTPUTS. It does not open `clients.json`, it does not import
+`pipeline`, and it never recomputes a verdict.
+
+The rejected alternative was a `collect_clients` that read the registry itself. Two
+reasons it is struck, and the second is the expensive one:
+
+  1. `clients.json` is 162 rows, of which ~150 are cold hunt-list prospects with no rate
+     and no next_touch. A flat read puts 150 dead rows on his morning board.
+  2. Two things deriving one truth is how the v1 Notion CRM died. His own verdict on it:
+     "died because it was hand-fed". The fleet rule that came out of that (DEC-8/DEC-13,
+     `gtm_board.py`, `board_sync.py`) is that the board is a MIRROR and one writer owns
+     the computed state. A second derivation is a second writer wearing a reader's coat.
+
+## STALENESS IS AN ERROR, never a quiet mirror
+
+The card is written at 07:30 and this runs after it. If the heartbeat's date is not
+today, this returns an ERROR naming the age rather than rendering yesterday's clients as
+though they were this morning's. A mirror whose source is stale and which still looks
+fresh is worse than a blank section: he would act on it.
+
+That is the same law the rest of this brief already lives under -- an empty section and a
+broken section are different facts -- applied to a third case the fixed four never had,
+which is a section whose source is READABLE and WRONG.
+
+## The cross-repo boundary
+
+kipi-system reads the consulting instance's output FILES. It never imports `pipeline`,
+which is the same boundary `consulting/q-consult/pipeline/tests/test_boundary.py` holds
+in the other direction. `CONSULTING_ROOT` is resolved from `$KIPI_CONSULTING_ROOT` or
+from `Path.home()`, never a literal home path (the content tripwire refuses one).
+
+OFF switch: a missing consulting instance. `collect` returns None when the q-consult
+directory is absent, so this renders no section at all rather than four COULD NOT READ
+lines. The skeleton ships to instances that have no consulting book, and a fleet-wide
+script must be silent on a machine the feature does not apply to.
+"""
+from __future__ import annotations
+
+import datetime as dt
+import json
+import os
+import re
+from pathlib import Path
+from zoneinfo import ZoneInfo
+
+PT = ZoneInfo("America/Los_Angeles")
+
+#: How many client lines reach the brief. The card itself carries every red row; the
+#: Slack section is a summary and the Notion board is the full surface. 6 is the count
+#: that fits the founder's screen without scrolling, measured against the 2026-09-03 card
+#: (7 red). A withheld count is always printed rather than the rest being dropped silently.
+MAX_CLIENT_ROWS = 6
+
+
+def consulting_root() -> Path:
+    return Path(os.environ.get("KIPI_CONSULTING_ROOT")
+                or Path.home() / "projects" / "consulting")
+
+
+def _paths(root: Path | None = None) -> dict:
+    root = root or consulting_root()
+    q = root / "q-consult"
+    return {
+        "card": q / "output" / "today-card.md",
+        "heartbeat": q / "output" / "ask-crm-state-card-heartbeat.json",
+        "gtm": q / "my-project" / "gtm-queue.json",
+    }
+
+
+# A card line is one client's state, written by state_card.py in his own words, e.g.
+#   🔴 *Alice* · you said "..." — not sent
+#   📞 *2 to reach out* — 🔥 Portant (fire, ...)
+# The emoji is the health verdict and is NOT re-derived here: it is the card's.
+# The `*THE MOVE*` prefix on the top-ranked row is why this does not anchor the emoji
+# to line start. It cost the first smoke run its most important client: Alice was rank 1,
+# carried the prefix, and silently did not parse while six lesser rows did. A parser that
+# drops the FIRST row is worse than one that drops none, because the gap is invisible.
+_CLIENT_LINE = re.compile(
+    r"^\s*(?:\*THE MOVE\*\s*)?(?P<health>🔴|🟡|🟢|⚪|🟠)\s*\*(?P<name>[^*]+)\*"
+    r"\s*·\s*(?P<rest>.+)$")
+_REACH_LINE = re.compile(r"^\s*📞\s*\*(?P<what>[^*]+)\*\s*(?P<rest>.*)$")
+
+
+def read_card(paths=None) -> tuple[list[dict], str | None]:
+    """The card's client lines, parsed but never re-judged. (rows, error)."""
+    paths = paths or _paths()
+    path = paths["card"]
+    if not path.exists():
+        return [], f"no state card at {path.name}; the 07:30 job has not written one"
+    try:
+        text = path.read_text(encoding="utf-8")
+    except OSError as exc:
+        return [], f"could not read {path.name}: {exc}"
+
+    rows = []
+    for line in text.splitlines():
+        m = _CLIENT_LINE.match(line)
+        if m:
+            rows.append({"kind": "client", "health": m.group("health"),
+                         "name": m.group("name").strip(), "detail": m.group("rest").strip()})
+            continue
+        m = _REACH_LINE.match(line)
+        if m:
+            rows.append({"kind": "reach", "health": "📞",
+                         "name": m.group("what").strip(), "detail": m.group("rest").strip()})
+    if not rows:
+        # A card that exists and parses to nothing is a FORMAT change, not a quiet
+        # morning. state_card.py always emits at least the book line, so zero parsed
+        # rows means this reader and that writer have drifted apart.
+        return [], (f"{path.name} parsed to zero client lines; the card format changed "
+                    "and this reader did not")
+    return rows, None
+
+
+def read_heartbeat(now: dt.datetime, paths=None) -> tuple[dict, str | None]:
+    """The card's freshness and counts. Refuses a stale heartbeat loudly."""
+    paths = paths or _paths()
+    path = paths["heartbeat"]
+    if not path.exists():
+        return {}, f"no state-card heartbeat at {path.name}"
+    try:
+        beat = json.loads(path.read_text(encoding="utf-8"))
+    except (OSError, ValueError) as exc:
+        return {}, f"could not read {path.name}: {exc}"
+
+    if beat.get("crash"):
+        return beat, f"the 07:30 state card crashed: {beat['crash']}"
+
+    stamped = (beat.get("card") or {}).get("date")
+    today = now.astimezone(PT).date().isoformat()
+    if stamped != today:
+        return beat, (f"the state card is from {stamped}, not {today}. "
+                      "Showing it as today's book would be wrong, so it is withheld")
+    return beat, None
+
+
+def read_gtm(paths=None) -> tuple[dict | None, str | None]:
+    """The ONE GTM action, from the queue's own ranking. Never re-ranked here."""
+    paths = paths or _paths()
+    path = paths["gtm"]
+    if not path.exists():
+        return None, f"no GTM queue at {path.name}"
+    try:
+        data = json.loads(path.read_text(encoding="utf-8"))
+    except (OSError, ValueError) as exc:
+        return None, f"could not read {path.name}: {exc}"
+
+    rows = data.get("rows") if isinstance(data, dict) else data
+    # `rows` is a DICT keyed by step id ("1.1"), not a list. Measured, not assumed:
+    # the first draft of this reader typed `isinstance(rows, list)` and reported
+    # COULD NOT READ against a perfectly good queue.
+    if isinstance(rows, dict):
+        rows = list(rows.values())
+    if not isinstance(rows, list):
+        return None, f"{path.name} carries no rows"
+
+    # The card surfaces only what needs HIM. `gtm_queue`'s own rule: a `founder`
+    # performer, in a state that is not already worked. `mechanism` rows are the
+    # machine's and belong in Sana's queue, never on his morning board.
+    live = [r for r in rows
+            if isinstance(r, dict)
+            and r.get("performer") == "founder"
+            and r.get("state") in ("ready", "surfaced", "blocked")]
+    if not live:
+        return None, None          # nothing waiting on him is not an error
+    live.sort(key=lambda r: (r.get("rank") if isinstance(r.get("rank"), (int, float))
+                             else 10**6))
+    return live[0], None
+
+
+def collect(now: dt.datetime, sources: dict, paths=None):
+    """(rows, error) for the brief's consulting section. The registered entry point."""
+    paths = paths or _paths()
+    if not paths["card"].parent.parent.exists():
+        return None                       # OFF: no consulting instance on this machine
+    beat, beat_err = read_heartbeat(now, paths)
+    if beat_err:
+        return [], beat_err
+
+    card_rows, card_err = read_card(paths)
+    if card_err:
+        return [], card_err
+
+    rows = []
+    counts = (beat.get("card") or {}).get("counts") or {}
+    if counts:
+        rows.append(f"book: {counts.get('red', 0)} owed, {counts.get('reach', 0)} to reach out")
+
+    shown = card_rows[:MAX_CLIENT_ROWS]
+    for row in shown:
+        rows.append(f"{row['health']} {row['name']} · {row['detail']}")
+    withheld = len(card_rows) - len(shown)
+    if withheld:
+        # Never a silent trim. The count is the founder's cue that the board has more.
+        rows.append(f"...and {withheld} more on the board")
+
+    move, gtm_err = read_gtm(paths)
+    if gtm_err:
+        # A missing GTM move does not void the clients. It is named and the section
+        # still delivers, which is the partial-delivery posture the reddit lane learned.
+        rows.append(f"GTM: COULD NOT READ ({gtm_err})")
+    elif move:
+        rows.append(f"GTM: {move.get('action') or move.get('id')}")
+
+    return rows, None
+
+
+def buckets(now: dt.datetime, sources: dict, paths=None) -> dict:
+    """The board's three buckets, for notion_board.py's row writer.
+
+    Separate from `collect` on purpose. `collect` answers "what does the Slack line
+    say"; this answers "what rows does the board hold". One shared read, two renderings,
+    and neither one recomputes the other's verdict.
+    """
+    paths = paths or _paths()
+    beat, beat_err = read_heartbeat(now, paths)
+    if beat_err:
+        return {"error": beat_err, "top_of_mind": [], "this_week": [], "inbox": []}
+
+    card_rows, card_err = read_card(paths)
+    if card_err:
+        return {"error": card_err, "top_of_mind": [], "this_week": [], "inbox": []}
+
+    top, week = [], []
+    for row in card_rows:
+        item = {"title": f"{row['health']} {row['name']}", "detail": row["detail"],
+                "source": "State card", "bucket_reason": row["health"]}
+        # 🔴 and 📞 are today. Everything else is this week. The split is the card's
+        # own health verdict, not a rule invented here.
+        (top if row["health"] in ("🔴", "📞") else week).append(item)
+
+    move, gtm_err = read_gtm(paths)
+    if move:
+        top.append({"title": move.get("action") or move.get("id"),
+                    "detail": move.get("done_looks_like") or "", "source": "GTM queue",
+                    "bucket_reason": "gtm"})
+    elif gtm_err:
+        top.append({"title": "GTM: COULD NOT READ", "detail": gtm_err,
+                    "source": "GTM queue", "bucket_reason": "error"})
+
+    inbox = []
+    for key, label in (("mail", "Gmail"), ("groupme", "GroupMe"), ("slack", "Slack")):
+        got = sources.get(key)
+        if not got:
+            continue
+        rows, err = got
+        if err:
+            inbox.append({"title": f"{label}: COULD NOT READ", "detail": err,
+                          "source": label, "bucket_reason": "error"})
+            continue
+        for row in rows:
+            inbox.append({"title": str(row)[:180], "detail": "", "source": label,
+                          "bucket_reason": "inbox"})
+
+    return {"error": None, "top_of_mind": top, "this_week": week, "inbox": inbox}

--- a/q-system/.q-system/scripts/consulting_board.py
+++ b/q-system/.q-system/scripts/consulting_board.py
@@ -260,6 +260,48 @@ def collect(now: dt.datetime, sources: dict, paths=None):
 # a row without one. `test_no_identity_is_derived_from_rendered_text` fails if this
 # file ever grows a text-scrubbing identity again.
 
+#: Priority from the STATE CARD'S OWN VERDICT, never a second judgement. The card
+#: already decides severity per client every morning (state_card.py: red = an open
+#: promise past due, yellow = due inside 48h, and so on) and `board_sync.HEALTH` turns
+#: each into a job: "do today", "do this week", "reach out". Re-deriving urgency here
+#: would be a second thing computing one truth, which is the defect the whole mirror
+#: design exists to avoid (DEC-8/DEC-13, and the v1 CRM that died of hand-feeding).
+#: So this is a TRANSLATION table, not a scoring rule: his card's dot, in Bloom's
+#: P0-P3 vocabulary.
+PRIORITY_BY_HEALTH = {
+    "🔴": "P0",    # do today: a promise he made, past due
+    "🟠": "P0",    # answer them: a person is waiting on a reply
+    "📞": "P1",    # reach out
+    "🟡": "P1",    # do this week
+    "🟢": "P3",    # nothing to do
+    "⚪": "P3",    # their move
+}
+
+#: What FINISHING one of these looks like, in his own terms. Bloom's board carries a
+#: "Done signal" on every inbox row and it is the half that makes a row actionable:
+#: a title says what the thing IS, a done signal says when to stop looking at it.
+#: AUDHD rule A2 (next physical action) is the same requirement from the other side.
+DONE_DEFAULT = "you have acted on it"
+DONE_BY_KIND = {
+    "client": "you sent the thing you promised",
+    "reach": "you sent the message",
+}
+#: A GTM step whose plan text carries no "done looks like". Deliberately vague,
+#: because inventing a specific completion test for a step nobody wrote one for would
+#: be this module making up the plan.
+DONE_GTM_FALLBACK = "the step is done or you wrote down why it did not happen"
+DONE_BY_SOURCE = {
+    "Gmail": "you replied in the thread",
+    "GroupMe": "you answered in the chat",
+}
+
+#: Size is DELIBERATELY not written. Bloom's board carries XS/S/M and nothing this
+#: board reads knows how big a piece of work is: the state card measures urgency, not
+#: effort, and the GTM queue carries no estimate. A size guessed by this module would
+#: look like a measurement and be a fabrication, so the column stays empty until
+#: something that actually knows fills it.
+
+
 def buckets(now: dt.datetime, sources: dict, paths=None) -> dict:
     """The board's three buckets, for notion_board.py's row writer.
 
@@ -283,6 +325,7 @@ def buckets(now: dt.datetime, sources: dict, paths=None) -> dict:
     # "card" is unconditional: a card failure returns early, above this line.
     healthy = {"card"}
     top, week = [], []
+
     for row in card_rows:
         # `key` is what the row id is hashed from and it carries NO health dot.
         # Codex finding (major), 2026-09-03: the id was hashed from `title`, which
@@ -298,6 +341,9 @@ def buckets(now: dt.datetime, sources: dict, paths=None) -> dict:
         item = {"title": f"{row['health']} {row['name']}",
                 "key": f"{row['kind']}:{row['name']}",
                 "detail": row["detail"], "source": "State card", "scope": "card",
+                "priority": PRIORITY_BY_HEALTH.get(row["health"], "P2"),
+                "domain": "Consulting",
+                "done": DONE_BY_KIND.get(row["kind"], DONE_DEFAULT),
                 "bucket_reason": row["health"]}
         # 🔴 and 📞 are today. Everything else is this week. The split is the card's
         # own health verdict, not a rule invented here.
@@ -314,11 +360,19 @@ def buckets(now: dt.datetime, sources: dict, paths=None) -> dict:
         top.append({"title": move.get("action") or move.get("id"),
                     "key": f"gtm:{move.get('id')}",   # the step id, stable across rewordings
                     "detail": move.get("done_looks_like") or "", "source": "GTM queue",
-                    "scope": "gtm",
+                    "scope": "gtm", "priority": "P1", "domain": "GTM",
+                    # The queue writes what done looks like for most steps, so this
+                    # row's signal is the plan's own words where they exist. A step
+                    # that carries none still gets one: an empty Done signal column is
+                    # the "field he forgot to fill" look this whole change removes,
+                    # and every other row on the board has one.
+                    "done": move.get("done_looks_like") or DONE_GTM_FALLBACK,
                     "bucket_reason": "gtm"})
     elif gtm_err:
         top.append({"title": "GTM: COULD NOT READ", "key": "gtm:error", "scope": "gtm",
-                    "detail": gtm_err, "source": "GTM queue", "bucket_reason": "error"})
+                    "detail": gtm_err, "source": "GTM queue", "priority": "P1",
+                    "domain": "Fleet", "done": "the GTM queue reads again",
+                    "bucket_reason": "error"})
 
     inbox = []
     # Gmail and GroupMe only. Codex finding (major), 2026-09-03: this asked for a
@@ -334,6 +388,8 @@ def buckets(now: dt.datetime, sources: dict, paths=None) -> dict:
         if err:
             inbox.append({"title": f"{label}: COULD NOT READ", "key": f"{label}:error",
                           "detail": err, "source": label, "scope": f"inbox:{label}",
+                          "priority": "P1", "domain": "Fleet",
+                          "done": f"{label} reads again",
                           "bucket_reason": "error"})
             continue                      # scope deliberately NOT marked healthy
         healthy.add(f"inbox:{label}")
@@ -359,6 +415,13 @@ def buckets(now: dt.datetime, sources: dict, paths=None) -> dict:
                     "keying on the rendered line is the PR #296 rounds 1-4 defect.")
             inbox.append({"title": text, "key": key, "detail": "",
                           "source": label, "scope": f"inbox:{label}",
+                          # Inbox rows are things a person is waiting on. P2: below a
+                          # client he owes something to and below a broken source, above
+                          # anything merely scheduled. Not P0 -- an unread message is not
+                          # by itself today's most important act, and a board where
+                          # everything is urgent has no priority at all.
+                          "priority": "P2", "domain": "Consulting",
+                          "done": DONE_BY_SOURCE.get(label, DONE_DEFAULT),
                           "bucket_reason": "inbox"})
 
     return {"error": None, "top_of_mind": top, "this_week": week, "inbox": inbox,

--- a/q-system/.q-system/scripts/consulting_board.py
+++ b/q-system/.q-system/scripts/consulting_board.py
@@ -94,6 +94,15 @@ _CLIENT_LINE = re.compile(
 _REACH_LINE = re.compile(r"^\s*📞\s*\*(?P<what>[^*]+)\*\s*(?P<rest>.*)$")
 #: "     then: 🔥 nicest.ai (fire)" -- the second reach-out, on its own indented line.
 _THEN_LINE = re.compile(r"^\s+then:\s*(?:[^\w\s]\s*)*(?P<who>[^(]+?)\s*(?:\(|$)")
+#: "— 🔥 Portant (fire, v1 CRM: ...)" -- the person, out of the reach-out header's tail.
+_REACH_WHO = re.compile(r"^[^A-Za-z0-9]*(?P<who>[A-Za-z0-9][^(:]*?)\s*(?:\(|:|$)")
+
+
+def _person_from_reach(rest: str):
+    """The NAME out of a reach-out line's tail, or None when there is none."""
+    m = _REACH_WHO.match((rest or "").lstrip("—- ").strip())
+    who = (m.group("who").strip() if m else "")
+    return who or None
 
 
 def read_card(paths=None) -> tuple[list[dict], str | None]:
@@ -116,8 +125,14 @@ def read_card(paths=None) -> tuple[list[dict], str | None]:
             continue
         m = _REACH_LINE.match(line)
         if m:
-            rows.append({"kind": "reach", "health": "📞",
-                         "name": m.group("what").strip(), "detail": m.group("rest").strip()})
+            # The BOLD part is a count ("2 to reach out"); the PERSON is in the rest,
+            # after the dash. Codex round 2 (major): keying on the count meant every
+            # different person inherited one Notion row, its status and the bucket he
+            # had dragged it to. A row's identity has to be the thing, not the tally.
+            who = _person_from_reach(m.group("rest"))
+            if who:
+                rows.append({"kind": "reach", "health": "📞", "name": who,
+                             "detail": m.group("rest").strip()})
             continue
         m = _THEN_LINE.match(line)
         if m:
@@ -230,6 +245,20 @@ def collect(now: dt.datetime, sources: dict, paths=None):
     return rows, None
 
 
+#: Tokens that change while the THING does not: ages, counts, times, dates. Stripped
+#: before an inbox row's identity is hashed. Codex round 2 (major): the id was the
+#: rendered row, so "2h ago" -> "3h ago" minted a new id, archived the row he had
+#: positioned and created a replacement in the default bucket. Same defect class as the
+#: health dot in round 1, at a call site the round-1 fix did not reach.
+_VOLATILE = re.compile(r"\b\d+\s*(?:[smhd]|min|mins|hour|hours|day|days|ago)\b"
+                       r"|\b\d{1,2}:\d{2}\b|\b\d{4}-\d{2}-\d{2}\b|\d+", re.I)
+
+
+def _stable(text: str) -> str:
+    """`text` with every volatile token removed, for use as an identity."""
+    return " ".join(_VOLATILE.sub("", text or "").split()).lower()[:160]
+
+
 def buckets(now: dt.datetime, sources: dict, paths=None) -> dict:
     """The board's three buckets, for notion_board.py's row writer.
 
@@ -240,11 +269,13 @@ def buckets(now: dt.datetime, sources: dict, paths=None) -> dict:
     paths = paths or _paths()
     beat, beat_err = read_heartbeat(now, paths)
     if beat_err:
-        return {"error": beat_err, "top_of_mind": [], "this_week": [], "inbox": []}
+        return {"error": beat_err, "top_of_mind": [], "this_week": [], "inbox": [],
+                "healthy_scopes": set()}
 
     card_rows, card_err = read_card(paths)
     if card_err:
-        return {"error": card_err, "top_of_mind": [], "this_week": [], "inbox": []}
+        return {"error": card_err, "top_of_mind": [], "this_week": [], "inbox": [],
+                "healthy_scopes": set()}
 
     top, week = [], []
     for row in card_rows:
@@ -255,7 +286,7 @@ def buckets(now: dt.datetime, sources: dict, paths=None) -> dict:
         # replacement in a computed bucket, silently undoing his move. The whole
         # "his drag always wins" promise depended on an id that does not move.
         item = {"title": f"{row['health']} {row['name']}", "key": row["name"],
-                "detail": row["detail"], "source": "State card",
+                "detail": row["detail"], "source": "State card", "scope": "card",
                 "bucket_reason": row["health"]}
         # 🔴 and 📞 are today. Everything else is this week. The split is the card's
         # own health verdict, not a rule invented here.
@@ -266,12 +297,17 @@ def buckets(now: dt.datetime, sources: dict, paths=None) -> dict:
         top.append({"title": move.get("action") or move.get("id"),
                     "key": f"gtm:{move.get('id')}",   # the step id, stable across rewordings
                     "detail": move.get("done_looks_like") or "", "source": "GTM queue",
+                    "scope": "gtm",
                     "bucket_reason": "gtm"})
     elif gtm_err:
-        top.append({"title": "GTM: COULD NOT READ", "key": "gtm:error",
+        top.append({"title": "GTM: COULD NOT READ", "key": "gtm:error", "scope": "gtm",
                     "detail": gtm_err, "source": "GTM queue", "bucket_reason": "error"})
 
     inbox = []
+    #: Scopes that produced a set worth ARCHIVING AGAINST this run. "card" and "gtm"
+    #: are here because a failure in either returns early above; an inbox source only
+    #: joins after it answered without an error.
+    healthy = {"card", "gtm"}
     # Gmail and GroupMe only. Codex finding (major), 2026-09-03: this asked for a
     # "slack" source too, and `collect_all` registers no Slack producer, so that
     # channel was silently absent forever while the docs claimed three. An unwired
@@ -284,11 +320,19 @@ def buckets(now: dt.datetime, sources: dict, paths=None) -> dict:
         rows, err = got
         if err:
             inbox.append({"title": f"{label}: COULD NOT READ", "key": f"{label}:error",
-                          "detail": err, "source": label, "bucket_reason": "error"})
-            continue
+                          "detail": err, "source": label, "scope": f"inbox:{label}",
+                          "bucket_reason": "error"})
+            continue                      # scope deliberately NOT marked healthy
+        healthy.add(f"inbox:{label}")
         for row in rows:
             text = str(row)[:180]
-            inbox.append({"title": text, "key": f"{label}:{text}", "detail": "",
-                          "source": label, "bucket_reason": "inbox"})
+            inbox.append({"title": text, "key": f"{label}:{_stable(text)}", "detail": "",
+                          "source": label, "scope": f"inbox:{label}",
+                          "bucket_reason": "inbox"})
 
-    return {"error": None, "top_of_mind": top, "this_week": week, "inbox": inbox}
+    return {"error": None, "top_of_mind": top, "this_week": week, "inbox": inbox,
+            # Which scopes produced a TRUSTWORTHY set this run. The painter archives
+            # only inside these; see board_rows.paint. Codex round 2 (major): a
+            # transient Gmail error replaced its rows with a single error row, and the
+            # painter then archived every inbox row he had positioned.
+            "healthy_scopes": healthy}

--- a/q-system/.q-system/scripts/consulting_board.py
+++ b/q-system/.q-system/scripts/consulting_board.py
@@ -108,7 +108,11 @@ _REACH_LINE = re.compile(
 _THEN_LINE = re.compile(r"^\s+then:\s*(?P<rest>.+)$")
 #: What the card puts between two people on a `then:` line.
 _THEN_SEP = "·"
+#: The producer's own tail on that line: "+3 more, lowest-scoring, on the board".
+_MORE_SUMMARY = re.compile(r"^\+\s*\d+\s+more\b")
 #: "— 🔥 Portant (fire, v1 CRM: ...)" -- the person, out of the reach-out header's tail.
+#: `build_card`'s first line, always present. See `read_card` for why it decides.
+_BOOK_HEADER = re.compile(r"\*Your book today\*")
 _REACH_WHO = re.compile(r"^[^A-Za-z0-9]*(?P<who>[A-Za-z0-9][^(:]*?)\s*(?:\(|:|$)")
 
 
@@ -158,16 +162,31 @@ def read_card(paths=None) -> tuple[list[dict], str | None]:
             # sentence still half true: the line was matched and then read as ONE
             # person, so three of four went missing just as quietly.
             for piece in m.group("rest").split(_THEN_SEP):
+                # The producer ends this line with its own "+N more, lowest-scoring,
+                # on the board" summary. Round 12 (major): the split handed that
+                # summary to the person extractor, which produced a row named after
+                # the sentence -- while the people it stands for still did not reach
+                # the board. A count is not a contact.
+                if _MORE_SUMMARY.match(piece.strip()):
+                    continue
                 who = _person_from_reach(piece)
                 if who:
                     rows.append({"kind": "reach", "health": "📞", "name": who,
                                  "detail": "then, after the first"})
     if not rows:
-        # A card that exists and parses to nothing is a FORMAT change, not a quiet
-        # morning. state_card.py always emits at least the book line, so zero parsed
-        # rows means this reader and that writer have drifted apart.
-        return [], (f"{path.name} parsed to zero client lines; the card format changed "
-                    "and this reader did not")
+        # ZERO ROWS IS TWO DIFFERENT FACTS and this used to call both a format change.
+        # Round 12 (major): a day where every client is green or waiting on THEM emits
+        # a card with a header and no client lines, which is correct output, and this
+        # reported it broken -- a P0 alarm row on the board every quiet day, which is
+        # exactly the wolf-cry that costs the real alert later.
+        #
+        # The discriminator is the producer's own header, which `build_card` always
+        # writes. Header present and no rows is a quiet morning. No header either
+        # means this reader and that writer really have drifted apart.
+        if _BOOK_HEADER.search(text):
+            return [], None
+        return [], (f"{path.name} parsed to zero client lines and carries no book "
+                    "header; the card format changed and this reader did not")
     return rows, None
 
 

--- a/q-system/.q-system/scripts/consulting_board.py
+++ b/q-system/.q-system/scripts/consulting_board.py
@@ -253,8 +253,13 @@ def collect(now: dt.datetime, sources: dict, paths=None):
 #: Round 3 (minor): the trailing `|\d+` stripped EVERY digit run, so "invoice 4021"
 #: and "invoice 4022" collapsed to one board row. Only digits bound to a time unit, a
 #: clock time or a date are volatile; a bare number is usually the identifying part.
+#: Round 4 (major, the first real Codex read after two rounds on the Opus fallback):
+#: the REAL mail producer, morning-brief.collect_mail, renders an age as `[2h]`, a
+#: bracketed unit with no "ago". None of the forms below matched it, so the round-2
+#: fix held for the fixture and not for the producer. The test now drives the producer.
 _VOLATILE = re.compile(r"\b\d+\s*(?:secs?|mins?|hours?|days?|weeks?)\b"
                        r"|\b\d+\s*[smhdw]\s+ago\b"
+                       r"|\[\s*\d+\s*[smhdw]\s*\]"
                        r"|\b\d{1,2}:\d{2}\b"
                        r"|\b\d{4}-\d{2}-\d{2}\b"
                        r"|\bago\b", re.I)

--- a/q-system/.q-system/scripts/consulting_board.py
+++ b/q-system/.q-system/scripts/consulting_board.py
@@ -580,9 +580,16 @@ def buckets(now: dt.datetime, sources: dict, paths=None) -> dict:
         phrase = my_side_phrase(rec, now) if rec else ""
         if phrase:
             item["detail"] = f"{item['detail']}\n{phrase}" if item["detail"] else phrase
-        # 🔴 and 📞 are today. Everything else is this week. The split is the card's
+        # 🔴, 🟠 and 📞 are today. Everything else is this week. The split is the card's
         # own health verdict, not a rule invented here.
-        (top if row["health"] in ("🔴", "📞") else week).append(item)
+        #
+        # 🟠 joined the today group in round 7 (minor): PRIORITY_BY_HEALTH calls it P0
+        # "answer them: a person is waiting on a reply" while this line sent it to This
+        # Week, so one module said today and not-today about the same row. The dot is
+        # not emitted by `state_card.py`, the only producer this reads -- `board_sync`
+        # uses it on the Clients board -- so this makes two tables in this file agree
+        # rather than changing a live path. `_CLIENT_LINE` has always parsed it.
+        (top if row["health"] in ("🔴", "🟠", "📞") else week).append(item)
 
     # The dates failing is reported ONCE, as its own row, never as a line stapled to
     # every client. A test proves this module still delivers with no registry in the

--- a/q-system/.q-system/scripts/consulting_board.py
+++ b/q-system/.q-system/scripts/consulting_board.py
@@ -92,6 +92,8 @@ _CLIENT_LINE = re.compile(
     r"^\s*(?:\*THE MOVE\*\s*)?(?P<health>🔴|🟡|🟢|⚪|🟠)\s*\*(?P<name>[^*]+)\*"
     r"\s*·\s*(?P<rest>.+)$")
 _REACH_LINE = re.compile(r"^\s*📞\s*\*(?P<what>[^*]+)\*\s*(?P<rest>.*)$")
+#: "     then: 🔥 nicest.ai (fire)" -- the second reach-out, on its own indented line.
+_THEN_LINE = re.compile(r"^\s+then:\s*(?:[^\w\s]\s*)*(?P<who>[^(]+?)\s*(?:\(|$)")
 
 
 def read_card(paths=None) -> tuple[list[dict], str | None]:
@@ -116,6 +118,16 @@ def read_card(paths=None) -> tuple[list[dict], str | None]:
         if m:
             rows.append({"kind": "reach", "health": "📞",
                          "name": m.group("what").strip(), "detail": m.group("rest").strip()})
+            continue
+        m = _THEN_LINE.match(line)
+        if m:
+            # The card puts the SECOND person to reach out on an indented "then:"
+            # continuation line. Codex finding, 2026-09-03: this reader matched only
+            # the header line, so the board claimed to be the full surface while the
+            # second prospect never reached it. A dropped row is worse than a missing
+            # section, because nothing says it is missing.
+            rows.append({"kind": "reach", "health": "📞",
+                         "name": m.group("who").strip(), "detail": "then, after the first"})
     if not rows:
         # A card that exists and parses to nothing is a FORMAT change, not a quiet
         # morning. state_card.py always emits at least the book line, so zero parsed
@@ -236,8 +248,15 @@ def buckets(now: dt.datetime, sources: dict, paths=None) -> dict:
 
     top, week = [], []
     for row in card_rows:
-        item = {"title": f"{row['health']} {row['name']}", "detail": row["detail"],
-                "source": "State card", "bucket_reason": row["health"]}
+        # `key` is what the row id is hashed from and it carries NO health dot.
+        # Codex finding (major), 2026-09-03: the id was hashed from `title`, which
+        # embeds the emoji, so a client going red -> green minted a new id. The next
+        # unattended paint then archived the row he had dragged and created a
+        # replacement in a computed bucket, silently undoing his move. The whole
+        # "his drag always wins" promise depended on an id that does not move.
+        item = {"title": f"{row['health']} {row['name']}", "key": row["name"],
+                "detail": row["detail"], "source": "State card",
+                "bucket_reason": row["health"]}
         # 🔴 and 📞 are today. Everything else is this week. The split is the card's
         # own health verdict, not a rule invented here.
         (top if row["health"] in ("🔴", "📞") else week).append(item)
@@ -245,24 +264,31 @@ def buckets(now: dt.datetime, sources: dict, paths=None) -> dict:
     move, gtm_err = read_gtm(paths)
     if move:
         top.append({"title": move.get("action") or move.get("id"),
+                    "key": f"gtm:{move.get('id')}",   # the step id, stable across rewordings
                     "detail": move.get("done_looks_like") or "", "source": "GTM queue",
                     "bucket_reason": "gtm"})
     elif gtm_err:
-        top.append({"title": "GTM: COULD NOT READ", "detail": gtm_err,
-                    "source": "GTM queue", "bucket_reason": "error"})
+        top.append({"title": "GTM: COULD NOT READ", "key": "gtm:error",
+                    "detail": gtm_err, "source": "GTM queue", "bucket_reason": "error"})
 
     inbox = []
-    for key, label in (("mail", "Gmail"), ("groupme", "GroupMe"), ("slack", "Slack")):
+    # Gmail and GroupMe only. Codex finding (major), 2026-09-03: this asked for a
+    # "slack" source too, and `collect_all` registers no Slack producer, so that
+    # channel was silently absent forever while the docs claimed three. An unwired
+    # channel named in code reads as coverage. Wiring a Slack collector is real work
+    # and is not smuggled in here; when it exists it is one tuple entry.
+    for key, label in (("mail", "Gmail"), ("groupme", "GroupMe")):
         got = sources.get(key)
         if not got:
             continue
         rows, err = got
         if err:
-            inbox.append({"title": f"{label}: COULD NOT READ", "detail": err,
-                          "source": label, "bucket_reason": "error"})
+            inbox.append({"title": f"{label}: COULD NOT READ", "key": f"{label}:error",
+                          "detail": err, "source": label, "bucket_reason": "error"})
             continue
         for row in rows:
-            inbox.append({"title": str(row)[:180], "detail": "", "source": label,
-                          "bucket_reason": "inbox"})
+            text = str(row)[:180]
+            inbox.append({"title": text, "key": f"{label}:{text}", "detail": "",
+                          "source": label, "bucket_reason": "inbox"})
 
     return {"error": None, "top_of_mind": top, "this_week": week, "inbox": inbox}

--- a/q-system/.q-system/scripts/consulting_board.py
+++ b/q-system/.q-system/scripts/consulting_board.py
@@ -324,7 +324,7 @@ def read_gtm(paths=None) -> tuple[dict | None, str | None]:
 WEEK_DAYS = 7
 
 
-def read_week(now: dt.datetime, paths=None) -> tuple[list[dict], str | None]:
+def read_week(now: dt.datetime, paths=None) -> tuple[list[dict], str | None, set]:
     """This Week: the GTM moves waiting on him, and deliverables coming due.
 
     Founder, 2026-09-03: *"This week should be this week's GTM moves and deliverables
@@ -342,9 +342,22 @@ def read_week(now: dt.datetime, paths=None) -> tuple[list[dict], str | None]:
     - Open commitments whose due date lands inside the next `WEEK_DAYS`. An OVERDUE
       one is deliberately excluded: it is already red in Top of Mind, and showing it
       in both places teaches him the two sections mean the same thing.
+
+    ## The third return value
+
+    Which of the two sources answered THIS RUN, as the scopes they emit. Codex round 6
+    (major): both scopes existed and neither was ever reported healthy, so the painter
+    could not archive inside them and a delivered commitment sat on the board forever.
+    Reported per SOURCE rather than per section, because the section has two of them and
+    one being down says nothing about the other.
+
+    A scope is healthy only when its source was READ. An absent commitment book is OFF
+    rather than broken (no error row), and it is still not healthy: a file that is not
+    there has said nothing about the rows written when it was, and nothing is not "they
+    are gone" (the round-2 archive-the-lot scar).
     """
     paths = paths or _paths()
-    out, errors = [], []
+    out, errors, healthy = [], [], set()
 
     lead, gtm_err = read_gtm(paths)
     if gtm_err:
@@ -372,6 +385,7 @@ def read_week(now: dt.datetime, paths=None) -> tuple[list[dict], str | None]:
                     "domain": "GTM",
                     "done": r.get("done_looks_like") or DONE_GTM_FALLBACK,
                     "bucket_reason": "gtm-week"})
+            healthy.add("week:gtm")       # only after the rows are actually built
         except (OSError, ValueError) as exc:
             errors.append(f"GTM queue unreadable ({type(exc).__name__})")
 
@@ -403,6 +417,7 @@ def read_week(now: dt.datetime, paths=None) -> tuple[list[dict], str | None]:
                 "domain": "Consulting",
                 "done": "you delivered it, or you moved the date with them",
                 "bucket_reason": "due-this-week"})
+        healthy.add("week:due")           # the book was read start to finish
     # A file that is ABSENT is not a file that is BROKEN. A machine with no commitment
     # book has no promises to report, which is a fact; a book that exists and cannot be
     # parsed or read is a failure that must be said out loud. Collapsing the two either
@@ -413,7 +428,7 @@ def read_week(now: dt.datetime, paths=None) -> tuple[list[dict], str | None]:
     except OSError as exc:
         errors.append(f"commitment book unreadable ({type(exc).__name__})")
 
-    return out, ("; ".join(errors) if errors else None)
+    return out, ("; ".join(errors) if errors else None), healthy
 
 
 def collect(now: dt.datetime, sources: dict, paths=None):
@@ -572,6 +587,11 @@ def buckets(now: dt.datetime, sources: dict, paths=None) -> dict:
     # The dates failing is reported ONCE, as its own row, never as a line stapled to
     # every client. A test proves this module still delivers with no registry in the
     # tree at all, and per-row noise would make that delivery look broken.
+    if not my_side_err:
+        # The apology row below is scoped `myside`, and until round 6 that scope was
+        # never healthy, so the row outlived the outage it reported and nothing could
+        # clear it. A source that recovered is what authorises clearing its own alarm.
+        healthy.add("myside")
     if my_side_err:
         top.append({"title": "Promise dates: COULD NOT READ", "key": "myside:error",
                     "detail": my_side_err, "source": "State card", "scope": "myside",
@@ -579,8 +599,14 @@ def buckets(now: dt.datetime, sources: dict, paths=None) -> dict:
                     "done": "the commitment book and registry read again",
                     "bucket_reason": "error"})
 
-    week_rows, week_err = read_week(now, paths)
+    week_rows, week_err, week_healthy = read_week(now, paths)
     week.extend(week_rows)
+    # Per SOURCE, not per section. Round 6 (major): `week:gtm` and `week:due` were
+    # emitted by every run and never reported healthy, so the painter could not archive
+    # inside them and a delivered commitment stayed on the board forever.
+    healthy |= week_healthy
+    if not week_err:
+        healthy.add("week")            # clears this section's own COULD NOT READ row
     if week_err:
         week.append({"title": "This Week: COULD NOT READ", "key": "week:error",
                      "detail": week_err, "source": "GTM queue", "scope": "week",

--- a/q-system/.q-system/scripts/consulting_board.py
+++ b/q-system/.q-system/scripts/consulting_board.py
@@ -93,9 +93,21 @@ def _paths(root: Path | None = None) -> dict:
 _CLIENT_LINE = re.compile(
     r"^\s*(?:\*THE MOVE\*\s*)?(?P<health>🔴|🟡|🟢|⚪|🟠)\s*\*(?P<name>[^*]+)\*"
     r"\s*·\s*(?P<rest>.+)$")
-_REACH_LINE = re.compile(r"^\s*📞\s*\*(?P<what>[^*]+)\*\s*(?P<rest>.*)$")
-#: "     then: 🔥 nicest.ai (fire)" -- the second reach-out, on its own indented line.
-_THEN_LINE = re.compile(r"^\s+then:\s*(?:[^\w\s]\s*)*(?P<who>[^(]+?)\s*(?:\(|$)")
+#: The `*THE MOVE*` prefix is optional HERE TOO. Round 8 (major): only `_CLIENT_LINE`
+#: had been taught it, so on a day whose top-ranked row is a reach-out -- which is what
+#: the card looks like with no red clients -- this line did not match at all and every
+#: person on it was dropped at exit 0. The sibling was hardened; this one was not, and
+#: nothing in the file made that asymmetry visible.
+_REACH_LINE = re.compile(
+    r"^\s*(?:\*THE MOVE\*\s*)?📞\s*\*(?P<what>[^*]+)\*\s*(?P<rest>.*)$")
+#: "     then: 🔥 Beta (fire) · 🔥 Gamma (fire)" -- EVERY remaining reach-out, packed
+#: onto one indented line. Round 8 (major): this used to capture a single name, so a
+#: card with three more people put one on the board and said nothing about the rest.
+#: The tail is split on the card's own separator and each piece goes through the same
+#: person extractor as the header line.
+_THEN_LINE = re.compile(r"^\s+then:\s*(?P<rest>.+)$")
+#: What the card puts between two people on a `then:` line.
+_THEN_SEP = "·"
 #: "— 🔥 Portant (fire, v1 CRM: ...)" -- the person, out of the reach-out header's tail.
 _REACH_WHO = re.compile(r"^[^A-Za-z0-9]*(?P<who>[A-Za-z0-9][^(:]*?)\s*(?:\(|:|$)")
 
@@ -138,13 +150,18 @@ def read_card(paths=None) -> tuple[list[dict], str | None]:
             continue
         m = _THEN_LINE.match(line)
         if m:
-            # The card puts the SECOND person to reach out on an indented "then:"
+            # The card puts every OTHER person to reach out on an indented "then:"
             # continuation line. Codex finding, 2026-09-03: this reader matched only
             # the header line, so the board claimed to be the full surface while the
             # second prospect never reached it. A dropped row is worse than a missing
-            # section, because nothing says it is missing.
-            rows.append({"kind": "reach", "health": "📞",
-                         "name": m.group("who").strip(), "detail": "then, after the first"})
+            # section, because nothing says it is missing. Round 8 found the same
+            # sentence still half true: the line was matched and then read as ONE
+            # person, so three of four went missing just as quietly.
+            for piece in m.group("rest").split(_THEN_SEP):
+                who = _person_from_reach(piece)
+                if who:
+                    rows.append({"kind": "reach", "health": "📞", "name": who,
+                                 "detail": "then, after the first"})
     if not rows:
         # A card that exists and parses to nothing is a FORMAT change, not a quiet
         # morning. state_card.py always emits at least the book line, so zero parsed

--- a/q-system/.q-system/scripts/engineering_route.py
+++ b/q-system/.q-system/scripts/engineering_route.py
@@ -1,0 +1,63 @@
+#!/usr/bin/env python3
+"""Engineering signal from the morning brief -> Sana's Linear triage. Never the founder.
+
+Founder, 2026-08-10, in slack-notify.sh's own header: *"I dont want to see any of these.
+Any of the ones that need attention should go to Sana - not me."* And 2026-09-03, on the
+board: *"I'm not looking for this to be a build dashboard, but a consulting dashboard."*
+So `Owed today` (Linear) and `Overnight jobs` (launchd) left his brief. They did not stop
+being collected; they come here.
+
+## Why this is its OWN file and not four lines inside morning-brief.py
+
+`test_morning_brief.py::test_no_source_file_calls_slack_notify` greps morning-brief.py,
+morning-brief-deadman.py and slack_founder.py for the string "slack-notify" and fails on
+a hit. That guard is correct and stays: the founder's BRIEF must never go out through the
+fleet alert path, which files a Linear ticket and sends him nothing. Routing a side
+channel to Sana is a different act from delivering his brief, but the guard is a source
+grep and cannot tell them apart, and the fix for a blunt-but-right guard is to stop
+tripping it rather than to loosen it. The first attempt put `_notify_sana` inside
+morning-brief.py and the guard caught it, which is the guard working.
+
+## Degraded only
+
+One line per DEGRADED section, and nothing at all for a healthy one. A ticket every
+morning for a clean overnight run is how an alert channel gets muted, and a muted channel
+is worse than none. `founder-notifications.md`: alert on state change, once.
+"""
+from __future__ import annotations
+
+import subprocess
+from pathlib import Path
+
+HERE = Path(__file__).resolve().parent
+NOTIFY = HERE / "slack-notify.sh"
+TIMEOUT_S = 20
+
+
+def messages(sources: dict, sections) -> list:
+    """The lines a degraded run should file. Pure, so a test needs no subprocess."""
+    out = []
+    for key, title in sections:
+        _rows, error = sources.get(key, ([], f"section {key} was never collected"))
+        if error:
+            out.append(f"morning-brief: {title} is degraded: {error}")
+    return out
+
+
+def send(message: str) -> None:
+    if not NOTIFY.exists():
+        return
+    subprocess.run(["bash", str(NOTIFY), message], check=False,
+                   capture_output=True, timeout=TIMEOUT_S)
+
+
+def route(sources: dict, sections, notify=None) -> list:
+    """File the degraded ones. Never raises: a broken notifier must not cost his brief."""
+    lines = messages(sources, sections)
+    notify = notify or send
+    for line in lines:
+        try:
+            notify(line)
+        except Exception:                                   # noqa: BLE001
+            pass
+    return lines

--- a/q-system/.q-system/scripts/engineering_route.py
+++ b/q-system/.q-system/scripts/engineering_route.py
@@ -45,19 +45,40 @@ def messages(sources: dict, sections) -> list:
 
 
 def send(message: str) -> None:
+    """Raise when the notifier did not file. The caller records the failure.
+
+    Codex finding (major), 2026-09-03: this swallowed the exit status and returned
+    None, so `route` reported the line as ROUTED whether or not a Linear issue was
+    ever created. That is the write-only-integration defect this repo has a lesson
+    file about, written into the one module whose whole job is delivery. An absent
+    script is still a legitimate no-op (an unconfigured machine); a script that RAN
+    and failed is not.
+    """
     if not NOTIFY.exists():
         return
-    subprocess.run(["bash", str(NOTIFY), message], check=False,
-                   capture_output=True, timeout=TIMEOUT_S)
+    done = subprocess.run(["bash", str(NOTIFY), message], check=False,
+                          capture_output=True, timeout=TIMEOUT_S)
+    if done.returncode != 0:
+        raise RuntimeError(
+            f"slack-notify.sh exited {done.returncode}: "
+            f"{(done.stderr or b'').decode('utf-8', 'replace').strip()[:200]}")
 
 
-def route(sources: dict, sections, notify=None) -> list:
-    """File the degraded ones. Never raises: a broken notifier must not cost his brief."""
+def route(sources: dict, sections, notify=None) -> tuple:
+    """(filed, failed). Never raises: a broken notifier must not cost him his brief.
+
+    Returns what was ACTUALLY filed and what was attempted and failed, rather than the
+    old single list that reported every attempt as a success. A caller that prints
+    `filed` is now telling the truth, and `failed` is the thing worth shouting about:
+    it means an engineering problem was detected and then lost.
+    """
     lines = messages(sources, sections)
     notify = notify or send
+    filed, failed = [], []
     for line in lines:
         try:
             notify(line)
-        except Exception:                                   # noqa: BLE001
-            pass
-    return lines
+            filed.append(line)
+        except Exception as exc:                            # noqa: BLE001
+            failed.append((line, f"{type(exc).__name__}: {exc}"))
+    return filed, failed

--- a/q-system/.q-system/scripts/engineering_route.py
+++ b/q-system/.q-system/scripts/engineering_route.py
@@ -55,7 +55,14 @@ def send(message: str) -> None:
     and failed is not.
     """
     if not NOTIFY.exists():
-        return
+        # ABSENT IS NOT FILED (round 12, major). This returned None, which `route`
+        # counts as a successful filing, so an unconfigured machine reported every
+        # engineering line as routed to Sana while no issue existed anywhere. The
+        # module's own docstring calls that the write-only-integration defect and
+        # this was the last place it still lived. A no-op is still legitimate; it
+        # just has to say so rather than claim a delivery.
+        raise FileNotFoundError(
+            f"no notifier at {NOTIFY}; nothing was filed and no issue exists")
     done = subprocess.run(["bash", str(NOTIFY), message], check=False,
                           capture_output=True, timeout=TIMEOUT_S)
     if done.returncode != 0:

--- a/q-system/.q-system/scripts/fleet-health-daily.py
+++ b/q-system/.q-system/scripts/fleet-health-daily.py
@@ -1500,7 +1500,8 @@ def plist_drift_findings(template_dir=None, launch_agents=None, render=None) -> 
     return out
 
 
-def never_installed_findings(template_dir=None, launch_agents=None) -> list:
+def never_installed_findings(template_dir=None, launch_agents=None,
+                            paused_labels=None) -> list:
     """A committed launchd template with no installed job at all.
 
     THE GAP THIS CLOSES. `plist_drift_findings` compares a template against the job
@@ -1520,9 +1521,16 @@ def never_installed_findings(template_dir=None, launch_agents=None) -> list:
     """
     templates = Path(template_dir) if template_dir else PLIST_TEMPLATE_DIR
     agents = Path(launch_agents) if launch_agents else LAUNCH_AGENTS
+    # THE OPT-OUT IS THE SAME ONE `detect_dark_jobs` USES (round 13, major, against
+    # this detector on the day it shipped). Without it a template deliberately not
+    # wanted on a machine files a permanent issue that the next daily run reopens
+    # forever, which trains the operator to ignore the whole channel.
+    paused = set(paused_labels or _paused_labels())
     out = []
     for template in sorted(templates.glob("com.kipi.*.plist")):
         label = template.stem
+        if label in paused:
+            continue
         if (agents / f"{label}.plist").is_file():
             continue
         out.append({

--- a/q-system/.q-system/scripts/fleet-health-daily.py
+++ b/q-system/.q-system/scripts/fleet-health-daily.py
@@ -1474,9 +1474,12 @@ def plist_drift_findings(template_dir=None, launch_agents=None, render=None) -> 
     for template in sorted(templates.glob("com.kipi.*.plist")):
         label = template.stem
         live_path = agents / f"{label}.plist"
-        # NOT INSTALLED IS NOT DRIFT. `detect_dark_jobs` already owns "a job that
-        # should be running is not"; filing it here too would put one condition
-        # on two permanent issues.
+        # NOT INSTALLED IS NOT DRIFT, and it is not dark either. This comment used
+        # to name `detect_dark_jobs` as the owner, which was wrong: that detector
+        # walks the plists ALREADY in ~/Library/LaunchAgents, so a template nobody
+        # ever installed is invisible to it too. PR #296 round 9 (major) found the
+        # gap with a plist that would have merged and simply never run. It is owned
+        # by `never_installed_findings` below.
         if not live_path.is_file():
             continue
         try:
@@ -1495,6 +1498,55 @@ def plist_drift_findings(template_dir=None, launch_agents=None, render=None) -> 
         if changed or only_committed or only_live:
             out.append(_drift_finding(label, changed, only_committed, only_live))
     return out
+
+
+def never_installed_findings(template_dir=None, launch_agents=None) -> list:
+    """A committed launchd template with no installed job at all.
+
+    THE GAP THIS CLOSES. `plist_drift_findings` compares a template against the job
+    installed from it and skips a template that has none. `detect_dark_jobs` walks the
+    plists already in `~/Library/LaunchAgents`. So a template that is committed,
+    reviewed, merged and never installed is invisible to both: the job simply does not
+    exist, nothing is red, and the feature it ships is dead on the founder's machine.
+    Measured 2026-09-04 on this Mac: 3 of 14 committed templates had never been
+    installed, one of them the hourly job PR #296 exists to ship.
+
+    WHY A FINDING AND NOT AN AUTO-INSTALL. Installing every committed template on
+    every machine that syncs the skeleton is a fleet-wide behaviour change with a
+    blast radius of every instance, and some templates are deliberately not wanted
+    everywhere. The repo's standing posture for launchd is REPORT, NEVER REPAIR (see
+    the header above `plist_drift_findings`), and this holds it: the finding names the
+    one command that installs the job, and a human decides.
+    """
+    templates = Path(template_dir) if template_dir else PLIST_TEMPLATE_DIR
+    agents = Path(launch_agents) if launch_agents else LAUNCH_AGENTS
+    out = []
+    for template in sorted(templates.glob("com.kipi.*.plist")):
+        label = template.stem
+        if (agents / f"{label}.plist").is_file():
+            continue
+        out.append({
+            "subject": label,
+            "title": f"committed launchd template was never installed: {label}",
+            "body": (
+                f"`{template.name}` is committed but there is no "
+                f"`~/Library/LaunchAgents/{label}.plist`, so the job has never run on "
+                "this machine and nothing else notices: the drift detector compares "
+                "against an installed copy and the dark-job detector walks installed "
+                "copies.\n\n"
+                f"Install it with:\n\n"
+                f"    bash q-system/.q-system/scripts/install-plist.sh {label}\n\n"
+                "Run it from a PRIMARY checkout, never a worktree: install-plist.sh "
+                "resolves `__KIPI_REPO__` from its own location, so a worktree install "
+                "points launchd at a path that disappears.\n\n"
+                "If the job is deliberately not wanted on this machine, that is a "
+                "decision worth recording rather than leaving as a silent absence."),
+        })
+    return out
+
+
+def detect_never_installed(_ctx) -> list:
+    return never_installed_findings()
 
 
 def detect_plist_drift(_ctx) -> list:
@@ -1599,6 +1651,13 @@ DETECTORS = [
         "detect": detect_untracked_unwired,
         "action": "file_issue",
         "lesson": "a-defect-absence-gate-is-a-floor-not-a-finish-line",
+    },
+    {
+        "id": "launchd-never-installed",
+        "description": "a committed launchd template that was never installed at all",
+        "detect": detect_never_installed,
+        "action": "file_issue",
+        "lesson": "a-freshness-deadman-must-live-off-the-machine-it-watches",
     },
     {
         "id": "launchd-dark",

--- a/q-system/.q-system/scripts/groupme_inbox.py
+++ b/q-system/.q-system/scripts/groupme_inbox.py
@@ -1,0 +1,148 @@
+#!/usr/bin/env python3
+"""GroupMe conversations waiting on the founder, for the morning brief's Inbox.
+
+Founder, 2026-09-03: everything on the board is connected and automated, nothing by hand.
+GroupMe was one of the three inbox channels he named.
+
+## Why this is a NEW reader and not a call into the one that exists
+
+One of the consulting instance's client projects already carries a `groupme_pull.py`
+that reads this API and already knows the two things that are easy to get wrong (below). Its own docstring says,
+in capitals, ANALYSIS TOOL ONLY and must never become a production path: it pages whole histories to
+JSONL for a client measurement. A morning brief that shells it would put a
+client-analysis tool on a 07:40 schedule. So this borrows its KNOWLEDGE and not its code.
+It is not named here because this repo is public and that path names a client.
+
+The two things it knows, both of which cost that file a silent wrong answer once:
+
+  1. DMs are a different endpoint. `/groups` does not carry them, `/chats` does. Reading
+     only `/groups` excluded three live client conversations and nothing said so, because
+     a channel you never fetch cannot show up as missing.
+  2. The response key differs. `/groups/<id>/messages` returns `messages`,
+     `/direct_messages` returns `direct_messages`. Reading the wrong key yields an empty
+     page, which a pager reads as "history exhausted" and reports as a clean finish.
+
+## What counts as waiting on him
+
+The last message in a conversation is not his, and it landed inside the window. That is
+all. No model call, no sentiment read: this is a cheap deterministic check that runs
+inside the brief's 20s optional-section budget.
+
+Credential: `~/.config/kipi/groupme-token` or `$GROUPME_TOKEN`, resolved via
+`Path.home()`, never a literal home path.
+
+OFF switch: a missing token file. `collect` returns None and the brief renders no
+GroupMe section at all, exactly as `notion_board.py`'s missing page-id file does. Absent
+is not an error and is not "nobody messaged you".
+"""
+from __future__ import annotations
+
+import datetime as dt
+import json
+import os
+import urllib.error
+import urllib.parse
+import urllib.request
+from pathlib import Path
+
+API = "https://api.groupme.com/v3"
+TOKEN_FILE = Path.home() / ".config" / "kipi" / "groupme-token"
+
+#: How far back a conversation still counts as live. Matches the brief's mail section,
+#: which the founder already reads as "since I last looked".
+WINDOW_HOURS = 48
+#: Conversations scanned per run. GroupMe returns them most-recent-first, so this is a
+#: recency cut and not a sample. Bounded because this shares a 20s budget with the board.
+MAX_CONVERSATIONS = 25
+TIMEOUT_S = 6.0
+
+
+def load_token() -> str | None:
+    tok = (os.environ.get("GROUPME_TOKEN") or "").strip()
+    if tok:
+        return tok
+    if TOKEN_FILE.exists():
+        tok = TOKEN_FILE.read_text(encoding="utf-8").strip()
+        if tok:
+            return tok
+    return None
+
+
+def _get(path: str, token: str, opener=None, **params):
+    params["token"] = token
+    url = f"{API}{path}?{urllib.parse.urlencode(params)}"
+    open_fn = opener or urllib.request.urlopen
+    with open_fn(urllib.request.Request(url), timeout=TIMEOUT_S) as fh:
+        return json.load(fh).get("response")
+
+
+def _me(token: str, opener=None) -> str:
+    return str((_get("/users/me", token, opener) or {}).get("user_id") or "")
+
+
+def waiting(now: dt.datetime, token: str, opener=None) -> list[dict]:
+    """Conversations whose newest message is not his, inside the window."""
+    cutoff = (now - dt.timedelta(hours=WINDOW_HOURS)).timestamp()
+    me = _me(token, opener)
+    out = []
+
+    groups = _get("/groups", token, opener, per_page=MAX_CONVERSATIONS) or []
+    for g in groups:
+        meta = g.get("messages") or {}
+        created = meta.get("last_message_created_at") or 0
+        if created < cutoff:
+            continue
+        preview = meta.get("preview") or {}
+        # THE PREVIEW HAS NO AUTHOR. Measured live 2026-09-03: its keys are exactly
+        # nickname, text, image_url, attachments. The first draft of this function read
+        # `preview["user_id"]`, got "" for every group, and the `sender != me` test
+        # therefore dropped all four -- reporting a clean zero on a morning when three
+        # groups were live. A nickname is not an id (it varies per group), so the author
+        # is fetched from the message itself, and only for groups already inside the
+        # window, which keeps this at a handful of calls rather than one per group.
+        sender = ""
+        try:
+            msgs = (_get(f"/groups/{g.get('id')}/messages", token, opener, limit=1)
+                    or {}).get("messages") or []
+            if msgs:
+                sender = str(msgs[0].get("user_id") or msgs[0].get("sender_id") or "")
+        except (urllib.error.URLError, urllib.error.HTTPError, OSError, ValueError):
+            # One unreadable group must not void the others, and it must not be
+            # mistaken for "he sent the last message". Unknown author is surfaced.
+            sender = ""
+        if sender == me:
+            continue
+        out.append({"channel": "group", "name": g.get("name") or "(unnamed group)",
+                    "who": preview.get("nickname") or "someone",
+                    "text": (preview.get("text") or "")[:160], "at": created})
+
+    # /chats is the DM list. Its shape differs from /groups: the peer is `other_user`
+    # and the newest message is `last_message`, not `messages.preview`.
+    chats = _get("/chats", token, opener, per_page=MAX_CONVERSATIONS) or []
+    for c in chats:
+        last = c.get("last_message") or {}
+        created = last.get("created_at") or c.get("updated_at") or 0
+        sender = str(last.get("user_id") or last.get("sender_id") or "")
+        if created >= cutoff and sender and sender != me:
+            who = (c.get("other_user") or {}).get("name") or "someone"
+            out.append({"channel": "dm", "name": who, "who": who,
+                        "text": (last.get("text") or "")[:160], "at": created})
+
+    out.sort(key=lambda r: r["at"], reverse=True)
+    return out
+
+
+def collect(now: dt.datetime, sources: dict, opener=None):
+    """(rows, error), or None when no token exists. The registered entry point."""
+    token = load_token()
+    if not token:
+        return None                      # OFF, not broken
+    try:
+        rows = waiting(now, token, opener)
+    except (urllib.error.URLError, urllib.error.HTTPError, OSError, ValueError) as exc:
+        # Never a silent zero. A GroupMe outage must not read as "nobody messaged you".
+        return [], f"GroupMe unreachable: {type(exc).__name__}: {exc}"
+    if not rows:
+        return [], None
+    return [f"{r['name']}: {r['who']} said "
+            f"{' '.join((r['text'] or '').split())[:140]!r}" for r in rows], None

--- a/q-system/.q-system/scripts/groupme_inbox.py
+++ b/q-system/.q-system/scripts/groupme_inbox.py
@@ -56,6 +56,39 @@ WINDOW_HOURS = 48
 MAX_CONVERSATIONS = 25
 TIMEOUT_S = 6.0
 
+#: The allowlist of GroupMe conversations worth reading. Founder-directed 2026-09-03,
+#: verbatim: *"you're looking in too many channels. I only want you to look in the AI
+#: chat channel, the other ones have nothing for me."*
+#:
+#: Machine-local and NOT in this repo, which is public: the ids name client
+#: conversations, the same reason the sibling `groupme_pull.py` path is described here
+#: and never written out. One id per line, `#` comments and blank lines ignored.
+#:
+#: THE FILE BEING ABSENT IS NOT AN EMPTY ALLOWLIST. A missing file means nobody has
+#: chosen yet, so every conversation is read, which is the behaviour that shipped. An
+#: EMPTY file is a choice and reads nothing. Collapsing the two would turn a lost
+#: config file into a silently quiet section, which is the failure this brief exists to
+#: not have.
+CHANNELS_FILE = Path.home() / ".config" / "kipi" / "groupme-channels"
+
+
+def load_allowlist(path=None) -> set | None:
+    """The set of allowed conversation ids, or None when no choice is recorded.
+
+    None and set() mean different things on purpose; see CHANNELS_FILE.
+    """
+    path = Path(path) if path else CHANNELS_FILE
+    try:
+        raw = path.read_text(encoding="utf-8")
+    except OSError:
+        return None
+    ids = set()
+    for line in raw.splitlines():
+        line = line.split("#", 1)[0].strip()
+        if line:
+            ids.add(line)
+    return ids
+
 
 def load_token() -> str | None:
     tok = (os.environ.get("GROUPME_TOKEN") or "").strip()
@@ -86,8 +119,12 @@ def waiting(now: dt.datetime, token: str, opener=None) -> list[dict]:
     me = _me(token, opener)
     out = []
 
+    allow = load_allowlist()
+
     groups = _get("/groups", token, opener, per_page=MAX_CONVERSATIONS) or []
     for g in groups:
+        if allow is not None and str(g.get("id")) not in allow:
+            continue
         meta = g.get("messages") or {}
         created = meta.get("last_message_created_at") or 0
         if created < cutoff:
@@ -124,7 +161,12 @@ def waiting(now: dt.datetime, token: str, opener=None) -> list[dict]:
 
     # /chats is the DM list. Its shape differs from /groups: the peer is `other_user`
     # and the newest message is `last_message`, not `messages.preview`.
-    chats = _get("/chats", token, opener, per_page=MAX_CONVERSATIONS) or []
+    # DMs are skipped entirely once an allowlist exists. The docstring above records
+    # the scar that reading only /groups once hid three live client DMs; that scar is
+    # about a channel nobody CHOSE to exclude. An allowlist is the founder choosing,
+    # and a chosen exclusion is not a silent one.
+    chats = [] if allow is not None else (
+        _get("/chats", token, opener, per_page=MAX_CONVERSATIONS) or [])
     for c in chats:
         last = c.get("last_message") or {}
         created = last.get("created_at") or c.get("updated_at") or 0

--- a/q-system/.q-system/scripts/groupme_inbox.py
+++ b/q-system/.q-system/scripts/groupme_inbox.py
@@ -80,8 +80,18 @@ def load_allowlist(path=None) -> set | None:
     path = Path(path) if path else CHANNELS_FILE
     try:
         raw = path.read_text(encoding="utf-8")
-    except OSError:
-        return None
+    except FileNotFoundError:
+        return None                      # no choice recorded; read everything
+    except OSError as exc:
+        # ABSENT AND UNREADABLE ARE DIFFERENT FACTS, and collapsing them here failed
+        # OPEN (Codex round 7, minor): a permission error on the founder's own
+        # narrowing -- "I only want you to look in the AI chat channel" -- silently
+        # went back to reading every channel and every DM, with no line anywhere. The
+        # same file this module lives beside states the rule twice and implements it:
+        # `except FileNotFoundError: pass` separate from `except OSError`.
+        raise OSError(
+            f"the GroupMe allowlist at {path} exists and cannot be read ({exc}); "
+            "refusing to widen back to every conversation") from exc
     ids = set()
     for line in raw.splitlines():
         line = line.split("#", 1)[0].strip()
@@ -166,12 +176,21 @@ def waiting(now: dt.datetime, token: str, opener=None) -> list[dict]:
     # the scar that reading only /groups once hid three live client DMs; that scar is
     # about a channel nobody CHOSE to exclude. An allowlist is the founder choosing,
     # and a chosen exclusion is not a silent one.
-    chats = [] if allow is not None else (
-        _get("/chats", token, opener, per_page=MAX_CONVERSATIONS) or [])
+    chats = _get("/chats", token, opener, per_page=MAX_CONVERSATIONS) or []
     for c in chats:
         last = c.get("last_message") or {}
         created = last.get("created_at") or c.get("updated_at") or 0
         sender = str(last.get("user_id") or last.get("sender_id") or "")
+        # THE ALLOWLIST SELECTS DMs TOO. It used to skip /chats entirely whenever an
+        # allowlist existed, which made a DM peer id written into the file match
+        # nothing and say nothing (Codex round 7, minor) -- the file gave no signal it
+        # had been ignored. The comment above justified that as "a chosen exclusion is
+        # not a silent one", which was true of the groups he did not list and false of
+        # the DM he DID list. Now the same rule governs both: named is included,
+        # unnamed is excluded, and an empty file still means nothing.
+        peer = str((c.get("other_user") or {}).get("id") or "")
+        if allow is not None and peer not in allow:
+            continue
         if created >= cutoff and sender and sender != me:
             who = (c.get("other_user") or {}).get("name") or "someone"
             out.append({"id": str(c.get("other_user", {}).get("id") or ""),
@@ -205,6 +224,8 @@ def collect(now: dt.datetime, sources: dict, opener=None):
     try:
         rows = waiting(now, token, opener)
     except (urllib.error.URLError, urllib.error.HTTPError, OSError, ValueError) as exc:
+        # OSError now also carries an unreadable allowlist, which belongs here: an
+        # error line the founder sees, never a silent widening.
         # Never a silent zero. A GroupMe outage must not read as "nobody messaged you".
         return [], f"GroupMe unreachable: {type(exc).__name__}: {exc}"
     if not rows:

--- a/q-system/.q-system/scripts/groupme_inbox.py
+++ b/q-system/.q-system/scripts/groupme_inbox.py
@@ -100,20 +100,26 @@ def waiting(now: dt.datetime, token: str, opener=None) -> list[dict]:
         # groups were live. A nickname is not an id (it varies per group), so the author
         # is fetched from the message itself, and only for groups already inside the
         # window, which keeps this at a handful of calls rather than one per group.
-        sender = ""
+        sender, unreadable = "", False
         try:
             msgs = (_get(f"/groups/{g.get('id')}/messages", token, opener, limit=1)
                     or {}).get("messages") or []
             if msgs:
                 sender = str(msgs[0].get("user_id") or msgs[0].get("sender_id") or "")
+            unreadable = False
         except (urllib.error.URLError, urllib.error.HTTPError, OSError, ValueError):
             # One unreadable group must not void the others, and it must not be
-            # mistaken for "he sent the last message". Unknown author is surfaced.
-            sender = ""
+            # mistaken for "he sent the last message" EITHER WAY. Codex finding
+            # (minor), 2026-09-03: this set sender="" and fell through, so a group
+            # whose author could not be read was rendered as a confirmed "waiting on
+            # you". Unknown is now carried as unknown and says so in the row.
+            sender, unreadable = "", True
         if sender == me:
             continue
         out.append({"channel": "group", "name": g.get("name") or "(unnamed group)",
-                    "who": preview.get("nickname") or "someone",
+                    "who": ("author unreadable" if unreadable
+                            else preview.get("nickname") or "someone"),
+                    "unreadable": unreadable,
                     "text": (preview.get("text") or "")[:160], "at": created})
 
     # /chats is the DM list. Its shape differs from /groups: the peer is `other_user`
@@ -144,5 +150,12 @@ def collect(now: dt.datetime, sources: dict, opener=None):
         return [], f"GroupMe unreachable: {type(exc).__name__}: {exc}"
     if not rows:
         return [], None
-    return [f"{r['name']}: {r['who']} said "
-            f"{' '.join((r['text'] or '').split())[:140]!r}" for r in rows], None
+    out = []
+    for r in rows:
+        text = " ".join((r["text"] or "").split())[:140]
+        if r.get("unreadable"):
+            out.append(f"{r['name']}: COULD NOT READ who sent the last message "
+                       f"({text!r})")
+        else:
+            out.append(f"{r['name']}: {r['who']} said {text!r}")
+    return out, None

--- a/q-system/.q-system/scripts/groupme_inbox.py
+++ b/q-system/.q-system/scripts/groupme_inbox.py
@@ -153,7 +153,8 @@ def waiting(now: dt.datetime, token: str, opener=None) -> list[dict]:
             sender, unreadable = "", True
         if sender == me:
             continue
-        out.append({"channel": "group", "name": g.get("name") or "(unnamed group)",
+        out.append({"id": str(g.get("id") or ""),
+                    "channel": "group", "name": g.get("name") or "(unnamed group)",
                     "who": ("author unreadable" if unreadable
                             else preview.get("nickname") or "someone"),
                     "unreadable": unreadable,
@@ -173,11 +174,27 @@ def waiting(now: dt.datetime, token: str, opener=None) -> list[dict]:
         sender = str(last.get("user_id") or last.get("sender_id") or "")
         if created >= cutoff and sender and sender != me:
             who = (c.get("other_user") or {}).get("name") or "someone"
-            out.append({"channel": "dm", "name": who, "who": who,
+            out.append({"id": str(c.get("other_user", {}).get("id") or ""),
+                        "channel": "dm", "name": who, "who": who,
                         "text": (last.get("text") or "")[:160], "at": created})
 
     out.sort(key=lambda r: r["at"], reverse=True)
     return out
+
+
+def _load_brief():
+    """morning-brief.py, for its `Row` type. Imported lazily and defensively: this
+    module is also run standalone, and a missing brief must degrade to plain strings
+    rather than take the GroupMe section down."""
+    try:
+        import importlib.util
+        path = Path(__file__).resolve().parent / "morning-brief.py"
+        spec = importlib.util.spec_from_file_location("morning_brief_row", path)
+        mod = importlib.util.module_from_spec(spec)
+        spec.loader.exec_module(mod)
+        return mod
+    except Exception:                    # noqa: BLE001
+        return None
 
 
 def collect(now: dt.datetime, sources: dict, opener=None):
@@ -192,12 +209,19 @@ def collect(now: dt.datetime, sources: dict, opener=None):
         return [], f"GroupMe unreachable: {type(exc).__name__}: {exc}"
     if not rows:
         return [], None
+    # Rows carry the CONVERSATION id, not their rendered text. See morning-brief.Row:
+    # the board keys on this, and a key derived from rendering is what PR #296 spent
+    # four review rounds patching. The id is stable while the message quoted in the
+    # line changes every time somebody speaks.
+    brief = _load_brief()
     out = []
     for r in rows:
         text = " ".join((r["text"] or "").split())[:140]
         if r.get("unreadable"):
-            out.append(f"{r['name']}: COULD NOT READ who sent the last message "
-                       f"({text!r})")
+            line = (f"{r['name']}: COULD NOT READ who sent the last message "
+                    f"({text!r})")
         else:
-            out.append(f"{r['name']}: {r['who']} said {text!r}")
+            line = f"{r['name']}: {r['who']} said {text!r}"
+        key = f"groupme:{r.get('id') or r['name']}"
+        out.append(brief.Row(line, key) if brief else line)
     return out, None

--- a/q-system/.q-system/scripts/groupme_inbox.py
+++ b/q-system/.q-system/scripts/groupme_inbox.py
@@ -81,7 +81,16 @@ def load_allowlist(path=None) -> set | None:
     try:
         raw = path.read_text(encoding="utf-8")
     except FileNotFoundError:
-        return None                      # no choice recorded; read everything
+        # NO FILE MEANS NO CHOICE RECORDED, AND THAT STAYS PERMISSIVE. Round 10 called
+        # this a silent widening: if he had narrowed to one channel and the file later
+        # vanished, collection quietly goes back to everything. That is true and it is
+        # still the right side to fail to, because nothing on disk distinguishes "his
+        # file vanished" from "this machine never had one" -- and the alternative,
+        # requiring a marker before reading anything, silences GroupMe entirely on
+        # every machine that has no file, which is most of them. A section that
+        # silently reports nothing is the failure this whole brief was built against;
+        # a section that reports too much is visible in the founder's own output.
+        return None
     except OSError as exc:
         # ABSENT AND UNREADABLE ARE DIFFERENT FACTS, and collapsing them here failed
         # OPEN (Codex round 7, minor): a permission error on the founder's own

--- a/q-system/.q-system/scripts/morning-brief-deadman.py
+++ b/q-system/.q-system/scripts/morning-brief-deadman.py
@@ -43,8 +43,9 @@ off, asleep or wedged silences the brief AND its alarm together.
 The gap is narrower than it sounds, and the narrowing is why StartInterval was
 chosen over StartCalendarInterval. A StartCalendarInterval job that misses its
 fire time is skipped outright; launchd does not catch up on wake. A StartInterval
-job with RunAtLoad DOES run on the next wake. So a Mac that was off at 07:00 and
-opens at 11:00 gets the alarm within thirty minutes of waking, not never.
+job with RunAtLoad DOES run on the next wake. So a Mac that was off at the brief's
+fire time and opens hours later gets the alarm within thirty minutes of waking,
+not never.
 
 What remains uncovered is precisely: the machine stays off past the moment the
 founder wanted to know. He is also not at his desk in that window, which is why
@@ -81,7 +82,10 @@ STATE_DIR = Path(os.environ.get("KIPI_STATE_DIR", os.path.expanduser("~/.config/
 RECEIPT_PATH = STATE_DIR / "morning-brief-last.json"
 ALARM_STATE = STATE_DIR / "morning-brief-deadman-state.json"
 
-# The brief fires at 07:00 local. The deadline is 09:00, founder-directed.
+# The deadline is 09:00, founder-directed. This file deliberately does NOT name the
+# hour the brief fires: it was a third copy of that number and it went stale the day
+# the schedule moved to 07:40, so the alarm told the founder "the 07:00 job did not
+# run" about a job that runs at 07:40 (Codex round 9). The plist is the record.
 DEADLINE_HOUR = int(os.environ.get("KIPI_BRIEF_DEADLINE_HOUR", "9"))
 
 
@@ -104,7 +108,7 @@ def check(now: dt.datetime, receipt_path=None):
     stamped = data.get("date")
     if stamped != today:
         return False, (f"last morning brief is stamped {stamped}, not {today} "
-                       f"-- the 07:00 job did not run")
+                       f"-- this morning's job did not run")
     if not data.get("delivered"):
         return False, (f"the {today} brief was built but NOT delivered: "
                        f"{data.get('reason') or 'no reason recorded'}")

--- a/q-system/.q-system/scripts/morning-brief.py
+++ b/q-system/.q-system/scripts/morning-brief.py
@@ -536,6 +536,15 @@ def _guarded(key: str, fn, budget_s: float, log_path) -> tuple:
     - finding-4: a collector is bounded. The board writer runs here, before the
       Slack send, so a hung Notion call must cost at most `budget_s`, never the
       morning. The worker thread is abandoned on timeout; the brief moves on.
+
+    THIS GUARD BOUNDS THE WAIT, NOT THE WORK. Codex round 4 on the consulting board
+    (major): an abandoned worker that MUTATES (board_rows, the only one) kept writing
+    Notion rows after this returned "timed out". A guard that cannot cancel what it
+    abandons is the wrong place to fix that, so the rule is on the collector: a
+    mutating collector owns a budget BELOW `budget_s`, checks it before every call
+    and caps the call in flight to what is left (notion_board._Budget, shared). Then
+    its own cancel fires first and this guard is only the backstop.
+    test_consulting_board pins board_rows.BUDGET_S < COLLECT_BUDGET_S.
     """
     # A DAEMON thread, not a ThreadPoolExecutor. Codex review of this issue
     # (findings 1 and 2, 2026-09-01): pool workers are non-daemon and the

--- a/q-system/.q-system/scripts/morning-brief.py
+++ b/q-system/.q-system/scripts/morning-brief.py
@@ -285,12 +285,26 @@ def collect_mail(now: dt.datetime, runner=None):
     # keeping it under an id that may move. Keeping it wins, and it is not close: a
     # row he never sees cannot be acted on at all, while a row whose id shifts costs
     # him a position on the board. The suffix is ordinal and deliberately provisional.
-    seen = {}
-    for i, row in enumerate(rows):
-        n = seen.get(row.key, 0) + 1
-        seen[row.key] = n
-        if n > 1:
-            rows[i] = Row(str(row), f"{row.key}#{n}")
+    # THE ORDINAL SUFFIX WAS WITHDRAWN (round 10, major). It numbered duplicates by
+    # POSITION, so when the first of two "Re: invoice" threads was answered and left
+    # the list, the second was renumbered onto the first one's key -- and inherited its
+    # board row, its Status and the bucket he had dragged it to. A thread wearing
+    # another thread's identity is worse than either failure the note above weighed.
+    #
+    # With no thread id there is nothing that tells two identical rows apart, so this
+    # stops pretending there is. The group becomes ONE row that SAYS it is a group.
+    # No task is hidden (the count is on the row), no id is invented, and the key is
+    # stable because it is the thing they have in common.
+    groups = {}
+    for row in rows:
+        groups.setdefault(row.key, []).append(row)
+    rows = []
+    for key, members in groups.items():
+        if len(members) == 1:
+            rows.append(members[0])
+            continue
+        rows.append(Row(f"{members[0]} ({len(members)} threads, same sender and "
+                        "subject)", key))
     if len(rows) > MAIL_ROW_CAP:
         # Never a silent trim: the last row says how many are not shown, the same
         # rule the client section already follows.

--- a/q-system/.q-system/scripts/morning-brief.py
+++ b/q-system/.q-system/scripts/morning-brief.py
@@ -186,12 +186,43 @@ def collect_calendar(now: dt.datetime, runner=None):
 # Section 2: mail that needs an answer
 # ---------------------------------------------------------------------------
 
+class Row(str):
+    """A rendered brief line that also carries the STABLE IDENTITY of the thing it
+    describes.
+
+    ## Why this exists, and it is the end of a four-round loop
+
+    PR #296 rounds 1-4 are all one defect. The Notion board keys each row so a row he
+    has dragged is never archived and re-created underneath him. Four of the five
+    producers pass a real id (client `kind:name`, `gtm:<step id>`, literal error keys).
+    The inbox rows had nothing but their own RENDERED TEXT, so the key was that text
+    with volatile bits scrubbed by a regex -- and every round patched the regex for one
+    more surface form: the health dot, then "2h ago", then a bare digit run that
+    collapsed two different invoice numbers, then the `[2h]` the real producer emits.
+    A fifth form was guaranteed, because rendering keeps changing and the regex can
+    only ever chase it.
+
+    A row is a `str`, so every existing renderer (`_section`, the f-strings, the
+    slicing) is untouched and this needed no caller changes. What it adds is `.key`:
+    the Gmail thread id, the GroupMe conversation id -- an identity the producer KNOWS
+    and was throwing away at the moment it rendered.
+    """
+    __slots__ = ("key",)
+
+    def __new__(cls, text: str, key: str):
+        row = super().__new__(cls, text)
+        row.key = key
+        return row
+
+
 MAIL_PROMPT = """Call {tool} to find email threads from the last 48 hours where a
 REAL PERSON wrote to the founder and the founder has not replied yet. Exclude
 newsletters, notifications, receipts, calendar invites, automated senders and
 no-reply addresses.
 Reply with ONE JSON object and nothing else, no prose, no code fence:
-{{"threads": [{{"from": "email or name", "subject": "...", "age_hours": <int>}}]}}
+{{"threads": [{{"id": "<the thread id the tool returned>", "from": "email or name", "subject": "...", "age_hours": <int>}}]}}
+`id` is the thread's own id from the tool result, copied verbatim. It is what keeps a
+board row stable while its age changes, so never invent or shorten it.
 If the tool call fails, reply with exactly: {{"error": "<what failed>"}}"""
 
 
@@ -209,7 +240,13 @@ def collect_mail(now: dt.datetime, runner=None):
             continue
         age = th.get("age_hours")
         age_text = f"  [{age}h]" if isinstance(age, int) else ""
-        rows.append(f"{str(th.get('from', 'unknown'))[:40]}  {str(th.get('subject', ''))[:70]}{age_text}")
+        sender = str(th.get("from", "unknown"))[:40]
+        subject = str(th.get("subject", ""))[:70]
+        # The thread id when the model returned one, else sender+subject -- both are
+        # stable while the AGE changes, which is the only thing that was minting new
+        # ids. Never the rendered line: that is the defect rounds 1-4 kept patching.
+        key = str(th.get("id") or "").strip() or f"{sender}|{subject}"
+        rows.append(Row(f"{sender}  {subject}{age_text}", f"mail:{key}"))
     return rows, None
 
 

--- a/q-system/.q-system/scripts/morning-brief.py
+++ b/q-system/.q-system/scripts/morning-brief.py
@@ -215,10 +215,35 @@ class Row(str):
         return row
 
 
-MAIL_PROMPT = """Call {tool} to find email threads from the last 48 hours where a
+#: How far back the mail sweep looks, and it is a CONSTANT because it was a hardcoded
+#: "48 hours" inside the prompt for weeks and nobody could see it.
+#:
+#: THE BUG THIS FIXES, measured 2026-09-03. The brief printed "Mail needing an answer:
+#: nothing" on 09-01, 09-02 and 09-03 while two client threads sat unanswered since
+#: 2026-08-11 and 2026-08-13. Both are real, both are named by
+#: `email-watch/ledger.py needs-reply`, and both are 3 weeks old, so a 48-hour window
+#: could not see either one. The section was not empty; it was blind, and it reported
+#: blindness as calm.
+#:
+#: 30 days because the oldest of the two is 23 days old and a window that only just
+#: covers today's example is a window that will fail next month. The prompt still
+#: excludes automated senders and still requires that HE has not replied, so widening
+#: the window does not widen the noise; it only stops hiding the old ones.
+#:
+#: The deterministic answer is `ledger.py needs-reply`, which has no window at all and
+#: knows which threads are clients. It is not wired here yet: it reads the Notion
+#: ledger live, so it is a cross-repo runtime dependency and its own piece of work.
+MAIL_WINDOW_DAYS = 30
+#: The most inbox rows one sweep may put on the board. A 30-day window over a real
+#: inbox can return a lot; this is a phone-screen limit, not a judgement about which
+#: mail matters.
+MAIL_ROW_CAP = 15
+
+MAIL_PROMPT = """Call {tool} to find email threads from the last {days} days where a
 REAL PERSON wrote to the founder and the founder has not replied yet. Exclude
 newsletters, notifications, receipts, calendar invites, automated senders and
-no-reply addresses.
+no-reply addresses. Oldest first: a thread waiting three weeks matters more than
+one waiting an hour.
 Reply with ONE JSON object and nothing else, no prose, no code fence:
 {{"threads": [{{"id": "<the thread id the tool returned>", "from": "email or name", "subject": "...", "age_hours": <int>}}]}}
 `id` is the thread's own id from the tool result, copied verbatim. It is what keeps a
@@ -228,7 +253,8 @@ If the tool call fails, reply with exactly: {{"error": "<what failed>"}}"""
 
 def collect_mail(now: dt.datetime, runner=None):
     runner = runner or (lambda p, t: run_claude(p, t))
-    text, error = runner(MAIL_PROMPT.format(tool=MAIL_TOOL), [MAIL_TOOL])
+    text, error = runner(MAIL_PROMPT.format(tool=MAIL_TOOL, days=MAIL_WINDOW_DAYS),
+                         [MAIL_TOOL])
     if error:
         return [], error
     threads, parse_error = _parse_json_block(text, "threads")
@@ -265,6 +291,13 @@ def collect_mail(now: dt.datetime, runner=None):
         seen[row.key] = n
         if n > 1:
             rows[i] = Row(str(row), f"{row.key}#{n}")
+    if len(rows) > MAIL_ROW_CAP:
+        # Never a silent trim: the last row says how many are not shown, the same
+        # rule the client section already follows.
+        hidden = len(rows) - MAIL_ROW_CAP
+        rows = rows[:MAIL_ROW_CAP] + [
+            Row(f"...and {hidden} more unanswered in the last {MAIL_WINDOW_DAYS} days",
+                "mail:overflow")]
     return rows, None
 
 
@@ -507,7 +540,10 @@ def _section(title, rows, error, cap=MAX_ROWS):
 # retire `notion_board`'s only input.
 SECTIONS = (
     ("calendar", "Today"),
-    ("mail", "Mail needing an answer (48h)"),
+    # The window is INTERPOLATED, never typed. It read "(48h)" while the prompt also
+    # said 48 hours, so when the window was wrong the label agreed with it and the
+    # section looked correct. A number written twice is a number that will disagree.
+    ("mail", f"Mail needing an answer ({MAIL_WINDOW_DAYS}d)"),
 )
 
 #: Collected, never rendered to him. One line each into Sana's queue, and only when the
@@ -673,6 +709,46 @@ def route_engineering(sources: dict, notify=None) -> list:
     return mod.route(sources, ENGINEERING_SECTIONS, notify=notify)   # (filed, failed)
 
 
+#: What the hourly run collects. Mail and GroupMe are the inbox; board_rows paints it.
+#: consulting_board is here for the healthy-scope reason in main(), not for its rows.
+#: Calendar, Linear and the launchd sweep are DELIBERATELY absent: none of them change
+#: within an hour in a way he would act on, and each costs a model call or a sweep.
+HOURLY_SECTIONS = ("consulting_board.py", "groupme_inbox.py", "board_rows.py")
+
+
+def collect_hourly(now: dt.datetime, log_path=None, budget_s: float = COLLECT_BUDGET_S,
+                   fixed_budget_s: float = None) -> dict:
+    """Mail + GroupMe + the board paint. Same guards, same (rows, error) contract,
+    same budgets as collect_all -- this is a narrower SELECTION, never a second
+    implementation, because two collectors drift and one of them is the one nobody
+    watches."""
+    log_path = log_path or ERROR_LOG
+    if fixed_budget_s is None:
+        fixed_budget_s = FIXED_BUDGET_S
+    sources = {"mail": _guarded("mail", lambda: collect_mail(now),
+                                fixed_budget_s, log_path)}
+    for stem, key, _title in OPTIONAL_SECTIONS:
+        if stem not in HOURLY_SECTIONS:
+            continue
+        absent = object()
+
+        def load_and_collect(stem=stem):
+            mod = _optional_module(stem)
+            if mod is None:
+                return absent
+            return mod.collect(now, dict(sources))
+
+        result = _guarded(key, load_and_collect, budget_s, log_path)
+        if result is absent:
+            _log_line(log_path, f"hourly section {key}: module {stem} absent")
+            continue
+        if result is None:
+            _log_line(log_path, f"hourly section {key}: module {stem} reports off")
+            continue
+        sources[key] = result
+    return sources
+
+
 def collect_all(now: dt.datetime, log_path=None, budget_s: float = COLLECT_BUDGET_S,
                 fixed_budget_s: float = None) -> dict:
     """`budget_s` bounds the OPTIONAL sections (the board's Notion round trip,
@@ -750,9 +826,42 @@ def main(argv=None) -> int:
     ap = argparse.ArgumentParser()
     ap.add_argument("--dry-run", action="store_true",
                     help="build and print; send nothing, write no receipt")
+    ap.add_argument("--inbox-only", action="store_true",
+                    help="mail + GroupMe + the Notion board, nothing else. The hourly "
+                         "runner: no Slack message, no receipt, no calendar, no Linear, "
+                         "no launchd sweep.")
     args = ap.parse_args(argv)
 
     now = dt.datetime.now().astimezone()
+
+    if args.inbox_only:
+        # Founder-directed 2026-09-03: *"the email and groupme should be once an
+        # hour."* The board is where he looks; a once-a-day inbox means a client who
+        # writes at 08:00 is invisible until tomorrow.
+        #
+        # NO SLACK SEND, on purpose. Twelve messages a day is how a channel gets
+        # muted, and the 07:00 brief already carries the daily read. This run only
+        # repaints the board.
+        #
+        # consulting_board IS collected even though nothing here changes its rows,
+        # because board_rows archives only inside the scopes reported healthy. Skip it
+        # and the client scope is absent, not healthy, so those rows are KEPT -- but
+        # relying on that is relying on a safety net rather than on the design. Cheap
+        # anyway: it is three file reads.
+        if args.dry_run:
+            os.environ["KIPI_BRIEF_DRY_RUN"] = "1"
+        sources = collect_hourly(now)
+        for key in ("mail", "groupme", "board_rows"):
+            rows, error = sources.get(key, ([], "never collected"))
+            if error:
+                print(f"[{key}] COULD NOT READ: {error}")
+            else:
+                print(f"[{key}] {len(rows)} row(s)")
+        # Exit 1 on a degraded run so launchd column 2 shows it and the fleet
+        # watchdog can see a broken hour without a human reading a log.
+        return 1 if any(sources.get(k, ([], None))[1]
+                        for k in ("mail", "groupme", "board_rows")) else 0
+
     if args.dry_run:
         # Reaches the optional sections, which can write to places the send flag never
         # covered. Set before collect_all, because collection IS when they write.

--- a/q-system/.q-system/scripts/morning-brief.py
+++ b/q-system/.q-system/scripts/morning-brief.py
@@ -852,15 +852,26 @@ def main(argv=None) -> int:
             os.environ["KIPI_BRIEF_DRY_RUN"] = "1"
         sources = collect_hourly(now)
         for key in ("mail", "groupme", "board_rows"):
-            rows, error = sources.get(key, ([], "never collected"))
+            if key not in sources:
+                # OFF IS NOT BROKEN, and this line said it was (Codex round 7, minor).
+                # `collect_hourly` omits a module that reported itself off -- no
+                # GroupMe token, no Notion token -- which is the default on any fleet
+                # machine, so a healthy run printed two COULD NOT READ lines twelve
+                # times a day. It inverted the empty-versus-broken rule the whole file
+                # is built on, in the one surface an operator actually reads.
+                print(f"[{key}] off (not configured on this machine)")
+                continue
+            rows, error = sources[key]
             if error:
                 print(f"[{key}] COULD NOT READ: {error}")
             else:
                 print(f"[{key}] {len(rows)} row(s)")
         # Exit 1 on a degraded run so launchd column 2 shows it and the fleet
-        # watchdog can see a broken hour without a human reading a log.
-        return 1 if any(sources.get(k, ([], None))[1]
-                        for k in ("mail", "groupme", "board_rows")) else 0
+        # watchdog can see a broken hour without a human reading a log. An OFF
+        # section is not degraded: it is absent from `sources` and contributes
+        # nothing here, which is why this reads the dict rather than a default.
+        return 1 if any(sources[k][1] for k in ("mail", "groupme", "board_rows")
+                        if k in sources) else 0
 
     if args.dry_run:
         # Reaches the optional sections, which can write to places the send flag never

--- a/q-system/.q-system/scripts/morning-brief.py
+++ b/q-system/.q-system/scripts/morning-brief.py
@@ -242,11 +242,29 @@ def collect_mail(now: dt.datetime, runner=None):
         age_text = f"  [{age}h]" if isinstance(age, int) else ""
         sender = str(th.get("from", "unknown"))[:40]
         subject = str(th.get("subject", ""))[:70]
-        # The thread id when the model returned one, else sender+subject -- both are
-        # stable while the AGE changes, which is the only thing that was minting new
-        # ids. Never the rendered line: that is the defect rounds 1-4 kept patching.
+        # The thread id when the model returned one, else sender+subject. Both are
+        # stable while the AGE changes, which is what was minting new ids. Never the
+        # rendered line: that is the defect rounds 1-4 kept patching.
         key = str(th.get("id") or "").strip() or f"{sender}|{subject}"
         rows.append(Row(f"{sender}  {subject}{age_text}", f"mail:{key}"))
+
+    # A COLLAPSE IS NOT A DEDUPE. Codex, 2026-09-03: when the model omits thread ids,
+    # two different threads from one person with one subject ("Re: invoice", twice)
+    # produce one key, the board writes ONE row, and the second task is gone -- while
+    # read-back still says ok, because it compares what was written to what was
+    # wanted and both had already lost it. That is worse than the bug it replaced:
+    # rounds 1-4 lost a DRAG, this loses WORK.
+    #
+    # Nothing stable distinguishes them, so the choice is between dropping a task and
+    # keeping it under an id that may move. Keeping it wins, and it is not close: a
+    # row he never sees cannot be acted on at all, while a row whose id shifts costs
+    # him a position on the board. The suffix is ordinal and deliberately provisional.
+    seen = {}
+    for i, row in enumerate(rows):
+        n = seen.get(row.key, 0) + 1
+        seen[row.key] = n
+        if n > 1:
+            rows[i] = Row(str(row), f"{row.key}#{n}")
     return rows, None
 
 

--- a/q-system/.q-system/scripts/morning-brief.py
+++ b/q-system/.q-system/scripts/morning-brief.py
@@ -440,9 +440,25 @@ def _section(title, rows, error, cap=MAX_ROWS):
     return out
 
 
+# THE FOUNDER'S SECTIONS. Consulting only, 2026-09-03, founder-directed:
+# "I'm not looking for this to be a build dashboard, but a consulting dashboard."
+#
+# `owed` (Linear) and `overnight` (launchd) LEFT this tuple and did NOT stop being
+# collected. They are engineering signal, and `founder-notifications.md` has said since
+# 2026-08-10 that engineering signal goes to Sana's Linear triage and never to him:
+# "I dont want to see any of these." They now render through ENGINEERING_SECTIONS into
+# slack-notify.sh. Deleting the collectors instead would have been the wrong fix twice
+# over -- it would drop the deadman's view of overnight jobs, and it would silently
+# retire `notion_board`'s only input.
 SECTIONS = (
     ("calendar", "Today"),
     ("mail", "Mail needing an answer (48h)"),
+)
+
+#: Collected, never rendered to him. One line each into Sana's queue, and only when the
+#: section is degraded: a healthy overnight run is not news and a ticket per morning is
+#: how an alert channel gets muted.
+ENGINEERING_SECTIONS = (
     ("owed", "Owed today"),
     ("overnight", "Overnight jobs"),
 )
@@ -460,8 +476,21 @@ SECTIONS = (
 # notion_board.py reported inert on CI while this registry was its real caller
 # (PR #294, 2026-09-02). _optional_module accepts either spelling.
 OPTIONAL_SECTIONS = (
+    # consulting_board runs FIRST: board_rows reads its buckets, and the registry is
+    # ordered, so a later entry sees the earlier one's result in `sources`.
+    ("consulting_board.py", "consulting", "Your book"),
+    ("groupme_inbox.py", "groupme", "GroupMe waiting on you"),
     ("unknown_terms.py", "unknown_terms", "Terms I do not know"),
-    ("notion_board.py", "board", "Notion board"),
+    ("board_rows.py", "board_rows", "Notion board"),
+    # notion_board.py is UNREGISTERED here, and the comment this replaces was wrong.
+    # It claimed the module would fall quiet because `owed` had left the founder's
+    # sections. It did not: `owed` is still COLLECTED in collect_all's fixed tuple, so
+    # notion_board's guard never fired and the first live dry-run rendered its bullets
+    # right underneath board_rows' rows. Two writers on one board, which is the exact
+    # thing this work exists to stop. Its bullets were never visible in the board's own
+    # views anyway: the three sections are FILTERED VIEWS of the Kipi backlog database
+    # split by the Bucket select, measured 2026-09-03. The file and its tests stay on
+    # disk; only its registration is removed, so the revert is one line.
 )
 
 ERROR_LOG = STATE_DIR / "logs" / "morning-brief-errors.log"
@@ -556,7 +585,28 @@ def build(now: dt.datetime, sources: dict):
             degraded = True
         lines += _section(title, rows, error)
         lines.append("")
+    for key, _title in ENGINEERING_SECTIONS:
+        # DEGRADED WITHOUT RENDERING. Found by its own test: moving these two out of
+        # SECTIONS also moved them out of this flag, and the flag is what the deadman
+        # and the receipt read. A section that stops being VISIBLE to him must not
+        # quietly stop being MONITORED -- that is the failure deleting the collectors
+        # would have caused, arriving by another door.
+        _rows, error = sources.get(key, ([], None))
+        if error:
+            degraded = True
     return "\n".join(lines).rstrip(), degraded
+
+
+def route_engineering(sources: dict, notify=None) -> list:
+    """Engineering sections leave his brief for Sana. Delegates to engineering_route.
+
+    The routing lives in a SIBLING module, not here, because
+    `test_no_source_file_calls_slack_notify` greps this file for "slack-notify" and is
+    right to: the founder's brief must never go out through the fleet alert path. That
+    guard caught the first version of this function, which is the guard working.
+    """
+    mod = _load_sibling("engineering_route", "engineering_route.py")
+    return mod.route(sources, ENGINEERING_SECTIONS, notify=notify)
 
 
 def collect_all(now: dt.datetime, log_path=None, budget_s: float = COLLECT_BUDGET_S,
@@ -639,7 +689,17 @@ def main(argv=None) -> int:
     args = ap.parse_args(argv)
 
     now = dt.datetime.now().astimezone()
-    message, degraded = build(now, collect_all(now))
+    if args.dry_run:
+        # Reaches the optional sections, which can write to places the send flag never
+        # covered. Set before collect_all, because collection IS when they write.
+        os.environ["KIPI_BRIEF_DRY_RUN"] = "1"
+    sources = collect_all(now)
+    # Engineering leaves BEFORE the founder's message is built, so a routing failure
+    # cannot silently become a section he reads.
+    routed = route_engineering(sources, notify=(lambda _m: None) if args.dry_run else None)
+    for line in routed:
+        print(f"[to sana] {line}")
+    message, degraded = build(now, sources)
     print(message)
     if args.dry_run:
         print("\n[dry-run] nothing sent, no receipt written")

--- a/q-system/.q-system/scripts/morning-brief.py
+++ b/q-system/.q-system/scripts/morning-brief.py
@@ -606,7 +606,7 @@ def route_engineering(sources: dict, notify=None) -> list:
     guard caught the first version of this function, which is the guard working.
     """
     mod = _load_sibling("engineering_route", "engineering_route.py")
-    return mod.route(sources, ENGINEERING_SECTIONS, notify=notify)
+    return mod.route(sources, ENGINEERING_SECTIONS, notify=notify)   # (filed, failed)
 
 
 def collect_all(now: dt.datetime, log_path=None, budget_s: float = COLLECT_BUDGET_S,
@@ -696,9 +696,14 @@ def main(argv=None) -> int:
     sources = collect_all(now)
     # Engineering leaves BEFORE the founder's message is built, so a routing failure
     # cannot silently become a section he reads.
-    routed = route_engineering(sources, notify=(lambda _m: None) if args.dry_run else None)
-    for line in routed:
+    filed, failed = route_engineering(
+        sources, notify=(lambda _m: None) if args.dry_run else None)
+    for line in filed:
         print(f"[to sana] {line}")
+    for line, why in failed:
+        # Printed as NOT filed. An engineering problem that was detected and then lost
+        # on the way to the queue is worse than one never detected: it looks handled.
+        print(f"[to sana FAILED, not filed] {line} :: {why}")
     message, degraded = build(now, sources)
     print(message)
     if args.dry_run:

--- a/q-system/.q-system/scripts/morning-brief.py
+++ b/q-system/.q-system/scripts/morning-brief.py
@@ -234,10 +234,20 @@ class Row(str):
 #: knows which threads are clients. It is not wired here yet: it reads the Notion
 #: ledger live, so it is a cross-repo runtime dependency and its own piece of work.
 MAIL_WINDOW_DAYS = 30
-#: The most inbox rows one sweep may put on the board. A 30-day window over a real
-#: inbox can return a lot; this is a phone-screen limit, not a judgement about which
-#: mail matters.
-MAIL_ROW_CAP = 15
+#: MAIL_ROW_CAP LIVED HERE AND IS DELETED (claude review, 2026-09-04, major).
+#: It trimmed the PRODUCER's rows to 15. Trimmed threads never entered
+#: `buckets["inbox"]`, yet `inbox:Gmail` still reported healthy (every remaining key
+#: was a real thread id), so the painter archived their board rows -- pins included --
+#: inside a healthy scope. An unanswered client thread disappeared off his board, which
+#: is the exact failure this board exists to prevent.
+#:
+#: The cap was also redundant. `_section` already trims DISPLAY to MAX_ROWS and prints
+#: "...and N more", so the Slack message was never going to be 50 lines. One cap for
+#: display, none for data: the brief stays short and the board sees every thread.
+#:
+#: Round 11 fixed this same class inside the painter with its `capped` set, on the
+#: rule that a cap is a write budget and not a statement that the work is finished.
+#: The rule is right; a second cap upstream of the producer routed around it.
 
 MAIL_PROMPT = """Call {tool} to find email threads from the last {days} days where a
 REAL PERSON wrote to the founder and the founder has not replied yet. Exclude
@@ -305,13 +315,6 @@ def collect_mail(now: dt.datetime, runner=None):
             continue
         rows.append(Row(f"{members[0]} ({len(members)} threads, same sender and "
                         "subject)", key))
-    if len(rows) > MAIL_ROW_CAP:
-        # Never a silent trim: the last row says how many are not shown, the same
-        # rule the client section already follows.
-        hidden = len(rows) - MAIL_ROW_CAP
-        rows = rows[:MAIL_ROW_CAP] + [
-            Row(f"...and {hidden} more unanswered in the last {MAIL_WINDOW_DAYS} days",
-                "mail:overflow")]
     return rows, None
 
 

--- a/q-system/.q-system/scripts/morning-brief.py
+++ b/q-system/.q-system/scripts/morning-brief.py
@@ -897,7 +897,11 @@ def main(argv=None) -> int:
     filed, failed = route_engineering(
         sources, notify=(lambda _m: None) if args.dry_run else None)
     for line in filed:
-        print(f"[to sana] {line}")
+        # DRY RUN SAYS SO (round 11, minor). The notifier injected above sends
+        # nothing, and this printed the same "[to sana]" either way, so a dry run
+        # reported an alert that no one received. Every other refusal in this file
+        # names itself; this one claimed a delivery.
+        print(f"[to sana{' (dry run, not sent)' if args.dry_run else ''}] {line}")
     for line, why in failed:
         # Printed as NOT filed. An engineering problem that was detected and then lost
         # on the way to the queue is worse than one never detected: it looks handled.

--- a/q-system/.q-system/scripts/test/test-fleet-health-daily.py
+++ b/q-system/.q-system/scripts/test/test-fleet-health-daily.py
@@ -531,6 +531,42 @@ _LESSONS = Path(__file__).resolve().parents[3] / "lessons"
 check("cron-shells-claude's lesson slug is a real file",
       (_LESSONS / f"{_by_id['cron-shells-claude']['lesson']}.md").is_file(), True)
 
+# ---------------------------------------------------------------------------
+# launchd-never-installed (PR #296 round 9): a committed template nobody installed
+# is invisible to BOTH the drift detector (it skips a template with no live copy)
+# and the dark-job detector (it walks live copies). The job just never runs.
+# ---------------------------------------------------------------------------
+import tempfile as _tempfile
+
+with _tempfile.TemporaryDirectory() as _tmp:
+    _templates = Path(_tmp) / "scripts"
+    _agents = Path(_tmp) / "LaunchAgents"
+    _templates.mkdir()
+    _agents.mkdir()
+    (_templates / "com.kipi.installed-one.plist").write_text("<plist/>")
+    (_templates / "com.kipi.never-installed.plist").write_text("<plist/>")
+    (_agents / "com.kipi.installed-one.plist").write_text("<plist/>")
+    _found = fh.never_installed_findings(template_dir=_templates, launch_agents=_agents)
+    check("an uninstalled template is reported",
+          [f["subject"] for f in _found], ["com.kipi.never-installed"])
+    check("an installed one is not",
+          any("installed-one" in f["subject"] for f in _found), False)
+    check("the finding names the command that fixes it",
+          "install-plist.sh com.kipi.never-installed" in _found[0]["body"], True)
+    check("and warns against installing from a worktree",
+          "worktree" in _found[0]["body"], True)
+    # The negative control: install it and the finding must disappear, or the
+    # detector is one that can never go green and will nag forever.
+    (_agents / "com.kipi.never-installed.plist").write_text("<plist/>")
+    check("installing it clears the finding",
+          fh.never_installed_findings(template_dir=_templates, launch_agents=_agents), [])
+
+check("launchd-never-installed is registered", "launchd-never-installed" in _by_id, True)
+check("it declares an action",
+      _by_id.get("launchd-never-installed", {}).get("action"), "file_issue")
+check("its lesson slug is a real file",
+      (_LESSONS / f"{_by_id['launchd-never-installed']['lesson']}.md").is_file(), True)
+
 if failures:
     print("FAIL:")
     for line in failures:

--- a/q-system/.q-system/tests/test_consulting_board.py
+++ b/q-system/.q-system/tests/test_consulting_board.py
@@ -262,9 +262,49 @@ class TestAStaleCardIsAnError:
         _, err = cb.collect(NOW, {}, _tree(tmp_path, card="# TODAY CARD\nno rows here\n"))
         assert "format changed" in err
 
-    def test_and_a_stale_card_writes_no_rows_at_all(self, tmp_path):
+    def test_a_stale_card_writes_no_CLIENT_rows(self, tmp_path):
+        """The round-2 rule, unchanged: a source that could not answer writes nothing,
+        and its rows are neither refreshed nor archived. What changed in round 9 is the
+        RADIUS, not this."""
         b = cb.buckets(NOW, {}, _tree(tmp_path, date="2026-09-02"))
-        assert b["error"] and b["top_of_mind"] == [] and b["this_week"] == []
+        assert not any(r["scope"] == "card" for r in b["top_of_mind"] + b["this_week"])
+        assert not any(r["scope"] == "myside" for r in b["top_of_mind"])
+        assert "card" not in b["healthy_scopes"], "a stale card must not authorise archiving"
+        # The GTM queue is its OWN file and answered. Silencing it because a different
+        # producer is late is the radius mistake this change exists to remove, so this
+        # asserts it keeps working rather than leaving it to chance.
+        assert any(r["scope"] == "gtm" for r in b["top_of_mind"])
+
+    def test_but_it_no_longer_silences_the_inbox(self, tmp_path):
+        """Founder-facing reason this changed: a late 07:30 job used to mean no mail on
+        the board either, from a source that answered perfectly well. The abort was not
+        even protecting him from stale client rows, since nothing archives or
+        overwrites them either way. It cost him today's mail to keep yesterday's
+        clients he was going to see regardless."""
+        b = cb.buckets(NOW, {"mail": ([_brief().Row("a thread", "mail:t1")], None)},
+                       _tree(tmp_path, date="2026-09-02"))
+        assert [r["key"] for r in b["inbox"]] == ["mail:t1"]
+        assert "inbox:Gmail" in b["healthy_scopes"]
+
+    def test_and_the_board_carries_an_alarm_row_that_can_be_cleared(self, tmp_path):
+        """A partial board must never be a silent one. The alarm sits in its own scope
+        which is ALWAYS healthy, so the morning the card comes back the row is archived
+        rather than becoming permanent furniture."""
+        stale = cb.buckets(NOW, {}, _tree(tmp_path, date="2026-09-02"))
+        alarm = [r for r in stale["top_of_mind"] if r["scope"] == cb.CARD_ALARM]
+        assert len(alarm) == 1 and "2026-09-02" in alarm[0]["detail"]
+        assert cb.CARD_ALARM in stale["healthy_scopes"]
+
+        fresh = cb.buckets(NOW, {}, _tree(tmp_path))
+        assert not any(r["scope"] == cb.CARD_ALARM for r in fresh["top_of_mind"])
+        assert cb.CARD_ALARM in fresh["healthy_scopes"]
+
+    def test_the_painter_still_writes_nothing_on_a_real_error(self):
+        """`error` keeps its old meaning and its old teeth. A card problem is not one."""
+        with pytest.raises(ValueError):
+            board_rows.paint({"error": "everything is broken", "top_of_mind": [],
+                              "this_week": [], "inbox": [], "healthy_scopes": set()},
+                             "t", "db", opener=lambda *a, **k: None)
 
 
 class TestTheGtmMoveIsOnlyWhatNeedsHim:
@@ -1146,11 +1186,12 @@ class TestRateLimitedNotionIsRetriedNotAbandoned:
         the brief has moved on. A Retry-After longer than what is left is refused
         rather than slept through."""
         opener = self._opener(fail_on=2, retry_after="60")
-        # 2.0 rather than a fraction of a second: a budget that can expire before the
-        # first request turns this into a load-sensitive coin flip, and a flaky
-        # negative control is worse than none. The clamped wait (5s) is longer than
-        # this budget either way, which is the condition under test.
-        budget = board_rows._Budget(2.0)
+        # Above WRITE_RESERVE_S so a write is actually attempted, and below the
+        # clamped Retry-After (5s) so the wait cannot fit, which is the condition under
+        # test. Not a fraction of a second: a budget that can expire before the first
+        # request turns this into a load-sensitive coin flip, and a flaky negative
+        # control is worse than none.
+        budget = board_rows._Budget(board_rows.WRITE_RESERVE_S + 2.0)
         started = time.monotonic()
         # EITHER refusal is correct: the retry declines because the wait does not fit,
         # or the budget was already spent and the next request refuses. The exception
@@ -1179,3 +1220,143 @@ class TestRateLimitedNotionIsRetriedNotAbandoned:
                 {"top_of_mind": [], "this_week": [], "inbox": self._rows(1),
                  "healthy_scopes": {"inbox:Gmail"}}, "t", "db", opener=opener)
         assert len(calls) <= 1 + board_rows.RATE_LIMIT_RETRIES + 1, calls
+
+
+class TestTheBoardDoesNotRewriteWhatItAlreadyHolds:
+    """Round 9 (major): BUDGET_ROWS is per BUCKET, so a full paint could ask for 120
+    sequential mutations inside a 15-second budget, against an API documented at
+    roughly three requests a second.
+
+    The answer is not a second invented cap. Almost every one of those writes changed
+    nothing, and the page needed to prove that has ALREADY been read.
+    """
+
+    ITEM = {"key": "k1", "title": "t", "detail": "d", "scope": "card",
+            "domain": "Consulting"}
+
+    def _painted_page(self, bucket="Top of Mind"):
+        """A row exactly as this painter would have left it last run."""
+        props = board_rows._properties(self.ITEM, bucket,
+                                       board_rows.item_id("top_of_mind", self.ITEM),
+                                       include_bucket=True, status="Not started")
+        page = {"id": "p1", "properties": dict(props)}
+        page["properties"]["Bucket"] = {"select": {"name": bucket}}
+        return page
+
+    def _paint(self, page, monkeypatch, budget=None):
+        have = {board_rows.item_id("top_of_mind", self.ITEM): page}
+        monkeypatch.setattr(board_rows, "existing_rows", lambda *a, **k: have)
+        calls = []
+        monkeypatch.setattr(
+            board_rows, "_request",
+            lambda token, method, path, body=None, opener=None, budget=None:
+            calls.append(method) or {})
+        counts = board_rows.paint(
+            {"top_of_mind": [dict(self.ITEM)], "this_week": [], "inbox": [],
+             "healthy_scopes": {"card"}}, "t", "db", budget=budget)
+        return counts, calls
+
+    def test_an_unchanged_row_costs_no_request_at_all(self, monkeypatch):
+        counts, calls = self._paint(self._painted_page(), monkeypatch)
+        assert calls == [], f"a row that already holds its values was rewritten: {calls}"
+        assert counts["unchanged"] == 1 and counts["updated"] == 0
+
+    def test_but_a_changed_detail_is_still_written(self, monkeypatch):
+        """The negative control. A skip that never writes is not an optimisation, it is
+        an outage, so the same fixture with one moved value must produce a PATCH."""
+        page = self._painted_page()
+        page["properties"]["Notes"] = {"rich_text": [{"plain_text": "something else"}]}
+        counts, calls = self._paint(page, monkeypatch)
+        assert calls == ["PATCH"] and counts["updated"] == 1
+
+    def test_an_unreadable_property_is_written_not_assumed_to_match(self, monkeypatch):
+        page = self._painted_page()
+        page["properties"]["Domain"] = {"some_new_notion_shape": True}
+        _counts, calls = self._paint(page, monkeypatch)
+        assert calls == ["PATCH"], "an unrecognised property shape was assumed equal"
+
+    def test_a_spent_write_budget_defers_rather_than_running_past_it(self, monkeypatch):
+        page = self._painted_page()
+        page["properties"]["Notes"] = {"rich_text": [{"plain_text": "changed"}]}
+        budget = board_rows._Budget(board_rows.WRITE_RESERVE_S / 2)
+        counts, calls = self._paint(page, monkeypatch, budget=budget)
+        assert calls == [], "it wrote with no time left to prove the write"
+        assert counts["deferred"] == 1
+
+    def test_a_deferred_CREATE_is_not_expected_by_the_read_back(self, tmp_path, monkeypatch):
+        """A row we never created is not on the board. Counting it as expected would
+        report a read-back mismatch about a row we deliberately did not write, which is
+        the false-alarm class round 3 already charged for once."""
+        (tmp_path / "tok").write_text("t")
+        (tmp_path / "db").write_text("db1")
+        monkeypatch.setattr(board_rows, "LOCK_FILE", tmp_path / "board.lock")
+        monkeypatch.delenv("PYTEST_CURRENT_TEST", raising=False)
+        monkeypatch.delenv("KIPI_BRIEF_DRY_RUN", raising=False)
+        monkeypatch.setattr(board_rows.consulting_board, "buckets", lambda *a, **k: {
+            "error": None, "card_error": None, "top_of_mind": [dict(self.ITEM)],
+            "this_week": [], "inbox": [], "healthy_scopes": {"card"}})
+        monkeypatch.setattr(board_rows, "WRITE_RESERVE_S", 999.0)   # nothing may write
+        rows, err = board_rows.collect(
+            NOW, {}, opener=lambda *a, **k: io.BytesIO(
+                b'{"results": [], "has_more": false}'),
+            token_file=tmp_path / "tok", db_file=tmp_path / "db")
+        assert err is None, err
+        assert "1 row(s) deferred" in rows[0], rows
+
+
+class TestTheAllowlistIsHisChoiceAndFailsCLOSED:
+    """Codex round 7 (minor), twice over. The founder's narrowing -- "I only want you
+    to look in the AI chat channel" -- could be widened by an IO error, and could not
+    name a DM at all."""
+
+    def _tree(self, tmp_path, groups=(), chats=()):
+        import json as _json
+
+        def opener(req, timeout):
+            url = req.full_url.split("?")[0]
+            if url.endswith("/users/me"):
+                return io.BytesIO(_json.dumps({"response": {"user_id": "me"}}).encode())
+            if "/groups/" in url and url.endswith("/messages"):
+                return io.BytesIO(_json.dumps(
+                    {"response": {"messages": [{"user_id": "them"}]}}).encode())
+            body = list(groups) if url.endswith("/groups") else list(chats)
+            return io.BytesIO(_json.dumps({"response": body}).encode())
+        return opener
+
+    def test_an_unreadable_allowlist_refuses_rather_than_widening(self, tmp_path, monkeypatch):
+        path = tmp_path / "groupme-channels"
+        path.write_text("g1\n", encoding="utf-8")
+        path.chmod(0o000)
+        try:
+            monkeypatch.setattr(gm, "CHANNELS_FILE", path)
+            monkeypatch.setattr(gm, "load_token", lambda: "t")
+            monkeypatch.setattr(gm, "waiting",
+                                lambda *a, **k: gm.load_allowlist() and [])
+            rows, err = gm.collect(NOW, {})
+        finally:
+            path.chmod(0o600)
+        assert rows == [] and err, "an unreadable allowlist read as no allowlist"
+        assert "allowlist" in err
+
+    def test_an_ABSENT_allowlist_still_means_no_choice_recorded(self, tmp_path, monkeypatch):
+        monkeypatch.setattr(gm, "CHANNELS_FILE", tmp_path / "not-there")
+        assert gm.load_allowlist() is None
+
+    def test_a_DM_he_NAMED_is_carried(self, tmp_path, monkeypatch):
+        """It used to skip /chats entirely whenever an allowlist existed, so a DM peer
+        id in the file matched nothing and the file said nothing about ignoring it."""
+        monkeypatch.setattr(gm, "CHANNELS_FILE", tmp_path / "ch")
+        (tmp_path / "ch").write_text("u77\n", encoding="utf-8")
+        chats = [{"other_user": {"id": "u77", "name": "Dana"},
+                  "last_message": {"user_id": "u77", "created_at": 10 ** 12,
+                                   "text": "hi"}}]
+        rows = gm.waiting(NOW, "t", self._tree(tmp_path, chats=chats))
+        assert [r["id"] for r in rows] == ["u77"], rows
+
+    def test_and_a_DM_he_did_not_name_is_not(self, tmp_path, monkeypatch):
+        monkeypatch.setattr(gm, "CHANNELS_FILE", tmp_path / "ch")
+        (tmp_path / "ch").write_text("u77\n", encoding="utf-8")
+        chats = [{"other_user": {"id": "u99", "name": "Someone"},
+                  "last_message": {"user_id": "u99", "created_at": 10 ** 12,
+                                   "text": "hi"}}]
+        assert gm.waiting(NOW, "t", self._tree(tmp_path, chats=chats)) == []

--- a/q-system/.q-system/tests/test_consulting_board.py
+++ b/q-system/.q-system/tests/test_consulting_board.py
@@ -664,17 +664,24 @@ class TestTwoThreadsAreNeverOneRow:
     Notion row. Read-back still passed, because `wanted` had already lost the second
     one -- the same shape as the round-3 defect, one layer up."""
 
-    def test_two_threads_from_one_person_with_one_subject_stay_two_rows(self):
+    def test_two_indistinguishable_threads_become_one_row_that_SAYS_two(self):
         brief = _brief()
         runner = lambda p, t: (json.dumps({"threads": [
             {"from": "Alice", "subject": "Re: invoice", "age_hours": 2},
             {"from": "Alice", "subject": "Re: invoice", "age_hours": 9}]}), None)
         rows, err = brief.collect_mail(None, runner)
         assert err is None
-        assert len(rows) == 2, "the producer must emit both threads"
-        assert rows[0].key != rows[1].key, (
-            f"both threads share the key {rows[0].key!r}; the board writes one row and "
-            "the second task is silently gone")
+        # ROUND 10 REVERSED THE SHAPE OF THIS FIX, and the harm it was written against
+        # still governs. The first fix numbered duplicates by POSITION, so answering
+        # the first thread renumbered the second onto its key and handed it that row's
+        # Status and the bucket he had dragged it to. A thread wearing another
+        # thread's identity is worse than either outcome the original note weighed.
+        #
+        # With no thread id nothing tells these two apart, so the group is ONE row
+        # that says how many it stands for. The task is not silently gone, which is
+        # what this class exists to prevent: he can see there are two and open both.
+        assert len(rows) == 1
+        assert "2 threads" in str(rows[0]), str(rows[0])
 
     def test_a_real_thread_id_still_wins_and_stays_stable(self):
         """The suffix is only for the id-less case. A thread WITH an id must not pick
@@ -693,7 +700,16 @@ class TestTwoThreadsAreNeverOneRow:
             {"from": "Alice", "subject": "Re: invoice", "age_hours": 9}]}), None)
         rows, _ = brief.collect_mail(None, runner)
         inbox = cb.buckets(NOW, {"mail": (rows, None)}, _tree(tmp_path))["inbox"]
-        assert len({i["key"] for i in inbox}) == 2, "one task never reached the board"
+        assert len(inbox) == 1 and "2 threads" in inbox[0]["title"], inbox
+        # And the id-LESS case is the only one that collapses: with real ids the board
+        # still gets two rows. That is the normal path and it must not regress.
+        keyed = lambda p, t: (json.dumps({"threads": [
+            {"id": "t1", "from": "Alice", "subject": "Re: invoice", "age_hours": 2},
+            {"id": "t2", "from": "Alice", "subject": "Re: invoice", "age_hours": 9}]}),
+            None)
+        rows2, _ = brief.collect_mail(None, keyed)
+        inbox2 = cb.buckets(NOW, {"mail": (rows2, None)}, _tree(tmp_path))["inbox"]
+        assert len({i["key"] for i in inbox2}) == 2, "a real thread id stopped working"
 
 
 class TestHisSideCarriesItsDates:
@@ -1360,3 +1376,48 @@ class TestTheAllowlistIsHisChoiceAndFailsCLOSED:
                   "last_message": {"user_id": "u99", "created_at": 10 ** 12,
                                    "text": "hi"}}]
         assert gm.waiting(NOW, "t", self._tree(tmp_path, chats=chats)) == []
+
+
+class TestABookWeCouldNotFullyReadArchivesNothing:
+    def test_a_malformed_line_withholds_the_week_due_scope(self, tmp_path):
+        """Round 10 (major), and it is my round-7 fix's own hole. `week:due` was
+        declared healthy after the loop finished, but the loop `continue`s past a line
+        that will not parse -- so the painter was authorised to archive the row for the
+        very deliverable the corrupt line described."""
+        due = (NOW.date() + dt.timedelta(days=3)).isoformat()
+        paths = _tree(tmp_path, commitments="\n".join([
+            "{ not json at all",
+            json.dumps({"id": "c1", "slug": "acme", "state": "open", "due": due,
+                        "promise": "send the audit"}),
+        ]), clients={"clients": []})
+        _rows, err, healthy = cb.read_week(NOW, paths)
+        assert "week:due" not in healthy
+        assert err and "unreadable line" in err
+
+    def test_a_clean_book_still_authorises_it(self, tmp_path):
+        due = (NOW.date() + dt.timedelta(days=3)).isoformat()
+        paths = _tree(tmp_path, commitments=json.dumps(
+            {"id": "c1", "slug": "acme", "state": "open", "due": due,
+             "promise": "send the audit"}), clients={"clients": []})
+        _rows, err, healthy = cb.read_week(NOW, paths)
+        assert err is None and "week:due" in healthy
+
+    def test_a_junk_DUE_DATE_is_still_only_a_skipped_row(self, tmp_path):
+        """Deliberately NOT the same thing. The row parsed; one field in it did not.
+        Withholding the whole scope for that would keep every deliverable row on the
+        board forever over one typo, which is the over-application I made first and
+        backed out."""
+        paths = _tree(tmp_path, commitments=json.dumps(
+            {"id": "c1", "slug": "acme", "state": "open", "due": "soon-ish",
+             "promise": "send the audit"}), clients={"clients": []})
+        _rows, err, healthy = cb.read_week(NOW, paths)
+        assert err is None and "week:due" in healthy
+
+    def test_no_allowlist_file_reads_everything_ON_PURPOSE(self, tmp_path, monkeypatch):
+        """Round 10 called this a silent widening. Kept, as a decision rather than an
+        oversight: nothing distinguishes a vanished file from a machine that never had
+        one, and requiring a marker would silence GroupMe on every machine without the
+        file. Reporting too much is visible in his own output; reporting nothing is the
+        failure the whole brief exists to prevent."""
+        monkeypatch.setattr(gm, "CHANNELS_FILE", tmp_path / "absent")
+        assert gm.load_allowlist() is None

--- a/q-system/.q-system/tests/test_consulting_board.py
+++ b/q-system/.q-system/tests/test_consulting_board.py
@@ -320,15 +320,22 @@ class TestTheDryRunWritesNothing:
 
 
 class TestHisDragAlwaysWins:
-    def test_an_existing_row_is_never_given_a_bucket(self):
+    def test_declining_to_move_a_row_writes_neither_Bucket_nor_Status(self):
+        """The narrow half of the promise. WHEN this module declines is
+        `_bucket_decision`'s call and is pinned by
+        TestARowHeNeverTouchedFollowsItsHealth; this holds that a decline really does
+        leave both columns alone. The old name said "an existing row is NEVER given a
+        bucket", which is the over-wide rule Codex round 6 charged for: a row nobody
+        touched was frozen in its first morning's bucket forever."""
         props = board_rows._properties({"title": "t", "detail": "d"}, "Top of Mind",
                                        "cb:abc", include_bucket=False)
         assert "Bucket" not in props and "Status" not in props
 
     def test_a_new_row_is(self):
         props = board_rows._properties({"title": "t"}, "Inbox", "cb:abc",
-                                       include_bucket=True)
+                                       include_bucket=True, status="Not started")
         assert props["Bucket"]["select"]["name"] == "Inbox"
+        assert props["Status"]["select"]["name"] == "Not started"
 
     def test_the_id_is_stable_across_mornings(self):
         """Hashed from `key` alone. The detail moves daily (due dates, reply counts)."""
@@ -763,7 +770,7 @@ class TestThisWeekHasASourceAtLast:
             "9.9": {"id": "9.9", "action": "a machine job", "performer": "mechanism",
                     "state": "ready", "rank": 1},
         }})
-        rows, err = cb.read_week(NOW, paths)
+        rows, err, _healthy = cb.read_week(NOW, paths)
         assert err is None
         assert not any(r["key"] == "gtm:9.9" for r in rows)
 
@@ -772,7 +779,7 @@ class TestThisWeekHasASourceAtLast:
         paths = _tree(tmp_path, commitments=json.dumps(
             {"id": "c1", "slug": "acme", "state": "open", "due": due,
              "promise": "send the audit"}), clients={"clients": []})
-        rows, _ = cb.read_week(NOW, paths)
+        rows, _, _healthy = cb.read_week(NOW, paths)
         hit = [r for r in rows if r["key"] == "due:c1"]
         assert hit, "a deliverable due in 3 days never reached This Week"
         assert "(3d)" in hit[0]["detail"]
@@ -784,7 +791,7 @@ class TestThisWeekHasASourceAtLast:
         paths = _tree(tmp_path, commitments=json.dumps(
             {"id": "c1", "slug": "acme", "state": "open", "due": past,
              "promise": "send the audit"}), clients={"clients": []})
-        rows, _ = cb.read_week(NOW, paths)
+        rows, _, _healthy = cb.read_week(NOW, paths)
         assert not any(r["key"] == "due:c1" for r in rows)
 
     def test_a_deliverable_beyond_the_week_is_not_this_weeks_problem(self, tmp_path):
@@ -792,13 +799,198 @@ class TestThisWeekHasASourceAtLast:
         paths = _tree(tmp_path, commitments=json.dumps(
             {"id": "c1", "slug": "acme", "state": "open", "due": far,
              "promise": "send the audit"}), clients={"clients": []})
-        rows, _ = cb.read_week(NOW, paths)
+        rows, _, _healthy = cb.read_week(NOW, paths)
         assert not any(r["key"] == "due:c1" for r in rows)
 
     def test_a_junk_due_date_is_skipped_not_crashed_on(self, tmp_path):
         paths = _tree(tmp_path, commitments=json.dumps(
             {"id": "c1", "slug": "acme", "state": "open", "due": "soon-ish",
              "promise": "send the audit"}), clients={"clients": []})
-        rows, err = cb.read_week(NOW, paths)
+        rows, err, _healthy = cb.read_week(NOW, paths)
         assert err is None
         assert not any(r["key"] == "due:c1" for r in rows)
+
+
+class TestARowHeNeverTouchedFollowsItsHealth:
+    """Codex round 6 (major): `Bucket` was written ONLY on create, so a client that
+    went red -> green stayed in Top of Mind forever and a human had to move it by hand.
+
+    The promise the module makes is narrower than the rule it implemented: HIS drag
+    wins, not every stale value the machine itself painted. Told apart the way
+    `gtm_board.apply_board_moves` does it -- record what THIS module last wrote, and a
+    live value that differs from that record was put there by a human, because nothing
+    else writes that column.
+    """
+
+    ITEM = {"key": "k1", "title": "t", "detail": "d", "scope": "card"}
+
+    @staticmethod
+    def _page(live_bucket, note):
+        return {"id": "p1", "properties": {
+            "Bucket": {"select": ({"name": live_bucket} if live_bucket else None)},
+            "Notes": {"rich_text": [{"plain_text": note}]}}}
+
+    def _patch(self, monkeypatch, live_bucket, note, computed_key, item=None):
+        """Paint over ONE existing row; return the properties it PATCHed."""
+        item = item or dict(self.ITEM)
+        have = {board_rows.item_id(computed_key, item): self._page(live_bucket, note)}
+        monkeypatch.setattr(board_rows, "existing_rows", lambda *a, **k: have)
+        calls = []
+        monkeypatch.setattr(
+            board_rows, "_request",
+            lambda token, method, path, body=None, opener=None, budget=None:
+            calls.append((method, body)) or {})
+        buckets = {"top_of_mind": [], "this_week": [], "inbox": [],
+                   "healthy_scopes": {"card"}}
+        buckets[computed_key] = [item]
+        board_rows.paint(buckets, "t", "db")
+        patches = [b for m, b in calls if m == "PATCH"]
+        assert len(patches) == 1, calls
+        return patches[0]["properties"]
+
+    @staticmethod
+    def _note(props):
+        return "".join(t["text"]["content"] for t in props["Notes"]["rich_text"])
+
+    def test_a_row_we_painted_and_he_never_moved_gets_its_new_bucket(self, monkeypatch):
+        """The finding. Live value equals what we last painted, so nobody has touched
+        it, so the computed health is free to move it."""
+        props = self._patch(monkeypatch, "Top of Mind",
+                            "d\nscope=card\nbucket=Top of Mind", "this_week")
+        assert props["Bucket"]["select"]["name"] == "This Week"
+        assert "bucket=This Week" in self._note(props)
+
+    def test_a_row_he_DRAGGED_is_not_moved_back(self, monkeypatch):
+        """Live Inbox against a record of Top of Mind: nothing but a human puts it
+        there. The row is pinned from this run on."""
+        props = self._patch(monkeypatch, "Inbox",
+                            "d\nscope=card\nbucket=Top of Mind", "top_of_mind")
+        assert "Bucket" not in props
+        assert "pinned=1" in self._note(props)
+
+    def test_and_it_STAYS_pinned_on_the_next_run(self, monkeypatch):
+        """The negative control, and the reason a straight port of gtm_board is wrong
+        here. There a drag CHANGES the computed state, so adopting the live value as
+        the new baseline is correct. Here health is computed from the card and a drag
+        cannot change it, so adopting would agree with the record next morning and
+        move the row back one run later. A pinned row is pinned for good."""
+        props = self._patch(monkeypatch, "Inbox",
+                            "d\nscope=card\nbucket=Inbox\npinned=1", "top_of_mind")
+        assert "Bucket" not in props
+        assert "pinned=1" in self._note(props)
+
+    def test_a_row_written_before_this_change_is_moved_ONCE(self, monkeypatch):
+        """Cold start: no record, and the live bucket disagrees with the computed one.
+        Nothing on disk can tell his drag from our own stale paint, so the bet is made
+        toward the reversible side. Moving a row he dragged costs one drag; pinning a
+        row he never touched is silent, permanent, and leaves the board wrong."""
+        props = self._patch(monkeypatch, "Top of Mind", "d\nscope=card", "this_week")
+        assert props["Bucket"]["select"]["name"] == "This Week"
+        assert "pinned=1" not in self._note(props)
+
+    def test_and_his_drag_back_pins_it_for_good(self, monkeypatch):
+        """The other half of that bet, and what makes it cost exactly one drag."""
+        props = self._patch(monkeypatch, "Inbox",
+                            "d\nscope=card\nbucket=This Week", "this_week")
+        assert "Bucket" not in props
+        assert "pinned=1" in self._note(props)
+
+    def test_a_cold_row_that_already_agrees_is_adopted_not_pinned(self, monkeypatch):
+        """Nothing is lost by recording a baseline that matches what is on screen."""
+        props = self._patch(monkeypatch, "This Week", "d\nscope=card", "this_week")
+        assert "bucket=This Week" in self._note(props)
+        assert "pinned=1" not in self._note(props)
+
+    def test_a_row_in_NO_bucket_is_given_one(self, monkeypatch):
+        """His three views all filter on Bucket, so a row with none is on no view at
+        all. Leaving it invisible forever is worse than placing it."""
+        props = self._patch(monkeypatch, "", "d\nscope=card", "top_of_mind")
+        assert props["Bucket"]["select"]["name"] == "Top of Mind"
+
+    def test_Status_is_never_rewritten_on_an_existing_row(self, monkeypatch):
+        """He marks rows done. A refresh that resets Status to Not started would undo
+        that every morning."""
+        props = self._patch(monkeypatch, "Top of Mind",
+                            "d\nscope=card\nbucket=Top of Mind", "this_week")
+        assert "Status" not in props
+
+    def test_the_machinery_lines_survive_a_long_detail(self, monkeypatch):
+        """`scope=` and `bucket=` live at the END of the note and the note is capped.
+        A long detail used to be able to push them off, which reads back as an unknown
+        scope (kept forever) and an unknown bucket (pinned forever) with no error."""
+        item = dict(self.ITEM, detail="x" * 4000, done="y" * 400)
+        props = self._patch(monkeypatch, "Top of Mind",
+                            "d\nscope=card\nbucket=Top of Mind", "this_week", item=item)
+        note = self._note(props)
+        assert len(note) <= 1900
+        assert "scope=card" in note and "bucket=This Week" in note
+
+
+class TestAWeeklyRowLeavesWhenItsWorkDoes:
+    """Codex round 6 (major): `read_week` emits `week:gtm` and `week:due`, and neither
+    scope was ever reported healthy, so the painter could not archive inside them. A
+    delivered commitment or a finished GTM step sat on the board forever.
+
+    The rule the other scopes follow holds here: healthy means THIS SOURCE ANSWERED
+    THIS RUN. An unreadable GTM queue or commitment book authorises nothing.
+    """
+
+    def _healthy_tree(self, tmp_path):
+        due = (NOW.date() + dt.timedelta(days=3)).isoformat()
+        return _tree(tmp_path, commitments=json.dumps(
+            {"id": "c1", "slug": "acme", "state": "open", "due": due,
+             "promise": "send the audit"}), clients={"clients": []})
+
+    def test_both_week_scopes_are_healthy_when_both_sources_read(self, tmp_path):
+        b = cb.buckets(NOW, {}, self._healthy_tree(tmp_path))
+        assert {"week:gtm", "week:due"} <= b["healthy_scopes"]
+
+    def test_an_unreadable_gtm_queue_does_NOT_authorise_archiving_week_gtm(self, tmp_path):
+        paths = self._healthy_tree(tmp_path)
+        paths["gtm"].write_text("{not json", encoding="utf-8")
+        b = cb.buckets(NOW, {}, paths)
+        assert "week:gtm" not in b["healthy_scopes"]
+        assert "week:due" in b["healthy_scopes"], "one broken source must not mute the other"
+
+    def test_an_unreadable_commitment_book_does_NOT_authorise_archiving_week_due(self, tmp_path):
+        paths = self._healthy_tree(tmp_path)
+        paths["commitments"].unlink()
+        paths["commitments"].mkdir()          # readable path, unreadable file
+        b = cb.buckets(NOW, {}, paths)
+        assert "week:due" not in b["healthy_scopes"]
+        assert "week:gtm" in b["healthy_scopes"]
+
+    def test_an_ABSENT_commitment_book_authorises_nothing_either(self, tmp_path):
+        """OFF, not broken: no book is a fact and not a failure, so no error row. It
+        still says NOTHING about rows written when the book existed, and nothing is
+        not "they are gone"."""
+        paths = _tree(tmp_path)
+        b = cb.buckets(NOW, {}, paths)
+        assert "week:due" not in b["healthy_scopes"]
+        assert not any("COULD NOT READ" in r["title"] for r in b["this_week"])
+
+    def test_every_scope_the_producer_emits_can_be_archived_when_it_is_healthy(self, tmp_path):
+        """The structural check, not a list of the scopes that exist today. Round 6
+        found two scopes with no health decision at all; this fails on the third."""
+        b = cb.buckets(NOW, {"mail": ([_brief().Row("a thread", "mail:t1")], None)},
+                       self._healthy_tree(tmp_path))
+        emitted = {r.get("scope") for r in b["top_of_mind"] + b["this_week"] + b["inbox"]}
+        assert emitted, "the fixture produced no rows at all"
+        assert emitted <= b["healthy_scopes"], (
+            f"scopes with no health decision: {sorted(emitted - b['healthy_scopes'])}")
+
+    def test_an_error_row_is_archived_once_its_source_recovers(self, tmp_path):
+        """The same hole, in the rows that REPORT the hole. A COULD NOT READ row is
+        scoped `week` or `myside`, and neither was ever healthy, so the apology
+        outlived the outage and nothing could clear it."""
+        paths = self._healthy_tree(tmp_path)
+        paths["gtm"].write_text("{not json", encoding="utf-8")
+        broken = cb.buckets(NOW, {}, paths)
+        assert any(r["scope"] == "week" for r in broken["this_week"])
+        assert "week" not in broken["healthy_scopes"]
+
+        paths = self._healthy_tree(tmp_path)          # source recovers
+        fixed = cb.buckets(NOW, {}, paths)
+        assert not any(r["scope"] == "week" for r in fixed["this_week"])
+        assert "week" in fixed["healthy_scopes"], "the apology row can never be cleared"
+        assert "myside" in fixed["healthy_scopes"]

--- a/q-system/.q-system/tests/test_consulting_board.py
+++ b/q-system/.q-system/tests/test_consulting_board.py
@@ -1573,3 +1573,101 @@ class TestRound13:
     def test_but_a_card_with_rows_still_authorises_it(self, tmp_path):
         b = cb.buckets(NOW, {}, _tree(tmp_path))
         assert "card" in b["healthy_scopes"]
+
+
+class TestNoSourceStarvesAnother:
+    """claude review 2026-09-04, major, and it is the OPPOSITE of the finding before
+    it. Capping mail at the producer deleted rows; not capping it let mail take the
+    whole 40-row write budget in source order, so every GroupMe row fell past it and
+    sat frozen on his board forever. `capped` protects them from archiving, which is
+    round 11 working, but protected is not updated."""
+
+    def test_a_busy_source_cannot_push_another_source_off_the_budget(self):
+        rows = ([{"scope": "inbox:Gmail", "key": f"mail:{i}"} for i in range(60)]
+                + [{"scope": "inbox:GroupMe", "key": f"gm:{i}"} for i in range(3)])
+        head = board_rows._fair_share(rows, 40)[:40]
+        assert any(r["scope"] == "inbox:GroupMe" for r in head), (
+            "every GroupMe row fell past the write budget and freezes on the board")
+
+    def test_order_WITHIN_a_source_is_never_re_made(self):
+        """The mail prompt sorts oldest first. That ordering is a judgement this
+        function must not second-guess."""
+        rows = [{"scope": "inbox:Gmail", "key": f"mail:{i}"} for i in range(5)]
+        rows += [{"scope": "inbox:GroupMe", "key": f"gm:{i}"} for i in range(5)]
+        out = board_rows._fair_share(rows, 40)
+        mail = [r["key"] for r in out if r["scope"] == "inbox:Gmail"]
+        assert mail == [f"mail:{i}" for i in range(5)]
+
+    def test_one_source_alone_is_left_exactly_as_it_came(self):
+        rows = [{"scope": "card", "key": f"c:{i}"} for i in range(5)]
+        assert board_rows._fair_share(rows, 40) == rows
+
+    def test_PAINT_ITSELF_shares_the_budget(self, monkeypatch):
+        """Drives paint(), not the helper. The first version of these tests called
+        `_fair_share` directly, so BYPASSING IT AT THE CALL SITE broke nothing and
+        the mutant survived: a helper with no wiring test is an undefended helper.
+        This one fails if paint stops calling it."""
+        created = []
+        monkeypatch.setattr(board_rows, "existing_rows", lambda *a, **k: {})
+        monkeypatch.setattr(
+            board_rows, "_request",
+            lambda token, method, path, body=None, opener=None, budget=None:
+            created.append(((body or {}).get("properties") or {})) or {"id": "x"})
+        buckets = {"top_of_mind": [], "this_week": [],
+                   "inbox": ([{"title": f"m{i}", "key": f"mail:{i}", "detail": "",
+                               "scope": "inbox:Gmail"} for i in range(60)]
+                             + [{"title": f"g{i}", "key": f"gm:{i}", "detail": "",
+                                 "scope": "inbox:GroupMe"} for i in range(3)]),
+                   "healthy_scopes": {"inbox:Gmail", "inbox:GroupMe"}}
+        board_rows.paint(buckets, "t", "db")
+        titles = ["".join(t["text"]["content"] for t in (props.get("Task") or {}).get("title", []))
+                  for props in created]
+        assert any(t.startswith("g") for t in titles), (
+            "paint wrote 40 mail rows and no GroupMe row; the channel freezes")
+
+    def test_nothing_is_lost_or_duplicated_by_the_reordering(self):
+        rows = ([{"scope": "a", "key": f"a{i}"} for i in range(7)]
+                + [{"scope": "b", "key": f"b{i}"} for i in range(2)]
+                + [{"scope": "c", "key": f"c{i}"} for i in range(11)])
+        out = board_rows._fair_share(rows, 40)
+        assert sorted(r["key"] for r in out) == sorted(r["key"] for r in rows)
+
+
+class TestTwoDeliverablesAreTwoRows:
+    """claude review 2026-09-04, minor. Two open commitments for one client with no
+    id both keyed `due:<slug>`, so the second overwrote the first in `wanted` and the
+    read-back still said ok -- it counts what it wrote, and the row was gone before
+    the count. A key derived from too little is a collision, and a collision is a
+    silent deletion."""
+
+    def test_two_id_less_deliverables_for_one_client_stay_two_rows(self, tmp_path):
+        due = (NOW.date() + dt.timedelta(days=3)).isoformat()
+        paths = _tree(tmp_path, commitments="\n".join([
+            json.dumps({"slug": "acme", "state": "open", "due": due,
+                        "promise": "send the audit"}),
+            json.dumps({"slug": "acme", "state": "open", "due": due,
+                        "promise": "send the invoice"}),
+        ]), clients={"clients": []})
+        rows = cb.read_week(NOW, paths)[0]
+        keys = [r["key"] for r in rows if r["key"].startswith("due:")]
+        assert len(keys) == 2, "one deliverable was silently dropped"
+        assert len(set(keys)) == 2, f"both deliverables share one key: {keys}"
+
+    def test_the_key_does_not_move_when_the_countdown_does(self, tmp_path):
+        """The detail carries days-remaining, which changes every morning. Keying on
+        the rendered line would mint a new row daily."""
+        def key_on(days):
+            due = (NOW.date() + dt.timedelta(days=days)).isoformat()
+            paths = _tree(tmp_path, commitments=json.dumps(
+                {"slug": "acme", "state": "open", "due": due,
+                 "promise": "send the audit"}), clients={"clients": []})
+            return [r["key"] for r in cb.read_week(NOW, paths)[0]
+                    if r["key"].startswith("due:")][0]
+        assert key_on(2) == key_on(5)
+
+    def test_a_real_commitment_id_still_wins(self, tmp_path):
+        due = (NOW.date() + dt.timedelta(days=3)).isoformat()
+        paths = _tree(tmp_path, commitments=json.dumps(
+            {"id": "c1", "slug": "acme", "state": "open", "due": due,
+             "promise": "send the audit"}), clients={"clients": []})
+        assert any(r["key"] == "due:c1" for r in cb.read_week(NOW, paths)[0])

--- a/q-system/.q-system/tests/test_consulting_board.py
+++ b/q-system/.q-system/tests/test_consulting_board.py
@@ -20,6 +20,15 @@ SCRIPTS = HERE.parent / "scripts"
 sys.path.insert(0, str(SCRIPTS))
 
 import board_rows  # noqa: E402
+
+
+def _load_engineering_route():
+    import importlib.util
+    spec = importlib.util.spec_from_file_location(
+        "engineering_route", SCRIPTS / "engineering_route.py")
+    mod = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(mod)
+    return mod
 import consulting_board as cb  # noqa: E402
 import groupme_inbox as gm  # noqa: E402
 
@@ -1466,3 +1475,58 @@ class TestACappedRowIsNotAnAbsentRow:
             {"top_of_mind": [], "this_week": [], "inbox": [],
              "healthy_scopes": {"inbox:Gmail"}}, "t", "db")
         assert {"archived": True} in calls and counts["archived"] == 1
+
+
+class TestRound12:
+    QUIET = "*Your book today* · 4 active · 0 in proposal · 0 to reach out · 2026-09-03\n"
+
+    def test_a_quiet_morning_is_not_a_format_change(self, tmp_path):
+        """Every client green or waiting on THEM emits a header and no client lines.
+        Calling that broken put a P0 alarm row on the board every quiet day, which is
+        the wolf-cry that costs the real alert later."""
+        rows, err = cb.read_card(_tree(tmp_path, card=self.QUIET))
+        assert rows == [] and err is None
+
+    def test_but_a_card_with_no_header_at_all_is_still_a_format_change(self, tmp_path):
+        """The negative control. If both cases return None the reader can no longer
+        tell it has drifted from its writer, which is what the original check was for."""
+        rows, err = cb.read_card(_tree(tmp_path, card="something else entirely\n"))
+        assert rows == [] and err and "format changed" in err
+
+    def test_and_a_quiet_card_raises_no_alarm_row(self, tmp_path):
+        b = cb.buckets(NOW, {}, _tree(tmp_path, card=self.QUIET))
+        assert not any(r["scope"] == cb.CARD_ALARM for r in b["top_of_mind"])
+        assert "card" in b["healthy_scopes"]
+
+    def test_the_producers_plus_N_more_tail_is_not_a_person(self, tmp_path):
+        """A count is not a contact. The split handed the producer's own summary to
+        the person extractor, so the board grew a row named after the sentence while
+        the people it stands for still never arrived."""
+        card = ("*Your book today* · 0 active · 0 in proposal · 4 to reach out · 2026-09-03\n"
+                "*THE MOVE* 📞 *4 to reach out* — 🔥 Alpha (fire): contact Alpha\n"
+                "     then: 🔥 Beta (fire) · +2 more, lowest-scoring, on the board\n")
+        rows, err = cb.read_card(_tree(tmp_path, card=card))
+        assert err is None
+        names = [r["name"] for r in rows]
+        assert names == ["Alpha", "Beta"], names
+        assert not any("more" in n for n in names)
+
+
+class TestAnAbsentNotifierIsNotAFiling:
+    def test_send_refuses_when_there_is_no_notifier(self, tmp_path, monkeypatch):
+        er = _load_engineering_route()
+        monkeypatch.setattr(er, "NOTIFY", tmp_path / "not-there.sh")
+        with pytest.raises(FileNotFoundError):
+            er.send("anything")
+
+    def test_and_route_counts_it_as_failed_not_filed(self, tmp_path, monkeypatch):
+        """It returned None, which `route` reads as a successful filing, so an
+        unconfigured machine reported every engineering line as routed to Sana while
+        no issue existed anywhere."""
+        er = _load_engineering_route()
+        monkeypatch.setattr(er, "NOTIFY", tmp_path / "not-there.sh")
+        # DEGRADED, because a healthy section is deliberately not news: 
+        # emits nothing for it, so a clean source proves nothing about filing.
+        filed, failed = er.route({"owed": ([], "linear down")}, (("owed", "Owed today"),))
+        assert filed == []
+        assert len(failed) == 1 and "no notifier" in failed[0][1]

--- a/q-system/.q-system/tests/test_consulting_board.py
+++ b/q-system/.q-system/tests/test_consulting_board.py
@@ -731,3 +731,74 @@ class TestHisSideCarriesItsDates:
         assert not any("Ghost Prospect" in r["title"]
                        for r in b["top_of_mind"] + b["this_week"] + b["inbox"]), (
             "the registry was enumerated onto the board")
+
+
+class TestThisWeekHasASourceAtLast:
+    """Founder, 2026-09-03: *"This week should be this week's GTM moves and
+    deliverables that are coming up."* Before this the section had NO source and
+    carried a description copied off a reference board describing a Sunday planning
+    ritual he does not have, so it would have stayed empty while calling itself
+    "the plan"."""
+
+    def test_the_top_of_mind_gtm_step_is_never_also_in_this_week(self, tmp_path):
+        """Top of Mind takes the top-ranked founder step; This Week takes the rest.
+        One step on two surfaces teaches him the sections mean the same thing."""
+        paths = _tree(tmp_path, gtm={"rows": {
+            "1.1": {"id": "1.1", "action": "the lead", "performer": "founder",
+                    "state": "ready", "rank": 1},
+            "1.2": {"id": "1.2", "action": "the second", "performer": "founder",
+                    "state": "ready", "rank": 2},
+        }})
+        b = cb.buckets(NOW, {}, paths)
+        top = {r["key"] for r in b["top_of_mind"]}
+        week = {r["key"] for r in b["this_week"]}
+        assert "gtm:1.1" in top and "gtm:1.2" in week
+        assert not (top & week), f"a row is on both surfaces: {top & week}"
+
+    def test_mechanism_steps_never_reach_this_week(self, tmp_path):
+        """The machine's own steps belong in the engineer's queue. 51 of 57 rows are
+        `mechanism`; letting them through would put the build plan back on his board,
+        which is the complaint this whole board exists to answer."""
+        paths = _tree(tmp_path, gtm={"rows": {
+            "9.9": {"id": "9.9", "action": "a machine job", "performer": "mechanism",
+                    "state": "ready", "rank": 1},
+        }})
+        rows, err = cb.read_week(NOW, paths)
+        assert err is None
+        assert not any(r["key"] == "gtm:9.9" for r in rows)
+
+    def test_a_deliverable_due_inside_the_week_is_carried(self, tmp_path):
+        due = (NOW.date() + dt.timedelta(days=3)).isoformat()
+        paths = _tree(tmp_path, commitments=json.dumps(
+            {"id": "c1", "slug": "acme", "state": "open", "due": due,
+             "promise": "send the audit"}), clients={"clients": []})
+        rows, _ = cb.read_week(NOW, paths)
+        hit = [r for r in rows if r["key"] == "due:c1"]
+        assert hit, "a deliverable due in 3 days never reached This Week"
+        assert "(3d)" in hit[0]["detail"]
+
+    def test_an_OVERDUE_deliverable_is_NOT_repeated_here(self, tmp_path):
+        """It is already red in Top of Mind. Two surfaces for one fact is how a
+        section stops meaning anything."""
+        past = (NOW.date() - dt.timedelta(days=4)).isoformat()
+        paths = _tree(tmp_path, commitments=json.dumps(
+            {"id": "c1", "slug": "acme", "state": "open", "due": past,
+             "promise": "send the audit"}), clients={"clients": []})
+        rows, _ = cb.read_week(NOW, paths)
+        assert not any(r["key"] == "due:c1" for r in rows)
+
+    def test_a_deliverable_beyond_the_week_is_not_this_weeks_problem(self, tmp_path):
+        far = (NOW.date() + dt.timedelta(days=cb.WEEK_DAYS + 1)).isoformat()
+        paths = _tree(tmp_path, commitments=json.dumps(
+            {"id": "c1", "slug": "acme", "state": "open", "due": far,
+             "promise": "send the audit"}), clients={"clients": []})
+        rows, _ = cb.read_week(NOW, paths)
+        assert not any(r["key"] == "due:c1" for r in rows)
+
+    def test_a_junk_due_date_is_skipped_not_crashed_on(self, tmp_path):
+        paths = _tree(tmp_path, commitments=json.dumps(
+            {"id": "c1", "slug": "acme", "state": "open", "due": "soon-ish",
+             "promise": "send the audit"}), clients={"clients": []})
+        rows, err = cb.read_week(NOW, paths)
+        assert err is None
+        assert not any(r["key"] == "due:c1" for r in rows)

--- a/q-system/.q-system/tests/test_consulting_board.py
+++ b/q-system/.q-system/tests/test_consulting_board.py
@@ -1530,3 +1530,32 @@ class TestAnAbsentNotifierIsNotAFiling:
         filed, failed = er.route({"owed": ([], "linear down")}, (("owed", "Owed today"),))
         assert filed == []
         assert len(failed) == 1 and "no notifier" in failed[0][1]
+
+
+class TestRound13:
+    def test_an_idless_mail_answer_withholds_the_archive_authority(self, tmp_path):
+        """When the model returns ids the key is the id; when it does not, it is
+        sender+subject. Both are stable in themselves and they are DIFFERENT ids for
+        one thread, so the day the model stops returning ids the painter would archive
+        the row he pinned and recreate it at "Not started". The rows still paint."""
+        brief = _brief()
+        rows = [brief.Row("Alice  Re: invoice", "mail:Alice|Re: invoice")]
+        b = cb.buckets(NOW, {"mail": (rows, None)}, _tree(tmp_path))
+        assert [r["key"] for r in b["inbox"]] == ["mail:Alice|Re: invoice"]
+        assert "inbox:Gmail" not in b["healthy_scopes"]
+
+    def test_but_real_thread_ids_still_authorise_it(self, tmp_path):
+        """The negative control: withholding it always would mean answered mail never
+        leaves the board."""
+        brief = _brief()
+        rows = [brief.Row("Alice  Re: invoice", "mail:19ff4af34dbc0f56")]
+        b = cb.buckets(NOW, {"mail": (rows, None)}, _tree(tmp_path))
+        assert "inbox:Gmail" in b["healthy_scopes"]
+
+    def test_two_unreadable_properties_are_not_equal_to_each_other(self):
+        """`_already_holds` promised an unreadable property fails toward writing, while
+        None == None made two of them compare EQUAL and skip the write, so a row kept
+        stale text forever. The docstring was right and the code was not."""
+        a = board_rows._prop_value({"some_new_notion_shape": True})
+        b = board_rows._prop_value({"another_unknown": 1})
+        assert a != b and a != None  # noqa: E711  -- the None case is the defect

--- a/q-system/.q-system/tests/test_consulting_board.py
+++ b/q-system/.q-system/tests/test_consulting_board.py
@@ -38,7 +38,8 @@ CARD = """# TODAY CARD
 """
 
 
-def _tree(tmp_path, card=CARD, date=TODAY, crash=None, gtm=None):
+def _tree(tmp_path, card=CARD, date=TODAY, crash=None, gtm=None,
+          commitments=None, clients=None):
     q = tmp_path / "q-consult"
     # exist_ok: a test may build the tree twice in one tmp_path to compare two runs.
     (q / "output").mkdir(parents=True, exist_ok=True)
@@ -54,6 +55,13 @@ def _tree(tmp_path, card=CARD, date=TODAY, crash=None, gtm=None):
                              "1.2": {"id": "1.2", "action": "machine thing",
                                      "performer": "mechanism", "state": "ready", "rank": 0}}}),
         encoding="utf-8")
+    # Written ONLY when a test asks for them. The default tree deliberately has
+    # neither, because test_the_registry_is_never_opened proves this module delivers
+    # without the registry and that must keep being true.
+    if commitments is not None:
+        (q / "my-project" / "commitments.jsonl").write_text(commitments, encoding="utf-8")
+    if clients is not None:
+        (q / "my-project" / "clients.json").write_text(json.dumps(clients), encoding="utf-8")
     return cb._paths(tmp_path)
 
 
@@ -638,3 +646,88 @@ class TestTwoThreadsAreNeverOneRow:
         rows, _ = brief.collect_mail(None, runner)
         inbox = cb.buckets(NOW, {"mail": (rows, None)}, _tree(tmp_path))["inbox"]
         assert len({i["key"] for i in inbox}) == 2, "one task never reached the board"
+
+
+class TestHisSideCarriesItsDates:
+    """Founder, 2026-09-03: *"a learning from the [a retainer client] fiasco -- they said I
+    wasn't doing things and I've actually been waiting on deliverables for weeks."*
+    A row that renders a promise with no date cannot tell a promise made yesterday
+    from one made in July, so it cannot settle that argument. Scoped by him to HIS
+    side only one message later; there is deliberately no reader for their promises."""
+
+    def test_the_phrase_carries_when_he_said_it_and_how_long_ago(self):
+        now = dt.datetime(2026, 9, 3, tzinfo=dt.timezone.utc)
+        phrase = cb.my_side_phrase(
+            {"said_on": "2026-08-18T21:47:47+00:00", "due": "2026-08-31",
+             "last_touch": "2026-09-02"}, now)
+        assert "said 2026-08-18" in phrase
+        assert "(16d ago)" in phrase
+        assert "due 2026-08-31" in phrase
+        assert "last touch 2026-09-02" in phrase
+
+    def test_a_missing_date_is_omitted_never_rendered_as_unknown(self):
+        now = dt.datetime(2026, 9, 3, tzinfo=dt.timezone.utc)
+        phrase = cb.my_side_phrase({"said_on": "2026-08-18", "due": None,
+                                    "last_touch": None}, now)
+        assert "due" not in phrase and "last touch" not in phrase
+        assert "said 2026-08-18" in phrase
+
+    def test_an_unparseable_date_never_renders_as_zero_days(self):
+        """0d would read as "today" and be a lie about how long he has waited."""
+        assert cb._days("not-a-date", dt.datetime.now(dt.timezone.utc)) is None
+        phrase = cb.my_side_phrase({"said_on": "not-a-date"},
+                                   dt.datetime.now(dt.timezone.utc))
+        assert "0d" not in phrase
+
+    def test_only_OPEN_promises_count(self, tmp_path):
+        """A resolved promise is not something he still owes. Surfacing one would
+        recreate the "you did not do this" claim the dates exist to defend against."""
+        paths = _tree(tmp_path, commitments="\n".join([
+            json.dumps({"slug": "acme", "state": "resolved",
+                        "extracted_at": "2026-01-01T00:00:00+00:00"}),
+            json.dumps({"slug": "acme", "state": "open",
+                        "extracted_at": "2026-08-20T00:00:00+00:00", "due": None}),
+        ]), clients={"clients": []})
+        got, err = cb.read_my_side(dt.datetime(2026, 9, 3, tzinfo=dt.timezone.utc), paths)
+        assert err is None
+        assert got["acme"]["said_on"].startswith("2026-08-20")
+
+    def test_the_oldest_open_promise_is_the_one_shown(self, tmp_path):
+        """Two open promises to one client: the OLDEST is the exposure, because that
+        is the number a client would quote back at him."""
+        paths = _tree(tmp_path, commitments="\n".join([
+            json.dumps({"slug": "acme", "state": "open",
+                        "extracted_at": "2026-08-29T00:00:00+00:00"}),
+            json.dumps({"slug": "acme", "state": "open",
+                        "extracted_at": "2026-07-04T00:00:00+00:00"}),
+        ]), clients={"clients": []})
+        got, _ = cb.read_my_side(dt.datetime(2026, 9, 3, tzinfo=dt.timezone.utc), paths)
+        assert got["acme"]["said_on"].startswith("2026-07-04")
+
+    def test_one_corrupt_line_never_voids_the_book(self, tmp_path):
+        paths = _tree(tmp_path, commitments="\n".join([
+            "{ not json",
+            json.dumps({"slug": "acme", "state": "open",
+                        "extracted_at": "2026-08-20T00:00:00+00:00"}),
+        ]), clients={"clients": []})
+        got, err = cb.read_my_side(dt.datetime(2026, 9, 3, tzinfo=dt.timezone.utc), paths)
+        assert err is None and "acme" in got
+
+    def test_the_registry_is_a_lookup_and_is_never_enumerated_onto_the_board(self, tmp_path):
+        """clients.json is 162 rows, ~150 of them cold prospects with no rate and no
+        next_touch. Walking it would put every one of them on his morning board."""
+        paths = _tree(tmp_path, clients={"clients": [
+            {"slug": "ghost-%d" % i, "name": "Ghost Prospect %d" % i,
+             "last_touch": None} for i in range(150)]})
+        b = cb.buckets(NOW, {}, paths)
+        card = paths["card"].read_text(encoding="utf-8")
+        # Only rows sourced from the CARD are client rows; gtm/error rows are not.
+        client_rows = [r for r in b["top_of_mind"] + b["this_week"]
+                       if r["key"].startswith(("client:", "reach:"))]
+        assert client_rows, "fixture produced no client rows"
+        for r in client_rows:
+            bare = r["title"].split(" ", 1)[-1] if r["title"][:1] in "🔴🟡🟢⚪📞🟠" else r["title"]
+            assert bare in card, f"{bare!r} reached the board without being on the card"
+        assert not any("Ghost Prospect" in r["title"]
+                       for r in b["top_of_mind"] + b["this_week"] + b["inbox"]), (
+            "the registry was enumerated onto the board")

--- a/q-system/.q-system/tests/test_consulting_board.py
+++ b/q-system/.q-system/tests/test_consulting_board.py
@@ -37,8 +37,9 @@ CARD = """# TODAY CARD
 
 def _tree(tmp_path, card=CARD, date=TODAY, crash=None, gtm=None):
     q = tmp_path / "q-consult"
-    (q / "output").mkdir(parents=True)
-    (q / "my-project").mkdir(parents=True)
+    # exist_ok: a test may build the tree twice in one tmp_path to compare two runs.
+    (q / "output").mkdir(parents=True, exist_ok=True)
+    (q / "my-project").mkdir(parents=True, exist_ok=True)
     (q / "output" / "today-card.md").write_text(card, encoding="utf-8")
     (q / "output" / "ask-crm-state-card-heartbeat.json").write_text(
         json.dumps({"at": "x", "card": {"date": date, "counts": {"red": 2, "reach": 1}},
@@ -75,7 +76,85 @@ class TestItMirrorsTheCardAndNeverRederivesIt:
 
     def test_the_health_verdict_is_the_cards_not_recomputed(self, tmp_path):
         rows, _ = cb.read_card(_tree(tmp_path))
-        assert {r["name"]: r["health"] for r in rows}["Kestrel Group"] == "⚪"
+        # Scoped to CLIENT rows: since Codex round 2 a reach-out row is named for the
+        # PERSON too, so the same name legitimately appears twice with two verdicts.
+        clients = {r["name"]: r["health"] for r in rows if r["kind"] == "client"}
+        assert clients["Kestrel Group"] == "⚪"
+
+
+class TestIdentityIsTheTHING_NotItsRendering:
+    """Codex round 2. Round 1 fixed the health dot in ONE producer; the same defect
+    class sat untouched at two other call sites. A fix whose blast radius is one call
+    site cannot fix a defect whose blast radius is a category."""
+
+    def test_a_reach_out_row_is_named_for_the_PERSON_not_the_count(self, tmp_path):
+        rows, _ = cb.read_card(_tree(tmp_path))
+        reach = [r["name"] for r in rows if r["kind"] == "reach"]
+        assert "Kestrel Group" in reach
+        assert not any("to reach out" in n for n in reach), (
+            "keying on the tally makes different people share one row, its status "
+            "and the bucket he dragged it to")
+
+    def test_an_inbox_id_survives_the_age_changing(self, tmp_path):
+        a = cb.buckets(NOW, {"mail": (["Portant: 2h ago about the docs"], None)},
+                       _tree(tmp_path))["inbox"][0]["key"]
+        b = cb.buckets(NOW, {"mail": (["Portant: 5h ago about the docs"], None)},
+                       _tree(tmp_path))["inbox"][0]["key"]
+        assert a == b, "an age change minted a new id and would orphan his row"
+
+    def test_but_a_different_thread_is_a_different_row(self, tmp_path):
+        a = cb.buckets(NOW, {"mail": (["Portant: about the docs"], None)},
+                       _tree(tmp_path))["inbox"][0]["key"]
+        b = cb.buckets(NOW, {"mail": (["Harbor: about the invoice"], None)},
+                       _tree(tmp_path))["inbox"][0]["key"]
+        assert a != b, "stripping volatile tokens must not collapse distinct rows"
+
+
+class TestAQuietSourceNeverArchivesHisRows:
+    """Codex round 2 (major): a transient Gmail error replaced that source's rows with
+    a single error row, so every inbox row he had positioned fell out of `wanted` and
+    the painter archived the lot. A source that could not answer has said nothing, and
+    nothing is not "they are gone"."""
+
+    def test_a_failed_source_is_not_a_healthy_scope(self, tmp_path):
+        b = cb.buckets(NOW, {"mail": ([], "gmail down")}, _tree(tmp_path))
+        assert "inbox:Gmail" not in b["healthy_scopes"]
+        assert any("COULD NOT READ" in i["title"] for i in b["inbox"])
+
+    def test_a_healthy_source_IS_one(self, tmp_path):
+        b = cb.buckets(NOW, {"mail": (["a thread"], None)}, _tree(tmp_path))
+        assert "inbox:Gmail" in b["healthy_scopes"]
+
+    def test_the_painter_REFUSES_buckets_with_no_scope_information(self):
+        """Archiving without it would delete rows on any transient failure, so an
+        absent field is a refusal rather than a permissive default."""
+        with pytest.raises(ValueError):
+            board_rows.paint({"top_of_mind": [], "this_week": [], "inbox": []},
+                             "t", "db", opener=lambda *a, **k: None)
+
+    def test_an_unknown_scope_on_an_existing_row_is_KEPT(self):
+        """Fails safe: a row this module cannot classify is never archived."""
+        assert board_rows._scope_of({"properties": {}}) == ""
+
+
+class TestOnlyOnePainterAtATime:
+    """Codex round 2 (major): paint() queries then creates, so two simultaneous runs
+    both saw "absent" and both created. Round 1 only DETECTED the duplicates after the
+    fact, which reports a mess instead of preventing one."""
+
+    def test_a_second_painter_is_refused_immediately(self, tmp_path):
+        lock = tmp_path / "board.lock"
+        with board_rows.exclusive(lock):
+            with pytest.raises(board_rows.BoardBusy):
+                with board_rows.exclusive(lock):
+                    pass
+
+    def test_and_the_lock_is_released_afterwards(self, tmp_path):
+        lock = tmp_path / "board.lock"
+        with board_rows.exclusive(lock):
+            pass
+        with board_rows.exclusive(lock):
+            pass                                   # no raise means it was released
 
 
 class TestAStaleCardIsAnError:

--- a/q-system/.q-system/tests/test_consulting_board.py
+++ b/q-system/.q-system/tests/test_consulting_board.py
@@ -121,16 +121,35 @@ class TestTheDryRunWritesNothing:
     had already created 12 rows on the live board. The send flag only ever covered the
     Slack send, because until board_rows no section could write."""
 
+    def _token(self, tmp_path):
+        """A credential the guard can get PAST.
+
+        Both tests below passed on the author's machine and failed in CI with
+        `cannot unpack non-iterable NoneType`, because CI has no
+        ~/.config/kipi/notion-token: the OFF switch fired first and returned None, so
+        the guard under test was never reached. The ordering is correct behaviour and
+        the tests were wrong to depend on the developer's own credentials. Supplying a
+        fake token is what makes these assert the guard rather than the environment.
+        """
+        tf = tmp_path / "notion-token"
+        tf.write_text("t", encoding="utf-8")
+        return str(tf)
+
     def test_the_flag_stops_the_board_write(self, tmp_path, monkeypatch):
         monkeypatch.setenv("KIPI_BRIEF_DRY_RUN", "1")
         monkeypatch.delenv("PYTEST_CURRENT_TEST", raising=False)
-        rows, err = board_rows.collect(NOW, {})
+        rows, err = board_rows.collect(NOW, {}, token_file=self._token(tmp_path))
         assert rows == [] and "dry-run" in err
 
-    def test_pytest_alone_also_stops_it(self, monkeypatch):
+    def test_pytest_alone_also_stops_it(self, tmp_path, monkeypatch):
         monkeypatch.delenv("KIPI_BRIEF_DRY_RUN", raising=False)
-        rows, err = board_rows.collect(NOW, {})
+        rows, err = board_rows.collect(NOW, {}, token_file=self._token(tmp_path))
         assert rows == [] and "pytest" in err
+
+    def test_and_with_NO_credential_it_is_OFF_before_either_guard(self, tmp_path):
+        """The negative control the two above were accidentally exercising in CI.
+        Pinned deliberately so the ordering is a decision, not a coincidence."""
+        assert board_rows.collect(NOW, {}, token_file=str(tmp_path / "absent")) is None
 
 
 class TestHisDragAlwaysWins:

--- a/q-system/.q-system/tests/test_consulting_board.py
+++ b/q-system/.q-system/tests/test_consulting_board.py
@@ -994,3 +994,64 @@ class TestAWeeklyRowLeavesWhenItsWorkDoes:
         assert not any(r["scope"] == "week" for r in fixed["this_week"])
         assert "week" in fixed["healthy_scopes"], "the apology row can never be cleared"
         assert "myside" in fixed["healthy_scopes"]
+
+
+class TestRound7:
+    """Two findings the round-7 review raised against surfaces round 6 had not touched."""
+
+    def test_an_answer_them_row_is_today_in_BOTH_tables(self, tmp_path):
+        """PRIORITY_BY_HEALTH called 🟠 a P0 while the split sent it to This Week, so
+        one module said today and not-today about the same row.
+
+        Pins consistency between two tables in this file, NOT a producer behaviour:
+        `state_card.py` emits only 🔴🟡🟢⚪📞 and `board_sync.py` is where 🟠 lives. The
+        reviewer flagged that too, which is why this test says so rather than implying
+        the dot arrives today.
+        """
+        card = ("# TODAY CARD\n"
+                '🟠 *Northwind Design* · you said "reply to them" — not sent\n')
+        b = cb.buckets(NOW, {}, _tree(tmp_path, card=card))
+        top = [r for r in b["top_of_mind"] if "Northwind" in r["title"]]
+        assert top, "an 🟠 row landed outside Top of Mind while being called P0"
+        assert top[0]["priority"] == cb.PRIORITY_BY_HEALTH["🟠"] == "P0"
+
+    def test_a_row_over_the_cap_is_counted_and_said_out_loud(self, tmp_path, monkeypatch):
+        """The cap was silent, and the read-back structurally cannot see it: `wanted`
+        has lost the row before the count is taken. The inbox alone can produce 41."""
+        rows = [{"key": f"k{i}", "title": f"t{i}", "detail": "", "scope": "card"}
+                for i in range(board_rows.BUDGET_ROWS + 3)]
+        counts = board_rows.paint(
+            {"top_of_mind": [], "this_week": [], "inbox": rows,
+             "healthy_scopes": {"card"}}, "t", "db",
+            opener=lambda *a, **k: io.BytesIO(b'{"results": [], "has_more": false}'))
+        assert counts["wanted"] == board_rows.BUDGET_ROWS
+        assert counts["over_cap"] == 3
+
+    def test_and_the_brief_line_names_the_drop(self, tmp_path, monkeypatch):
+        (tmp_path / "tok").write_text("t")
+        (tmp_path / "db").write_text("db1")
+        monkeypatch.setattr(board_rows, "LOCK_FILE", tmp_path / "board.lock")
+        monkeypatch.delenv("PYTEST_CURRENT_TEST", raising=False)
+        monkeypatch.delenv("KIPI_BRIEF_DRY_RUN", raising=False)
+        rows = [{"key": f"k{i}", "title": f"t{i}", "detail": "", "scope": "card"}
+                for i in range(board_rows.BUDGET_ROWS + 1)]
+        monkeypatch.setattr(board_rows.consulting_board, "buckets", lambda *a, **k: {
+            "error": None, "top_of_mind": [], "this_week": [], "inbox": rows,
+            "healthy_scopes": {"card"}})
+
+        made = []
+
+        def opener(req, timeout):
+            if "/databases/" in req.full_url:
+                results = [{"properties": {
+                    "Item id": {"rich_text": [{"plain_text": i}]},
+                    "Notes": {"rich_text": [{"plain_text": "scope=card"}]}}} for i in made]
+                return io.BytesIO(json.dumps(
+                    {"results": results, "has_more": False}).encode())
+            made.append(board_rows.item_id("inbox", rows[len(made)]))
+            return io.BytesIO(b'{"id": "p1"}')
+
+        out, err = board_rows.collect(NOW, {}, opener=opener,
+                                      token_file=tmp_path / "tok", db_file=tmp_path / "db")
+        assert err is None, err
+        assert "1 row(s) over the" in out[0], out

--- a/q-system/.q-system/tests/test_consulting_board.py
+++ b/q-system/.q-system/tests/test_consulting_board.py
@@ -6,6 +6,7 @@ Both pin defects this work actually hit, not defects imagined for it.
 import datetime as dt
 import io
 import json
+import pathlib
 import os
 import sys
 import time
@@ -98,18 +99,39 @@ class TestIdentityIsTheTHING_NotItsRendering:
             "and the bucket he dragged it to")
 
     def test_an_inbox_id_survives_the_age_changing(self, tmp_path):
-        a = cb.buckets(NOW, {"mail": (["Portant: 2h ago about the docs"], None)},
+        """Same intent as the round-2 test this replaces, on the real seam. The id is
+        the thread's, so ANY rendering change is now irrelevant by construction rather
+        than by a regex that has to have anticipated it."""
+        brief = _brief()
+        a = cb.buckets(NOW, {"mail": ([brief.Row("Portant: 2h ago", "mail:t1")], None)},
                        _tree(tmp_path))["inbox"][0]["key"]
-        b = cb.buckets(NOW, {"mail": (["Portant: 5h ago about the docs"], None)},
+        b = cb.buckets(NOW, {"mail": ([brief.Row("Portant: 5h ago", "mail:t1")], None)},
                        _tree(tmp_path))["inbox"][0]["key"]
         assert a == b, "an age change minted a new id and would orphan his row"
 
     def test_but_a_different_thread_is_a_different_row(self, tmp_path):
-        a = cb.buckets(NOW, {"mail": (["Portant: about the docs"], None)},
+        brief = _brief()
+        a = cb.buckets(NOW, {"mail": ([brief.Row("Portant: docs", "mail:t1")], None)},
                        _tree(tmp_path))["inbox"][0]["key"]
-        b = cb.buckets(NOW, {"mail": (["Harbor: about the invoice"], None)},
+        b = cb.buckets(NOW, {"mail": ([brief.Row("Harbor: invoice", "mail:t2")], None)},
                        _tree(tmp_path))["inbox"][0]["key"]
-        assert a != b, "stripping volatile tokens must not collapse distinct rows"
+        assert a != b, "two threads must never share one row"
+
+    def test_an_inbox_row_with_NO_key_is_REFUSED(self, tmp_path):
+        """The fallback is the defect. A producer that forgets must fail loudly, not
+        quietly regress to keying on its own rendered text -- which is precisely how
+        this survived three fixes."""
+        with pytest.raises(TypeError, match="no stable key"):
+            cb.buckets(NOW, {"mail": (["a bare string"], None)}, _tree(tmp_path))
+
+    def test_no_identity_is_derived_from_rendered_text(self):
+        """The regex is deleted and must stay deleted. Rounds 1-4 were four patches to
+        it; a fifth surface form was guaranteed while it existed."""
+        src = pathlib.Path(cb.__file__).read_text(encoding="utf-8")
+        code = "\n".join(l for l in src.splitlines()
+                          if not l.lstrip().startswith("#"))
+        assert "_VOLATILE" not in code and "_stable" not in code, (
+            "consulting_board grew a text-scrubbing identity again")
 
 
 class TestRound3:
@@ -137,18 +159,24 @@ class TestRound3:
         assert "gtm" in cb.buckets(NOW, {}, _tree(tmp_path))["healthy_scopes"]
 
     def test_two_threads_differing_only_by_a_number_stay_two_rows(self, tmp_path):
-        """The volatile-token strip removed EVERY digit run, so "invoice 4021" and
+        """Round 3's finding is now unreachable: nothing reads the digits at all.
+        Kept, driving the real key, because the BEHAVIOUR it protects is the point.
+        The volatile-token strip removed EVERY digit run, so "invoice 4021" and
         "invoice 4022" became one board row."""
-        a = cb.buckets(NOW, {"mail": (["invoice 4021 from them"], None)},
+        brief = _brief()
+        a = cb.buckets(NOW, {"mail": ([brief.Row("invoice 4021 from them", "mail:t1")], None)},
                        _tree(tmp_path))["inbox"][0]["key"]
-        b = cb.buckets(NOW, {"mail": (["invoice 4022 from them"], None)},
+        b = cb.buckets(NOW, {"mail": ([brief.Row("invoice 4022 from them", "mail:t2")], None)},
                        _tree(tmp_path))["inbox"][0]["key"]
         assert a != b
 
     def test_but_an_age_is_still_volatile(self, tmp_path):
-        a = cb.buckets(NOW, {"mail": (["invoice 4021, 2 hours ago"], None)},
+        """One thread, two renderings, one row. Under the regex this held only for the
+        age forms somebody had thought of; under a thread id it holds for all of them."""
+        brief = _brief()
+        a = cb.buckets(NOW, {"mail": ([brief.Row("invoice 4021, 2 hours ago", "mail:t1")], None)},
                        _tree(tmp_path))["inbox"][0]["key"]
-        b = cb.buckets(NOW, {"mail": (["invoice 4021, 5 hours ago"], None)},
+        b = cb.buckets(NOW, {"mail": ([brief.Row("invoice 4021, 5 hours ago", "mail:t1")], None)},
                        _tree(tmp_path))["inbox"][0]["key"]
         assert a == b
 
@@ -173,7 +201,8 @@ class TestAQuietSourceNeverArchivesHisRows:
         assert any("COULD NOT READ" in i["title"] for i in b["inbox"])
 
     def test_a_healthy_source_IS_one(self, tmp_path):
-        b = cb.buckets(NOW, {"mail": (["a thread"], None)}, _tree(tmp_path))
+        b = cb.buckets(NOW, {"mail": ([_brief().Row("a thread", "mail:t1")], None)},
+                       _tree(tmp_path))
         assert "inbox:Gmail" in b["healthy_scopes"]
 
     def test_the_painter_REFUSES_buckets_with_no_scope_information(self):
@@ -441,9 +470,10 @@ class TestRound4:
         assert a == b, f"an age change minted a new id: {a!r} != {b!r}"
 
     def test_but_a_bracketed_number_that_is_not_an_age_stays(self, tmp_path):
-        a = cb.buckets(NOW, {"mail": (["Alice  ticket [4021]"], None)},
+        brief = _brief()
+        a = cb.buckets(NOW, {"mail": ([brief.Row("Alice ticket [4021]", "mail:t1")], None)},
                        _tree(tmp_path))["inbox"][0]["key"]
-        b = cb.buckets(NOW, {"mail": (["Alice  ticket [4022]"], None)},
+        b = cb.buckets(NOW, {"mail": ([brief.Row("Alice ticket [4022]", "mail:t2")], None)},
                        _tree(tmp_path))["inbox"][0]["key"]
         assert a != b
 

--- a/q-system/.q-system/tests/test_consulting_board.py
+++ b/q-system/.q-system/tests/test_consulting_board.py
@@ -1421,3 +1421,48 @@ class TestABookWeCouldNotFullyReadArchivesNothing:
         failure the whole brief exists to prevent."""
         monkeypatch.setattr(gm, "CHANNELS_FILE", tmp_path / "absent")
         assert gm.load_allowlist() is None
+
+
+class TestACappedRowIsNotAnAbsentRow:
+    """Round 11 (major): rows trimmed by BUDGET_ROWS never entered `wanted`, so the
+    archive loop saw their live pages inside a HEALTHY scope and archived them. A
+    producer emitting one row too many destroyed a row he had dragged and pinned."""
+
+    def test_a_row_over_the_cap_is_kept_not_archived(self, monkeypatch):
+        rows = [{"key": f"mail:{i}", "title": f"t{i}", "detail": "",
+                 "scope": "inbox:Gmail"} for i in range(board_rows.BUDGET_ROWS + 2)]
+        over = rows[board_rows.BUDGET_ROWS:]
+        have = {}
+        for item in over:
+            iid = board_rows.item_id("inbox", item)
+            have[iid] = {"id": f"p-{iid}", "properties": {
+                "Notes": {"rich_text": [{"plain_text": "scope=inbox:Gmail"}]}}}
+        monkeypatch.setattr(board_rows, "existing_rows", lambda *a, **k: have)
+        calls = []
+        monkeypatch.setattr(
+            board_rows, "_request",
+            lambda token, method, path, body=None, opener=None, budget=None:
+            calls.append((method, body)) or {})
+        counts = board_rows.paint(
+            {"top_of_mind": [], "this_week": [], "inbox": rows,
+             "healthy_scopes": {"inbox:Gmail"}}, "t", "db")
+        archived = [b for m, b in calls if b == {"archived": True}]
+        assert archived == [], f"a capped row's page was archived: {archived}"
+        assert counts["archived"] == 0 and counts["kept"] == 2
+
+    def test_but_a_row_whose_work_is_DONE_is_still_archived(self, monkeypatch):
+        """The negative control. If nothing is ever archived the board only grows,
+        which is the state this painter was built to end."""
+        gone = board_rows.item_id("inbox", {"key": "mail:old"})
+        have = {gone: {"id": "p1", "properties": {
+            "Notes": {"rich_text": [{"plain_text": "scope=inbox:Gmail"}]}}}}
+        monkeypatch.setattr(board_rows, "existing_rows", lambda *a, **k: have)
+        calls = []
+        monkeypatch.setattr(
+            board_rows, "_request",
+            lambda token, method, path, body=None, opener=None, budget=None:
+            calls.append(body) or {})
+        counts = board_rows.paint(
+            {"top_of_mind": [], "this_week": [], "inbox": [],
+             "healthy_scopes": {"inbox:Gmail"}}, "t", "db")
+        assert {"archived": True} in calls and counts["archived"] == 1

--- a/q-system/.q-system/tests/test_consulting_board.py
+++ b/q-system/.q-system/tests/test_consulting_board.py
@@ -544,3 +544,97 @@ class TestRound4:
         time.sleep(0.3)
         with board_rows.exclusive(tmp_path / "board.lock"):
             pass                                        # no BoardBusy: it was released
+
+
+class TestTheBoardLooksLikeTheOneHeAsked_For:
+    """Founder, 2026-09-03, with two screenshots of Bloom's board: *"This is what I
+    wanted my board to look like."* The schema already matched. Three things his
+    screenshots carry that this writer did not fill."""
+
+    def test_every_row_carries_a_priority(self, tmp_path):
+        """Bloom's board is scanned by P0-P3. A board that writes no Priority renders
+        an empty column, which is worse than no column: it looks like a field he
+        forgot to fill."""
+        b = cb.buckets(NOW, {"mail": ([_brief().Row("Portant: docs", "mail:t1")], None)},
+                       _tree(tmp_path))
+        rows = b["top_of_mind"] + b["this_week"] + b["inbox"]
+        assert rows, "fixture produced no rows, so this proves nothing"
+        missing = [r["title"] for r in rows if not r.get("priority")]
+        assert not missing, f"rows with no priority: {missing}"
+        assert all(r["priority"] in ("P0", "P1", "P2", "P3") for r in rows)
+
+    def test_priority_is_the_cards_verdict_translated_not_a_second_judgement(self):
+        """The mirror rule: one thing computes urgency. This table only renames it."""
+        assert cb.PRIORITY_BY_HEALTH["🔴"] == "P0"
+        assert cb.PRIORITY_BY_HEALTH["⚪"] == "P3"
+        src = pathlib.Path(cb.__file__).read_text(encoding="utf-8")
+        code = "\n".join(l for l in src.splitlines() if not l.lstrip().startswith("#"))
+        for invented in ("days_overdue", "score", "urgency"):
+            assert invented not in code, (
+                f"{invented!r} suggests this module started computing urgency itself; "
+                "the state card owns that verdict")
+
+    def test_every_row_carries_a_done_signal(self, tmp_path):
+        b = cb.buckets(NOW, {"mail": ([_brief().Row("Portant: docs", "mail:t1")], None)},
+                       _tree(tmp_path))
+        rows = b["top_of_mind"] + b["this_week"] + b["inbox"]
+        missing = [r["title"] for r in rows if not (r.get("done") or "").strip()]
+        assert not missing, f"rows with no done signal: {missing}"
+
+    def test_the_done_signal_reaches_notion_and_leads_the_note(self):
+        props = board_rows._properties(
+            {"title": "t", "scope": "card", "detail": "d", "done": "you sent it"},
+            "Top of Mind", "kipi-abc", True)
+        note = props["Notes"]["rich_text"][0]["text"]["content"]
+        assert note.startswith("Done signal: you sent it"), note
+        assert "scope=card" in note, "the painter still has to read its scope back"
+
+    def test_domain_is_the_producers_not_a_hardcoded_Consulting(self):
+        gtm = board_rows._properties({"title": "t", "domain": "GTM"}, "Top of Mind", "i", True)
+        assert gtm["Domain"]["multi_select"][0]["name"] == "GTM"
+        bare = board_rows._properties({"title": "t"}, "Top of Mind", "i", True)
+        assert bare["Domain"]["multi_select"][0]["name"] == "Consulting", "safe default"
+
+    def test_size_is_never_invented(self):
+        """Bloom's board has XS/S/M. Nothing here knows effort, so the column stays
+        empty rather than carrying a number that looks measured and is not."""
+        props = board_rows._properties({"title": "t", "priority": "P0"}, "Inbox", "i", True)
+        assert "Size" not in props
+
+
+class TestTwoThreadsAreNeverOneRow:
+    """Codex, 2026-09-03, on the fix for rounds 1-4: the `sender|subject` fallback
+    (used when the model returns no thread id) collapsed two distinct threads into one
+    Notion row. Read-back still passed, because `wanted` had already lost the second
+    one -- the same shape as the round-3 defect, one layer up."""
+
+    def test_two_threads_from_one_person_with_one_subject_stay_two_rows(self):
+        brief = _brief()
+        runner = lambda p, t: (json.dumps({"threads": [
+            {"from": "Alice", "subject": "Re: invoice", "age_hours": 2},
+            {"from": "Alice", "subject": "Re: invoice", "age_hours": 9}]}), None)
+        rows, err = brief.collect_mail(None, runner)
+        assert err is None
+        assert len(rows) == 2, "the producer must emit both threads"
+        assert rows[0].key != rows[1].key, (
+            f"both threads share the key {rows[0].key!r}; the board writes one row and "
+            "the second task is silently gone")
+
+    def test_a_real_thread_id_still_wins_and_stays_stable(self):
+        """The suffix is only for the id-less case. A thread WITH an id must not pick
+        one up, or the age-stability the whole change exists for is undone."""
+        brief = _brief()
+        runner = lambda p, t: (json.dumps({"threads": [
+            {"id": "t1", "from": "Alice", "subject": "Re: invoice", "age_hours": 2},
+            {"id": "t2", "from": "Alice", "subject": "Re: invoice", "age_hours": 9}]}), None)
+        rows, _ = brief.collect_mail(None, runner)
+        assert [r.key for r in rows] == ["mail:t1", "mail:t2"]
+
+    def test_both_rows_reach_the_board(self, tmp_path):
+        brief = _brief()
+        runner = lambda p, t: (json.dumps({"threads": [
+            {"from": "Alice", "subject": "Re: invoice", "age_hours": 2},
+            {"from": "Alice", "subject": "Re: invoice", "age_hours": 9}]}), None)
+        rows, _ = brief.collect_mail(None, runner)
+        inbox = cb.buckets(NOW, {"mail": (rows, None)}, _tree(tmp_path))["inbox"]
+        assert len({i["key"] for i in inbox}) == 2, "one task never reached the board"

--- a/q-system/.q-system/tests/test_consulting_board.py
+++ b/q-system/.q-system/tests/test_consulting_board.py
@@ -1,0 +1,214 @@
+"""The consulting morning board: mirror, never a second derivation (2026-09-03).
+
+The load-bearing classes are TestAStaleCardIsAnError and TestTheDryRunWritesNothing.
+Both pin defects this work actually hit, not defects imagined for it.
+"""
+import datetime as dt
+import json
+import os
+import sys
+from pathlib import Path
+
+import pytest
+
+HERE = Path(__file__).resolve().parent
+SCRIPTS = HERE.parent / "scripts"
+sys.path.insert(0, str(SCRIPTS))
+
+import board_rows  # noqa: E402
+import consulting_board as cb  # noqa: E402
+import groupme_inbox as gm  # noqa: E402
+
+NOW = dt.datetime(2026, 9, 3, 14, 45, tzinfo=dt.timezone.utc)   # 07:45 PT
+TODAY = "2026-09-03"
+
+# INVENTED NAMES, and that is a rule rather than a style choice. kipi-system is a
+# PUBLIC repo; `client-name-guard.py` blocks a real client name in staged content and it
+# caught the first version of this fixture, which used three of them. A fixture only
+# needs the card's SHAPE, and the shape is what these tests are about.
+CARD = """# TODAY CARD
+*Your book today* - 4 active
+*THE MOVE* 🔴 *Northwind Design* · you said "add a renewal date" — not sent
+🔴 *Harbor Labs* · you said "build the records" — not sent
+⚪ *Kestrel Group* · their move
+📞 *2 to reach out* — 🔥 Kestrel Group (fire)
+"""
+
+
+def _tree(tmp_path, card=CARD, date=TODAY, crash=None, gtm=None):
+    q = tmp_path / "q-consult"
+    (q / "output").mkdir(parents=True)
+    (q / "my-project").mkdir(parents=True)
+    (q / "output" / "today-card.md").write_text(card, encoding="utf-8")
+    (q / "output" / "ask-crm-state-card-heartbeat.json").write_text(
+        json.dumps({"at": "x", "card": {"date": date, "counts": {"red": 2, "reach": 1}},
+                    "crash": crash}), encoding="utf-8")
+    (q / "my-project" / "gtm-queue.json").write_text(
+        json.dumps(gtm if gtm is not None else
+                   {"rows": {"1.1": {"id": "1.1", "action": "Run the audit week",
+                                     "performer": "founder", "state": "ready", "rank": 1},
+                             "1.2": {"id": "1.2", "action": "machine thing",
+                                     "performer": "mechanism", "state": "ready", "rank": 0}}}),
+        encoding="utf-8")
+    return cb._paths(tmp_path)
+
+
+class TestItMirrorsTheCardAndNeverRederivesIt:
+    def test_the_registry_is_never_opened(self, tmp_path):
+        """No clients.json in the tree at all, and the section still delivers.
+
+        This is the whole design in one assertion. `clients.json` is 162 rows of which
+        ~150 are cold prospects; a collector that read it would put them on his board.
+        """
+        rows, err = cb.collect(NOW, {}, _tree(tmp_path))
+        assert err is None
+        assert any("Northwind Design" in r for r in rows)
+
+    def test_the_THE_MOVE_prefix_still_parses(self, tmp_path):
+        """The rank-1 row carries a `*THE MOVE*` prefix. The first parser anchored the
+        health emoji to line start, so it dropped the rank-1 row, the most important one,
+        while every lesser row parsed. A parser that drops the FIRST row hides its own gap."""
+        card_rows, err = cb.read_card(_tree(tmp_path))
+        assert err is None
+        assert card_rows[0]["name"] == "Northwind Design"
+        assert card_rows[0]["health"] == "🔴"
+
+    def test_the_health_verdict_is_the_cards_not_recomputed(self, tmp_path):
+        rows, _ = cb.read_card(_tree(tmp_path))
+        assert {r["name"]: r["health"] for r in rows}["Kestrel Group"] == "⚪"
+
+
+class TestAStaleCardIsAnError:
+    """Never a quiet mirror. He would act on it."""
+
+    def test_yesterdays_card_is_withheld_and_named(self, tmp_path):
+        rows, err = cb.collect(NOW, {}, _tree(tmp_path, date="2026-09-02"))
+        assert rows == []
+        assert "2026-09-02" in err and "2026-09-03" in err
+
+    def test_a_crashed_card_job_is_an_error(self, tmp_path):
+        _, err = cb.collect(NOW, {}, _tree(tmp_path, crash="boom"))
+        assert "crashed" in err
+
+    def test_a_card_that_parses_to_nothing_is_a_format_change_not_a_quiet_morning(self, tmp_path):
+        _, err = cb.collect(NOW, {}, _tree(tmp_path, card="# TODAY CARD\nno rows here\n"))
+        assert "format changed" in err
+
+    def test_and_a_stale_card_writes_no_rows_at_all(self, tmp_path):
+        b = cb.buckets(NOW, {}, _tree(tmp_path, date="2026-09-02"))
+        assert b["error"] and b["top_of_mind"] == [] and b["this_week"] == []
+
+
+class TestTheGtmMoveIsOnlyWhatNeedsHim:
+    def test_rows_is_a_dict_not_a_list(self, tmp_path):
+        """Measured: the first reader typed isinstance(rows, list) and reported
+        COULD NOT READ against a perfectly good queue."""
+        move, err = cb.read_gtm(_tree(tmp_path))
+        assert err is None and move["action"] == "Run the audit week"
+
+    def test_a_mechanism_row_never_reaches_his_board(self, tmp_path):
+        move, _ = cb.read_gtm(_tree(tmp_path))
+        assert move["performer"] == "founder"      # rank 0 mechanism row outranked it
+
+    def test_nothing_waiting_on_him_is_not_an_error(self, tmp_path):
+        paths = _tree(tmp_path, gtm={"rows": {}})
+        move, err = cb.read_gtm(paths)
+        assert move is None and err is None
+
+
+class TestTheDryRunWritesNothing:
+    """The defect this work shipped and caught: `--dry-run` printed "nothing sent" and
+    had already created 12 rows on the live board. The send flag only ever covered the
+    Slack send, because until board_rows no section could write."""
+
+    def test_the_flag_stops_the_board_write(self, tmp_path, monkeypatch):
+        monkeypatch.setenv("KIPI_BRIEF_DRY_RUN", "1")
+        monkeypatch.delenv("PYTEST_CURRENT_TEST", raising=False)
+        rows, err = board_rows.collect(NOW, {})
+        assert rows == [] and "dry-run" in err
+
+    def test_pytest_alone_also_stops_it(self, monkeypatch):
+        monkeypatch.delenv("KIPI_BRIEF_DRY_RUN", raising=False)
+        rows, err = board_rows.collect(NOW, {})
+        assert rows == [] and "pytest" in err
+
+
+class TestHisDragAlwaysWins:
+    def test_an_existing_row_is_never_given_a_bucket(self):
+        props = board_rows._properties({"title": "t", "detail": "d"}, "Top of Mind",
+                                       "cb:abc", include_bucket=False)
+        assert "Bucket" not in props and "Status" not in props
+
+    def test_a_new_row_is(self):
+        props = board_rows._properties({"title": "t"}, "Inbox", "cb:abc",
+                                       include_bucket=True)
+        assert props["Bucket"]["select"]["name"] == "Inbox"
+
+    def test_the_id_is_stable_across_mornings(self):
+        """Hashed from the title only. Hashing the detail too would mint a new row every
+        morning as due-dates and reply counts move, and the board would only grow."""
+        a = board_rows.item_id("top_of_mind", {"title": "Northwind", "detail": "due Mon"})
+        b = board_rows.item_id("top_of_mind", {"title": "Northwind", "detail": "due Tue"})
+        assert a == b and a.startswith(board_rows.OWNED_PREFIX)
+
+    def test_a_hand_made_row_is_not_owned(self):
+        assert not "some-hand-id".startswith(board_rows.OWNED_PREFIX)
+
+
+class TestGroupMeNeverReportsASilentZero:
+    def test_an_outage_is_an_error_not_an_empty_inbox(self, monkeypatch):
+        monkeypatch.setattr(gm, "load_token", lambda: "t")
+        def boom(*a, **k):
+            raise OSError("down")
+        monkeypatch.setattr(gm, "waiting", boom)
+        rows, err = gm.collect(NOW, {})
+        assert rows == [] and "unreachable" in err
+
+    def test_no_token_is_OFF_not_broken(self, monkeypatch):
+        monkeypatch.setattr(gm, "load_token", lambda: None)
+        assert gm.collect(NOW, {}) is None
+
+    def test_the_group_author_is_read_from_the_message_not_the_preview(self):
+        """The preview has no user_id. Reading it there returned "" for every group and
+        the "is it his?" test dropped all four, on a morning three were live."""
+        src = (SCRIPTS / "groupme_inbox.py").read_text(encoding="utf-8")
+        assert "/groups/{g.get('id')}/messages" in src
+
+
+class TestEngineeringLeavesHisBrief:
+    def _brief(self):
+        import importlib.util
+        spec = importlib.util.spec_from_file_location(
+            "morning_brief", SCRIPTS / "morning-brief.py")
+        mod = importlib.util.module_from_spec(spec)
+        spec.loader.exec_module(mod)
+        return mod
+
+    def test_owed_and_overnight_are_not_founder_sections(self):
+        mb = self._brief()
+        keys = {k for k, _ in mb.SECTIONS}
+        assert "owed" not in keys and "overnight" not in keys
+
+    def test_they_are_still_collected_and_routed(self):
+        mb = self._brief()
+        assert {k for k, _ in mb.ENGINEERING_SECTIONS} == {"owed", "overnight"}
+        sent = []
+        mb.route_engineering({"owed": ([], "linear down"),
+                              "overnight": (["fine"], None)}, notify=sent.append)
+        assert len(sent) == 1 and "linear down" in sent[0]
+
+    def test_a_healthy_section_pages_nobody(self):
+        """A ticket every morning is how an alert channel gets muted."""
+        mb = self._brief()
+        sent = []
+        mb.route_engineering({"owed": (["x"], None), "overnight": ([], None)},
+                             notify=sent.append)
+        assert sent == []
+
+    def test_only_one_module_writes_the_board(self):
+        mb = self._brief()
+        stems = {s for s, _, _ in mb.OPTIONAL_SECTIONS}
+        assert "board_rows.py" in stems
+        assert "notion_board.py" not in stems, (
+            "notion_board.py writes bullets to the same page board_rows writes rows to; "
+            "the first live dry-run rendered both")

--- a/q-system/.q-system/tests/test_consulting_board.py
+++ b/q-system/.q-system/tests/test_consulting_board.py
@@ -110,6 +110,55 @@ class TestIdentityIsTheTHING_NotItsRendering:
         assert a != b, "stripping volatile tokens must not collapse distinct rows"
 
 
+class TestRound3:
+    """Every finding here was CAUSED by a round-2 fix. Pinned so the repair does not
+    have to be rediscovered by a fourth review."""
+
+    def test_a_client_row_and_a_reach_out_row_for_one_person_are_two_rows(self, tmp_path):
+        """Both are named for the person, so keying on the name alone collapsed them:
+        the reach-out action was dropped and read-back still said ok, because `wanted`
+        had already merged them before the count was taken."""
+        b = cb.buckets(NOW, {}, _tree(tmp_path))
+        keys = [i["key"] for i in b["top_of_mind"] + b["this_week"]]
+        assert len(keys) == len(set(keys)), f"two rows collapsed onto one key: {keys}"
+        assert any(k.startswith("reach:") for k in keys)
+        assert any(k.startswith("client:") for k in keys)
+
+    def test_an_unreadable_gtm_queue_does_NOT_authorise_archiving_its_scope(self, tmp_path):
+        """It was unconditionally healthy, so a broken queue let the painter delete the
+        GTM row he had positioned and recreate it in a computed bucket."""
+        paths = _tree(tmp_path)
+        paths["gtm"].write_text("{ not json", encoding="utf-8")
+        assert "gtm" not in cb.buckets(NOW, {}, paths)["healthy_scopes"]
+
+    def test_a_readable_gtm_queue_DOES(self, tmp_path):
+        assert "gtm" in cb.buckets(NOW, {}, _tree(tmp_path))["healthy_scopes"]
+
+    def test_two_threads_differing_only_by_a_number_stay_two_rows(self, tmp_path):
+        """The volatile-token strip removed EVERY digit run, so "invoice 4021" and
+        "invoice 4022" became one board row."""
+        a = cb.buckets(NOW, {"mail": (["invoice 4021 from them"], None)},
+                       _tree(tmp_path))["inbox"][0]["key"]
+        b = cb.buckets(NOW, {"mail": (["invoice 4022 from them"], None)},
+                       _tree(tmp_path))["inbox"][0]["key"]
+        assert a != b
+
+    def test_but_an_age_is_still_volatile(self, tmp_path):
+        a = cb.buckets(NOW, {"mail": (["invoice 4021, 2 hours ago"], None)},
+                       _tree(tmp_path))["inbox"][0]["key"]
+        b = cb.buckets(NOW, {"mail": (["invoice 4021, 5 hours ago"], None)},
+                       _tree(tmp_path))["inbox"][0]["key"]
+        assert a == b
+
+    def test_kept_rows_do_not_fake_a_read_back_mismatch(self):
+        """`kept` rows are on the board and deliberately not in `wanted`. Comparing
+        `seen` to `wanted` alone made every quiet source report a mismatch and mark the
+        brief degraded, which trains him to ignore the word."""
+        src = (SCRIPTS / "board_rows.py").read_text(encoding="utf-8")
+        assert 'expected = counts["wanted"] + counts["kept"]' in src
+        assert "if seen != expected:" in src
+
+
 class TestAQuietSourceNeverArchivesHisRows:
     """Codex round 2 (major): a transient Gmail error replaced that source's rows with
     a single error row, so every inbox row he had positioned fell out of `wanted` and

--- a/q-system/.q-system/tests/test_consulting_board.py
+++ b/q-system/.q-system/tests/test_consulting_board.py
@@ -164,11 +164,40 @@ class TestHisDragAlwaysWins:
         assert props["Bucket"]["select"]["name"] == "Inbox"
 
     def test_the_id_is_stable_across_mornings(self):
-        """Hashed from the title only. Hashing the detail too would mint a new row every
-        morning as due-dates and reply counts move, and the board would only grow."""
-        a = board_rows.item_id("top_of_mind", {"title": "Northwind", "detail": "due Mon"})
-        b = board_rows.item_id("top_of_mind", {"title": "Northwind", "detail": "due Tue"})
+        """Hashed from `key` alone. The detail moves daily (due dates, reply counts)."""
+        a = board_rows.item_id("top_of_mind", {"key": "Northwind", "title": "🔴 Northwind",
+                                               "detail": "due Mon"})
+        b = board_rows.item_id("top_of_mind", {"key": "Northwind", "title": "🔴 Northwind",
+                                               "detail": "due Tue"})
         assert a == b and a.startswith(board_rows.OWNED_PREFIX)
+
+    def test_the_id_SURVIVES_a_health_change(self):
+        """The Codex finding, pinned. The id used to be hashed from the title, which
+        embeds the health dot, so red -> green minted a new id: the next paint archived
+        the row he had DRAGGED and created a replacement in a computed bucket. The
+        promise this class is named for depended on an id that does not move."""
+        red = board_rows.item_id("top_of_mind", {"key": "Northwind", "title": "🔴 Northwind"})
+        green = board_rows.item_id("this_week", {"key": "Northwind", "title": "🟢 Northwind"})
+        assert red == green, "a health change minted a new id and would orphan his row"
+
+    def test_an_item_with_no_key_is_REFUSED_never_fallen_back(self):
+        """A title fallback would work quietly, with the unstable id, which is exactly
+        how the defect returns."""
+        with pytest.raises(ValueError):
+            board_rows.item_id("top_of_mind", {"title": "🔴 Northwind"})
+
+    def test_every_producer_supplies_a_key(self, tmp_path):
+        """Drives the real buckets() rather than asserting the contract in prose."""
+        b = cb.buckets(NOW, {}, _tree(tmp_path))
+        items = b["top_of_mind"] + b["this_week"] + b["inbox"]
+        assert items
+        for item in items:
+            assert item.get("key"), item
+
+    def test_a_health_dot_never_reaches_a_key(self, tmp_path):
+        b = cb.buckets(NOW, {}, _tree(tmp_path))
+        for item in b["top_of_mind"] + b["this_week"]:
+            assert not any(d in item["key"] for d in "🔴🟡🟢⚪🟠📞"), item["key"]
 
     def test_a_hand_made_row_is_not_owned(self):
         assert not "some-hand-id".startswith(board_rows.OWNED_PREFIX)
@@ -212,17 +241,35 @@ class TestEngineeringLeavesHisBrief:
         mb = self._brief()
         assert {k for k, _ in mb.ENGINEERING_SECTIONS} == {"owed", "overnight"}
         sent = []
-        mb.route_engineering({"owed": ([], "linear down"),
-                              "overnight": (["fine"], None)}, notify=sent.append)
+        filed, failed = mb.route_engineering(
+            {"owed": ([], "linear down"), "overnight": (["fine"], None)},
+            notify=sent.append)
         assert len(sent) == 1 and "linear down" in sent[0]
+        assert filed == sent and failed == []
+
+    def test_a_notifier_that_FAILS_is_reported_not_counted_as_filed(self):
+        """Codex finding (major), 2026-09-03: route returned every attempted line as
+        routed, whether or not slack-notify.sh actually filed. A detected engineering
+        problem that is then lost on the way to the queue looks handled, which is worse
+        than one never detected."""
+        mb = self._brief()
+
+        def broken(_message):
+            raise RuntimeError("notifier down")
+
+        filed, failed = mb.route_engineering(
+            {"owed": ([], "linear down"), "overnight": ([], "launchd down")},
+            notify=broken)
+        assert filed == []
+        assert len(failed) == 2 and all("notifier down" in why for _l, why in failed)
 
     def test_a_healthy_section_pages_nobody(self):
         """A ticket every morning is how an alert channel gets muted."""
         mb = self._brief()
         sent = []
-        mb.route_engineering({"owed": (["x"], None), "overnight": ([], None)},
-                             notify=sent.append)
-        assert sent == []
+        filed, failed = mb.route_engineering(
+            {"owed": (["x"], None), "overnight": ([], None)}, notify=sent.append)
+        assert sent == [] and filed == [] and failed == []
 
     def test_only_one_module_writes_the_board(self):
         mb = self._brief()

--- a/q-system/.q-system/tests/test_consulting_board.py
+++ b/q-system/.q-system/tests/test_consulting_board.py
@@ -4,9 +4,11 @@ The load-bearing classes are TestAStaleCardIsAnError and TestTheDryRunWritesNoth
 Both pin defects this work actually hit, not defects imagined for it.
 """
 import datetime as dt
+import io
 import json
 import os
 import sys
+import time
 from pathlib import Path
 
 import pytest
@@ -406,3 +408,109 @@ class TestEngineeringLeavesHisBrief:
         assert "notion_board.py" not in stems, (
             "notion_board.py writes bullets to the same page board_rows writes rows to; "
             "the first live dry-run rendered both")
+
+
+def _brief():
+    import importlib.util
+    spec = importlib.util.spec_from_file_location("morning_brief", SCRIPTS / "morning-brief.py")
+    mod = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(mod)
+    return mod
+
+
+class TestRound4:
+    """The first real Codex read after rounds 2 and 3 ran on the Opus fallback. Both
+    findings are the same shape: a fix that held for the fixture and not for the
+    producer. So these tests drive the PRODUCER (collect_mail, collect) and not a
+    hand-typed row."""
+
+    def test_the_real_mail_producers_age_form_is_volatile(self, tmp_path):
+        """collect_mail renders `[2h]`, not "2h ago". Round 2's regex never matched it,
+        so every age change replaced the Notion row and lost his drag."""
+        brief = _brief()
+
+        def runner(age):
+            return lambda p, t: (json.dumps({"threads": [
+                {"from": "Alice", "subject": "Docs", "age_hours": age}]}), None)
+
+        a_rows, _ = brief.collect_mail(None, runner(2))
+        b_rows, _ = brief.collect_mail(None, runner(3))
+        assert a_rows != b_rows, "the producer must actually render the age, or this proves nothing"
+        a = cb.buckets(NOW, {"mail": (a_rows, None)}, _tree(tmp_path))["inbox"][0]["key"]
+        b = cb.buckets(NOW, {"mail": (b_rows, None)}, _tree(tmp_path))["inbox"][0]["key"]
+        assert a == b, f"an age change minted a new id: {a!r} != {b!r}"
+
+    def test_but_a_bracketed_number_that_is_not_an_age_stays(self, tmp_path):
+        a = cb.buckets(NOW, {"mail": (["Alice  ticket [4021]"], None)},
+                       _tree(tmp_path))["inbox"][0]["key"]
+        b = cb.buckets(NOW, {"mail": (["Alice  ticket [4022]"], None)},
+                       _tree(tmp_path))["inbox"][0]["key"]
+        assert a != b
+
+    @staticmethod
+    def _fake_db(slow_first_query_s: float):
+        """The database API, just enough of it. Records every call; the first query
+        sleeps past the budget so the worker is abandoned mid-paint."""
+        class Fake:
+            def __init__(self):
+                self.calls = []
+
+            def __call__(self, req, timeout):
+                method, url = req.get_method(), req.full_url
+                if "/databases/" in url and not self.calls:
+                    self.calls.append(("query-slow", timeout))
+                    time.sleep(slow_first_query_s)
+                    return io.BytesIO(b'{"results": [], "has_more": false}')
+                self.calls.append((method, url))
+                if "/databases/" in url:
+                    return io.BytesIO(b'{"results": [], "has_more": false}')
+                return io.BytesIO(b'{"id": "p1"}')
+        return Fake()
+
+    def test_no_write_lands_after_the_timeout_was_reported(self, tmp_path, monkeypatch):
+        """Codex round 4 (major): the guard abandoned the worker and it kept writing.
+        Now the budget is cancelled before the timeout is reported, so the worker's
+        next request refuses and the paint stops where it stood."""
+        (tmp_path / "tok").write_text("t")
+        (tmp_path / "db").write_text("db1")
+        monkeypatch.setattr(board_rows, "LOCK_FILE", tmp_path / "board.lock")
+        buckets = {"top_of_mind": [{"key": "k1", "title": "t", "detail": "d", "scope": "card"}],
+                   "this_week": [], "inbox": [], "healthy_scopes": {"card"}}
+        monkeypatch.setattr(board_rows.consulting_board, "buckets", lambda *a, **k: buckets)
+        fake = self._fake_db(slow_first_query_s=0.15)
+        rows, error = board_rows.collect(NOW, {}, opener=fake, token_file=tmp_path / "tok",
+                                         db_file=tmp_path / "db", budget_s=0.05)
+        assert rows == [] and "timed out" in error and "no further write" in error
+        time.sleep(0.4)                      # let the abandoned worker run on and try
+        writes = [c for c in fake.calls if c[0] in ("POST", "PATCH") and "/pages" in c[1]]
+        assert writes == [], f"writes landed after the timeout: {writes}"
+
+    def test_and_the_in_flight_call_is_capped_to_what_is_left(self, tmp_path, monkeypatch):
+        """A 10s HTTP timeout on a request that starts with 0.02s left would outlive
+        the budget. The request's own timeout is clipped to the remainder."""
+        seen = []
+
+        def opener(req, timeout):
+            seen.append(timeout)
+            return io.BytesIO(b'{"results": [], "has_more": false}')
+        budget = board_rows._Budget(0.05)
+        board_rows.existing_rows("t", "db", opener, budget=budget)
+        assert seen and seen[0] <= 0.05 < board_rows.TIMEOUT_S
+
+    def test_the_boards_own_budget_fires_before_the_briefs_guard(self):
+        """Two bounds, one ordering. If the brief's guard fired first the worker would
+        be abandoned with a live budget, which is exactly the round-4 defect."""
+        assert board_rows.BUDGET_S < _brief().COLLECT_BUDGET_S
+
+    def test_a_worker_that_ran_out_of_time_also_let_go_of_the_lock(self, tmp_path, monkeypatch):
+        (tmp_path / "tok").write_text("t")
+        (tmp_path / "db").write_text("db1")
+        monkeypatch.setattr(board_rows, "LOCK_FILE", tmp_path / "board.lock")
+        buckets = {"top_of_mind": [], "this_week": [], "inbox": [], "healthy_scopes": {"card"}}
+        monkeypatch.setattr(board_rows.consulting_board, "buckets", lambda *a, **k: buckets)
+        fake = self._fake_db(slow_first_query_s=0.15)
+        board_rows.collect(NOW, {}, opener=fake, token_file=tmp_path / "tok",
+                           db_file=tmp_path / "db", budget_s=0.05)
+        time.sleep(0.3)
+        with board_rows.exclusive(tmp_path / "board.lock"):
+            pass                                        # no BoardBusy: it was released

--- a/q-system/.q-system/tests/test_consulting_board.py
+++ b/q-system/.q-system/tests/test_consulting_board.py
@@ -12,6 +12,7 @@ import sys
 import time
 from pathlib import Path
 
+import urllib.error
 import pytest
 
 HERE = Path(__file__).resolve().parent
@@ -1055,3 +1056,126 @@ class TestRound7:
                                       token_file=tmp_path / "tok", db_file=tmp_path / "db")
         assert err is None, err
         assert "1 row(s) over the" in out[0], out
+
+
+class TestEveryPersonOnTheCardReachesTheBoard:
+    """Codex round 8 (major): the real producer emitted four people to reach out and
+    this reader parsed ONE of them, at exit 0, with the board reporting success.
+
+    Two defects in one line-shape, and the first is a scar this file already carries.
+    `_CLIENT_LINE` was taught to tolerate the `*THE MOVE*` prefix after it silently
+    dropped the top-ranked client; the reach line is its sibling and was never
+    hardened, so when the top-ranked row is a reach-out (which is what the card looks
+    like on a day with no red clients) the whole line failed to match. The second is
+    the `then:` continuation, which the card packs with every remaining person and
+    this reader read as exactly one.
+
+    CAPTURED, not typed. The fixture below is the verbatim output of
+    `state_card.build_card` for four fire-temperature prospects, run 2026-09-03. It
+    cannot be imported here (`test_boundary.py` forbids this package from reaching into
+    the consulting pipeline), and a hand-written approximation of a producer's format
+    is what let this ship: every earlier fixture in this file puts `*THE MOVE*` on a
+    CLIENT line, so no test ever saw the shape the producer actually emits.
+    """
+
+    CAPTURED = (
+        "*Your book today* · 0 active · 0 in proposal · 4 to reach out · 2026-09-03\n"
+        "*THE MOVE* 📞 *4 to reach out* — 🔥 Alpha (fire, Alpha context): contact Alpha\n"
+        "     then: 🔥 Beta (fire) · 🔥 Gamma (fire) · 🔥 Delta (fire)\n"
+    )
+
+    def _rows(self, tmp_path):
+        paths = _tree(tmp_path, card=self.CAPTURED)
+        rows, err = cb.read_card(paths)
+        assert err is None, err
+        return rows
+
+    def test_all_four_are_parsed(self, tmp_path):
+        names = [r["name"] for r in self._rows(tmp_path)]
+        assert sorted(names) == ["Alpha", "Beta", "Delta", "Gamma"], names
+
+    def test_the_lead_person_is_not_the_one_dropped(self, tmp_path):
+        """Alpha carries `*THE MOVE*`, which is the card's own ranking: the person it
+        drops is the most important one on the line."""
+        assert "Alpha" in [r["name"] for r in self._rows(tmp_path)]
+
+    def test_each_one_is_its_own_board_row(self, tmp_path):
+        b = cb.buckets(NOW, {}, _tree(tmp_path, card=self.CAPTURED))
+        keys = [r["key"] for r in b["top_of_mind"] if r["key"].startswith("reach:")]
+        assert len(set(keys)) == 4, keys
+
+
+class TestRateLimitedNotionIsRetriedNotAbandoned:
+    """Codex round 8 (major): Notion documents ~3 requests/second and asks clients to
+    honour `Retry-After` on 429. This painter sends up to 40 sequential mutations with
+    no pacing and no retry, so an ordinary paint could abort part-written and report
+    the morning degraded. The next run reconciles the board, so the damage is alert
+    noise rather than corruption, which is why this is a retry and not a rewrite.
+    """
+
+    @staticmethod
+    def _opener(fail_on, retry_after="0"):
+        calls = []
+
+        def opener(req, timeout):
+            calls.append(req.full_url)
+            if len(calls) == fail_on:
+                raise urllib.error.HTTPError(
+                    req.full_url, 429, "rate_limited", {"Retry-After": retry_after},
+                    io.BytesIO(b"{}"))
+            if "/query" in req.full_url:
+                return io.BytesIO(b'{"results": [], "has_more": false}')
+            return io.BytesIO(b'{"id": "p1"}')
+        opener.calls = calls
+        return opener
+
+    def _rows(self, n=4):
+        return [{"key": f"mail:{i}", "title": f"t{i}", "detail": "",
+                 "scope": "inbox:Gmail"} for i in range(n)]
+
+    def test_a_429_mid_paint_is_retried_and_the_paint_completes(self):
+        opener = self._opener(fail_on=4)
+        counts = board_rows.paint(
+            {"top_of_mind": [], "this_week": [], "inbox": self._rows(),
+             "healthy_scopes": {"inbox:Gmail"}}, "t", "db", opener=opener)
+        assert counts["created"] == 4, counts
+        assert len(opener.calls) == 6, "the rejected write was not retried"
+
+    def test_a_retry_never_outlives_the_budget(self):
+        """The budget is the whole point of the round-4 fix: nothing may write after
+        the brief has moved on. A Retry-After longer than what is left is refused
+        rather than slept through."""
+        opener = self._opener(fail_on=2, retry_after="60")
+        # 2.0 rather than a fraction of a second: a budget that can expire before the
+        # first request turns this into a load-sensitive coin flip, and a flaky
+        # negative control is worse than none. The clamped wait (5s) is longer than
+        # this budget either way, which is the condition under test.
+        budget = board_rows._Budget(2.0)
+        started = time.monotonic()
+        # EITHER refusal is correct: the retry declines because the wait does not fit,
+        # or the budget was already spent and the next request refuses. The exception
+        # TYPE is not the property -- raising is what the unfixed code did too. The
+        # CLOCK is the property, and it separates the fix from the defect on its own
+        # (removing the budget check makes this same assertion fail after five seconds).
+        with pytest.raises((urllib.error.HTTPError, board_rows.Cancelled)):
+            board_rows.paint(
+                {"top_of_mind": [], "this_week": [], "inbox": self._rows(1),
+                 "healthy_scopes": {"inbox:Gmail"}}, "t", "db",
+                opener=opener, budget=budget)
+        assert time.monotonic() - started < 1.0, "it slept through the Retry-After"
+
+    def test_a_permanently_rate_limited_endpoint_gives_up(self):
+        """A retry loop with no cap is how a 15-second budget becomes a hung job."""
+        calls = []
+
+        def opener(req, timeout):
+            calls.append(req.full_url)
+            if "/query" in req.full_url:
+                return io.BytesIO(b'{"results": [], "has_more": false}')
+            raise urllib.error.HTTPError(req.full_url, 429, "rate_limited",
+                                         {"Retry-After": "0"}, io.BytesIO(b"{}"))
+        with pytest.raises(urllib.error.HTTPError):
+            board_rows.paint(
+                {"top_of_mind": [], "this_week": [], "inbox": self._rows(1),
+                 "healthy_scopes": {"inbox:Gmail"}}, "t", "db", opener=opener)
+        assert len(calls) <= 1 + board_rows.RATE_LIMIT_RETRIES + 1, calls

--- a/q-system/.q-system/tests/test_consulting_board.py
+++ b/q-system/.q-system/tests/test_consulting_board.py
@@ -1496,7 +1496,8 @@ class TestRound12:
     def test_and_a_quiet_card_raises_no_alarm_row(self, tmp_path):
         b = cb.buckets(NOW, {}, _tree(tmp_path, card=self.QUIET))
         assert not any(r["scope"] == cb.CARD_ALARM for r in b["top_of_mind"])
-        assert "card" in b["healthy_scopes"]
+        # The scope is deliberately NOT healthy here; round 14 explains why, and
+        # test_a_card_that_parses_to_nothing_never_archives_his_rows pins it.
 
     def test_the_producers_plus_N_more_tail_is_not_a_person(self, tmp_path):
         """A count is not a contact. The split handed the producer's own summary to
@@ -1559,3 +1560,16 @@ class TestRound13:
         a = board_rows._prop_value({"some_new_notion_shape": True})
         b = board_rows._prop_value({"another_unknown": 1})
         assert a != b and a != None  # noqa: E711  -- the None case is the defect
+
+    def test_a_card_that_parses_to_nothing_never_archives_his_rows(self, tmp_path):
+        """Round 14 (major), against round 12's fix. A format change that keeps the
+        header parses to zero rows and looks exactly like a quiet morning, so calling
+        that scope healthy handed the painter authority to archive every client row
+        including the pinned ones. Quiet costs nothing; drifted costs everything."""
+        b = cb.buckets(NOW, {}, _tree(tmp_path, card=TestRound12.QUIET))
+        assert "card" not in b["healthy_scopes"]
+        assert not any(r["scope"] == cb.CARD_ALARM for r in b["top_of_mind"])
+
+    def test_but_a_card_with_rows_still_authorises_it(self, tmp_path):
+        b = cb.buckets(NOW, {}, _tree(tmp_path))
+        assert "card" in b["healthy_scopes"]

--- a/q-system/.q-system/tests/test_morning_brief.py
+++ b/q-system/.q-system/tests/test_morning_brief.py
@@ -937,3 +937,37 @@ def test_the_documented_hour_is_the_one_launchd_runs():
     assert stated, "CLAUDE.md no longer states the brief's schedule at all"
     assert stated.group(1) == runs_at, (
         f"CLAUDE.md says {stated.group(1)}, launchd runs {runs_at}")
+
+
+def test_no_hourly_slot_fires_before_the_card_it_mirrors():
+    """Codex round 7 (major): the hourly inbox job's first slot was 07:05.
+
+    The consulting state card is written at 07:30 by another repo's job, and the board
+    MIRRORS that card: `read_heartbeat` withholds a card stamped yesterday, so a run at
+    07:05 can only ever see yesterday's. Every morning it spent a headless Opus mail
+    call, threw the result away, refused the board write and exited 1 into the launchd
+    watchdog. Not broken. Early, by construction, forever.
+
+    The anchor is the BRIEF's own slot rather than a 07:30 literal, because that plist
+    is this repo's record of "after the card is written" and a literal here would be a
+    second copy of it to drift.
+    """
+    import pathlib
+    import plistlib
+    scripts = pathlib.Path(__file__).resolve().parents[1] / "scripts"
+
+    def minute_of_day(entry):
+        return entry["Hour"] * 60 + entry["Minute"]
+
+    brief = plistlib.loads((scripts / "com.kipi.morning-brief.plist").read_bytes())
+    after_the_card = minute_of_day(brief["StartCalendarInterval"])
+
+    hourly = plistlib.loads((scripts / "com.kipi.morning-inbox.plist").read_bytes())
+    slots = hourly["StartCalendarInterval"]
+    assert isinstance(slots, list) and slots, "the hourly job lost its schedule"
+    early = ["%02d:%02d" % (s["Hour"], s["Minute"])
+             for s in slots if minute_of_day(s) < after_the_card]
+    assert not early, (
+        f"slots {early} fire before the state card exists (the brief waits until "
+        f"{after_the_card // 60:02d}:{after_the_card % 60:02d}); each one is a wasted "
+        "model call and an exit 1 the watchdog reads as a broken hour")

--- a/q-system/.q-system/tests/test_morning_brief.py
+++ b/q-system/.q-system/tests/test_morning_brief.py
@@ -1003,3 +1003,33 @@ def test_the_deadman_alarm_names_no_clock_time():
     assert ok is False
     assert not re.search(r"\b\d{1,2}:\d{2}\b", reason), (
         f"the alarm names a wall-clock time again: {reason!r}")
+
+
+def test_inbox_only_says_OFF_rather_than_COULD_NOT_READ(brief, capsys, monkeypatch):
+    """Codex round 7 (minor): a module that reported itself OFF is absent from
+    `collect_hourly`, and this loop's default turned that absence into
+    "COULD NOT READ: never collected".
+
+    That is the empty-versus-broken rule inverted, in the one surface an operator
+    reads, on any machine with no GroupMe token and no Notion token -- which is the
+    default -- twelve times a day. A log that cries wolf twelve times a day is a log
+    nobody reads on the morning it is right.
+    """
+    mb = brief
+    monkeypatch.setattr(mb, "collect_hourly", lambda *a, **k: {"mail": ([], None)})
+    rc = mb.main(["--inbox-only"])
+    out = capsys.readouterr().out
+    assert "COULD NOT READ" not in out, out
+    assert "[groupme] off" in out and "[board_rows] off" in out, out
+    assert rc == 0, "an OFF section made a healthy hour report itself broken"
+
+
+def test_but_a_real_failure_still_exits_1(brief, capsys, monkeypatch):
+    """The negative control. If OFF and BROKEN both print quietly, the fix has
+    replaced a false alarm with a missing one."""
+    mb = brief
+    monkeypatch.setattr(mb, "collect_hourly",
+                        lambda *a, **k: {"mail": ([], "gmail down")})
+    rc = mb.main(["--inbox-only"])
+    out = capsys.readouterr().out
+    assert "COULD NOT READ: gmail down" in out and rc == 1

--- a/q-system/.q-system/tests/test_morning_brief.py
+++ b/q-system/.q-system/tests/test_morning_brief.py
@@ -79,14 +79,22 @@ NOW = dt.datetime(2026, 8, 30, 7, 0, 0, tzinfo=dt.timezone.utc).astimezone()
 # --------------------------------------------------------------------------
 
 def _sources(**overrides):
-    """Four sections, all empty-and-healthy, with per-section overrides."""
+    """Every COLLECTED section, empty-and-healthy, with per-section overrides.
+
+    `owed` and `overnight` stayed here after 2026-09-03. They stopped being FOUNDER
+    sections and route to Sana instead; they did not stop being collected.
+    """
     base = {k: ([], None) for k in ("calendar", "mail", "owed", "overnight")}
     base.update(overrides)
     return base
 
 
 def test_every_section_can_say_failed_distinctly_from_zero(brief):
-    for name in ("calendar", "mail", "owed", "overnight"):
+    # Read from the registry, not typed. `owed` and `overnight` left this list on
+    # 2026-09-03: they no longer RENDER, so a broken one cannot look different from an
+    # empty one in a message that shows neither. The property they keep is asserted
+    # separately below, and it is the one that still matters for them.
+    for name, _title in brief.SECTIONS:
         empty, _ = brief.build(NOW, _sources())
         broken, degraded = brief.build(NOW, _sources(**{name: ([], "boom")}))
         assert empty != broken, f"{name}: a broken section renders like an empty one"
@@ -95,17 +103,43 @@ def test_every_section_can_say_failed_distinctly_from_zero(brief):
         assert degraded, f"{name}: a broken section did not mark the run degraded"
 
 
+def test_a_broken_ENGINEERING_section_still_degrades_the_run_without_rendering(brief):
+    """The half of the property above that survives for a routed section.
+
+    He never sees `Owed today` again, but a Linear outage must still mark the run
+    degraded, because the deadman and the receipt read that flag. A section that stops
+    being visible must not quietly stop being MONITORED, which is exactly what deleting
+    the collectors would have done."""
+    for name, _title in brief.ENGINEERING_SECTIONS:
+        message, degraded = brief.build(NOW, _sources(**{name: ([], "boom")}))
+        assert degraded, f"{name}: a broken engineering section did not degrade the run"
+        assert "boom" not in message, f"{name}: engineering detail reached his brief"
+
+
 def test_all_empty_is_not_degraded_and_says_nothing(brief):
     message, degraded = brief.build(NOW, _sources())
     assert not degraded
     assert "COULD NOT READ" not in message
-    assert message.count("nothing") == 4
+    # Counted from the module's own SECTIONS, never typed. It was 4 until 2026-09-03,
+    # when `owed` and `overnight` left the founder's brief for Sana's queue; taking the
+    # number from the registry means the next section change moves it by itself.
+    assert message.count("nothing") == len(brief.SECTIONS)
 
 
-def test_all_four_sections_are_present_by_name(brief):
+def test_all_founder_sections_are_present_by_name(brief):
     message, _ = brief.build(NOW, _sources())
-    for title in ("Today", "Mail", "Owed", "Overnight"):
+    for _key, title in brief.SECTIONS:
         assert title in message, f"section {title} missing from the brief"
+
+
+def test_the_engineering_sections_are_ABSENT_from_his_brief(brief):
+    """Founder 2026-09-03: "I'm not looking for this to be a build dashboard, but a
+    consulting dashboard." He found his board reporting Sana's Linear queue and the
+    overnight launchd run. This is the assertion that keeps them out, and it is the
+    inverse of the one above rather than a deletion of it."""
+    message, _ = brief.build(NOW, _sources())
+    for _key, title in brief.ENGINEERING_SECTIONS:
+        assert title not in message, f"{title} is engineering and is not his to read"
 
 
 def test_no_html_no_cards_no_scores(brief):
@@ -668,7 +702,11 @@ def test_a_raising_collector_costs_its_own_section_only(brief, tmp_path, monkeyp
     sources = brief.collect_all(NOW, log_path=log)
     message, degraded = brief.build(NOW, sources)
     assert degraded
-    assert message.count("fine") == 3, "the healthy sections did not render"
+    # One less than the founder's section count: mail is the victim here. Derived, so
+    # the 2026-09-03 drop from four sections to two did not need this line rewritten by
+    # hand -- and neither will the next change.
+    assert message.count("fine") == len(brief.SECTIONS) - 1, (
+        "the healthy sections did not render")
     assert "COULD NOT READ: mail failed (RuntimeError)" in message
     assert "abc123" not in message, "an exception message reached the brief"
     assert "abc123" in log.read_text(), "the message was not kept in the local log"
@@ -750,7 +788,10 @@ def test_an_optional_module_that_raises_at_import_costs_its_own_section_only(bri
     sources = brief.collect_all(NOW, log_path=tmp_path / "e.log")
     message, degraded = brief.build(NOW, sources)
     assert degraded
-    assert message.count("fine") == 4, "the healthy sections did not render"
+    # Every founder section is healthy here; only the optional module broke. Derived
+    # from the registry so the section set can change without this line being rewritten.
+    assert message.count("fine") == len(brief.SECTIONS), (
+        "the healthy sections did not render")
     assert "COULD NOT READ: broken failed (ImportError)" in message
     assert "import-time-token" not in message
 
@@ -791,8 +832,21 @@ def test_every_registered_section_is_guarded(brief, tmp_path, monkeypatch):
     monkeypatch.setattr(brief, "OPTIONAL_SECTIONS",
                         (("fake_section", "fake", "Fake section"),))
     monkeypatch.setattr(brief, "_optional_module", lambda stem: FakeMod)
+    # RENDERED keys only. The guard still wraps `owed` and `overnight` (they are in
+    # collect_all's fixed tuple and asserted below), but since 2026-09-03 they do not
+    # reach his message, so "COULD NOT READ: owed failed" cannot be looked for there.
     keys = [k for k, _ in brief.SECTIONS] + [k for _, k, _ in brief.OPTIONAL_SECTIONS]
-    assert len(keys) >= 5 and "fake" in keys
+    engineering = {k for k, _ in brief.ENGINEERING_SECTIONS}
+    for victim in engineering:
+        _all_ok(brief, monkeypatch)
+        def boom(*a, **k):
+            raise RuntimeError("secret=xyz")
+        monkeypatch.setattr(brief, f"collect_{victim}", boom)
+        sources = brief.collect_all(NOW, log_path=tmp_path / "e.log")
+        assert sources[victim][1] and "xyz" not in sources[victim][1], victim
+        assert brief.build(NOW, sources)[1], f"{victim} broke and the run was not degraded"
+    keys = [k for k in keys if k not in engineering]
+    assert "fake" in keys
     for victim in keys:
         _all_ok(brief, monkeypatch)
         if victim != "fake":
@@ -842,13 +896,16 @@ def test_an_optional_module_returning_none_is_off_not_a_section(brief, tmp_path,
     assert "board" in log.read_text() and "off" in log.read_text()
 
 
-def test_a_present_optional_module_renders_after_the_fixed_four(brief, tmp_path, monkeypatch):
+def test_a_present_optional_module_renders_after_the_fixed_sections(brief, tmp_path, monkeypatch):
     _all_ok(brief, monkeypatch)
 
     class Mod:
         @staticmethod
         def collect(now, sources):
-            assert sources["owed"] == (["fine"], None), "optional sections see the fixed four"
+            # `owed` is still COLLECTED after 2026-09-03, it just stopped being
+            # rendered, so an optional module still sees it. That is the whole reason
+            # the collectors were routed rather than deleted.
+            assert sources["owed"] == (["fine"], None), "optional sections see every collected section"
             return (["Widgetcorp"], None)
 
     monkeypatch.setattr(brief, "OPTIONAL_SECTIONS",
@@ -857,4 +914,5 @@ def test_a_present_optional_module_renders_after_the_fixed_four(brief, tmp_path,
     sources = brief.collect_all(NOW, log_path=tmp_path / "e.log")
     message, degraded = brief.build(NOW, sources)
     assert not degraded
-    assert message.index("Overnight") < message.index("Terms I do not know") < message.index("Widgetcorp")
+    last_fixed = brief.SECTIONS[-1][1]
+    assert message.index(last_fixed) < message.index("Terms I do not know") < message.index("Widgetcorp")

--- a/q-system/.q-system/tests/test_morning_brief.py
+++ b/q-system/.q-system/tests/test_morning_brief.py
@@ -1033,3 +1033,43 @@ def test_but_a_real_failure_still_exits_1(brief, capsys, monkeypatch):
     rc = mb.main(["--inbox-only"])
     out = capsys.readouterr().out
     assert "COULD NOT READ: gmail down" in out and rc == 1
+
+
+class TestNoCapUpstreamOfTheBoard:
+    """claude review 2026-09-04, major. A producer-side cap on mail trimmed threads
+    before `buckets()` saw them, so their board rows were archived inside a scope
+    that reported healthy -- an unanswered client thread vanished off his board,
+    pin and all.
+
+    Round 11 fixed this class inside the painter (`capped`: a cap is a write budget,
+    not a statement that the work is finished). A second cap upstream of the producer
+    routed around that rule. Display is capped by `_section`; data is not capped."""
+
+    def test_every_thread_the_model_returns_reaches_the_caller(self, brief):
+        n = 40
+        payload = json.dumps({"threads": [
+            {"id": f"t{i}", "from": f"p{i}@x.com", "subject": f"s{i}", "age_hours": i}
+            for i in range(n)]})
+        rows, error = brief.collect_mail(None, lambda p, t: (payload, None))
+        assert error is None
+        assert len(rows) == n, (
+            f"the producer dropped {n - len(rows)} threads; their board rows would be "
+            "archived inside a healthy scope")
+        assert len({r.key for r in rows}) == n
+
+    def test_no_synthetic_overflow_row_is_minted(self, brief):
+        """An overflow row needs a stable id and a scope. Inventing one puts a row on
+        the board that no thread corresponds to."""
+        payload = json.dumps({"threads": [
+            {"id": f"t{i}", "from": "p@x.com", "subject": "s", "age_hours": 1}
+            for i in range(30)]})
+        rows, _ = brief.collect_mail(None, lambda p, t: (payload, None))
+        assert not any("more unanswered" in str(r) for r in rows)
+        assert all(getattr(r, "key", "").startswith("mail:t") for r in rows)
+
+    def test_the_SECTION_still_caps_what_he_reads(self, brief):
+        """The Slack message stays short. That was the cap's only legitimate job."""
+        rows = [brief.Row(f"line {i}", f"mail:t{i}") for i in range(40)]
+        out = brief._section("Mail", rows, None)
+        assert len(out) == brief.MAX_ROWS + 2, out[:3]
+        assert "and 25 more" in out[-1]

--- a/q-system/.q-system/tests/test_morning_brief.py
+++ b/q-system/.q-system/tests/test_morning_brief.py
@@ -971,3 +971,35 @@ def test_no_hourly_slot_fires_before_the_card_it_mirrors():
         f"slots {early} fire before the state card exists (the brief waits until "
         f"{after_the_card // 60:02d}:{after_the_card % 60:02d}); each one is a wasted "
         "model call and an exit 1 the watchdog reads as a broken hour")
+
+
+def test_the_deadman_alarm_names_no_clock_time():
+    """Codex round 9 (minor): the alarm said "the 07:00 job did not run" while launchd
+    ran it at 07:40. That was the THIRD copy of the schedule, after CLAUDE.md and a
+    comment in the plist, and it is the copy that reaches the founder.
+
+    The fix is to carry no hour rather than to sync a third one. A number that only
+    has to agree with two other places is a number that eventually will not.
+    """
+    import datetime as dt
+    import importlib.util
+    import json
+    import pathlib
+    import re
+    import tempfile
+    path = (pathlib.Path(__file__).resolve().parents[1] / "scripts"
+            / "morning-brief-deadman.py")
+    spec = importlib.util.spec_from_file_location("deadman", path)
+    deadman = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(deadman)
+
+    # DRIVE the alarm rather than grep its source: the first cut of this test scanned
+    # every double-quoted string and caught the module docstring's narrative, which
+    # says nothing to the founder.
+    with tempfile.TemporaryDirectory() as tmp:
+        receipt = pathlib.Path(tmp) / "receipt.json"
+        receipt.write_text(json.dumps({"date": "2026-09-02", "delivered": True}))
+        ok, reason = deadman.check(dt.datetime(2026, 9, 3, 9, 30), receipt_path=receipt)
+    assert ok is False
+    assert not re.search(r"\b\d{1,2}:\d{2}\b", reason), (
+        f"the alarm names a wall-clock time again: {reason!r}")

--- a/q-system/.q-system/tests/test_morning_brief.py
+++ b/q-system/.q-system/tests/test_morning_brief.py
@@ -916,3 +916,24 @@ def test_a_present_optional_module_renders_after_the_fixed_sections(brief, tmp_p
     assert not degraded
     last_fixed = brief.SECTIONS[-1][1]
     assert message.index(last_fixed) < message.index("Terms I do not know") < message.index("Widgetcorp")
+
+
+def test_the_documented_hour_is_the_one_launchd_runs():
+    """Codex round 6 (minor): CLAUDE.md said 07:00 while the plist ran 07:40.
+
+    Held by a check rather than by care, because the two live in different files and
+    the only thing that had been keeping them together was somebody remembering. The
+    plist is the record: it is what actually fires.
+    """
+    import pathlib
+    import plistlib
+    import re
+    root = pathlib.Path(__file__).resolve().parents[3]
+    plist = root / "q-system" / ".q-system" / "scripts" / "com.kipi.morning-brief.plist"
+    when = plistlib.loads(plist.read_bytes())["StartCalendarInterval"]
+    runs_at = "%02d:%02d" % (when["Hour"], when["Minute"])
+    docs = (root / "CLAUDE.md").read_text(encoding="utf-8")
+    stated = re.search(r"Runs itself at ([0-9:]+) \(`com\.kipi\.morning-brief`\)", docs)
+    assert stated, "CLAUDE.md no longer states the brief's schedule at all"
+    assert stated.group(1) == runs_at, (
+        f"CLAUDE.md says {stated.group(1)}, launchd runs {runs_at}")

--- a/q-system/.q-system/tests/test_off_switches.py
+++ b/q-system/.q-system/tests/test_off_switches.py
@@ -185,6 +185,11 @@ def test_every_new_script_declares_its_off_switch_in_its_docstring():
     registered = _registered_scripts()
     expectations = {
         "notion_board.py": "OFF switch",
+        # The consulting morning board, 2026-09-03. Each names a REAL switch in its
+        # docstring: no consulting instance, no GroupMe token, no Notion token.
+        "consulting_board.py": "OFF switch",
+        "groupme_inbox.py": "OFF switch",
+        "board_rows.py": "OFF switch",
         "unknown_terms.py": "never pulls anything",
         "weekly-improve.py": "trigger is weekly-improve.sh",
         "friction-note.sh": "instance-owned",

--- a/q-system/canonical/decisions.md
+++ b/q-system/canonical/decisions.md
@@ -256,6 +256,12 @@ Monthly audit (1st of month): count decisions by origin tag. If >60% are rubber-
   sections: today's calendar, mail needing an answer, owed today, overnight jobs.
   No HTML, no action cards, no scores. Its freshness is watched by a SEPARATE
   launchd job, `com.kipi.morning-brief-deadman`, on a different trigger class.
+- **Amended 2026-09-03 [SYSTEM-INFERRED]:** the schedule moved from 07:00 to 07:40
+  local. The brief now MIRRORS the consulting state card, which is written at 07:30 by
+  `io.askconsulting.ask-crm-state-card`; at 07:00 it mirrored yesterday. A second job
+  at 07:40 was the alternative and was rejected, because two jobs racing one board is
+  how two writers start. The plist is the record; `test_the_documented_hour_is_the_one
+  _launchd_runs` holds the docs to it.
 - **Reason:** Founder-directed 2026-08-30: fully automated, no HTML page, one
   Slack message each morning. Measured the same day: the pipeline's last artifact
   is `schedule-data-2026-04-04.json`, 148 days old, and `find . -name


### PR DESCRIPTION
Founder-directed 2026-09-03: *"I'm not looking for this to be a build dashboard, but a consulting dashboard"*, then *"copy it but everyting needs to be actually connected fully and is automated so its not done by hand"*.

## The shape: MIRROR, never a second derivation

The consulting instance's `state_card.py` already computes his book at 07:30. `consulting_board.py` READS that output. It never opens the client registry (162 rows, ~150 cold prospects) and never recomputes a health verdict. The rejected alternative was a collector that read the registry itself; two things deriving one truth is how the v1 Notion CRM died.

## What moved

- `SECTIONS` drops `owed` (Linear) and `overnight` (launchd). Still collected, still guarded, still mark the run degraded, now routed to Sana's queue via `engineering_route.py`, degraded-only.
- `consulting_board.py` -- his book plus the one GTM move, from output files only.
- `groupme_inbox.py` -- conversations waiting on him, groups AND DMs.
- `board_rows.py` -- writes ROWS into the Kipi backlog database. The board's three sections are FILTERED VIEWS of it, measured live, so the old bullet writer was invisible to them. His drag always wins: `Bucket` is written on create only.
- `notion_board.py` unregistered; its bullets rendered under the new rows on the first live run.
- The brief moves 07:00 to 07:40, after the 07:30 card. At 07:00 it mirrored yesterday.

## Five defects found by running it, not reading it

- `--dry-run` created 12 live board rows while printing "nothing sent"
- dropping the two sections also dropped them from `degraded`, which the deadman reads
- the card parser silently dropped the rank-1 row (it alone carries a `*THE MOVE*` prefix)
- GroupMe's `/groups` preview carries no `user_id`, so the "is it his?" test dropped all four groups and reported a clean zero on a morning three were live
- the GTM queue's `rows` is a dict, not a list

## Three existing gates fired and none is weakened

`test_no_source_file_calls_slack_notify` moved the routing into its own module. `test_off_switches` made each new script carry a real switch. `client-name-guard` caught real client names in a test fixture; this repo is public, and the fixture now uses invented names.

Staleness is an error, never a quiet mirror: a card that is not today's is withheld and named.

## After merge

`bash q-system/.q-system/scripts/install-plist.sh com.kipi.morning-brief` to pick up 07:40. The plist is a TEMPLATE and must be rendered by that installer, never copied (a `cp` during this work put a literal `__KIPI_REPO__` into the installed job).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Wgue8qvCjz3Nynq2eUxfSS