### PR TITLE
fix(review-gate): an empty findings block cannot approve, and a bold prose verdict counts (ASK-1227)

### DIFF
--- a/q-system/.q-system/scripts/pr-review-agent.sh
+++ b/q-system/.q-system/scripts/pr-review-agent.sh
@@ -1096,11 +1096,18 @@ REVIEWED_BY="$CODEX_MODEL"
 # The record path comes from the ONE resolver (repo-slug-lib.sh), passed in as
 # argv 16 rather than rebuilt in python -- a second place that knows the naming
 # rule is a second writer, which is the defect class this repo keeps finding.
-python3 - "$PR" "$ISSUE" "$VERDICT" "$REVIEW" "$(TS)" "$STATED_VERDICT" "$DERIVED_VERDICT" "$ROUND" "$HEAD_SHA" "$VERDICT_DIR" "$ENGINE" "$INVOKER" "$REVIEW_USABLE" "$REVIEWED_BY" "$DEGRADED" "$(verdict_record_write_path "$VERDICT_DIR" "$REVIEW_SLUG" "$PR")" <<'PY'
+python3 - "$PR" "$ISSUE" "$VERDICT" "$REVIEW" "$(TS)" "$STATED_VERDICT" "$DERIVED_VERDICT" "$ROUND" "$HEAD_SHA" "$VERDICT_DIR" "$ENGINE" "$INVOKER" "$REVIEW_USABLE" "$REVIEWED_BY" "$DEGRADED" "$(verdict_record_write_path "$VERDICT_DIR" "$REVIEW_SLUG" "$PR")" "${STATUS_CONTEXT:-}" "${PRIMARY_ENGINE:-}" <<'PY'
 import json, sys
 (pr, issue, verdict, review, ts, stated, derived, rnd, head_sha, verdict_dir,
  engine, invoker, usable, reviewed_by, degraded) = sys.argv[1:16]
 out = sys.argv[16]
+# WHICH SLOT THIS RECORD ANSWERED FOR (ASK-1227). Both are `${VAR:-}` at the call
+# site on purpose: test-review-degraded-provenance.sh extracts this writer by awk
+# range and runs it in a BARE SUBSHELL, where an unguarded new variable would trip
+# `set -u`, kill the writer, and make the suite report a broken test instead of
+# the defect it exists to catch.
+status_context = sys.argv[17] if len(sys.argv) > 17 else ""
+primary_engine = sys.argv[18] if len(sys.argv) > 18 else ""
 json.dump({"pr": int(pr), "issue": issue, "verdict": verdict,
            "stated": stated, "derived": derived,
            "source": "findings" if derived else "prose",
@@ -1116,6 +1123,17 @@ json.dump({"pr": int(pr), "issue": issue, "verdict": verdict,
            # would call every phantom review usable -- the exact inversion this
            # key exists to prevent.
            "usable": usable == "1",
+           # THE SLOT IS NOW PART OF THE RECORD (ASK-1227). Slot placement is a
+           # function of KIPI_REVIEW_PRIMARY_ENGINE, an environment variable, so
+           # two runs of the SAME command line could write two different slots
+           # and nothing in the record said which or why. Measured on PR #79
+           # 2026-09-03: the 12:49 run landed in the primary slot and the 13:15
+           # run in the advisory one, and the records were indistinguishable.
+           # Recording the context the run answered for, and the primary engine
+           # in effect, makes that auditable from the artifact instead of from a
+           # shell history nobody kept.
+           "status_context": status_context,
+           "primary_engine": primary_engine,
            "round": int(rnd), "review": review, "head_sha": head_sha,
            "ts": ts}, open(out, "w"), indent=2)
 PY

--- a/q-system/.q-system/scripts/pr-review-agent.sh
+++ b/q-system/.q-system/scripts/pr-review-agent.sh
@@ -840,12 +840,32 @@ END FINDINGS"
 # `codex exec` READS STDIN and hangs without a redirect (observed: "Reading
 # additional input from stdin..."), and outside a trusted directory it refuses
 # with "Not inside a trusted directory". Both are load-bearing, not decoration.
+#
+# `-o <file>` IS THE VERDICT BOUNDARY (ASK-1227 round 5). `codex exec` writes its
+# WHOLE agent session to stdout -- the echoed prompt, every tool call, every diff
+# and file it read -- and five review rounds in a row found a new region of that
+# stream where a stray verdict token fabricated a verdict nobody gave. Codex's own
+# fix-first on round 5: "replace whole-session Markdown inference with a
+# deterministic boundary for the reviewer's final response." This is that boundary.
+# `-o` writes ONLY the agent's final message, so pr-verdict-lib.sh parses the
+# reviewer's answer instead of inferring where it starts. The full session still
+# lands in $2 and is still what gets kept for the record.
+#
+# TRUNCATED BEFORE EVERY RUN, INCLUDING THE CLAUDE ONE. The sidecar is named after
+# the destination file, and the DEGRADED path reuses that same destination for the
+# Opus fallback after codex failed. Without this, a partial sidecar from the dead
+# codex attempt would be read as the FALLBACK's final message -- one engine's
+# verdict recorded against another engine's review, which is the false-provenance
+# shape aimed at the gating reader. `:` truncates rather than deletes: the readers
+# gate on `-s`, so a zero-byte sidecar already means "no answer here, use the
+# session", and claude has no `-o` equivalent to fill it.
 run_engine() {   # run_engine <claude|codex> <destination-file>
+  : > "$2.last" 2>/dev/null || true
   case "$1" in
     claude) run_bounded "$TIMEOUT_SECONDS" bash -c \
               "cd '$REVIEW_ROOT' && claude -p --model '$CLAUDE_MODEL' \"\$1\" </dev/null > '$2' 2>&1" _ "$PROMPT" ;;
     codex)  run_bounded "$TIMEOUT_SECONDS" bash -c \
-              "codex exec --ignore-user-config --skip-git-repo-check --model '$CODEX_MODEL' -C '$REVIEW_ROOT' \"\$1\" </dev/null > '$2' 2>&1" _ "$PROMPT" ;;
+              "codex exec --ignore-user-config --skip-git-repo-check --model '$CODEX_MODEL' -C '$REVIEW_ROOT' -o '$2.last' \"\$1\" </dev/null > '$2' 2>&1" _ "$PROMPT" ;;
   esac
 }
 

--- a/q-system/.q-system/scripts/pr-verdict-lib.sh
+++ b/q-system/.q-system/scripts/pr-verdict-lib.sh
@@ -36,7 +36,11 @@ _strip_quoted_material() {
     /^[[:space:]]*(```|~~~)/ { fence = !fence; next }
     fence { next }
     /^[[:space:]]*[+>-]/     { next }
-    /^    /                  { next }
+    # An indented code block is four spaces OR ONE TAB. The first cut of this
+    # filter matched only the spaces, and codex round 3 on PR #297 showed a
+    # tab-indented quoted `VERDICT: BLOCK` sailing through to fabricate a BLOCK --
+    # the same defect this filter exists to stop, one indent character over.
+    /^(    |\t)/             { next }
     { print }
   ' 2>/dev/null
 }

--- a/q-system/.q-system/scripts/pr-verdict-lib.sh
+++ b/q-system/.q-system/scripts/pr-verdict-lib.sh
@@ -96,6 +96,31 @@ extract_verdict() {
       line = $0
       gsub(/BLOCKERS?/, "", line)
     }
+    # FALLBACK, USED ONLY WHEN NO `VERDICT`-MARKED LINE STATED ONE (ASK-1227).
+    # A reviewer that did the whole job and stated its call in bold prose --
+    # never writing the literal word VERDICT -- used to score identical to one
+    # that never ran. Measured on PR #79 2026-09-03 12:49: a 6-minute review
+    # closing "three minor findings, **APPROVE WITH NITS**" recorded stated ""
+    # and posted a FAILURE.
+    #
+    # EMPHASIS IS THE WHOLE DISCRIMINATOR, and it is not a style preference. The
+    # reviewer prompt is echoed verbatim into every codex transcript and carries
+    # the grading ladder as plain text ("only minor/nit findings => APPROVE WITH
+    # NITS"), so a fallback matching BARE tokens would read a verdict straight
+    # out of that ladder in the prompt. Measured across the 80 recorded reviews on
+    # this machine 2026-09-03: zero carry a BOLD verdict token in their prompt
+    # region, and the one bold hit was the real review above. Widening this to
+    # bare tokens needs a measured review that motivates it.
+    #
+    # LAST ONE WINS, matching findings_block taking the LAST complete block: a
+    # review that weighs "**REQUEST CHANGES**" and settles on "**APPROVE WITH
+    # NITS**" means the one it settled on.
+    {
+      if (line ~ /\*\*APPROVE WITH NITS\*\*/)    bold = "APPROVE WITH NITS"
+      else if (line ~ /\*\*REQUEST CHANGES\*\*/) bold = "REQUEST CHANGES"
+      else if (line ~ /\*\*APPROVE\*\*/)         bold = "APPROVE"
+      else if (line ~ /\*\*BLOCK\*\*/)           bold = "BLOCK"
+    }
     # Under a bare heading the FIRST non-blank line decides, and it decides either
     # way: prose there is not a verdict, it is a heading with no statement under
     # it. Continuing to scan would walk into the next paragraph.
@@ -114,7 +139,10 @@ extract_verdict() {
       # Bare marker: nothing but punctuation/emphasis left on the line.
       if (rest ~ /^[[:space:]*_:#-]*$/) awaiting = 1
     }
-    END { if (found != "") printf "%s", found }
+    END {
+      if (found != "")     printf "%s", found
+      else if (bold != "") printf "%s", bold
+    }
   ' "$f" 2>/dev/null
 }
 
@@ -351,6 +379,30 @@ verdict_rank() {   # verdict_rank <verdict>
 
 resolve_verdict() {   # resolve_verdict <stated> <derived>
   local stated="${1:-}" derived="${2:-}" sr dr
+  # AN EMPTY-BLOCK APPROVE MAY NOT STAND ALONE (ASK-1227). APPROVE is the ONLY
+  # verdict the ladder can derive from a block with zero severity rows, so
+  # derived == APPROVE is exactly the statement "this block was empty" -- and
+  # "reviewed, found nothing" is byte-identical to "never started" INSIDE the
+  # block. has_complete_findings_block says so in its own header and points here
+  # for the fix; this is that fix, and until now it was a comment with no code.
+  #
+  # THE SCAR, 2026-09-03, PR #78. codex could not reach api.github.com, read no
+  # diff at all, and said so in full: "VERDICT: NOT ISSUED. No evidence-based
+  # verdict is possible.", then closed a structurally perfect EMPTY block.
+  # "NOT ISSUED" is not one of the four tokens, so extract_verdict returned
+  # empty, the empty derivation stood alone, kipi/reviewer-approved went green,
+  # and a worker merged on a review that had read nothing.
+  #
+  # So the empty derivation now needs corroboration from OUTSIDE the block: the
+  # reviewer's own stated verdict. An unrecognised stated verdict (rank 9) counts
+  # as none, which is what makes an explicit refusal fail closed rather than read
+  # as silence. Corroborated empty blocks are untouched -- a round 2 that refutes
+  # every round-1 finding states APPROVE and still lands, which the controls in
+  # test-severity-floor.sh pin by name.
+  if [ "$derived" = "APPROVE" ] && [ "$(verdict_rank "$stated")" = "9" ]; then
+    printf ''
+    return 0
+  fi
   [ -n "$derived" ] || { printf '%s' "$stated"; return 0; }
   [ -n "$stated" ]  || { printf '%s' "$derived"; return 0; }
   sr="$(verdict_rank "$stated")"

--- a/q-system/.q-system/scripts/pr-verdict-lib.sh
+++ b/q-system/.q-system/scripts/pr-verdict-lib.sh
@@ -12,6 +12,44 @@
 # The worker only falls back to re-extracting from the review .md for PRs
 # reviewed before the record existed.
 
+# _final_message <review-file>
+# The path of the file holding ONLY the reviewer final message, or nothing.
+#
+# THE BOUNDARY, INSTEAD OF A FIFTH REGION RULE (ASK-1227 round 5). `codex exec`
+# writes its whole agent session to stdout -- the echoed prompt, every tool call,
+# every diff and file it read -- and the four rounds before this one each excluded
+# the one region that had just fabricated a verdict, then lost to the next. Round
+# 5 found two more at once on this branch: an unmatched fence anywhere in the
+# session hides the closing verdict (see _reviewer_prose), and `rg`-shaped tool
+# output `path:line:VERDICT: BLOCK` is statement-shaped prose (see extract_verdict).
+#
+# Both are the same defect: no textual rule separates the agent own answer from
+# the material it quoted, because the session file does not mark where the answer
+# begins. `codex exec -o FILE` does -- it writes ONLY the final agent message.
+# pr-review-agent.sh passes `-o "$REVIEW.last"`, so from this commit forward the
+# reader parses the reviewer answer instead of inferring it.
+#
+# ABSENT MEANS LEGACY, NOT BROKEN. All 991 records on disk at this commit predate
+# the flag and have no sidecar, and the claude fallback engine has no equivalent
+# flag, so the session file stays the source when the sidecar is missing or empty.
+# `-s`, not `-e`: a killed run can leave a zero-byte sidecar, and an empty answer
+# must fall back rather than read as a review that said nothing.
+_final_message() {
+  local last="${1:-}.last"
+  [ -s "$last" ] && printf '%s' "$last"
+  return 0
+}
+
+# _verdict_source <review-file>
+# The file the DELIMITED readers parse: the final message when there is one, the
+# whole session otherwise. Delimited, because `FINDINGS:` / `END FINDINGS` mark
+# their own region -- a findings block needs no positional window and never got one.
+_verdict_source() {
+  local m; m="$(_final_message "${1:-}")"
+  [ -n "$m" ] && { printf '%s' "$m"; return 0; }
+  printf '%s' "${1:-}"
+}
+
 # _reviewer_prose
 # stdin -> stdout, emitting ONLY lines that can be the reviewer's own prose
 # conclusion. Everything else is dropped.
@@ -59,17 +97,82 @@
 # takes, and reversible by a human. Measured across all 81 recorded transcripts in
 # ~/.config/kipi/pr-reviews: this filter changes the extracted verdict on none of
 # them, while flipping every reproducer above.
+#
+# THE FENCE RULE APPLIES ONLY WHEN ITS STATE IS WELL-FORMED (ASK-1227 round 5,
+# first major). Fence parity is the ONLY rule here that carries state between
+# lines; every other rule decides a line on its own bytes. That makes it the only
+# one an upstream oddity can knock out of phase, and an out-of-phase parity does
+# not degrade, it INVERTS: every line after the stray fence is judged backwards.
+#
+# It landed both ways on real records:
+#
+#   pr-190  23 lines match this pattern, an ODD count, so parity leaves the
+#           closing `**VERDICT: APPROVE**` inside a phantom fence -> read as
+#           quoted, verdict lost, and a required status stuck red on an approval.
+#   pr-159  17 matches in the last 250 lines, so the SAME closing verdict is
+#           visible whole-file and hidden window-scoped.
+#
+# Most of those lines are not fences at all. They are compiler and shellcheck
+# squiggles (`~~~~~~~~^^^^^^`) in tool output that merely START with three tildes,
+# and no tightening of the pattern fixes the class -- an agent session can quote
+# anything, including half of a fenced block.
+#
+# So the rule states its own precondition instead of assuming it. An EVEN number
+# of fence lines in the region means the fences close and parity is sound, so it
+# is tracked. An ODD number is proof the region is not fence-balanced, parity
+# would be a coin flip, and the rule stands down to the stateless filters, which
+# cannot be inverted by anything upstream.
+#
+# WHY STANDING DOWN IS THE SAFE SIDE. On an unbalanced region a fenced decoy token
+# does become visible. It cannot manufacture a verdict on its own: extract_verdict
+# needs a statement-shaped line whose marker LEADS, and the tail fallback takes the
+# LAST bold token, which is the reviewer's own conclusion because a review answers
+# after the material it read. Measured over all 991 recorded transcripts, no
+# resolved verdict moves toward approval. The inverted-parity bug, by contrast,
+# silently destroyed the verdict on 8 of them.
+#
+# TWO PASSES, because the count has to be known before the first line is judged.
+# The region is a bounded window or one final message, so buffering it is cheap.
 _reviewer_prose() {
   awk '
-    /^[[:space:]]*(```|~~~)/   { fence = !fence; next }
-    fence                      { next }
-    /^[[:space:]]*[+>-]/       { next }
-    # Indented code is four spaces or one tab; a diff CONTEXT line is one space.
-    /^(    |\t| )/             { next }
-    # A pipe means a row or a table. Neither is a sentence.
-    /[|]/                      { next }
-    { print }
+    { buf[NR] = $0; if ($0 ~ /^[[:space:]]*(```|~~~)/) nfence++ }
+    END {
+      # Odd => the region is not fence-balanced => parity is meaningless here.
+      tracked = (nfence % 2 == 0)
+      for (i = 1; i <= NR; i++) {
+        line = buf[i]
+        if (tracked && line ~ /^[[:space:]]*(```|~~~)/) { fence = !fence; continue }
+        if (tracked && fence)             continue
+        if (line ~ /^[[:space:]]*[+>-]/)  continue
+        # Indented code is four spaces or one tab; a diff CONTEXT line is one space.
+        if (line ~ /^(    |\t| )/)        continue
+        # A pipe means a row or a table. Neither is a sentence.
+        if (line ~ /[|]/)                 continue
+        print line
+      }
+    }
   ' 2>/dev/null
+}
+
+# _reviewer_prose_of <review-file>
+# THE ONE ENTRY POINT for both prose readers: pick the region, then filter it.
+#
+# ONE FUNCTION BECAUSE TWO WAS THE BUG. extract_verdict scanned the WHOLE file
+# while _bold_verdict_in_tail scanned the last 250 lines, so the two readers
+# disagreed about how much text existed -- and this file own header already names
+# that hazard: "Which of the two readers sees a quoted token first must not change
+# the answer, so both read the same filtered text." Now there is one region, one
+# filter, one place to change either.
+#
+# The final message is passed WHOLE; a legacy session gets the
+# measured tail window, which review_comment_body records the same way ("the
+# reviewer actual message is the last ~250 lines") and is the only boundary a
+# record with no sidecar offers.
+_reviewer_prose_of() {
+  local f="${1:-}" m
+  m="$(_final_message "$f")"
+  if [ -n "$m" ]; then _reviewer_prose <"$m" 2>/dev/null; return 0; fi
+  tail -n "${KIPI_VERDICT_TAIL_LINES:-250}" "$f" 2>/dev/null | _reviewer_prose partial
 }
 
 # extract_verdict <review-file>
@@ -155,7 +258,7 @@ _reviewer_prose() {
 extract_verdict() {
   local f="$1" found
   [ -s "$f" ] || return 0
-  found="$(_reviewer_prose <"$f" 2>/dev/null | awk '
+  found="$(_reviewer_prose_of "$f" | awk '
     function leading_token(s,   t) {
       sub(/^[[:space:]*_]+/, "", s)
       if (s ~ /^APPROVE WITH NITS/) return "APPROVE WITH NITS"
@@ -178,7 +281,18 @@ extract_verdict() {
       if (t != "") found = t
       next
     }
-    line ~ /VERDICT/ {
+    # THE MARKER LEADS THE SENTENCE, the mirror of the token rule below it
+    # (ASK-1227 round 5, second major). The token must lead what FOLLOWS
+    # `VERDICT:`; this says the marker must lead what PRECEDES it, modulo
+    # emphasis and heading punctuation. Without it the `^.*VERDICT` strip below
+    # is greedy, so `q-system/check.sh:42:VERDICT: BLOCK` -- the literal shape of
+    # the `rg` output a reviewer pastes into a real transcript -- parses as a
+    # stated BLOCK and outranks the closing approval the reviewer wrote. Not a
+    # fifth denylist entry: nothing here names rg, tool output, or a path. It is
+    # the existing shape test applied to the other side of the marker. Measured
+    # across all 991 recorded transcripts: it changes the extracted verdict on
+    # none of them, while flipping the reproducer above.
+    line ~ /^[[:space:]]*[*_#[:space:]]*VERDICT/ {
       rest = line
       sub(/^.*VERDICT[*_]*[[:space:]]*:?[[:space:]]*/, "", rest)
       t = leading_token(rest)
@@ -227,7 +341,7 @@ _bold_verdict_in_tail() {
   # (review_comment_body: "the reviewer's actual message is the last ~250 lines"),
   # so filtering before slicing would widen the window by however much quoted
   # material the stream happened to carry.
-  tail -n "${KIPI_VERDICT_TAIL_LINES:-250}" "$f" 2>/dev/null | _reviewer_prose | awk '
+  _reviewer_prose_of "$f" | awk '
     {
       line = $0
       gsub(/BLOCKERS?/, "", line)
@@ -316,6 +430,11 @@ _bold_verdict_in_tail() {
 findings_block() {
   local f="$1"
   [ -s "$f" ] || return 0
+  # The sidecar when there is one: the prompt puts the block LAST in the answer,
+  # so the final message carries it, and reading it there makes the echoed
+  # template and every quoted prior-round block structurally unreachable rather
+  # than merely skipped.
+  f="$(_verdict_source "$f")"
   awk '
     /^FINDINGS:/            { buf = $0 "\n"; open = 1; rows = 0; sev = 0; next }
     open && /^END FINDINGS/ { if (rows == 0 || sev > 0) last = buf $0 "\n"
@@ -337,7 +456,7 @@ findings_block() {
 # answer that never started. Internal to review_declined_to_start.
 _text_after_last_findings_block() {
   awk '/^END FINDINGS/ { tail = ""; next } { tail = tail $0 "\n" }
-       END { printf "%s", tail }' "${1:-}" 2>/dev/null
+       END { printf "%s", tail }' "$(_verdict_source "${1:-}")" 2>/dev/null
 }
 
 # review_declined_to_start <review-file>

--- a/q-system/.q-system/scripts/pr-verdict-lib.sh
+++ b/q-system/.q-system/scripts/pr-verdict-lib.sh
@@ -12,35 +12,62 @@
 # The worker only falls back to re-extracting from the review .md for PRs
 # reviewed before the record existed.
 
-# _strip_quoted_material
-# stdin -> stdout, dropping every line that is material the reviewer READ rather
-# than prose the reviewer WROTE: fenced blocks, diff +/- lines, blockquotes, and
-# 4-space-indented code.
+# _reviewer_prose
+# stdin -> stdout, emitting ONLY lines that can be the reviewer's own prose
+# conclusion. Everything else is dropped.
 #
-# ONE FILTER, TWO CALLERS (ASK-1227 round 2). A `codex exec` stream is not a
-# review, it is the whole agent session, so it replays the PR diff and every file
-# the agent opened. A verdict token inside that material was written by the author
-# under review, never by the reviewer. This shipped on the tail fallback alone and
-# left the primary reader matching inside quoted diff lines; see extract_verdict's
-# header for the reproducer that found it.
+# AN ALLOWLIST, BECAUSE THE DENYLIST LOST THREE ROUNDS RUNNING (ASK-1227). One
+# `codex exec` stream is the whole agent session, and a verdict token can appear in
+# it for many reasons that are not the reviewer concluding anything. Each round we
+# excluded the region that had just burned us and the next round found another:
+#
+#   round 1  the bold fallback scanned the ENTIRE transcript      -> tail-scoped it
+#   round 2  the primary reader matched inside quoted diff lines  -> excluded quotes
+#   round 3  a TAB-indented quoted line survived the space rule   -> added the tab
+#   round 4  a FINDINGS row's claim text set the verdict          -> you are here
+#
+# Round 4 demonstrated itself live: the reviewer wrote a minor whose claim text
+# contained the words `VERDICT: BLOCK`, our reader took it over the reviewer's own
+# stated `**REQUEST CHANGES**`, and the gate posted BLOCK on cbc4b751. Naming a
+# fifth region to exclude would buy round five, so the question is inverted here.
+# Instead of listing what a verdict is NOT written in, this emits only what a prose
+# conclusion CAN be written in, and the reader sees nothing else.
+#
+# THE THREE STRUCTURAL DISCRIMINATORS, none of them positional:
+#
+#   1. QUOTED MATERIAL is what the reviewer READ. Fenced blocks, blockquotes, diff
+#      +/- lines, diff CONTEXT lines (one leading space), and indented code (four
+#      spaces or one tab). A token there was written by the author under review.
+#   2. A ROW IS NEVER A SENTENCE. Findings rows are pipe-delimited by contract
+#      (`severity|claim|file:line`), so any surviving line containing `|` is a row
+#      or a table, never the sentence a reviewer states a verdict in.
+#
+# WHY THE ROW RULE AND NOT A FINDINGS-BLOCK REGION SKIP. Skipping `^FINDINGS:` ..
+# `^END FINDINGS` here was written first and reverted: it makes this a SECOND piece
+# of code that recognises the block delimiter, and `test-findings-block-reader.sh`
+# case 6 refuses exactly that ("expected exactly ONE findings-block extractor in
+# the lib, found 2"). That guard is correct and not an inconvenience -- two readers
+# of one delimiter drifting apart is the defect class this whole lib exists to
+# close. The row rule needs no delimiter at all, and it is strictly the stronger of
+# the two anyway: it also catches a row that leaked OUTSIDE its block, which is how
+# a truncated or echoed block arrives.
 #
 # THE `-` RULE COSTS A MARKDOWN BULLET, AND THAT IS THE CHEAPER SIDE. `- ` opens a
 # list item as well as a diff removal, and this cannot tell them apart. So a
 # reviewer writing its verdict as `- **VERDICT:** APPROVE` reads unstated, which
 # posts failure and HOLDS the PR -- the same safe direction the rest of this file
-# takes, and reversible by a human. Measured before shipping across all 81 recorded
-# transcripts in ~/.config/kipi/pr-reviews: filtering changes the extracted verdict
-# on exactly the reproducer's shape and on no real review.
-_strip_quoted_material() {
+# takes, and reversible by a human. Measured across all 81 recorded transcripts in
+# ~/.config/kipi/pr-reviews: this filter changes the extracted verdict on none of
+# them, while flipping every reproducer above.
+_reviewer_prose() {
   awk '
-    /^[[:space:]]*(```|~~~)/ { fence = !fence; next }
-    fence { next }
-    /^[[:space:]]*[+>-]/     { next }
-    # An indented code block is four spaces OR ONE TAB. The first cut of this
-    # filter matched only the spaces, and codex round 3 on PR #297 showed a
-    # tab-indented quoted `VERDICT: BLOCK` sailing through to fabricate a BLOCK --
-    # the same defect this filter exists to stop, one indent character over.
-    /^(    |\t)/             { next }
+    /^[[:space:]]*(```|~~~)/   { fence = !fence; next }
+    fence                      { next }
+    /^[[:space:]]*[+>-]/       { next }
+    # Indented code is four spaces or one tab; a diff CONTEXT line is one space.
+    /^(    |\t| )/             { next }
+    # A pipe means a row or a table. Neither is a sentence.
+    /[|]/                      { next }
     { print }
   ' 2>/dev/null
 }
@@ -128,7 +155,7 @@ _strip_quoted_material() {
 extract_verdict() {
   local f="$1" found
   [ -s "$f" ] || return 0
-  found="$(_strip_quoted_material <"$f" 2>/dev/null | awk '
+  found="$(_reviewer_prose <"$f" 2>/dev/null | awk '
     function leading_token(s,   t) {
       sub(/^[[:space:]*_]+/, "", s)
       if (s ~ /^APPROVE WITH NITS/) return "APPROVE WITH NITS"
@@ -200,7 +227,7 @@ _bold_verdict_in_tail() {
   # (review_comment_body: "the reviewer's actual message is the last ~250 lines"),
   # so filtering before slicing would widen the window by however much quoted
   # material the stream happened to carry.
-  tail -n "${KIPI_VERDICT_TAIL_LINES:-250}" "$f" 2>/dev/null | _strip_quoted_material | awk '
+  tail -n "${KIPI_VERDICT_TAIL_LINES:-250}" "$f" 2>/dev/null | _reviewer_prose | awk '
     {
       line = $0
       gsub(/BLOCKERS?/, "", line)

--- a/q-system/.q-system/scripts/pr-verdict-lib.sh
+++ b/q-system/.q-system/scripts/pr-verdict-lib.sh
@@ -12,6 +12,35 @@
 # The worker only falls back to re-extracting from the review .md for PRs
 # reviewed before the record existed.
 
+# _strip_quoted_material
+# stdin -> stdout, dropping every line that is material the reviewer READ rather
+# than prose the reviewer WROTE: fenced blocks, diff +/- lines, blockquotes, and
+# 4-space-indented code.
+#
+# ONE FILTER, TWO CALLERS (ASK-1227 round 2). A `codex exec` stream is not a
+# review, it is the whole agent session, so it replays the PR diff and every file
+# the agent opened. A verdict token inside that material was written by the author
+# under review, never by the reviewer. This shipped on the tail fallback alone and
+# left the primary reader matching inside quoted diff lines; see extract_verdict's
+# header for the reproducer that found it.
+#
+# THE `-` RULE COSTS A MARKDOWN BULLET, AND THAT IS THE CHEAPER SIDE. `- ` opens a
+# list item as well as a diff removal, and this cannot tell them apart. So a
+# reviewer writing its verdict as `- **VERDICT:** APPROVE` reads unstated, which
+# posts failure and HOLDS the PR -- the same safe direction the rest of this file
+# takes, and reversible by a human. Measured before shipping across all 81 recorded
+# transcripts in ~/.config/kipi/pr-reviews: filtering changes the extracted verdict
+# on exactly the reproducer's shape and on no real review.
+_strip_quoted_material() {
+  awk '
+    /^[[:space:]]*(```|~~~)/ { fence = !fence; next }
+    fence { next }
+    /^[[:space:]]*[+>-]/     { next }
+    /^    /                  { next }
+    { print }
+  ' 2>/dev/null
+}
+
 # extract_verdict <review-file>
 # Prints APPROVE | APPROVE WITH NITS | REQUEST CHANGES | BLOCK, or nothing if
 # the file states no verdict (empty file, killed run, freeform prose).
@@ -80,10 +109,22 @@
 # BLOCKER/BLOCKERS is still stripped before token matching: "Fix first: **BLOCKER
 # 1**" after a verdict line made a bare BLOCK match report verdict BLOCK on the
 # real PR #11 round 2 payload.
+#
+# THE QUOTED-MATERIAL FILTER IS SHARED WITH THE FALLBACK, AND HAS TO BE (ASK-1227
+# round 2). Round one put the exclusion on `_bold_verdict_in_tail` only. Codex
+# proved the hole with a reproducer: a statement-shaped `VERDICT: REQUEST CHANGES`
+# sitting inside a QUOTED diff line is matched HERE and returned at the `[ -n
+# "$found" ]` guard below, so the fallback never runs and the reviewer's real
+# closing `**APPROVE WITH NITS**` is discarded -- a false RED on a review that
+# approved. The order rule above ("among candidates that pass the shape test the
+# last one wins") cannot reach that case: it only ranks candidates this reader
+# accepted, and a review that states its verdict in prose contributes no candidate
+# at all. Which of the two readers sees a quoted token first must not change the
+# answer, so both read the same filtered text.
 extract_verdict() {
   local f="$1" found
   [ -s "$f" ] || return 0
-  found="$(awk '
+  found="$(_strip_quoted_material <"$f" 2>/dev/null | awk '
     function leading_token(s,   t) {
       sub(/^[[:space:]*_]+/, "", s)
       if (s ~ /^APPROVE WITH NITS/) return "APPROVE WITH NITS"
@@ -115,7 +156,7 @@ extract_verdict() {
       if (rest ~ /^[[:space:]*_:#-]*$/) awaiting = 1
     }
     END { if (found != "") printf "%s", found }
-  ' "$f" 2>/dev/null)"
+  ' 2>/dev/null)"
   # A stated verdict on a VERDICT-marked line always wins. The tail fallback is
   # strictly a second chance for a review that stated its call and never used the
   # word, never an override of one that did.
@@ -151,13 +192,11 @@ extract_verdict() {
 _bold_verdict_in_tail() {
   local f="${1:-}"
   [ -s "$f" ] || return 0
-  tail -n "${KIPI_VERDICT_TAIL_LINES:-250}" "$f" 2>/dev/null | awk '
-    # Fenced code is material the reviewer read, not its own statement.
-    /^[[:space:]]*(```|~~~)/ { fence = !fence; next }
-    fence { next }
-    # Diff markers, blockquotes, and indented code blocks: all quoted material.
-    /^[[:space:]]*[+>-]/ { next }
-    /^    / { next }
+  # TAIL FIRST, THEN FILTER. The 250-line window is measured on the RAW stream
+  # (review_comment_body: "the reviewer's actual message is the last ~250 lines"),
+  # so filtering before slicing would widen the window by however much quoted
+  # material the stream happened to carry.
+  tail -n "${KIPI_VERDICT_TAIL_LINES:-250}" "$f" 2>/dev/null | _strip_quoted_material | awk '
     {
       line = $0
       gsub(/BLOCKERS?/, "", line)

--- a/q-system/.q-system/scripts/pr-verdict-lib.sh
+++ b/q-system/.q-system/scripts/pr-verdict-lib.sh
@@ -98,59 +98,43 @@ _verdict_source() {
 # ~/.config/kipi/pr-reviews: this filter changes the extracted verdict on none of
 # them, while flipping every reproducer above.
 #
-# THE FENCE RULE APPLIES ONLY WHEN ITS STATE IS WELL-FORMED (ASK-1227 round 5,
-# first major). Fence parity is the ONLY rule here that carries state between
-# lines; every other rule decides a line on its own bytes. That makes it the only
-# one an upstream oddity can knock out of phase, and an out-of-phase parity does
-# not degrade, it INVERTS: every line after the stray fence is judged backwards.
+# FENCE PARITY STAYS ON, AND ITS COST IS STATED (ASK-1227 rounds 5 and 6). Parity
+# is the only rule here that carries state between lines, so a stray line that
+# merely LOOKS like a fence (a `~~~~~~~~^^^^^` compiler squiggle in tool output)
+# puts it out of phase, and an out-of-phase parity does not degrade, it INVERTS.
 #
-# It landed both ways on real records:
+# Round 6 measured what happens if the rule stands down on an unbalanced region.
+# The fenced content becomes visible, and a fenced `VERDICT: BLOCK` is
+# statement-shaped with a leading marker, so it reads as the reviewer's own
+# conclusion and outranks a later approval: a fabricated BLOCK wedging an
+# unattended gate, which is the expensive direction. The round-6 reviewer found it
+# with an executed reproducer, on this branch, an hour after the stand-down landed.
+# The stand-down was reverted rather than patched; this comment is what is left of
+# it, so the next person does not re-derive it.
 #
-#   pr-190  23 lines match this pattern, an ODD count, so parity leaves the
-#           closing `**VERDICT: APPROVE**` inside a phantom fence -> read as
-#           quoted, verdict lost, and a required status stuck red on an approval.
-#   pr-159  17 matches in the last 250 lines, so the SAME closing verdict is
-#           visible whole-file and hidden window-scoped.
+# So parity stays unconditional and the REGION is what got fixed instead. Both
+# prose readers now read the same bounded answer (see _reviewer_prose_of), and on
+# that region parity behaves: the real pr-190 record, which the whole-file reader
+# resolved to nothing, carries 4 fence lines in its answer window and reads its
+# stated APPROVE.
 #
-# Most of those lines are not fences at all. They are compiler and shellcheck
-# squiggles (`~~~~~~~~^^^^^^`) in tool output that merely START with three tildes,
-# and no tightening of the pattern fixes the class -- an agent session can quote
-# anything, including half of a fenced block.
-#
-# So the rule states its own precondition instead of assuming it. An EVEN number
-# of fence lines in the region means the fences close and parity is sound, so it
-# is tracked. An ODD number is proof the region is not fence-balanced, parity
-# would be a coin flip, and the rule stands down to the stateless filters, which
-# cannot be inverted by anything upstream.
-#
-# WHY STANDING DOWN IS THE SAFE SIDE. On an unbalanced region a fenced decoy token
-# does become visible. It cannot manufacture a verdict on its own: extract_verdict
-# needs a statement-shaped line whose marker LEADS, and the tail fallback takes the
-# LAST bold token, which is the reviewer's own conclusion because a review answers
-# after the material it read. Measured over all 991 recorded transcripts, no
-# resolved verdict moves toward approval. The inverted-parity bug, by contrast,
-# silently destroyed the verdict on 8 of them.
-#
-# TWO PASSES, because the count has to be known before the first line is judged.
-# The region is a bounded window or one final message, so buffering it is cheap.
+# THE HONEST COST, MEASURED, NOT ASSUMED. On 30 of the 991 recorded transcripts
+# the answer window is fence-UNbalanced, phase inverts, and the reviewer's stated
+# verdict is dropped. That is a real loss, and it is the safe direction twice
+# over: every one of those 30 carries a non-empty, non-APPROVE derived verdict, so
+# no resolved verdict moves, and an unstated verdict HOLDS a PR where a fabricated
+# one releases or wedges it. Do NOT read this filter as sound on a session file.
+# It is not. The sidecar is the fix; this is only the floor under legacy records.
 _reviewer_prose() {
   awk '
-    { buf[NR] = $0; if ($0 ~ /^[[:space:]]*(```|~~~)/) nfence++ }
-    END {
-      # Odd => the region is not fence-balanced => parity is meaningless here.
-      tracked = (nfence % 2 == 0)
-      for (i = 1; i <= NR; i++) {
-        line = buf[i]
-        if (tracked && line ~ /^[[:space:]]*(```|~~~)/) { fence = !fence; continue }
-        if (tracked && fence)             continue
-        if (line ~ /^[[:space:]]*[+>-]/)  continue
-        # Indented code is four spaces or one tab; a diff CONTEXT line is one space.
-        if (line ~ /^(    |\t| )/)        continue
-        # A pipe means a row or a table. Neither is a sentence.
-        if (line ~ /[|]/)                 continue
-        print line
-      }
-    }
+    /^[[:space:]]*(```|~~~)/   { fence = !fence; next }
+    fence                      { next }
+    /^[[:space:]]*[+>-]/       { next }
+    # Indented code is four spaces or one tab; a diff CONTEXT line is one space.
+    /^(    |\t| )/             { next }
+    # A pipe means a row or a table. Neither is a sentence.
+    /[|]/                      { next }
+    { print }
   ' 2>/dev/null
 }
 

--- a/q-system/.q-system/scripts/pr-verdict-lib.sh
+++ b/q-system/.q-system/scripts/pr-verdict-lib.sh
@@ -81,9 +81,9 @@
 # 1**" after a verdict line made a bare BLOCK match report verdict BLOCK on the
 # real PR #11 round 2 payload.
 extract_verdict() {
-  local f="$1"
+  local f="$1" found
   [ -s "$f" ] || return 0
-  awk '
+  found="$(awk '
     function leading_token(s,   t) {
       sub(/^[[:space:]*_]+/, "", s)
       if (s ~ /^APPROVE WITH NITS/) return "APPROVE WITH NITS"
@@ -95,31 +95,6 @@ extract_verdict() {
     {
       line = $0
       gsub(/BLOCKERS?/, "", line)
-    }
-    # FALLBACK, USED ONLY WHEN NO `VERDICT`-MARKED LINE STATED ONE (ASK-1227).
-    # A reviewer that did the whole job and stated its call in bold prose --
-    # never writing the literal word VERDICT -- used to score identical to one
-    # that never ran. Measured on PR #79 2026-09-03 12:49: a 6-minute review
-    # closing "three minor findings, **APPROVE WITH NITS**" recorded stated ""
-    # and posted a FAILURE.
-    #
-    # EMPHASIS IS THE WHOLE DISCRIMINATOR, and it is not a style preference. The
-    # reviewer prompt is echoed verbatim into every codex transcript and carries
-    # the grading ladder as plain text ("only minor/nit findings => APPROVE WITH
-    # NITS"), so a fallback matching BARE tokens would read a verdict straight
-    # out of that ladder in the prompt. Measured across the 80 recorded reviews on
-    # this machine 2026-09-03: zero carry a BOLD verdict token in their prompt
-    # region, and the one bold hit was the real review above. Widening this to
-    # bare tokens needs a measured review that motivates it.
-    #
-    # LAST ONE WINS, matching findings_block taking the LAST complete block: a
-    # review that weighs "**REQUEST CHANGES**" and settles on "**APPROVE WITH
-    # NITS**" means the one it settled on.
-    {
-      if (line ~ /\*\*APPROVE WITH NITS\*\*/)    bold = "APPROVE WITH NITS"
-      else if (line ~ /\*\*REQUEST CHANGES\*\*/) bold = "REQUEST CHANGES"
-      else if (line ~ /\*\*APPROVE\*\*/)         bold = "APPROVE"
-      else if (line ~ /\*\*BLOCK\*\*/)           bold = "BLOCK"
     }
     # Under a bare heading the FIRST non-blank line decides, and it decides either
     # way: prose there is not a verdict, it is a heading with no statement under
@@ -139,11 +114,63 @@ extract_verdict() {
       # Bare marker: nothing but punctuation/emphasis left on the line.
       if (rest ~ /^[[:space:]*_:#-]*$/) awaiting = 1
     }
-    END {
-      if (found != "")     printf "%s", found
-      else if (bold != "") printf "%s", bold
+    END { if (found != "") printf "%s", found }
+  ' "$f" 2>/dev/null)"
+  # A stated verdict on a VERDICT-marked line always wins. The tail fallback is
+  # strictly a second chance for a review that stated its call and never used the
+  # word, never an override of one that did.
+  if [ -n "$found" ]; then printf '%s' "$found"; return 0; fi
+  _bold_verdict_in_tail "$f"
+}
+
+# _bold_verdict_in_tail <review-file>
+# The FALLBACK reader, used ONLY when no `VERDICT`-marked line stated a verdict.
+#
+# WHY IT EXISTS (ASK-1227). A real six-minute review on PR #79 2026-09-03 12:49
+# closed with "three minor findings, **APPROVE WITH NITS**" and never wrote the
+# literal word VERDICT, the only thing extract_verdict could see. It recorded
+# stated "" and posted a FAILURE: a reviewer that did the whole job scored
+# identically to one that never ran.
+#
+# TAIL-SCOPED, AND THAT SCOPE IS THE FINDING THAT PUT IT HERE. The first cut of
+# this fallback scanned the WHOLE file, and codex called it a major on PR #297:
+# a codex transcript is not a review, it is the agent session INCLUDING every
+# diff and file it read, so an emphasized token in quoted source could fabricate
+# a verdict the reviewer never gave -- and a fabricated BLOCK wedges an
+# unattended gate. review_comment_body already records the measurement this
+# relies on: "the reviewer's actual message is the last ~250 lines."
+#
+# QUOTED LINES ARE EXCLUDED for the same reason: diff markers, blockquotes and
+# fenced or indented code are material the reviewer READ, never its conclusion.
+#
+# EMPHASIS IS THE OTHER HALF. The reviewer prompt is echoed verbatim into every
+# codex transcript carrying the grading ladder as plain text ("only minor/nit
+# findings => APPROVE WITH NITS"), so a bare-token fallback would read a verdict
+# straight out of the prompt. Measured across 80 recorded transcripts: zero carry
+# a BOLD verdict token in their prompt region.
+_bold_verdict_in_tail() {
+  local f="${1:-}"
+  [ -s "$f" ] || return 0
+  tail -n "${KIPI_VERDICT_TAIL_LINES:-250}" "$f" 2>/dev/null | awk '
+    # Fenced code is material the reviewer read, not its own statement.
+    /^[[:space:]]*(```|~~~)/ { fence = !fence; next }
+    fence { next }
+    # Diff markers, blockquotes, and indented code blocks: all quoted material.
+    /^[[:space:]]*[+>-]/ { next }
+    /^    / { next }
+    {
+      line = $0
+      gsub(/BLOCKERS?/, "", line)
+      # LAST ONE WINS, matching findings_block taking the LAST complete block: a
+      # review that weighs one call and settles on another means the one it
+      # settled on.
+      if (line ~ /\*\*APPROVE WITH NITS\*\*/)    bold = "APPROVE WITH NITS"
+      else if (line ~ /\*\*REQUEST CHANGES\*\*/) bold = "REQUEST CHANGES"
+      else if (line ~ /\*\*APPROVE\*\*/)         bold = "APPROVE"
+      else if (line ~ /\*\*BLOCK\*\*/)           bold = "BLOCK"
     }
-  ' "$f" 2>/dev/null
+    END { if (bold != "") printf "%s", bold }
+  ' 2>/dev/null
 }
 
 # findings_block <review-file>

--- a/q-system/.q-system/scripts/test/test-review-gate-no-fake-green.sh
+++ b/q-system/.q-system/scripts/test/test-review-gate-no-fake-green.sh
@@ -163,8 +163,29 @@ check "a stated APPROVE is still overridden by derived REQUEST CHANGES" \
       "$([ "$(resolve_verdict 'APPROVE' 'REQUEST CHANGES')" = "REQUEST CHANGES" ] && echo 0 || echo 1)"
 check "agreement passes through unchanged" \
       "$([ "$(resolve_verdict 'APPROVE' 'APPROVE')" = "APPROVE" ] && echo 0 || echo 1)"
-check "a lone derived verdict stands when nothing was stated" \
-      "$([ "$(resolve_verdict '' 'APPROVE')" = "APPROVE" ] && echo 0 || echo 1)"
+# A LONE DERIVED VERDICT STANDS ONLY WHEN IT IS NOT AN APPROVAL (ASK-1227).
+#
+# This check used to read `resolve_verdict '' 'APPROVE'` = APPROVE, and that
+# assertion PINNED THE DEFECT rather than a contract. APPROVE is the only verdict
+# the ladder can derive from a block with ZERO severity rows, so "derived APPROVE
+# with nothing stated" is precisely: an empty block, and a reviewer that never
+# said the PR was fine.
+#
+# Measured 2026-09-03 on PR #78: codex could not reach api.github.com, read no
+# diff, said "VERDICT: NOT ISSUED", and closed an empty block. NOT ISSUED is not
+# a verdict token, so stated was "" -- this exact call -- and the gate went green
+# on a review that had read nothing. A worker merged on it.
+#
+# The harsher directions are untouched: a lone derived BLOCK or REQUEST CHANGES
+# still stands alone, because failing closed needs no corroboration.
+check "a lone derived APPROVE does NOT stand when nothing was stated" \
+      "$([ -z "$(resolve_verdict '' 'APPROVE')" ] && echo 0 || echo 1)"
+check "a lone derived BLOCK still stands when nothing was stated" \
+      "$([ "$(resolve_verdict '' 'BLOCK')" = "BLOCK" ] && echo 0 || echo 1)"
+check "a lone derived REQUEST CHANGES still stands when nothing was stated" \
+      "$([ "$(resolve_verdict '' 'REQUEST CHANGES')" = "REQUEST CHANGES" ] && echo 0 || echo 1)"
+check "a lone derived APPROVE WITH NITS still stands when nothing was stated" \
+      "$([ "$(resolve_verdict '' 'APPROVE WITH NITS')" = "APPROVE WITH NITS" ] && echo 0 || echo 1)"
 check "a lone stated verdict stands when nothing derived" \
       "$([ "$(resolve_verdict 'REQUEST CHANGES' '')" = "REQUEST CHANGES" ] && echo 0 || echo 1)"
 

--- a/q-system/.q-system/scripts/test/test-severity-floor.sh
+++ b/q-system/.q-system/scripts/test/test-severity-floor.sh
@@ -3909,4 +3909,108 @@ ok "the reviewer parses (bash -n)"
 bash -n "$LIB" || fail "pr-verdict-lib.sh does not parse"
 ok "the lib parses (bash -n)"
 
+
+# --- ASK-1227 case A: the network-blocked codex run that posted SUCCESS -------
+#
+# VERBATIM tail of the real producer: codex v0.147.0 on PR #78 2026-09-03
+# 12:31 (~/.config/kipi/pr-reviews/codex/assafkip_ASK_AI_consultant__pr-78-20260903-123139.md).
+# `gh` could not reach api.github.com, so codex read NOTHING and said so, then
+# closed a STRUCTURALLY COMPLETE but EMPTY findings block.
+#
+# What the old code did with it, step by step:
+#   extract_verdict      -> ""         ("NOT ISSUED" is not one of the four tokens)
+#   verdict_from_findings -> "APPROVE" (zero severity rows == nothing was wrong)
+#   resolve_verdict "" APPROVE -> "APPROVE"   <-- the empty derivation stood alone
+# and kipi/reviewer-approved went green on a review that had read no diff at all.
+# A worker then merged on it. This is the worst outcome available in this script:
+# absent evidence read as consent.
+cat > "$WORK/notissued.md" <<'EOF'
+Review blocked by the repository fail-stop rule.
+
+- Broken step: `gh -R assafkip/ASK_AI_consultant pr view 78`
+- Output:
+
+```text
+error connecting to api.github.com
+check your internet connection or https://githubstatus.com
+```
+
+- Impact: I could not read the PR diff or earlier review rounds.
+- Required: restore GitHub API access, then rerun this review.
+- VERDICT: NOT ISSUED. No evidence-based verdict is possible.
+
+FINDINGS:
+END FINDINGS
+EOF
+
+[ -z "$(extract_verdict "$WORK/notissued.md")" ] \
+  || fail "'VERDICT: NOT ISSUED' must not parse as a verdict, got '$(extract_verdict "$WORK/notissued.md")'"
+ok "case A: an explicit NOT ISSUED yields no stated verdict"
+
+# The derivation itself is UNCHANGED on purpose. Empty-block-derives-APPROVE is a
+# deliberate contract (a round 2 that refutes every round-1 finding closes with an
+# empty block and must be able to land). Moving the fix into this function would
+# collide with that contract and with test-findings-block-reader.sh case 2.
+[ "$(verdict_from_findings "$WORK/notissued.md")" = "APPROVE" ] \
+  || fail "verdict_from_findings must still derive APPROVE from an empty block (pinned contract)"
+ok "case A: the empty-block derivation is left alone"
+
+# THE FIX, at the composition. "Reviewed and found nothing" and "never started"
+# are byte-identical INSIDE the block, so the empty derivation needs corroboration
+# from OUTSIDE it -- the reviewer's own stated verdict. With none, this is unstated.
+[ -z "$(resolve_verdict "" "APPROVE")" ] \
+  || fail "an empty-block APPROVE with NO stated verdict must resolve to UNSTATED, got '$(resolve_verdict "" "APPROVE")'"
+ok "case A: empty-block APPROVE + no stated verdict => UNSTATED (the false green is closed)"
+
+# NEGATIVE CONTROL for case A. The corroborated shape must still land, or a
+# clean round 2 wedges forever and the fix is worse than the defect.
+[ "$(resolve_verdict "APPROVE" "APPROVE")" = "APPROVE" ] \
+  || fail "a reviewer that STATED approve over an empty block must still land APPROVE"
+ok "case A control: stated APPROVE over an empty block still lands"
+[ "$(resolve_verdict "APPROVE WITH NITS" "APPROVE")" = "APPROVE WITH NITS" ] \
+  || fail "stated APPROVE WITH NITS over an empty block must survive"
+ok "case A control: a corroborated empty block keeps the stated verdict"
+
+# --- ASK-1227 case B: the real 6-minute review scored UNSTATED ----------------
+#
+# VERBATIM slice of the real producer: the --engine claude run on PR #79
+# 2026-09-03 12:49 (~/.config/kipi/pr-reviews/assafkip_ASK_AI_consultant__pr-79-20260903-124901.md),
+# recorded verdict "" / stated "" / source prose / usable false, and posted a
+# FAILURE. It is a substantive review that states its verdict in bold prose and
+# never writes the literal word VERDICT, which is the only thing the old
+# extractor could see. A reviewer that did the work got the same status as one
+# that never ran.
+cat > "$WORK/proseverdict.md" <<'EOF'
+Last gap closed: `test_granola_candidates.py` has zero `SlackTransport` hits (grep exit 1). The background search agrees with what I found directly, `GRANOLA_GENERAL_OVERRIDE` has no consumer anywhere, `REFUSED_CHANNELS` and `SlackTransport` are referenced only in their own module, the tests, and `GRANOLA-APPROVALS.md`, and the only live path is `granola_candidates.py` to `TerminalTransport`. No launchd plist and no `.claude/commands/` entry touches this lane, so the "not headless" claim holds.
+
+That confirms the reachability premise all three findings were already scored against. The review stands as posted: three minor findings, **APPROVE WITH NITS**, fix finding 1 first (`offer_all` should check `cand.lane == transport.lane`).
+EOF
+
+[ "$(extract_verdict "$WORK/proseverdict.md")" = "APPROVE WITH NITS" ] \
+  || fail "a stated bold prose verdict must be read when the review carries no findings block, got '$(extract_verdict "$WORK/proseverdict.md")'"
+ok "case B: a bold prose verdict is read (the false red is closed)"
+
+# NEGATIVE CONTROL for case B, and the reason the fallback demands EMPHASIS.
+# The reviewer PROMPT is echoed into every codex transcript and contains the
+# grading ladder as plain text. Measured across 80 recorded reviews on
+# 2026-09-03: zero carry a BOLD verdict token in their prompt region. A fallback
+# that matched bare tokens would read a verdict out of the prompt's own rules.
+cat > "$WORK/promptecho.md" <<'EOF'
+- **VERDICT:** decided by THIS RULE, not by feel:
+    - any blocker finding             => BLOCK
+    - any major finding               => REQUEST CHANGES
+    - only minor/nit findings         => APPROVE WITH NITS
+    - nothing above nit               => APPROVE
+EOF
+[ -z "$(extract_verdict "$WORK/promptecho.md")" ] \
+  || fail "the prompt's own grading ladder must not be read as a stated verdict, got '$(extract_verdict "$WORK/promptecho.md")'"
+ok "case B control: the echoed prompt ladder yields no verdict"
+
+# A truncated stream is NOT case B and must stay unstated: it ATTEMPTED a block
+# and died inside it. The discriminator is the orphan FINDINGS: marker.
+printf 'Some partial analysis.\n\nFINDINGS:\nmajor|foo.py|1|it broke\n' > "$WORK/truncated.md"
+[ -z "$(verdict_from_findings "$WORK/truncated.md")" ] \
+  || fail "an unclosed findings block must derive nothing, got '$(verdict_from_findings "$WORK/truncated.md")'"
+ok "case B control: a truncated block still derives nothing"
+
 echo "PASS: $PASS/$PASS severity-floor checks"

--- a/q-system/.q-system/scripts/test/test-severity-floor.sh
+++ b/q-system/.q-system/scripts/test/test-severity-floor.sh
@@ -4148,4 +4148,51 @@ ok "case D: tab-indented quoted material is excluded like space-indented"
 [ "$(awk '/^\tVERDICT: BLOCK/ { n++ } END { print n+0 }' "$WORK/tabquote.md")" = "1" ]   || fail "the tab fixture is not actually tab-indented, so the case above proves nothing"
 ok "case D control: the fixture really is TAB-indented"
 
+# --- case E: a FINDINGS ROW is not verdict prose (ASK-1227 round 4) ------------
+# THE REVIEWER'S EXACT CASE, and it demonstrated itself live. Round 4 of codex on
+# PR #297 wrote a minor whose CLAIM TEXT contained the words `VERDICT: BLOCK`.
+# extract_verdict scanned the machine-readable block as prose, took that token
+# over the reviewer's own stated `**REQUEST CHANGES**`, and the gate posted
+# kipi/reviewer-approved=failure with verdict BLOCK on cbc4b751. A review reporting
+# this defect was mis-scored BY the defect.
+#
+# Rows are pipe-delimited by contract, so a line containing `|` is a row or a
+# table and never the sentence a verdict is stated in. That rule holds even when a
+# row leaks OUTSIDE its block, which is how a truncated or echoed block arrives.
+{
+  printf 'VERDICT: APPROVE WITH NITS\n\n'
+  printf 'FINDINGS:\n'
+  printf 'minor|The quote filter accepts VERDICT: BLOCK from a diff context line|q-system/.q-system/scripts/pr-verdict-lib.sh:38\n'
+  printf 'END FINDINGS\n'
+} > "$WORK/findings-row-verdict.md"
+
+[ "$(extract_verdict "$WORK/findings-row-verdict.md")" = "APPROVE WITH NITS" ]   || fail "a FINDINGS row's claim text overwrote the stated verdict: got '$(extract_verdict "$WORK/findings-row-verdict.md")' (expected APPROVE WITH NITS)"
+ok "case E: a VERDICT token inside a findings row cannot overwrite the stated verdict"
+
+# The trap is REALLY IN the fixture, and the stated verdict really is above it.
+grep -q '^minor|.*VERDICT: BLOCK' "$WORK/findings-row-verdict.md"   || fail "case E fixture carries no findings row naming a verdict, so it proves nothing"
+grep -q '^VERDICT: APPROVE WITH NITS' "$WORK/findings-row-verdict.md"   || fail "case E fixture states no verdict above the block, so it proves nothing"
+ok "case E control: the fixture really pairs a stated verdict with a verdict-naming row"
+
+# A row that leaked OUTSIDE its block is the truncated/echoed shape. The pipe rule
+# is what holds here; the block-region rule cannot see it.
+printf 'VERDICT: APPROVE WITH NITS\nminor|claim mentioning VERDICT: BLOCK|lib.sh:38\n' > "$WORK/orphan-row.md"
+[ "$(extract_verdict "$WORK/orphan-row.md")" = "APPROVE WITH NITS" ]   || fail "a findings row outside its block set the verdict: got '$(extract_verdict "$WORK/orphan-row.md")'"
+ok "case E: a findings row outside its block is still not verdict prose"
+
+# A diff CONTEXT line begins with ONE SPACE, so it survived a filter that only knew
+# +/- and four-space indents. Same round-4 review named this one.
+printf ' VERDICT: BLOCK\nReviewer conclusion: **APPROVE WITH NITS**\n' > "$WORK/diff-context.md"
+[ "$(extract_verdict "$WORK/diff-context.md")" = "APPROVE WITH NITS" ]   || fail "a one-space diff CONTEXT line fabricated a verdict: got '$(extract_verdict "$WORK/diff-context.md")'"
+ok "case E: a diff context line (one leading space) is quoted material"
+
+# AND THE ALLOWLIST MUST NOT EAT THE ANSWER. An explicit conclusion still wins,
+# stated above its own findings block exactly as the prompt orders them.
+{
+  printf 'Reviewed the whole diff.\n\n## VERDICT\n\n**REQUEST CHANGES**\n\n'
+  printf 'FINDINGS:\nmajor|a real problem|lib.sh:10\nEND FINDINGS\n'
+} > "$WORK/conclusion-wins.md"
+[ "$(extract_verdict "$WORK/conclusion-wins.md")" = "REQUEST CHANGES" ]   || fail "the allowlist swallowed a real stated conclusion: got '$(extract_verdict "$WORK/conclusion-wins.md")' (expected REQUEST CHANGES)"
+ok "case E control: an explicit conclusion above the findings block still wins"
+
 echo "PASS: $PASS/$PASS severity-floor checks"

--- a/q-system/.q-system/scripts/test/test-severity-floor.sh
+++ b/q-system/.q-system/scripts/test/test-severity-floor.sh
@@ -4195,4 +4195,137 @@ ok "case E: a diff context line (one leading space) is quoted material"
 [ "$(extract_verdict "$WORK/conclusion-wins.md")" = "REQUEST CHANGES" ]   || fail "the allowlist swallowed a real stated conclusion: got '$(extract_verdict "$WORK/conclusion-wins.md")' (expected REQUEST CHANGES)"
 ok "case E control: an explicit conclusion above the findings block still wins"
 
+# --- ASK-1227 round 5: the reviewer FINAL MESSAGE is the boundary --------------
+#
+# Rounds 1-4 each excluded the region that had just fabricated a verdict, and
+# round 5 found two more at once. Codex own fix-first: "replace whole-session
+# Markdown inference with a deterministic boundary for the reviewer final
+# response." `codex exec -o FILE` is that boundary; these cases pin it.
+
+# --- case F: a stateful fence rule cannot survive a session transcript ---------
+#
+# THE REAL PRODUCER. On the recorded pr-190 review, whose artifact plainly ends
+# `**VERDICT: APPROVE**`, the round-4 lib resolved stated=<> derived=<APPROVE>
+# resolved=<> -- an approving review held red forever. Cause: 23 lines in that
+# session START with three tildes or backticks, so fence parity leaves the closing
+# verdict inside a phantom fence. Most of them are compiler squiggles
+# (`~~~~~~~~^^^^^`) in tool output, not fences. It lands the other way too: on
+# pr-159 the same verdict is visible whole-file and hidden in the last 250 lines.
+#
+# Fence tracking is the ONLY rule in _reviewer_prose that carries state between
+# lines, so it is the only one a truncated or noisy document can knock out of
+# phase. It now runs on the final message (a complete document) and nowhere else.
+{
+  printf 'Running shellcheck on the changed files.\n\n'
+  printf '```text\n'
+  printf 'In pr-verdict-lib.sh line 64:\n'
+  printf '~~~~~~~~~~^^^^^^^^^^^^^^^\n'
+  printf '```\n\n'
+  printf 'That is the whole read; nothing survived reproduction.\n\n'
+  printf '**VERDICT: APPROVE**\n\n'
+  printf 'FINDINGS:\nEND FINDINGS\n'
+} > "$WORK/squiggle.md"
+
+# The trap is REALLY THERE: an ODD number of fence-matching lines ahead of the
+# verdict is what puts it inside a phantom fence. Without this the case could pass
+# on a fixture that never contained the defect.
+FENCEN="$(awk '/^[[:space:]]*(```|~~~)/ { n++ } END { print n+0 }' "$WORK/squiggle.md")"
+[ "$((FENCEN % 2))" = "1" ] \
+  || fail "case F fixture has $FENCEN fence-matching lines (even), so parity never flips and the case proves nothing"
+ok "case F control: the fixture really carries an odd number of fence-matching lines"
+
+[ "$(extract_verdict "$WORK/squiggle.md")" = "APPROVE" ] \
+  || fail "an unmatched fence hid the closing verdict: got '$(extract_verdict "$WORK/squiggle.md")' (expected APPROVE)"
+[ "$(resolve_verdict "$(extract_verdict "$WORK/squiggle.md")" "$(verdict_from_findings "$WORK/squiggle.md")")" = "APPROVE" ] \
+  || fail "case F: an approving review with an empty block must resolve APPROVE, got '$(resolve_verdict "$(extract_verdict "$WORK/squiggle.md")" "$(verdict_from_findings "$WORK/squiggle.md")")'"
+ok "case F: a squiggle line that merely starts with ~~~ cannot hide the verdict"
+
+# THE REAL ARTIFACT, when this machine still has it. Operator-local, so its absence
+# is announced rather than silently skipped -- the synthetic fixture above is what
+# makes the case portable, this is what makes it producer-real.
+PR190="$HOME/.config/kipi/pr-reviews/codex/assafkip_kipi-system__pr-190-20260815-023743.md"
+if [ -s "$PR190" ]; then
+  grep -q '^\*\*VERDICT: APPROVE\*\*' "$PR190" \
+    || fail "the pr-190 record no longer ends in a stated APPROVE; the control below would prove nothing"
+  [ "$(extract_verdict "$PR190")" = "APPROVE" ] \
+    || fail "REGRESSION on the real pr-190 transcript: got '$(extract_verdict "$PR190")', artifact says **VERDICT: APPROVE**"
+  ok "case F: the real pr-190 transcript resolves to its stated APPROVE"
+else
+  echo "  SKIP case F real-artifact control: $PR190 is not on this machine"
+fi
+
+# --- case G: the sidecar is the source when it exists --------------------------
+#
+# pr-review-agent.sh passes `-o "$REVIEW.last"`, so codex writes ONLY its final
+# message there. Every reader takes it when present. The session file below is
+# deliberately hostile -- it states a BLOCK in clean prose and closes a major
+# findings block -- so the assertions can only pass by reading the sidecar.
+{
+  printf 'Prompt echo and tool output follow.\n\n'
+  printf 'VERDICT: BLOCK\n\n'
+  printf 'FINDINGS:\nmajor|read out of the session, not the answer|lib.sh:1\nEND FINDINGS\n'
+} > "$WORK/sidecar.md"
+{
+  printf 'Two nits, nothing that blocks.\n\n'
+  printf '**VERDICT: APPROVE WITH NITS**\n\n'
+  printf 'FINDINGS:\nminor|a real nit|lib.sh:2\nEND FINDINGS\n'
+} > "$WORK/sidecar.md.last"
+
+[ "$(extract_verdict "$WORK/sidecar.md")" = "APPROVE WITH NITS" ] \
+  || fail "case G: extract_verdict ignored the final-message sidecar, got '$(extract_verdict "$WORK/sidecar.md")'"
+[ "$(verdict_from_findings "$WORK/sidecar.md")" = "APPROVE WITH NITS" ] \
+  || fail "case G: verdict_from_findings read the SESSION block, got '$(verdict_from_findings "$WORK/sidecar.md")'"
+review_is_usable "$WORK/sidecar.md" \
+  || fail "case G: a review with a complete sidecar block must be usable"
+ok "case G: prose, findings and usability all read the final-message sidecar"
+
+# THE NEGATIVE SELF-TEST. Detach the sidecar and the SAME session file must give
+# the hostile answer. Without this the case above passes on a fixture whose
+# session half never disagreed, which is a check that cannot fail.
+mv "$WORK/sidecar.md.last" "$WORK/sidecar-detached"
+[ "$(extract_verdict "$WORK/sidecar.md")" = "BLOCK" ] \
+  || fail "case G control: with no sidecar the session file should read BLOCK, got '$(extract_verdict "$WORK/sidecar.md")' -- the sidecar was not what changed the answer"
+[ "$(verdict_from_findings "$WORK/sidecar.md")" = "REQUEST CHANGES" ] \
+  || fail "case G control: with no sidecar the session block should derive REQUEST CHANGES, got '$(verdict_from_findings "$WORK/sidecar.md")'"
+ok "case G control: without the sidecar the same file reads the session, so the sidecar is what did it"
+
+# An EMPTY sidecar is a killed run, not an answer, so it must fall back. `-s`, not
+# `-e`, is what makes that true.
+: > "$WORK/sidecar.md.last"
+[ "$(extract_verdict "$WORK/sidecar.md")" = "BLOCK" ] \
+  || fail "case G: a zero-byte sidecar must fall back to the session, got '$(extract_verdict "$WORK/sidecar.md")'"
+mv "$WORK/sidecar.md.last" "$WORK/sidecar-empty"
+ok "case G: a zero-byte sidecar falls back to the session file"
+
+# --- case H: tool output is not a verdict statement ---------------------------
+#
+# Codex round 5, second confirmed major, with a producer-real reproducer: existing
+# transcripts carry raw `rg` results shaped `path:line:source`, and some of those
+# source lines are verdict statements. The greedy `^.*VERDICT` strip took the
+# token and outranked the reviewer own later approval, posting a phantom BLOCK.
+# The marker must LEAD the sentence -- the mirror of the rule that the token must
+# lead what follows the marker.
+printf 'q-system/check.sh:42:VERDICT: BLOCK\nReviewer conclusion: **APPROVE WITH NITS**\n' > "$WORK/rgline.md"
+[ "$(extract_verdict "$WORK/rgline.md")" = "APPROVE WITH NITS" ] \
+  || fail "path-prefixed tool output fabricated a verdict: got '$(extract_verdict "$WORK/rgline.md")' (expected APPROVE WITH NITS)"
+ok "case H: a path:line: prefixed VERDICT is tool output, not a stated verdict"
+
+# The trap is REALLY IN the fixture.
+grep -q '^q-system/check.sh:42:VERDICT: BLOCK' "$WORK/rgline.md" \
+  || fail "case H fixture carries no path-prefixed verdict line, so it proves nothing"
+ok "case H control: the fixture really carries rg-shaped tool output"
+
+# AND THE REAL SHAPES STILL READ. Each of these is a conclusion recorded in the
+# corpus; the leading-marker rule must not eat any of them. Measured across all
+# 991 records: the rule changes the extracted verdict on none of them.
+printf '**VERDICT: APPROVE**\n'          > "$WORK/lead1.md"
+printf '## VERDICT: REQUEST CHANGES\n'   > "$WORK/lead2.md"
+printf 'VERDICT: APPROVE WITH NITS\n'    > "$WORK/lead3.md"
+printf '**VERDICT:** BLOCK\n'            > "$WORK/lead4.md"
+[ "$(extract_verdict "$WORK/lead1.md")" = "APPROVE" ]              || fail "case H: bold marker shape lost, got '$(extract_verdict "$WORK/lead1.md")'"
+[ "$(extract_verdict "$WORK/lead2.md")" = "REQUEST CHANGES" ]      || fail "case H: heading marker shape lost, got '$(extract_verdict "$WORK/lead2.md")'"
+[ "$(extract_verdict "$WORK/lead3.md")" = "APPROVE WITH NITS" ]    || fail "case H: bare marker shape lost, got '$(extract_verdict "$WORK/lead3.md")'"
+[ "$(extract_verdict "$WORK/lead4.md")" = "BLOCK" ]                || fail "case H: bold-colon marker shape lost, got '$(extract_verdict "$WORK/lead4.md")'"
+ok "case H control: every real marker shape in the corpus still reads"
+
 echo "PASS: $PASS/$PASS severity-floor checks"

--- a/q-system/.q-system/scripts/test/test-severity-floor.sh
+++ b/q-system/.q-system/scripts/test/test-severity-floor.sh
@@ -4102,4 +4102,40 @@ ok "case C control: an explicit VERDICT line still wins over the fallback"
 [ -z "$(extract_verdict "$WORK/decoy-noverdict.md")" ]   || fail "a transcript that stated NO verdict got one manufactured from quoted material: got '$(extract_verdict "$WORK/decoy-noverdict.md")'"
 ok "case C sharp: quoted tokens with no stated conclusion yield NO verdict"
 
+# --- case D: the PRIMARY reader must exclude quoted material too (ASK-1227 rd 2) -
+# Case C above proved the TAIL FALLBACK ignores quoted tokens. It could not see
+# this: a quoted line that is STATEMENT-shaped (`VERDICT: <token>` with the token
+# leading) is matched by extract_verdict's own reader, which returns before the
+# fallback ever runs. Codex's round-2 reproducer on PR #297, verbatim in shape --
+# a diff line adding a printf of a verdict, then the reviewer's real prose call.
+# Ran against 850a56d3 it returned REQUEST CHANGES on a review that approved: a
+# false RED, which on a required context wedges the PR with nobody watching.
+{
+  printf -- '+printf %sVERDICT: REQUEST CHANGES\n' "'"
+  printf 'Reviewer conclusion: **APPROVE WITH NITS**\n'
+} > "$WORK/quoted-statement.md"
+
+[ "$(extract_verdict "$WORK/quoted-statement.md")" = "APPROVE WITH NITS" ]   || fail "a statement-shaped VERDICT inside a quoted diff line beat the reviewer's own conclusion: got '$(extract_verdict "$WORK/quoted-statement.md")' (expected APPROVE WITH NITS)"
+ok "case D: a quoted statement-shaped VERDICT line cannot outrank the real conclusion"
+
+# The trap is REALLY IN the fixture. Without this the case above passes on a
+# fixture that never carried a quoted verdict statement -- a check that cannot fail.
+grep -q '^+printf .VERDICT: REQUEST CHANGES' "$WORK/quoted-statement.md"   || fail "case D fixture carries no quoted VERDICT statement, so it proves nothing"
+ok "case D control: the fixture really does carry a quoted VERDICT statement"
+
+# End to end, the way the gate consumes it: the resolved verdict is what gets
+# posted. resolve_verdict takes the HARSHER of stated and derived, so a false
+# REQUEST CHANGES here survives all the way to the status.
+[ "$(resolve_verdict "$(extract_verdict "$WORK/quoted-statement.md")" "APPROVE WITH NITS")" = "APPROVE WITH NITS" ]   || fail "resolved verdict for the quoted-statement transcript should be APPROVE WITH NITS, got '$(resolve_verdict "$(extract_verdict "$WORK/quoted-statement.md")" "APPROVE WITH NITS")'"
+ok "case D: the resolved verdict the gate posts is APPROVE WITH NITS"
+
+# The same exclusion must not swallow a REAL verdict statement that merely sits
+# near quoted material. Pairs with the case C control above, one layer down.
+{
+  printf -- '+ added_line = "**BLOCK**"\n'
+  printf 'VERDICT: REQUEST CHANGES\n'
+} > "$WORK/quoted-then-real.md"
+[ "$(extract_verdict "$WORK/quoted-then-real.md")" = "REQUEST CHANGES" ]   || fail "an unquoted VERDICT statement next to a diff line was dropped, got '$(extract_verdict "$WORK/quoted-then-real.md")'"
+ok "case D control: an unquoted VERDICT statement beside quoted material still counts"
+
 echo "PASS: $PASS/$PASS severity-floor checks"

--- a/q-system/.q-system/scripts/test/test-severity-floor.sh
+++ b/q-system/.q-system/scripts/test/test-severity-floor.sh
@@ -4013,4 +4013,93 @@ printf 'Some partial analysis.\n\nFINDINGS:\nmajor|foo.py|1|it broke\n' > "$WORK
   || fail "an unclosed findings block must derive nothing, got '$(verdict_from_findings "$WORK/truncated.md")'"
 ok "case B control: a truncated block still derives nothing"
 
+# --- ASK-1227 case C: codex major on PR #297 round 1 --------------------------
+#
+# THE FINDING, verbatim: "The bold fallback treats any emphasized verdict token
+# anywhere in the transcript as the reviewer conclusion, so unrelated source text
+# can fabricate a BLOCK and wedge the unattended review gate"
+# (pr-verdict-lib.sh:119). It was right, and the first cut of case B scanned the
+# whole file.
+#
+# WHY IT MATTERS MORE THAN A FALSE APPROVE. A codex review file is not a review,
+# it is the whole agent session INCLUDING every diff and file it read. This very
+# repo is full of emphasized verdict tokens: the reviewer prompt, this test, and
+# the lib comments all contain them. A fabricated BLOCK on an unattended gate
+# wedges the PR with a verdict no reviewer gave.
+#
+# The fixture puts the decoy in the transcript body -- quoted diff, blockquote,
+# and fenced code, which is how read material actually appears -- and the real
+# conclusion in the tail, exactly the layout of a codex transcript.
+{
+  printf 'Reading the diff for PR 900.
+
+'
+  printf '```
+**BLOCK**
+```
+
+'
+  printf '> a quoted earlier round said **REQUEST CHANGES**
+
+'
+  printf -- '+ some_added_line = "**BLOCK**"
+'
+  printf -- '-  removed_line = "**REQUEST CHANGES**"
+
+'
+  printf '    indented_code = "**BLOCK**"
+
+'
+  for i in $(seq 1 400); do printf 'transcript filler line %s
+' "$i"; done
+  printf '
+That is the whole read. **APPROVE WITH NITS**, fix the naming first.
+'
+} > "$WORK/decoy.md"
+
+[ "$(extract_verdict "$WORK/decoy.md")" = "APPROVE WITH NITS" ]   || fail "quoted source in the transcript body fabricated a verdict: got '$(extract_verdict "$WORK/decoy.md")' (expected the tail conclusion APPROVE WITH NITS)"
+ok "case C: quoted diff/fence/blockquote tokens cannot fabricate a verdict"
+
+# The decoys are REALLY THERE. Without this the case above could pass because the
+# fixture never contained them, which is a test that cannot fail.
+grep -q '\*\*BLOCK\*\*' "$WORK/decoy.md"   || fail "the decoy fixture carries no **BLOCK** token, so case C proves nothing"
+ok "case C control: the fixture really does carry decoy verdict tokens"
+
+# And a VERDICT-marked line still outranks the tail fallback.
+printf 'VERDICT: REQUEST CHANGES
+
+closing thought **APPROVE**
+' > "$WORK/marked.md"
+[ "$(extract_verdict "$WORK/marked.md")" = "REQUEST CHANGES" ]   || fail "the tail fallback overrode an explicit VERDICT line, got '$(extract_verdict "$WORK/marked.md")'"
+ok "case C control: an explicit VERDICT line still wins over the fallback"
+
+# THE SHARP HALF of the codex finding: a transcript that states NO verdict of its
+# own, carrying emphasized tokens only in material it READ. Last-one-wins already
+# stops a decoy from beating a real later conclusion, so this is the shape where
+# the exclusion rules are the only thing standing between quoted source and a
+# fabricated verdict on an unattended gate.
+{
+  printf 'I read the following files.
+
+'
+  printf '```
+**BLOCK**
+```
+
+'
+  printf '> earlier round: **REQUEST CHANGES**
+
+'
+  printf -- '+ added = "**APPROVE**"
+'
+  printf '    indented = "**BLOCK**"
+
+'
+  printf 'I ran out of budget before forming a conclusion.
+'
+} > "$WORK/decoy-noverdict.md"
+
+[ -z "$(extract_verdict "$WORK/decoy-noverdict.md")" ]   || fail "a transcript that stated NO verdict got one manufactured from quoted material: got '$(extract_verdict "$WORK/decoy-noverdict.md")'"
+ok "case C sharp: quoted tokens with no stated conclusion yield NO verdict"
+
 echo "PASS: $PASS/$PASS severity-floor checks"

--- a/q-system/.q-system/scripts/test/test-severity-floor.sh
+++ b/q-system/.q-system/scripts/test/test-severity-floor.sh
@@ -4138,4 +4138,14 @@ ok "case D: the resolved verdict the gate posts is APPROVE WITH NITS"
 [ "$(extract_verdict "$WORK/quoted-then-real.md")" = "REQUEST CHANGES" ]   || fail "an unquoted VERDICT statement next to a diff line was dropped, got '$(extract_verdict "$WORK/quoted-then-real.md")'"
 ok "case D control: an unquoted VERDICT statement beside quoted material still counts"
 
+# A TAB is an indented code block too (codex round 3 on PR #297). The filter's
+# first cut matched four spaces only, so tab-indented quoted source fabricated a
+# BLOCK -- the worst direction, since a false BLOCK wedges an unattended gate.
+printf 'I read this file:\n\tVERDICT: BLOCK\nReviewer conclusion: **APPROVE WITH NITS**\n' > "$WORK/tabquote.md"
+[ "$(extract_verdict "$WORK/tabquote.md")" = "APPROVE WITH NITS" ]   || fail "a TAB-indented quoted VERDICT fabricated a verdict: got '$(extract_verdict "$WORK/tabquote.md")' (expected APPROVE WITH NITS)"
+ok "case D: tab-indented quoted material is excluded like space-indented"
+
+[ "$(awk '/^\tVERDICT: BLOCK/ { n++ } END { print n+0 }' "$WORK/tabquote.md")" = "1" ]   || fail "the tab fixture is not actually tab-indented, so the case above proves nothing"
+ok "case D control: the fixture really is TAB-indented"
+
 echo "PASS: $PASS/$PASS severity-floor checks"

--- a/q-system/.q-system/scripts/test/test-severity-floor.sh
+++ b/q-system/.q-system/scripts/test/test-severity-floor.sh
@@ -4234,11 +4234,16 @@ FENCEN="$(awk '/^[[:space:]]*(```|~~~)/ { n++ } END { print n+0 }' "$WORK/squigg
   || fail "case F fixture has $FENCEN fence-matching lines (even), so parity never flips and the case proves nothing"
 ok "case F control: the fixture really carries an odd number of fence-matching lines"
 
-[ "$(extract_verdict "$WORK/squiggle.md")" = "APPROVE" ] \
-  || fail "an unmatched fence hid the closing verdict: got '$(extract_verdict "$WORK/squiggle.md")' (expected APPROVE)"
-[ "$(resolve_verdict "$(extract_verdict "$WORK/squiggle.md")" "$(verdict_from_findings "$WORK/squiggle.md")")" = "APPROVE" ] \
-  || fail "case F: an approving review with an empty block must resolve APPROVE, got '$(resolve_verdict "$(extract_verdict "$WORK/squiggle.md")" "$(verdict_from_findings "$WORK/squiggle.md")")'"
-ok "case F: a squiggle line that merely starts with ~~~ cannot hide the verdict"
+# ON AN UNBALANCED WINDOW THE VERDICT IS LOST, AND THAT IS THE ACCEPTED COST.
+# Round 6 tried making the fence rule stand down when the count is odd, so this
+# fixture would read APPROVE. It did read APPROVE, and it also made a FENCED
+# `VERDICT: BLOCK` visible, which is statement-shaped and outranks a later
+# approval -- case I below is that reproducer. Losing a stated verdict holds a PR;
+# fabricating one wedges it. So the loss stands and the test says so out loud
+# rather than pinning a behaviour the lib does not have.
+[ -z "$(resolve_verdict "$(extract_verdict "$WORK/squiggle.md")" "$(verdict_from_findings "$WORK/squiggle.md")")" ] \
+  || fail "case F: an unbalanced window must resolve UNSTATED (hold), never a manufactured verdict, got '$(resolve_verdict "$(extract_verdict "$WORK/squiggle.md")" "$(verdict_from_findings "$WORK/squiggle.md")")'"
+ok "case F: an unbalanced answer window holds the PR instead of manufacturing a verdict"
 
 # THE REAL ARTIFACT, when this machine still has it. Operator-local, so its absence
 # is announced rather than silently skipped -- the synthetic fixture above is what
@@ -4327,5 +4332,39 @@ printf '**VERDICT:** BLOCK\n'            > "$WORK/lead4.md"
 [ "$(extract_verdict "$WORK/lead3.md")" = "APPROVE WITH NITS" ]    || fail "case H: bare marker shape lost, got '$(extract_verdict "$WORK/lead3.md")'"
 [ "$(extract_verdict "$WORK/lead4.md")" = "BLOCK" ]                || fail "case H: bold-colon marker shape lost, got '$(extract_verdict "$WORK/lead4.md")'"
 ok "case H control: every real marker shape in the corpus still reads"
+
+# --- case I: a fenced verdict must never outrank a later approval (round 6) -----
+#
+# THE ROUND-6 REVIEWER'S EXACT FIXTURE, and it demonstrated the defect on this
+# branch: a fenced `VERDICT: BLOCK` beside a `~~~~~~~~^^^^` compiler diagnostic,
+# which makes the fence count ODD, then a real closing `**APPROVE WITH NITS**`.
+# Under the fence stand-down the fenced token became visible, parsed as a stated
+# BLOCK, and outranked the approval -- a phantom rejection on an unattended gate.
+# Reproduced 2026-09-03, `stated=<BLOCK> ... resolved=<BLOCK>`; the stand-down was
+# reverted, and this pins that it stays reverted.
+{
+  printf 'Review evidence:\n\n'
+  printf '```text\n'
+  printf 'VERDICT: BLOCK\n'
+  printf '~~~~~~~~^^^^ compiler diagnostic\n'
+  printf '```\n\n'
+  printf 'Nothing gates. **APPROVE WITH NITS**\n\n'
+  printf 'FINDINGS:\nminor|bounded wording issue|demo.sh:1\nEND FINDINGS\n'
+} > "$WORK/fenced-block.md"
+
+# The trap is REALLY THERE: the fenced BLOCK and the odd fence count both.
+grep -q '^VERDICT: BLOCK' "$WORK/fenced-block.md" \
+  || fail "case I fixture carries no fenced VERDICT: BLOCK, so it proves nothing"
+FENCEI="$(awk '/^[[:space:]]*(```|~~~)/ { n++ } END { print n+0 }' "$WORK/fenced-block.md")"
+[ "$((FENCEI % 2))" = "1" ] \
+  || fail "case I fixture has $FENCEI fence-matching lines (even); the defect needed an ODD count, so it proves nothing"
+ok "case I control: the fixture really pairs a fenced BLOCK with an odd fence count"
+
+RESI="$(resolve_verdict "$(extract_verdict "$WORK/fenced-block.md")" "$(verdict_from_findings "$WORK/fenced-block.md")")"
+[ "$RESI" != "BLOCK" ] \
+  || fail "case I: a FENCED verdict token fabricated a BLOCK over the reviewer's approval (got '$RESI')"
+[ "$RESI" = "APPROVE WITH NITS" ] \
+  || fail "case I: expected the minor-derived APPROVE WITH NITS to stand, got '$RESI'"
+ok "case I: a fenced VERDICT: BLOCK cannot outrank a later approving conclusion"
 
 echo "PASS: $PASS/$PASS severity-floor checks"


### PR DESCRIPTION
## Two defects, opposite directions, one cause (ASK-1227)

The verdict comes from comparing a **stated** verdict against a **derived** one.
Both readers were wrong about what silence means.

### False green: PR #78, codex 12:31

codex could not reach `api.github.com`, read no diff, and said so plainly:

```
- VERDICT: NOT ISSUED. No evidence-based verdict is possible.

FINDINGS:
END FINDINGS
```

`NOT ISSUED` is not one of the four verdict tokens, so `extract_verdict` returned
empty. An empty block derives APPROVE. `resolve_verdict` let that lone derivation
stand. `kipi/reviewer-approved` went green and a worker merged on a review that
had read nothing.

### False red: PR #79, claude 12:49

A real six-minute review closed with "three minor findings, **APPROVE WITH
NITS**" and never wrote the literal word VERDICT, which is the only thing
`extract_verdict` could see. Recorded `stated: ""`, posted a FAILURE. A reviewer
that did the work scored identically to one that never ran.

## The fixes are at the reader, not the derivation

`verdict_from_findings` still derives APPROVE from an empty block. That is a
deliberate contract (a round 2 that refutes every round-1 finding closes with a
legitimately empty block) pinned by name in two suites, so moving the fix there
would collide with it.

- **`resolve_verdict`** now requires an empty-block APPROVE to be corroborated by
  the reviewer's own stated verdict. "Reviewed, found nothing" and "never
  started" are byte-identical *inside* the block, so the discriminator has to
  come from outside it. `has_complete_findings_block` already said exactly this
  in its header and pointed here for the fix; this is that fix, which until now
  was a comment with no code.
- **`extract_verdict`** falls back to a BOLD standalone verdict token when no
  `VERDICT`-marked line stated one.

Emphasis is the whole discriminator, and it is not a style preference. The
reviewer prompt is echoed verbatim into every codex transcript and carries the
grading ladder as plain text (`only minor/nit findings => APPROVE WITH NITS`), so
a bare-token fallback would read a verdict straight out of the prompt. Measured:
of 80 sampled transcripts, **zero** carry a bold verdict token in their prompt
region.

## The suite pinned the defect

`test-review-gate-no-fake-green.sh` asserted `resolve_verdict '' 'APPROVE'` =
APPROVE, under the name "a lone derived verdict stands when nothing was stated".
That is precisely the PR #78 call. It is now inverted for the approving direction
and widened to prove BLOCK / REQUEST CHANGES / APPROVE WITH NITS still stand
alone, because failing closed needs no corroboration.

## Evidence

Reproducers first. Both cases were added to `test-severity-floor.sh` and shown
RED against unpatched code before either fix:

```
FAIL: an empty-block APPROVE with NO stated verdict must resolve to UNSTATED, got 'APPROVE'
FAIL: a stated bold prose verdict must be read when the review carries no findings block, got ''
```

Then green, with negative controls for both (a corroborated empty block still
lands; the echoed prompt ladder yields no verdict; a truncated block still
derives nothing).

**Population check, not just the two reproducers.** Both readers were run over
all 984 recorded reviews on this machine, old vs new:

- 17 changed, every one from `stated: ""` to a real verdict
- 15 of the 17 now match the independently derived verdict **exactly**
- nothing moved toward approval

Suites: 206/206 severity-floor checks, and 16 of 16 related suites green
(converge, findings-block-reader, verdict-usability, verdict-statement-shape,
reviewer-floor, both provenance suites, the gh-repo-scope trio, and the rest).

## Also in here

The verdict record now carries `status_context` and `primary_engine`. Slot
placement is a function of `KIPI_REVIEW_PRIMARY_ENGINE`, so two runs of the same
command line could write different slots with indistinguishable records
(measured on PR #79: the 12:49 run landed primary, the 13:15 run advisory). Both
are passed as `${VAR:-}` because `test-review-degraded-provenance.sh` extracts
this writer by awk range and runs it in a bare subshell under `set -u`.

The `--engine claude` routing is deliberately left as-is: codex stays PRIMARY and
an explicit claude run stays advisory. The Opus **fallback** already writes the
primary slot with `degraded: true` when codex actually fails, which is the case
that must not wedge. What was missing was not the routing but the record of it.

Closes spillover `sp-1015d7a4`, `sp-8f13d9be`, `sp-3b31e4f5`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_017CqJJFqfVDPSjHiTxnjFrZ
