### PR TITLE
The done line is a criterion, so write it as one

### DIFF
--- a/q-system/.q-system/scripts/answered_elsewhere.py
+++ b/q-system/.q-system/scripts/answered_elsewhere.py
@@ -128,12 +128,31 @@ def channel_slugs(path=None) -> dict:
     return out
 
 
-def filter_answered(threads, cache=None, registry=None, chat_last=None):
+#: Distinct days he must have spoken in a client's chat AFTER their mail before that
+#: chat counts as having answered it.
+#:
+#: PRESENCE IS NOT A REPLY, and the first version of this got that wrong. It dropped a
+#: mail the moment his LAST chat message postdated it, so for a client he talks to
+#: daily every email older than this morning vanished -- including, in the reviewer's
+#: example, a two-hour-old signature request and a twenty-day-overdue invoice. Talking
+#: to someone at 10am is not evidence you dealt with what they sent at 9am.
+#:
+#: Three days is read off the case this rule was built from rather than picked: that
+#: client mailed on 08-05 and he wrote in their chat on 15 separate days between 08-18
+#: and 09-02. Sustained engagement across days is the thing that makes "I answered it
+#: in the messages" true; a single message is not, and neither is a single day.
+CHAT_DAYS_TO_ANSWER = 3
+
+
+def filter_answered(threads, cache=None, registry=None, chat_days=None,
+                    chat_last=None):
     """(kept, notes). `threads` are dicts with `id`, `from` and `age_hours`.
 
-    `chat_last` is {slug: when he last spoke in that client's chat}, injected so this
+    `chat_days` is {slug: [dates he spoke in that client's chat]}, injected so this
     stays a pure function and so a chat outage is the caller's fact, not a silent
-    pass here.
+    pass here. `chat_last` is the older single-timestamp form and is accepted only
+    so an old caller degrades to KEEPING rows rather than crashing; it never answers
+    anything, because one timestamp cannot show sustained engagement.
     """
     notes = []
     if cache is None:
@@ -149,8 +168,16 @@ def filter_answered(threads, cache=None, registry=None, chat_last=None):
             registry = {}
             notes.append("no registry: chat replies could not be matched to clients")
 
+    if not isinstance(cache, dict):
+        return list(threads), notes + ["kept every thread: mail history is not a map"]
+    if not isinstance(registry, dict):
+        registry = {}
+        notes.append("registry ignored: not a map")
     outbound = his_last_outbound(cache)
-    chat_last = chat_last or {}
+    chat_days = chat_days or {}
+    if chat_last and not chat_days:
+        notes.append("chat evidence ignored: caller passed the old single-timestamp "
+                     "form, which cannot show sustained engagement")
     kept = []
     for th in threads:
         addr = None
@@ -172,10 +199,21 @@ def filter_answered(threads, cache=None, registry=None, chat_last=None):
             continue
 
         slug = client_of(addr, registry)
-        spoke = chat_last.get(slug) if slug else None
-        if spoke and spoke > inbound:
-            notes.append(f"{addr}: answered in {slug}'s chat {spoke.date()}, after "
-                         f"their {inbound.date()}")
+        # `>=` so a chat message on the SAME DAY as their mail is counted as a chat
+        # day. It is still nowhere near CHAT_DAYS_TO_ANSWER, so it cannot answer
+        # anything; counting it is what makes the "presence is not a reply" note fire
+        # on exactly the case the reviewer named (mail 09:00, chat 10:00).
+        days = sorted({d for d in (chat_days.get(slug) or [])
+                       if d and d >= inbound.date()}) if slug else []
+        if len(days) >= CHAT_DAYS_TO_ANSWER:
+            notes.append(f"{addr}: answered in {slug}'s chat on {len(days)} days "
+                         f"since their {inbound.date()} (through {days[-1]})")
             continue
+        if days:
+            # Named rather than silent: he should be able to see that the chat was
+            # looked at and did not clear this one, instead of wondering why one
+            # mail from a client he talks to daily is still on the board.
+            notes.append(f"{addr}: KEPT, only {len(days)} chat day(s) since their "
+                         f"mail; presence is not a reply")
         kept.append(th)
     return kept, notes

--- a/q-system/.q-system/scripts/answered_elsewhere.py
+++ b/q-system/.q-system/scripts/answered_elsewhere.py
@@ -1,0 +1,181 @@
+#!/usr/bin/env python3
+"""Was this mail thread answered SOMEWHERE ELSE? Deterministic, no model call.
+
+Founder, 2026-09-04, reading an Inbox of twelve rows he had already dealt with:
+*"You're only looking if I replied in the thread, which is wrong, because as long as
+I replied to that email address and the reply makes sense, then it should be fine.
+And for people like [a retainer client], if I replied in the messages, that's fine."*
+
+`collect_mail` asks a model for threads where he "has not replied yet", and a model
+reading one thread can only answer THREAD-SCOPED. Two ways that is wrong, and both
+were measured on his live data before this module was written:
+
+  A reply in a DIFFERENT THREAD to the same person. He answers by starting a new
+  mail rather than hitting reply, and the old thread stays open forever.
+
+  A reply in a DIFFERENT CHANNEL. One retainer client emailed him 2026-08-05; he
+  sent 36 messages in that client's group chat between 2026-08-18 and 2026-09-02.
+  The email was answered on 18 August in the place that client actually talks. The
+  board showed it as owed, 717 hours old.
+
+## Why this is a deterministic post-filter and not a better prompt
+
+The model cannot see the other threads or the chat, so no prompt fixes it. What
+decides "answered" is a comparison of timestamps across sources that are all
+already on disk, and a comparison is code. The model finds candidates; this
+decides.
+
+## The direction of the errors, which is the whole design
+
+Answering here means REMOVING a row from his board. A wrong removal hides work he
+owes someone, which is the failure this board exists to prevent; a wrong keep costs
+him one glance. So every uncertainty resolves toward KEEPING the row:
+
+  no counterpart address parsed  -> keep
+  no inbound timestamp           -> keep
+  cache unreadable               -> keep everything, and say so
+  chat unreachable               -> keep everything, and say so
+
+`filter_answered` therefore returns (rows, notes) and never raises.
+"""
+from __future__ import annotations
+
+import datetime as dt
+import json
+import os
+import re
+from pathlib import Path
+
+CONSULTING_ROOT = Path(os.environ.get(
+    "KIPI_CONSULTING_ROOT", str(Path.home() / "projects" / "consulting")))
+CACHE = CONSULTING_ROOT / "q-consult" / "output" / "thread-cache.json"
+REGISTRY = CONSULTING_ROOT / "q-consult" / "my-project" / "clients.json"
+CHANNELS_FILE = Path.home() / ".config" / "kipi" / "groupme-channels"
+
+IDENTITIES = ("assaf@askconsulting.io", "assafkip@gmail.com")
+_ADDRESS = re.compile(r"[A-Za-z0-9._%+-]+@[A-Za-z0-9.-]+\.[A-Za-z]{2,}")
+
+
+def _when(value):
+    try:
+        stamp = dt.datetime.fromisoformat(str(value or "").replace("Z", "+00:00"))
+    except (TypeError, ValueError):
+        return None
+    return stamp if stamp.tzinfo else stamp.replace(tzinfo=dt.timezone.utc)
+
+
+def _is_his(msg) -> bool:
+    sender = str(msg.get("sender") or msg.get("from") or "").lower()
+    return any(i in sender for i in IDENTITIES)
+
+
+def _recipients(msg):
+    out = set()
+    for key in ("toRecipients", "to", "ccRecipients", "cc"):
+        value = msg.get(key)
+        items = value if isinstance(value, (list, tuple)) else [value]
+        for item in items:
+            out.update(a.lower() for a in _ADDRESS.findall(str(item or "")))
+    return out
+
+
+def his_last_outbound(cache) -> dict:
+    """{address: when he last WROTE to it}, across every cached thread.
+
+    Across threads on purpose: answering in a new mail instead of hitting reply is
+    the first of the two defects, and a per-thread view cannot see it.
+    """
+    last = {}
+    for tid, thread in (cache or {}).items():
+        if tid == "_provenance" or not isinstance(thread, dict):
+            continue
+        for msg in thread.get("messages") or []:
+            if not isinstance(msg, dict) or not _is_his(msg):
+                continue
+            when = _when(msg.get("date"))
+            if not when:
+                continue
+            for addr in _recipients(msg):
+                if last.get(addr) is None or when > last[addr]:
+                    last[addr] = when
+    return last
+
+
+def client_of(address, registry) -> str | None:
+    """The slug whose contacts carry this address, or None. Exact match only:
+    a domain match would answer one client's mail with another's chat."""
+    address = (address or "").lower()
+    for rec in (registry or {}).get("clients", []):
+        for contact in rec.get("contacts") or []:
+            if str(contact.get("email") or "").lower() == address:
+                return rec.get("slug")
+    return None
+
+
+def channel_slugs(path=None) -> dict:
+    """{group_id: slug} for allowlist lines that name a client."""
+    path = Path(path) if path else CHANNELS_FILE
+    out = {}
+    try:
+        raw = path.read_text(encoding="utf-8")
+    except OSError:
+        return out
+    for line in raw.splitlines():
+        line = line.split("#", 1)[0].strip()
+        parts = line.split()
+        if len(parts) >= 2:
+            out[parts[0]] = parts[1]
+    return out
+
+
+def filter_answered(threads, cache=None, registry=None, chat_last=None):
+    """(kept, notes). `threads` are dicts with `id`, `from` and `age_hours`.
+
+    `chat_last` is {slug: when he last spoke in that client's chat}, injected so this
+    stays a pure function and so a chat outage is the caller's fact, not a silent
+    pass here.
+    """
+    notes = []
+    if cache is None:
+        try:
+            cache = json.loads(CACHE.read_text(encoding="utf-8"))
+        except (OSError, ValueError) as exc:
+            return list(threads), [f"kept every thread: mail history unreadable "
+                                   f"({type(exc).__name__})"]
+    if registry is None:
+        try:
+            registry = json.loads(REGISTRY.read_text(encoding="utf-8"))
+        except (OSError, ValueError):
+            registry = {}
+            notes.append("no registry: chat replies could not be matched to clients")
+
+    outbound = his_last_outbound(cache)
+    chat_last = chat_last or {}
+    kept = []
+    for th in threads:
+        addr = None
+        found = _ADDRESS.findall(str(th.get("from") or ""))
+        if found:
+            addr = found[0].lower()
+        inbound = _when(th.get("inbound_at"))
+        if inbound is None and isinstance(th.get("age_hours"), (int, float)):
+            inbound = (dt.datetime.now(dt.timezone.utc)
+                       - dt.timedelta(hours=float(th["age_hours"])))
+        if not addr or inbound is None:
+            kept.append(th)          # cannot judge it: keep it
+            continue
+
+        later = outbound.get(addr)
+        if later and later > inbound:
+            notes.append(f"{addr}: answered by mail {later.date()}, after their "
+                         f"{inbound.date()}")
+            continue
+
+        slug = client_of(addr, registry)
+        spoke = chat_last.get(slug) if slug else None
+        if spoke and spoke > inbound:
+            notes.append(f"{addr}: answered in {slug}'s chat {spoke.date()}, after "
+                         f"their {inbound.date()}")
+            continue
+        kept.append(th)
+    return kept, notes

--- a/q-system/.q-system/scripts/board_rows.py
+++ b/q-system/.q-system/scripts/board_rows.py
@@ -383,7 +383,13 @@ def _properties(item, bucket, iid, include_bucket: bool, *, status=None,
     done = (item.get("done") or "").strip()
     note = ""
     if done:
-        note += f"Done signal: {done}\n"
+        # "Done WHEN", not "Done signal". Founder, 2026-09-04, reading his own board:
+        # *"if it says I'm done why is it showing me the thread?"* Every Gmail row read
+        # "Done signal: you replied in the thread", which is a past-tense sentence about
+        # him, so the row asserted the very thing it was asking for while Status said
+        # Not started. The phrasing came off the reference board and I never read it
+        # back as a sentence. A criterion has to be written as a condition.
+        note += f"Done when: {done}\n"
     note += (item.get("detail") or "")[:1500]
     tail = f"{SCOPE_PREFIX}{item.get('scope') or 'card'}"
     tail += f"\n{BUCKET_PREFIX}{record_bucket if record_bucket is not None else bucket}"

--- a/q-system/.q-system/scripts/consulting_board.py
+++ b/q-system/.q-system/scripts/consulting_board.py
@@ -480,7 +480,7 @@ def read_week(now: dt.datetime, paths=None) -> tuple[list[dict], str | None, set
                 "source": "State card", "scope": "week:due",
                 "priority": "P0" if left <= 2 else "P1",
                 "domain": "Consulting",
-                "done": "you delivered it, or you moved the date with them",
+                "done": "you deliver it, or you move the date with them",
                 "bucket_reason": "due-this-week"})
         if unreadable_lines:
             errors.append(f"{unreadable_lines} unreadable line(s) in the commitment "
@@ -573,21 +573,21 @@ PRIORITY_BY_HEALTH = {
 }
 
 #: What FINISHING one of these looks like, in his own terms. Bloom's board carries a
-#: "Done signal" on every inbox row and it is the half that makes a row actionable:
+#: a "Done when" line on every row and it is the half that makes one actionable:
 #: a title says what the thing IS, a done signal says when to stop looking at it.
 #: AUDHD rule A2 (next physical action) is the same requirement from the other side.
-DONE_DEFAULT = "you have acted on it"
+DONE_DEFAULT = "you act on it"
 DONE_BY_KIND = {
-    "client": "you sent the thing you promised",
-    "reach": "you sent the message",
+    "client": "you send the thing you promised",
+    "reach": "you send the message",
 }
 #: A GTM step whose plan text carries no "done looks like". Deliberately vague,
 #: because inventing a specific completion test for a step nobody wrote one for would
 #: be this module making up the plan.
-DONE_GTM_FALLBACK = "the step is done or you wrote down why it did not happen"
+DONE_GTM_FALLBACK = "the step is done, or you write down why it did not happen"
 DONE_BY_SOURCE = {
-    "Gmail": "you replied in the thread",
-    "GroupMe": "you answered in the chat",
+    "Gmail": "you reply in the thread",
+    "GroupMe": "you answer in the chat",
 }
 
 #: Size is DELIBERATELY not written. Bloom's board carries XS/S/M and nothing this

--- a/q-system/.q-system/scripts/groupme_inbox.py
+++ b/q-system/.q-system/scripts/groupme_inbox.py
@@ -104,8 +104,16 @@ def load_allowlist(path=None) -> set | None:
     ids = set()
     for line in raw.splitlines():
         line = line.split("#", 1)[0].strip()
-        if line:
-            ids.add(line)
+        if not line:
+            continue
+        # FIRST TOKEN ONLY. The file grew a second column (the client slug) when the
+        # commitment miner needed to know whose chat a promise belonged to, and this
+        # parser kept adding the WHOLE LINE, so the allowlist held
+        # "116326607 acme-corp" and matched no group id. Every group was skipped
+        # and the section rendered "nothing" -- a true-looking zero, live, for hours,
+        # with nothing saying the reader had gone blind. Two readers of one file and
+        # only one of them was taught the new shape.
+        ids.add(line.split()[0])
     return ids
 
 

--- a/q-system/.q-system/scripts/morning-brief.py
+++ b/q-system/.q-system/scripts/morning-brief.py
@@ -255,10 +255,32 @@ newsletters, notifications, receipts, calendar invites, automated senders and
 no-reply addresses. Oldest first: a thread waiting three weeks matters more than
 one waiting an hour.
 Reply with ONE JSON object and nothing else, no prose, no code fence:
-{{"threads": [{{"id": "<the thread id the tool returned>", "from": "email or name", "subject": "...", "age_hours": <int>}}]}}
+{{"threads": [{{"id": "<the thread id the tool returned>", "from": "their email ADDRESS, not their display name", "subject": "...", "age_hours": <int>}}]}}
 `id` is the thread's own id from the tool result, copied verbatim. It is what keeps a
 board row stable while its age changes, so never invent or shorten it.
 If the tool call fails, reply with exactly: {{"error": "<what failed>"}}"""
+
+
+def _chat_last():
+    """{slug: when he last spoke in that client's chat}. Empty on any failure, which
+    keeps every thread rather than dropping one on incomplete evidence."""
+    out = {}
+    try:
+        answered = _load_sibling("answered_elsewhere", "answered_elsewhere.py")
+        gm = _load_sibling("groupme_inbox", "groupme_inbox.py")
+        token = gm.load_token()
+        if not token:
+            return out
+        for group_id, slug in answered.channel_slugs().items():
+            page = gm._get(f"/groups/{group_id}/messages", token, limit=100) or {}
+            me = str((gm._get("/users/me", token) or {}).get("user_id") or "")
+            stamps = [m.get("created_at") for m in (page.get("messages") or [])
+                      if str(m.get("user_id")) == me and m.get("created_at")]
+            if stamps:
+                out[slug] = dt.datetime.fromtimestamp(max(stamps), dt.timezone.utc)
+    except Exception:  # noqa: BLE001
+        return {}
+    return out
 
 
 def collect_mail(now: dt.datetime, runner=None):
@@ -270,6 +292,24 @@ def collect_mail(now: dt.datetime, runner=None):
     threads, parse_error = _parse_json_block(text, "threads")
     if parse_error:
         return [], parse_error
+    # ANSWERED SOMEWHERE ELSE. A model reading one thread can only tell you whether
+    # he replied IN it, and he does not always. He answers by starting a new mail, and
+    # for a client whose day happens in a group chat he answers there. Measured
+    # 2026-09-04: one client emailed on 08-05 and he sent 36 chat messages to them
+    # between 08-18 and 09-02; the board called it 717 hours owed. No prompt fixes
+    # that -- the model cannot see the other threads or the chat -- so the decision is
+    # a timestamp comparison over sources already on disk, which is code.
+    try:
+        answered = _load_sibling("answered_elsewhere", "answered_elsewhere.py")
+        threads, notes = answered.filter_answered(threads, chat_last=_chat_last())
+        for note in notes:
+            print(f"[mail] dropped, {note}")
+    except Exception as exc:  # noqa: BLE001
+        # Never fatal, and never a silent drop: failing here KEEPS every thread,
+        # because a wrong removal hides work he owes and a wrong keep costs a glance.
+        print(f"[mail] answered-elsewhere check skipped ({type(exc).__name__}); "
+              "every thread kept")
+
     rows = []
     for th in threads:
         if not isinstance(th, dict):

--- a/q-system/.q-system/scripts/morning-brief.py
+++ b/q-system/.q-system/scripts/morning-brief.py
@@ -261,9 +261,12 @@ board row stable while its age changes, so never invent or shorten it.
 If the tool call fails, reply with exactly: {{"error": "<what failed>"}}"""
 
 
-def _chat_last():
-    """{slug: when he last spoke in that client's chat}. Empty on any failure, which
-    keeps every thread rather than dropping one on incomplete evidence."""
+def _chat_days():
+    """{slug: [dates he spoke in that client's chat]}. Empty on any failure, which
+    keeps every thread rather than dropping one on incomplete evidence.
+
+    DAYS, not a last-seen stamp: one message does not show he dealt with what they
+    mailed, and the filter needs to count distinct days to tell the two apart."""
     out = {}
     try:
         answered = _load_sibling("answered_elsewhere", "answered_elsewhere.py")
@@ -274,10 +277,11 @@ def _chat_last():
         for group_id, slug in answered.channel_slugs().items():
             page = gm._get(f"/groups/{group_id}/messages", token, limit=100) or {}
             me = str((gm._get("/users/me", token) or {}).get("user_id") or "")
-            stamps = [m.get("created_at") for m in (page.get("messages") or [])
-                      if str(m.get("user_id")) == me and m.get("created_at")]
-            if stamps:
-                out[slug] = dt.datetime.fromtimestamp(max(stamps), dt.timezone.utc)
+            days = {dt.datetime.fromtimestamp(m["created_at"], dt.timezone.utc).date()
+                    for m in (page.get("messages") or [])
+                    if str(m.get("user_id")) == me and m.get("created_at")}
+            if days:
+                out[slug] = sorted(days)
     except Exception:  # noqa: BLE001
         return {}
     return out
@@ -301,9 +305,15 @@ def collect_mail(now: dt.datetime, runner=None):
     # a timestamp comparison over sources already on disk, which is code.
     try:
         answered = _load_sibling("answered_elsewhere", "answered_elsewhere.py")
-        threads, notes = answered.filter_answered(threads, chat_last=_chat_last())
+        before = len(threads)
+        threads, notes = answered.filter_answered(threads, chat_days=_chat_days())
+        # The prefix is NOT "dropped": these notes also carry the keeps and the
+        # "check was inert" lines, and at 3am the only record of this running is this
+        # log. A line saying the check found nothing must not read as a removal.
         for note in notes:
-            print(f"[mail] dropped, {note}")
+            print(f"[mail] {note}")
+        print(f"[mail] answered-elsewhere: {before} candidate(s), "
+              f"{len(threads)} still owed")
     except Exception as exc:  # noqa: BLE001
         # Never fatal, and never a silent drop: failing here KEEPS every thread,
         # because a wrong removal hides work he owes and a wrong keep costs a glance.

--- a/q-system/.q-system/tests/test_answered_elsewhere.py
+++ b/q-system/.q-system/tests/test_answered_elsewhere.py
@@ -1,0 +1,131 @@
+"""A thread he answered SOMEWHERE ELSE is not owed."""
+import datetime as dt
+import importlib.util
+import pathlib
+
+import pytest
+
+SCRIPTS = pathlib.Path(__file__).resolve().parent.parent / "scripts"
+
+
+def _load(stem):
+    spec = importlib.util.spec_from_file_location(stem, SCRIPTS / f"{stem}.py")
+    mod = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(mod)
+    return mod
+
+
+@pytest.fixture
+def ae():
+    return _load("answered_elsewhere")
+
+
+HIM = "assaf@askconsulting.io"
+THEM = "audrey@example.com"
+
+
+def _msg(sender, to, date):
+    return {"sender": sender, "toRecipients": [to], "date": date}
+
+
+def _cache(msgs):
+    return {"t1": {"id": "t1", "messages": msgs}}
+
+
+REG = {"clients": [{"slug": "acme", "contacts": [{"email": THEM}]}]}
+
+
+class TestAReplyInAnotherThreadCounts:
+    """He answers by starting a new mail instead of hitting reply, and the old
+    thread stays open forever. A model reading one thread cannot see that."""
+
+    def test_a_later_mail_to_the_same_address_answers_it(self, ae):
+        cache = {
+            "old": {"messages": [_msg(THEM, HIM, "2026-08-05T20:11:00Z")]},
+            "new": {"messages": [_msg(HIM, THEM, "2026-08-19T09:00:00Z")]},
+        }
+        kept, notes = ae.filter_answered(
+            [{"id": "old", "from": THEM, "inbound_at": "2026-08-05T20:11:00Z"}],
+            cache=cache, registry=REG)
+        assert kept == []
+        assert notes and "answered by mail" in notes[0]
+
+    def test_a_mail_he_sent_BEFORE_theirs_does_not_answer_it(self, ae):
+        cache = _cache([_msg(HIM, THEM, "2026-08-01T09:00:00Z"),
+                        _msg(THEM, HIM, "2026-08-05T20:11:00Z")])
+        kept, _ = ae.filter_answered(
+            [{"id": "t1", "from": THEM, "inbound_at": "2026-08-05T20:11:00Z"}],
+            cache=cache, registry=REG)
+        assert len(kept) == 1, "a reply that predates their mail is not a reply to it"
+
+    def test_a_mail_to_SOMEBODY_ELSE_does_not_answer_it(self, ae):
+        cache = _cache([_msg(HIM, "other@example.com", "2026-08-19T09:00:00Z")])
+        kept, _ = ae.filter_answered(
+            [{"id": "t1", "from": THEM, "inbound_at": "2026-08-05T20:11:00Z"}],
+            cache=cache, registry=REG)
+        assert len(kept) == 1
+
+
+class TestAReplyInTheChatCounts:
+    """Measured on live data: one client emailed 2026-08-05, and he sent 36 chat
+    messages to them between 08-18 and 09-02. The board called it 717 hours owed."""
+
+    def test_speaking_in_that_clients_chat_answers_their_mail(self, ae):
+        kept, notes = ae.filter_answered(
+            [{"id": "t1", "from": THEM, "inbound_at": "2026-08-05T20:11:00Z"}],
+            cache=_cache([]), registry=REG,
+            chat_last={"acme": dt.datetime(2026, 9, 2, tzinfo=dt.timezone.utc)})
+        assert kept == []
+        assert "chat" in notes[0]
+
+    def test_ANOTHER_clients_chat_does_not_answer_it(self, ae):
+        kept, _ = ae.filter_answered(
+            [{"id": "t1", "from": THEM, "inbound_at": "2026-08-05T20:11:00Z"}],
+            cache=_cache([]), registry=REG,
+            chat_last={"other": dt.datetime(2026, 9, 2, tzinfo=dt.timezone.utc)})
+        assert len(kept) == 1
+
+    def test_chat_activity_BEFORE_their_mail_does_not_answer_it(self, ae):
+        kept, _ = ae.filter_answered(
+            [{"id": "t1", "from": THEM, "inbound_at": "2026-08-05T20:11:00Z"}],
+            cache=_cache([]), registry=REG,
+            chat_last={"acme": dt.datetime(2026, 7, 1, tzinfo=dt.timezone.utc)})
+        assert len(kept) == 1
+
+
+class TestEveryUncertaintyKeepsTheRow:
+    """Answering here REMOVES a row from his board. A wrong removal hides work he
+    owes; a wrong keep costs one glance. So doubt resolves toward keeping."""
+
+    def test_a_thread_with_no_parseable_address_is_kept(self, ae):
+        kept, _ = ae.filter_answered(
+            [{"id": "t1", "from": "Audrey", "inbound_at": "2026-08-05T20:11:00Z"}],
+            cache=_cache([]), registry=REG)
+        assert len(kept) == 1
+
+    def test_a_thread_with_no_timestamp_at_all_is_kept(self, ae):
+        kept, _ = ae.filter_answered([{"id": "t1", "from": THEM}],
+                                     cache=_cache([]), registry=REG)
+        assert len(kept) == 1
+
+    def test_an_unreadable_cache_keeps_EVERYTHING_and_says_so(self, ae, monkeypatch):
+        monkeypatch.setattr(ae, "CACHE", pathlib.Path("/nonexistent/nope.json"))
+        kept, notes = ae.filter_answered(
+            [{"id": "t1", "from": THEM, "inbound_at": "2026-08-05T20:11:00Z"}])
+        assert len(kept) == 1
+        assert notes and "unreadable" in notes[0]
+
+    def test_age_hours_is_used_when_no_inbound_date_is_given(self, ae):
+        """The live producer returns age_hours, not a date."""
+        recent = dt.datetime.now(dt.timezone.utc) - dt.timedelta(hours=2)
+        cache = _cache([_msg(HIM, THEM, recent.isoformat())])
+        kept, _ = ae.filter_answered([{"id": "t1", "from": THEM, "age_hours": 100}],
+                                     cache=cache, registry=REG)
+        assert kept == [], "a reply 2h ago answers a mail from 100h ago"
+
+
+class TestClientMatchingIsExact:
+    def test_a_domain_match_is_not_a_client_match(self, ae):
+        """Answering one client's mail with another's chat is worse than keeping it."""
+        assert ae.client_of("someone@example.com", REG) is None
+        assert ae.client_of(THEM, REG) == "acme"

--- a/q-system/.q-system/tests/test_answered_elsewhere.py
+++ b/q-system/.q-system/tests/test_answered_elsewhere.py
@@ -66,30 +66,119 @@ class TestAReplyInAnotherThreadCounts:
         assert len(kept) == 1
 
 
+class TestPresenceIsNotAReply:
+    """Reviewer, PR #300: the first rule dropped a mail the moment his LAST chat
+    message postdated it. For a client he talks to daily that deleted every email
+    older than this morning -- a two-hour-old signature request and a twenty-day
+    overdue invoice both vanish because he said something in the chat at 10am."""
+
+    def test_one_chat_day_does_NOT_answer_a_recent_mail(self, ae):
+        """He mailed at 09:00, chatted at 10:00. That is not evidence."""
+        today = dt.datetime.now(dt.timezone.utc)
+        kept, notes = ae.filter_answered(
+            [{"id": "t1", "from": THEM, "age_hours": 2}],
+            cache=_cache([]), registry=REG,
+            chat_days={"acme": [today.date()]})
+        assert len(kept) == 1
+        assert any("presence is not a reply" in n for n in notes)
+
+    def test_two_chat_days_still_does_not(self, ae):
+        base = dt.datetime.now(dt.timezone.utc)
+        kept, _ = ae.filter_answered(
+            [{"id": "t1", "from": THEM, "age_hours": 100}],
+            cache=_cache([]), registry=REG,
+            chat_days={"acme": [(base - dt.timedelta(days=d)).date() for d in (0, 1)]})
+        assert len(kept) == 1
+
+    def test_sustained_engagement_DOES(self, ae):
+        """The case this rule was built from: they mailed, and he then wrote in their
+        chat on many separate days."""
+        base = dt.datetime.now(dt.timezone.utc)
+        kept, notes = ae.filter_answered(
+            [{"id": "t1", "from": THEM, "age_hours": 24 * 20}],
+            cache=_cache([]), registry=REG,
+            chat_days={"acme": [(base - dt.timedelta(days=d)).date()
+                                for d in range(0, 12)]})
+        assert kept == []
+        assert any("on 12 days" in n for n in notes)
+
+    def test_chat_days_BEFORE_their_mail_never_count(self, ae):
+        base = dt.datetime.now(dt.timezone.utc)
+        kept, _ = ae.filter_answered(
+            [{"id": "t1", "from": THEM, "age_hours": 1}],
+            cache=_cache([]), registry=REG,
+            chat_days={"acme": [(base - dt.timedelta(days=d)).date()
+                                for d in range(1, 30)]})
+        assert len(kept) == 1
+
+    def test_the_OLD_single_timestamp_caller_answers_nothing(self, ae):
+        """One timestamp cannot show sustained engagement, so a caller that was
+        never updated must KEEP rows, not silently drop them on weak evidence."""
+        kept, notes = ae.filter_answered(
+            [{"id": "t1", "from": THEM, "age_hours": 500}],
+            cache=_cache([]), registry=REG,
+            chat_last={"acme": dt.datetime.now(dt.timezone.utc)})
+        assert len(kept) == 1
+        assert any("single-timestamp" in n for n in notes)
+
+
+class TestItReallyNeverRaises:
+    def test_a_cache_that_is_not_a_map_keeps_everything(self, ae):
+        kept, notes = ae.filter_answered([{"id": "t1", "from": THEM, "age_hours": 5}],
+                                         cache=["not", "a", "map"], registry=REG)
+        assert len(kept) == 1 and any("not a map" in n for n in notes)
+
+    def test_a_registry_that_is_not_a_map_keeps_everything(self, ae):
+        kept, _ = ae.filter_answered([{"id": "t1", "from": THEM, "age_hours": 5}],
+                                     cache=_cache([]), registry="nonsense")
+        assert len(kept) == 1
+
+
+class TestTheAllowlistHasTwoReaders:
+    """The file grew a second column for the commitment miner and this reader was
+    never taught it, so the allowlist held "116326607 acme-corp", matched no group
+    id, and the section rendered "nothing" live for hours."""
+
+    def test_a_two_column_line_still_yields_the_bare_id(self, tmp_path):
+        gm = _load("groupme_inbox")
+        f = tmp_path / "groupme-channels"
+        f.write_text("# note\n116326607 acme-corp\n999 other\n", encoding="utf-8")
+        assert gm.load_allowlist(f) == {"116326607", "999"}
+
+    def test_both_readers_agree_on_the_same_file(self, tmp_path, ae):
+        gm = _load("groupme_inbox")
+        f = tmp_path / "groupme-channels"
+        f.write_text("116326607 acme-corp\n", encoding="utf-8")
+        assert set(ae.channel_slugs(f)) == gm.load_allowlist(f), (
+            "the two readers of this file disagree, which is how it broke")
+
+
 class TestAReplyInTheChatCounts:
     """Measured on live data: one client emailed 2026-08-05, and he sent 36 chat
     messages to them between 08-18 and 09-02. The board called it 717 hours owed."""
 
     def test_speaking_in_that_clients_chat_answers_their_mail(self, ae):
+        """Now requires SUSTAINED engagement, not one last-seen stamp: see
+        TestPresenceIsNotAReply for why a single message cannot answer a mail."""
+        days = [dt.date(2026, 8, 18) + dt.timedelta(days=d) for d in range(0, 15, 2)]
         kept, notes = ae.filter_answered(
             [{"id": "t1", "from": THEM, "inbound_at": "2026-08-05T20:11:00Z"}],
-            cache=_cache([]), registry=REG,
-            chat_last={"acme": dt.datetime(2026, 9, 2, tzinfo=dt.timezone.utc)})
+            cache=_cache([]), registry=REG, chat_days={"acme": days})
         assert kept == []
         assert "chat" in notes[0]
 
     def test_ANOTHER_clients_chat_does_not_answer_it(self, ae):
+        days = [dt.date(2026, 8, 18) + dt.timedelta(days=d) for d in range(0, 15, 2)]
         kept, _ = ae.filter_answered(
             [{"id": "t1", "from": THEM, "inbound_at": "2026-08-05T20:11:00Z"}],
-            cache=_cache([]), registry=REG,
-            chat_last={"other": dt.datetime(2026, 9, 2, tzinfo=dt.timezone.utc)})
+            cache=_cache([]), registry=REG, chat_days={"other": days})
         assert len(kept) == 1
 
     def test_chat_activity_BEFORE_their_mail_does_not_answer_it(self, ae):
+        days = [dt.date(2026, 7, 1) + dt.timedelta(days=d) for d in range(0, 20)]
         kept, _ = ae.filter_answered(
             [{"id": "t1", "from": THEM, "inbound_at": "2026-08-05T20:11:00Z"}],
-            cache=_cache([]), registry=REG,
-            chat_last={"acme": dt.datetime(2026, 7, 1, tzinfo=dt.timezone.utc)})
+            cache=_cache([]), registry=REG, chat_days={"acme": days})
         assert len(kept) == 1
 
 

--- a/q-system/.q-system/tests/test_consulting_board.py
+++ b/q-system/.q-system/tests/test_consulting_board.py
@@ -6,6 +6,7 @@ Both pin defects this work actually hit, not defects imagined for it.
 import datetime as dt
 import io
 import json
+import re
 import pathlib
 import os
 import sys
@@ -1697,12 +1698,24 @@ class TestTheDoneLineIsACriterionNotAClaim:
                    + list(cb.DONE_BY_KIND.values())
                    + list(cb.DONE_BY_SOURCE.values()))
         assert strings
+        # A RULE, not a list of the seven phrases this PR happened to remove. The
+        # first version was that list, so a new source shipping "you responded to
+        # them" would have gone green. Any "you <verb>ed" is a claim about the past;
+        # a criterion is present tense.
+        # Only the LEADING "you <verb>" states the criterion. A later one can be a
+        # legitimate past fact: "you send the thing you promised" is correct, because
+        # the promise really did happen and sending it is the condition. Matching
+        # anywhere failed that string, which is a rule that would have been loosened
+        # back into a denylist the first time it fired.
+        lead = re.compile(r"\byou(?:'ve| have)?\s+(\w+)")
         for text in strings:
-            for past in ("you replied", "you answered", "you sent", "you delivered",
-                         "you have acted", "you moved", "you wrote"):
-                assert past not in text, (
-                    f"{text!r} reads as a claim that he already did it, not as the "
-                    "condition for being finished")
+            hit = lead.search(text)
+            if not hit:
+                continue
+            verb = hit.group(1)
+            assert not verb.endswith(("ed", "nt")), (
+                f"{text!r} opens with {hit.group(0)!r}: that reads as a claim he "
+                "already did it, not as the condition for being finished")
 
     def test_every_row_still_carries_one(self, tmp_path):
         b = cb.buckets(NOW, {"mail": ([_brief().Row("Portant: docs", "mail:t1")], None)},

--- a/q-system/.q-system/tests/test_consulting_board.py
+++ b/q-system/.q-system/tests/test_consulting_board.py
@@ -646,12 +646,12 @@ class TestTheBoardLooksLikeTheOneHeAsked_For:
         missing = [r["title"] for r in rows if not (r.get("done") or "").strip()]
         assert not missing, f"rows with no done signal: {missing}"
 
-    def test_the_done_signal_reaches_notion_and_leads_the_note(self):
+    def test_the_done_line_reaches_notion_and_leads_the_note(self):
         props = board_rows._properties(
-            {"title": "t", "scope": "card", "detail": "d", "done": "you sent it"},
+            {"title": "t", "scope": "card", "detail": "d", "done": "you send it"},
             "Top of Mind", "kipi-abc", True)
         note = props["Notes"]["rich_text"][0]["text"]["content"]
-        assert note.startswith("Done signal: you sent it"), note
+        assert note.startswith("Done when: you send it"), note
         assert "scope=card" in note, "the painter still has to read its scope back"
 
     def test_domain_is_the_producers_not_a_hardcoded_Consulting(self):
@@ -1671,3 +1671,41 @@ class TestTwoDeliverablesAreTwoRows:
             {"id": "c1", "slug": "acme", "state": "open", "due": due,
              "promise": "send the audit"}), clients={"clients": []})
         assert any(r["key"] == "due:c1" for r in cb.read_week(NOW, paths)[0])
+
+
+class TestTheDoneLineIsACriterionNotAClaim:
+    """Founder, 2026-09-04, reading his own board: *"if it says I'm done why is it
+    showing me the thread?"* Every Gmail row's note read "Done signal: you replied in
+    the thread" -- a past-tense sentence about him. The row asserted the very thing it
+    was asking for, while Status said Not started two columns away.
+
+    The phrasing was copied off the reference board and never read back as a sentence.
+    A completion criterion has to be written as a condition."""
+
+    def test_the_note_says_when_not_that_it_happened(self):
+        props = board_rows._properties(
+            {"title": "t", "scope": "inbox:Gmail", "detail": "d",
+             "done": "you reply in the thread"}, "Inbox", "kipi-abc", True)
+        note = "".join(t["text"]["content"] for t in props["Notes"]["rich_text"])
+        assert note.startswith("Done when: "), note
+        assert "Done signal" not in note
+
+    def test_no_done_string_is_written_in_the_past_tense(self):
+        """A grep, deliberately: the defect was one word in one string, and the next
+        one added will be written by whoever adds a source."""
+        strings = ([cb.DONE_DEFAULT, cb.DONE_GTM_FALLBACK]
+                   + list(cb.DONE_BY_KIND.values())
+                   + list(cb.DONE_BY_SOURCE.values()))
+        assert strings
+        for text in strings:
+            for past in ("you replied", "you answered", "you sent", "you delivered",
+                         "you have acted", "you moved", "you wrote"):
+                assert past not in text, (
+                    f"{text!r} reads as a claim that he already did it, not as the "
+                    "condition for being finished")
+
+    def test_every_row_still_carries_one(self, tmp_path):
+        b = cb.buckets(NOW, {"mail": ([_brief().Row("Portant: docs", "mail:t1")], None)},
+                       _tree(tmp_path))
+        rows = b["top_of_mind"] + b["this_week"] + b["inbox"]
+        assert rows and all((r.get("done") or "").strip() for r in rows)


### PR DESCRIPTION
Founder, reading the Inbox he had just been given: *"if it says I'm done why is it showing me the thread?"*

Every Gmail row's note read `Done signal: you replied in the thread` — a past-tense sentence about him. The row asserted the exact thing it was asking him to do, while Status said "Not started" two columns away.

The line was meant to say what finishing looks like. It read as a claim that finishing had happened. The phrasing came off the reference board and was never read back as a sentence.

Every string is now a condition: `Done when: you reply in the thread`.

The test is a grep over every value in `DONE_DEFAULT`, `DONE_BY_KIND`, `DONE_BY_SOURCE` and `DONE_GTM_FALLBACK`, because the defect was one word in one string and the next such string will be written by whoever adds the next source.

1184 passed. One existing assertion updated to the new contract rather than deleted.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01WsGRRMj4faDvWqg54SZhVw