### PR TITLE
fix(morning-brief): read every calendar, not the account default (ASK-1235)

### DIFF
--- a/q-system/.q-system/scripts/morning-brief.py
+++ b/q-system/.q-system/scripts/morning-brief.py
@@ -64,6 +64,7 @@ import re
 import subprocess
 import sys
 import threading
+import time
 from pathlib import Path
 
 HERE = Path(__file__).resolve().parent
@@ -84,6 +85,13 @@ CAL_LIST_TOOL = "mcp__claude_ai_Google_Calendar__list_calendars"
 # (en.usa#holiday@..., en.uk#holiday@...) and it carries nothing the founder
 # acts on. Everything else the account can read is his day.
 HOLIDAY_MARKER = "holiday@group.v.calendar.google.com"
+
+# The calendar collector now makes 1 + N model calls where it used to make one.
+# PR #299 review, minor 3: N calls each inside CLAUDE_TIMEOUT can outrun the
+# section deadline in `_guarded` (FIXED_BUDGET_S), which abandons the thread and
+# reports a bare "calendar timed out". The collector owns a total budget of its
+# own so it fails FIRST and says which calendars it never reached.
+CAL_TOTAL_BUDGET_S = float(os.environ.get("KIPI_BRIEF_CAL_BUDGET", str(CLAUDE_TIMEOUT)))
 MAIL_TOOL = "mcp__claude_ai_Gmail__search_threads"
 
 MAX_ROWS = 15
@@ -100,8 +108,8 @@ def _load_sibling(stem: str, filename: str):
 # The model seam
 # ---------------------------------------------------------------------------
 
-def run_claude(prompt: str, tools: list, timeout: int = CLAUDE_TIMEOUT):
-    """(stdout, error). One bounded headless call.
+def _claude_exec(prompt: str, tools: list, timeout: int, extra_args=()):
+    """(stdout, error). One bounded headless call. The single subprocess site.
 
     REFUSES UNDER PYTEST. Same chokepoint posture as slack_founder.deliver: the
     refusal lives at the destination, not in per-test stubs, because per-test
@@ -117,7 +125,7 @@ def run_claude(prompt: str, tools: list, timeout: int = CLAUDE_TIMEOUT):
     env["ANTHROPIC_MODEL"] = BRIEF_MODEL
     try:
         proc = subprocess.run(
-            ["claude", "-p", prompt, "--allowedTools", *tools],
+            ["claude", "-p", prompt, "--allowedTools", *tools, *extra_args],
             capture_output=True, text=True, timeout=timeout,
             stdin=subprocess.DEVNULL, env=env)
     except FileNotFoundError:
@@ -130,6 +138,67 @@ def run_claude(prompt: str, tools: list, timeout: int = CLAUDE_TIMEOUT):
         detail = (proc.stderr or proc.stdout or "").strip()[:200]
         return None, f"claude exited {proc.returncode}: {detail}"
     return proc.stdout, None
+
+
+def run_claude(prompt: str, tools: list, timeout: int = CLAUDE_TIMEOUT):
+    """(stdout, error). The plain-text call. Mail still uses this."""
+    return _claude_exec(prompt, tools, timeout)
+
+
+def _parse_stream_json(stdout: str):
+    """(answer, error, tool_calls) out of `--output-format stream-json` output.
+
+    Shape measured 2026-09-04 against the live connector, not assumed: the
+    transcript is one JSON object per line; `assistant` lines carry
+    `message.content[]` blocks where a `tool_use` block has `name` and `input`;
+    the final `result` line carries `is_error` and the prose answer in `result`.
+
+    A line that does not parse is skipped rather than fatal (the CLI interleaves
+    diagnostics), but a transcript with NO result line is an error. Fail closed:
+    a run whose answer never arrived must not read as an answer of nothing.
+    """
+    calls, answer, saw_result = [], None, False
+    for line in (stdout or "").splitlines():
+        line = line.strip()
+        if not line:
+            continue
+        try:
+            obj = json.loads(line)
+        except ValueError:
+            continue
+        if not isinstance(obj, dict):
+            continue
+        kind = obj.get("type")
+        if kind == "assistant":
+            content = (obj.get("message") or {}).get("content") or []
+            for block in content:
+                if isinstance(block, dict) and block.get("type") == "tool_use":
+                    calls.append({"name": block.get("name"),
+                                  "input": block.get("input") or {}})
+        elif kind == "result":
+            saw_result = True
+            if obj.get("is_error"):
+                return None, f"claude reported an error: {str(obj.get('result'))[:200]}", calls
+            answer = obj.get("result")
+    if not saw_result:
+        return None, "no result line in the stream-json transcript", calls
+    return answer, None, calls
+
+
+def run_claude_traced(prompt: str, tools: list, timeout: int = CLAUDE_TIMEOUT):
+    """(answer, error, tool_calls). The call whose TOOL ARGUMENTS are readable.
+
+    PR #299 major: `run_claude` returns only the model's prose. A model that was
+    asked for calendarId X and silently read the default calendar answers
+    `{"events": []}`, which is indistinguishable from a genuinely empty day. The
+    prompt is not evidence of what ran; the tool_use block is. So the calendar
+    path asks for the whole transcript and checks the argument that executed.
+    """
+    stdout, error = _claude_exec(prompt, tools, timeout,
+                                 ("--output-format", "stream-json", "--verbose"))
+    if error:
+        return None, error, []
+    return _parse_stream_json(stdout)
 
 
 def _parse_json_block(text: str, key: str):
@@ -185,8 +254,30 @@ def _event_sort_key(start: str):
     return (0, "") if start == "all-day" else (1, start)
 
 
-def collect_calendar(now: dt.datetime, runner=None):
-    """(rows, error). Reads EVERY calendar on the account, not the default one.
+def _executed_calendar_ids(tool_calls) -> set:
+    """The calendarIds `list_events` was ACTUALLY invoked with, off the transcript.
+
+    Filtered by tool name on purpose. The live transcript (measured 2026-09-04)
+    also carries a ToolSearch call, and a `calendarId` appearing in some other
+    tool's input is not evidence that the calendar was read.
+    """
+    found = set()
+    for call in tool_calls or []:
+        if not isinstance(call, dict) or call.get("name") != CAL_TOOL:
+            continue
+        payload = call.get("input")
+        if not isinstance(payload, dict):
+            continue
+        for key in ("calendarId", "calendar_id"):
+            value = payload.get(key)
+            if isinstance(value, str) and value.strip():
+                found.add(value.strip())
+    return found
+
+
+def collect_calendar(now: dt.datetime, runner=None, budget_s: float = None,
+                     clock=None):
+    """(rows, error). Reads EVERY calendar on the account, and PROVES it did.
 
     ## Scar sp-57823aef, measured 2026-09-04
 
@@ -203,44 +294,79 @@ def collect_calendar(now: dt.datetime, runner=None):
     prose is not an argument, and on this account "primary" resolves to a
     calendar with no events on it.
 
+    ## Why the prompt naming a calendarId is ALSO not enough (PR #299 major)
+
+    Putting the id in the prompt only moves the same defect one step: a model
+    that ignores it and reads the default still answers `{"events": []}`, which
+    renders as a quiet morning. So the runner returns the TRANSCRIPT, and a
+    calendar's answer is refused unless a `list_events` tool_use actually
+    carried that id. The check is on the executed argument, never on the ask.
+
     ## Why a failure anywhere returns an error and never a short list
 
-    An enumeration that fails, or one calendar that fails while the others
-    answer, returns ([], error) so the section renders COULD NOT READ. A partial
+    An enumeration that fails, one calendar that fails while the others answer,
+    a calendar entry with no usable id, a refused answer, or a budget that ran
+    out all return ([], error) so the section renders COULD NOT READ. A partial
     read rendered as a complete one is the same lie as printing "nothing": the
     founder cannot see that an account was dropped. That distinction is the
     property this whole file exists to hold.
     """
     day = now.strftime("%Y-%m-%d")
-    runner = runner or (lambda p, t: run_claude(p, t))
+    clock = clock or time.monotonic
+    budget_s = CAL_TOTAL_BUDGET_S if budget_s is None else budget_s
+    started = clock()
 
-    text, error = runner(CAL_LIST_PROMPT.format(tool=CAL_LIST_TOOL), [CAL_LIST_TOOL])
+    def remaining():
+        return budget_s - (clock() - started)
+
+    def default_runner(prompt, tools):
+        return run_claude_traced(prompt, tools,
+                                 timeout=max(1, int(min(CLAUDE_TIMEOUT, remaining()))))
+
+    runner = runner or default_runner
+
+    text, error, _ = runner(CAL_LIST_PROMPT.format(tool=CAL_LIST_TOOL), [CAL_LIST_TOOL])
     if error:
         return [], f"calendar list: {error}"
     calendars, parse_error = _parse_json_block(text, "calendars")
     if parse_error:
         return [], f"calendar list: {parse_error}"
 
-    ids = []
+    ids, malformed = [], 0
     for cal in calendars:
         cid = cal.get("id") if isinstance(cal, dict) else cal
         if not isinstance(cid, str) or not cid.strip():
+            malformed += 1
             continue
         cid = cid.strip()
         if HOLIDAY_MARKER in cid:
             continue
         if cid not in ids:
             ids.append(cid)
+    if malformed:
+        # PR #299 minor 2. Dropping these quietly while the rest rendered made a
+        # partial read wear a complete read's clothes, which is the one thing
+        # this section is not allowed to do.
+        return [], (f"calendar list had {malformed} entry/entries with no usable id; "
+                    "the read is partial, not empty")
     if not ids:
         return [], (f"calendar list returned {len(calendars)} calendar(s), none readable "
-                    "(every one was a holiday feed or carried no id)")
+                    "(every one was a holiday feed)")
 
     dated = []
-    for cid in ids:
-        text, error = runner(
+    for index, cid in enumerate(ids):
+        if remaining() <= 0:
+            return [], (f"calendar budget of {budget_s}s exhausted with "
+                        f"{len(ids) - index} calendar(s) unread, starting at {cid}")
+        text, error, tool_calls = runner(
             CAL_PROMPT.format(tool=CAL_TOOL, day=day, calendar_id=cid), [CAL_TOOL])
         if error:
             return [], f"{cid}: {error}"
+        executed = _executed_calendar_ids(tool_calls)
+        if cid not in executed:
+            return [], (f"{cid}: refused, {CAL_TOOL} was executed with "
+                        f"{sorted(executed) or 'no calendarId'} — that answer is "
+                        "about some other calendar")
         events, parse_error = _parse_json_block(text, "events")
         if parse_error:
             return [], f"{cid}: {parse_error}"

--- a/q-system/.q-system/scripts/morning-brief.py
+++ b/q-system/.q-system/scripts/morning-brief.py
@@ -158,6 +158,10 @@ def _parse_stream_json(stdout: str):
     a run whose answer never arrived must not read as an answer of nothing.
     """
     calls, answer, saw_result = [], None, False
+    # tool_use_id -> the raw text the TOOL returned. Kept separately because
+    # tool_result blocks arrive in `user` messages, one or more lines after the
+    # `assistant` line that asked for them.
+    results = {}
     for line in (stdout or "").splitlines():
         line = line.strip()
         if not line:
@@ -174,12 +178,31 @@ def _parse_stream_json(stdout: str):
             for block in content:
                 if isinstance(block, dict) and block.get("type") == "tool_use":
                     calls.append({"name": block.get("name"),
-                                  "input": block.get("input") or {}})
+                                  "input": block.get("input") or {},
+                                  "id": block.get("id")})
+        elif kind == "user":
+            # THE RAW TOOL ANSWER, which is the only completeness boundary there
+            # is. PR #299 round 2 major: the enumeration parsed the model's
+            # REWRITTEN list, so a calendar the model omitted from its prose was
+            # never read and the day rendered clean. Reviewer's reproducer: raw
+            # result carried 2 calendars, the answer carried 1, list_events ran
+            # once, rows [] and error None. The model is a narrator here, not a
+            # source; what the tool returned is the source.
+            content = (obj.get("message") or {}).get("content") or []
+            for block in content:
+                if isinstance(block, dict) and block.get("type") == "tool_result":
+                    body = block.get("content")
+                    if isinstance(body, list):
+                        body = " ".join(str(b.get("text", "")) if isinstance(b, dict)
+                                        else str(b) for b in body)
+                    results[block.get("tool_use_id")] = str(body or "")
         elif kind == "result":
             saw_result = True
             if obj.get("is_error"):
                 return None, f"claude reported an error: {str(obj.get('result'))[:200]}", calls
             answer = obj.get("result")
+    for call in calls:
+        call["result"] = results.get(call.get("id"), "")
     if not saw_result:
         return None, "no result line in the stream-json transcript", calls
     return answer, None, calls
@@ -275,6 +298,14 @@ def _executed_calendar_ids(tool_calls) -> set:
     return found
 
 
+#: An email-shaped calendar id in the raw tool result. Deliberately a shape and not
+#: a JSON parse: the connector's result text is not a contract this file controls,
+#: and a parser tied to today's envelope would silently stop checking the day that
+#: envelope changes. A missed address here weakens the check; a wrong parse would
+#: disable it.
+_ADDRESS = re.compile(r"[A-Za-z0-9._%+-]+@[A-Za-z0-9.-]+\.[A-Za-z]{2,}")
+
+
 def collect_calendar(now: dt.datetime, runner=None, budget_s: float = None,
                      clock=None):
     """(rows, error). Reads EVERY calendar on the account, and PROVES it did.
@@ -325,12 +356,39 @@ def collect_calendar(now: dt.datetime, runner=None, budget_s: float = None,
 
     runner = runner or default_runner
 
-    text, error, _ = runner(CAL_LIST_PROMPT.format(tool=CAL_LIST_TOOL), [CAL_LIST_TOOL])
+    text, error, list_calls = runner(CAL_LIST_PROMPT.format(tool=CAL_LIST_TOOL),
+                                     [CAL_LIST_TOOL])
     if error:
         return [], f"calendar list: {error}"
     calendars, parse_error = _parse_json_block(text, "calendars")
     if parse_error:
         return [], f"calendar list: {parse_error}"
+
+    # THE RAW RESULT IS THE COMPLETENESS BOUNDARY, not the model's rewrite of it.
+    # PR #299 round 2 major, with a reproducer: the raw list_calendars result
+    # carried 2 calendars, the model's answer carried 1, list_events ran once, and
+    # the section rendered rows [] with error None -- a silently dropped account
+    # wearing a clean day's clothes.
+    #
+    # Every address the TOOL returned must appear in the answer. A subset is a
+    # refusal, never a short list, because the founder cannot see an account that
+    # was never read. Absent evidence is a refusal too: reading the answer alone
+    # is the defect, so a transcript that carries no raw result cannot be treated
+    # as agreement.
+    raw = " ".join(c.get("result") or "" for c in (list_calls or [])
+                   if c.get("name") == CAL_LIST_TOOL)
+    if not raw.strip():
+        return [], ("calendar list: the transcript carried no raw list_calendars "
+                    "result, so the answer's completeness cannot be checked")
+    answered = " ".join(str(c.get("id") if isinstance(c, dict) else c)
+                        for c in calendars).lower()
+    missing = sorted({addr for addr in _ADDRESS.findall(raw)
+                      if HOLIDAY_MARKER not in addr
+                      and addr.lower() not in answered})
+    if missing:
+        return [], ("calendar list: the tool returned %d calendar(s) the answer "
+                    "left out (%s); the read would be partial"
+                    % (len(missing), ", ".join(missing[:3])))
 
     ids, malformed = [], 0
     for cal in calendars:

--- a/q-system/.q-system/scripts/morning-brief.py
+++ b/q-system/.q-system/scripts/morning-brief.py
@@ -79,6 +79,11 @@ BRIEF_MODEL = os.environ.get("KIPI_BRIEF_MODEL", "claude-opus-5")
 CLAUDE_TIMEOUT = int(os.environ.get("KIPI_BRIEF_CLAUDE_TIMEOUT", "180"))
 
 CAL_TOOL = "mcp__claude_ai_Google_Calendar__list_events"
+CAL_LIST_TOOL = "mcp__claude_ai_Google_Calendar__list_calendars"
+# Substring, not an exact id: Google names the holiday feed per locale
+# (en.usa#holiday@..., en.uk#holiday@...) and it carries nothing the founder
+# acts on. Everything else the account can read is his day.
+HOLIDAY_MARKER = "holiday@group.v.calendar.google.com"
 MAIL_TOOL = "mcp__claude_ai_Gmail__search_threads"
 
 MAX_ROWS = 15
@@ -156,30 +161,100 @@ def _parse_json_block(text: str, key: str):
 # Section 1: today's calendar
 # ---------------------------------------------------------------------------
 
-CAL_PROMPT = """Call {tool} for calendar "primary" restricted to {day} local time only.
+CAL_LIST_PROMPT = """Call {tool} and list every calendar this account can read.
+Reply with ONE JSON object and nothing else, no prose, no code fence:
+{{"calendars": [{{"id": "<the calendar id, an email address>", "summary": "..."}}]}}
+Include every calendar the tool returns. Do not filter, do not pick one.
+If the tool call fails, reply with exactly: {{"error": "<what failed>"}}"""
+
+CAL_PROMPT = """Call {tool} with calendarId "{calendar_id}" restricted to {day}
+local time only. Read that calendar and no other.
 Reply with ONE JSON object and nothing else, no prose, no code fence:
 {{"events": [{{"start": "HH:MM", "title": "...", "who": ["name", ...]}}]}}
 Use "all-day" as start for all-day events. "who" is the other attendees, may be [].
 If the tool call fails, reply with exactly: {{"error": "<what failed>"}}"""
 
 
+def _event_sort_key(start: str):
+    """All-day first, then HH:MM ascending.
+
+    Rows arrive grouped by calendar, which is an ordering the founder never
+    asked for. He reads the section top-to-bottom as a day, so the merge sorts
+    by start or the second account's 08:00 lands under the first account's 17:00.
+    """
+    return (0, "") if start == "all-day" else (1, start)
+
+
 def collect_calendar(now: dt.datetime, runner=None):
+    """(rows, error). Reads EVERY calendar on the account, not the default one.
+
+    ## Scar sp-57823aef, measured 2026-09-04
+
+    This used to call list_events with no calendarId, which reads the account
+    default. `list_calendars` on this account returns three calendars and NONE
+    of them is flagged primary: assafkip@gmail.com, assaf@askconsulting.io, and
+    the US holiday feed. The default read returned zero events for the whole
+    week 2026-09-01..08 while an explicit read of assafkip@gmail.com returned 9
+    (2026-09-02 09:00 "Weekly project planning", 2026-09-07 08:00 "Project plan
+    - Weekly"). So the brief printed "nothing" on days that had meetings, and
+    the zero read as a pass.
+
+    Naming "primary" in the prompt prose was not enough and was never the fix:
+    prose is not an argument, and on this account "primary" resolves to a
+    calendar with no events on it.
+
+    ## Why a failure anywhere returns an error and never a short list
+
+    An enumeration that fails, or one calendar that fails while the others
+    answer, returns ([], error) so the section renders COULD NOT READ. A partial
+    read rendered as a complete one is the same lie as printing "nothing": the
+    founder cannot see that an account was dropped. That distinction is the
+    property this whole file exists to hold.
+    """
     day = now.strftime("%Y-%m-%d")
     runner = runner or (lambda p, t: run_claude(p, t))
-    text, error = runner(CAL_PROMPT.format(tool=CAL_TOOL, day=day), [CAL_TOOL])
+
+    text, error = runner(CAL_LIST_PROMPT.format(tool=CAL_LIST_TOOL), [CAL_LIST_TOOL])
     if error:
-        return [], error
-    events, parse_error = _parse_json_block(text, "events")
+        return [], f"calendar list: {error}"
+    calendars, parse_error = _parse_json_block(text, "calendars")
     if parse_error:
-        return [], parse_error
-    rows = []
-    for ev in events:
-        if not isinstance(ev, dict):
+        return [], f"calendar list: {parse_error}"
+
+    ids = []
+    for cal in calendars:
+        cid = cal.get("id") if isinstance(cal, dict) else cal
+        if not isinstance(cid, str) or not cid.strip():
             continue
-        who = ev.get("who") or []
-        who_text = f"  ({', '.join(str(w) for w in who)})" if who else ""
-        rows.append(f"{ev.get('start', '??:??')}  {str(ev.get('title', 'untitled'))[:80]}{who_text}")
-    return rows, None
+        cid = cid.strip()
+        if HOLIDAY_MARKER in cid:
+            continue
+        if cid not in ids:
+            ids.append(cid)
+    if not ids:
+        return [], (f"calendar list returned {len(calendars)} calendar(s), none readable "
+                    "(every one was a holiday feed or carried no id)")
+
+    dated = []
+    for cid in ids:
+        text, error = runner(
+            CAL_PROMPT.format(tool=CAL_TOOL, day=day, calendar_id=cid), [CAL_TOOL])
+        if error:
+            return [], f"{cid}: {error}"
+        events, parse_error = _parse_json_block(text, "events")
+        if parse_error:
+            return [], f"{cid}: {parse_error}"
+        for ev in events:
+            if not isinstance(ev, dict):
+                continue
+            who = ev.get("who") or []
+            who_text = f"  ({', '.join(str(w) for w in who)})" if who else ""
+            start = str(ev.get("start", "??:??"))
+            title = str(ev.get("title", "untitled"))[:80]
+            dated.append((start, f"{start}  {title}{who_text}"))
+
+    dated.sort(key=lambda row: _event_sort_key(row[0]))
+    return [row[1] for row in dated], None
 
 
 # ---------------------------------------------------------------------------

--- a/q-system/.q-system/tests/test_morning_brief.py
+++ b/q-system/.q-system/tests/test_morning_brief.py
@@ -252,6 +252,128 @@ def test_model_call_refuses_under_pytest(brief):
 # Collectors: each one turns a broken source into an error, not into []
 # --------------------------------------------------------------------------
 
+# --- sp-57823aef: the account has three calendars and none is flagged primary --
+# Measured 2026-09-04 with list_calendars on the live account. The collector
+# called list_events with NO calendarId, so it read the account default, which
+# returned zero events for the whole week 2026-09-01..08 while an explicit read
+# of assafkip@gmail.com returned 9. The brief printed "nothing" on days that had
+# meetings. These ids are the live ones; the events are two real rows off that
+# week (2026-09-02 09:00 and 2026-09-07 08:00).
+
+CAL_LIST_JSON = json.dumps({"calendars": [
+    {"id": "assafkip@gmail.com", "summary": "assafkip@gmail.com"},
+    {"id": "assaf@askconsulting.io", "summary": "assaf@askconsulting.io"},
+    {"id": "en.usa#holiday@group.v.calendar.google.com",
+     "summary": "Holidays in United States"},
+]})
+
+REAL_SHAPED_EVENTS = json.dumps({"events": [
+    {"start": "09:00", "title": "Weekly project planning", "who": []},
+    {"start": "08:00", "title": "Project plan - Weekly", "who": []},
+]})
+
+
+def _cal_runner(per_calendar=None, listing=CAL_LIST_JSON, listing_error=None,
+                seen=None):
+    """Fake model seam shaped like the live account.
+
+    Keys on the PROMPT TEXT, never on call order. The defect was that the
+    collector named no calendarId at all, and a call-order fake cannot tell
+    "named no calendar" apart from "named the right one" -- it would go green
+    against the unfixed code. Any prompt that names no known calendar id falls
+    through to the empty read, which is exactly what the account default did.
+    """
+    per_calendar = per_calendar or {}
+
+    def run(prompt, tools):
+        if seen is not None:
+            seen.append(prompt)
+        if "list_calendars" in prompt:
+            if listing_error:
+                return None, listing_error
+            return listing, None
+        for cid, payload in per_calendar.items():
+            if cid in prompt:
+                return payload
+        return json.dumps({"events": []}), None
+
+    return run
+
+
+def test_calendar_reads_every_calendar_not_the_account_default(brief):
+    """The reproducer for sp-57823aef. RED on the pre-fix collector: it names
+    no calendarId, falls through to the empty default read, and returns 0 rows.
+    """
+    seen = []
+    runner = _cal_runner(
+        per_calendar={"assafkip@gmail.com": (REAL_SHAPED_EVENTS, None)}, seen=seen)
+    rows, error = brief.collect_calendar(NOW, runner=runner)
+    assert error is None, error
+    assert len(rows) == 2, f"read the account default, not the calendars: {rows}"
+    # merged output is sorted by start, so the 08:00 row leads
+    assert "Project plan - Weekly" in rows[0], rows
+    assert "Weekly project planning" in rows[1], rows
+    assert any("assafkip@gmail.com" in p for p in seen), \
+        "no prompt ever named a calendarId"
+
+
+def test_calendar_reads_the_second_account_too(brief):
+    """Both non-holiday calendars are read, not just the first one."""
+    seen = []
+    brief.collect_calendar(NOW, runner=_cal_runner(seen=seen))
+    assert any("assaf@askconsulting.io" in p for p in seen), seen
+
+
+def test_calendar_skips_the_holiday_feed(brief):
+    seen = []
+    brief.collect_calendar(NOW, runner=_cal_runner(seen=seen))
+    assert not any("holiday@group.v.calendar.google.com" in p for p in seen), seen
+
+
+def test_calendar_enumeration_failure_is_could_not_read_not_nothing(brief):
+    """The control. A dead connector must render COULD NOT READ. Returning []
+    here would make a broken calendar indistinguishable from a free morning,
+    which is the defect that let the 9-phase pipeline die silently.
+    """
+    rows, error = brief.collect_calendar(
+        NOW, runner=_cal_runner(listing_error="claude exited 1"))
+    assert rows == []
+    assert error is not None
+    assert "claude exited 1" in error
+
+
+def test_calendar_unparseable_enumeration_is_an_error(brief):
+    rows, error = brief.collect_calendar(
+        NOW, runner=_cal_runner(listing="I could not list the calendars"))
+    assert rows == []
+    assert error is not None
+
+
+def test_calendar_one_broken_calendar_fails_the_section(brief):
+    """A partial read is not reported as a complete one. If any calendar could
+    not be read the section says COULD NOT READ, because silently dropping one
+    account is the same class of lie as printing "nothing".
+    """
+    rows, error = brief.collect_calendar(NOW, runner=_cal_runner(per_calendar={
+        "assafkip@gmail.com": (REAL_SHAPED_EVENTS, None),
+        "assaf@askconsulting.io": (None, "claude timed out after 180s"),
+    }))
+    assert rows == []
+    assert error is not None
+    assert "assaf@askconsulting.io" in error
+
+
+def test_calendar_all_calendars_filtered_out_is_an_error(brief):
+    """Degenerate case: an enumeration that yields nothing readable is a broken
+    read, not a quiet day."""
+    only_holidays = json.dumps({"calendars": [
+        {"id": "en.usa#holiday@group.v.calendar.google.com", "summary": "Holidays"}]})
+    rows, error = brief.collect_calendar(
+        NOW, runner=_cal_runner(listing=only_holidays))
+    assert rows == []
+    assert error is not None
+
+
 def test_calendar_collector_reports_a_model_failure(brief):
     rows, error = brief.collect_calendar(
         NOW, runner=lambda prompt, tools: (None, "claude exited 1"))
@@ -269,15 +391,20 @@ def test_calendar_collector_reports_unparseable_output(brief):
 def test_calendar_collector_parses_events(brief):
     payload = json.dumps({"events": [
         {"start": "09:00", "title": "Chris PI sync", "who": ["chris"]}]})
-    rows, error = brief.collect_calendar(NOW, runner=lambda p, t: (payload, None))
+    rows, error = brief.collect_calendar(
+        NOW, runner=_cal_runner(per_calendar={"assafkip@gmail.com": (payload, None)}))
     assert error is None
     assert len(rows) == 1
     assert "Chris PI sync" in rows[0]
+    assert "(chris)" in rows[0]
 
 
 def test_calendar_empty_is_empty_not_an_error(brief):
-    rows, error = brief.collect_calendar(
-        NOW, runner=lambda p, t: (json.dumps({"events": []}), None))
+    """Every calendar enumerated and every one genuinely empty. This is the ONE
+    shape allowed to render as a quiet day, and sp-57823aef is why it has to be
+    reached by reading them rather than by reading none of them.
+    """
+    rows, error = brief.collect_calendar(NOW, runner=_cal_runner())
     assert rows == []
     assert error is None
 

--- a/q-system/.q-system/tests/test_morning_brief.py
+++ b/q-system/.q-system/tests/test_morning_brief.py
@@ -286,13 +286,20 @@ _UNSET = object()
 
 
 def _cal_runner(per_calendar=None, listing=CAL_LIST_JSON, listing_error=None,
-                seen=None, executed_id=_UNSET):
+                seen=None, executed_id=_UNSET, raw_listing=_UNSET):
     """Fake model seam shaped like the live `--output-format stream-json` run.
 
     Measured 2026-09-04 against the real connector, not invented: the transcript
     carries `assistant` messages whose `content[]` holds `tool_use` blocks with
     `name` and `input.calendarId`, then a `result` line with the prose answer.
     So this returns (answer, error, tool_calls).
+
+    `raw_listing` is what the list_calendars TOOL returned, which the collector
+    treats as the completeness boundary. It defaults to agreeing with `listing`
+    because that is the healthy case; pass it explicitly to simulate a model that
+    dropped a calendar from its prose while the tool had returned it. That split
+    is the round-2 major: the collector parsed the model's rewrite, so an omitted
+    account was never read and the day rendered clean.
 
     `executed_id` is what the TRANSCRIPT says list_events actually ran with,
     and it is deliberately independent of what the prompt asked for. That split
@@ -309,7 +316,9 @@ def _cal_runner(per_calendar=None, listing=CAL_LIST_JSON, listing_error=None,
         if "list_calendars" in prompt:
             if listing_error:
                 return None, listing_error, []
-            return listing, None, [{"name": LIST_CALENDARS, "input": {}}]
+            raw = listing if raw_listing is _UNSET else raw_listing
+            return listing, None, [{"name": LIST_CALENDARS, "input": {},
+                                    "id": "toolu_list", "result": raw}]
 
         asked = next((cid for cid in ALL_CAL_IDS if cid in prompt), None)
         answer, error = json.dumps({"events": []}), None
@@ -415,7 +424,12 @@ def test_calendar_ignores_tool_use_from_a_different_tool(brief):
     """
     def runner(prompt, tools):
         if "list_calendars" in prompt:
-            return CAL_LIST_JSON, None, [{"name": LIST_CALENDARS, "input": {}}]
+            # Carries the raw tool result, so this test reaches the tool-NAME
+            # filter it exists for instead of being refused one step earlier by
+            # the completeness check. Two guards, and each needs its own test.
+            return CAL_LIST_JSON, None, [{"name": LIST_CALENDARS, "input": {},
+                                          "id": "toolu_list",
+                                          "result": CAL_LIST_JSON}]
         asked = next((cid for cid in ALL_CAL_IDS if cid in prompt), None)
         return json.dumps({"events": []}), None, [
             {"name": "ToolSearch", "input": {"calendarId": asked}}]
@@ -1134,3 +1148,71 @@ def test_a_present_optional_module_renders_after_the_fixed_four(brief, tmp_path,
     message, degraded = brief.build(NOW, sources)
     assert not degraded
     assert message.index("Overnight") < message.index("Terms I do not know") < message.index("Widgetcorp")
+
+
+class TestTheToolsAnswerIsTheBoundaryNotTheModels:
+    """PR #299 round 2 major, with the reviewer's own reproducer: the raw
+    list_calendars result carried 2 calendars, the model's answer carried 1,
+    list_events ran once, and the section returned rows [] with error None. A
+    dropped account rendered as a clean day.
+
+    The model is a NARRATOR of the enumeration, not its source. Every guard
+    already in this file checks what the model DID against what it was asked;
+    this one checks what it REPORTED against what the tool returned, which is
+    the same class of defect one level up."""
+
+    def test_a_calendar_the_model_omits_is_REFUSED_not_silently_dropped(self, brief):
+        raw = json.dumps({"calendars": [
+            {"id": "assafkip@gmail.com"},
+            {"id": "assaf@askconsulting.io"}]})
+        rewritten = json.dumps({"calendars": [{"id": "assafkip@gmail.com"}]})
+        rows, error = brief.collect_calendar(
+            NOW, runner=_cal_runner(listing=rewritten, raw_listing=raw))
+        assert rows == []
+        assert error is not None, "a dropped account rendered as a clean day"
+        assert "assaf@askconsulting.io" in error, error
+        assert "partial" in error
+
+    def test_agreement_reads_normally(self, brief):
+        payload = json.dumps({"events": [
+            {"start": "19:00", "title": "Founder call", "who": []}]})
+        rows, error = brief.collect_calendar(
+            NOW, runner=_cal_runner(per_calendar={"assafkip@gmail.com": (payload, None)}))
+        assert error is None
+        assert any("Founder call" in r for r in rows)
+
+    def test_NO_raw_result_is_a_refusal_not_an_assumption_of_agreement(self, brief):
+        """Absent evidence cannot mean agreement. Reading the answer alone is the
+        defect, so a transcript with nothing to check against must fail closed."""
+        rows, error = brief.collect_calendar(
+            NOW, runner=_cal_runner(raw_listing=""))
+        assert rows == []
+        assert error is not None and "no raw list_calendars result" in error
+
+    def test_the_holiday_feed_being_absent_from_the_answer_is_fine(self, brief):
+        """It is filtered on purpose, so its absence is not a dropped account."""
+        raw = json.dumps({"calendars": [
+            {"id": "assafkip@gmail.com"},
+            {"id": "assaf@askconsulting.io"},
+            {"id": "en.usa#holiday@group.v.calendar.google.com"}]})
+        answered = json.dumps({"calendars": [
+            {"id": "assafkip@gmail.com"}, {"id": "assaf@askconsulting.io"}]})
+        _rows, error = brief.collect_calendar(
+            NOW, runner=_cal_runner(listing=answered, raw_listing=raw))
+        assert error is None, error
+
+    def test_the_parser_pairs_a_tool_result_to_its_call(self, brief):
+        """tool_result blocks arrive in `user` messages, one or more lines after
+        the assistant line that asked. Matched by tool_use_id, never by order."""
+        transcript = "\n".join([
+            json.dumps({"type": "assistant", "message": {"content": [
+                {"type": "tool_use", "id": "toolu_A", "name": LIST_CALENDARS,
+                 "input": {}}]}}),
+            json.dumps({"type": "user", "message": {"content": [
+                {"type": "tool_result", "tool_use_id": "toolu_A",
+                 "content": [{"type": "text", "text": "RAW-A"}]}]}}),
+            json.dumps({"type": "result", "is_error": False, "result": "{}"}),
+        ])
+        _answer, error, calls = brief._parse_stream_json(transcript)
+        assert error is None
+        assert calls[0]["result"] == "RAW-A"

--- a/q-system/.q-system/tests/test_morning_brief.py
+++ b/q-system/.q-system/tests/test_morning_brief.py
@@ -273,15 +273,33 @@ REAL_SHAPED_EVENTS = json.dumps({"events": [
 ]})
 
 
-def _cal_runner(per_calendar=None, listing=CAL_LIST_JSON, listing_error=None,
-                seen=None):
-    """Fake model seam shaped like the live account.
+ALL_CAL_IDS = ("assafkip@gmail.com", "assaf@askconsulting.io",
+               "en.usa#holiday@group.v.calendar.google.com")
 
-    Keys on the PROMPT TEXT, never on call order. The defect was that the
-    collector named no calendarId at all, and a call-order fake cannot tell
-    "named no calendar" apart from "named the right one" -- it would go green
-    against the unfixed code. Any prompt that names no known calendar id falls
-    through to the empty read, which is exactly what the account default did.
+# The live tool names, spelled out rather than read off the module under test.
+# A rename in the script must turn these red, not silently keep passing against
+# a constant that moved with it.
+LIST_EVENTS = "mcp__claude_ai_Google_Calendar__list_events"
+LIST_CALENDARS = "mcp__claude_ai_Google_Calendar__list_calendars"
+
+_UNSET = object()
+
+
+def _cal_runner(per_calendar=None, listing=CAL_LIST_JSON, listing_error=None,
+                seen=None, executed_id=_UNSET):
+    """Fake model seam shaped like the live `--output-format stream-json` run.
+
+    Measured 2026-09-04 against the real connector, not invented: the transcript
+    carries `assistant` messages whose `content[]` holds `tool_use` blocks with
+    `name` and `input.calendarId`, then a `result` line with the prose answer.
+    So this returns (answer, error, tool_calls).
+
+    `executed_id` is what the TRANSCRIPT says list_events actually ran with,
+    and it is deliberately independent of what the prompt asked for. That split
+    is the whole point of the PR #299 major: the collector could only see its
+    own prompt, so a model that ignored calendarId and read the default handed
+    back a clean `{"events": []}` and the brief printed a quiet morning. Pass
+    None to simulate a call that carried no calendarId at all.
     """
     per_calendar = per_calendar or {}
 
@@ -290,14 +308,145 @@ def _cal_runner(per_calendar=None, listing=CAL_LIST_JSON, listing_error=None,
             seen.append(prompt)
         if "list_calendars" in prompt:
             if listing_error:
-                return None, listing_error
-            return listing, None
+                return None, listing_error, []
+            return listing, None, [{"name": LIST_CALENDARS, "input": {}}]
+
+        asked = next((cid for cid in ALL_CAL_IDS if cid in prompt), None)
+        answer, error = json.dumps({"events": []}), None
         for cid, payload in per_calendar.items():
             if cid in prompt:
-                return payload
-        return json.dumps({"events": []}), None
+                answer, error = payload
+        executed = asked if executed_id is _UNSET else executed_id
+        calls = [{"name": LIST_EVENTS,
+                  "input": {"calendarId": executed} if executed else {}}]
+        return answer, error, calls
 
     return run
+
+
+# Lifted verbatim off a real `claude -p --output-format stream-json --verbose`
+# run on 2026-09-04 (the Guinea Pig Cleaning event is genuinely on the calendar).
+# Producer-shaped, not invented: an invented transcript would only test what I
+# assumed the CLI emits.
+LIVE_TOOL_USE_LINE = json.dumps({"type": "assistant", "message": {"content": [
+    {"type": "tool_use", "id": "toolu_01UWnDhHdRGxWejrLbo71zir",
+     "name": "mcp__claude_ai_Google_Calendar__list_events",
+     "input": {"calendarId": "assafkip@gmail.com",
+               "startTime": "2026-09-04T00:00:00-07:00",
+               "endTime": "2026-09-05T00:00:00-07:00",
+               "orderBy": "startTime", "timeZone": "America/Los_Angeles"}}]}})
+LIVE_RESULT_LINE = json.dumps({
+    "type": "result", "subtype": "success", "is_error": False,
+    "result": '{"events": [{"start": "19:00", "title": "Guinea Pig Cleaning", "who": []}]}'})
+
+
+def test_stream_json_parser_reads_the_tool_use_and_the_answer(brief):
+    answer, error, calls = brief._parse_stream_json(
+        "\n".join([LIVE_TOOL_USE_LINE, LIVE_RESULT_LINE]))
+    assert error is None
+    assert "Guinea Pig Cleaning" in answer
+    assert calls[0]["name"] == LIST_EVENTS
+    assert calls[0]["input"]["calendarId"] == "assafkip@gmail.com"
+
+
+def test_stream_json_parser_without_a_result_line_is_an_error(brief):
+    """Fail closed. A transcript whose answer never arrived must not read as an
+    answer of nothing, which is this file's whole reason to exist."""
+    answer, error, calls = brief._parse_stream_json(LIVE_TOOL_USE_LINE)
+    assert answer is None
+    assert error is not None
+    assert calls, "the tool_use was still collected"
+
+
+def test_stream_json_parser_surfaces_an_error_result(brief):
+    line = json.dumps({"type": "result", "subtype": "error_during_execution",
+                       "is_error": True, "result": "connector unavailable"})
+    answer, error, _ = brief._parse_stream_json(line)
+    assert answer is None
+    assert "connector unavailable" in error
+
+
+def test_stream_json_parser_survives_non_json_noise(brief):
+    """The CLI interleaves diagnostics. A junk line is skipped, not fatal."""
+    answer, error, calls = brief._parse_stream_json(
+        "\n".join(["not json at all", LIVE_TOOL_USE_LINE, "", LIVE_RESULT_LINE]))
+    assert error is None
+    assert len(calls) == 1
+
+
+def test_calendar_refuses_an_answer_from_a_different_calendar(brief):
+    """The PR #299 major. The prompt names assafkip@gmail.com, the transcript
+    shows list_events was executed against the holiday feed, and the prose
+    answer is a clean empty list. Prompt presence is not proof. Only the
+    executed argument is, so this must be COULD NOT READ.
+    """
+    rows, error = brief.collect_calendar(NOW, runner=_cal_runner(
+        executed_id="en.usa#holiday@group.v.calendar.google.com"))
+    assert rows == []
+    assert error is not None
+    assert "assafkip@gmail.com" in error
+
+
+def test_calendar_refuses_an_answer_with_no_calendarid_at_all(brief):
+    """The original sp-57823aef shape, now caught at the transcript instead of
+    being invisible: list_events ran with no calendarId, so it read the account
+    default, and the default has no events on it."""
+    rows, error = brief.collect_calendar(NOW, runner=_cal_runner(executed_id=None))
+    assert rows == []
+    assert error is not None
+
+
+def test_calendar_accepts_an_answer_whose_tool_use_carries_the_id(brief):
+    """The positive half. A refusal that fires on everything is not a check."""
+    rows, error = brief.collect_calendar(NOW, runner=_cal_runner(
+        per_calendar={"assafkip@gmail.com": (REAL_SHAPED_EVENTS, None)}))
+    assert error is None, error
+    assert len(rows) == 2
+
+
+def test_calendar_ignores_tool_use_from_a_different_tool(brief):
+    """ToolSearch runs in the live transcript before list_events (measured
+    2026-09-04). A tool_use for some other tool must never satisfy the check.
+
+    The fake echoes the ASKED id back under the wrong tool name for EVERY
+    calendar. An earlier version only did it for the first one, so dropping the
+    tool-name filter still failed on the second calendar and this test passed
+    for a reason that had nothing to do with the filter. That mutant survived.
+    """
+    def runner(prompt, tools):
+        if "list_calendars" in prompt:
+            return CAL_LIST_JSON, None, [{"name": LIST_CALENDARS, "input": {}}]
+        asked = next((cid for cid in ALL_CAL_IDS if cid in prompt), None)
+        return json.dumps({"events": []}), None, [
+            {"name": "ToolSearch", "input": {"calendarId": asked}}]
+
+    rows, error = brief.collect_calendar(NOW, runner=runner)
+    assert rows == []
+    assert error is not None
+    assert "no calendarId" in error
+
+
+def test_calendar_malformed_entry_marks_the_read_partial(brief):
+    """PR #299 minor 2. One calendar entry with no id used to be dropped in
+    silence while the others rendered, which is a partial read wearing a
+    complete read's clothes."""
+    listing = json.dumps({"calendars": [
+        {"id": "assafkip@gmail.com"}, {"summary": "calendar whose id was omitted"}]})
+    rows, error = brief.collect_calendar(NOW, runner=_cal_runner(listing=listing))
+    assert rows == []
+    assert error is not None
+
+
+def test_calendar_stops_when_the_total_budget_is_gone(brief):
+    """PR #299 minor 3. N sequential model calls, each inside its own timeout,
+    could still outrun the section deadline in _guarded. The collector owns a
+    total budget of its own and says which calendars it never reached."""
+    ticks = iter([0.0] + [99.0] * 12)  # the clock jumps past the budget
+    rows, error = brief.collect_calendar(
+        NOW, runner=_cal_runner(), budget_s=10.0, clock=lambda: next(ticks))
+    assert rows == []
+    assert error is not None
+    assert "budget" in error
 
 
 def test_calendar_reads_every_calendar_not_the_account_default(brief):
@@ -376,14 +525,14 @@ def test_calendar_all_calendars_filtered_out_is_an_error(brief):
 
 def test_calendar_collector_reports_a_model_failure(brief):
     rows, error = brief.collect_calendar(
-        NOW, runner=lambda prompt, tools: (None, "claude exited 1"))
+        NOW, runner=lambda prompt, tools: (None, "claude exited 1", []))
     assert rows == []
     assert "claude exited 1" in error
 
 
 def test_calendar_collector_reports_unparseable_output(brief):
     rows, error = brief.collect_calendar(
-        NOW, runner=lambda prompt, tools: ("I could not reach the calendar", None))
+        NOW, runner=lambda prompt, tools: ("I could not reach the calendar", None, []))
     assert rows == []
     assert error
 


### PR DESCRIPTION
Fixes ASK-1235. Resolves spillover sp-57823aef.

## The defect

`collect_calendar` in `q-system/.q-system/scripts/morning-brief.py` called
`mcp__claude_ai_Google_Calendar__list_events` with no `calendarId`, so it read
the account default. The prompt named calendar "primary" in prose, but prose is
not an argument.

Measured 2026-09-04: `list_calendars` on this account returns three calendars and
NONE is flagged primary (`assafkip@gmail.com`, `assaf@askconsulting.io`,
`en.usa#holiday@group.v.calendar.google.com`). The default read returned 0 events
for the whole week 2026-09-01..08 while an explicit read of `assafkip@gmail.com`
returned 9, including 2026-09-02 09:00 "Weekly project planning" and 2026-09-07
08:00 "Project plan - Weekly".

So the brief printed "nothing" on days that had meetings, and a zero read as a
pass. That is the exact class of defect this file exists to refuse.

## The fix

`collect_calendar` enumerates with `list_calendars`, skips the holiday feed by
substring (Google names it per locale), reads `list_events` per calendar for the
day, merges and sorts by start (all-day first).

Every failure mode returns `(rows=[], error)` so the section renders COULD NOT
READ, never "nothing": enumeration failure, an unparseable listing, one calendar
failing while others answer, or an enumeration that yields nothing readable. A
partial read rendered as a complete one is the same lie as printing "nothing".

## Verification

The reproducer's fake runner keys on **prompt text, not call order**. A
call-order fake cannot tell "named no calendar" apart from "named the right one"
and would go green against the unfixed code.

Red first on the pre-fix collector:

    AssertionError: read the account default, not the calendars: []
    assert 0 == 2

Green after: `60 passed` in the module, `60 passed, 983 deselected` on
`pytest -q q-system/.q-system/tests -x -k morning`.

Mutation-tested, 3/3 killed:

| mutant | killed by |
|---|---|
| drop the holiday filter | `test_calendar_skips_the_holiday_feed`, `..._all_calendars_filtered_out_is_an_error` |
| drop the merge sort | `test_calendar_reads_every_calendar_not_the_account_default` |
| read only the first calendar | `..._reads_the_second_account_too`, `..._one_broken_calendar_fails_the_section` |

Two pre-existing tests (`test_calendar_collector_parses_events`,
`test_calendar_empty_is_empty_not_an_error`) pinned the single-call shape that
WAS the defect, so inverting them is part of the fix, not collateral.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01KzSWSV9yqnPB2D2x2sM7Pe
