### PR TITLE
knowledge-supply Phase 2: recall producer + write-side src/alias convention

### DIFF
--- a/q-system/.q-system/scripts/knowledge_supply.py
+++ b/q-system/.q-system/scripts/knowledge_supply.py
@@ -1081,7 +1081,8 @@ def _record_misses(qroot: Path, prompt: str, scan: str, truncated: bool,
 # ------------------------------------------------------------------ entry point
 
 def supply(root: Path, prompt: str, *, session_id: str, now: dt.date | None = None,
-           record: bool = True, deadline_s: float | None = None) -> dict | None:
+           record: bool = True, deadline_s: float | None = None,
+           recall_path: Path | None = None) -> dict | None:
     t0 = time.time()
     t_deadline = t0 + (SUPPLY_DEADLINE_S if deadline_s is None else deadline_s)
     deadline_hit: dict | None = None
@@ -1246,6 +1247,7 @@ def supply(root: Path, prompt: str, *, session_id: str, now: dt.date | None = No
     if record:
         append_jsonl(receipts_path, receipt)
         _record_misses(qroot, prompt, scan, truncated, entities, ts, session_id)
+        _record_recall(bundle, session_id, recall_path)
     return bundle
 
 
@@ -1275,6 +1277,31 @@ def fit_to_ceiling(bundle: dict, ceiling: int, cut: int, source_cut: int,
     overflow = max(0, bundle["budget"]["used"] - ceiling)
     bundle["budget"]["overflow"] = overflow   # chars the pins alone ran past the ceiling; 0 when honest
     return cut, ceiling_hit, overflow
+
+
+def _record_recall(bundle: dict, session_id: str, recall_path: Path | None) -> None:
+    """Producer half of the memory outcome loop (knowledge-supply plan, Phase 2).
+    Each distinct source file this pass surfaced is recorded in the session
+    recall artifact, the same one memory-scores-surface.py writes, so the Stop
+    hook memory_autocapture.py can score it: useful if the model opened that
+    file this session, dead_end if it never touched it. That is the only proxy
+    for "the bundle was used" this repo has, and it needs no new mechanism. The
+    id prefix lets a consumer tell these rows from auto-memory rows. Best
+    effort: a recall write must never fail a supply pass."""
+    try:
+        spec = importlib.util.spec_from_file_location(
+            "session_recall", Path(__file__).resolve().parent / "session_recall.py")
+        sr = importlib.util.module_from_spec(spec)
+        spec.loader.exec_module(sr)
+        seen: dict[str, str] = {}
+        for it in bundle["items"]:
+            seen.setdefault(it["abs_src"], it["src"])
+        entries = [{"memory_id": f"knowledge-supply:{rel_src}", "source_file": abs_src}
+                   for abs_src, rel_src in seen.items()]
+        if entries:
+            sr.record_surfaced(entries, session_id=session_id, path=recall_path)
+    except Exception:
+        pass
 
 
 def _hash(text: str) -> str:

--- a/q-system/.q-system/scripts/test_knowledge_supply.py
+++ b/q-system/.q-system/scripts/test_knowledge_supply.py
@@ -710,6 +710,25 @@ def test_entities_capped_and_dropped_names_in_receipt(tmp_path):
     assert "ENTITIES DROPPED" in ks.render(b) and b["receipt"]["entities_dropped"][0] in ks.render(b)
 
 
+# ---------------------------------------------------------------- Phase 2: recall producer
+
+def test_recall_records_each_surfaced_source_once(tmp_path):
+    """Every distinct source file the pass surfaced lands in the session recall
+    artifact under this session, so memory_autocapture can score it at Stop
+    (useful if opened, dead_end if never touched). record=False writes nothing."""
+    root, q = make_instance(tmp_path)
+    recall = tmp_path / "recall.json"
+    b = run(root, "what do we know about Dana Okafor", recall_path=recall)
+    entries = json.loads(recall.read_text())["test-session"]["surfaced"]
+    srcs = {e["source_file"] for e in entries}
+    assert srcs == {i["abs_src"] for i in b["items"]} and len(srcs) > 1
+    assert len(entries) == len(srcs), "one entry per source file"
+    assert all(e["memory_id"].startswith("knowledge-supply:") for e in entries)
+    recall.unlink()
+    run(root, "what do we know about Dana Okafor", record=False, recall_path=recall)
+    assert not recall.exists()
+
+
 # ---------------------------------------------------------------- receipts and misses
 
 def test_receipt_and_misses_are_written(tmp_path):

--- a/q-system/methodology/debrief-template.md
+++ b/q-system/methodology/debrief-template.md
@@ -274,6 +274,10 @@ After completing the template and implications analysis, route insights to canon
   {"s":"Person Name","p":"resonated_with","o":"nervous system metaphor","t":"2026-03-12"}
   {"s":"Connector Name","p":"introduced","o":"Person Name","t":"2026-03-12"}
   ```
+- Two optional fields the reader (`knowledge-inject`, the UserPromptSubmit hook that supplies these facts back) uses when present:
+  - `"src"`: where the fact came from, as `path:line` or a transcript id. Example: `{"s":"Person Name","p":"cares_about","o":"cross-silo coordination","t":"2026-03-12","src":"output/debrief-2026-03-12-person.md:41"}`
+  - an alias row, so a short form resolves to the full name: `{"s":"PN","p":"alias_of","o":"Person Name","t":"2026-03-12"}`. An alias under 4 characters matches only as an uppercase whole word.
+- Never delete a triple. A changed state gets a new row with a later `t`; the reader marks the older row STALE for state predicates (status, works_at, role) and keeps every row of an accumulative one (owns, confirmed, discovered).
 
 ### 7. Positioning changes → `my-project/current-state.md`
 - If the conversation revealed that a claim is invalid, update "claimed but unproven"


### PR DESCRIPTION
## What

Phase 2 quick wins from `q-system/output/plans/knowledge-supply-2026-09-04.md`, stacked on #302.

- Recall producer: each distinct source file a supply pass surfaces is recorded in the session recall artifact (the one `memory-scores-surface.py` writes), under ids prefixed `knowledge-supply:`. `memory_autocapture.py` can then score it at Stop: useful if the model opened that file this session, dead_end if it never touched it. The only proxy for "the bundle was used" the repo has; no new mechanism. `record=False` writes nothing.
- `debrief-template.md` step 6: the two optional fields the reader uses when present (`src` as `path:line` or a transcript id; `alias_of` rows with the under-4-chars uppercase rule) and the never-delete rule with what the reader does with superseding rows.

## Measured

44 tests; the recall-call mutation goes red on a copy.

## Status

Draft until #302 lands. Base is `sana/knowledge-supply`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
