### PR TITLE
voiceloop slice 0: reconcile the engine tree, skeleton side

### DIFF
--- a/plugins/kipi-core/.claude-plugin/plugin.json
+++ b/plugins/kipi-core/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "kipi-core",
-  "version": "1.9.6",
+  "version": "1.9.7",
   "description": "Core founder OS \u2014 voice, research, AUDHD, LinkedIn/brand, RCA skills + kipi-mcp server",
   "author": {
     "name": "Assaf Kipnis",

--- a/plugins/kipi-core/.claude-plugin/plugin.json
+++ b/plugins/kipi-core/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "kipi-core",
-  "version": "1.9.7",
+  "version": "1.9.8",
   "description": "Core founder OS \u2014 voice, research, AUDHD, LinkedIn/brand, RCA skills + kipi-mcp server",
   "author": {
     "name": "Assaf Kipnis",

--- a/plugins/kipi-core/.claude-plugin/plugin.json
+++ b/plugins/kipi-core/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "kipi-core",
-  "version": "1.9.5",
+  "version": "1.9.6",
   "description": "Core founder OS \u2014 voice, research, AUDHD, LinkedIn/brand, RCA skills + kipi-mcp server",
   "author": {
     "name": "Assaf Kipnis",

--- a/plugins/kipi-core/.claude-plugin/plugin.json
+++ b/plugins/kipi-core/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "kipi-core",
-  "version": "1.9.9",
+  "version": "1.9.10",
   "description": "Core founder OS \u2014 voice, research, AUDHD, LinkedIn/brand, RCA skills + kipi-mcp server",
   "author": {
     "name": "Assaf Kipnis",

--- a/plugins/kipi-core/.claude-plugin/plugin.json
+++ b/plugins/kipi-core/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "kipi-core",
-  "version": "1.9.8",
+  "version": "1.9.9",
   "description": "Core founder OS \u2014 voice, research, AUDHD, LinkedIn/brand, RCA skills + kipi-mcp server",
   "author": {
     "name": "Assaf Kipnis",

--- a/plugins/kipi-core/voiceloop/assemble.py
+++ b/plugins/kipi-core/voiceloop/assemble.py
@@ -23,11 +23,36 @@ from __future__ import annotations
 
 from . import selector
 
-BUDGET_CHARS = 20000     # asserted by validate.feasible + the consumer's suite,
+BUDGET_CHARS = 24000     # asserted by validate.feasible + the consumer's suite,
                          # NEVER enforced by a runtime raise or slice (ASK-461:
                          # a cap you cannot see is the same bug; a cap that kills
                          # the daily job is a worse one).
+                         #
+                         # RAISED FROM 20000 ON 2026-08-31, and this is a headroom
+                         # alarm being re-set, not a gate being switched off. It is a
+                         # round number with no model limit behind it -- 20000 chars
+                         # is roughly 5k tokens -- and it fires at suite time only.
+                         # What tripped it: landing the four measured 2026-08-24 shape
+                         # corrections from the stranded fix/restatement branch took
+                         # linkedin's worst assembly from 18731 to 20315 (measured,
+                         # both numbers, by rendering 12 counters each way). Dropping
+                         # a measured correction to stay under a round number would be
+                         # the redundancy dismissal the brief bans.
+                         #
+                         # THE REAL SIGNAL IS STILL REAL and is captured as spillover:
+                         # every correction renders into every in-scope prompt, so the
+                         # ledger grows without bound and this alarm will trip again.
+                         # Raising it buys room; it does not fix growth.
 
+
+#: Corrections carrying this source were derived from aggregate performance
+#: research on OTHER accounts, not from the founder correcting his own draft.
+#: They render as options under their own header instead of the override header,
+#: because "posts he has written" and his own corrections are measurements of HIM,
+#: while an external lift number is a hypothesis about what might also work for
+#: him. Unmarked rows render exactly as they always did, so a corpus that never
+#: uses this field behaves byte for byte as before (ASK fleet-wide).
+EXTERNAL_SOURCE = "external-performance"
 
 def _lexicon_positive(lexicon):
     lines = []
@@ -76,16 +101,26 @@ def voice_section(voice, channel, counter, slot_index=0, k=selector.DEFAULT_K,
     # the one that looks authoritative.
     applied = [r for r in (corrections or [])
                if not r.get("scope") or channel in r["scope"]]
-    if applied:
-        lines = "\n".join(f"- {r['instruction']}" for r in applied)
+    his = [r for r in applied if r.get("source") != EXTERNAL_SOURCE]
+    researched = [r for r in applied if r.get("source") == EXTERNAL_SOURCE]
+    if his:
+        lines = "\n".join(f"- {r['instruction']}" for r in his)
         if lines:
             parts.append("STANDING CORRECTIONS (these override everything above):\n"
                          + lines)
+    if researched:
+        lines = "\n".join(f"- {r['instruction']}" for r in researched)
+        parts.append(
+            "RESEARCHED SHAPES (measured on other writers' posts, not on the posts "
+            "above. Optional: use a shape when it fits the idea, ignore it when it "
+            "fights how he writes. The posts above and the standing corrections win "
+            "anywhere they disagree):\n" + lines)
 
     provenance = {
         "exemplar_ids": [str(r.get("id")) for r in picked],
         "exemplar_texts": [(r.get("text") or "") for r in picked],
         "correction_ids": [str(r.get("id")) for r in applied],
+        "external_correction_ids": [str(r.get("id")) for r in researched],
         "selection_reason": selector.selection_reason(picked, channel, counter,
                                                       slot_index),
         "skipped_rows": voice.skipped_rows,

--- a/plugins/kipi-core/voiceloop/fingerprint.py
+++ b/plugins/kipi-core/voiceloop/fingerprint.py
@@ -310,3 +310,76 @@ def load(path):
     whether a missing/broken file degrades (daily job: yes) or fails (validator: no)."""
     with open(path, encoding="utf-8") as handle:
         return json.load(handle)
+
+
+# --- continuous scoring (2026-08-24, RCA-voice-enforcement) -------------------------
+#
+# why: binary min/max bounds answer "did he EVER do this" and almost always the
+# answer is yes, because generation is anchored on his own exemplars. The brief-era
+# failure was exactly that: a draft at colon_rate 1.29 scored inside [0, 20] and
+# every layer reported clean while the founder read it as not-him. Continuous
+# distance answers the question a human is actually asking: how FAR from his center
+# is this, measured in units of his own spread. External practice (style-drift
+# detection, stylometry verification) uses per-feature z-scores plus a multi-feature
+# aggregate; both are defined here so the caller keeps choosing policy.
+
+_P90_Z = 1.2816     # p90 of a standard normal: p10..p90 spans 2 x this
+_RANGE_DIV = 4.0    # degenerate-band fallback: treat observed range as ~4 sigma
+_MIN_SIGMA = {
+    # Counts and rates move in small steps; without a floor, one colon in a short
+    # post produces an enormous z and the aggregate becomes single-metric theater.
+    # Floors are in the metric's OWN units, chosen at the instrument level so no
+    # caller can forget them.
+    "colon_rate": 0.35, "hedge_count": 0.5, "formal_pair_count": 0.5,
+    "midpost_questions": 0.5, "monotony_run": 0.5, "para_max_sentences": 0.75,
+}
+
+
+def _sigma(band):
+    """Robust spread estimate for one metric's band, in the metric's units."""
+    p10, p90 = band.get("p10"), band.get("p90")
+    if p10 is None or p90 is None:
+        return None
+    if p90 > p10:
+        return max((p90 - p10) / (2 * _P90_Z), 0.0)
+    lo, hi = _bounds(band)
+    if lo is not None and hi is not None and hi > lo:
+        return (hi - lo) / _RANGE_DIV
+    return None
+
+
+def zscores(text, fingerprint_doc):
+    """Per-metric robust z: (value - p50) / sigma, sigma from the p10-p90 span.
+
+    Signed: negative means BELOW his median (e.g. too few first-person tokens),
+    positive means above. Metrics whose spread cannot be estimated are omitted
+    rather than guessed. Pure; no clock, no model.
+    """
+    got = metrics(text)
+    out = {}
+    for name, band in ((fingerprint_doc or {}).get("metrics") or {}).items():
+        value = got.get(name)
+        sigma = _sigma(band)
+        if value is None or not sigma:
+            continue
+        sigma = max(sigma, _MIN_SIGMA.get(name, 0.0))
+        p50 = band.get("p50")
+        if p50 is None:
+            continue
+        out[name] = round((value - p50) / sigma, 2)
+    return out
+
+
+def style_distance(zs, cap=8.0):
+    """Aggregate multi-axis distance: root sum of squares of capped |z|.
+
+    The cap stops one wild metric from dominating; the sqrt-of-sum keeps the
+    property that several mild deviations together outweigh one mild one, which
+    is the drift signal binary bounds cannot express at all.
+    """
+    total = 0.0
+    for z in (zs or {}).values():
+        az = min(abs(z), cap)
+        if az >= 0:
+            total += az * az
+    return round(total ** 0.5, 2)

--- a/plugins/kipi-core/voiceloop/selector.py
+++ b/plugins/kipi-core/voiceloop/selector.py
@@ -49,12 +49,20 @@ def eligible(rows, channel, slot_kind="post", target_words=None):
     at 169 words, the one long-form linkedin sample a long-form request most needs.
     The founder's spec is that the skill sees all the examples; it saw 41 of 59.
 
+    A row with `eligible_for_voice_reference` explicitly False is OUT of both
+    tiers, anchors included (2026-08-23). Before this line the field was dead:
+    the corpus carried it, curation flipped it, and selection never read it, so
+    a hype-register post ("It's ALIVE!!!") sat as an anchor in every linkedin
+    prompt while believing it was retired. Absent or null keeps the row live --
+    retirement is an explicit act, recorded on the row with a reason.
+
     The 2026-08-09 scar is preserved exactly, because it is a scar about SHORT
     slots: article rhythm taught post slots and the engine published essays on a
     280-char channel. A short request still gets the strict tiering that fixed it.
     Only a long request promotes, and for a long request article rhythm is the
     right answer rather than the bug.
     """
+    rows = [r for r in rows if r.get("eligible_for_voice_reference") is not False]
     tiers = ELIGIBLE_KINDS.get(slot_kind, ELIGIBLE_KINDS["post"])
     primary_kinds, fallback_kinds = tiers[0], tiers[1]
     if (target_words is not None and target_words >= LONG_WORDS

--- a/plugins/kipi-core/voiceloop/tests/test_voiceloop.py
+++ b/plugins/kipi-core/voiceloop/tests/test_voiceloop.py
@@ -572,13 +572,35 @@ class TestValidate:
         # two extremums of it.
         rows = _rows(20)
         for i, r in enumerate(rows):
-            r["text"] = f"Run {i}. " + "I watched the queue back up. " * (1 + i * 3)
+            # DESCENDING, so the shortest rows sit at the END of the pool order and
+            # the thinnest assembly falls at counter 16. Ascending put it at counter
+            # 0, where a 12-counter window still finds it -- that fixture let a
+            # range(12) mutant survive at 122 passed. A bound only fakes a check
+            # when the answer happens to sit inside it.
+            r["text"] = ("Run {}. ".format(i)
+                         + "I watched the queue back up. " * (1 + (19 - i) * 3))
         heavy = [{"id": f"c{i}", "status": "active",
                   "instruction": f"Rule {i}. " * 200} for i in range(6)]
         d = _voice_dir(tmp_path, rows=rows, corrections=heavy,
                        fp=self._fresh_fp(rows))
         voice = corpus.load(d)
-        lengths = [len(assemble.voice_section(voice, "x", c)[0]) for c in range(12)]
+        # THE ORACLE IS DERIVED INDEPENDENTLY, over the FULL rotation. Its first
+        # draft looped `range(12)` because the code did, which is the trap
+        # `_resolved_slots` already names in this file: a checker that re-derives
+        # the rule it checks is testing its own copy. The 12-window hid a second
+        # bug of the same class (PR #301 review round 2) because test and code
+        # sampled the same wrong window and agreed.
+        period = len(selector.resolved_pool(voice.active_exemplars(), "x", "post",
+                                            selector.DEFAULT_K))
+        assert period > 12, (
+            f"this fixture's rotation period is {period}, so a 12-counter window "
+            "would cover it and the test cannot see an under-sampling bug")
+        lengths = [len(assemble.voice_section(voice, "x", c)[0])
+                   for c in range(period)]
+        assert lengths.index(min(lengths)) >= 12, (
+            "the thinnest assembly is at counter "
+            f"{lengths.index(min(lengths))}, inside a 12-counter window, so this "
+            "fixture cannot tell full-rotation sampling from the old range(12)")
         rules = sum(len(c["instruction"]) for c in heavy)
         assert rules / max(lengths) <= validate.CORRECTION_SHARE_CEILING, (
             "the fattest assembly must read CLEAN here, or the old max-denominator "

--- a/plugins/kipi-core/voiceloop/tests/test_voiceloop.py
+++ b/plugins/kipi-core/voiceloop/tests/test_voiceloop.py
@@ -550,73 +550,116 @@ class TestValidate:
                                                      corrections=heavy[:1] + retired,
                                                      fp=self._fresh_fp(rows))))
 
-    def test_the_share_is_measured_at_the_THINNEST_prompt_not_the_fattest(self,
-                                                                          tmp_path):
-        """The denominator, and it is the whole guard.
+    def test_the_share_samples_the_WHOLE_rotation_not_a_fixed_twelve(self,
+                                                                     tmp_path):
+        """The counter axis, isolated from the other two.
 
-        Shipped taking the MAX over 12 counters, copied from `check_budget` where
-        max is right. Max reports the BEST case of the thing being graded, so on
-        the live ASK corpus 2026-09-04 the x channel read 60% against the max and
-        71% against the min, and the guard returned [] with the ceiling at 70%.
+        `selector.select` offsets by `counter % len(pool)`, so the period is the
+        pool size. The guard inherited `range(12)` from `check_budget` and could
+        not see counters 12 upward. Live pools measured 45 / 31 / 10.
 
-        This fixture is sized so the two denominators DISAGREE ON THE VERDICT:
-        66% against the fattest assembly, which is clean, and 90% against the
-        thinnest, which is red. A fixture merely far over the line passes against
-        either extremum and would not have caught the bug.
+        EVERY ROW CARRIES THE SAME WORD COUNT on purpose. A length target draws
+        the nearest rows by word count, so on a mixed-register corpus it reaches
+        the thin rows on its own and a `range(12)` mutant survives -- measured,
+        it did. With one register the target axis cannot get there, and the only
+        way to the thinnest prompt is counting past 12. Character length falls as
+        the id rises, which puts that prompt at counter 16.
+
+        Sized so the two windows DISAGREE ON THE VERDICT: 60% over `range(12)`,
+        which is clean, and 74% over the full rotation, which is red.
         """
         import re
-        # EVERY ROW A DIFFERENT LENGTH, on purpose. The first attempt at this
-        # fixture used two repeated bodies, so every row of a class was byte
-        # identical, every counter assembled to exactly 13615 chars, and min and
-        # max were one number. A uniform corpus cannot show a difference between
-        # two extremums of it.
-        rows = _rows(20)
-        for i, r in enumerate(rows):
-            # DESCENDING, so the shortest rows sit at the END of the pool order and
-            # the thinnest assembly falls at counter 16. Ascending put it at counter
-            # 0, where a 12-counter window still finds it -- that fixture let a
-            # range(12) mutant survive at 122 passed. A bound only fakes a check
-            # when the answer happens to sit inside it.
-            r["text"] = ("Run {}. ".format(i)
-                         + "I watched the queue back up. " * (1 + (19 - i) * 3))
+        rows = []
+        for i in range(20):
+            word = "queuebackup" * max(7 - i // 3, 1)
+            rows.append({"id": f"ex-{i:02d}", "kind": "post", "channel": "any",
+                         "status": "active", "weight": 1.0, "anchor": False,
+                         "text": " ".join([word] * 30)})
         heavy = [{"id": f"c{i}", "status": "active",
-                  "instruction": f"Rule {i}. " * 200} for i in range(6)]
+                  "instruction": f"Rule {i}. " * 150} for i in range(6)]
         d = _voice_dir(tmp_path, rows=rows, corrections=heavy,
                        fp=self._fresh_fp(rows))
         voice = corpus.load(d)
-        # THE ORACLE IS DERIVED INDEPENDENTLY, over the FULL rotation. Its first
-        # draft looped `range(12)` because the code did, which is the trap
-        # `_resolved_slots` already names in this file: a checker that re-derives
-        # the rule it checks is testing its own copy. The 12-window hid a second
-        # bug of the same class (PR #301 review round 2) because test and code
-        # sampled the same wrong window and agreed.
-        period = len(selector.resolved_pool(voice.active_exemplars(), "x", "post",
-                                            selector.DEFAULT_K))
-        assert period > 12, (
-            f"this fixture's rotation period is {period}, so a 12-counter window "
-            "would cover it and the test cannot see an under-sampling bug")
-        lengths = [len(assemble.voice_section(voice, "x", c)[0])
-                   for c in range(period)]
-        assert lengths.index(min(lengths)) >= 12, (
-            "the thinnest assembly is at counter "
-            f"{lengths.index(min(lengths))}, inside a 12-counter window, so this "
-            "fixture cannot tell full-rotation sampling from the old range(12)")
         rules = sum(len(c["instruction"]) for c in heavy)
-        assert rules / max(lengths) <= validate.CORRECTION_SHARE_CEILING, (
-            "the fattest assembly must read CLEAN here, or the old max-denominator "
-            f"code passes this test too: {rules / max(lengths):.0%}")
+        # The oracle is derived INDEPENDENTLY of the code's own window. Its first
+        # draft looped `range(12)` because the code did, which is the trap
+        # `validate._resolved_slots` names in this file: a checker that re-derives
+        # the rule it checks is testing its own copy.
+        pool = selector.resolved_pool(voice.active_exemplars(), "x", "post",
+                                      selector.DEFAULT_K)
+        assert len({selector._words(r) for r in pool}) == 1, (
+            "this fixture must be a single length register, or a length target "
+            "reaches the thin rows and the counter window stops mattering")
+        assert len(pool) > 12, f"rotation period is {len(pool)}, nothing to miss"
+        lengths = [len(assemble.voice_section(voice, "x", c)[0])
+                   for c in range(len(pool))]
+        assert lengths.index(min(lengths)) >= 12, (
+            f"the thinnest prompt is at counter {lengths.index(min(lengths))}, "
+            "inside a 12-counter window, so this fixture cannot tell the two apart")
+        assert rules / min(lengths[:12]) <= validate.CORRECTION_SHARE_CEILING, (
+            "a 12-counter window must read CLEAN here, or the old code passes "
+            f"this test too: {rules / min(lengths[:12]):.0%}")
         assert rules / min(lengths) > validate.CORRECTION_SHARE_CEILING, (
-            f"the thinnest assembly must read RED: {rules / min(lengths):.0%}")
+            f"the full rotation must read RED: {rules / min(lengths):.0%}")
 
         problems = [p for p in validate.check_correction_share(voice)
                     if p.startswith("x:")]
         assert problems, (
-            "the guard graded the fattest prompt and called a corpus clean that is "
-            f"{rules / min(lengths):.0%} rules at its thinnest")
+            "the guard stopped at counter 11 and called a corpus clean that is "
+            f"{rules / min(lengths):.0%} rules at counter "
+            f"{lengths.index(min(lengths))}")
         reported = int(re.search(r" of (\d+) chars", problems[0]).group(1))
         assert reported == min(lengths), (
-            f"the guard divided by {reported}; the thinnest assembly is "
-            f"{min(lengths)} and the fattest is {max(lengths)}")
+            f"the guard divided by {reported}; the thinnest prompt over the whole "
+            f"rotation is {min(lengths)} and the fattest is {max(lengths)}")
+
+    def test_the_share_samples_the_length_target_the_CLI_always_passes(self,
+                                                                      tmp_path):
+        """The third axis, and the third round of one defect class.
+
+        `voice_ref.py` declares `--words` required, so every prompt production
+        builds carries a length target, and a target REPLACES the pool with the
+        nearest k rows. The guard only ever sampled `target_words=None`, which is
+        a shape production never builds.
+
+        The fixture has two registers and is sized so the two paths DISAGREE ON
+        THE VERDICT: the untargeted prompt reads 68%, under the 70% ceiling, and
+        the shortest register reads 93%.
+        """
+        rows = []
+        for i in range(12):
+            body = "I watched the queue back up. " * (60 if i % 2 == 0 else 2)
+            rows.append({"id": f"ex-{i:02d}", "kind": "post", "channel": "any",
+                         "status": "active", "weight": 1.0, "anchor": False,
+                         "text": body + f" Tag {i}."})
+        heavy = [{"id": f"c{i}", "status": "active",
+                  "instruction": f"Rule {i}. " * 180} for i in range(6)]
+        d = _voice_dir(tmp_path, rows=rows, corrections=heavy,
+                       fp=self._fresh_fp(rows))
+        voice = corpus.load(d)
+        rules = sum(len(c["instruction"]) for c in heavy)
+        base = selector.resolved_pool(voice.active_exemplars(), "x", "post",
+                                      selector.DEFAULT_K)
+        thin_none = min(len(assemble.voice_section(voice, "x", c)[0])
+                        for c in range(len(base)))
+        assert rules / thin_none <= validate.CORRECTION_SHARE_CEILING, (
+            "the untargeted path must read CLEAN here, or a guard that samples "
+            f"only target_words=None passes this test too: {rules / thin_none:.0%}")
+
+        shortest = min(selector._words(r) for r in base)
+        pool = selector.resolved_pool(voice.active_exemplars(), "x", "post",
+                                      selector.DEFAULT_K, shortest)
+        thin_target = min(
+            len(assemble.voice_section(voice, "x", c, target_words=shortest)[0])
+            for c in range(len(pool)))
+        assert rules / thin_target > validate.CORRECTION_SHARE_CEILING, (
+            f"the shortest register must read RED: {rules / thin_target:.0%}")
+
+        problems = [p for p in validate.check_correction_share(voice)
+                    if p.startswith("x:")]
+        assert problems, (
+            "the guard never asked for a length target, so it graded a prompt "
+            f"shape the CLI cannot build and missed a real {rules / thin_target:.0%}")
 
 
 # --- voice-1-instrument: review findings 1, 2, 8 ----------------------------------

--- a/plugins/kipi-core/voiceloop/tests/test_voiceloop.py
+++ b/plugins/kipi-core/voiceloop/tests/test_voiceloop.py
@@ -550,6 +550,52 @@ class TestValidate:
                                                      corrections=heavy[:1] + retired,
                                                      fp=self._fresh_fp(rows))))
 
+    def test_the_share_is_measured_at_the_THINNEST_prompt_not_the_fattest(self,
+                                                                          tmp_path):
+        """The denominator, and it is the whole guard.
+
+        Shipped taking the MAX over 12 counters, copied from `check_budget` where
+        max is right. Max reports the BEST case of the thing being graded, so on
+        the live ASK corpus 2026-09-04 the x channel read 60% against the max and
+        71% against the min, and the guard returned [] with the ceiling at 70%.
+
+        This fixture is sized so the two denominators DISAGREE ON THE VERDICT:
+        66% against the fattest assembly, which is clean, and 90% against the
+        thinnest, which is red. A fixture merely far over the line passes against
+        either extremum and would not have caught the bug.
+        """
+        import re
+        # EVERY ROW A DIFFERENT LENGTH, on purpose. The first attempt at this
+        # fixture used two repeated bodies, so every row of a class was byte
+        # identical, every counter assembled to exactly 13615 chars, and min and
+        # max were one number. A uniform corpus cannot show a difference between
+        # two extremums of it.
+        rows = _rows(20)
+        for i, r in enumerate(rows):
+            r["text"] = f"Run {i}. " + "I watched the queue back up. " * (1 + i * 3)
+        heavy = [{"id": f"c{i}", "status": "active",
+                  "instruction": f"Rule {i}. " * 200} for i in range(6)]
+        d = _voice_dir(tmp_path, rows=rows, corrections=heavy,
+                       fp=self._fresh_fp(rows))
+        voice = corpus.load(d)
+        lengths = [len(assemble.voice_section(voice, "x", c)[0]) for c in range(12)]
+        rules = sum(len(c["instruction"]) for c in heavy)
+        assert rules / max(lengths) <= validate.CORRECTION_SHARE_CEILING, (
+            "the fattest assembly must read CLEAN here, or the old max-denominator "
+            f"code passes this test too: {rules / max(lengths):.0%}")
+        assert rules / min(lengths) > validate.CORRECTION_SHARE_CEILING, (
+            f"the thinnest assembly must read RED: {rules / min(lengths):.0%}")
+
+        problems = [p for p in validate.check_correction_share(voice)
+                    if p.startswith("x:")]
+        assert problems, (
+            "the guard graded the fattest prompt and called a corpus clean that is "
+            f"{rules / min(lengths):.0%} rules at its thinnest")
+        reported = int(re.search(r" of (\d+) chars", problems[0]).group(1))
+        assert reported == min(lengths), (
+            f"the guard divided by {reported}; the thinnest assembly is "
+            f"{min(lengths)} and the fattest is {max(lengths)}")
+
 
 # --- voice-1-instrument: review findings 1, 2, 8 ----------------------------------
 

--- a/plugins/kipi-core/voiceloop/tests/test_voiceloop.py
+++ b/plugins/kipi-core/voiceloop/tests/test_voiceloop.py
@@ -435,6 +435,33 @@ class TestAssemble:
             assert body.strip() in text
 
 
+    def test_external_source_correction_renders_under_its_own_header(self, tmp_path):
+        cor = [{"id": "his", "status": "active",
+                "instruction": "Never open with a number."},
+               {"id": "ext", "status": "active",
+                "source": assemble.EXTERNAL_SOURCE,
+                "instruction": "End on a colon line."}]
+        v = corpus.load(_voice_dir(tmp_path, corrections=cor))
+        text, prov = assemble.voice_section(v, "linkedin", counter=0)
+        standing = text.find("STANDING CORRECTIONS")
+        researched = text.find("RESEARCHED SHAPES")
+        assert -1 not in (standing, researched) and standing < researched
+        assert "End on a colon line" not in text[standing:researched], (
+            "an external correction must never sit under the override header")
+        assert prov["external_correction_ids"] == ["ext"]
+        assert prov["correction_ids"] == ["his", "ext"]
+
+    def test_unmarked_corrections_render_exactly_as_before(self, tmp_path):
+        """The fleet contract: a corpus that never sets source gets the legacy
+        single-block rendering byte for byte."""
+        cor = [{"id": "c1", "status": "active",
+                "instruction": "Never open with a number."}]
+        v = corpus.load(_voice_dir(tmp_path, corrections=cor))
+        text, prov = assemble.voice_section(v, "linkedin", counter=0)
+        assert "STANDING CORRECTIONS" in text
+        assert "RESEARCHED SHAPES" not in text
+        assert prov["external_correction_ids"] == []
+
 # --- validate ---------------------------------------------------------------------
 
 class TestValidate:
@@ -472,6 +499,56 @@ class TestValidate:
             r["text"] = "Long. " * 2000
         d = _voice_dir(tmp_path, rows=rows, fp=self._fresh_fp(rows))
         assert any("budget" in p for p in validate.check_all(d))
+
+    def test_corrections_crowding_out_his_writing_is_red(self, tmp_path):
+        """The share guard, and the reason it is not the size guard restated: this
+        corpus sits WELL INSIDE budget and is still wrong, because the rules about
+        him outweigh the writing by him."""
+        rows = _rows(6)
+        for r in rows:
+            r["text"] = "Short."
+        cor = [{"id": f"c{i}", "status": "active", "instruction": "Rule. " * 200}
+               for i in range(6)]
+        d = _voice_dir(tmp_path, rows=rows, corrections=cor,
+                       fp=self._fresh_fp(rows))
+        problems = validate.check_all(d)
+        assert any("crowd" in p or "ceiling" in p for p in problems), problems
+        assert not any("budget" in p for p in problems), (
+            "this fixture must be inside budget, or it proves nothing the size "
+            "check did not already catch: " + repr(problems))
+
+    def test_a_corpus_of_his_writing_with_few_rules_is_GREEN(self, tmp_path):
+        """The other side, so the guard cannot pass by refusing everything."""
+        rows = _rows(6)
+        for r in rows:
+            r["text"] = "I watched the queue back up. " * 40
+        cor = [{"id": "c1", "status": "active", "instruction": "End on a verdict."}]
+        d = _voice_dir(tmp_path, rows=rows, corrections=cor,
+                       fp=self._fresh_fp(rows))
+        assert not any("ceiling" in p for p in validate.check_all(d))
+
+    def test_a_RETIRED_correction_does_not_count_toward_the_share(self, tmp_path):
+        """Retirement is the named remedy, so it has to actually move the number."""
+        # His writing is held CONSTANT across both halves, so the only thing that
+        # moves the share is the retirement itself.
+        rows = _rows(6)
+        for r in rows:
+            r["text"] = "I watched the queue back up. " * 30
+        heavy = [{"id": f"c{i}", "status": "active", "instruction": "Rule. " * 400}
+                 for i in range(6)]
+        before = tmp_path / "before"
+        before.mkdir(parents=True, exist_ok=True)
+        after = tmp_path / "after"
+        after.mkdir(parents=True, exist_ok=True)
+        assert any("ceiling" in p for p in
+                   validate.check_all(_voice_dir(before, rows=rows,
+                                                 corrections=heavy,
+                                                 fp=self._fresh_fp(rows))))
+        retired = [dict(c, status="retired") for c in heavy[1:]]
+        assert not any("ceiling" in p for p in
+                       validate.check_all(_voice_dir(after, rows=rows,
+                                                     corrections=heavy[:1] + retired,
+                                                     fp=self._fresh_fp(rows))))
 
 
 # --- voice-1-instrument: review findings 1, 2, 8 ----------------------------------

--- a/plugins/kipi-core/voiceloop/tests/test_voiceloop.py
+++ b/plugins/kipi-core/voiceloop/tests/test_voiceloop.py
@@ -661,6 +661,57 @@ class TestValidate:
             "the guard never asked for a length target, so it graded a prompt "
             f"shape the CLI cannot build and missed a real {rules / thin_target:.0%}")
 
+    def test_the_share_grades_every_slot_kind_the_engine_declares(self, tmp_path):
+        """The fourth axis, and the reason this loop now enumerates nothing.
+
+        `validate.SLOT_KINDS` is the vocabulary this module declares and
+        `voice_ref.py --slot-kind` offers. The guard pinned "post", so a corpus
+        whose COMMENT prompts are almost entirely rules read clean.
+
+        Long post rows plus short comment rows, sized so the two slots DISAGREE
+        ON THE VERDICT.
+        """
+        rows = []
+        for i in range(12):
+            rows.append({"id": f"ex-{i:02d}", "kind": "post", "channel": "any",
+                         "status": "active", "weight": 1.0, "anchor": False,
+                         "text": "I watched the queue back up. " * 70 + f" P{i}."})
+        for i in range(6):
+            rows.append({"id": f"cm-{i:02d}", "kind": "comment", "channel": "any",
+                         "status": "active", "weight": 1.0, "anchor": False,
+                         "text": f"Short comment {i}. It broke."})
+        heavy = [{"id": f"c{i}", "status": "active",
+                  "instruction": f"Rule {i}. " * 200} for i in range(6)]
+        d = _voice_dir(tmp_path, rows=rows, corrections=heavy,
+                       fp=self._fresh_fp(rows))
+        voice = corpus.load(d)
+        rules = sum(len(c["instruction"]) for c in heavy)
+
+        def thinnest(slot_kind):
+            base = selector.resolved_pool(voice.active_exemplars(), "x", slot_kind,
+                                          selector.DEFAULT_K)
+            out = []
+            for target in (None, min(selector._words(r) for r in base)):
+                pool = selector.resolved_pool(voice.active_exemplars(), "x",
+                                              slot_kind, selector.DEFAULT_K, target)
+                out += [len(assemble.voice_section(voice, "x", c,
+                                                   slot_kind=slot_kind,
+                                                   target_words=target)[0])
+                        for c in range(len(pool))]
+            return min(out)
+
+        assert rules / thinnest("post") <= validate.CORRECTION_SHARE_CEILING, (
+            "the post slot must read CLEAN here, or a guard pinned to post passes "
+            f"this test too: {rules / thinnest('post'):.0%}")
+        assert rules / thinnest("comment") > validate.CORRECTION_SHARE_CEILING, (
+            f"the comment slot must read RED: {rules / thinnest('comment'):.0%}")
+
+        problems = [p for p in validate.check_correction_share(voice)
+                    if p.startswith("x:")]
+        assert problems, (
+            "the guard graded only the post slot and missed a comment prompt that "
+            f"is {rules / thinnest('comment'):.0%} rules")
+
 
 # --- voice-1-instrument: review findings 1, 2, 8 ----------------------------------
 

--- a/plugins/kipi-core/voiceloop/validate.py
+++ b/plugins/kipi-core/voiceloop/validate.py
@@ -393,18 +393,30 @@ def check_correction_share(voice, channels=None):
         # from the corpus keeps this derived; a list of example word counts would be
         # the same guess in a new costume.
         rows = voice.active_exemplars()
-        base = selector.resolved_pool(rows, channel, "post", selector.DEFAULT_K)
-        targets = [None] + ([min(selector._words(r) for r in base)] if base else [])
         lengths = []
-        for target in targets:
-            pool = selector.resolved_pool(rows, channel, "post", selector.DEFAULT_K,
-                                          target)
-            # len(pool) is an upper bound on the rotation once a target narrows it,
-            # so this covers the full period. Over-sampling a pure string build is
-            # free; the live corpus measures 0.01s.
-            lengths += [len(assemble.voice_section(voice, channel, counter,
-                                                   target_words=target)[0])
-                        for counter in range(len(pool) or 1)]
+        # slot_kind: taken from SLOT_KINDS, the vocabulary this module already
+        # DECLARES and `voice_ref.py --slot-kind` already offers. It was pinned to
+        # "post", so a corpus whose comment prompts are 97% rules read clean.
+        for slot_kind in SLOT_KINDS:
+            base = selector.resolved_pool(rows, channel, slot_kind,
+                                          selector.DEFAULT_K)
+            if not base:
+                continue
+            # target_words: the corpus's own shortest register, which is the target
+            # that collapses the pool hardest -- `length_band` ranks by distance, so
+            # no other target draws shorter rows. None is kept because pre-2026
+            # callers still pass it.
+            for target in (None, min(selector._words(r) for r in base)):
+                pool = selector.resolved_pool(rows, channel, slot_kind,
+                                              selector.DEFAULT_K, target)
+                # counter: the period is the pool size, not a literal.
+                # len(pool) is an upper bound once a target narrows it, so this
+                # covers the full rotation. Over-sampling a pure string build is
+                # free; the live corpus measures 0.01s.
+                lengths += [len(assemble.voice_section(voice, channel, counter,
+                                                       slot_kind=slot_kind,
+                                                       target_words=target)[0])
+                            for counter in range(len(pool) or 1)]
         # A counter that assembles to nothing has no share to measure, and taking a
         # minimum over it divides by zero. Drop the empties so the channel is graded
         # on the prompts it really produces; a channel with no prompt at all is

--- a/plugins/kipi-core/voiceloop/validate.py
+++ b/plugins/kipi-core/voiceloop/validate.py
@@ -325,6 +325,56 @@ def check_budget(voice, channels=None):
     return problems
 
 
+#: The share of an assembled prompt that may be CORRECTIONS rather than his own
+#: writing. A headroom alarm in the same posture as `assemble.BUDGET_CHARS`:
+#: suite-time only, never a runtime slice.
+#:
+#: why a share and not just a size: the founder-directed premise of this corpus is
+#: that posts are written FROM his examples, never from a model's impression of
+#: him. Corrections are RULES ABOUT him. When the rules outweigh the examples, that
+#: premise has quietly inverted while every size check still passes, because the
+#: total can sit inside budget with the mix completely wrong.
+#:
+#: MEASURED 2026-08-31 before the line was picked, both channels, worst assembly of
+#: 12 counters: linkedin 11618 of 20552 chars (57%), x 10154 of 16994 (60%). Set at
+#: 0.70 so it does not fire today and bites within a few additions, which is the
+#: point -- a guard set below the current reading is a guard someone switches off.
+#:
+#: The remedy when it fires is RETIREMENT, never rotation and never a quiet drop.
+#: `status` already gates this (`corpus.active_corrections` renders only "active";
+#: verified 2026-08-31 that promoted/retired rows really are absent from the
+#: prompt), so retiring a superseded rule is a one-field edit. Two rules that
+#: genuinely say one thing get MERGED into one loud statement, never dropped.
+CORRECTION_SHARE_CEILING = 0.70
+
+
+def check_correction_share(voice, channels=None):
+    """Corrections must not crowd his own writing out of the prompt."""
+    channels = channels or channel_registry.DEFAULT
+    problems = []
+    for channel in channels.assembled:
+        worst_text, worst_len = "", 0
+        for counter in range(12):
+            text, _ = assemble.voice_section(voice, channel, counter)
+            if len(text) > worst_len:
+                worst_text, worst_len = text, len(text)
+        if not worst_len:
+            continue
+        applied = [r for r in voice.active_corrections()
+                   if not r.get("scope") or channel in r["scope"]]
+        rules = sum(len(r.get("instruction") or "") for r in applied)
+        share = rules / worst_len
+        if share > CORRECTION_SHARE_CEILING:
+            problems.append(
+                f"{channel}: corrections are {rules} of {worst_len} chars "
+                f"({share:.0%}) of the largest assembly, over the "
+                f"{CORRECTION_SHARE_CEILING:.0%} ceiling. Retire a superseded "
+                f"correction (set its status off 'active'), or merge two that say "
+                f"one thing into one statement. Do not rotate them: a correction "
+                f"dropped from a prompt is a rule the model never sees.")
+    return problems
+
+
 def check_all(voice_dir, channels=None):
     """Every check, one list. [] is a healthy corpus.
 
@@ -353,6 +403,7 @@ def check_all(voice_dir, channels=None):
     problems += check_rotation_headroom(voice, channels=channels)
     problems += check_fingerprint_fresh(voice)
     problems += check_budget(voice, channels)
+    problems += check_correction_share(voice, channels)
     if voice.skipped_rows:
         problems.append(f"{voice.skipped_rows} corrupt JSONL row(s) skipped by the "
                         f"loader -- fix or remove them")

--- a/plugins/kipi-core/voiceloop/validate.py
+++ b/plugins/kipi-core/voiceloop/validate.py
@@ -335,10 +335,23 @@ def check_budget(voice, channels=None):
 #: premise has quietly inverted while every size check still passes, because the
 #: total can sit inside budget with the mix completely wrong.
 #:
-#: MEASURED 2026-08-31 before the line was picked, both channels, worst assembly of
-#: 12 counters: linkedin 11618 of 20552 chars (57%), x 10154 of 16994 (60%). Set at
-#: 0.70 so it does not fire today and bites within a few additions, which is the
-#: point -- a guard set below the current reading is a guard someone switches off.
+#: MEASURED 2026-08-31 against the LARGEST assembly of 12 counters: linkedin 11618
+#: of 20552 chars (57%), x 10154 of 16994 (60%). Set at 0.70 to sit above that and
+#: bite within a few additions -- a guard set below the current reading is a guard
+#: someone switches off.
+#:
+#: THAT DENOMINATOR WAS THE WRONG END, so the two numbers above are the best case
+#: rather than the reading that matters (found in review on PR #301). Rules crowd
+#: his writing out worst at the THINNEST prompt a rotation produces, not the
+#: fattest. Re-measured 2026-09-04 on the live ASK corpus, same rows, dividing by
+#: the minimum: linkedin 11618 of 17995 (65%), x 10154 of 14293 (71%), reddit 527
+#: of 7541 (7%).
+#:
+#: 0.70 IS DELIBERATELY LEFT ALONE, so x trips the moment an instance picks this
+#: up. Moving the ceiling to clear a reading the corrected arithmetic has just
+#: exposed would be switching the alarm off in the same edit that made it work.
+#: How much of his prompt may be rules is the voice owner's number. The
+#: arithmetic under it is the engine's.
 #:
 #: The remedy when it fires is RETIREMENT, never rotation and never a quiet drop.
 #: `status` already gates this (`corpus.active_corrections` renders only "active";
@@ -353,21 +366,32 @@ def check_correction_share(voice, channels=None):
     channels = channels or channel_registry.DEFAULT
     problems = []
     for channel in channels.assembled:
-        worst_text, worst_len = "", 0
-        for counter in range(12):
-            text, _ = assemble.voice_section(voice, channel, counter)
-            if len(text) > worst_len:
-                worst_text, worst_len = text, len(text)
-        if not worst_len:
+        # THE MINIMUM, not the maximum. `check_budget` right above this uses `max`
+        # and is correct to -- largest assembly against a size cap -- and this loop
+        # was written from that one, which is how the wrong extremum arrived. Here
+        # the max reports the BEST case of the very thing being graded: a rotation's
+        # prompts differ by thousands of characters, so the fattest one always
+        # flatters the share. Measured on the live ASK corpus 2026-09-04, the x
+        # channel read 60% against the max and 71% against the min, with the ceiling
+        # at 70%. The guard returned [] on a corpus already over its own line.
+        lengths = [len(assemble.voice_section(voice, channel, counter)[0])
+                   for counter in range(12)]
+        # A counter that assembles to nothing has no share to measure, and taking a
+        # minimum over it divides by zero. Drop the empties so the channel is graded
+        # on the prompts it really produces; a channel with no prompt at all is
+        # skipped, which is what the old `if not worst_len` meant.
+        lengths = [n for n in lengths if n]
+        if not lengths:
             continue
+        thinnest = min(lengths)
         applied = [r for r in voice.active_corrections()
                    if not r.get("scope") or channel in r["scope"]]
         rules = sum(len(r.get("instruction") or "") for r in applied)
-        share = rules / worst_len
+        share = rules / thinnest
         if share > CORRECTION_SHARE_CEILING:
             problems.append(
-                f"{channel}: corrections are {rules} of {worst_len} chars "
-                f"({share:.0%}) of the largest assembly, over the "
+                f"{channel}: corrections are {rules} of {thinnest} chars "
+                f"({share:.0%}) of the thinnest assembly, over the "
                 f"{CORRECTION_SHARE_CEILING:.0%} ceiling. Retire a superseded "
                 f"correction (set its status off 'active'), or merge two that say "
                 f"one thing into one statement. Do not rotate them: a correction "

--- a/plugins/kipi-core/voiceloop/validate.py
+++ b/plugins/kipi-core/voiceloop/validate.py
@@ -374,8 +374,18 @@ def check_correction_share(voice, channels=None):
         # flatters the share. Measured on the live ASK corpus 2026-09-04, the x
         # channel read 60% against the max and 71% against the min, with the ceiling
         # at 70%. The guard returned [] on a corpus already over its own line.
+        # THE FULL ROTATION, not a fixed 12. `selector.select` offsets by
+        # `counter % len(pool)`, so the period is the pool size and a 12-counter
+        # window (inherited from `check_budget` with the rest of this loop) simply
+        # does not see counters 12..n-1. Measured on the live ASK corpus 2026-09-04:
+        # pools are 45 / 31 / 10, and linkedin's true thinnest prompt is 16987 chars
+        # against the 17995 the 12-window reported. Same defect class as the max/min
+        # bug this loop was just fixed for -- right extremum, wrong sample -- which
+        # is why the period is DERIVED here instead of being a second literal.
+        pool = selector.resolved_pool(voice.active_exemplars(), channel, "post",
+                                      selector.DEFAULT_K)
         lengths = [len(assemble.voice_section(voice, channel, counter)[0])
-                   for counter in range(12)]
+                   for counter in range(len(pool) or 1)]
         # A counter that assembles to nothing has no share to measure, and taking a
         # minimum over it divides by zero. Drop the empties so the channel is graded
         # on the prompts it really produces; a channel with no prompt at all is

--- a/plugins/kipi-core/voiceloop/validate.py
+++ b/plugins/kipi-core/voiceloop/validate.py
@@ -374,18 +374,37 @@ def check_correction_share(voice, channels=None):
         # flatters the share. Measured on the live ASK corpus 2026-09-04, the x
         # channel read 60% against the max and 71% against the min, with the ceiling
         # at 70%. The guard returned [] on a corpus already over its own line.
-        # THE FULL ROTATION, not a fixed 12. `selector.select` offsets by
-        # `counter % len(pool)`, so the period is the pool size and a 12-counter
-        # window (inherited from `check_budget` with the rest of this loop) simply
-        # does not see counters 12..n-1. Measured on the live ASK corpus 2026-09-04:
-        # pools are 45 / 31 / 10, and linkedin's true thinnest prompt is 16987 chars
-        # against the 17995 the 12-window reported. Same defect class as the max/min
-        # bug this loop was just fixed for -- right extremum, wrong sample -- which
-        # is why the period is DERIVED here instead of being a second literal.
-        pool = selector.resolved_pool(voice.active_exemplars(), channel, "post",
-                                      selector.DEFAULT_K)
-        lengths = [len(assemble.voice_section(voice, channel, counter)[0])
-                   for counter in range(len(pool) or 1)]
+        # EVERY AXIS THE PRODUCER VARIES, all DERIVED, none written as a literal.
+        # This loop arrived as a copy of `check_budget` and each parameter it failed
+        # to reproduce was a blind spot: three review rounds on PR #301 found three,
+        # one per round, all the same class. `validate._resolved_slots` already
+        # states the rule they break -- a checker that re-derives the rule it checks
+        # is testing its own copy.
+        #
+        # counter: `selector.select` offsets by `counter % len(pool)`, so the period
+        # is the pool size, not the 12 this loop inherited. Live pools are 45/31/10.
+        #
+        # target_words: `voice_ref.py` declares `--words` required, so a prompt
+        # assembled with None is a shape production never builds, and it was the
+        # only shape sampled. A target REPLACES the pool with the nearest k rows
+        # (`selector.select`), so the thinnest prompt reachable is the one whose
+        # target sits at the corpus's own shortest register -- `length_band` ranks
+        # by distance, so no other target draws shorter rows. Taking that minimum
+        # from the corpus keeps this derived; a list of example word counts would be
+        # the same guess in a new costume.
+        rows = voice.active_exemplars()
+        base = selector.resolved_pool(rows, channel, "post", selector.DEFAULT_K)
+        targets = [None] + ([min(selector._words(r) for r in base)] if base else [])
+        lengths = []
+        for target in targets:
+            pool = selector.resolved_pool(rows, channel, "post", selector.DEFAULT_K,
+                                          target)
+            # len(pool) is an upper bound on the rotation once a target narrows it,
+            # so this covers the full period. Over-sampling a pure string build is
+            # free; the live corpus measures 0.01s.
+            lengths += [len(assemble.voice_section(voice, channel, counter,
+                                                   target_words=target)[0])
+                        for counter in range(len(pool) or 1)]
         # A counter that assembles to nothing has no share to measure, and taking a
         # minimum over it divides by zero. Drop the empties so the channel is graded
         # on the prompts it really produces; a channel with no prompt at all is


### PR DESCRIPTION
Skeleton side of slice 0 of the VoiceLoop package extraction. Plan of record:
`q-system/output/plans/voiceloop-package-extraction-2026-09-04.md` (slice 0) and
`voiceloop-slice-0-sync-2026-09-05.md`, both instance-local in `~/projects/consulting`.

## The problem

`plugins/kipi-core/voiceloop/` had diverged in BOTH directions between the
consulting instance and this skeleton. The fleet propagation script rsyncs
`plugins/` from the skeleton working tree with a delete flag, so a naive one-way
copy in either direction destroys real work. An instance-to-skeleton copy would
have reverted PR #291.

## Direction, measured per file

Measured in a worktree cut from `origin/main` f9f74ac1, by AST symbol diff both
ways plus a check for main-only lines a carry-up would destroy. Never by size,
never by mtime.

| Direction | Files |
|---|---|
| Byte identical, untouched | `corpus.py`, `echo.py`, `voice_ref.py`, `tests/test_length_axis.py`, `tests/test_no_founder_data.py`, `tests/test_selector_form_match.py` |
| Main already ahead, untouched here | `channel_registry.py` (main defines `instance_root_for`, `for_path`, `_MAX_WALK`), `tests/test_channel_registry.py` (main has 6 symbols the instance lacks), `__init__.py` |
| Instance ahead, carried up | `fingerprint.py` (`_sigma`, `style_distance`, `zscores`), `selector.py`, `tests/test_voiceloop.py` (5 new tests), `assemble.py` (`EXTERNAL_SOURCE`) |
| Hand merged | `validate.py` |

`assemble.py` is the only carried-up file with main-only lines, and all three
are superseded rather than reverted: `BUDGET_CHARS` 20000 to 24000 is the
documented 2026-08-31 headroom raise, and the `if applied:` block is replaced by
the his/researched split `EXTERNAL_SOURCE` introduces.

## Why validate.py could not be a copy either way

Two properties lived on opposite sides:

- `check_correction_share` plus `CORRECTION_SHARE_CEILING`, only in the instance
- `channels = channel_registry.for_path(voice_dir)` in `check_all`, only on main

Copying the instance copy over this one reverts #291's load-path wiring and
deletes the scar comment recording that "documenting a seam is not wiring one".
Copying this one over the instance drops the share guard. Both are now in one
file.

## Verification

```
python3 -m pytest plugins/kipi-core/voiceloop/tests/ -q
121 passed in 0.15s
```

Negative self-test, one mutant per merged property, `PYTHONDONTWRITEBYTECODE=1`,
run against the worktree and never a live tree:

| Mutant | Result |
|---|---|
| delete the `check_correction_share` call from `check_all` | 2 failed: `test_corrections_crowding_out_his_writing_is_red`, `test_a_RETIRED_correction_does_not_count_toward_the_share` |
| revert `for_path(voice_dir)` to `channel_registry.DEFAULT` | 1 failed: `test_check_all_loads_the_instance_registry` |

Both restored, suite back to 121 passed, restored file byte-identical to the
pre-mutation copy.

`./kipi check` on the skeleton: exit 1 both before and after, with the same two
REDs, neither related to this change (`~/projects/anthology` has no off-disk
remote; `~/projects/consulting/.opencode` is not a git repo). Green was never an
available criterion here.

## Scope

Skeleton only. The consulting instance receiving `for_path` and the fixed
`check_all` is a separate sequenced step.
`plugins/kipi-core/.claude-plugin/plugin.json` 1.9.5 to 1.9.6 is the lefthook
`plugin-version-bump` gate doing its job: the plugin cache is version keyed, so a
changed plugin that does not bump serves the stale copy.

The skeleton checkout itself is untouched. It sits on
`fix/candidate-draft-one-definition` with unrelated uncommitted work, so the
fleet propagation preflight still aborts on its branch guard. That is correct and
is not something this PR tries to fix.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01M41mnfj2RWAZ1UomJxeXfx
