### PR TITLE
fix(voiceloop): carry slice 1's engine modules upstream before a sync deletes them

### DIFF
--- a/plugins/kipi-core/voiceloop/experience.py
+++ b/plugins/kipi-core/voiceloop/experience.py
@@ -1,0 +1,488 @@
+#!/usr/bin/env python3
+"""Find the author's OWN material that matches an idea. The experience lane.
+
+why this exists (author-directed 2026-08-24, verbatim: "when I say write me a post
+about something, you find what it's about from my experience through the knowledge
+base, use my voice, and then build that into one of these post archetypes"):
+
+The idea lane took his typed sentence and nothing else. A corpus directory holds a
+`scars.md` that is the verified, audience-mapped library of what he actually did at
+the employers he worked for, and nothing reached for it. The instance rule that
+governs first-person output already said any such draft is written only after
+reading that file, and records the defect behind the rule: a comment draft cleared
+all fourteen output gates with ZERO violations while using none of his experience,
+because every one of those gates is a NEGATIVE check. The employer gate blocks a
+FALSE employer claim and nothing anywhere requires a TRUE one.
+
+**A clean gate run is not evidence a draft used his material.** This module is the
+positive half.
+
+## THE CORPUS DIRECTORY IS HANDED IN. There is no default and there must not be.
+
+Every public function here takes the corpus directory, or the explicit file paths
+inside it, from its caller. A default resolved from `__file__` would put ONE
+author's corpus on everyone's machine the moment this package ships fleet-wide,
+which is the same failure `voice_ref` refuses by carrying no default corpus path at
+all. The instance adapter binds its own directory; the engine binds nothing.
+
+## What it may hand to a writer, and what it may never hand to one
+
+`scars.md` rows carry a flag. `public-safe` rows are cleared for publication.
+`permission-required` rows name people whose OK has not been obtained.
+`_PUBLISHABLE` is an ALLOWLIST, not a blocklist: a row whose flag this module does
+not recognise is treated as not clearing, so a new flag spelling fails closed
+instead of publishing something uncleared.
+
+The rows also carry PROVENANCE notes explaining which thesis a story maps to. Those
+notes are for a human reading the file. The row parser returns the quoted material
+and the flag and drops the rest, because the note is where private brand names live.
+That stripping is the primary control; the instance's own separation gate in the
+output stack is the backstop for when this stripping is wrong, and both are tested.
+
+## Retrieval is deliberately dumb
+
+Token overlap against the row's title and story text, stopworded, ranked. No
+embedding, no model call. A model call here would make the one deterministic half of
+the lane non-deterministic and would put a second unreviewed prompt between his idea
+and his post. If the matching is too crude, the fix is better rows, not a smarter
+matcher: a wrong row surfaced to him costs one glance, and he is the one who picks.
+"""
+from __future__ import annotations
+
+import json
+import os
+import re
+
+# The three corpus files, by name. The DIRECTORY is the caller's; the layout inside
+# it is this module's contract, so a caller cannot half-bind a corpus by naming two
+# of three files and silently reading a third from somewhere else.
+SCARS_FILE = "scars.md"
+BUILT_FILE = "built.md"
+MINED_FILE = "built-mined.jsonl"
+
+
+class CorpusNotBound(ValueError):
+    """No corpus directory was supplied, so there is nothing to read.
+
+    why this is loud rather than a fallback (2026-09-05, the package extraction):
+    the module this was lifted from resolved all three paths from `__file__`. In an
+    instance that is correct and invisible; in a shared package it silently points
+    every founder at whichever corpus happens to sit beside the code. A refusal is
+    the only answer that cannot be wrong quietly. A caller that wants a corpus
+    passes one.
+    """
+
+
+def corpus_paths(corpus_dir):
+    """The three corpus file paths inside `corpus_dir`. REFUSES a missing dir.
+
+    Deliberately does not check that the files exist: the three loaders each return
+    [] for a file that is not there, and that degradation is a decision made in
+    their own docstrings. What is refused here is the absence of an ANSWER to
+    "whose corpus", which no loader can degrade its way out of.
+    """
+    if not corpus_dir:
+        raise CorpusNotBound(
+            "experience needs a corpus directory and has no default. Pass the "
+            "directory holding %s, %s and %s."
+            % (SCARS_FILE, BUILT_FILE, MINED_FILE))
+    return {
+        "scars": os.path.join(corpus_dir, SCARS_FILE),
+        "built": os.path.join(corpus_dir, BUILT_FILE),
+        "mined": os.path.join(corpus_dir, MINED_FILE),
+    }
+
+
+def _resolve(corpus_dir, scars_path=None, built_path=None, mined_path=None):
+    """Per-file overrides on top of a corpus directory.
+
+    The overrides exist for the benchmark and for tests, which build one file at a
+    time. `corpus_dir` is still required even when all three are given, because a
+    caller that can name three files can name the directory, and making it optional
+    reopens exactly the "no default" hole this module was moved to close.
+    """
+    paths = corpus_paths(corpus_dir)
+    return (scars_path or paths["scars"],
+            built_path or paths["built"],
+            mined_path or paths["mined"])
+
+
+# `| **Item** | flag | The specific |`  -- the flagged tables.
+_BUILT_ROW = re.compile(
+    r"^\|\s*\*\*(?P<title>.+?)\*\*\s*\|(?P<flags>[^|]*)\|(?P<body>.*?)\|\s*$")
+
+# `| **Trace** | The specific |` -- the lineage table, which has NO per-row flag
+# column. Its section prose may say the engagement behind a row is confidential.
+# Prose above a table is not a clearance, so an unflagged row yields flags=[] and
+# fails the `_PUBLISHABLE` allowlist like any other unrecognised flag. It still
+# reaches the AUTHOR in the card, marked, exactly as a permission-required row does.
+_BUILT_ROW_UNFLAGGED = re.compile(
+    r"^\|\s*\*\*(?P<title>.+?)\*\*\s*\|(?P<body>[^|]*)\|\s*$")
+
+# Inline markdown carried straight into a writer prompt reads as formatting the model
+# should imitate. The words are the material; the emphasis is not.
+_MD_NOISE = re.compile(r"\*\*|`")
+
+# ALLOWLIST. An unrecognised flag does not clear. See the docstring.
+_PUBLISHABLE = ("public-safe",)
+
+_STOPWORDS = frozenset("""
+a an and are as at be been but by for from had has have how i if in into is it its of on
+or that the their them then there these they this to was were what when which who will
+with you your we our us my me not no do does did can could should would about after
+before over under more most some any than too very just so such own same other
+""".split())
+
+# `| **Title** | flags | audience | body |`
+_ROW = re.compile(r"^\|\s*\*\*(?P<title>.+?)\*\*\s*\|(?P<flags>[^|]*)\|(?P<audience>[^|]*)\|(?P<body>.*?)\|\s*$")
+
+# A row whose title is still a template placeholder is not a story yet.
+_PLACEHOLDER = re.compile(r"\{\{.*?\}\}")
+
+# `### Google` / `### Meta` ... the company each row below it belongs to.
+_SECTION = re.compile(r"^###\s+(?P<name>.+?)\s*$")
+
+# Only these carry an employer claim into a post. The corpus file also has "Adjacent
+# Credibility (NOT Companies)" sections, and attributing a row to one of those would
+# manufacture an employment claim out of a section heading that explicitly says it is
+# not one. An unrecognised heading yields NO company, and the writer is told nothing
+# rather than told something invented.
+#
+# KNOWN GAP, carried deliberately into the package (2026-09-05): this list is one
+# author's employers, so it is DATA sitting in engine code. It was not parameterised
+# in the move because doing so changes what `load` returns, and the move's whole
+# acceptance was that retrieval stays bit-identical. Captured as a follow-up rather
+# than smuggled into a file move.
+_REAL_EMPLOYERS = ("Google", "Meta", "LinkedIn", "ElevenLabs")
+
+# These terms describe a writing request, not the material behind it. Keeping them
+# out of the match set prevents a single generic word from selecting real work.
+_MATCH_NOISE = frozenset("make team teams voice".split())
+
+# One shared term is not enough evidence to put a row in a writer's prompt.
+MIN_MATCH_SCORE = 2
+
+# A MINED row needs three, and the difference is not a preference. A hand-written row
+# is a distilled claim of a few dozen words that somebody chose to write down, so two
+# shared terms is real signal. A mined row is a paragraph lifted whole out of a
+# docstring: ~80 tokens, of which "file", "script", "built" and "function" are
+# ordinary vocabulary. Measured the hour the mined corpus landed: an idea about an
+# executive-function skill returned three shell scripts, matched on {file, script} and
+# {built, function}, ranked above everything because 322 mined rows raised the odds of
+# a generic collision roughly twentyfold over the 19 hand-written ones. Same matcher,
+# different base rate. This is the corpus growing, not the matcher breaking.
+MIN_MINED_MATCH_SCORE = 3
+
+
+def _tokens(text):
+    return {word for word in re.findall(r"[a-z0-9]+", (text or "").lower())
+            if word not in _STOPWORDS and word not in _MATCH_NOISE and len(word) > 2}
+
+
+def _quoted(body):
+    """The QUOTED story inside a row's body, or "" when the row has none.
+
+    The quote is the publishable material. Everything outside it is the provenance
+    note, which is where private references live.
+
+    FAILS CLOSED, and it did not at first (caught 2026-08-24 by running the parser
+    over the real file instead of trusting it). The first version fell back to the
+    raw body when a row carried no quotation, and a career-arc row was exactly that
+    shape: an unquoted arrow list of employers ending in a private brand name, plus
+    an editorial note about which posts to use it in.
+
+    So the primary control handed a private brand name and an editorial note straight
+    to the writer, and only the output stack's separation gate stood between that and
+    a published post. A row with no quotation has no cleared extract. It gets none,
+    and `reference_section` drops it. It still reaches the AUTHOR in the card by
+    title, because a story he has to phrase himself is still one worth surfacing.
+    """
+    quotes = re.findall(r'"([^"]+)"', body or "")
+    if not quotes:
+        return ""
+    return max(quotes, key=len).strip()
+
+
+def load(path):
+    """Every scar row in the file at `path`. Returns [] if missing or unreadable.
+
+    Never raises on the READ: a drafting lane that dies because a reference file
+    moved is worse than one that drafts without the reference and says so. The path
+    itself is required, which is a different question and is answered loudly.
+    """
+    try:
+        with open(path, encoding="utf-8") as handle:
+            lines = handle.read().split("\n")
+    except OSError:
+        return []
+    rows = []
+    company = ""
+    for line in lines:
+        section = _SECTION.match(line.strip())
+        if section:
+            name = section.group("name").strip()
+            company = name if name in _REAL_EMPLOYERS else ""
+            continue
+        match_row = _ROW.match(line.strip())
+        if not match_row:
+            continue
+        title = match_row.group("title").strip()
+        if _PLACEHOLDER.search(title) or _PLACEHOLDER.search(match_row.group("body")):
+            continue
+        flags = [f.strip().lower()
+                 for f in match_row.group("flags").split(",") if f.strip()]
+        rows.append({
+            "title": title,
+            "flags": flags,
+            "publishable": any(f.startswith(_PUBLISHABLE) for f in flags),
+            "audience": [a.strip()
+                         for a in match_row.group("audience").split(",") if a.strip()],
+            "company": company,
+            "story": _quoted(match_row.group("body")),
+            "kind": "scar",
+        })
+    return rows
+
+
+def load_built(path):
+    """Every row in the built file. Same contract as `load`: never raises, [] on trouble.
+
+    The BODY is the material here, and that is the one real difference from the scar
+    parser. Scar rows mix a quotation with a provenance note naming the thesis it maps
+    to, which is why `_quoted` exists and strips a row down to the quotation. The built
+    file carries no such notes -- its "What NOT to say" section keeps client names,
+    private repo names and the employer claim out of the rows themselves -- so quoting
+    would throw the material away and return a fragment. The output stack's separation
+    gate remains the backstop either way.
+    """
+    try:
+        with open(path, encoding="utf-8") as handle:
+            lines = handle.read().split("\n")
+    except OSError:
+        return []
+    rows = []
+    for line in lines:
+        line = line.strip()
+        if line.startswith("|---") or _PLACEHOLDER.search(line):
+            continue
+        hit = _BUILT_ROW.match(line)
+        flags = []
+        if hit:
+            flags = [f.strip().lower() for f in hit.group("flags").split(",") if f.strip()]
+        else:
+            hit = _BUILT_ROW_UNFLAGGED.match(line)
+            if not hit:
+                continue
+        body = _MD_NOISE.sub("", hit.group("body")).strip()
+        if not body:
+            continue
+        rows.append({
+            "title": _MD_NOISE.sub("", hit.group("title")).strip(),
+            "flags": flags,
+            "publishable": bool(flags) and any(f.startswith(_PUBLISHABLE) for f in flags),
+            "audience": [],
+            # DELIBERATELY EMPTY. A built item is a claim about his own work, not about
+            # an employer, and `reference_section` prints "At <company>: " whenever this
+            # is set. Attributing a mechanism he built for his own practice to a past
+            # employer would manufacture exactly the employment claim the employer gate
+            # cannot see.
+            "company": "",
+            "story": body,
+            "kind": "built",
+        })
+    return rows
+
+
+def _mined_row(row):
+    """One extractor row in the shape every other row in this module has.
+
+    `kind` is "built" and not a third kind on purpose. A mined row and a hand-written
+    built row are the same KIND of authority -- a mechanism in his own system -- so the
+    tie-break in `match` and the one-source-per-output rule both keep working without
+    learning a new name. `origin` records which door it came through, for the card only.
+    """
+    flag = (row or {}).get("flag")
+    flags = [flag] if flag else []
+    return {
+        "title": (row or {}).get("title", ""),
+        "flags": flags,
+        # SAME ALLOWLIST as everything else here. A row whose flag this module does not
+        # recognise -- including a row the extractor could not classify at all, which it
+        # writes as null -- does not clear.
+        "publishable": bool(flags) and any(f.startswith(_PUBLISHABLE) for f in flags),
+        "audience": [],
+        # Deliberately empty, for the reason `load_built` gives: a mechanism he built for
+        # his own practice is not work done at an employer.
+        "company": "",
+        "story": (row or {}).get("story", ""),
+        "kind": "built",
+        "origin": "mined",
+        "where": "/".join(x for x in [(row or {}).get("repo"),
+                                      (row or {}).get("path")] if x),
+    }
+
+
+def load_mined(path):
+    """Every mined row at `path`. Same contract as `load`: never raises, [] on trouble.
+
+    A malformed LINE is skipped rather than killing the read. The alternative is that
+    one bad row silently removes his entire work corpus from every draft, and the lane
+    would look identical to the day before this module could see it.
+    """
+    try:
+        with open(path, encoding="utf-8") as handle:
+            lines = handle.read().split("\n")
+    except OSError:
+        return []
+    rows = []
+    for line in lines:
+        line = line.strip()
+        if not line:
+            continue
+        try:
+            raw = json.loads(line)
+        except ValueError:
+            continue
+        row = _mined_row(raw)
+        if row["title"] and row["story"]:
+            rows.append(row)
+    return rows
+
+
+def match(idea_text, corpus_dir, limit=3, publishable_only=True,
+          scars_path=None, built_path=None, mined_path=None):
+    """Rows ranked by token overlap with the idea. Best first, empty when nothing hits.
+
+    `corpus_dir` is POSITIONAL AND REQUIRED. Calling `match(idea)` is a TypeError and
+    `match(idea, None)` is a `CorpusNotBound`; neither silently reads a corpus that
+    happens to sit beside this file. See the module docstring.
+
+    `publishable_only` defaults True and every writer path uses the default. The
+    parameter exists so a test can prove the filter is doing work rather than matching
+    nothing anyway.
+    """
+    scars, built, mined = _resolve(corpus_dir, scars_path, built_path, mined_path)
+    wanted = _tokens(idea_text)
+    if not wanted:
+        return []
+    scored = []
+    for row in list(load(scars)) + list(load_built(built)) + list(load_mined(mined)):
+        if publishable_only and not row["publishable"]:
+            continue
+        overlap = wanted & _tokens(f"{row['title']} {row['story']}")
+        floor = (MIN_MINED_MATCH_SCORE if row.get("origin") == "mined"
+                 else MIN_MATCH_SCORE)
+        if len(overlap) >= floor:
+            scored.append((len(overlap), sorted(overlap), row))
+    # BUILT WINS A TIE (author-directed 2026-09-04). On a post about his work the
+    # credential is the mechanism and its number; the witnessed story is the weaker
+    # fit, and the two are never equally right for one draft.
+    scored.sort(key=lambda item: (-item[0], item[2].get("kind") != "built",
+                                  item[2]["title"]))
+    # ONE SOURCE PER OUTPUT, and it is the top row's source that decides. The instance
+    # rule: never one of each in the same piece, because two stacked reads as a
+    # portfolio tour. Filtering here rather than in `reference_section` means the trail
+    # and the card he reads agree with the prompt the writer got, instead of showing him
+    # a match the writer never saw.
+    if scored:
+        winner = scored[0][2].get("kind")
+        scored = [item for item in scored if item[2].get("kind") == winner]
+    return [dict(row, matched_on=terms, score=score)
+            for score, terms, row in scored[:limit]]
+
+
+def reference_section(matches):
+    """The matched material as text a writer may be shown. Publishable rows only.
+
+    Returns "" for no matches, so a lane with nothing to offer renders the prompt it
+    rendered before this module existed.
+
+    Belt and braces: `match()` already filters, and this filters AGAIN on the way out.
+    The two filters are not redundant. This function is public and a future caller
+    could hand it rows from somewhere else.
+    """
+    # BOTH conditions. `publishable` is the row's own clearance flag; `story` is
+    # non-empty only when a cleared quotation was actually extracted. A row can be
+    # public-safe and still have no quotable extract (see `_quoted`), and handing the
+    # writer an empty bullet is the least bad of the wrong answers there.
+    rows = [row for row in (matches or [])
+            if row.get("publishable") and (row.get("story") or "").strip()]
+    if not rows:
+        return ""
+    # The header names which library these came from, because the two carry different
+    # kinds of authority and a writer told "his own experience" about a mechanism he
+    # built will reach for a career framing that is not in the row.
+    if all(row.get("kind") == "built" for row in rows):
+        out = ["WHAT HE BUILT (real, verified, cleared for publication; use it only if "
+               "it fits the idea, and never restate it as a quotation). These are "
+               "mechanisms in his own systems. They are NOT work done at an employer, "
+               "so never attach a company name to one:"]
+    else:
+        out = ["HIS OWN EXPERIENCE (real, verified, cleared for publication; use it only "
+               "if it fits the idea, and never restate it as a quotation). The company "
+               "named on a line is where it happened; do not attribute it anywhere else:"]
+    # THE EMPLOYER IS NAMED, not left to be inferred (2026-08-24, found in review).
+    # `_quoted` strips a row to its quotation, and the quotations do not carry the
+    # company. So the writer was handed a real story with the employer removed and
+    # guessed one. It guessed right in the observed run and there is nothing that would
+    # have caught a wrong guess: the employer gate blocks a forbidden ROLE phrase paired
+    # with a KNOWN employer, so a company he never worked at is invisible to it ("four
+    # teams at Amazon" returns clean, verified 2026-08-24). Removing the guess is cheaper
+    # and safer than widening that gate, whose blast radius is every post in the engine.
+    for row in rows:
+        prefix = f"At {row['company']}: " if row.get("company") else ""
+        out.append(f"- {prefix}{row['story']}")
+    return "\n".join(out)
+
+
+def card_matches(idea_text, corpus_dir, limit=3, scars_path=None,
+                 built_path=None, mined_path=None):
+    """The card's own door into retrieval, and the ONLY caller that asks for the
+    rows a writer may not see.
+
+    why it is separate (2026-09-04): `match()` defaults to `publishable_only=True` and
+    every writer path uses that default, so the "PERMISSION REQUIRED" branch below was
+    unreachable in production -- a confidential row was mined, labelled, stored, and
+    then shown to nobody. The contract is that such a row NEVER reaches the writer and
+    ALWAYS reaches the author, marked. Half of that contract needs a door of its own.
+    """
+    return match(idea_text, corpus_dir, limit=limit, publishable_only=False,
+                 scars_path=scars_path, built_path=built_path, mined_path=mined_path)
+
+
+def _flag_label(row):
+    """The row's OWN flag, not a boolean rendered as a phrase.
+
+    "PERMISSION REQUIRED" is right for a row naming someone whose OK has not been
+    obtained. It is wrong for a confidential mechanism, where no permission is coming
+    and the answer is to describe the pattern without the engagement. Showing him the
+    same words for both hides which one he is looking at.
+    """
+    if row.get("publishable"):
+        return "public-safe"
+    flags = [f for f in (row.get("flags") or []) if f]
+    return flags[0] if flags else "PERMISSION REQUIRED"
+
+
+def card_lines(matches):
+    """What to show the AUTHOR in the terminal: the title, the flag, and why it matched.
+
+    Includes non-publishable rows he may want to use with permission, clearly marked,
+    because the card is his own terminal and a story he cannot publish today is still
+    one he can ask about.
+    """
+    lines = []
+    for row in matches or []:
+        flag = _flag_label(row)
+        terms = ", ".join(row.get("matched_on") or [])
+        where = f" @ {row['company']}" if row.get("company") else ""
+        # Which library it came from, so a glance tells him whether he is being offered
+        # something he witnessed or something he built.
+        source = "built" if row.get("kind") == "built" else "scar"
+        # WHERE it came from, for a mined row only. A hand-written built row reads as a
+        # claim; a mined row is a quotation from one file, and the file is how he checks
+        # it in ten seconds instead of trusting the extractor.
+        origin = f" {row['where']}" if row.get("origin") == "mined" and row.get("where") else ""
+        lines.append(
+            f"{row['title']}{where} [{source}, {flag}{origin}] (matched on: {terms})")
+    return lines

--- a/plugins/kipi-core/voiceloop/experience_bench.py
+++ b/plugins/kipi-core/voiceloop/experience_bench.py
@@ -1,0 +1,795 @@
+#!/usr/bin/env python3
+"""Does `experience.match` find the RIGHT row? A read-only benchmark.
+
+why this exists: the matcher is token overlap with two floors, `MIN_MATCH_SCORE = 2`
+for hand rows and `MIN_MINED_MATCH_SCORE = 3` for mined ones. Those numbers were
+chosen against 11 scars and 19 hand-written built rows. The corpus is now ~500 rows.
+Nobody had measured whether the matcher still finds the right one, and two standing
+decisions in `experience.py`'s docstring, no model in retrieval and "if the matching
+is too crude the fix is better rows, not a smarter matcher", were being held on
+argument rather than on a number.
+
+This module produces the numbers. It changes nothing: no writes to the corpus, no
+model call, no embedding, no import of anything that publishes.
+
+## EVERY NUMBER ON THE PAGE IS COMPUTED HERE. None is prose.
+
+The first version of this module carried three figures in its docstring and its
+report ("3911 pairs across 135 exemplars", "roughly 29 per exemplar", "221 pairs")
+that came from throwaway scripts written while designing it. Two reviewers
+independently re-derived them: 24 readings of the first and none landed within 180
+of 3911, and no reading produced 135 exemplars at all; the second contradicted this
+module's own `module_name_pairs`, which returns 74. A benchmark whose report cites
+figures its own code cannot reproduce is the defect it exists to catch, wearing a
+lab coat. So the alternate pairings are COMPUTED now (`door_b_variants`), and
+nothing on the page comes from memory.
+
+## Ground truth is DERIVED, never labelled, and one of the two doors does not work
+
+Waiting on the founder to label pairs would make the measurement his homework, so
+both doors read a pairing somebody already recorded for another reason.
+
+**Door A, scars: a human wrote the pairing down.** a scar row's Notes name the
+writing sample a scar was used in ("Used in Mar 2026 LinkedIn post + Medium article
+(Samples 17-18)"), and exemplar `source` strings carry `writing-samples.md sample N`.
+That is a (post -> row) pair with no judgment and no token overlap in it.
+
+Its PAIRING is non-circular. Its MISS ATTRIBUTION is not, and the report says so:
+`paired_overlap` recomputes `experience._tokens`, the matcher's own scorer, so
+"row problem" versus "ranking problem" restates the matcher's internal state rather
+than checking it from outside.
+
+**Door B, mined rows: measured, and it yields nothing usable.** Three pairings are
+computed and printed side by side so the refusal is reproducible rather than
+asserted: the module name where the basename could only be a module, the module
+name where the basename may be an ordinary English word, and the two-distinct-title-
+tokens rule. The last is CIRCULAR and that is the fatal half: a ground truth built
+from token overlap cannot grade a token-overlap matcher.
+
+## So the deciding numbers are the ones that need no pairs at all
+
+And each one is printed WITH the artifact that could be producing it, because two
+reviewers showed that all three move on something other than retrieval quality:
+
+- **returned nothing**, split by WHY. A row scoring 2 that is mined is blocked by
+  `MIN_MINED_MATCH_SCORE` alone; a row scoring 1 is under every floor; a score of 0
+  means the corpus has nothing. Reporting only the total hides the one number that
+  informs a floor change, and the total moves by tens of points on that constant.
+- **false surfacing**, over TWO probe sets plus each set's mean token overlap with
+  the corpus. The rate is a property of the probe list: the shipped list was chosen
+  to "share no vocabulary with the corpus", which selects on the axis being
+  measured, and a second off-domain list written without that rule scores several
+  times higher. A rate that moves on probe choice is not a rate, and the page has to
+  say so next to the number.
+- **discrimination**, printed with the top-score histogram. Most ties are FORCED: an
+  idea whose top score equals the mined floor cannot have a runner-up below it, so
+  gap 0 is arithmetic, not an absence of signal.
+
+## Degenerate cases, decided rather than left to crash
+
+- the mined corpus file is gitignored by construction and absent in a fresh
+  clone. Every mined-derived number then changes, by up to 19 points, and the first
+  version printed those changed numbers with no marker beyond one corpus line while
+  still printing door B's conclusion. `degraded()` now collects the reason, `render`
+  prints a banner, and every affected section is labelled NOT MEASURED rather than
+  given a conclusion.
+- No scar Notes naming a sample: door A reports n=0 and no hit rate. A rate over an
+  empty population is not a rate.
+- Below three DISTINCT PIECES it is an OBSERVATION, not a claim, and is labelled as
+  one. Distinct pieces, not ids: exemplars carry a `group`, and door A's two pairs
+  are two excerpts of one piece with the same first sentence, so an id count would
+  print one observation as two.
+"""
+from __future__ import annotations
+
+import argparse
+import json
+import os
+import re
+import sys
+
+from . import experience
+
+# The off-domain probes for the false-surfacing control. Two sets on purpose.
+#
+# SHARED_NOTHING was written to "share no vocabulary with the corpus", which selects
+# on the axis being measured and lands it about one token under the floor by
+# construction. ORDINARY was written the way he actually writes, keeping the
+# ordinary abstract words (why, rule, change, one, real) that any English sentence
+# carries. Both are 100% off-domain. Reporting only the first understates the rate
+# several fold, which is what an adversarial pass measured.
+SHARED_NOTHING_PROBES = (
+    "sourdough starter hydration ratios in a cold kitchen",
+    "why the offside rule ruins the flow of a football match",
+    "repotting a monstera that has outgrown its ceramic pot",
+    "tuning a bicycle derailleur after the cable stretches",
+    "the best month to see puffins on the Farne Islands",
+    "why medieval cathedrals used flying buttresses",
+    "brewing temperature for a light roast Ethiopian coffee",
+    "how tides work around a spring equinox",
+    "choosing snow tyres for a rear wheel drive estate car",
+    "the difference between a viola and a violin bow hold",
+    "growing tomatoes in a greenhouse without blossom end rot",
+    "why vinyl records need a stylus tracking force adjustment",
+    "the rules of a cribbage crib and pegging",
+    "how to proof a cold fermented pizza dough overnight",
+    "sharpening a chisel on a waterstone to a mirror bevel",
+    "the migration route of the arctic tern",
+    "why cast iron pans need seasoning rather than soap",
+    "setting the intonation on an electric guitar bridge",
+    "how a sextant fixes a position at sea",
+    "the difference between a stout and a porter",
+)
+
+ORDINARY_PROBES = (
+    "I finally worked out why my sourdough never rises the way the book says",
+    "Every knitter I know has one project they will never actually finish",
+    "The real rule with beekeeping is that you check less than you want to",
+    "Nobody tells you that the hardest part of fly fishing is the walking",
+    "I changed one thing about how I prune the orchid and it flowered again",
+    "Most people get the tomato watering completely backwards and nothing happens",
+    "The way you hold the bow changes everything and no one explains it",
+    "I spent a year thinking my coffee was the problem when it was the water",
+    "There is a moment in every long walk where the map stops being useful",
+    "What actually made the difference was doing less to the cast iron pan",
+    "I kept buying better running shoes instead of running more often",
+    "The one thing that made my bread work was measuring the flour by weight",
+    "Everyone says you need expensive tools and then the cheap chisel wins",
+    "I was told to repot every spring and it turns out that was wrong",
+    "The number of people who overwater a monstera is genuinely remarkable",
+    "It took me three seasons to see why the bees were leaving that hive",
+    "My whole approach to the garden changed after one very dry summer",
+    "There is no way to learn this except by ruining a few of them first",
+    "The difference between a good loaf and a bad one is almost never the oven",
+    "I check the tyre pressure now because one winter taught me to",
+)
+
+_SENTENCE_END = re.compile(r"(?<=[.!?])\s+")
+
+# `Samples 17-18`, `Sample 7`, `Samples 1, 2`. The scars file writes all three.
+_SAMPLE_REF = re.compile(r"Samples?\s+(\d+)(?:\s*[-–]\s*(\d+))?(?:\s*,\s*(\d+))?")
+
+
+def first_sentence(text):
+    """What he would have TYPED, not the finished post.
+
+    Handing the matcher the whole exemplar is the answer leaking into the question:
+    a 300-word post shares dozens of tokens with any row it is about, and the score
+    stops being about retrieval. The first sentence is the closest thing on disk to
+    the one-line idea the lane actually receives.
+    """
+    body = " ".join((text or "").split())
+    if not body:
+        return ""
+    return _SENTENCE_END.split(body)[0].strip()
+
+
+def load_exemplars(path):
+    """Exemplar rows. READ ONLY: the exemplar file has one writer,
+    `pipeline.voice exemplars add`, and this module is not it.
+
+    A line that parses but is not an OBJECT is skipped, not appended. The first
+    version guarded `ValueError` per line and then appended whatever came back, so
+    a line like `[1,2,3]` reached `row.get("id")` and killed the whole run with an
+    AttributeError. A malformed corpus must degrade the benchmark, never crash it.
+    """
+    rows = []
+    try:
+        with open(path, encoding="utf-8") as handle:
+            for line in handle:
+                line = line.strip()
+                if not line:
+                    continue
+                try:
+                    parsed = json.loads(line)
+                except ValueError:
+                    continue
+                if isinstance(parsed, dict) and parsed.get("id"):
+                    rows.append(parsed)
+    except OSError:
+        return []
+    return rows
+
+
+def sample_numbers(body):
+    """Every writing-sample number a scar row's Notes name."""
+    found = set()
+    for hit in _SAMPLE_REF.finditer(body or ""):
+        start = int(hit.group(1))
+        found.add(start)
+        if hit.group(2):
+            for number in range(start, int(hit.group(2)) + 1):
+                found.add(number)
+        if hit.group(3):
+            found.add(int(hit.group(3)))
+    return sorted(found)
+
+
+def scar_pairs(scars_path, exemplars):
+    """Door A. (exemplar, scar title) pairs a human recorded in the Notes column."""
+    by_id = {row.get("id"): row for row in exemplars}
+    try:
+        with open(scars_path, encoding="utf-8") as handle:
+            lines = handle.read().split("\n")
+    except OSError:
+        return []
+    pairs = []
+    for line in lines:
+        hit = experience._ROW.match(line.strip())
+        if not hit:
+            continue
+        title = hit.group("title").strip()
+        # A row still carrying a template placeholder is not a scar yet, and
+        # `experience.load` drops it. Without this the two disagree: the pair set
+        # would name a title the matcher can never return, and every such pair
+        # would count as a permanent miss. Found by mutation, not by reading: the
+        # first version of the test passed only because its fixture placeholder
+        # named a sample id that did not exist.
+        if experience._PLACEHOLDER.search(title) or \
+                experience._PLACEHOLDER.search(hit.group("body")):
+            continue
+        for number in sample_numbers(hit.group("body")):
+            exemplar = by_id.get("sample-%02d" % number)
+            if exemplar is not None:
+                pairs.append({"exemplar_id": exemplar["id"],
+                              "idea": first_sentence(exemplar.get("text")),
+                              "full_text": exemplar.get("text") or "",
+                              # THE PIECE, not the id. Two excerpts of one article
+                              # are one observation; door A's own two pairs are
+                              # exactly that, with a byte-identical first sentence.
+                              "group": exemplar.get("group") or exemplar["id"],
+                              "title": title, "kind": "scar"})
+    return pairs
+
+
+def distinct_pieces(pairs):
+    """How many separate PIECES a pair set really represents."""
+    return len({(p.get("group"), p.get("title")) for p in pairs})
+
+
+def _basename(row):
+    return os.path.splitext(os.path.basename(row.get("where") or ""))[0]
+
+
+def module_name_pairs(rows, exemplars, snake_only=True, one_per_row=True):
+    """Door B by module name. Every (row, exemplar) hit unless `one_per_row`.
+
+    `snake_only` is the discriminator and the reason the door fails. A basename with
+    an underscore could only be a module. A basename without one is frequently an
+    English word (`control`, `ledger`, `digest`) that appears in his prose for
+    reasons that have nothing to do with the file.
+
+    `one_per_row` exists because the two halves of the comparison were counted with
+    DIFFERENT rules in the first version: this door stopped at the first matching
+    exemplar while the figure it was set against counted every combination, which
+    understated the loose door about fourfold. Both counts are reported now.
+    """
+    pairs = []
+    for row in rows:
+        base = _basename(row)
+        if not base or (snake_only and "_" not in base):
+            continue
+        variants = {base.lower(), base.replace("_", " ").lower(),
+                    base.replace("_", "-").lower(), base.replace("_", "").lower()}
+        for exemplar in exemplars:
+            body = (exemplar.get("text") or "").lower()
+            if any(variant in body for variant in variants):
+                pairs.append({"exemplar_id": exemplar.get("id"),
+                              "idea": first_sentence(exemplar.get("text")),
+                              "full_text": exemplar.get("text") or "",
+                              "group": exemplar.get("group") or exemplar.get("id"),
+                              "title": row.get("title", ""), "kind": "mined"})
+                if one_per_row:
+                    break
+    return pairs
+
+
+def title_token_pairs(rows, exemplars, minimum=2):
+    """Door B by shared title tokens. THE CIRCULAR ONE, computed so its yield is a
+    number on the page rather than a claim in a docstring.
+
+    It pairs a row with an exemplar when they share `minimum` distinct title tokens,
+    which is the matcher's own scoring function with the ranking thrown away. It
+    cannot grade the matcher and no hit rate is reported from it. It is here to make
+    the size of the problem reproducible: a ground truth this loose pairs every
+    exemplar with dozens of rows.
+    """
+    pairs = []
+    exemplar_tokens = [(e, experience._tokens(e.get("text"))) for e in exemplars]
+    for row in rows:
+        wanted = experience._tokens(row.get("title"))
+        if not wanted:
+            continue
+        for exemplar, tokens in exemplar_tokens:
+            if len(wanted & tokens) >= minimum:
+                pairs.append((row.get("title", ""), exemplar.get("id")))
+    return pairs
+
+
+def _rank(idea, match_fn, limit):
+    return match_fn(idea, limit=limit) or []
+
+
+def paired_overlap(pair, rows_by_key):
+    """The paired row's ACTUAL overlap with the idea, its floor, and its clearance.
+
+    why this is carried rather than inferred: "the matcher did not return it" has
+    three different causes and reporting the wrong one sends the fix to the wrong
+    place. Under the floor is a ROW problem. Over the floor and absent is a RANKING
+    problem. NOT CLEARED is neither: `match` defaults to `publishable_only=True`, so
+    an uncleared row can never be returned however well it scores, and the first
+    version called that a ranking problem.
+
+    NOT independent of the matcher, and the report says so: this recomputes
+    `experience._tokens`, which is the matcher's own scorer.
+    """
+    row = rows_by_key.get(pair["title"])
+    if row is None:
+        return None, None, None
+    wanted = experience._tokens(pair.get("idea"))
+    overlap = wanted & experience._tokens("%s %s" % (row.get("title", ""),
+                                                     row.get("story", "")))
+    floor = (experience.MIN_MINED_MATCH_SCORE if row.get("origin") == "mined"
+             else experience.MIN_MATCH_SCORE)
+    return len(overlap), floor, bool(row.get("publishable"))
+
+
+def score_pairs(pairs, match_fn, limit=3, rows_by_key=None, idea_key="idea"):
+    """hit@1, hit@3, and the THREE different ways a paired row can be missing."""
+    rows_by_key = rows_by_key or {}
+    hit1 = hit3 = below = ranked_out = uncleared = unknown = 0
+    misses = []
+    for pair in pairs:
+        idea = pair.get(idea_key) or ""
+        ranked = _rank(idea, match_fn, limit)
+        titles = [row.get("title", "") for row in ranked]
+        if titles[:1] == [pair["title"]]:
+            hit1 += 1
+        if pair["title"] in titles:
+            hit3 += 1
+            continue
+        score, floor, cleared = paired_overlap(dict(pair, idea=idea), rows_by_key)
+        if score is None:
+            unknown += 1
+        elif cleared is False:
+            uncleared += 1
+        elif score >= floor:
+            ranked_out += 1
+        else:
+            below += 1
+        misses.append({"exemplar_id": pair["exemplar_id"], "wanted": pair["title"],
+                       "paired_score": score, "floor": floor, "cleared": cleared,
+                       "got": titles})
+    return {"n": len(pairs), "n_distinct_pieces": distinct_pieces(pairs),
+            "hit_at_1": hit1, "hit_at_3": hit3, "below_floor": below,
+            "ranked_out": ranked_out, "uncleared": uncleared,
+            "title_not_in_corpus": unknown, "misses": misses}
+
+
+def corpus_overlap(probes, rows):
+    """Mean and median count of probe tokens that appear anywhere in the corpus.
+
+    This is the selection effect, measured. A probe list chosen to share no
+    vocabulary with the corpus sits under the floor by construction, so its
+    false-surfacing rate is a fact about the list, not about the matcher.
+    """
+    corpus = set()
+    for row in rows:
+        corpus |= experience._tokens("%s %s" % (row.get("title", ""),
+                                                row.get("story", "")))
+    counts = sorted(len(experience._tokens(p) & corpus) for p in probes)
+    if not counts:
+        return {"n": 0, "mean": None, "median": None}
+    return {"n": len(counts),
+            "mean": round(sum(counts) / len(counts), 2),
+            "median": counts[len(counts) // 2]}
+
+
+def false_surfacing(match_fn, probes, rows, limit=3):
+    """How often an idea from outside his work returns a row anyway."""
+    surfaced = []
+    for probe in probes:
+        ranked = _rank(probe, match_fn, limit)
+        if ranked:
+            surfaced.append({"probe": probe, "title": ranked[0].get("title", ""),
+                             "score": ranked[0].get("score", 0),
+                             "matched_on": list(ranked[0].get("matched_on") or [])})
+    return {"n": len(probes), "surfaced": len(surfaced), "detail": surfaced,
+            "probe_corpus_overlap": corpus_overlap(probes, rows)}
+
+
+def why_nothing(ideas, rows):
+    """THE NUMBER THAT INFORMS A FLOOR CHANGE, which the first version withheld.
+
+    "returned nothing" has three causes and only one of them is about the corpus:
+
+    - the best publishable row scores under EVERY floor. Nothing to retrieve.
+    - the best publishable row is MINED and scores at or above the hand floor but
+      under the mined floor. Blocked by one constant, not by the corpus.
+    - the best publishable row scores zero. The corpus genuinely has nothing.
+
+    An adversarial pass measured that moving `MIN_MINED_MATCH_SCORE` from 3 to 2
+    moves the headline by tens of points, and the first version's closing advice was
+    "read these before changing a floor" while withholding exactly this split.
+    """
+    pub = [row for row in rows if row.get("publishable")]
+    scored = [(row, experience._tokens("%s %s" % (row.get("title", ""),
+                                                  row.get("story", "")))) for row in pub]
+    out = {"returned": 0, "under_every_floor": 0,
+           "blocked_only_by_the_mined_floor": 0, "corpus_has_nothing": 0}
+    for idea in ideas:
+        wanted = experience._tokens(idea)
+        best, best_mined = 0, False
+        for row, tokens in scored:
+            overlap = len(wanted & tokens)
+            if overlap > best:
+                best, best_mined = overlap, row.get("origin") == "mined"
+            elif overlap == best and row.get("origin") == "mined":
+                best_mined = True
+        floor = (experience.MIN_MINED_MATCH_SCORE if best_mined
+                 else experience.MIN_MATCH_SCORE)
+        if best == 0:
+            out["corpus_has_nothing"] += 1
+        elif best >= floor:
+            out["returned"] += 1
+        elif best_mined and best >= experience.MIN_MATCH_SCORE:
+            out["blocked_only_by_the_mined_floor"] += 1
+        else:
+            out["under_every_floor"] += 1
+    out["n"] = len(ideas)
+    return out
+
+
+def discrimination(ideas, match_fn, limit=3):
+    """Top score minus runner-up, WITH the top-score histogram beside it.
+
+    The histogram is not decoration. Most ties are forced: an idea whose top score
+    equals the mined floor cannot have a runner-up scoring below it, so gap 0 is
+    arithmetic and not an absence of signal. Reporting the tie rate alone reads as
+    "there is nothing to rank on", which is a stronger claim than the data supports.
+    """
+    gaps, tops = [], []
+    empty = singles = 0
+    for idea in ideas:
+        ranked = _rank(idea, match_fn, limit)
+        if not ranked:
+            empty += 1
+            continue
+        tops.append(ranked[0].get("score", 0))
+        if len(ranked) < 2:
+            singles += 1
+            continue
+        gaps.append(ranked[0].get("score", 0) - ranked[1].get("score", 0))
+    out = {"n": len(ideas), "returned_nothing": empty, "returned_one": singles,
+           "gaps": gaps, "top_scores": {}}
+    for score in tops:
+        out["top_scores"][str(score)] = out["top_scores"].get(str(score), 0) + 1
+    if gaps:
+        ordered = sorted(gaps)
+        out["gap_min"] = ordered[0]
+        out["gap_median"] = ordered[len(ordered) // 2]
+        out["gap_max"] = ordered[-1]
+        out["gap_zero"] = sum(1 for gap in gaps if gap == 0)
+    return out
+
+
+# The exemplar file sits beside the three corpus files, in the same directory.
+# Named here rather than resolved from `__file__` for the reason the matcher itself
+# was moved: a path derived from where the CODE lives points every founder at
+# whichever corpus happens to ship next to the package.
+EXEMPLARS_FILE = "exemplars.jsonl"
+
+
+def run(corpus_dir=None, scars_path=None, built_path=None, mined_path=None,
+        exemplars_path=None, match_fn=None, limit=3, probe_sets=None):
+    """Every number, in one dict. Reads only; writes nothing anywhere.
+
+    `corpus_dir` binds all four inputs at once. Individual paths override it, which
+    is what the fixture suite uses to build one file at a time in tmp_path. What is
+    REFUSED is neither: an unbound benchmark used to resolve the live corpus off
+    `experience.__file__`, and after the package extraction that file sits inside the
+    plugin, so the same call would have measured an empty directory and reported the
+    zeros as a result.
+    """
+    if not isinstance(limit, int) or limit < 1:
+        # A limit of 0 makes `match` return an empty slice for every idea, and the
+        # first version rendered that as "returned nothing: 161/161 (100%)" and
+        # "false surfacing 0/20" as if both were measurements.
+        raise ValueError("limit must be a positive int, got %r" % (limit,))
+    if corpus_dir:
+        _paths = experience.corpus_paths(corpus_dir)
+        scars_path = scars_path or _paths["scars"]
+        built_path = built_path or _paths["built"]
+        mined_path = mined_path or _paths["mined"]
+        exemplars_path = exemplars_path or os.path.join(corpus_dir, EXEMPLARS_FILE)
+    unbound = [name for name, value in (("scars_path", scars_path),
+                                        ("built_path", built_path),
+                                        ("mined_path", mined_path),
+                                        ("exemplars_path", exemplars_path))
+               if not value]
+    if unbound:
+        raise experience.CorpusNotBound(
+            "the benchmark has no corpus: pass corpus_dir, or every one of %s"
+            % ", ".join(unbound))
+    if match_fn is None:
+        def match_fn(idea, limit=3):
+            return experience.match(idea, corpus_dir or os.path.dirname(scars_path),
+                                    limit=limit, scars_path=scars_path,
+                                    built_path=built_path, mined_path=mined_path)
+    probe_sets = probe_sets or (("shared-nothing", SHARED_NOTHING_PROBES),
+                                ("ordinary-words", ORDINARY_PROBES))
+
+    exemplars = load_exemplars(exemplars_path)
+    mined_rows = experience.load_mined(mined_path)
+    mined_present = os.path.exists(mined_path)
+    hand_rows = list(experience.load(scars_path)) + list(
+        experience.load_built(built_path))
+    all_rows = hand_rows + mined_rows
+
+    # KEYED ON TITLE because that is what `score_pairs` compares, and the collision
+    # count is REPORTED rather than swallowed: last-writer-wins means a lookup can
+    # read a different row's story and origin than the pair names.
+    rows_by_key = {}
+    collisions = 0
+    for row in all_rows:
+        if row.get("title") in rows_by_key:
+            collisions += 1
+        rows_by_key[row.get("title")] = row
+
+    door_a = scar_pairs(scars_path, exemplars)
+    ideas = [first_sentence(row.get("text")) for row in exemplars]
+    ideas = [idea for idea in ideas if idea]
+
+    degraded = []
+    if not mined_present:
+        degraded.append(
+            "the mined corpus file is ABSENT. It is gitignored by construction, so "
+            "a fresh clone has none of it. Door B, the returned-nothing split, the "
+            "false-surfacing rate and the discrimination numbers below were all "
+            "computed against the %d hand rows only. They are NOT MEASURED for this "
+            "corpus and no conclusion may be drawn from them." % len(hand_rows))
+
+    return {
+        "corpus": {
+            "scars": len([r for r in hand_rows if r.get("kind") == "scar"]),
+            "built_hand": len([r for r in hand_rows if r.get("kind") == "built"]),
+            "mined": len(mined_rows),
+            "mined_present": mined_present,
+            "exemplars": len(exemplars),
+            "title_collisions": collisions,
+            "distinct_titles": len(rows_by_key),
+        },
+        "degraded": degraded,
+        "floors": {"hand": experience.MIN_MATCH_SCORE,
+                   "mined": experience.MIN_MINED_MATCH_SCORE},
+        "door_a": score_pairs(door_a, match_fn, limit, rows_by_key),
+        # DIAGNOSTIC ONLY, and labelled as one everywhere it is printed. Feeding the
+        # matcher the whole post leaks the answer into the question, so this is not a
+        # hit rate anybody may quote. It exists to separate two causes the
+        # first-sentence number alone cannot: if the row is findable from the full
+        # post and not from the opening line, the defect is the IDEA, his posts open
+        # with a hook whose vocabulary is unrelated to the material underneath.
+        "door_a_full_text_diagnostic": score_pairs(
+            door_a, match_fn, limit, rows_by_key, idea_key="full_text"),
+        "door_b_variants": {
+            "module_name_strict": len(module_name_pairs(mined_rows, exemplars,
+                                                        snake_only=True)),
+            "module_name_any_basename": len(module_name_pairs(mined_rows, exemplars,
+                                                              snake_only=False)),
+            "module_name_any_basename_all_hits": len(
+                module_name_pairs(mined_rows, exemplars, snake_only=False,
+                                  one_per_row=False)),
+            "two_title_tokens": len(title_token_pairs(mined_rows, exemplars)),
+            "two_title_tokens_exemplars": len(
+                {eid for _, eid in title_token_pairs(mined_rows, exemplars)}),
+        },
+        "why_nothing": why_nothing(ideas, all_rows),
+        "false_surfacing": {name: false_surfacing(match_fn, probes, all_rows, limit)
+                            for name, probes in probe_sets},
+        "discrimination": discrimination(ideas, match_fn, limit),
+    }
+
+
+def _rate(part, whole):
+    if not whole:
+        return "n/a (population is empty)"
+    return "%d/%d (%.0f%%)" % (part, whole, 100.0 * part / whole)
+
+
+def _not_measured(result):
+    return " NOT MEASURED, see the banner above." if result.get("degraded") else ""
+
+
+def render(result, at):
+    """The report. Numbers and their populations, never a bare percentage."""
+    corpus = result["corpus"]
+    door_a = result["door_a"]
+    variants = result["door_b_variants"]
+    why = result["why_nothing"]
+    disc = result["discrimination"]
+    caveat = _not_measured(result)
+    lines = ["# Retrieval benchmark: does experience.match find the right row?", "",
+             "Generated %s by `python3 -m pipeline.experience_bench`. Read only." % at,
+             ""]
+    for reason in result.get("degraded") or []:
+        lines += ["> **DEGRADED RUN.** " + reason, ""]
+    lines += [
+        "## Corpus under test", "",
+        "- scars.md rows: %d" % corpus["scars"],
+        "- built.md rows: %d" % corpus["built_hand"],
+        "- mined rows: %s" % (str(corpus["mined"]) if corpus["mined_present"]
+                              else "absent (gitignored; a fresh clone has none, and "
+                                   "every mined number below is NOT MEASURABLE, not "
+                                   "zero)"),
+        "- exemplars: %d" % corpus["exemplars"],
+        "- floors: hand %d, mined %d" % (result["floors"]["hand"],
+                                         result["floors"]["mined"]),
+        "- rows sharing a title with another row: %d (%d distinct titles). A lookup "
+        "by title reads the last one written, so a pair naming a colliding title may "
+        "be scored against a different row." % (corpus["title_collisions"],
+                                                corpus["distinct_titles"]),
+        "",
+        "## Door A: pairs a human recorded (scars.md Notes name a writing sample)", "",
+        "- pairs: n=%d, across %d DISTINCT PIECES" % (door_a["n"],
+                                                      door_a["n_distinct_pieces"]),
+    ]
+    if door_a["n"]:
+        lines += [
+            "- hit@1: %s" % _rate(door_a["hit_at_1"], door_a["n"]),
+            "- hit@3: %s" % _rate(door_a["hit_at_3"], door_a["n"]),
+            "- misses by cause: %d under the paired row's floor (a row or floor "
+            "problem), %d over it and still absent (ranking, or the "
+            "one-source-per-output filter), %d not cleared for publication so the "
+            "matcher could never return them, %d whose title is not in the corpus "
+            "at all." % (door_a["below_floor"], door_a["ranked_out"],
+                         door_a["uncleared"], door_a["title_not_in_corpus"]),
+            "- this attribution is NOT independent of the matcher: it recomputes "
+            "`experience._tokens`, the matcher's own scorer, so it restates the "
+            "matcher's internal state rather than checking it from outside.",
+        ]
+    if door_a["n_distinct_pieces"] < 3:
+        lines.append(
+            "- **%d distinct pieces, so this is an OBSERVATION and not a claim** "
+            "(agent-brief-constraints.md constraint 2). Distinct PIECES, not ids: "
+            "two excerpts of one article share a first sentence, so an id count "
+            "would print one observation as two."
+            % door_a["n_distinct_pieces"])
+    for miss in door_a["misses"]:
+        lines.append(
+            "  - miss: %s wanted `%s` (that row's overlap with the idea was %s, its "
+            "floor is %s, cleared=%s), got %s"
+            % (miss["exemplar_id"], miss["wanted"], miss["paired_score"],
+               miss["floor"], miss["cleared"], miss["got"] or "nothing"))
+    diag = result.get("door_a_full_text_diagnostic") or {}
+    if diag.get("n"):
+        lines += [
+            "",
+            "**Diagnostic, NOT a hit rate to quote.** The same pairs re-run with the "
+            "WHOLE exemplar as the idea, which leaks the answer into the question: "
+            "hit@1 %s, hit@3 %s. High here while the first-sentence number above is "
+            "low would mean the defect is the IDEA rather than the corpus. On this "
+            "corpus it rests on %d distinct piece(s), so it is a lead to test, not a "
+            "finding." % (_rate(diag["hit_at_1"], diag["n"]),
+                          _rate(diag["hit_at_3"], diag["n"]),
+                          door_a["n_distinct_pieces"])]
+    lines += [
+        "",
+        "## Door B: the mined-row pairings, all computed here, none quoted from prose",
+        "",
+        "- module name, snake_case basenames only (a token that could only be a "
+        "module): %d pairs.%s" % (variants["module_name_strict"], caveat),
+        "- module name, any basename including ordinary English words like `control` "
+        "and `ledger`: %d rows matched, %d (row, exemplar) hits.%s"
+        % (variants["module_name_any_basename"],
+           variants["module_name_any_basename_all_hits"], caveat),
+        "- two distinct title tokens: %d pairs across %d exemplars.%s"
+        % (variants["two_title_tokens"], variants["two_title_tokens_exemplars"],
+           caveat),
+        "",
+        "The two-title-token rule is CIRCULAR and that is the fatal half: a ground "
+        "truth built from token overlap cannot grade a token-overlap matcher, so no "
+        "mined hit rate is reported. The module-name doors are reported as counts "
+        "only; whether they justify a conclusion depends on the mined corpus being "
+        "present, and the banner above says whether it was.",
+        "",
+        "## Why an idea returns nothing, split by cause", "",
+        "- probe ideas (first sentence of every exemplar): %d" % why["n"],
+        "- returned something: %s" % _rate(why["returned"], why["n"]),
+        "- best row is under EVERY floor: %s (nothing to retrieve)"
+        % _rate(why["under_every_floor"], why["n"]),
+        "- best row is MINED and scores at or above the hand floor but under the "
+        "mined floor: %s. **This bucket is blocked by one constant, not by the "
+        "corpus.**%s" % (_rate(why["blocked_only_by_the_mined_floor"], why["n"]),
+                         caveat),
+        "- corpus genuinely has nothing (best score 0): %s"
+        % _rate(why["corpus_has_nothing"], why["n"]),
+        "",
+        "## False surfacing, over TWO probe sets, because the rate is a property of "
+        "the list", "",
+    ]
+    for name, block in sorted(result["false_surfacing"].items()):
+        overlap = block["probe_corpus_overlap"]
+        lines.append(
+            "- `%s`: %s returned at least one row. Mean probe tokens that appear "
+            "anywhere in the corpus: %s (median %s), against floors of %d and %d.%s"
+            % (name, _rate(block["surfaced"], block["n"]), overlap["mean"],
+               overlap["median"], result["floors"]["hand"],
+               result["floors"]["mined"], caveat))
+        for row in block["detail"][:5]:
+            lines.append("  - `%s` -> `%s` (score %s, on %s)"
+                         % (row["probe"][:58], row["title"][:58], row["score"],
+                            ", ".join(row["matched_on"])))
+    lines += [
+        "",
+        "`shared-nothing` was written to share no vocabulary with the corpus, which "
+        "selects on the axis being measured. `ordinary-words` is equally off-domain "
+        "and keeps the ordinary abstract words any English sentence carries. Read "
+        "the two together; neither alone is a rate.",
+        "",
+        "## Discrimination: is there a signal to rank on?", "",
+        "- returned nothing: %s" % _rate(disc["returned_nothing"], disc["n"]),
+        "- returned exactly one row: %s" % _rate(disc["returned_one"], disc["n"]),
+    ]
+    if disc.get("gaps"):
+        lines += [
+            "- top-minus-runner-up gap: min %s, median %s, max %s"
+            % (disc["gap_min"], disc["gap_median"], disc["gap_max"]),
+            "- gap of ZERO: %s" % _rate(disc["gap_zero"], len(disc["gaps"])),
+            "- top-score histogram: %s" % ", ".join(
+                "%s -> %d" % (k, v) for k, v in sorted(disc["top_scores"].items())),
+            "- **most ties are FORCED, not an absence of signal.** An idea whose top "
+            "score equals the mined floor (%d) cannot have a runner-up below it, so "
+            "gap 0 is arithmetic. Read the histogram before reading the tie rate.%s"
+            % (result["floors"]["mined"], caveat),
+        ]
+    lines += [
+        "",
+        "## What these numbers do and do not settle", "",
+        "- They do NOT settle hit rate on mined rows. No non-circular pairing exists "
+        "in the corpus today, and inventing one by hand would be the labelling this "
+        "issue exists to avoid.",
+        "- They do NOT settle whether a smarter matcher would help. Every number "
+        "here is computed in the matcher's own units, at its own floors.",
+        "- They DO settle where the returned-nothing population comes from, and that "
+        "is the number to read before changing a floor: the mined-floor bucket is "
+        "the one a single constant moves.",
+        "",
+    ]
+    return "\n".join(lines)
+
+
+def main(argv=None):
+    parser = argparse.ArgumentParser(
+        description="Measure whether experience.match finds the right row. "
+                    "Read only: no corpus writes, no model call, no embedding.")
+    parser.add_argument("--corpus-dir", dest="corpus_dir", required=True,
+                        help="the directory holding scars.md, built.md, "
+                             "built-mined.jsonl and exemplars.jsonl")
+    parser.add_argument("--out", required=True,
+                        help="where to write the markdown report")
+    parser.add_argument("--limit", type=int, default=3)
+    parser.add_argument("--json", dest="json_out", default=None,
+                        help="also write the raw numbers here")
+    args = parser.parse_args(argv)
+
+    import datetime
+    at = datetime.datetime.now(datetime.timezone.utc).strftime("%Y-%m-%dT%H:%M:%SZ")
+    result = run(corpus_dir=args.corpus_dir, limit=args.limit)
+    text = render(result, at)
+    # BOTH destinations get their directory made BEFORE either file is written. The
+    # first version made `--out`'s directory and not `--json`'s, so an unwritable
+    # json path left the markdown on disk, no json, and no stdout: a partial
+    # artifact that looks like a finished run.
+    for dest in [d for d in (args.out, args.json_out) if d]:
+        os.makedirs(os.path.dirname(os.path.abspath(dest)) or ".", exist_ok=True)
+    with open(args.out, "w", encoding="utf-8") as handle:
+        handle.write(text)
+    if args.json_out:
+        with open(args.json_out, "w", encoding="utf-8") as handle:
+            json.dump(result, handle, indent=1, sort_keys=True)
+    print(text)
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/plugins/kipi-core/voiceloop/tests/test_experience_bench.py
+++ b/plugins/kipi-core/voiceloop/tests/test_experience_bench.py
@@ -1,0 +1,703 @@
+#!/usr/bin/env python3
+"""The retrieval benchmark, on a fixture corpus where the right answer is known.
+
+Every test here builds its corpus in `tmp_path` and drives the REAL
+`experience.match` against it. Nothing reads or writes the live corpus: the live
+exemplar file has one writer and it is not this module, and a benchmark
+that mutated the thing it measures would be worthless the second time it ran.
+
+WHY SO MANY ASSERTIONS ON `render`: two review passes mutation-tested the first
+version and 15 of 30 (and 17 of 45) module mutations survived a green suite. Every
+survivor was a number the report PRINTS and no test READ: the gap metrics, the
+top-score histogram, hit@1 versus hit@3, the full-text diagnostic, the probe
+population, and `_rate`'s percentage itself, which could be inverted with the suite
+staying green. A benchmark whose report is unasserted is a benchmark that can lie
+quietly, which is the exact defect it exists to catch.
+"""
+import json
+import os
+import sys
+
+import pytest
+
+PKG = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
+sys.path.insert(0, os.path.dirname(PKG))
+
+from voiceloop import experience, experience_bench  # noqa: E402
+
+
+SCARS = """# scars
+
+### Google
+
+| Scar | Flags | Audience | Notes |
+|---|---|---|---|
+| **Four teams fought one scam operation** | public-safe | CISO | "Four teams fought the same scam operation across ads and search. None of them knew." Used in Mar 2026 LinkedIn post (Samples 1-2). |
+| **Nobody warned us rooms** | public-safe | CISO | "I have been in too many rooms where the question was why did nobody warn us." (Sample 3) |
+| **{{PLACEHOLDER}} row** | public-safe | VC | "not a scar yet" (Sample 4) |
+| **The credentialing friction** | permission-required | practitioner | "Being told I was not technical enough to translate the findings." (Sample 6) |
+"""
+
+# The same file with the first row's TITLE and MATERIAL replaced and its Sample
+# reference kept. The pairing still exists; the tokens to find it do not.
+SCARS_FORCED_MISS = SCARS.replace(
+    '**Four teams fought one scam operation**', '**Kiln firing schedules**').replace(
+    '"Four teams fought the same scam operation across ads and search. None of '
+    'them knew."',
+    '"Bisque temperature for a stoneware glaze."')
+
+BUILT = """# built
+
+| Item | Flags | The specific |
+|---|---|---|
+| **A gate that refuses an unsourced figure** | public-safe | The gate refuses any number in a draft that no source artifact carries. |
+"""
+
+MINED = [
+    # A basename that is ALSO an ordinary English word. It is what makes the
+    # strict-vs-loose distinction measurable: `control` appears in his prose for
+    # reasons that have nothing to do with the file.
+    {"title": "The brakes and the pulse",
+     "story": "Every job has a brake row and the runner checks it before acting.",
+     "flag": "public-safe", "repo": "consulting", "path": "pipeline/control.py"},
+    {"title": "Deterministic repair before the voice gate",
+     "story": "Repair the draft deterministically before the voice gate reads it.",
+     "flag": "public-safe", "repo": "consulting", "path": "pipeline/post_repair.py"},
+    {"title": "A receipt carries the loop evidence",
+     "story": "The receipt carries the loop's own evidence and the gate recomputes it.",
+     "flag": "public-safe", "repo": "consulting", "path": "pipeline/route_contract.py"},
+    # SAME TITLE as the first row, different path. The live mined corpus carries
+    # repeats like this (one filename mined from several repos), and keying a
+    # lookup on title silently drops one of them. Without a collision in the
+    # fixture the counter can be deleted with the suite green.
+    {"title": "The brakes and the pulse",
+     "story": "A second copy of the brake row, mined from another repo.",
+     "flag": "public-safe", "repo": "other", "path": "pipeline/other_thing.py"},
+]
+
+EXEMPLARS = [
+    {"id": "sample-01", "source": "writing-samples.md sample 1", "status": "active",
+     "group": "piece-four-teams",
+     "text": "Four teams fought the same scam operation and none of them knew. "
+             "The ads team would take down a warhead and it came back."},
+    {"id": "sample-02", "source": "writing-samples.md sample 2", "status": "active",
+     "group": "piece-four-teams-two",
+     "text": "Four teams fought one scam operation across ads and search. "
+             "Nobody touched the infrastructure underneath."},
+    {"id": "sample-03", "source": "writing-samples.md sample 3", "status": "active",
+     "group": "piece-rooms",
+     "text": "I have been in too many rooms where the question was why did nobody "
+             "warn us. Somebody usually saw it weeks earlier. The control you "
+             "think you have is the one nobody tested."},
+    # EXISTS on purpose. The placeholder scar row names Sample 4, so the only thing
+    # that can stop it becoming a pair is the placeholder skip itself.
+    {"id": "sample-04", "source": "writing-samples.md sample 4", "status": "active",
+     "group": "piece-naming",
+     "text": "Naming the dysfunction is the whole job. "
+             "Everyone in the room already knows."},
+    # Pairs to a PERMISSION-REQUIRED scar, so it can never be returned however well
+    # it scores. That is neither a row problem nor a ranking problem.
+    {"id": "sample-06", "source": "writing-samples.md sample 6", "status": "active",
+     "group": "piece-credentialing",
+     "text": "Being told I was not technical enough to translate the findings. "
+             "That became the reason I build."},
+    # Ranks BOTH scars, so `discrimination` has a real gap population. Without a
+    # two-result idea every gap field is unreachable and five mutants survive.
+    {"id": "sample-07", "source": "founder-supplied", "status": "active",
+     "group": "piece-two-hits",
+     "text": "Four teams in too many rooms and nobody knew why. "
+             "That is the whole pattern."},
+    # gap 0. Scores 2 against BOTH scars, so the runner-up ties the top and the
+    # tie is observable. Its second sentence carries `control`, giving the
+    # non-snake module door a SECOND matching exemplar so the one-hit-per-row
+    # break is measurable.
+    {"id": "sample-11", "source": "founder-supplied", "status": "active",
+     "group": "piece-tie",
+     "text": "A scam operation and nobody warned us. "
+             "The control was never tested."},
+    # gap 1. Scores 2 against one scar and 3 against the other.
+    {"id": "sample-12", "source": "founder-supplied", "status": "active",
+     "group": "piece-gap-one",
+     "text": "A scam operation nobody warned us about in those rooms. "
+             "Same shape every time."},
+    {"id": "sample-09", "source": "founder-supplied", "status": "active",
+     "group": "piece-kayak",
+     "text": "Choosing a kayak paddle length for touring water. "
+             "Feather angle matters more than blade shape."},
+]
+
+
+def _corpus(tmp_path, scars_text=SCARS, with_mined=True):
+    scars = tmp_path / "scars.md"
+    scars.write_text(scars_text, encoding="utf-8")
+    built = tmp_path / "built.md"
+    built.write_text(BUILT, encoding="utf-8")
+    mined = tmp_path / "built-mined.jsonl"
+    if with_mined:
+        mined.write_text("\n".join(json.dumps(r) for r in MINED) + "\n",
+                         encoding="utf-8")
+    exemplars = tmp_path / "exemplars.jsonl"
+    exemplars.write_text("\n".join(json.dumps(r) for r in EXEMPLARS) + "\n",
+                         encoding="utf-8")
+    # THE FIXTURE SUPPLIES THE CORPUS DIRECTORY. Nothing here is found on disk:
+    # the engine has no default corpus and refuses an unbound call, so a suite that
+    # forgot to bind one goes red instead of silently measuring whatever ships
+    # beside the package.
+    return {"corpus_dir": str(tmp_path),
+            "scars_path": str(scars), "built_path": str(built),
+            "mined_path": str(mined), "exemplars_path": str(exemplars)}
+
+
+@pytest.fixture
+def bound():
+    """The matcher, bound to the fixture corpus by ARGUMENT.
+
+    It used to monkeypatch two module constants, because the matcher resolved
+    built/mined from `__file__`. Those constants are gone: the engine takes its
+    corpus from the caller, so binding is now a call and needs no teardown. That is
+    the whole point of the extraction, expressed in the one place a test can see it.
+    """
+    def _bind(paths):
+        def match_fn(idea, limit=3):
+            return experience.match(idea, paths["corpus_dir"], limit=limit,
+                                    scars_path=paths["scars_path"],
+                                    built_path=paths["built_path"],
+                                    mined_path=paths["mined_path"])
+        return match_fn
+    return _bind
+
+
+class TestTheGroundTruthIsDerivedAndTheHitRateIsKnown:
+
+    def test_hit_at_1_is_exactly_three_of_four_on_the_fixture(self, tmp_path, bound):
+        paths = _corpus(tmp_path)
+        result = experience_bench.run(match_fn=bound(paths), **paths)
+        door_a = result["door_a"]
+        # samples 1 and 2 pair to the first scar (Samples 1-2), sample 3 to the
+        # second (Sample 3), sample 6 to the permission-required one (Sample 6).
+        # The {{PLACEHOLDER}} row is skipped, so its Sample 4 yields no pair.
+        assert door_a["n"] == 4, door_a
+        assert door_a["hit_at_1"] == 3, door_a["misses"]
+        assert door_a["hit_at_3"] == 3
+        assert door_a["below_floor"] == 0
+
+    def test_hit_at_3_is_not_the_same_number_as_hit_at_1(self, tmp_path, bound):
+        """Two mutants survived because every fixture had hit@1 == hit@3, so the
+        two were behaviourally identical everywhere the suite looked. This idea
+        ranks the paired row SECOND."""
+        paths = _corpus(tmp_path)
+        match_fn = bound(paths)
+        pairs = [{"exemplar_id": "x", "title": "Nobody warned us rooms",
+                  "group": "g", "full_text": "",
+                  # Scores 2 against "Nobody warned us rooms" and 3 against the
+                  # four-teams scar, so the paired row lands at rank 2.
+                  "idea": "Four teams fought a scam operation in too many rooms"}]
+        rows = {r["title"]: r for r in experience.load(paths["scars_path"])}
+        scored = experience_bench.score_pairs(pairs, match_fn, 3, rows)
+        assert scored["hit_at_1"] == 0, scored
+        assert scored["hit_at_3"] == 1, scored
+
+    def test_removing_the_title_tokens_drops_hit_at_1(self, tmp_path, bound):
+        """THE NEGATIVE SELF-TEST. Same pairs, same matcher, material gutted. A
+        benchmark that cannot go down is not measuring anything."""
+        paths = _corpus(tmp_path, scars_text=SCARS_FORCED_MISS)
+        result = experience_bench.run(match_fn=bound(paths), **paths)
+        door_a = result["door_a"]
+        assert door_a["n"] == 4, door_a
+        assert door_a["hit_at_1"] == 1, door_a["misses"]
+        assert door_a["below_floor"] == 2
+        assert {m["exemplar_id"] for m in door_a["misses"]} >= {"sample-01",
+                                                                "sample-02"}
+
+    def test_a_placeholder_scar_row_never_becomes_a_pair(self, tmp_path):
+        paths = _corpus(tmp_path)
+        exemplars = experience_bench.load_exemplars(paths["exemplars_path"])
+        assert any(r["id"] == "sample-04" for r in exemplars)
+        pairs = experience_bench.scar_pairs(paths["scars_path"], exemplars)
+        titles = {p["title"] for p in pairs}
+        assert not any("PLACEHOLDER" in t for t in titles), titles
+        assert "sample-04" not in {p["exemplar_id"] for p in pairs}
+
+    def test_an_uncleared_row_is_not_called_a_ranking_problem(self, tmp_path, bound):
+        """`match` defaults to publishable_only=True, so a permission-required row
+        can never be returned however well it scores. The first version bucketed
+        that as ranked_out and the report then named two causes, both wrong."""
+        paths = _corpus(tmp_path)
+        result = experience_bench.run(match_fn=bound(paths), **paths)
+        door_a = result["door_a"]
+        assert door_a["uncleared"] == 1, door_a["misses"]
+        assert door_a["ranked_out"] == 0, door_a["misses"]
+        miss = [m for m in door_a["misses"] if m["exemplar_id"] == "sample-06"][0]
+        assert miss["cleared"] is False
+        text = experience_bench.render(result, "2026-09-04T00:00:00Z")
+        assert "not cleared for publication" in text
+
+    def test_distinct_pieces_not_ids_decides(self, tmp_path):
+        """Two excerpts of one article share a first sentence, so an id count
+        prints one observation as two. The live door A is exactly that shape."""
+        pairs = [{"exemplar_id": "a", "group": "piece-x", "title": "T"},
+                 {"exemplar_id": "b", "group": "piece-x", "title": "T"},
+                 {"exemplar_id": "c", "group": "piece-y", "title": "T"}]
+        assert experience_bench.distinct_pieces(pairs) == 2
+
+
+class TestTheIdeaIsWhatHeWouldHaveTyped:
+
+    def test_only_the_first_sentence_reaches_the_matcher(self):
+        idea = experience_bench.first_sentence(EXEMPLARS[0]["text"])
+        assert idea == "Four teams fought the same scam operation and none of them knew."
+        assert "warhead" not in idea
+
+    def test_door_a_is_actually_wired_to_first_sentence_and_not_the_whole_post(
+            self, tmp_path, bound):
+        """MUTATION-COVERED WIRING. Feeding door A the whole post survived a green
+        suite in the first version, which is the exact leak `first_sentence` exists
+        to prevent: the class name claimed coverage the assertions did not give.
+
+        The fixture's second sentence carries `warhead`, a token no row has, so the
+        two readings produce a DIFFERENT match set and the wiring is observable.
+        """
+        paths = _corpus(tmp_path)
+        exemplars = experience_bench.load_exemplars(paths["exemplars_path"])
+        pairs = experience_bench.scar_pairs(paths["scars_path"], exemplars)
+        first = [p for p in pairs if p["exemplar_id"] == "sample-01"][0]
+        assert "warhead" not in first["idea"]
+        assert "warhead" in first["full_text"]
+        # And `run` scores door A on `idea`, never on `full_text`. Asserted by CALL
+        # ORDER, not by membership: `discrimination` also ranks every first
+        # sentence, so "a first sentence was passed at some point" stays true even
+        # when door A is fed whole posts. Both mutants survived that weaker check.
+        seen = []
+
+        def spy(idea, limit=3):
+            seen.append(idea)
+            return bound(paths)(idea, limit=limit)
+        experience_bench.run(match_fn=spy, **paths)
+        n = len(pairs)
+        door_a_calls, diagnostic_calls = seen[:n], seen[n:2 * n]
+        assert not any("warhead" in call for call in door_a_calls), door_a_calls
+        assert set(door_a_calls) == {p["idea"] for p in pairs}
+        assert any("warhead" in call for call in diagnostic_calls), diagnostic_calls
+
+    def test_an_empty_exemplar_yields_an_empty_idea_rather_than_raising(self):
+        assert experience_bench.first_sentence("") == ""
+        assert experience_bench.first_sentence(None) == ""
+
+    @pytest.mark.parametrize("body,expected", [
+        ("Used in Mar 2026 (Samples 17-18).", [17, 18]),
+        ("The CIB framing in Sample 7 is the same operation.", [7]),
+        ("Tested against Bard (writing-samples Samples 1, 2)", [1, 2]),
+        ("no reference at all", []),
+    ])
+    def test_every_sample_reference_shape_in_the_real_file_parses(self, body, expected):
+        assert experience_bench.sample_numbers(body) == expected
+
+
+class TestTheDoorThatDoesNotWorkReportsThatItDoesNotWork:
+
+    def test_the_module_name_door_yields_nothing_on_snake_case_names(self, tmp_path,
+                                                                     bound):
+        paths = _corpus(tmp_path)
+        variants = experience_bench.run(match_fn=bound(paths),
+                                        **paths)["door_b_variants"]
+        assert variants["module_name_strict"] == 0
+        # THE OTHER HALF, and the reason the zero means anything: the same corpus
+        # carries `pipeline/control.py`, whose basename is an ordinary English word
+        # that sample-03 uses. The loose door pairs it.
+        assert variants["module_name_any_basename"] == 1
+
+    def test_the_two_counting_rules_are_reported_separately(self, tmp_path, bound):
+        """The first version compared a one-hit-per-row count against an
+        every-combination count in the same paragraph, understating the loose door
+        about fourfold. Both rules are printed now, and this proves they differ."""
+        paths = _corpus(tmp_path)
+        variants = experience_bench.run(match_fn=bound(paths),
+                                        **paths)["door_b_variants"]
+        # `control` matches TWO exemplars, so the two rules give different numbers.
+        # With one hit per row it is 1; counting every combination it is 2.
+        assert variants["module_name_any_basename"] == 1, variants
+        assert variants["module_name_any_basename_all_hits"] == 2, variants
+
+    def test_the_circular_door_is_computed_and_not_quoted(self, tmp_path, bound):
+        """Every figure the report prints has to come from this run. The first
+        version carried three numbers from throwaway scripts and two reviewers
+        could not reproduce any of them."""
+        paths = _corpus(tmp_path)
+        result = experience_bench.run(match_fn=bound(paths), **paths)
+        variants = result["door_b_variants"]
+        text = experience_bench.render(result, "2026-09-04T00:00:00Z")
+        assert "%d pairs across %d exemplars" % (
+            variants["two_title_tokens"],
+            variants["two_title_tokens_exemplars"]) in text
+        # And the function itself pairs on two shared title tokens, proven on a
+        # crafted input rather than on whatever the fixture corpus happens to do.
+        rows = [{"title": "Deterministic repair before the voice gate"}]
+        assert experience_bench.title_token_pairs(
+            rows, [{"id": "hit", "text": "deterministic repair is the whole idea"}])
+        assert not experience_bench.title_token_pairs(
+            rows, [{"id": "miss", "text": "deterministic and nothing else"}])
+        # No figure from the retired prose survives anywhere on the page.
+        for stale in ("3911", "135 exemplars", "221 pairs", "roughly 29"):
+            assert stale not in text
+
+    def test_an_exemplar_naming_the_module_does_pair_so_the_door_is_not_broken(self):
+        """The negative control on the door itself: prove the zero above is a fact
+        about his writing and not a broken matcher."""
+        # BY PATH, not by index: MINED gained a row at position 0 and an index
+        # here silently pointed the test at a different fixture.
+        rows = [experience._mined_row(
+            next(r for r in MINED if "post_repair" in r["path"]))]
+        exemplars = [{"id": "x", "text": "I wrote post_repair.py to fix this."}]
+        pairs = experience_bench.module_name_pairs(rows, exemplars, snake_only=True)
+        assert [p["exemplar_id"] for p in pairs] == ["x"]
+
+
+class TestTheControlsThatNeedNoPairs:
+
+    def test_the_probe_population_is_reported_and_not_empty(self, tmp_path, bound):
+        """Replacing OFF_DOMAIN_PROBES with an empty tuple survived a green suite:
+        the rate passed over an empty population. The n is asserted now."""
+        paths = _corpus(tmp_path)
+        fs = experience_bench.run(match_fn=bound(paths), **paths)["false_surfacing"]
+        assert set(fs) == {"shared-nothing", "ordinary-words"}
+        for name, block in fs.items():
+            assert block["n"] == 20, (name, block["n"])
+        assert len(experience_bench.SHARED_NOTHING_PROBES) == 20
+        assert len(experience_bench.ORDINARY_PROBES) == 20
+        # CONTENT, not just the count. Replacing the list with filler kept the
+        # length and stayed green. A probe has to be a real sentence, and the two
+        # sets have to be different sentences.
+        both = list(experience_bench.SHARED_NOTHING_PROBES) + \
+            list(experience_bench.ORDINARY_PROBES)
+        assert len(set(both)) == 40, "probes must be distinct"
+        assert all(len(p.split()) >= 6 for p in both), \
+            [p for p in both if len(p.split()) < 6]
+
+    def test_the_probe_sets_carry_their_corpus_overlap(self, tmp_path, bound):
+        """The rate is a property of the list, so the selection effect has to be on
+        the page beside it. `shared-nothing` was chosen to share no vocabulary with
+        the corpus, which selects on the axis being measured."""
+        paths = _corpus(tmp_path)
+        result = experience_bench.run(match_fn=bound(paths), **paths)
+        for block in result["false_surfacing"].values():
+            overlap = block["probe_corpus_overlap"]
+            assert overlap["n"] == 20
+            assert overlap["mean"] is not None
+        # KNOWN ANSWER. `mean is not None` passed against a function hardcoded to
+        # return zero, which is the whole selection-effect measurement gone with a
+        # green suite.
+        rows = [{"title": "brake row", "story": "the runner checks the pulse"}]
+        known = experience_bench.corpus_overlap(
+            ["the brake row runner", "puffins on the island", "brake"], rows)
+        assert known == {"n": 3, "mean": 1.33, "median": 1}, known
+        text = experience_bench.render(result, "2026-09-04T00:00:00Z")
+        assert "Mean probe tokens that appear anywhere in the corpus" in text
+
+    def test_a_probe_that_must_match_proves_the_control_can_fire(self, tmp_path,
+                                                                bound):
+        """A zero false-surfacing rate is meaningless unless the same instrument is
+        shown returning something. Negative-control every zero."""
+        paths = _corpus(tmp_path)
+        result = experience_bench.run(
+            match_fn=bound(paths),
+            probe_sets=(("must-hit",
+                         ("Four teams fought one scam operation across ads and "
+                          "search.",)),),
+            **paths)
+        assert result["false_surfacing"]["must-hit"]["surfaced"] == 1
+
+    def test_why_nothing_splits_the_mined_floor_out_of_the_headline(self, tmp_path,
+                                                                    bound):
+        """The number that informs a floor change. A mined row scoring at the hand
+        floor but under the mined floor is blocked by ONE CONSTANT, not by the
+        corpus, and the first version folded it into a single total."""
+        paths = _corpus(tmp_path)
+        why = experience_bench.run(match_fn=bound(paths), **paths)["why_nothing"]
+        assert why["n"] == len(EXEMPLARS)
+        assert sum(why[k] for k in ("returned", "under_every_floor",
+                                    "blocked_only_by_the_mined_floor",
+                                    "corpus_has_nothing")) == why["n"]
+        # sample-09 is about kayaking and matches nothing in this corpus.
+        assert why["corpus_has_nothing"] >= 1
+
+    def test_the_mined_floor_bucket_can_actually_fill(self, tmp_path, bound):
+        """NEGATIVE CONTROL on the bucket above. A split that is always zero on
+        every fixture is a split nobody has seen work."""
+        paths = _corpus(tmp_path)
+        rows = [experience._mined_row(r) for r in MINED]
+        # Two shared tokens with the mined row's title+story: at the hand floor of
+        # 2, under the mined floor of 3.
+        why = experience_bench.why_nothing(["brake runner"], rows)
+        assert why["blocked_only_by_the_mined_floor"] == 1, why
+
+    def test_discrimination_reports_the_gap_the_ties_and_the_histogram(self,
+                                                                      tmp_path,
+                                                                      bound):
+        """Five mutants survived here: the gap could be inverted, the median made a
+        max, singles counted as empties and gap_zero forced to 0, all green. The
+        fixture now produces a real gap population and every field is read."""
+        paths = _corpus(tmp_path)
+        result = experience_bench.run(match_fn=bound(paths), **paths)
+        disc = result["discrimination"]
+        assert disc["n"] == len(EXEMPLARS)
+        assert disc["returned_nothing"] >= 1
+        # min, median and max must DIFFER, and there must be a real tie. With one
+        # gap value the median equals the max and `gap_zero = 0` is free, which is
+        # how four mutants survived.
+        assert sorted(set(disc["gaps"])) == [0, 1, 2], disc["gaps"]
+        assert disc["gap_zero"] >= 1, disc["gaps"]
+        assert disc["gap_min"] != disc["gap_median"] != disc["gap_max"]
+        assert disc["gap_min"] == min(disc["gaps"])
+        assert disc["gap_max"] == max(disc["gaps"])
+        assert disc["gap_median"] == sorted(disc["gaps"])[len(disc["gaps"]) // 2]
+        assert disc["gap_zero"] == sum(1 for g in disc["gaps"] if g == 0)
+        assert sum(disc["top_scores"].values()) == \
+            disc["n"] - disc["returned_nothing"]
+        text = experience_bench.render(result, "2026-09-04T00:00:00Z")
+        assert "top-score histogram" in text
+        assert "most ties are FORCED" in text
+
+    def test_a_single_returned_row_is_not_counted_as_returning_nothing(self):
+        """`returned_one` and `returned_nothing` were interchangeable in every
+        fixture, so a mutant swapping them stayed green."""
+        disc = experience_bench.discrimination(
+            ["a", "b"],
+            lambda idea, limit=3: [{"score": 4, "title": "T"}] if idea == "a" else [])
+        assert disc["returned_one"] == 1
+        assert disc["returned_nothing"] == 1
+
+
+class TestTheMinedCorpusIsGitignoredAndOftenAbsent:
+
+    def test_a_missing_mined_file_degrades_loudly_and_draws_no_conclusion(
+            self, tmp_path, bound):
+        """The first version printed door B's conclusion and three headline numbers
+        computed against hand rows only, with no marker beyond one corpus line. Its
+        test greped for the word "absent" anywhere on the page and stayed green."""
+        paths = _corpus(tmp_path, with_mined=False)
+        result = experience_bench.run(match_fn=bound(paths), **paths)
+        assert result["corpus"]["mined_present"] is False
+        assert result["corpus"]["mined"] == 0
+        assert result["degraded"], "an absent mined corpus must be recorded"
+        text = experience_bench.render(result, "2026-09-04T00:00:00Z")
+        assert "DEGRADED RUN" in text
+        assert "NOT MEASURABLE" in text
+        # Every mined-derived section carries the caveat, not just the corpus line.
+        assert text.count("NOT MEASURED, see the banner above.") >= 4
+
+    def test_a_present_mined_file_draws_no_degraded_banner(self, tmp_path, bound):
+        paths = _corpus(tmp_path)
+        result = experience_bench.run(match_fn=bound(paths), **paths)
+        assert result["corpus"]["mined_present"] is True
+        assert result["corpus"]["mined"] == len(MINED)
+        assert result["degraded"] == []
+        text = experience_bench.render(result, "2026-09-04T00:00:00Z")
+        assert "DEGRADED RUN" not in text
+        assert "NOT MEASURED" not in text
+
+
+class TestTheReportCarriesItsPopulations:
+
+    def test_a_rate_over_an_empty_population_is_not_rendered_as_a_percentage(self):
+        assert "n/a" in experience_bench._rate(0, 0)
+
+    def test_the_percentage_is_the_right_way_round(self):
+        """`_rate` could be inverted with the whole suite green, which made every
+        percentage in the report unasserted."""
+        assert experience_bench._rate(1, 4) == "1/4 (25%)"
+        assert experience_bench._rate(3, 4) == "3/4 (75%)"
+        assert experience_bench._rate(0, 7) == "0/7 (0%)"
+
+    def test_fewer_than_three_distinct_pieces_is_labelled_an_observation(self,
+                                                                        tmp_path,
+                                                                        bound):
+        paths = _corpus(tmp_path)
+        result = experience_bench.run(match_fn=bound(paths), **paths)
+        result["door_a"]["n_distinct_pieces"] = 2
+        text = experience_bench.render(result, "2026-09-04T00:00:00Z")
+        assert "OBSERVATION and not a claim" in text
+
+    def test_the_report_labels_each_number_with_its_own_name(self, tmp_path, bound):
+        """Four mutants swapped one rendered number for another (returned-nothing
+        for returned-one, below_floor for ranked_out, strict door for loose, scars
+        for built) and stayed green because nothing read the page."""
+        paths = _corpus(tmp_path)
+        result = experience_bench.run(match_fn=bound(paths), **paths)
+        text = experience_bench.render(result, "2026-09-04T00:00:00Z")
+        disc, corpus = result["discrimination"], result["corpus"]
+        variants = result["door_b_variants"]
+        assert "- returned nothing: %s" % experience_bench._rate(
+            disc["returned_nothing"], disc["n"]) in text
+        assert "- returned exactly one row: %s" % experience_bench._rate(
+            disc["returned_one"], disc["n"]) in text
+        assert "- scars.md rows: %d" % corpus["scars"] in text
+        assert "- built.md rows: %d" % corpus["built_hand"] in text
+        assert "snake_case basenames only (a token that could only be a module): " \
+               "%d pairs" % variants["module_name_strict"] in text
+        assert "%d rows matched, %d (row, exemplar) hits" % (
+            variants["module_name_any_basename"],
+            variants["module_name_any_basename_all_hits"]) in text
+
+    def test_the_report_names_the_live_floors_rather_than_a_copy(self, tmp_path,
+                                                                bound):
+        paths = _corpus(tmp_path)
+        result = experience_bench.run(match_fn=bound(paths), **paths)
+        assert result["floors"] == {"hand": experience.MIN_MATCH_SCORE,
+                                    "mined": experience.MIN_MINED_MATCH_SCORE}
+        text = experience_bench.render(result, "2026-09-04T00:00:00Z")
+        assert "floors: hand %d, mined %d" % (experience.MIN_MATCH_SCORE,
+                                              experience.MIN_MINED_MATCH_SCORE) in text
+
+    def test_the_full_text_diagnostic_uses_the_full_text(self, tmp_path, bound):
+        """Two mutants neutered the diagnostic (re-running it on `idea`, or
+        flipping the default key) and stayed green. It is the instrument the commit
+        message leaned on, and it had no test."""
+        paths = _corpus(tmp_path)
+        result = experience_bench.run(match_fn=bound(paths), **paths)
+        text = experience_bench.render(result, "2026-09-04T00:00:00Z")
+        assert "NOT a hit rate to quote" in text
+
+    def test_the_title_collision_count_is_reported(self, tmp_path, bound):
+        """Keying by title drops rows silently; the live corpus loses dozens. The
+        count is on the page so a reader knows a lookup may read a different row."""
+        paths = _corpus(tmp_path)
+        result = experience_bench.run(match_fn=bound(paths), **paths)
+        assert result["corpus"]["title_collisions"] == 1, result["corpus"]
+        corpus = result["corpus"]
+        # 3 scars (the placeholder row is dropped) + 1 built + 4 mined, minus the
+        # one duplicate title.
+        assert corpus["distinct_titles"] == \
+            corpus["scars"] + corpus["built_hand"] + corpus["mined"] - 1, corpus
+        text = experience_bench.render(result, "2026-09-04T00:00:00Z")
+        assert "rows sharing a title with another row: 1" in text
+
+
+class TestDegenerateInputsAreDecidedRatherThanCrashing:
+
+    def test_a_json_line_that_is_not_an_object_is_skipped(self, tmp_path):
+        path = tmp_path / "exemplars.jsonl"
+        path.write_text('[1,2,3]\n"a string"\n{"id":"ok","text":"fine."}\nnot json\n\n',
+                        encoding="utf-8")
+        rows = experience_bench.load_exemplars(str(path))
+        assert [r["id"] for r in rows] == ["ok"]
+
+    def test_a_missing_exemplars_file_returns_empty_rather_than_raising(self,
+                                                                       tmp_path):
+        assert experience_bench.load_exemplars(str(tmp_path / "nope.jsonl")) == []
+
+    @pytest.mark.parametrize("limit", [0, -1, None, "3"])
+    def test_a_limit_that_would_silently_zero_the_report_is_refused(self, tmp_path,
+                                                                    bound, limit):
+        """`--limit 0` made `match` return an empty slice for every idea and the
+        page rendered 100% returned-nothing and 0% false surfacing as measurements."""
+        paths = _corpus(tmp_path)
+        with pytest.raises(ValueError):
+            experience_bench.run(match_fn=bound(paths), limit=limit, **paths)
+
+    def test_a_missing_scars_file_yields_no_pairs_rather_than_raising(self, tmp_path):
+        assert experience_bench.scar_pairs(str(tmp_path / "nope.md"), []) == []
+
+    def test_a_paired_title_absent_from_the_corpus_is_its_own_bucket(self):
+        """`score=None` was bucketed as below-floor, so the page printed 'scored
+        UNDER its floor' next to 'overlap was None, floor is None'."""
+        scored = experience_bench.score_pairs(
+            [{"exemplar_id": "x", "title": "not in the corpus", "idea": "an idea",
+              "group": "g"}],
+            lambda idea, limit=3: [], 3, {})
+        assert scored["title_not_in_corpus"] == 1
+        assert scored["below_floor"] == 0
+
+
+class TestTheCLIWritesBothArtifactsOrNeither:
+
+    def test_main_creates_the_directory_for_the_json_as_well_as_the_report(
+            self, tmp_path, capsys):
+        """The first version made `--out`'s directory and not `--json`'s, so an
+        unwritable json path left the markdown on disk, no json and no stdout: a
+        partial artifact that looks like a finished run. `main` had no test at all.
+
+        It used to reach the fixture corpus by monkeypatching three module constants
+        AND wrapping `run` to force the paths back in, which meant the CLI's own
+        corpus plumbing was never exercised. `--corpus-dir` replaced all of it: the
+        flag is the only way in, so this now fails if that plumbing breaks.
+        """
+        _corpus(tmp_path)
+        out = tmp_path / "deep" / "nested" / "report.md"
+        raw = tmp_path / "other" / "deeper" / "raw.json"
+        assert experience_bench.main(["--corpus-dir", str(tmp_path),
+                                      "--out", str(out), "--json", str(raw)]) == 0
+        assert out.is_file() and raw.is_file()
+        assert json.loads(raw.read_text())["floors"]["hand"] == \
+            experience.MIN_MATCH_SCORE
+        assert "Retrieval benchmark" in capsys.readouterr().out
+
+
+class TestItNeverWritesTheCorpus:
+
+    def test_the_module_opens_the_corpus_read_only(self):
+        """A benchmark that can write `exemplars.jsonl` is a second writer, and the
+        single-writer rule on that file is what keeps a bad source string from
+        blocking everyone's commit.
+
+        AST, not a substring search: the first version grepped the source for
+        "exemplars add" and failed on its OWN docstring. And it enumerated only
+        `open`, so a `Path.write_text` or a `shutil.copyfile` added above `main`
+        stayed green. The check now walks every call node and matches a set of
+        write APIs by name.
+        """
+        writes = self._writes_above_main(experience_bench.__file__)
+        assert writes == [], writes
+
+    def test_the_write_detector_fires_on_every_api_it_claims_to_cover(self, tmp_path):
+        """NEGATIVE CONTROL, on the REAL detector. The first version of this test
+        re-implemented the scan inline over its own temp file, so it could not fail
+        for any change to the module and it stayed green while its sibling went red.
+        """
+        for snippet in ('def run():\n    open("/x", "a").write("1")\n',
+                        'import pathlib\ndef run():\n'
+                        '    pathlib.Path("/x").write_text("1")\n',
+                        'import shutil\ndef run():\n    shutil.copyfile("/a","/b")\n',
+                        'import os\ndef run():\n    os.replace("/a","/b")\n'):
+            bad = tmp_path / "bad.py"
+            bad.write_text(snippet + "\ndef main():\n    pass\n")
+            found = self._writes_above_main(str(bad))
+            assert found, snippet
+
+    @staticmethod
+    def _writes_above_main(path):
+        import ast
+        tree = ast.parse(open(path, encoding="utf-8").read())
+        main_line = 0
+        for node in ast.walk(tree):
+            if isinstance(node, ast.FunctionDef) and node.name == "main":
+                main_line = node.lineno
+        # Every API that can put bytes on disk, not just `open`. A guard that
+        # enumerates one name is a guard a one-line change walks past.
+        # Unambiguous on their own: nothing but a filesystem write is spelled this
+        # way. `replace` and `rename` are NOT here, because `str.replace` is all
+        # over this module and a bare name match reported three false writes.
+        UNAMBIGUOUS = {"write_text", "write_bytes", "writelines", "copyfile", "copy2"}
+        # These need their receiver, because the same word means something else on
+        # a string.
+        QUALIFIED = {("os", "replace"), ("os", "rename"), ("os", "remove"),
+                     ("os", "unlink"), ("os", "makedirs"), ("os", "mkdir"),
+                     ("shutil", "copy"), ("shutil", "copyfile"), ("shutil", "move"),
+                     ("json", "dump")}
+        found = []
+        for node in ast.walk(tree):
+            if not isinstance(node, ast.Call):
+                continue
+            name = getattr(node.func, "id", None) or getattr(node.func, "attr", None)
+            receiver = getattr(getattr(node.func, "value", None), "id", None)
+            if name in UNAMBIGUOUS or (receiver, name) in QUALIFIED:
+                found.append((node.lineno, name))
+            elif name == "open":
+                modes = [a.value for a in node.args[1:2]
+                         if isinstance(a, ast.Constant) and isinstance(a.value, str)]
+                modes += [kw.value.value for kw in node.keywords
+                          if kw.arg == "mode" and isinstance(kw.value, ast.Constant)]
+                if any(f in m for m in modes for f in ("w", "a", "x", "+")):
+                    found.append((node.lineno, "open:" + ",".join(modes)))
+        # Writes BELOW `main` are the report the caller asked for. Writes above it
+        # would be the benchmark mutating its own inputs.
+        return [f for f in found if f[0] < main_line]

--- a/plugins/kipi-core/voiceloop/tests/test_experience_engine.py
+++ b/plugins/kipi-core/voiceloop/tests/test_experience_engine.py
@@ -1,0 +1,148 @@
+#!/usr/bin/env python3
+"""The corpus seam: the matcher has NO default corpus and refuses an unbound call.
+
+why this file exists (2026-09-05, the package extraction). The matcher used to
+resolve all three corpus files from `__file__`. Inside one instance that is correct
+and invisible. Inside a package that ships fleet-wide it silently points every
+founder at whichever corpus happens to sit beside the code, which is the same
+failure `voice_ref` refuses by carrying no default corpus path at all.
+
+The refusal is the load-bearing half of the move, so it gets the test. Every case
+here builds its corpus in `tmp_path`; nothing reads a real one.
+"""
+import ast
+import os
+import sys
+
+import pytest
+
+sys.path.insert(0, os.path.dirname(os.path.dirname(os.path.dirname(
+    os.path.abspath(__file__)))))
+
+from voiceloop import experience  # noqa: E402
+
+SCARS = """# rows
+
+### Google
+
+| Row | Flags | Audience | Notes |
+|---|---|---|---|
+| **Four teams fought one operation** | public-safe | CISO | "Four teams fought the same operation across two surfaces. None of them knew." |
+"""
+
+BUILT = """## Mechanisms
+
+| Item | Flag | The specific |
+|---|---|---|
+| **A ledger that refuses an unverifiable row** | public-safe | The quarantine ledger keeps the row and refuses to score it, so an absence is visible instead of silent. |
+"""
+
+
+def _corpus(tmp_path, with_mined=True):
+    (tmp_path / "scars.md").write_text(SCARS, encoding="utf-8")
+    (tmp_path / "built.md").write_text(BUILT, encoding="utf-8")
+    if with_mined:
+        (tmp_path / "built-mined.jsonl").write_text("", encoding="utf-8")
+    return str(tmp_path)
+
+
+class TestTheEngineHasNoDefaultCorpus:
+
+    def test_match_without_a_corpus_dir_is_a_type_error(self):
+        """POSITIONAL AND REQUIRED. The old signature was `match(idea, path=None)`,
+        so the call the instance makes today, `match(idea)`, used to succeed against
+        a corpus resolved from the module's own location. It must now not compile a
+        call at all."""
+        with pytest.raises(TypeError):
+            experience.match("four teams fought one operation")
+
+    def test_match_with_an_empty_corpus_dir_refuses_loudly(self):
+        """THE MUTATION THIS FILE WAS WRITTEN FOR. Passing None is what an adapter
+        that lost its binding would do, and a `None` that fell through to a
+        `__file__` join would be the exact silent failure the move exists to end."""
+        with pytest.raises(experience.CorpusNotBound):
+            experience.match("four teams fought one operation", None)
+        with pytest.raises(experience.CorpusNotBound):
+            experience.match("four teams fought one operation", "")
+
+    def test_card_matches_refuses_on_the_same_terms(self):
+        """The card door is the ONLY caller that asks for rows a writer may not see.
+        A refusal that guarded one door and not the other would leak exactly the
+        uncleared rows, which is the worst available half-fix."""
+        with pytest.raises(experience.CorpusNotBound):
+            experience.card_matches("four teams fought one operation", None)
+
+    def test_corpus_paths_refuses_and_names_the_three_files(self):
+        with pytest.raises(experience.CorpusNotBound) as exc:
+            experience.corpus_paths(None)
+        for name in (experience.SCARS_FILE, experience.BUILT_FILE,
+                     experience.MINED_FILE):
+            assert name in str(exc.value)
+
+    def test_per_file_overrides_still_require_the_directory(self, tmp_path):
+        """NEGATIVE CONTROL on the override path. A caller able to name all three
+        files can name the directory, and letting the overrides stand in for it
+        reopens the hole one argument to the left."""
+        corpus = _corpus(tmp_path)
+        with pytest.raises(experience.CorpusNotBound):
+            experience.match("four teams fought one operation", None,
+                             scars_path=os.path.join(corpus, "scars.md"),
+                             built_path=os.path.join(corpus, "built.md"),
+                             mined_path=os.path.join(corpus, "built-mined.jsonl"))
+
+    @staticmethod
+    def _file_refs(source):
+        """`__file__` used as CODE, never as prose.
+
+        A substring grep was the first version and it failed on this module's own
+        docstring, which has to name `__file__` to explain why it does not use one.
+        AST separates the two: a use is an `ast.Name`, a mention is a string
+        constant.
+        """
+        return [node for node in ast.walk(ast.parse(source))
+                if isinstance(node, ast.Name) and node.id == "__file__"]
+
+    def test_the_module_holds_no_file_relative_corpus_constant(self):
+        """Read the tree, not the memory. A later edit that re-adds a
+        `dirname(__file__)` corpus join would restore the defect with every test
+        above still green, because those test the ARGUMENT and not the absence of a
+        fallback."""
+        with open(experience.__file__, encoding="utf-8") as handle:
+            source = handle.read()
+        found = self._file_refs(source)
+        assert found == [], (
+            "experience.py uses __file__ at line(s) %s. The corpus is the caller's; "
+            "a path derived from where the code lives is the defect the package "
+            "extraction removed." % [n.lineno for n in found])
+
+    def test_the_file_detector_fires_on_the_shape_it_claims_to_catch(self):
+        """NEGATIVE SELF-TEST. A detector that never fires reads exactly like one
+        that works."""
+        planted = ("import os\n"
+                   "P = os.path.join(os.path.dirname(__file__), 'voice', 'x.md')\n")
+        assert self._file_refs(planted)
+        assert self._file_refs("P = 'a comment about __file__ in a string'") == []
+
+
+class TestTheBoundCallStillRetrieves:
+    """The refusal is worthless if it also refuses the good case."""
+
+    def test_a_bound_call_finds_the_scar_row(self, tmp_path):
+        hits = experience.match("four teams fought the same operation",
+                                _corpus(tmp_path))
+        assert [row["title"] for row in hits] == ["Four teams fought one operation"]
+        assert hits[0]["company"] == "Google"
+
+    def test_a_bound_call_finds_the_built_row_and_never_names_a_company(self, tmp_path):
+        hits = experience.match("a ledger that refuses an unverifiable row",
+                                _corpus(tmp_path))
+        assert hits and hits[0]["kind"] == "built"
+        assert hits[0]["company"] == ""
+
+    def test_a_missing_corpus_FILE_degrades_to_empty_rather_than_raising(self, tmp_path):
+        """The DIRECTORY is required; a file inside it is not. `load_mined` returning
+        [] for an absent mined file is the documented degradation and is what a fresh
+        clone gets. Those are two different questions and only one of them refuses."""
+        corpus = _corpus(tmp_path, with_mined=False)
+        assert experience.load_mined(os.path.join(corpus, "built-mined.jsonl")) == []
+        assert experience.match("four teams fought the same operation", corpus)


### PR DESCRIPTION
Found while documenting the voice loop, not by a gate.

## The hazard

The consulting instance landed `experience.py` and `experience_bench.py` into its own `plugins/kipi-core/voiceloop/` via its PR #84. The skeleton never received them.

The fleet sync rsyncs `plugins/` from this repo with delete enabled. So the next run removes both files from that instance, and `q-consult/pipeline/experience.py` imports the engine module at column 0. That is an import-time crash on the entire voice path, including the 06:05 publishing job, not a degraded gate.

The destructive-op hook names the precedent in its own refusal text: on 2026-08-07 `voicekit` was deleted from 19 instances at once by this mechanism.

## Why it happened

Slice 0 of the VoiceLoop extraction was built specifically to close this gap, and its plan states that engine code is edited here and reaches instances via the fleet sync. Slice 1 then wrote engine code instance-side and reopened it. The rule was documented and not enforced.

## Measured before and after

`git archive` extraction of both `origin/main` engine trees, then `diff -rq`:

| Before | After |
|---|---|
| 4 files only in consulting | trees identical |

The four: `experience.py`, `experience_bench.py`, `tests/test_experience_bench.py`, `tests/test_experience_engine.py`. All one-way, nothing diverged in content.

## Verification

- `pytest voiceloop/tests/` in this repo: **178 passed**
- `test_no_founder_data.py` green on both moved modules, which is the gate that matters since this tree publishes to a public mirror
- pre-commit: 9 lefthook jobs green, including `pytest:plugins/kipi-core/voiceloop`

No Codex review: out of credits, so any review would fall back to Claude and stamp DEGRADED.

🤖 Generated with [Claude Code](https://claude.com/claude-code)