### PR TITLE
ASK-1261 knowledge-supply: one chokepoint for single-token resolution + six captured minors

### DIFF
--- a/q-system/.q-system/scripts/knowledge_supply.py
+++ b/q-system/.q-system/scripts/knowledge_supply.py
@@ -360,9 +360,14 @@ def single_token_hit(tok: str, prompt: str, rule: str) -> bool:
     elif rule == "identifier":
         if len(tok) < 4:
             return False
-        # Positions preserved: casefold plus the same two replacements norm() makes.
-        pat = re.compile(r"(?<!\w)" + re.escape(norm(tok)) + r"(?!\w)")
-        hay = prompt.casefold().replace("-", " ").replace("_", " ")
+        # Matched on the RAW prompt with IGNORECASE and a separator class, so
+        # every offset is exact. A casefolded haystack shifts offsets after any
+        # casefold-expanding character (PR #304 review).
+        parts = re.findall(r"[a-z0-9]+", norm(tok))
+        if not parts:
+            return False
+        pat = re.compile(r"(?<!\w)" + r"[\s_-]+".join(re.escape(p) for p in parts) + r"(?!\w)", re.IGNORECASE)
+        hay = prompt
     elif rule == "contact":
         if len(tok) < 4 or not tok[0].isupper():
             return False
@@ -731,11 +736,18 @@ def resolve_canonical(entity: dict, stores: dict, root: Path, kind: str = "canon
                       cls: str = "canonical") -> list[dict]:
     items = []
     for path in (files if files is not None else stores["canonical_files"]):
+        st = stores.setdefault("read_stats", {}).setdefault(cls, {"files": set(), "failed": set()})
+        st["files"].add(str(path))
         try:
             lines = read_lines(path)
         except OSError as exc:
             # sp-ca1769db: an unreadable file is a recorded problem, never a
-            # silent skip that reads as "present, 0 hits" under FULL.
+            # silent skip that reads as "present, 0 hits" under FULL. The
+            # class is UNREADABLE only when every file failed (read_stats),
+            # never from zero hits: PR #304 review found one unreadable file
+            # among readable ones marking the whole class unreadable on an
+            # entity with no hits, a false PARTIAL.
+            st["failed"].add(str(path))
             if errors is not None:
                 errors[cls] = f"{path.name}: {exc}"
             continue
@@ -755,13 +767,19 @@ def resolve_canonical(entity: dict, stores: dict, root: Path, kind: str = "canon
 
 
 def resolve_blocks(entity: dict, path: Path, root: Path, kind: str, max_lines: int,
-                   errors: dict | None = None, cls: str = "") -> list[dict]:
+                   errors: dict | None = None, cls: str = "", stores: dict | None = None) -> list[dict]:
     """### blocks in relationships.md / decisions.md that mention the entity."""
     if not path.is_file():
         return []
+    st = None
+    if stores is not None:
+        st = stores.setdefault("read_stats", {}).setdefault(cls or kind, {"files": set(), "failed": set()})
+        st["files"].add(str(path))
     try:
         lines = read_lines(path)
     except OSError as exc:
+        if st is not None:
+            st["failed"].add(str(path))
         if errors is not None:
             errors[cls or kind] = f"{path.name}: {exc}"   # sp-ca1769db
         return []
@@ -928,7 +946,9 @@ def assemble(items: list[dict], entities: list[dict], ceiling: int, header_len: 
     seen: set[tuple] = set()
     deduped = []
     for it in items:
-        if len(it["text"]) > ITEM_MAX_CHARS:
+        if it["kind"] == "graph" and len(it["text"]) > ITEM_MAX_CHARS:
+            # Graph triples only: a relationship block is a 12-line excerpt by
+            # design and was being cut at 600 (PR #304 review).
             it["text"] = it["text"][:ITEM_MAX_CHARS] + f" [cut at {ITEM_MAX_CHARS} chars; open src]"
         key = (norm(it["entity"]), it["kind"], norm(it["text"]))   # sp-1b3ef442: a shared line stays under each named entity
         if key in seen:
@@ -1226,9 +1246,9 @@ def supply(root: Path, prompt: str, *, session_id: str, now: dt.date | None = No
                 elif cls == "canonical":
                     got = resolve_canonical(ent, stores, root, errors=problems, cls=cls)
                 elif cls == "relationships":
-                    got = resolve_blocks(ent, paths["relationships"], root, "relationship", 12, errors=problems, cls=cls)
+                    got = resolve_blocks(ent, paths["relationships"], root, "relationship", 12, errors=problems, cls=cls, stores=stores)
                 elif cls == "decisions":
-                    got = resolve_blocks(ent, paths["decisions"], root, "decision", 8, errors=problems, cls=cls)
+                    got = resolve_blocks(ent, paths["decisions"], root, "decision", 8, errors=problems, cls=cls, stores=stores)
                 elif cls == "commitments":
                     got = resolve_commitments(ent, stores, root, window)
                 elif cls == "meetings":
@@ -1259,8 +1279,9 @@ def supply(root: Path, prompt: str, *, session_id: str, now: dt.date | None = No
                 if it["status"] == KNOWN and (d is None or (now - d).days > fresh_days):
                     it["status"] = STALE
         items += cls_items
-        if present and problems.get(cls) and not cls_items:
-            present = False   # every file of the class failed to read: unreadable, not empty (sp-ca1769db)
+        rs = stores.get("read_stats", {}).get(cls)
+        if present and rs and rs["failed"] and rs["failed"] >= rs["files"]:
+            present = False   # EVERY file of the class failed to read: unreadable, not empty (sp-ca1769db)
         if not present and spec.get("required"):
             missing.append(cls)
             missing_paths[cls] = f"{path_s or cls} {'unreadable' if cls in problems else 'absent'}"

--- a/q-system/.q-system/scripts/knowledge_supply.py
+++ b/q-system/.q-system/scripts/knowledge_supply.py
@@ -111,7 +111,14 @@ CAPABILITY_RE = re.compile(
     r"\b(?:how (?:does|do|is)|what (?:is|does|are)|what's|explain|describe|where (?:does|is)|walk me through)\s+"
     r"(?:the\s+|our\s+|kipi'?s?\s+)?([\w][\w./-]*(?:\s+[\w][\w./-]*){0,2})", re.IGNORECASE)
 HASH_REF_RE = re.compile(r"(?<![\w/])#\d{2,6}\b")
-CAP_BIGRAM_RE = re.compile(r"\b([A-Z][\w'-]+)\s+([A-Z][\w'-]+)\b")
+# Lookahead so the scan overlaps: "Ping Sarah Chen" yields "Sarah Chen" and not
+# only "Ping Sarah" (sp-c9b6401d). Sentence openers and articles as a FIRST
+# token are dropped by MISS_OPENERS, not by the initial-position rule, which
+# stays inside single_token_hit as its only call site.
+CAP_BIGRAM_RE = re.compile(r"(?=\b([A-Z][\w'-]+)\s+([A-Z][\w'-]+)\b)")
+MISS_OPENERS = {"the", "a", "an", "and", "or", "ping", "ask", "tell", "email", "call", "review",
+                "check", "send", "draft", "write", "read", "open", "run", "fix", "add", "update",
+                "see", "note", "re", "fw", "fwd", "please", "also", "then", "when", "what", "who"}
 DATE_RE = re.compile(r"\d{4}-\d{2}-\d{2}")
 
 WRITING_FALLBACK = [r"\bwrit\w*\b", r"\bdraft\w*\b", r"\bcompose\w*\b", r"\bemail\w*\b",
@@ -335,6 +342,39 @@ def candidate_keys(index: dict[str, Entity], ptoks: set[str]) -> list[str]:
     return out
 
 
+def single_token_hit(tok: str, prompt: str, rule: str) -> bool:
+    """THE one place a one-word name is accepted from the prompt: a contact
+    heading, an uppercase alias, an identifier kind the manifest lists, or a
+    first-name expansion. Every occurrence is checked with the initial-position
+    rule, so a sentence-, line- or bullet-initial token never fires on any
+    path. ASK-1261: PR #302 round 1 minor 4 and round 5 major were the same
+    defect on two paths (one guard, applied to one of them). Two paths, one
+    guard, is the repeat; one chokepoint is the fix, and
+    test_initial_position_has_one_call_site pins that this is the only caller."""
+    if not tok or tok.casefold() in STOPWORDS:
+        return False
+    if rule == "alias":
+        if not (len(tok) >= 4 or tok.isupper()):
+            return False
+        pat, hay = re.compile(r"(?<!\w)" + re.escape(tok) + r"(?!\w)"), prompt
+    elif rule == "identifier":
+        if len(tok) < 4:
+            return False
+        # Positions preserved: casefold plus the same two replacements norm() makes.
+        pat = re.compile(r"(?<!\w)" + re.escape(norm(tok)) + r"(?!\w)")
+        hay = prompt.casefold().replace("-", " ").replace("_", " ")
+    elif rule == "contact":
+        if len(tok) < 4 or not tok[0].isupper():
+            return False
+        pat, hay = re.compile(r"(?<!\w)" + re.escape(tok) + r"(?!\w)"), prompt
+    else:
+        return False
+    for m in pat.finditer(hay):
+        if not is_initial_position(prompt, m.start()):
+            return True
+    return False
+
+
 def resolve_entities(prompt: str, index: dict[str, Entity], fire_alone: set[str]) -> list[dict]:
     """Which index entities the prompt names. Multi-token: phrase match. Single
     token: identifier kinds on a whole-word match, contacts on the capitalized
@@ -358,24 +398,19 @@ def resolve_entities(prompt: str, index: dict[str, Entity], fire_alone: set[str]
                     hit_via = via
             else:
                 tok = toks[0] if toks else ""
-                if not tok or tok.casefold() in STOPWORDS:
-                    continue
+                # Every single-token path goes through single_token_hit. The
+                # manifest decides which identifier kinds fire on one word (no
+                # hardcoded second list, Codex round 1 on PR #302); a graph-only
+                # single token never fires alone.
                 if via == "alias":
-                    if (len(tok) >= 4 or tok.isupper()) and word_in_exact(tok, prompt):
+                    if single_token_hit(tok, prompt, "alias"):
                         hit_via = via
-                    continue
-                if len(tok) < 4:
-                    continue
-                if ent.kind in fire_alone:
-                    # The manifest decides which identifier kinds fire on one
-                    # word. No hardcoded second list: Codex round 1 on PR #302
-                    # found the knob inert because an `or` here overrode it.
-                    if re.search(r"(?<!\w)" + re.escape(norm(tok)) + r"(?!\w)", pn):
+                elif ent.kind in fire_alone:
+                    if single_token_hit(tok, prompt, "identifier"):
                         hit_via = via
                 elif ent.kind == "contact":
-                    if word_in_exact(tok, prompt) and tok[0].isupper():
+                    if single_token_hit(tok, prompt, "contact"):
                         hit_via = via
-                # graph-only single token: never alone
             if hit_via:
                 break
         if not hit_via:
@@ -407,14 +442,14 @@ def resolve_entities(prompt: str, index: dict[str, Entity], fire_alone: set[str]
             toks = ent.name.split()
             if len(toks) >= 2:
                 first_tokens.setdefault(toks[0].casefold(), []).append(key)
+        seen_tok: set[str] = set()
         for m in re.finditer(r"\b([A-Z][a-z]{3,})\b", prompt):
-            if is_initial_position(prompt, m.start()):
-                continue
             tok = m.group(1)
-            if tok.casefold() in STOPWORDS:
+            if tok in seen_tok:
                 continue
+            seen_tok.add(tok)
             keys = first_tokens.get(tok.casefold()) or []
-            if len(keys) == 1 and keys[0] not in found:
+            if len(keys) == 1 and keys[0] not in found and single_token_hit(tok, prompt, "contact"):
                 ent = index[keys[0]]
                 found[keys[0]] = {"name": ent.name, "kind": ent.kind, "resolved_from": "first_name",
                                   "ambiguous": len(ent.orgs) >= 2, "project": None,
@@ -618,7 +653,15 @@ def load_stores(qroot: Path, root: Path) -> tuple[dict, dict]:
     if paths["loops"].is_file():
         try:
             data = load_json(paths["loops"])
-            loops = data if isinstance(data, list) else (data.get("loops") or [])
+            if isinstance(data, list):
+                loops = data
+            elif isinstance(data, dict):
+                loops = data.get("loops") or []
+            else:
+                problems["loops"] = f"not an object or a list: {type(data).__name__}"   # sp-a4a5028a
+            if not isinstance(loops, list):
+                problems["loops"] = "loops is not a list"
+                loops = []
         except (OSError, ValueError) as exc:
             problems["loops"] = str(exc)
     stores["loops"] = [l for l in loops if isinstance(l, dict)]
@@ -665,8 +708,8 @@ def resolve_graph(entity: dict, stores: dict, root: Path, window: dict | None,
         objs = {norm(g["o"]) for g in grp}
         if len(objs) > 1:
             conflicts += 1
-            if len({g.get("t") for g in grp[:2]}) == 1:
-                conflict_keys.add(key)
+            if len({g.get("t") for g in grp[:2]}) == 1 and len({norm(g["o"]) for g in grp[:2]}) > 1:
+                conflict_keys.add(key)   # sp-67d54572: two newest agree -> the older row is STALE, not CONFLICTING
         newest_src[key] = f"{rel(path, root)}:{grp[0]['_line']}"
     for r in rows:
         key = (norm(r["s"]), norm(str(r.get("p"))), r.get("project"))
@@ -684,12 +727,17 @@ def resolve_graph(entity: dict, stores: dict, root: Path, window: dict | None,
 
 
 def resolve_canonical(entity: dict, stores: dict, root: Path, kind: str = "canonical",
-                      files: list[Path] | None = None) -> list[dict]:
+                      files: list[Path] | None = None, errors: dict | None = None,
+                      cls: str = "canonical") -> list[dict]:
     items = []
     for path in (files if files is not None else stores["canonical_files"]):
         try:
             lines = read_lines(path)
-        except OSError:
+        except OSError as exc:
+            # sp-ca1769db: an unreadable file is a recorded problem, never a
+            # silent skip that reads as "present, 0 hits" under FULL.
+            if errors is not None:
+                errors[cls] = f"{path.name}: {exc}"
             continue
         t = mtime_date(path)
         in_fence = False
@@ -706,13 +754,16 @@ def resolve_canonical(entity: dict, stores: dict, root: Path, kind: str = "canon
     return items
 
 
-def resolve_blocks(entity: dict, path: Path, root: Path, kind: str, max_lines: int) -> list[dict]:
+def resolve_blocks(entity: dict, path: Path, root: Path, kind: str, max_lines: int,
+                   errors: dict | None = None, cls: str = "") -> list[dict]:
     """### blocks in relationships.md / decisions.md that mention the entity."""
     if not path.is_file():
         return []
     try:
         lines = read_lines(path)
-    except OSError:
+    except OSError as exc:
+        if errors is not None:
+            errors[cls or kind] = f"{path.name}: {exc}"   # sp-ca1769db
         return []
     items, start, in_fence = [], None, False
     blocks = []
@@ -877,7 +928,9 @@ def assemble(items: list[dict], entities: list[dict], ceiling: int, header_len: 
     seen: set[tuple] = set()
     deduped = []
     for it in items:
-        key = (it["kind"], norm(it["text"]))
+        if len(it["text"]) > ITEM_MAX_CHARS:
+            it["text"] = it["text"][:ITEM_MAX_CHARS] + f" [cut at {ITEM_MAX_CHARS} chars; open src]"
+        key = (norm(it["entity"]), it["kind"], norm(it["text"]))   # sp-1b3ef442: a shared line stays under each named entity
         if key in seen:
             continue
         seen.add(key)
@@ -1016,7 +1069,7 @@ def miss_candidates(prompt: str, entities: list[dict]) -> list[dict]:
     out: dict[str, dict] = {}
     for m in CAP_BIGRAM_RE.finditer(prompt):
         a, b = m.group(1), m.group(2)
-        if a.casefold() in STOPWORDS or b.casefold() in STOPWORDS:
+        if a.casefold() in STOPWORDS or b.casefold() in STOPWORDS or a.casefold() in MISS_OPENERS:
             continue
         cand = f"{a} {b}"
         cn = norm(cand)
@@ -1060,6 +1113,10 @@ PROMPT_SCAN_CHARS = 12000
 # An entity CAP bounds the multiplier at the source; the dropped names go in
 # the receipt.
 MAX_ENTITIES = 12
+# One triple with a multi-KB object could carry the whole ceiling on its own
+# (sp-d830d71e). Text past this is cut with an explicit marker; the src stays
+# so the model opens the full row, and the verbatim pieces are untouched.
+ITEM_MAX_CHARS = 600
 SUPPLY_DEADLINE_S = float(os.environ.get("KNOWLEDGE_SUPPLY_DEADLINE_S", "3.5"))
 
 
@@ -1167,11 +1224,11 @@ def supply(root: Path, prompt: str, *, session_id: str, now: dt.date | None = No
                                            set(manifest.get("state_predicates") or []))
                     conflicts += c
                 elif cls == "canonical":
-                    got = resolve_canonical(ent, stores, root)
+                    got = resolve_canonical(ent, stores, root, errors=problems, cls=cls)
                 elif cls == "relationships":
-                    got = resolve_blocks(ent, paths["relationships"], root, "relationship", 12)
+                    got = resolve_blocks(ent, paths["relationships"], root, "relationship", 12, errors=problems, cls=cls)
                 elif cls == "decisions":
-                    got = resolve_blocks(ent, paths["decisions"], root, "decision", 8)
+                    got = resolve_blocks(ent, paths["decisions"], root, "decision", 8, errors=problems, cls=cls)
                 elif cls == "commitments":
                     got = resolve_commitments(ent, stores, root, window)
                 elif cls == "meetings":
@@ -1202,6 +1259,8 @@ def supply(root: Path, prompt: str, *, session_id: str, now: dt.date | None = No
                 if it["status"] == KNOWN and (d is None or (now - d).days > fresh_days):
                     it["status"] = STALE
         items += cls_items
+        if present and problems.get(cls) and not cls_items:
+            present = False   # every file of the class failed to read: unreadable, not empty (sp-ca1769db)
         if not present and spec.get("required"):
             missing.append(cls)
             missing_paths[cls] = f"{path_s or cls} {'unreadable' if cls in problems else 'absent'}"

--- a/q-system/.q-system/scripts/test_knowledge_supply.py
+++ b/q-system/.q-system/scripts/test_knowledge_supply.py
@@ -67,6 +67,9 @@ RELATIONSHIPS = """# Relationships
 
 ### Mark Chen — Engineer — Acme
 - **Type:** Practitioner
+
+### Ally — Founder — Intel Shop
+- **Type:** Design Partner
 """
 
 TALK_TRACKS = """# Talk tracks
@@ -727,6 +730,103 @@ def test_recall_records_each_surfaced_source_once(tmp_path):
     recall.unlink()
     run(root, "what do we know about Dana Okafor", record=False, recall_path=recall)
     assert not recall.exists()
+
+
+# ---------------------------------------------------------------- ASK-1261: one chokepoint + captured minors
+
+def test_single_token_chokepoint_all_paths(tmp_path):
+    """Contact heading, uppercase alias, first-name expansion: none fires at the
+    start of a sentence, a line or a bullet; each fires mid-sentence."""
+    root, _ = make_instance(tmp_path)
+    for path, tok in (("contact", "Ally"), ("alias", "DO"), ("first_name", "Dana")):
+        for prompt in (f"{tok} said hi", f"Fix it\n{tok} said hi", f"- {tok} said hi", f"1. {tok} said hi"):
+            assert run(root, prompt) is None, (path, prompt)
+        assert run(root, f"please ask {tok} about it") is not None, path
+    assert "Ally" in {e["name"] for e in run(root, "please ask Ally about it")["entities"]}
+    assert "Dana Okafor" in {e["name"] for e in run(root, "please ask DO about it")["entities"]}
+
+
+def test_initial_position_has_one_call_site():
+    """The grep-the-tree half of ASK-1261: the initial-position rule is called
+    from exactly one place in the engine, the chokepoint."""
+    lines = LIB.read_text().splitlines()
+    calls = [l for l in lines if "is_initial_position(" in l
+             and not l.lstrip().startswith(("def ", "#")) and '"""' not in l]
+    assert len(calls) == 1, calls
+    assert "single_token_hit" in "\n".join(lines[max(0, lines.index(calls[0]) - 40):lines.index(calls[0])])
+
+
+def test_unreadable_markdown_class_is_unreadable_not_empty(tmp_path):
+    """sp-ca1769db: every file of a markdown class unreadable -> the class is
+    a recorded problem and a required one drops coverage; never present, 0 hits."""
+    root, q = make_instance(tmp_path)
+    tt = q / "canonical" / "talk-tracks.md"
+    tt.chmod(0)
+    try:
+        b = run(root, "what do we know about Dana Okafor")
+    finally:
+        tt.chmod(0o644)
+    row = {s["class"]: s for s in b["receipt"]["sources"]}["canonical"]
+    assert row["problem"] and "talk-tracks" in row["problem"] and row["present"] is False
+    assert b["coverage"]["verdict"] == "PARTIAL" and "canonical" in b["coverage"]["missing"]
+
+
+def test_non_object_loops_is_a_problem_not_a_crash(tmp_path):
+    """sp-a4a5028a: a bare JSON string in open-loops.json is a recorded problem."""
+    root, q = make_instance(tmp_path)
+    (q / "memory" / "open-loops.json").write_text('"junk"')
+    b = run(root, "what do we know about Dana Okafor")
+    assert b is not None
+    row = {s["class"]: s for s in b["receipt"]["sources"]}["loops"]
+    assert row["present"] is False and "not an object" in row["problem"]
+
+
+def test_duplicate_facts_keep_each_entity_section(tmp_path):
+    """sp-1b3ef442: a line naming two entities renders under both sections."""
+    root, q = make_instance(tmp_path)
+    with open(q / "memory" / "graph.jsonl", "a") as f:
+        f.write(json.dumps({"s": "Priya Raman", "p": "works_at", "o": "Vendor Co", "t": "2026-08-01", "project": "v"}) + "\n")
+        f.write(json.dumps({"s": "Tomas Lind", "p": "works_at", "o": "Vendor Co", "t": "2026-08-01", "project": "v"}) + "\n")
+    with open(q / "canonical" / "talk-tracks.md", "a") as f:
+        f.write("Priya Raman and Tomas Lind both own the vendor review.\n")
+    b = run(root, "what do we know about Priya Raman and Tomas Lind")
+    assert items_of(b, "canonical", "Priya Raman") and items_of(b, "canonical", "Tomas Lind")
+    text = ks.render(b)
+    assert "== Priya Raman ==" in text and "== Tomas Lind ==" in text
+
+
+def test_conflict_only_when_newest_two_differ(tmp_path):
+    """sp-67d54572: two newest rows on one date that AGREE are not a conflict;
+    the older differing row is STALE."""
+    root, q = make_instance(tmp_path)
+    with open(q / "memory" / "graph.jsonl", "a") as f:
+        f.write(json.dumps({"s": "Dana Okafor", "p": "status", "o": "memo on hold pending send decision",
+                            "t": "2026-09-01", "project": "acme-app"}) + "\n")
+    b = run(root, "what is the memo status for Dana Okafor")
+    status = [i for i in items_of(b, "graph", "Dana Okafor") if i["predicate"] == "status"]
+    assert not any(i["status"] == "CONFLICTING" for i in status)
+    assert [i for i in status if i["t"] == "2026-08-20"][0]["status"] == "STALE"
+
+
+def test_miss_bigrams_overlap_and_skip_openers(tmp_path):
+    """sp-c9b6401d: 'Ping Sarah Chen about The Acme Contract' records the two
+    names, not the opener and the article."""
+    root, q = make_instance(tmp_path)
+    run(root, "Ping Sarah Chen about The Acme Contract")
+    rows = [json.loads(l) for l in (q / "memory" / ".knowledge-supply-misses.jsonl").read_text().splitlines()]
+    assert {r["candidate"] for r in rows} == {"Sarah Chen", "Acme Contract"}
+
+
+def test_item_text_capped_with_marker(tmp_path):
+    """sp-d830d71e: one multi-KB object cannot carry the ceiling; the text is cut
+    with an explicit marker, the src stays, the render fits."""
+    root, q = make_instance(tmp_path)
+    with open(q / "memory" / "graph.jsonl", "a") as f:
+        f.write(json.dumps({"s": "Dana Okafor", "p": "noted", "o": "x" * 5000, "t": "2026-09-03", "project": "acme-app"}) + "\n")
+    b = run(root, "what do we know about Dana Okafor")
+    big = [i for i in items_of(b, "graph", "Dana Okafor") if i["predicate"] == "noted"][0]
+    assert big["text"].endswith("open src]") and len(big["text"]) < ks.ITEM_MAX_CHARS + 60
+    assert len(ks.render(b)) <= b["budget"]["ceiling"] and b["budget"]["overflow"] == 0
 
 
 # ---------------------------------------------------------------- receipts and misses

--- a/q-system/.q-system/scripts/test_knowledge_supply.py
+++ b/q-system/.q-system/scripts/test_knowledge_supply.py
@@ -829,6 +829,51 @@ def test_item_text_capped_with_marker(tmp_path):
     assert len(ks.render(b)) <= b["budget"]["ceiling"] and b["budget"]["overflow"] == 0
 
 
+# ---------------------------------------------------------------- ASK-1261 review round
+
+def test_unreadable_is_every_file_not_zero_hits(tmp_path):
+    """One unreadable file among readable ones never marks the class
+    unreadable, with or without hits; every file failing does."""
+    root, q = make_instance(tmp_path)
+    (q / "canonical" / "objections.md").write_text("# Objections\nNothing about anyone here.\n")
+    tt = q / "canonical" / "talk-tracks.md"
+    tt.chmod(0)
+    try:
+        b_hits = run(root, "what do we know about Dana Okafor")
+        b_none = run(root, "what do we know about Mark Chen")
+    finally:
+        tt.chmod(0o644)
+    for b in (b_hits, b_none):
+        row = {s["class"]: s for s in b["receipt"]["sources"]}["canonical"]
+        assert row["present"] is True and row["problem"] and "talk-tracks" in row["problem"]
+        assert b["coverage"]["verdict"] == "FULL", "one unreadable file among readable ones is not PARTIAL"
+    (q / "canonical" / "objections.md").chmod(0)
+    tt.chmod(0)
+    try:
+        b = run(root, "what do we know about Mark Chen")
+    finally:
+        tt.chmod(0o644)
+        (q / "canonical" / "objections.md").chmod(0o644)
+    assert b["coverage"]["verdict"] == "PARTIAL" and "canonical" in b["coverage"]["missing"]
+
+
+def test_identifier_initial_position_survives_casefold_expansion(tmp_path):
+    """A casefold-expanding character before a line-initial slug must not shift
+    the offset the initial-position rule reads."""
+    root, _ = make_instance(tmp_path)
+    assert run(root, "Straße\nacme-labs said hi") is None
+    assert run(root, "Straße, then acme-labs said hi") is not None
+
+
+def test_relationship_block_is_not_cut(tmp_path):
+    root, q = make_instance(tmp_path)
+    with open(q / "my-project" / "relationships.md", "a") as f:
+        f.write("\n### Long Person — Ops — Big Co\n" + "".join(f"- **Note {n}:** " + "n" * 70 + "\n" for n in range(10)))
+    b = run(root, "what do we know about Long Person")
+    rel = items_of(b, "relationship", "Long Person")
+    assert rel and len(rel[0]["text"]) > ks.ITEM_MAX_CHARS and "[cut" not in rel[0]["text"]
+
+
 # ---------------------------------------------------------------- receipts and misses
 
 def test_receipt_and_misses_are_written(tmp_path):


### PR DESCRIPTION
## What (ASK-1261)

One chokepoint for every single-token entity resolution, plus the six minors captured from PR #302 rounds 4 and 5. Stacked on #303 (Phase 2), which is stacked on #302.

- `single_token_hit(tok, prompt, rule)` is now the only place a one-word name is accepted from a prompt: contact heading, uppercase alias, manifest identifier kind, first-name expansion. The initial-position rule lives inside it. `test_initial_position_has_one_call_site` greps the engine and pins exactly one call site; `test_single_token_chokepoint_all_paths` walks all three paths through sentence-, line- and bullet-initial prompts (none fire) and mid-sentence (each fires). Round 1 minor 4 and round 5 major on #302 were this defect on two paths.
- sp-ca1769db: an unreadable canonical, relationships or decisions file is a recorded problem; a class whose every file failed to read is UNREADABLE and a required one drops coverage to PARTIAL.
- sp-a4a5028a: a non-object, non-list `open-loops.json` is a recorded problem, not an exception past the pass.
- sp-1b3ef442: dedupe is per entity, so a line naming two entities renders under both sections.
- sp-67d54572: CONFLICTING only when the two newest rows share a date AND differ; when they agree, the older row is STALE.
- sp-c9b6401d: the misses bigram scan overlaps (lookahead) and drops openers and articles as a first token, so "Ping Sarah Chen about The Acme Contract" records "Sarah Chen" and "Acme Contract".
- sp-d830d71e: an item's text is cut at 600 chars with an explicit marker; the src stays and the verbatim pieces are untouched, so one multi-KB triple cannot carry the ceiling.

## Measured

52 tests. Seven mutations on copies each go red (chokepoint guard, dedupe key, conflict rule, loops guard, read-error recording, opener filter, item cap).

Commit 3d545290 carries this body as its message (a heredoc collision, the second time this session); 0356cc9f is an empty commit with the intended message. Squash-merge collapses both.

## Review posture

One review round, per the DoR on ASK-1261. Anything beyond this DoR is captured, not fixed here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
