### PR TITLE
feat(reddit): Arctic Shift is the only way this fleet reads Reddit

### DIFF
--- a/.verify-suites
+++ b/.verify-suites
@@ -69,6 +69,12 @@
 plugins/prd-os
 plugins/kipi-dsse
 plugins/kipi-core/voiceloop
+# The Arctic Shift transport, added 2026-09-05. It shipped with 26 tests and
+# was in NO manifest, so a revert of the one rule the module exists for -- raise
+# on a total mirror failure instead of returning [] -- would have merged green
+# (PR 307 review, MAJOR). A suite nothing runs is a suite that documents an
+# intention. Collects clean from the repo root.
+plugins/kipi-core/reddit_arctic
 automation
 rescued/memory-lifecycle
 q-system/.q-system/tests

--- a/lefthook.yml
+++ b/lefthook.yml
@@ -84,19 +84,21 @@ pre-commit:
     # lefthook (the ACTIVE framework) rather than .githooks (which core.hooksPath
     # does not point at) so they actually run on commit. Skeleton-only by nature.
     plugin-version-bump:
-      # --fix, not refuse (sp-97303649 / ASK-1039). Refusing deadlocked with the
-      # token-guard call ceiling (only `git commit` is exempt, and the bump needs
-      # an edit) AND left the refused changes STAGED, so the follow-up bump commit
-      # silently absorbed them -- the ASK-999 port landed under a message naming
-      # only a version bump, and fixing that needs a hook-blocked force-push. The
-      # patch bump is derivable, so it is derived and announced on stderr.
-      run: python3 q-system/.q-system/scripts/plugin-version-bump-check.py --staged --fix
-      stage_fixed: true
-      fail_text: "A changed plugin needs a .claude-plugin/plugin.json version bump and the auto-bump could not derive one (non-numeric patch?). Bump it by hand."
+      run: python3 q-system/.q-system/scripts/plugin-version-bump-check.py --staged
+      fail_text: "A changed plugin must bump its .claude-plugin/plugin.json version (else the version-keyed cache serves the stale copy)."
 
     settings-template-sync:
       run: CLAUDE_PROJECT_DIR="$(git rev-parse --show-toplevel)" python3 q-system/.q-system/scripts/settings-template-sync-check.py --check
       fail_text: "settings.json and settings-template.json are out of sync — a hook would ship dead to the fleet or run dead in the skeleton."
+
+    # Arctic Shift is the only way this fleet scrapes Reddit (founder-directed
+    # 2026-09-04). Scoped to THIS repo, not the fleet: a pre-commit hook that
+    # walked every checkout under ~/projects would fail this commit on somebody
+    # else's branch, which is how a gate gets switched off. The fleet-wide sweep
+    # is test_reddit_transport_audit.py::test_the_fleet_is_clean_right_now.
+    reddit-arctic-only:
+      run: python3 q-system/.q-system/scripts/reddit-transport-audit.py "$(git rev-parse --show-toplevel)"
+      fail_text: "A non-Arctic Reddit read. The transport is plugins/kipi-core/reddit_arctic — import it rather than building a URL."
 
     # Resurrected from a dead .git/hooks/pre-commit.old backup (sp-b417481b).
     # Ratchet, not absolute: the 300-line target was 214 under water when revived,

--- a/lefthook.yml
+++ b/lefthook.yml
@@ -84,21 +84,28 @@ pre-commit:
     # lefthook (the ACTIVE framework) rather than .githooks (which core.hooksPath
     # does not point at) so they actually run on commit. Skeleton-only by nature.
     plugin-version-bump:
-      run: python3 q-system/.q-system/scripts/plugin-version-bump-check.py --staged
-      fail_text: "A changed plugin must bump its .claude-plugin/plugin.json version (else the version-keyed cache serves the stale copy)."
+      # --fix, not refuse (sp-97303649 / ASK-1039). Refusing deadlocked with the
+      # token-guard call ceiling (only `git commit` is exempt, and the bump needs
+      # an edit) AND left the refused changes STAGED, so the follow-up bump commit
+      # silently absorbed them -- the ASK-999 port landed under a message naming
+      # only a version bump, and fixing that needs a hook-blocked force-push. The
+      # patch bump is derivable, so it is derived and announced on stderr.
+      run: python3 q-system/.q-system/scripts/plugin-version-bump-check.py --staged --fix
+      stage_fixed: true
+      fail_text: "A changed plugin needs a .claude-plugin/plugin.json version bump and the auto-bump could not derive one (non-numeric patch?). Bump it by hand."
 
     settings-template-sync:
       run: CLAUDE_PROJECT_DIR="$(git rev-parse --show-toplevel)" python3 q-system/.q-system/scripts/settings-template-sync-check.py --check
       fail_text: "settings.json and settings-template.json are out of sync — a hook would ship dead to the fleet or run dead in the skeleton."
 
-    # Arctic Shift is the only way this fleet scrapes Reddit (founder-directed
-    # 2026-09-04). Scoped to THIS repo, not the fleet: a pre-commit hook that
-    # walked every checkout under ~/projects would fail this commit on somebody
-    # else's branch, which is how a gate gets switched off. The fleet-wide sweep
-    # is test_reddit_transport_audit.py::test_the_fleet_is_clean_right_now.
+    # Arctic Shift is the only way this fleet reads Reddit (founder-directed
+    # 2026-09-04). Scoped to THIS repo: a hook that walked every checkout under
+    # ~/projects would fail your commit because of somebody else's branch, and a
+    # gate that fails for reasons you did not cause is a gate that gets switched
+    # off. The fleet-wide sweep lives in the test suite instead.
     reddit-arctic-only:
       run: python3 q-system/.q-system/scripts/reddit-transport-audit.py "$(git rev-parse --show-toplevel)"
-      fail_text: "A non-Arctic Reddit read. The transport is plugins/kipi-core/reddit_arctic — import it rather than building a URL."
+      fail_text: "A non-Arctic Reddit read. The transport is plugins/kipi-core/reddit_arctic -- import it rather than building a URL."
 
     # Resurrected from a dead .git/hooks/pre-commit.old backup (sp-b417481b).
     # Ratchet, not absolute: the 300-line target was 214 under water when revived,

--- a/plugins/kipi-core/.claude-plugin/plugin.json
+++ b/plugins/kipi-core/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "kipi-core",
-  "version": "1.10.7",
+  "version": "1.10.8",
   "description": "Core founder OS \u2014 voice, research, AUDHD, LinkedIn/brand, RCA skills + kipi-mcp server",
   "author": {
     "name": "Assaf Kipnis",

--- a/plugins/kipi-core/.claude-plugin/plugin.json
+++ b/plugins/kipi-core/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "kipi-core",
-  "version": "1.10.2",
+  "version": "1.10.3",
   "description": "Core founder OS \u2014 voice, research, AUDHD, LinkedIn/brand, RCA skills + kipi-mcp server",
   "author": {
     "name": "Assaf Kipnis",

--- a/plugins/kipi-core/.claude-plugin/plugin.json
+++ b/plugins/kipi-core/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "kipi-core",
-  "version": "1.10.3",
+  "version": "1.10.4",
   "description": "Core founder OS \u2014 voice, research, AUDHD, LinkedIn/brand, RCA skills + kipi-mcp server",
   "author": {
     "name": "Assaf Kipnis",

--- a/plugins/kipi-core/.claude-plugin/plugin.json
+++ b/plugins/kipi-core/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "kipi-core",
-  "version": "1.10.4",
+  "version": "1.10.5",
   "description": "Core founder OS \u2014 voice, research, AUDHD, LinkedIn/brand, RCA skills + kipi-mcp server",
   "author": {
     "name": "Assaf Kipnis",

--- a/plugins/kipi-core/.claude-plugin/plugin.json
+++ b/plugins/kipi-core/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "kipi-core",
-  "version": "1.10.5",
+  "version": "1.10.6",
   "description": "Core founder OS \u2014 voice, research, AUDHD, LinkedIn/brand, RCA skills + kipi-mcp server",
   "author": {
     "name": "Assaf Kipnis",

--- a/plugins/kipi-core/.claude-plugin/plugin.json
+++ b/plugins/kipi-core/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "kipi-core",
-  "version": "1.9.10",
+  "version": "1.10.0",
   "description": "Core founder OS \u2014 voice, research, AUDHD, LinkedIn/brand, RCA skills + kipi-mcp server",
   "author": {
     "name": "Assaf Kipnis",

--- a/plugins/kipi-core/.claude-plugin/plugin.json
+++ b/plugins/kipi-core/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "kipi-core",
-  "version": "1.10.0",
+  "version": "1.10.1",
   "description": "Core founder OS \u2014 voice, research, AUDHD, LinkedIn/brand, RCA skills + kipi-mcp server",
   "author": {
     "name": "Assaf Kipnis",

--- a/plugins/kipi-core/.claude-plugin/plugin.json
+++ b/plugins/kipi-core/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "kipi-core",
-  "version": "1.10.6",
+  "version": "1.10.7",
   "description": "Core founder OS \u2014 voice, research, AUDHD, LinkedIn/brand, RCA skills + kipi-mcp server",
   "author": {
     "name": "Assaf Kipnis",

--- a/plugins/kipi-core/.claude-plugin/plugin.json
+++ b/plugins/kipi-core/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "kipi-core",
-  "version": "1.10.8",
+  "version": "1.10.9",
   "description": "Core founder OS \u2014 voice, research, AUDHD, LinkedIn/brand, RCA skills + kipi-mcp server",
   "author": {
     "name": "Assaf Kipnis",

--- a/plugins/kipi-core/.claude-plugin/plugin.json
+++ b/plugins/kipi-core/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "kipi-core",
-  "version": "1.10.9",
+  "version": "1.11.0",
   "description": "Core founder OS \u2014 voice, research, AUDHD, LinkedIn/brand, RCA skills + kipi-mcp server",
   "author": {
     "name": "Assaf Kipnis",

--- a/plugins/kipi-core/.claude-plugin/plugin.json
+++ b/plugins/kipi-core/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "kipi-core",
-  "version": "1.10.1",
+  "version": "1.10.2",
   "description": "Core founder OS \u2014 voice, research, AUDHD, LinkedIn/brand, RCA skills + kipi-mcp server",
   "author": {
     "name": "Assaf Kipnis",

--- a/plugins/kipi-core/kipi-mcp/src/kipi_mcp/competitive_intel.py
+++ b/plugins/kipi-core/kipi-mcp/src/kipi_mcp/competitive_intel.py
@@ -890,13 +890,27 @@ def _collect_hackernews(
 
 def _collect_reddit_rss(source: dict[str, Any], limit: int, fetch_json: Any) -> list[dict[str, Any]]:
     records: list[dict[str, Any]] = []
+    failures: list[str] = []
     subs = [str(sub).lstrip("/").removeprefix("r/") for sub in source.get("subreddits", [])]
     after = (date.today() - timedelta(days=int(source.get("lookback_days", 35)))).isoformat()
     per_sub = int(source.get("posts_per_sub") or source.get("per_sub") or limit)
     for sub in subs:
         if len(records) >= limit:
             break
-        for entry in _reddit_archive_posts(sub, after, per_sub, fetch_json):
+        try:
+            entries = _reddit_archive_posts(sub, after, per_sub, fetch_json)
+        except RedditFetchFailed as exc:
+            # PER ROOM, not per source. This raise used to escape into
+            # collect_ai_raw_records' `except Exception: continue`, so ONE dead
+            # subreddit lost the other three and the harvest still wrote a
+            # success artifact with zero Reddit rows and a stderr line nobody
+            # reads (review, MAJOR 2).
+            #
+            # The raise itself is right and stays: what changed is who catches
+            # it. A refused room is recorded and the rest are still read.
+            failures.append("%s: %s" % (sub, exc))
+            continue
+        for entry in entries:
             records.append(
                 _raw_record(
                     source_name=source["name"],
@@ -914,6 +928,17 @@ def _collect_reddit_rss(source: dict[str, Any], limit: int, fetch_json: Any) -> 
             )
             if len(records) >= limit:
                 break
+    # A HARVEST THAT LOST EVERY ROOM IS NOT A HARVEST. Returning [] here made a
+    # total Reddit outage indistinguishable from a quiet week, which is the same
+    # defect the transport raises to prevent, one layer up.
+    if failures and not records:
+        raise RedditFetchFailed(
+            "every subreddit refused for %s: %s"
+            % (source.get("name") or "reddit", "; ".join(failures)))
+    if failures:
+        print("[competitive-intel] %s: %d of %d rooms refused: %s"
+              % (source.get("name") or "reddit", len(failures), len(subs),
+                 "; ".join(failures)), file=sys.stderr)
     return records
 
 

--- a/plugins/kipi-core/kipi-mcp/src/kipi_mcp/competitive_intel.py
+++ b/plugins/kipi-core/kipi-mcp/src/kipi_mcp/competitive_intel.py
@@ -267,6 +267,7 @@ def collect_ai_raw_records(
     token = os.environ.get("APIFY_TOKEN", "") if apify_token is None else apify_token
 
     raw_records: list[dict[str, Any]] = []
+    source_failures: list[dict[str, Any]] = []
     for source in config.get("sources", []):
         if not source.get("enabled", True):
             continue
@@ -284,6 +285,15 @@ def collect_ai_raw_records(
                 )
             )
         except Exception as exc:
+            # RECORDED IN THE ARTIFACT, not only on stderr. A stderr line at an
+            # unattended entry point is a line nobody reads: the run still exited
+            # 0 and still wrote a clean-looking harvest with zero Reddit rows
+            # (review). The failures now travel WITH the output, so a consumer
+            # can tell "nothing was posted" from "nothing was reached".
+            source_failures.append({
+                "source": source.get("name") or source.get("type"),
+                "error": "%s: %s" % (type(exc).__name__, exc),
+            })
             # NAMED, not swallowed. The bare `continue` that used to sit here is
             # the reason the transport's raise would otherwise be pointless: a
             # source that died and a source with nothing new produced the same
@@ -300,6 +310,16 @@ def collect_ai_raw_records(
         output = Path(output_path)
         output.parent.mkdir(parents=True, exist_ok=True)
         output.write_text(json.dumps(raw_records, indent=2))
+        if source_failures:
+            # Beside the artifact, not inside it, so every existing reader of
+            # that JSON list keeps working unchanged.
+            output.with_suffix(output.suffix + ".failures.json").write_text(
+                json.dumps(source_failures, indent=2))
+    if source_failures and not raw_records:
+        raise RedditFetchFailed(
+            "every source failed and the harvest is empty: %s"
+            % "; ".join("%s (%s)" % (f["source"], f["error"])
+                        for f in source_failures))
     return raw_records
 
 

--- a/plugins/kipi-core/kipi-mcp/src/kipi_mcp/competitive_intel.py
+++ b/plugins/kipi-core/kipi-mcp/src/kipi_mcp/competitive_intel.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 import json
 import os
 import re
+import sys
 import urllib.parse
 import urllib.request
 from html import unescape
@@ -15,9 +16,42 @@ from xml.etree import ElementTree
 import yaml
 
 
+def _load_reddit_transport():
+    """Walk up to the vendored `plugins/kipi-core` and import the transport.
+
+    A relative parents[N] would be right in this repo's src/ layout and wrong in
+    every other caller's, which is the failure `voiceloop/voice_ref.py` records:
+    a caller that does not travel with its engine is wired on one machine only.
+    """
+    import sys as _sys
+    here = Path(__file__).resolve()
+    for parent in here.parents:
+        for cand in (parent / "plugins" / "kipi-core", parent):
+            if cand.name == "kipi-core" or cand.parent.name == "plugins":
+                if (cand / "reddit_arctic").is_dir():
+                    if str(cand) not in _sys.path:
+                        _sys.path.insert(0, str(cand))
+                    from reddit_arctic import transport
+                    return transport
+    raise RuntimeError(
+        "no plugins/kipi-core/reddit_arctic above %s; the kipi updater has not "
+        "run in this instance" % here)
+
+
+
 USER_AGENT = "kipi-competitive-intel/1.0 (+https://ktlystlabs.com)"
-ARCTIC_BASE = "https://arctic-shift.photon-reddit.com"
-PULLPUSH_BASE = "https://api.pullpush.io"
+# THE REDDIT TRANSPORT IS NOT DEFINED HERE ANY MORE (2026-09-04, founder-directed
+# "this must be the only way we scrape reddit"). It lives once, in the kipi-core
+# plugin, and this module is a caller. Before the move there were two copies of
+# the same Arctic Shift fetch with OPPOSITE failure semantics: q-consult's raised
+# on a total refusal, this one returned [], so here a dead mirror and a quiet
+# subreddit were the same value and nothing downstream could tell them apart
+# (sp-a5461e0a). The copy that swallowed is the one that shipped to every
+# instance.
+_REDDIT = _load_reddit_transport()
+ARCTIC_BASE = _REDDIT.ARCTIC_BASE
+PULLPUSH_BASE = _REDDIT.PULLPUSH_BASE
+RedditFetchFailed = _REDDIT.RedditFetchFailed
 BROWSER_UA = (
     "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) "
     "AppleWebKit/605.1.15 (KHTML, like Gecko) Version/17.0 Safari/605.1.15"
@@ -249,7 +283,16 @@ def collect_ai_raw_records(
                     apify_token=token,
                 )
             )
-        except Exception:
+        except Exception as exc:
+            # NAMED, not swallowed. The bare `continue` that used to sit here is
+            # the reason the transport's raise would otherwise be pointless: a
+            # source that died and a source with nothing new produced the same
+            # empty harvest, and the run looked healthy either way. One source
+            # still must not kill the batch, so this stays a continue. It just
+            # says what it lost.
+            print("[competitive-intel] source %r failed: %s: %s"
+                  % (source.get("name") or source.get("type"),
+                     type(exc).__name__, exc), file=sys.stderr)
             continue
 
     raw_records = _dedupe_raw_records(raw_records)[: int(config.get("pool_size", 60))]
@@ -875,39 +918,33 @@ def _collect_reddit_rss(source: dict[str, Any], limit: int, fetch_json: Any) -> 
 
 
 def _reddit_archive_posts(subreddit: str, after: str, limit: int, fetch_json: Any) -> list[dict[str, Any]]:
-    try:
-        return [
-            post
-            for post in (_reddit_archive_post(item) for item in _archive_items(fetch_json(_arctic_posts_url(subreddit, after, limit))))
-            if post
-        ]
-    except Exception:
-        pass
-    try:
-        return [
-            post
-            for post in (_reddit_archive_post(item) for item in _archive_items(fetch_json(_pullpush_posts_url(subreddit, limit))))
-            if post
-        ]
-    except Exception:
-        return []
+    """Arctic first, PullPush second, RAISE if both refuse.
+
+    The raise is the behaviour change. This function used to return [] there,
+    which made a dead mirror and a quiet subreddit the same value forever after.
+    `collect_ai_raw_records` now names the source it lost instead of continuing
+    in silence.
+
+    `fetch_json` is passed straight through as the transport's `_get` seam, so
+    every existing test double keeps working.
+    """
+    raw, _mirror = _REDDIT.fetch_posts(subreddit, limit=limit, after=after,
+                                       _get=fetch_json)
+    return [post for post in (_reddit_archive_post(item) for item in raw) if post]
 
 
 def _archive_items(payload: Any) -> list[dict[str, Any]]:
-    if isinstance(payload, dict):
-        data = payload.get("data", [])
-        return data if isinstance(data, list) else []
-    return payload if isinstance(payload, list) else []
+    """Kept as a delegate. It had callers and its own tests; the unwrapping rule
+    itself now lives once, in the transport."""
+    return _REDDIT._items(payload)
 
 
 def _arctic_posts_url(subreddit: str, after: str, limit: int) -> str:
-    query = urllib.parse.urlencode({"subreddit": subreddit, "after": after, "limit": limit, "sort": "desc"})
-    return f"{ARCTIC_BASE}/api/posts/search?{query}"
+    return _REDDIT.arctic_url(subreddit, limit, after=after)
 
 
 def _pullpush_posts_url(subreddit: str, limit: int) -> str:
-    query = urllib.parse.urlencode({"subreddit": subreddit, "size": limit, "sort": "desc"})
-    return f"{PULLPUSH_BASE}/reddit/search/submission?{query}"
+    return _REDDIT.pullpush_url(subreddit, limit)
 
 
 def _reddit_archive_post(data: dict[str, Any]) -> dict[str, Any] | None:

--- a/plugins/kipi-core/reddit_arctic/__init__.py
+++ b/plugins/kipi-core/reddit_arctic/__init__.py
@@ -1,0 +1,43 @@
+"""Arctic Shift is the fleet's only Reddit transport. Import from here.
+
+    import sys
+    from pathlib import Path
+    sys.path.insert(0, str(<repo root> / "plugins" / "kipi-core"))
+    from reddit_arctic import transport
+
+`bootstrap.locate()` finds that path for a caller that does not want to hardcode
+it. The module lives beside `voiceloop` for the reason recorded in
+`voiceloop/voice_ref.py`: a caller that does not travel with its engine is not
+wired, it is wired on one machine.
+"""
+from reddit_arctic.transport import (  # noqa: F401
+    ARCTIC_BASE,
+    DEFAULT_MAX_ITEMS,
+    DEFAULT_TIMEOUT,
+    MAX_LIMIT,
+    PULLPUSH_BASE,
+    RETIRED_ACTOR,
+    USER_AGENT,
+    RedditFetchFailed,
+    arctic_url,
+    author_items,
+    author_url,
+    comments,
+    comments_url,
+    coverage,
+    fetch_posts,
+    normalize,
+    pullpush_url,
+    recent,
+    search,
+    thread,
+)
+
+__all__ = [
+    "ARCTIC_BASE", "PULLPUSH_BASE", "USER_AGENT", "RETIRED_ACTOR",
+    "DEFAULT_TIMEOUT", "DEFAULT_MAX_ITEMS", "MAX_LIMIT",
+    "RedditFetchFailed",
+    "arctic_url", "pullpush_url", "fetch_posts",
+    "comments_url", "comments", "author_url", "author_items",
+    "normalize", "recent", "search", "thread", "coverage",
+]

--- a/plugins/kipi-core/reddit_arctic/bootstrap.py
+++ b/plugins/kipi-core/reddit_arctic/bootstrap.py
@@ -1,0 +1,64 @@
+"""Find `plugins/kipi-core` from anywhere in a repo, so no caller hardcodes it.
+
+Every consumer of the transport lives at a different depth: a q-system script,
+a pipeline package, a cole-gtm gtm/scripts file, a kipi-mcp module inside a
+src/ layout. A relative `parents[N]` is correct in exactly one of those and
+silently wrong in the rest, which is the class of bug `voice_ref.py` records:
+a caller that does not travel with its engine is wired on one machine.
+
+Usage, from any depth:
+
+    from reddit_arctic.bootstrap import load
+    transport = load()
+
+or, when the package is not importable yet (the usual case, because finding it
+is the whole problem):
+
+    import importlib.util, pathlib, sys
+    for parent in pathlib.Path(__file__).resolve().parents:
+        cand = parent / "plugins" / "kipi-core"
+        if (cand / "reddit_arctic").is_dir():
+            sys.path.insert(0, str(cand)); break
+    from reddit_arctic import transport
+
+`plugin_root()` below is that loop, kept in one place for callers that CAN
+already import the package.
+"""
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+
+def plugin_root(start: Path | str | None = None) -> Path:
+    """The nearest `plugins/kipi-core` at or above `start`.
+
+    Walks UP rather than reading an env var: the fleet has one skeleton and many
+    instances, each carrying its own vendored copy, and a caller must get the
+    copy that shipped with it. An env var would let a stale export point an
+    instance at another instance's plugin, which is exactly the cross-instance
+    reach `test_boundary.py` forbids.
+    """
+    here = Path(start or __file__).resolve()
+    if here.is_file():
+        here = here.parent
+    for parent in [here, *here.parents]:
+        cand = parent / "plugins" / "kipi-core"
+        if (cand / "reddit_arctic").is_dir():
+            return cand
+        # the module may already BE inside plugins/kipi-core
+        if parent.name == "kipi-core" and (parent / "reddit_arctic").is_dir():
+            return parent
+    raise RuntimeError(
+        "no plugins/kipi-core/reddit_arctic at or above %s. The Reddit transport "
+        "ships with the kipi-core plugin; run `kipi update` in this instance."
+        % here)
+
+
+def load(start: Path | str | None = None):
+    """Import and return the transport module, putting the plugin on sys.path."""
+    root = plugin_root(start)
+    if str(root) not in sys.path:
+        sys.path.insert(0, str(root))
+    from reddit_arctic import transport
+    return transport

--- a/plugins/kipi-core/reddit_arctic/tests/test_transport.py
+++ b/plugins/kipi-core/reddit_arctic/tests/test_transport.py
@@ -302,3 +302,32 @@ def test_search_pages_because_it_matches_locally():
 
     t.search("x", "needle", _get=one)
     assert len(calls) == 1, calls
+
+
+def test_the_contract_competitive_intel_depends_on():
+    """kipi-mcp's own suite is SKIPPED in CI for missing plugin deps
+    (apify-client, feedparser, mcp, pyyaml, tenacity), which is a documented
+    exclusion with a ticket, sp-97ce989b. So `competitive_intel` is guarded by
+    nothing there (PR 307 review).
+
+    What that module now does with Reddit is delegate to this transport through
+    the `_get` seam, so the ONE rule it depends on can be pinned HERE, in a suite
+    the floor runs: both mirrors refusing raises, and a quiet subreddit returns
+    an empty list. Reverting `_reddit_archive_posts` to `return []` still would
+    not fail its own suite; reverting THIS breaks a suite that runs.
+
+    That is a smaller claim than "competitive_intel is tested in CI" and it is
+    the true one. The dependency install is a CI-environment change with its own
+    blast radius and belongs to its ticket, not to this PR.
+    """
+    op = opener_for({"arctic-shift": OSError("down"), "pullpush": OSError("down")})
+    with pytest.raises(t.RedditFetchFailed):
+        t.fetch_posts("taxpros", limit=5, _opener=op)
+
+    # the `_get` seam competitive_intel injects through, both ways
+    with pytest.raises(t.RedditFetchFailed):
+        t.fetch_posts("taxpros", limit=5,
+                      _get=lambda url: (_ for _ in ()).throw(OSError("down")))
+    rows, mirror = t.fetch_posts("taxpros", limit=5,
+                                 _get=lambda url: {"data": []})
+    assert rows == [] and mirror == "arctic", "a quiet room is still empty"

--- a/plugins/kipi-core/reddit_arctic/tests/test_transport.py
+++ b/plugins/kipi-core/reddit_arctic/tests/test_transport.py
@@ -331,3 +331,68 @@ def test_the_contract_competitive_intel_depends_on():
     rows, mirror = t.fetch_posts("taxpros", limit=5,
                                  _get=lambda url: {"data": []})
     assert rows == [] and mirror == "arctic", "a quiet room is still empty"
+
+
+# --- a caller's budget is not a host's problem ----------------------------
+
+def test_a_socket_timeout_still_takes_the_pullpush_fallback():
+    """THE ROUND-9 MAJOR, and a regression I shipped in round 8.
+
+    `socket.timeout` IS `TimeoutError` since Python 3.10. Round 8 let bare
+    TimeoutError through every handler here so a caller's deadline would not be
+    mistaken for a refusal, and in doing so stopped a genuinely hung mirror from
+    falling back to PullPush, at exactly the moment a fallback matters most.
+    """
+    import socket
+    calls = []
+
+    def opener(req, timeout=None):
+        calls.append(req.full_url)
+        if "arctic-shift" in req.full_url:
+            raise socket.timeout("hung")
+        return _Resp({"data": [{"id": "a"}]})
+
+    rows, mirror = t.fetch_posts("taxpros", limit=5, _opener=opener)
+    assert mirror == "pullpush" and len(rows) == 1
+    assert len(calls) == 2, calls
+
+
+def test_a_callers_own_deadline_still_propagates():
+    """The other half. A dedicated class, not a builtin somebody else raises."""
+    with pytest.raises(t.ReadDeadlineExceeded):
+        t.fetch_posts("x", limit=5, _get=lambda u: (_ for _ in ()).throw(
+            t.ReadDeadlineExceeded("budget")))
+
+
+def test_a_deadline_hands_back_the_pages_it_already_collected():
+    """The caller's budget ran out; the rows it already paid for are not the
+    mirror's to take back."""
+    seen = {"n": 0}
+
+    def fake(url):
+        seen["n"] += 1
+        if seen["n"] > 2:
+            raise t.ReadDeadlineExceeded("budget")
+        return {"data": [{"id": "c%d_%d" % (seen["n"], i),
+                          "created_utc": 1788136000 + seen["n"] * 1000 + i}
+                         for i in range(100)]}
+
+    with pytest.raises(t.ReadDeadlineExceeded) as err:
+        t.all_comments("x", _get=fake)
+    assert getattr(err.value, "partial", None), "the collected pages were dropped"
+    assert len(err.value.partial) == 200
+
+
+def test_an_unrecognised_body_is_a_failure_not_an_empty_room():
+    """A 200 carrying an error object, an HTML interstitial or a renamed field
+    made all_comments report complete=True for a thread it read none of. That is
+    this module's founding defect arriving through the parser instead of the
+    fetch."""
+    for body in ({"error": "nope"}, "html", 42):
+        with pytest.raises(t.RedditFetchFailed):
+            t._items(body)
+
+    # NEGATIVE CONTROL: the genuinely empty answers stay empty
+    assert t._items({"data": []}) == []
+    assert t._items([]) == []
+    assert t._items({}) == []

--- a/plugins/kipi-core/reddit_arctic/tests/test_transport.py
+++ b/plugins/kipi-core/reddit_arctic/tests/test_transport.py
@@ -1,0 +1,209 @@
+"""The transport's contract, proved against a fake opener. No network.
+
+The three claims worth pinning are the three that were WRONG somewhere in the
+fleet before this module existed:
+
+  1. a total failure raises, it never returns []   (competitive_intel returned [])
+  2. every URL is a mirror, never reddit.com       (reddit_read.py used old.reddit)
+  3. there is no write path                        (nothing had checked)
+"""
+from __future__ import annotations
+
+import io
+import json
+import sys
+from pathlib import Path
+
+import pytest
+
+PLUGIN_ROOT = Path(__file__).resolve().parents[2]
+sys.path.insert(0, str(PLUGIN_ROOT))
+
+from reddit_arctic import transport as t  # noqa: E402
+
+
+class _Resp:
+    def __init__(self, payload):
+        self._b = json.dumps(payload).encode()
+
+    def read(self):
+        return self._b
+
+    def __enter__(self):
+        return self
+
+    def __exit__(self, *a):
+        return False
+
+
+def opener_for(payload_by_host):
+    """A fake urlopen that answers per host, so an arctic failure and a pullpush
+    success can be expressed without patching two different things."""
+    def _open(req, timeout=None):
+        url = req.full_url if hasattr(req, "full_url") else str(req)
+        for host, payload in payload_by_host.items():
+            if host in url:
+                if isinstance(payload, Exception):
+                    raise payload
+                return _Resp(payload)
+        raise AssertionError("fake opener got an unexpected host: %s" % url)
+    return _open
+
+
+POST = {"id": "abc", "title": "invoice pile", "selftext": "we key them by hand",
+        "subreddit": "taxpros", "created_utc": 1788136000, "score": 4,
+        "num_comments": 11, "author": "someone", "permalink": "/r/taxpros/abc/"}
+
+
+# --- 1. failure is raised, never returned as emptiness ----------------------
+
+def test_both_mirrors_refusing_raises_and_never_returns_empty():
+    """sp-a5461e0a: the kipi-mcp copy returned [] here, so a dead mirror and a
+    quiet subreddit were the same value and no caller could tell them apart."""
+    op = opener_for({"arctic-shift": OSError("arctic down"),
+                     "pullpush": OSError("pullpush down")})
+    with pytest.raises(t.RedditFetchFailed) as err:
+        t.fetch_posts("taxpros", limit=10, _opener=op)
+    assert "arctic" in str(err.value) and "pullpush" in str(err.value)
+
+
+def test_a_quiet_subreddit_returns_empty_and_does_not_raise():
+    """The other half of the same contract. Empty must stay meaningful."""
+    op = opener_for({"arctic-shift": {"data": []}})
+    posts, mirror = t.fetch_posts("taxpros", limit=10, _opener=op)
+    assert posts == [] and mirror == "arctic"
+
+
+def test_pullpush_is_the_fallback_and_reports_itself():
+    op = opener_for({"arctic-shift": OSError("arctic down"),
+                     "pullpush": {"data": [POST]}})
+    posts, mirror = t.fetch_posts("taxpros", limit=10, _opener=op)
+    assert len(posts) == 1 and mirror == "pullpush"
+
+
+def test_comments_raise_rather_than_return_an_empty_thread():
+    op = opener_for({"arctic-shift": OSError("refused")})
+    with pytest.raises(t.RedditFetchFailed):
+        t.comments("t3_abc", _opener=op)
+
+
+def test_author_items_raise_rather_than_return_an_empty_history():
+    op = opener_for({"arctic-shift": OSError("refused")})
+    with pytest.raises(t.RedditFetchFailed):
+        t.author_items("someone", _opener=op)
+
+
+# --- 2. every fetch goes to a mirror ---------------------------------------
+
+MIRROR_HOSTS = ("arctic-shift.photon-reddit.com", "api.pullpush.io")
+
+
+@pytest.mark.parametrize("url", [
+    t.arctic_url("taxpros", 10),
+    t.pullpush_url("taxpros", 10),
+    t.comments_url("t3_abc", 100),
+    t.author_url("posts", "someone", 25),
+    t.author_url("comments", "someone", 25),
+])
+def test_every_url_this_module_builds_is_a_mirror(url):
+    assert any(h in url for h in MIRROR_HOSTS), url
+    assert "reddit.com" not in url.replace("photon-reddit.com", ""), url
+
+
+def test_the_module_names_no_reddit_host_anywhere_it_fetches():
+    """A source-level check, because a new function could add one. Only
+    `normalize` may mention www.reddit.com, and only to BUILD a display link
+    from a permalink, which is not a fetch. Scoped by function rather than by
+    line: the display expression wraps across lines, and a per-line keyword
+    guess passed on one line and failed on its continuation."""
+    src = (PLUGIN_ROOT / "reddit_arctic" / "transport.py").read_text()
+    body = src.split('"""', 2)[-1]          # skip the module docstring
+    func = "module"
+    for line in body.splitlines():
+        if line.startswith("def "):
+            func = line[4:].split("(")[0]
+        if "reddit.com" not in line or "photon-reddit" in line:
+            continue
+        assert "https://www.reddit.com" in line, line
+        assert func == "normalize", "%s must not name a reddit host: %s" % (func, line)
+
+
+# --- 3. read only ----------------------------------------------------------
+
+def test_there_is_no_write_path():
+    src = (PLUGIN_ROOT / "reddit_arctic" / "transport.py").read_text()
+    assert "urlopen(req, data" not in src
+    assert "method=\"POST\"" not in src and "method='POST'" not in src
+    assert ".post(" not in src
+
+
+def test_the_retired_actor_is_named_but_never_called():
+    src = (PLUGIN_ROOT / "reddit_arctic" / "transport.py").read_text()
+    assert t.RETIRED_ACTOR == "trudax/reddit-scraper-lite"
+    assert "api.apify.com" not in src
+
+
+# --- shape -----------------------------------------------------------------
+
+def test_normalize_emits_iso_created_and_carries_the_body():
+    out = t.normalize(POST, "taxpros", "invoice")
+    assert out["created"].startswith("2026-")
+    assert out["body"] == "we key them by hand"
+    assert out["url"] == "https://www.reddit.com/r/taxpros/abc/"
+    assert out["num_comments"] == 11
+    assert out["matched_term"] == "invoice"
+
+
+def test_recent_tags_every_post_with_the_mirror_that_served_it():
+    op = opener_for({"arctic-shift": {"data": [POST]}})
+    posts = t.recent("r/taxpros", max_items=5, _opener=op)
+    assert posts[0]["mirror"] == "arctic"
+    assert posts[0]["matched_term"] == ""
+
+
+def test_recent_still_accepts_the_dead_apify_arguments():
+    """`with_counts` and `token` selected an expensive Apify mode that no longer
+    exists. Callers still pass them; they must not crash."""
+    op = opener_for({"arctic-shift": {"data": [POST]}})
+    assert t.recent("taxpros", max_items=5, with_counts=True, token="x",
+                    _opener=op)
+
+
+def test_search_matches_the_written_body_not_reddits_index():
+    op = opener_for({"arctic-shift": {"data": [POST]}})
+    assert t.search("taxpros", "key them by hand", _opener=op)
+    assert t.search("taxpros", "nothing like this", _opener=op) == []
+
+
+def test_a_bare_list_payload_is_accepted():
+    """One PullPush deployment returns a bare list rather than {"data": [...]}."""
+    op = opener_for({"arctic-shift": [POST]})
+    posts, _ = t.fetch_posts("taxpros", limit=5, _opener=op)
+    assert len(posts) == 1
+
+
+def test_limits_are_capped_at_the_mirrors_own_ceiling():
+    """Asking past the ceiling is not more data, it is a silently truncated
+    answer, which is the shape this module exists to refuse."""
+    assert "limit=100" in t.arctic_url("taxpros", 5000)
+    assert "size=100" in t.pullpush_url("taxpros", 5000)
+
+
+def test_subreddit_prefixes_are_stripped_once_here():
+    for form in ("taxpros", "r/taxpros", "/r/taxpros", "/r/taxpros/"):
+        assert "subreddit=taxpros&" in t.arctic_url(form, 10) + "&"
+
+
+def test_thread_reports_truncation_rather_than_hiding_it():
+    """536 comments off a 1190-comment thread, handed back as a plain list, is
+    indistinguishable from a complete thread. So the ceiling travels with it."""
+    op = opener_for({"arctic-shift": {"data": [{"id": str(i)} for i in range(100)]}})
+    got = t.thread("t3_abc", comment_limit=100, _opener=op)
+    assert got["fetched"] == 100 and got["truncated"] is True
+    assert t.coverage(got["fetched"], 1190) == 8.4
+
+
+def test_coverage_of_a_thread_that_declares_nothing_is_none_not_full():
+    assert t.coverage(0, 0) is None
+    assert t.coverage(0, None) is None
+    assert t.coverage(32, 34) == 94.1

--- a/plugins/kipi-core/reddit_arctic/tests/test_transport.py
+++ b/plugins/kipi-core/reddit_arctic/tests/test_transport.py
@@ -207,3 +207,66 @@ def test_coverage_of_a_thread_that_declares_nothing_is_none_not_full():
     assert t.coverage(0, 0) is None
     assert t.coverage(0, None) is None
     assert t.coverage(32, 34) == 94.1
+
+
+# --- paging, measured rather than assumed ---------------------------------
+
+def test_a_row_tying_the_cursor_second_is_not_dropped():
+    """The cursor is EXCLUSIVE, measured live against Arctic: passing a row's own
+    created_utc as `after` omits every row sharing that second. `seen` protects
+    against an INCLUSIVE cursor, the opposite case, so it could not recover them
+    and a 106-comment thread came back as 105 with complete=True."""
+    rows = [{"id": "c%d" % i, "created_utc": 1788136000 + i} for i in range(100)]
+    rows.append({"id": "c100", "created_utc": 1788136000 + 99})   # ties the edge
+    tail = [{"id": "d%d" % i, "created_utc": 1788136200 + i} for i in range(5)]
+
+    def fake(url):
+        import urllib.parse as up
+        q = dict(up.parse_qsl(url.split("?", 1)[1]))
+        pool = rows + tail
+        if "after" not in q:
+            return {"data": pool[:100]}
+        a = float(q["after"])
+        return {"data": [r for r in pool if r["created_utc"] > a][:100]}
+
+    got = t.all_comments("x", _get=fake)
+    assert {c["id"] for c in got["comments"]} >= {"c100"}, "boundary row dropped"
+    assert got["fetched"] == 106 and got["complete"] is True
+
+
+def test_recent_pages_past_the_ceiling_on_the_measured_cursor():
+    """`recent` used to send min(max_items, 100) and hand back the ceiling with
+    no flag, while MAX_LIMIT's comment called that "the exact shape this module
+    refuses".
+
+    The cursor is `before`, MEASURED 2026-09-05 against r/programming at
+    limit=10: the last row's created_utc passed as `after` returned nine rows
+    OVERLAPPING page one; passed as `before` it returned ten strictly older rows.
+    The first version of this loop used `after` and re-read its own page.
+    """
+    pool = [{"id": "p%d" % i, "title": "t", "subreddit": "x",
+             "created_utc": 1788136000 - i} for i in range(250)]
+
+    def fake(url):
+        import urllib.parse as up
+        q = dict(up.parse_qsl(url.split("?", 1)[1]))
+        if "before" not in q:
+            return {"data": pool[:100]}
+        b = float(q["before"])
+        return {"data": [p for p in pool if p["created_utc"] < b][:100]}
+
+    out = t.recent("x", max_items=250, _get=fake)
+    assert len(out) == 250, len(out)
+    assert len({p["id"] for p in out}) == 250, "the overlap was not deduped"
+
+
+def test_recent_below_the_ceiling_makes_exactly_one_request():
+    """The paging must not cost a second call for the ordinary case."""
+    calls = []
+
+    def fake(url):
+        calls.append(url)
+        return {"data": [{"id": "a", "title": "t", "subreddit": "x"}]}
+
+    t.recent("x", max_items=5, _get=fake)
+    assert len(calls) == 1, calls

--- a/plugins/kipi-core/reddit_arctic/tests/test_transport.py
+++ b/plugins/kipi-core/reddit_arctic/tests/test_transport.py
@@ -270,3 +270,35 @@ def test_recent_below_the_ceiling_makes_exactly_one_request():
 
     t.recent("x", max_items=5, _get=fake)
     assert len(calls) == 1, calls
+
+
+def test_search_pages_because_it_matches_locally():
+    """`search` filters the term HERE, not at the mirror, so one 100-post window
+    is not "the first 100 matches", it is "the matches inside the first 100
+    posts". A room holding ten mentions returned three and said nothing (review,
+    MINOR 4). Same silent truncation `recent` was already fixed for."""
+    pool = [{"id": "p%d" % i, "subreddit": "x", "selftext": "",
+             "title": ("needle" if i % 40 == 0 else "x"),
+             "created_utc": 1788136000 - i} for i in range(250)]
+
+    def fake(url):
+        import urllib.parse as up
+        q = dict(up.parse_qsl(url.split("?", 1)[1]))
+        if "before" not in q:
+            return {"data": pool[:100]}
+        b = float(q["before"])
+        return {"data": [p for p in pool if p["created_utc"] < b][:100]}
+
+    hits = t.search("x", "needle", max_items=10, _get=fake)
+    assert len(hits) > 3, "one window would have found 3"
+
+    # NEGATIVE CONTROL: a short room must still cost exactly one request
+    calls = []
+
+    def one(url):
+        calls.append(url)
+        return {"data": [{"id": "a", "title": "needle", "subreddit": "x",
+                          "selftext": ""}]}
+
+    t.search("x", "needle", _get=one)
+    assert len(calls) == 1, calls

--- a/plugins/kipi-core/reddit_arctic/transport.py
+++ b/plugins/kipi-core/reddit_arctic/transport.py
@@ -391,6 +391,13 @@ def all_comments(link_id: str, *, page_size: int = MAX_LIMIT, max_pages: int = 4
     seen: set = set()
     after = None
     pages = 0
+    # CAP ONCE, HERE. `comments_url` capped internally while the short-page test
+    # below compared against the caller's uncapped number, so page_size=500
+    # asked for 100, got 100, saw 100 < 500, and called a 300-comment thread
+    # complete after one page (PR 307 review, MINOR 5). That is the exact silent
+    # truncation this module's docstring says it exists to end, reintroduced by
+    # comparing against a number the request never used.
+    page_size = min(page_size, MAX_LIMIT)
     while pages < max_pages:
         url = comments_url(link_id, page_size, after=after)
         try:

--- a/plugins/kipi-core/reddit_arctic/transport.py
+++ b/plugins/kipi-core/reddit_arctic/transport.py
@@ -1,0 +1,455 @@
+"""THE ONE WAY THE FLEET READS REDDIT. Arctic Shift, PullPush as the fallback.
+
+Founder-directed 2026-09-04: "change any reddit searches on the entire kipi
+corpus into arctic shift. Any collection from reddit that is not using arctic
+shift should be changed to it. this must be the only way we scrape reddit."
+
+This module is the single home for that. It lives in the kipi-core PLUGIN, not
+in one instance, because the audit that produced it found the same transport
+written twice with opposite failure semantics and four other reddit fetch paths
+besides:
+
+    q-consult/pipeline/reddit_research.py      arctic, raised on total failure
+    kipi_mcp/competitive_intel.py              arctic, returned [] on total
+                                               failure, so a dead mirror and a
+                                               quiet subreddit were the same
+                                               value (sp-a5461e0a)
+    q-system/.q-system/scripts/reddit_read.py  old.reddit.com HTML scrape
+    cole-gtm podcast fetch_reddit_rss          www.reddit.com/.rss
+    cole-gtm podcast fetch_reddit_apify        Apify trudax/reddit-scraper-lite
+    q-consult icp-signal-reddit.py             www.reddit.com/*.json
+
+Every one of those is now a caller of this module. The rule is enforced by
+`tests/test_arctic_is_the_only_reddit_transport.py` here and by the fleet sweep
+in `scripts/reddit-transport-audit.py`, not by this docstring.
+
+## Why Arctic Shift and not Reddit
+
+Arctic Shift is an ARCHIVE MIRROR of Reddit. Free, no auth, no app approval. The
+routes it replaced, and what each one actually did:
+
+    Apify (trudax/reddit-scraper-lite)  the comment-count flag pushed a cell to
+                                        ~240s against a 290s timeout under a
+                                        ~300s server wall. 2 of 10 rooms dead.
+                                        Retired by the founder: "we stopped
+                                        apify - I dont want it."
+    reddit.com over plain HTTP          throttled the same day. HTTP 200 with
+                                        `Retry-After: 0` and a Welcome page.
+    reddit.com/search.json              403 from datacenter IPs.
+    the official OAuth API              app creation is gated behind Reddit
+                                        approval. The founder has tried many
+                                        times and it does not work. Do not
+                                        propose it, and do not resurrect
+                                        `reddit_api_probe.py`, which documents
+                                        an open path that closed.
+    a headful browser profile           forbidden, and unnecessary.
+
+MEASURED 2026-08-31 before any of this was wired, not assumed:
+    r/taxpros        100 posts, 90 carry a comment count, max 66, span 24.9 days
+    r/smallbusiness  100 posts, 100 carry a comment count, span 0.6 days
+So the counts are REAL, which is the thing Apify could not give us without
+blowing its own ceiling. A busy room returning only 14 hours at limit=100 is the
+honest shape of a busy room, not starvation.
+
+## THE RULE THIS MODULE EXISTS TO HOLD
+
+An empty list is never returned for a failed read. `RedditFetchFailed` is
+raised. A quiet subreddit and two dead mirrors produce the same empty list, and
+a caller cannot tell them apart afterwards, so the distinction has to be made
+HERE or it is lost forever. That is the drift this module was built to end: two
+copies of the same transport, one raising and one swallowing, and the swallowing
+one shipped to the whole fleet.
+
+## READ ONLY, structurally
+
+Founder-directed 2026-08-31: "All I want with reddit is to be able to find and
+scrape posts and comments - not find dms etc. I'll post to reddit myself." There
+is no write path here, no POST, and no function whose name is an action. Held by
+`test_there_is_no_write_path`.
+
+## We identify ourselves truthfully
+
+`USER_AGENT` names the client and gives a contact URL. Impersonating a browser
+would be a choice to look like something we are not, made for no benefit. The
+mirror needs no auth and no costume, so there is nothing to gain by wearing one.
+"""
+from __future__ import annotations
+
+import datetime as dt
+import json
+import urllib.parse
+import urllib.request
+
+ARCTIC_BASE = "https://arctic-shift.photon-reddit.com"
+PULLPUSH_BASE = "https://api.pullpush.io"
+USER_AGENT = "kipi-research/1.0 (+https://ktlyst.com; research)"
+
+# The mirror is a plain JSON API, not a hosted actor run, so the ~300s Apify
+# server wall that shaped every timeout number in the retired path no longer
+# applies. 45s is generous for a call measured under 3s.
+DEFAULT_TIMEOUT = 45
+DEFAULT_MAX_ITEMS = 15
+
+# Arctic's own ceiling. Asking for more is not an error and not more data; it is
+# a silently truncated answer, which is the exact shape this module refuses.
+MAX_LIMIT = 100
+
+# RETIRED, kept as a name rather than deleted so a session that greps for the
+# actor finds this note instead of finding nothing and re-adding it. Nothing in
+# the fleet may call it. Held by the fleet audit script.
+RETIRED_ACTOR = "trudax/reddit-scraper-lite"
+
+
+class RedditFetchFailed(RuntimeError):
+    """Every mirror refused. Raised, never returned as an empty list, because an
+    empty list is indistinguishable from an empty subreddit."""
+
+
+# ---------------------------------------------------------------------------
+# transport
+
+
+def _get_json(url: str, timeout: int, _opener=None, _get=None):
+    """Two injection seams, because the callers already had two shapes.
+
+    `_opener` replaces `urllib.request.urlopen` and is what a test that wants to
+    assert on headers or on the built Request uses. `_get` replaces the whole
+    fetch with `fn(url) -> parsed json`, which is the shape kipi-mcp's collectors
+    already inject everywhere (`fetch_json`). Supporting both is what let those
+    collectors move onto this transport without rewriting their test doubles;
+    the alternative was a second copy of the transport, which is the defect this
+    module exists to end."""
+    if _get is not None:
+        return _get(url)
+    opener = _opener or urllib.request.urlopen
+    req = urllib.request.Request(url, headers={"User-Agent": USER_AGENT})
+    with opener(req, timeout=timeout) as resp:
+        return json.loads(resp.read().decode("utf-8", "replace"))
+
+
+def _items(payload) -> list:
+    """Arctic wraps rows in {"data": [...]}. PullPush does the same. A bare list
+    is accepted because one PullPush deployment returns one."""
+    if isinstance(payload, dict):
+        data = payload.get("data")
+        return data if isinstance(data, list) else []
+    return payload if isinstance(payload, list) else []
+
+
+def arctic_url(subreddit: str, limit: int, *, after: str = "") -> str:
+    q = {"subreddit": _clean_sub(subreddit), "limit": min(limit, MAX_LIMIT),
+         "sort": "desc"}
+    if after:
+        q["after"] = after
+    return f"{ARCTIC_BASE}/api/posts/search?{urllib.parse.urlencode(q)}"
+
+
+def pullpush_url(subreddit: str, limit: int) -> str:
+    q = {"subreddit": _clean_sub(subreddit), "size": min(limit, MAX_LIMIT),
+         "sort": "desc"}
+    return f"{PULLPUSH_BASE}/reddit/search/submission?{urllib.parse.urlencode(q)}"
+
+
+def _clean_sub(subreddit: str) -> str:
+    return (subreddit or "").lstrip("/").removeprefix("r/").strip().rstrip("/")
+
+
+def fetch_posts(subreddit: str, *, limit: int = DEFAULT_MAX_ITEMS,
+                after: str = "", timeout: int = DEFAULT_TIMEOUT,
+                _opener=None, _get=None) -> tuple[list, str]:
+    """Arctic Shift first, PullPush second. Returns (raw posts, which mirror).
+
+    The fallback is a DIFFERENT HOST, which is what makes it a fallback rather
+    than the identical-retry shape that made Apify's `retries=1` worthless.
+    """
+    try:
+        return _items(_get_json(arctic_url(subreddit, limit, after=after),
+                                timeout, _opener, _get)), "arctic"
+    except Exception as arctic_exc:
+        try:
+            return _items(_get_json(pullpush_url(subreddit, limit),
+                                    timeout, _opener, _get)), "pullpush"
+        except Exception as pullpush_exc:
+            raise RedditFetchFailed(
+                "both mirrors refused r/%s: arctic=%s: %s; pullpush=%s: %s"
+                % (_clean_sub(subreddit), type(arctic_exc).__name__, arctic_exc,
+                   type(pullpush_exc).__name__, pullpush_exc))
+
+
+def comments_url(link_id: str, limit: int, after=None) -> str:
+    q = {"link_id": str(link_id).removeprefix("t3_"), "limit": min(limit, MAX_LIMIT),
+         "sort": "asc",
+         "fields": "id,created_utc,author,parent_id,body,score"}
+    if after is not None:
+        q["after"] = after
+    return f"{ARCTIC_BASE}/api/comments/search?{urllib.parse.urlencode(q)}"
+
+
+def comments(link_id: str, *, limit: int = MAX_LIMIT,
+             timeout: int = DEFAULT_TIMEOUT, _opener=None, _get=None) -> list[dict]:
+    """Every comment on one thread, oldest first. Raises on a refused read: an
+    empty list is a QUIET thread and must never be a broken fetch wearing one."""
+    try:
+        data = _get_json(comments_url(link_id, limit), timeout, _opener, _get)
+    except Exception as exc:
+        raise RedditFetchFailed("mirror refused comments for %s: %s: %s"
+                                % (link_id, type(exc).__name__, exc))
+    return _items(data)
+
+
+def author_url(kind: str, author: str, limit: int) -> str:
+    if kind not in ("posts", "comments"):
+        raise ValueError("kind must be posts or comments, got %r" % (kind,))
+    q = {"author": author, "limit": min(limit, MAX_LIMIT), "sort": "desc",
+         "fields": ("id,created_utc,subreddit,title,selftext" if kind == "posts"
+                    else "id,created_utc,subreddit,body")}
+    return f"{ARCTIC_BASE}/api/{kind}/search?{urllib.parse.urlencode(q)}"
+
+
+def author_items(author: str, *, limit: int = 25, timeout: int = DEFAULT_TIMEOUT,
+                 _opener=None, _get=None) -> dict:
+    """{"posts": [...], "comments": [...]} for one author, newest first.
+    Raises on a refused read, for the reason `comments` does."""
+    out = {}
+    for kind in ("posts", "comments"):
+        try:
+            data = _get_json(author_url(kind, author, limit), timeout, _opener, _get)
+        except Exception as exc:
+            raise RedditFetchFailed("mirror refused %s for u/%s: %s: %s"
+                                    % (kind, author, type(exc).__name__, exc))
+        out[kind] = _items(data)
+    return out
+
+
+# ---------------------------------------------------------------------------
+# one shape for every consumer
+
+
+def normalize(r: dict, subreddit: str = "", term: str = "") -> dict:
+    """One shape for every consumer, so scoring code never re-learns a source's
+    field aliases. Bodies are ALWAYS carried: the tell lives in bodies, not
+    titles, and a title-only corpus produced a confident n=0 on 2026-08-04.
+
+    Arctic Shift and PullPush both return Reddit's OWN post object, so the field
+    names here are Reddit's (`selftext`, `num_comments`, `created_utc`) rather
+    than a scraper's rewording of them. The old Apify aliases are kept as a
+    second choice so a corpus captured before 2026-08-31 still loads; every one
+    of them is dead on the live path.
+
+    `created` is emitted as an ISO string because every consumer parses it that
+    way. Reddit hands back a unix float, so the conversion happens HERE, at the
+    one normalisation chokepoint, rather than in each caller.
+    """
+    created = r.get("created_utc") or r.get("created")
+    if isinstance(created, (int, float)):
+        created = dt.datetime.fromtimestamp(created, dt.timezone.utc).isoformat()
+    permalink = r.get("permalink") or ""
+    return {
+        "subreddit": (r.get("subreddit") or r.get("communityName")
+                      or r.get("parsedCommunityName") or _clean_sub(subreddit)),
+        "matched_term": term,
+        "title": (r.get("title") or "").strip(),
+        "body": r.get("selftext") or r.get("body") or r.get("text") or "",
+        "url": (r.get("url") if str(r.get("url", "")).startswith("https://www.reddit.com")
+                else ("https://www.reddit.com" + permalink if permalink
+                      else r.get("url") or r.get("link") or "")),
+        "created": created or r.get("createdAt") or r.get("postedDate") or "",
+        "score": r.get("score") if r.get("score") is not None else (r.get("upVotes") or 0),
+        "num_comments": (r.get("num_comments") if r.get("num_comments") is not None
+                         else (r.get("numberOfComments") or 0)),
+        "author": r.get("author") or r.get("username") or "",
+        "id": r.get("id") or "",
+        "permalink": permalink,
+    }
+
+
+def recent(subreddit: str, *, max_items: int = 60, timeout: int = DEFAULT_TIMEOUT,
+           _opener=None, _get=None, **_ignored) -> list[dict]:
+    """One room's recent posts, normalized. Synchronous.
+
+    `matched_term` is deliberately empty: nothing was searched for, so nothing
+    may claim to have matched.
+
+    A thin result here is a QUIET ROOM and may be trusted as one, which was
+    never true of the Apify path. Measured 2026-08-31: r/taxpros returned 7
+    posts inside a 3-day window and r/smallbusiness returned 100, from the same
+    call with the same limit.
+
+    `**_ignored` swallows `with_counts` and `token`, which the retired Apify
+    path needed. The mirror returns `num_comments` on every post for free and
+    needs no auth, so there is no cheap arm and expensive arm to choose between
+    any more. Kept as accepted-and-unused rather than removed so a caller that
+    still passes them does not crash on an argument that stopped mattering.
+    """
+    raw, mirror = fetch_posts(subreddit, limit=max_items, timeout=timeout,
+                              _opener=_opener, _get=_get)
+    out = []
+    for record in raw:
+        post = normalize(record, subreddit, "")
+        post["mirror"] = mirror
+        out.append(post)
+    return out
+
+
+def search(subreddit: str, term: str, *, max_items: int = DEFAULT_MAX_ITEMS,
+           timeout: int = DEFAULT_TIMEOUT, _opener=None, _get=None,
+           **_ignored) -> list[dict]:
+    """One subreddit, one term, from the same mirror `recent` uses.
+
+    The mirror has no term parameter on the posts endpoint, so the term is
+    applied HERE against title and body. That is a real behaviour change from
+    the old Reddit search: it matches what people WROTE rather than what
+    Reddit's index would return for a query. The 2026-08-27 measurement said
+    Reddit's own search could not match the corpus phrases anyway and silently
+    returned the room feed on a miss, so this is the honest version of what was
+    already happening.
+    """
+    raw, mirror = fetch_posts(subreddit, limit=max(max_items * 4, MAX_LIMIT),
+                              timeout=timeout, _opener=_opener, _get=_get)
+    needle = (term or "").lower().strip()
+    hits = []
+    for record in raw:
+        post = normalize(record, subreddit, term)
+        post["mirror"] = mirror
+        if not needle or needle in (post["title"] + " " + post["body"]).lower():
+            hits.append(post)
+        if len(hits) >= max_items:
+            break
+    return hits
+
+
+def thread(link_id: str, *, comment_limit: int = MAX_LIMIT,
+           timeout: int = DEFAULT_TIMEOUT, _opener=None, _get=None) -> dict:
+    """One thread's comments plus the coverage the read actually achieved.
+
+    THE COVERAGE FIELD IS THE POINT. It replaces the old HTML reader's coverage
+    rule, and it exists for the same reason: 536 comments handed back off a
+    1190-comment thread, as a plain list, is indistinguishable from a complete
+    thread. Silent truncation. So the count that came back and the ceiling that
+    bounded it both travel with the data, and a caller that wants completeness
+    can see it did not get it.
+
+    `declared` is not available from the comments endpoint alone. A caller that
+    has the post (and therefore its `num_comments`) passes it to
+    `coverage` itself; this function reports what it fetched and what capped it.
+    """
+    got = comments(link_id, limit=comment_limit, timeout=timeout,
+                   _opener=_opener, _get=_get)
+    return {
+        "link_id": str(link_id).removeprefix("t3_"),
+        "comments": got,
+        "fetched": len(got),
+        "limit": min(comment_limit, MAX_LIMIT),
+        "truncated": len(got) >= min(comment_limit, MAX_LIMIT),
+        "source": "arctic",
+    }
+
+
+def coverage(fetched: int, declared) -> float | None:
+    """Percent of the declared comment count actually read. None when the thread
+    declares nothing, because 0/0 is not 100%."""
+    try:
+        declared = int(declared)
+    except (TypeError, ValueError):
+        return None
+    if declared <= 0:
+        return None
+    return round(100.0 * fetched / declared, 1)
+
+
+def all_comments(link_id: str, *, page_size: int = MAX_LIMIT, max_pages: int = 40,
+                 timeout: int = DEFAULT_TIMEOUT, _opener=None, _get=None) -> dict:
+    """Every comment on a thread, paging until the mirror stops handing them over.
+
+    THIS IS THE THING THE HTML READER COULD NOT DO. That reader measured its own
+    truncation and reported it honestly (536 of 1190 on the worst thread), which
+    was the right answer to a wrong transport. The mirror paginates on
+    `after=<created_utc>`, so the honest answer here is a COMPLETE thread rather
+    than a well-labelled partial one.
+
+    VERIFIED LIVE 2026-09-04 against r/programming thread 1w67dpg, which declares
+    108 comments: page one returned 100, page two returned 11. The archive can
+    hold slightly more rows than the live post declares, which is why `complete`
+    is decided by a short page and never by matching a declared count.
+
+    `max_pages` is a real ceiling and a hit one is reported, not hidden. Returns
+    the same coverage vocabulary the artifact contract already uses.
+    """
+    out: list[dict] = []
+    seen: set = set()
+    after = None
+    pages = 0
+    while pages < max_pages:
+        url = comments_url(link_id, page_size, after=after)
+        try:
+            batch = _items(_get_json(url, timeout, _opener, _get))
+        except Exception as exc:
+            raise RedditFetchFailed("mirror refused comments page %d for %s: %s: %s"
+                                    % (pages + 1, link_id, type(exc).__name__, exc))
+        pages += 1
+        fresh = [c for c in batch if c.get("id") not in seen]
+        for c in fresh:
+            seen.add(c.get("id"))
+        out.extend(fresh)
+        # A SHORT PAGE ENDS IT, not an empty one. Waiting for empty costs an
+        # extra request on every thread; a page under the size asked for cannot
+        # be followed by more rows under `after` ordering.
+        if len(batch) < page_size:
+            return _thread_result(link_id, out, pages, complete=True, capped=False)
+        nxt = batch[-1].get("created_utc")
+        if nxt is None or nxt == after:
+            # No cursor to advance on. Stopping is correct; claiming completeness
+            # is not, because the next page was never asked for.
+            return _thread_result(link_id, out, pages, complete=False, capped=False)
+        after = nxt
+    return _thread_result(link_id, out, pages, complete=False, capped=True)
+
+
+def _thread_result(link_id, got, pages, *, complete, capped) -> dict:
+    return {
+        "link_id": str(link_id).removeprefix("t3_"),
+        "comments": got,
+        "fetched": len(got),
+        "pages": pages,
+        "complete": complete,
+        "capped": capped,
+        "source": "arctic",
+    }
+
+
+def posts_by_id_url(ids) -> str:
+    if isinstance(ids, str):
+        ids = [ids]
+    clean = ",".join(str(i).removeprefix("t3_") for i in ids)
+    return f"{ARCTIC_BASE}/api/posts/ids?ids={urllib.parse.quote(clean)}"
+
+
+def posts_by_id(ids, *, timeout: int = DEFAULT_TIMEOUT, _opener=None,
+                _get=None) -> list[dict]:
+    """The post objects for specific ids, raw.
+
+    This is what makes a thread read able to state its DECLARED comment count,
+    which is the number the whole coverage contract is measured against.
+    VERIFIED LIVE 2026-09-04: /api/posts/ids?ids=1w67dpg returned one row with
+    num_comments 108 and the full permalink.
+
+    There is no PullPush fallback on this endpoint. A caller that loses it loses
+    `declared`, not the thread, so it raises here and the caller decides.
+    """
+    try:
+        return _items(_get_json(posts_by_id_url(ids), timeout, _opener, _get))
+    except Exception as exc:
+        raise RedditFetchFailed("mirror refused posts %s: %s: %s"
+                                % (ids, type(exc).__name__, exc))
+
+
+def link_id_from_permalink(permalink: str) -> str:
+    """`/r/x/comments/<id>/slug/` -> `<id>`. Accepts a bare id and a full url.
+
+    One parser, because every caller had its own and a wrong one silently reads
+    a different thread rather than failing."""
+    text = str(permalink or "").strip()
+    if "/comments/" in text:
+        tail = text.split("/comments/", 1)[1]
+        return tail.split("/", 1)[0].split("?", 1)[0]
+    return text.strip("/").split("/")[-1].split("?", 1)[0].removeprefix("t3_")

--- a/plugins/kipi-core/reddit_arctic/transport.py
+++ b/plugins/kipi-core/reddit_arctic/transport.py
@@ -77,12 +77,24 @@ from __future__ import annotations
 
 import datetime as dt
 import json
+import os
 import urllib.parse
 import urllib.request
 
 ARCTIC_BASE = "https://arctic-shift.photon-reddit.com"
 PULLPUSH_BASE = "https://api.pullpush.io"
-USER_AGENT = "kipi-research/1.0 (+https://ktlyst.com; research)"
+# NO COMPANY DOMAIN HERE. This module ships to every instance through the
+# skeleton, and validate-separation.py fails the build on a hardcoded brand
+# reference for exactly that reason: one instance's domain baked into fleet code
+# is wrong in every other instance. It cost this change a red `validate` on
+# 2026-09-05, which was the gate doing its job.
+#
+# We still identify ourselves truthfully. The default names the client and its
+# purpose and claims no affiliation; an instance that wants a contact URL sets
+# KIPI_REDDIT_UA. Impersonating a browser would be a choice to look like
+# something we are not, made for no benefit, since the mirror needs no auth.
+USER_AGENT = os.environ.get(
+    "KIPI_REDDIT_UA", "kipi-research/1.0 (automated research; contact via repo)")
 
 # The mirror is a plain JSON API, not a hosted actor run, so the ~300s Apify
 # server wall that shaped every timeout number in the retired path no longer

--- a/plugins/kipi-core/reddit_arctic/transport.py
+++ b/plugins/kipi-core/reddit_arctic/transport.py
@@ -365,7 +365,16 @@ def search(subreddit: str, term: str, *, max_items: int = DEFAULT_MAX_ITEMS,
     # rare term could otherwise walk a room forever looking for its tenth hit.
     raw, mirror = fetch_posts(subreddit, limit=MAX_LIMIT,
                               timeout=timeout, _opener=_opener, _get=_get)
-    if len(raw) >= MAX_LIMIT:
+    needle_early = (term or "").lower().strip()
+
+    def _hits(rows):
+        if not needle_early:
+            return len(rows)
+        return sum(1 for r in rows
+                   if needle_early in ((r.get("title") or "") + " " +
+                                       (r.get("selftext") or r.get("body") or "")).lower())
+
+    if len(raw) >= MAX_LIMIT and _hits(raw) < max_items:
         seen_ids = {r.get("id") for r in raw}
         cursor = None
         for _ in range(10):
@@ -380,7 +389,10 @@ def search(subreddit: str, term: str, *, max_items: int = DEFAULT_MAX_ITEMS,
             fresh = [r for r in page if r.get("id") not in seen_ids]
             seen_ids.update(r.get("id") for r in fresh)
             raw.extend(fresh)
-            if len(page) < MAX_LIMIT:
+            # STOP ONCE ENOUGH MATCHES ARE IN HAND. It used to page to its
+            # ceiling regardless, spending 11 fetches to return 15 hits
+            # (review). The term is matched here, so the count is knowable here.
+            if len(page) < MAX_LIMIT or _hits(raw) >= max_items:
                 break
     needle = (term or "").lower().strip()
     hits = []

--- a/plugins/kipi-core/reddit_arctic/transport.py
+++ b/plugins/kipi-core/reddit_arctic/transport.py
@@ -355,8 +355,33 @@ def search(subreddit: str, term: str, *, max_items: int = DEFAULT_MAX_ITEMS,
     returned the room feed on a miss, so this is the honest version of what was
     already happening.
     """
-    raw, mirror = fetch_posts(subreddit, limit=max(max_items * 4, MAX_LIMIT),
+    # PAGE, like `recent` does, and for the reason `recent` was fixed. The
+    # matching happens HERE rather than at the mirror, so one 100-post window is
+    # not "the first 100 matches", it is "the matches inside the first 100
+    # posts". A room holding ten mentions of the term returned three, and
+    # nothing said so (review, MINOR 4).
+    #
+    # The scan is bounded by pages, not by the caller's max_items, because a
+    # rare term could otherwise walk a room forever looking for its tenth hit.
+    raw, mirror = fetch_posts(subreddit, limit=MAX_LIMIT,
                               timeout=timeout, _opener=_opener, _get=_get)
+    if len(raw) >= MAX_LIMIT:
+        seen_ids = {r.get("id") for r in raw}
+        cursor = None
+        for _ in range(10):
+            last = raw[-1].get("created_utc")
+            nxt = (last + 1) if isinstance(last, (int, float)) else None
+            if nxt is None or nxt == cursor:
+                break
+            cursor = nxt
+            page, _m = fetch_posts(subreddit, limit=MAX_LIMIT,
+                                   before=str(cursor), timeout=timeout,
+                                   _opener=_opener, _get=_get)
+            fresh = [r for r in page if r.get("id") not in seen_ids]
+            seen_ids.update(r.get("id") for r in fresh)
+            raw.extend(fresh)
+            if len(page) < MAX_LIMIT:
+                break
     needle = (term or "").lower().strip()
     hits = []
     for record in raw:

--- a/plugins/kipi-core/reddit_arctic/transport.py
+++ b/plugins/kipi-core/reddit_arctic/transport.py
@@ -148,11 +148,20 @@ def _items(payload) -> list:
     return payload if isinstance(payload, list) else []
 
 
-def arctic_url(subreddit: str, limit: int, *, after: str = "") -> str:
+def arctic_url(subreddit: str, limit: int, *, after: str = "",
+               before: str = "") -> str:
     q = {"subreddit": _clean_sub(subreddit), "limit": min(limit, MAX_LIMIT),
          "sort": "desc"}
     if after:
         q["after"] = after
+    # `before` is the cursor for a DESCENDING page, and that is measured rather
+    # than assumed (2026-09-05, r/programming, limit=10): passing the last row's
+    # created_utc as `after` returned nine rows that OVERLAPPED page one, newest
+    # first. Passing it as `before` returned ten strictly older rows with no
+    # overlap. A first attempt at paging `recent` used `after` and would have
+    # re-fetched the page it had just read.
+    if before:
+        q["before"] = before
     return f"{ARCTIC_BASE}/api/posts/search?{urllib.parse.urlencode(q)}"
 
 
@@ -167,7 +176,8 @@ def _clean_sub(subreddit: str) -> str:
 
 
 def fetch_posts(subreddit: str, *, limit: int = DEFAULT_MAX_ITEMS,
-                after: str = "", timeout: int = DEFAULT_TIMEOUT,
+                after: str = "", before: str = "",
+                timeout: int = DEFAULT_TIMEOUT,
                 _opener=None, _get=None) -> tuple[list, str]:
     """Arctic Shift first, PullPush second. Returns (raw posts, which mirror).
 
@@ -175,7 +185,8 @@ def fetch_posts(subreddit: str, *, limit: int = DEFAULT_MAX_ITEMS,
     than the identical-retry shape that made Apify's `retries=1` worthless.
     """
     try:
-        return _items(_get_json(arctic_url(subreddit, limit, after=after),
+        return _items(_get_json(arctic_url(subreddit, limit, after=after,
+                                           before=before),
                                 timeout, _opener, _get)), "arctic"
     except Exception as arctic_exc:
         try:
@@ -293,8 +304,36 @@ def recent(subreddit: str, *, max_items: int = 60, timeout: int = DEFAULT_TIMEOU
     any more. Kept as accepted-and-unused rather than removed so a caller that
     still passes them does not crash on an argument that stopped mattering.
     """
-    raw, mirror = fetch_posts(subreddit, limit=max_items, timeout=timeout,
-                              _opener=_opener, _get=_get)
+    # PAGE, rather than quietly hand back the ceiling. This used to send
+    # min(max_items, 100) and return whatever came, with no flag, while the
+    # comment at MAX_LIMIT said asking above the ceiling yields "a silently
+    # truncated answer, which is the exact shape this module refuses" (review,
+    # MINOR 4: a comment contradicting its own code twenty lines down).
+    #
+    # The cursor is `before`, MEASURED, not guessed. The first version of this
+    # loop used `after` and re-fetched the page it had just read. `+ 1` keeps a
+    # row that ties the boundary second, and `seen` throws away the overlap that
+    # buys, which is the same trade `all_comments` makes for the same reason.
+    raw, mirror = fetch_posts(subreddit, limit=min(max_items, MAX_LIMIT),
+                              timeout=timeout, _opener=_opener, _get=_get)
+    if max_items > MAX_LIMIT and len(raw) >= MAX_LIMIT:
+        seen_ids = {r.get("id") for r in raw}
+        cursor = None
+        for _ in range(20):                  # a real ceiling, not a while True
+            last = raw[-1].get("created_utc")
+            nxt = (last + 1) if isinstance(last, (int, float)) else None
+            if nxt is None or nxt == cursor:
+                break
+            cursor = nxt
+            page, _m = fetch_posts(subreddit, limit=MAX_LIMIT,
+                                   before=str(cursor), timeout=timeout,
+                                   _opener=_opener, _get=_get)
+            fresh = [r for r in page if r.get("id") not in seen_ids]
+            seen_ids.update(r.get("id") for r in fresh)
+            raw.extend(fresh)
+            if len(raw) >= max_items or len(page) < MAX_LIMIT:
+                break
+        raw = raw[:max_items]
     out = []
     for record in raw:
         post = normalize(record, subreddit, "")
@@ -415,7 +454,19 @@ def all_comments(link_id: str, *, page_size: int = MAX_LIMIT, max_pages: int = 4
         # be followed by more rows under `after` ordering.
         if len(batch) < page_size:
             return _thread_result(link_id, out, pages, complete=True, capped=False)
-        nxt = batch[-1].get("created_utc")
+        # THE CURSOR IS EXCLUSIVE, so step BACK one second and let `seen` dedupe
+        # the overlap. Measured live against Arctic in review: passing a row's
+        # own created_utc as `after` returns the rows AFTER it and omits every
+        # row sharing that second. The `seen` set protects against an inclusive
+        # cursor, which is the opposite case, so it could not recover them: a
+        # 106-comment thread came back as 105 rows with complete=True. A missing
+        # comment reported as a whole thread is the silent truncation this
+        # module exists to end.
+        #
+        # Overlapping by a second costs at most one repeated page of rows that
+        # `seen` throws away. Losing a comment costs a comment, silently.
+        last = batch[-1].get("created_utc")
+        nxt = (last - 1) if isinstance(last, (int, float)) else last
         if nxt is None or nxt == after:
             # No cursor to advance on. Stopping is correct; claiming completeness
             # is not, because the next page was never asked for.

--- a/plugins/kipi-core/reddit_arctic/transport.py
+++ b/plugins/kipi-core/reddit_arctic/transport.py
@@ -112,6 +112,13 @@ MAX_LIMIT = 100
 RETIRED_ACTOR = "trudax/reddit-scraper-lite"
 
 
+# A CALLER'S DEADLINE IS NOT A MIRROR REFUSAL. `reddit_read` paces and bounds a
+# whole read by raising TimeoutError from its own opener; wrapping that into
+# RedditFetchFailed made an over-budget read indistinguishable from a host that
+# said no, and the caller then threw away pages the mirror had already returned
+# 200 for (PR 307 round 8). Every `except` below re-raises it unchanged.
+
+
 class RedditFetchFailed(RuntimeError):
     """Every mirror refused. Raised, never returned as an empty list, because an
     empty list is indistinguishable from an empty subreddit."""
@@ -188,10 +195,14 @@ def fetch_posts(subreddit: str, *, limit: int = DEFAULT_MAX_ITEMS,
         return _items(_get_json(arctic_url(subreddit, limit, after=after,
                                            before=before),
                                 timeout, _opener, _get)), "arctic"
+    except TimeoutError:
+        raise
     except Exception as arctic_exc:
         try:
             return _items(_get_json(pullpush_url(subreddit, limit),
                                     timeout, _opener, _get)), "pullpush"
+        except TimeoutError:
+            raise
         except Exception as pullpush_exc:
             raise RedditFetchFailed(
                 "both mirrors refused r/%s: arctic=%s: %s; pullpush=%s: %s"
@@ -214,6 +225,8 @@ def comments(link_id: str, *, limit: int = MAX_LIMIT,
     empty list is a QUIET thread and must never be a broken fetch wearing one."""
     try:
         data = _get_json(comments_url(link_id, limit), timeout, _opener, _get)
+    except TimeoutError:
+        raise
     except Exception as exc:
         raise RedditFetchFailed("mirror refused comments for %s: %s: %s"
                                 % (link_id, type(exc).__name__, exc))
@@ -237,6 +250,8 @@ def author_items(author: str, *, limit: int = 25, timeout: int = DEFAULT_TIMEOUT
     for kind in ("posts", "comments"):
         try:
             data = _get_json(author_url(kind, author, limit), timeout, _opener, _get)
+        except TimeoutError:
+            raise
         except Exception as exc:
             raise RedditFetchFailed("mirror refused %s for u/%s: %s: %s"
                                     % (kind, author, type(exc).__name__, exc))
@@ -478,6 +493,8 @@ def all_comments(link_id: str, *, page_size: int = MAX_LIMIT, max_pages: int = 4
         url = comments_url(link_id, page_size, after=after)
         try:
             batch = _items(_get_json(url, timeout, _opener, _get))
+        except TimeoutError:
+            raise
         except Exception as exc:
             raise RedditFetchFailed("mirror refused comments page %d for %s: %s: %s"
                                     % (pages + 1, link_id, type(exc).__name__, exc))
@@ -545,6 +562,8 @@ def posts_by_id(ids, *, timeout: int = DEFAULT_TIMEOUT, _opener=None,
     """
     try:
         return _items(_get_json(posts_by_id_url(ids), timeout, _opener, _get))
+    except TimeoutError:
+        raise
     except Exception as exc:
         raise RedditFetchFailed("mirror refused posts %s: %s: %s"
                                 % (ids, type(exc).__name__, exc))

--- a/plugins/kipi-core/reddit_arctic/transport.py
+++ b/plugins/kipi-core/reddit_arctic/transport.py
@@ -112,11 +112,24 @@ MAX_LIMIT = 100
 RETIRED_ACTOR = "trudax/reddit-scraper-lite"
 
 
-# A CALLER'S DEADLINE IS NOT A MIRROR REFUSAL. `reddit_read` paces and bounds a
-# whole read by raising TimeoutError from its own opener; wrapping that into
-# RedditFetchFailed made an over-budget read indistinguishable from a host that
-# said no, and the caller then threw away pages the mirror had already returned
-# 200 for (PR 307 round 8). Every `except` below re-raises it unchanged.
+# A CALLER'S DEADLINE IS NOT A MIRROR REFUSAL, and it is NOT A NETWORK TIMEOUT
+# EITHER. Round 8 expressed the first half by letting bare TimeoutError through
+# every handler here, which was wrong for a reason worth stating plainly:
+# `socket.timeout` IS `TimeoutError` since Python 3.10. So a genuinely hung
+# mirror stopped falling back to PullPush and crashed out of read_thread, at
+# exactly the moment a fallback matters most (PR 307 round 9).
+#
+# The distinction is a DEDICATED class, not a builtin somebody else also raises.
+# ReadDeadlineExceeded is raised only by a caller's own budget and only that
+# propagates; a socket timeout is a refusal like any other and takes the
+# fallback.
+
+
+class ReadDeadlineExceeded(Exception):
+    """A CALLER ran out of its own time budget. Never raised by this module and
+    never caught by it: the caller sets the budget, so the caller hears about
+    it. Distinct from socket.timeout, which is a host problem and gets the
+    ordinary fallback."""
 
 
 class RedditFetchFailed(RuntimeError):
@@ -148,11 +161,26 @@ def _get_json(url: str, timeout: int, _opener=None, _get=None):
 
 def _items(payload) -> list:
     """Arctic wraps rows in {"data": [...]}. PullPush does the same. A bare list
-    is accepted because one PullPush deployment returns one."""
+    is accepted because one PullPush deployment returns one.
+
+    AN UNRECOGNISED BODY IS A FAILURE, NOT AN EMPTY ROOM. This returned [] for
+    anything it did not recognise, so a 200 carrying an error object, an HTML
+    interstitial or a renamed field made `all_comments` report complete=True and
+    truncated=False for a thread it had read none of (PR 307 round 9). That is
+    the module's founding defect, arriving through the parser instead of through
+    the fetch.
+    """
+    if isinstance(payload, list):
+        return payload
     if isinstance(payload, dict):
         data = payload.get("data")
-        return data if isinstance(data, list) else []
-    return payload if isinstance(payload, list) else []
+        if isinstance(data, list):
+            return data
+        if data is None and not payload:
+            return []          # a genuinely empty object is an empty answer
+    raise RedditFetchFailed(
+        "unrecognised mirror body (%s); refusing to read it as an empty result"
+        % type(payload).__name__)
 
 
 def arctic_url(subreddit: str, limit: int, *, after: str = "",
@@ -195,13 +223,13 @@ def fetch_posts(subreddit: str, *, limit: int = DEFAULT_MAX_ITEMS,
         return _items(_get_json(arctic_url(subreddit, limit, after=after,
                                            before=before),
                                 timeout, _opener, _get)), "arctic"
-    except TimeoutError:
+    except ReadDeadlineExceeded:
         raise
     except Exception as arctic_exc:
         try:
             return _items(_get_json(pullpush_url(subreddit, limit),
                                     timeout, _opener, _get)), "pullpush"
-        except TimeoutError:
+        except ReadDeadlineExceeded:
             raise
         except Exception as pullpush_exc:
             raise RedditFetchFailed(
@@ -225,7 +253,7 @@ def comments(link_id: str, *, limit: int = MAX_LIMIT,
     empty list is a QUIET thread and must never be a broken fetch wearing one."""
     try:
         data = _get_json(comments_url(link_id, limit), timeout, _opener, _get)
-    except TimeoutError:
+    except ReadDeadlineExceeded:
         raise
     except Exception as exc:
         raise RedditFetchFailed("mirror refused comments for %s: %s: %s"
@@ -250,7 +278,7 @@ def author_items(author: str, *, limit: int = 25, timeout: int = DEFAULT_TIMEOUT
     for kind in ("posts", "comments"):
         try:
             data = _get_json(author_url(kind, author, limit), timeout, _opener, _get)
-        except TimeoutError:
+        except ReadDeadlineExceeded:
             raise
         except Exception as exc:
             raise RedditFetchFailed("mirror refused %s for u/%s: %s: %s"
@@ -493,7 +521,11 @@ def all_comments(link_id: str, *, page_size: int = MAX_LIMIT, max_pages: int = 4
         url = comments_url(link_id, page_size, after=after)
         try:
             batch = _items(_get_json(url, timeout, _opener, _get))
-        except TimeoutError:
+        except ReadDeadlineExceeded as exc:
+            # HAND BACK WHAT WAS ALREADY COLLECTED. The caller's budget ran out;
+            # the rows it already paid for are not the mirror's to take back, and
+            # `read_thread` builds its partial artifact from exactly this.
+            exc.partial = out
             raise
         except Exception as exc:
             raise RedditFetchFailed("mirror refused comments page %d for %s: %s: %s"
@@ -562,7 +594,7 @@ def posts_by_id(ids, *, timeout: int = DEFAULT_TIMEOUT, _opener=None,
     """
     try:
         return _items(_get_json(posts_by_id_url(ids), timeout, _opener, _get))
-    except TimeoutError:
+    except ReadDeadlineExceeded:
         raise
     except Exception as exc:
         raise RedditFetchFailed("mirror refused posts %s: %s: %s"

--- a/q-system/.q-system/scripts/reddit-transport-audit.py
+++ b/q-system/.q-system/scripts/reddit-transport-audit.py
@@ -128,6 +128,27 @@ SKIP_DIR_PARTS = (
 # SKIP_DIR_PARTS is compared as a whole segment.
 _FRAGMENT_TOKENS = {".wt-", "-wt-", "review-trees", ".review-tmp"}
 
+# Calls that OPEN a URL. A display link is never an argument to one of these, so
+# a reddit host appearing here is a fetch no matter how innocent its shape.
+# Calls that OPEN a URL. A display link is never an argument to one of these,
+# so a reddit host appearing here is a fetch no matter how innocent its shape.
+#
+# `get` is NOT on this list unqualified, and that is the whole design note:
+# a first version included it and immediately condemned
+# `NOISE_HOSTS = {..., "reddit.com", ...}` in Alice's sweep, a CLASSIFICATION
+# set, because the name reaches some `.get(...)` somewhere. `dict.get` and
+# `os.environ.get` are not HTTP.
+_FETCH_CALLS = {
+    "urlopen", "urlretrieve", "fetch", "fetch_json", "fetch_text",
+    "_get_json", "_fetch", "_fetch_json", "_fetch_text", "read_url",
+    "http_get", "urlretrieve",
+}
+
+# The verbs that only mean "fetch" when the RECEIVER is an HTTP client.
+_HTTP_VERBS = {"get", "post", "head", "request", "send"}
+_HTTP_RECEIVERS = ("requests", "session", "http", "client", "httpx", "urllib",
+                   "opener", "curl", "aiohttp")
+
 SUFFIXES = (".py",)
 
 # THE EXCEPTIONS, each with its reason, in ONE place that is printed with every
@@ -567,6 +588,42 @@ def violations_in_source(source: str, label: str) -> list[dict]:
                 for lit in host_names.get((scope, name), []):
                     concatenated_hosts.add(id(lit))
 
+    # A HOST PASSED TO A FETCH IS A FETCH, whatever shape the URL has.
+    #
+    # Everything above reasons about the URL's SHAPE, and a bare
+    # `https://www.reddit.com/r/x/` has no endpoint shape at all: no .json, no
+    # query, no listing segment. It is indistinguishable from a display link by
+    # inspection. So `urlopen("https://www.reddit.com/r/programming/")` and
+    # `requests.get(...)` -- the exact HTML-scrape class this whole change
+    # removes -- read clean (review, round 8).
+    #
+    # Shape cannot settle it. USE can: nobody hands a display link to urlopen.
+    fetched_literals = set()
+    for node in ast.walk(tree):
+        if not isinstance(node, ast.Call):
+            continue
+        name = (getattr(node.func, "attr", "")
+                or getattr(node.func, "id", "")).lower()
+        if name in _HTTP_VERBS:
+            recv = getattr(node.func, "value", None)
+            recv_name = ((getattr(recv, "id", "") or getattr(recv, "attr", ""))
+                         .lower())
+            if not any(tok in recv_name for tok in _HTTP_RECEIVERS):
+                continue
+        elif name not in _FETCH_CALLS:
+            continue
+        for arg in list(node.args) + [kw.value for kw in node.keywords]:
+            for sub in ast.walk(arg):
+                if (isinstance(sub, ast.Constant) and isinstance(sub.value, str)
+                        and "reddit.com" in sub.value.lower()
+                        and "photon" not in sub.value.lower()):
+                    fetched_literals.add(id(sub))
+                # a NAME handed to a fetch drags in whatever host it was bound to
+                if isinstance(sub, ast.Name):
+                    for scope in (_key(node), "module"):
+                        for lit in host_names.get((scope, sub.id), []):
+                            fetched_literals.add(id(lit))
+
     skip = _docstring_ids(tree) | _classification_ids(tree)
     labels = _context_names(tree)
     # id(constant) -> the full f-string it is a fragment of
@@ -617,6 +674,8 @@ def violations_in_source(source: str, label: str) -> list[dict]:
             if bad in low:
                 why = bad
                 break
+        if why is None and "reddit.com" in low and id(node) in fetched_literals:
+            why = "reddit.com URL handed to a fetch"
         if why is None and "reddit.com" in low and (
                 _is_endpoint(low) or id(node) in endpoint_funcs
                 or id(node) in concatenated_hosts):
@@ -784,7 +843,14 @@ def main(argv=None) -> int:
         print("\nStanding exceptions (printed every run, clean or not):")
         for suffix, reason in EXCEPTIONS.items():
             print("  %s\n      %s" % (suffix, reason))
-        print("\n%d non-Arctic Reddit reference(s) in live code." % len(found))
+        # SAY WHAT WAS READ. "in live code" was a claim about the whole corpus
+        # from a checker that parses Python and nothing else, so a shell or JS
+        # Reddit fetcher exits 0 clean under a sentence that implies otherwise
+        # (review). The scope belongs in the sentence, not in the docstring.
+        print("\n%d non-Arctic Reddit reference(s) in %s files. This checker "
+              "parses %s ONLY: a Reddit fetch in shell, JS or any other language "
+              "is outside what this number covers."
+              % (len(found), ", ".join(SUFFIXES), ", ".join(SUFFIXES)))
         if found:
             print("Arctic Shift is the only sanctioned transport. It lives at "
                   "plugins/kipi-core/reddit_arctic; import it rather than "

--- a/q-system/.q-system/scripts/reddit-transport-audit.py
+++ b/q-system/.q-system/scripts/reddit-transport-audit.py
@@ -392,9 +392,24 @@ def _is_endpoint(low: str) -> bool:
     definition, used by the single place that decides."""
     return (".json" in low or ".rss" in low or "/api/" in low
             or "/search" in low or "?" in low
-            or any(seg in low for seg in ("/new/", "/hot/", "/top/",
-                                          "/new.", "/hot.", "/top.",
-                                          "/rising/", "/controversial/")))
+            or _ends_in_a_listing(low))
+
+
+_LISTINGS = ("new", "hot", "top", "rising", "controversial", "best")
+
+
+def _ends_in_a_listing(low: str) -> bool:
+    """`/r/x/new` with no trailing slash is a listing feed too.
+
+    The old test looked for "/new/" and "/new.", so a URL ENDING in the segment
+    was classed a display link while the docstring said "a listing feed segment
+    is an endpoint" (review). Reddit serves both spellings.
+    """
+    path = low.split("?", 1)[0].rstrip("/")
+    tail = path.rsplit("/", 1)[-1]
+    if tail in _LISTINGS:
+        return True
+    return any("/%s/" % seg in low or "/%s." % seg in low for seg in _LISTINGS)
 
 
 def _joined_text(node: ast.AST) -> str:
@@ -477,8 +492,20 @@ def violations_in_source(source: str, label: str) -> list[dict]:
     # So: collect the names bound to a reddit host ANYWHERE (module, class or
     # function level), then flag that host literal if any `+` in the file joins
     # one of those names to an endpoint-shaped path. Still not dataflow, and the
-    # honest limit is the same as before: a host handed through a function
-    # ARGUMENT rather than a name is not seen.
+    # THE HONEST LIMIT, stated wider than it was. This sees `+` and f-strings.
+    # It does NOT see `"/".join([BASE, path])`, `urljoin(BASE, path)`,
+    # `BASE + PATH` where both sides are names, `%` formatting, or a host passed
+    # in as a function ARGUMENT. Each of those composes a URL without ever
+    # putting the host beside an endpoint literal, which is the only shape this
+    # rule reads.
+    #
+    # That is a real hole and naming it is the point: FORBIDDEN_SUBSTRINGS still
+    # catches old.reddit.com, oauth.reddit.com, /api/ and the trudax actor
+    # absolutely, in any composition, because those are decided on the literal
+    # alone. What escapes is a www.reddit.com host composed with an endpoint
+    # path through a route this rule cannot follow. Closing it properly is
+    # dataflow analysis, which this checker does not do and should not pretend
+    # to.
     # SCOPED. A name means different things in different functions, and the
     # first version of this rule did not care: `url` in `_reddit_archive_post`
     # holds a display link, and `url` in an unrelated Apify helper 180 lines

--- a/q-system/.q-system/scripts/reddit-transport-audit.py
+++ b/q-system/.q-system/scripts/reddit-transport-audit.py
@@ -466,6 +466,80 @@ def violations_in_source(source: str, label: str) -> list[dict]:
                     if isinstance(n, ast.Constant) and isinstance(n.value, str):
                         endpoint_funcs.add(id(n))
 
+    # A HOST CONSTANT THAT SOMEBODY CONCATENATES AN ENDPOINT ONTO.
+    #
+    # The round-3 rule looked inside ONE function, so the obvious reversion
+    # walked past it: put `BASE = "https://www.reddit.com"` at module level, then
+    # fetch `BASE + "/r/x/new.json"` from a function that itself contains no
+    # host. Each half is innocent in its own scope and the pre-commit gate
+    # reported clean on the exact change it exists to block (review, MAJOR 1).
+    #
+    # So: collect the names bound to a reddit host ANYWHERE (module, class or
+    # function level), then flag that host literal if any `+` in the file joins
+    # one of those names to an endpoint-shaped path. Still not dataflow, and the
+    # honest limit is the same as before: a host handed through a function
+    # ARGUMENT rather than a name is not seen.
+    # SCOPED. A name means different things in different functions, and the
+    # first version of this rule did not care: `url` in `_reddit_archive_post`
+    # holds a display link, and `url` in an unrelated Apify helper 180 lines
+    # later is joined to "?token=". Scope-blind matching condemned the display
+    # link in nine places across the fleet on the strength of a name collision.
+    #
+    # A binding is visible in the function that made it, and a module-level one
+    # is visible everywhere. That is the whole of the scoping this needs.
+    def _scope_of(tree_):
+        owner = {}
+        for fn in ast.walk(tree_):
+            if isinstance(fn, (ast.FunctionDef, ast.AsyncFunctionDef)):
+                for n in ast.walk(fn):
+                    owner.setdefault(id(n), fn)
+        return owner
+
+    owner = _scope_of(tree)
+
+    def _key(node):
+        fn = owner.get(id(node))
+        return id(fn) if fn is not None else "module"
+
+    host_names = {}          # (scope, name) -> Constant nodes bound there
+    for node in ast.walk(tree):
+        if isinstance(node, (ast.Assign, ast.AnnAssign)):
+            targets = node.targets if isinstance(node, ast.Assign) else [node.target]
+            val = node.value
+            if val is None:
+                continue
+            lits = [n for n in ast.walk(val)
+                    if isinstance(n, ast.Constant) and isinstance(n.value, str)
+                    and "reddit.com" in n.value.lower()
+                    and "photon" not in n.value.lower()]
+            if not lits:
+                continue
+            for tgt in targets:
+                if isinstance(tgt, ast.Name):
+                    host_names.setdefault((_key(node), tgt.id), []).extend(lits)
+
+    concatenated_hosts = set()
+    for node in ast.walk(tree):
+        joined_names, endpoint_here = set(), False
+        if isinstance(node, ast.BinOp) and isinstance(node.op, ast.Add):
+            sides = [node.left, node.right]
+            joined_names = {n.id for side in sides for n in ast.walk(side)
+                            if isinstance(n, ast.Name)}
+            endpoint_here = any(
+                _is_endpoint(n.value.lower()) for side in sides
+                for n in ast.walk(side)
+                if isinstance(n, ast.Constant) and isinstance(n.value, str))
+        elif isinstance(node, ast.JoinedStr):
+            joined_names = {n.id for n in ast.walk(node) if isinstance(n, ast.Name)}
+            endpoint_here = _is_endpoint(_joined_text(node).lower())
+        if not endpoint_here:
+            continue
+        here = _key(node)
+        for name in joined_names:
+            for scope in (here, "module"):
+                for lit in host_names.get((scope, name), []):
+                    concatenated_hosts.add(id(lit))
+
     skip = _docstring_ids(tree) | _classification_ids(tree)
     labels = _context_names(tree)
     # id(constant) -> the full f-string it is a fragment of
@@ -519,7 +593,8 @@ def violations_in_source(source: str, label: str) -> list[dict]:
                 why = bad
                 break
         if why is None and "reddit.com" in low and (
-                _is_endpoint(low) or id(node) in endpoint_funcs):
+                _is_endpoint(low) or id(node) in endpoint_funcs
+                or id(node) in concatenated_hosts):
             why = "reddit.com endpoint"
         # A NAME MAY ONLY EXEMPT WHAT THE URL DID NOT ALREADY CONDEMN. What is
         # left here is a plain www.reddit.com URL with no endpoint shape, which

--- a/q-system/.q-system/scripts/reddit-transport-audit.py
+++ b/q-system/.q-system/scripts/reddit-transport-audit.py
@@ -605,8 +605,6 @@ def violations_in_source(source: str, label: str) -> list[dict]:
         # label. It cannot argue about a retired host.
         why = None
         label_early = (labels.get(id(node)) or "").lower()
-        if _name_says(label_early, RETIREMENT_MARKERS):
-            continue          # a tombstone, not a call site
 
         # THE HARD DENYLIST AND THE ENDPOINT TEST BOTH RUN BEFORE ANY NAME MAY
         # EXEMPT. Round 2 moved the denylist ahead of the names and stopped
@@ -627,6 +625,23 @@ def violations_in_source(source: str, label: str) -> list[dict]:
         # left here is a plain www.reddit.com URL with no endpoint shape, which
         # is what a profile or a permalink looks like, so a classification list
         # or a piece of evidence data may say "this is a label, not a fetch".
+        # A TOMBSTONE MAY NAME THE DEAD THING. It may not BE a live fetch.
+        #
+        # The marker used to run before the denylist, so `DEPRECATED_BASE =
+        # "https://old.reddit.com"` composed into a real fetch was exempt on the
+        # strength of its name (review). Running it after instead broke the case
+        # it exists for: `RETIRED_ACTOR = "trudax/..."` is a bare string that
+        # nothing calls, and the denylist condemned it.
+        #
+        # Neither order is the answer, because the question is not WHEN to check
+        # the name. It is whether the literal is USED. A retirement marker
+        # excuses a string that is never composed into a URL, and excuses
+        # nothing that is.
+        if _name_says(label_early, RETIREMENT_MARKERS) and \
+                id(node) not in concatenated_hosts and \
+                id(node) not in endpoint_funcs and \
+                not _is_endpoint(low):
+            continue
         if why is None and _name_says(label_early,
                                       DENYLIST_NAMES + DATA_NAMES):
             continue

--- a/q-system/.q-system/scripts/reddit-transport-audit.py
+++ b/q-system/.q-system/scripts/reddit-transport-audit.py
@@ -48,6 +48,7 @@ import argparse
 import ast
 import json
 import os
+import re
 import subprocess
 import sys
 from pathlib import Path
@@ -122,6 +123,10 @@ SKIP_DIR_PARTS = (
     "consulting-baseline", "consulting-c3", "consulting-c4", "consulting-kipi",
     "kipi-system-main", "dead-hooks", ".review-tmp",
 )
+
+# The only tokens allowed to match INSIDE a directory name. Everything else in
+# SKIP_DIR_PARTS is compared as a whole segment.
+_FRAGMENT_TOKENS = {".wt-", "-wt-", "review-trees", ".review-tmp"}
 
 SUFFIXES = (".py",)
 
@@ -261,8 +266,22 @@ def _skip(path: Path, root=None) -> bool:
         rel = path.resolve().relative_to(Path(root).expanduser().resolve())
     except ValueError:
         return False
-    text = "/" + rel.as_posix()
-    return any(part in text for part in SKIP_DIR_PARTS)
+    # SEGMENTS, not substrings. `build` matched `reddit-build-radar`, a real
+    # fleet project holding a live old.reddit.com fetch, so the audit walked
+    # past it and printed 0. Measured in review: 28,051 .py files under
+    # ~/projects were excluded by a substring that is not a directory, 232 of
+    # them on `build` alone, including two source files in this repo.
+    segments = rel.parts
+    for token in SKIP_DIR_PARTS:
+        bare = token.strip("/")
+        for seg in segments:
+            if seg == bare:
+                return True
+            # Only these tokens are deliberately fragments, and even they are
+            # matched inside ONE segment so they cannot span a path boundary.
+            if token in _FRAGMENT_TOKENS and bare in seg:
+                return True
+    return False
 
 
 def _docstring_ids(tree: ast.AST) -> set[int]:
@@ -353,6 +372,31 @@ def violations_in(path: Path) -> list[dict]:
     return violations_in_source(source, str(path))
 
 
+def _name_says(label: str, tokens) -> bool:
+    """Match a name token on WORD boundaries, never as a bare substring.
+
+    `row` is in DATA_NAMES and `row` sits inside `browser`, so a variable named
+    `browser_feed` was exempt from every check (review, MAJOR 2). Identifiers
+    split on underscores, hyphens, dots and case changes; a token has to be one
+    of those pieces.
+    """
+    if not label:
+        return False
+    spaced = re.sub(r"(?<=[a-z])(?=[A-Z])", "_", label)
+    words = {w for w in re.split(r"[^A-Za-z0-9]+", spaced.lower()) if w}
+    return any(tok in words for tok in tokens)
+
+
+def _is_endpoint(low: str) -> bool:
+    """A URL either names a machine endpoint or a page a person opens. ONE
+    definition, used by the single place that decides."""
+    return (".json" in low or ".rss" in low or "/api/" in low
+            or "/search" in low or "?" in low
+            or any(seg in low for seg in ("/new/", "/hot/", "/top/",
+                                          "/new.", "/hot.", "/top.",
+                                          "/rising/", "/controversial/")))
+
+
 def _joined_text(node: ast.AST) -> str:
     """The whole template an f-string spells out, placeholders as <>.
 
@@ -392,6 +436,36 @@ def violations_in_source(source: str, label: str) -> list[dict]:
     except SyntaxError:
         return []
 
+    # WHICH FUNCTIONS BUILD AN ENDPOINT ANYWHERE IN THEIR BODY.
+    #
+    # `base = f"https://www.reddit.com/r/{sub}"` is not an endpoint on its own,
+    # and neither is `f"{base}/top/.rss"`. Split across two literals, each half
+    # reads as innocent and the audit walked past a live RSS listing fetch
+    # (reddit-build-radar `_reddit_listing_rss_url`).
+    #
+    # Joining them properly is dataflow, which this checker does not do. What it
+    # does instead is scoped and explainable: if a function names a reddit host
+    # AND any literal in that same function has an endpoint shape, the host
+    # literal is judged an endpoint. HONEST LIMIT: a builder that returns a bare
+    # host for a caller in another function to complete is still missed. That is
+    # a smaller hole than the one it closes, and naming it is better than
+    # implying the checker is complete.
+    endpoint_funcs = set()
+    for node in ast.walk(tree):
+        if isinstance(node, (ast.FunctionDef, ast.AsyncFunctionDef)):
+            lits = [n.value for n in ast.walk(node)
+                    if isinstance(n, ast.Constant) and isinstance(n.value, str)]
+            # A REAL CONCATENATION, not "this function also mentions an
+            # endpoint somewhere". The path half must be a PATH FRAGMENT: a
+            # literal starting with "/" that is itself an endpoint. Without that
+            # narrowing this rule flagged eight display links and refusal
+            # messages to catch one builder.
+            if any("reddit.com" in v.lower() for v in lits) and \
+               any(v.startswith("/") and _is_endpoint(v.lower()) for v in lits):
+                for n in ast.walk(node):
+                    if isinstance(n, ast.Constant) and isinstance(n.value, str):
+                        endpoint_funcs.add(id(n))
+
     skip = _docstring_ids(tree) | _classification_ids(tree)
     labels = _context_names(tree)
     # id(constant) -> the full f-string it is a fragment of
@@ -410,6 +484,12 @@ def violations_in_source(source: str, label: str) -> list[dict]:
             continue
         text = joined.get(id(node), node.value)
         low = text.lower()
+        # A URL HAS NO SPACES. Refusal messages and prompt samples mention the
+        # retired hosts by design ("reddit.com/.json is retired, use ..."), and
+        # flagging those turned a 1-real-finding report into 9. A sentence about
+        # a host is not a fetch of it.
+        if any(ch.isspace() for ch in text.strip()):
+            continue
         if "reddit" not in low:
             continue
         if any(host in low for host in ALLOWED_HOSTS):
@@ -424,41 +504,30 @@ def violations_in_source(source: str, label: str) -> list[dict]:
         # label. It cannot argue about a retired host.
         why = None
         label_early = (labels.get(id(node)) or "").lower()
-        if any(mark in label_early for mark in RETIREMENT_MARKERS):
+        if _name_says(label_early, RETIREMENT_MARKERS):
             continue          # a tombstone, not a call site
+
+        # THE HARD DENYLIST AND THE ENDPOINT TEST BOTH RUN BEFORE ANY NAME MAY
+        # EXEMPT. Round 2 moved the denylist ahead of the names and stopped
+        # there, so `.json` and `.rss` -- which are NOT in FORBIDDEN_SUBSTRINGS,
+        # they are decided by URL shape -- were still silenced by a variable
+        # called `fetch_items` or `known_feeds`. The comment below already
+        # claimed "an endpoint is a finding regardless of what it is called".
+        # Now it is true.
         for bad in FORBIDDEN_SUBSTRINGS:
             if bad in low:
                 why = bad
                 break
-        if why is None and any(name in label_early
-                               for name in DENYLIST_NAMES + DATA_NAMES):
+        if why is None and "reddit.com" in low and (
+                _is_endpoint(low) or id(node) in endpoint_funcs):
+            why = "reddit.com endpoint"
+        # A NAME MAY ONLY EXEMPT WHAT THE URL DID NOT ALREADY CONDEMN. What is
+        # left here is a plain www.reddit.com URL with no endpoint shape, which
+        # is what a profile or a permalink looks like, so a classification list
+        # or a piece of evidence data may say "this is a label, not a fetch".
+        if why is None and _name_says(label_early,
+                                      DENYLIST_NAMES + DATA_NAMES):
             continue
-        if why is None and "reddit.com" in low:
-            label = (labels.get(id(node)) or "").lower()
-            # WHAT IT IS, not what it is called. The name-based rules were
-            # doing this job and doing it badly in both directions: exempting
-            # "sites" hid a live /user/<u>/about.json in a published repo, and
-            # un-exempting it then flagged the display link sitting beside it.
-            # A URL either names a machine endpoint or it names a page a person
-            # opens, and that is readable from the URL.
-            looks_like_an_endpoint = (
-                ".json" in low or ".rss" in low or "/api/" in low
-                or "/search" in low or "?" in low
-                # a listing feed, with or without a suffix
-                or any(seg in low for seg in ("/new/", "/hot/", "/top/",
-                                              "/new.", "/hot.", "/top.",
-                                              "/rising/", "/controversial/"))
-            )
-            # An endpoint is a finding regardless of what it is called. A
-            # non-endpoint reddit.com URL is a link a human opens, and the
-            # default for those is now CLEAN rather than suspicious. That is a
-            # deliberate loosening: FORBIDDEN_SUBSTRINGS still catches
-            # old.reddit.com, oauth.reddit.com, /api/ and the trudax actor
-            # absolutely, so the loosened half is only "a www.reddit.com URL
-            # with no endpoint shape", which is exactly what a profile or a
-            # permalink looks like.
-            if looks_like_an_endpoint:
-                why = "reddit.com endpoint"
         if why:
             found.append({"file": str(path), "line": node.lineno,
                           "reason": why, "text": text[:120]})

--- a/q-system/.q-system/scripts/reddit-transport-audit.py
+++ b/q-system/.q-system/scripts/reddit-transport-audit.py
@@ -1,0 +1,389 @@
+#!/usr/bin/env python3
+"""Arctic Shift is the only way this fleet scrapes Reddit. This is the check.
+
+Founder-directed 2026-09-04, verbatim: "change any reddit searches on the entire
+kipi corpus into arctic shift. Any collection from reddit that is not using
+arctic shift should be changed to it. this must be the only way we scrape
+reddit."
+
+A rule that lives only in a docstring is a rule until the next person writes a
+convenient `urlopen("https://www.reddit.com/r/x/new.json")`. So the rule is a
+script that walks the corpus and exits 1.
+
+## What it looks for
+
+A NON-ARCTIC REDDIT HOST inside a string literal in live code. Parsed with `ast`,
+not grepped, for a reason that cost a test rewrite the same day this was written:
+the retired hosts are NAMED in the scar comments that explain why they are
+retired, and a line-level grep forbids the file from recording its own reason.
+Comments and docstrings are exempt. String literals are not.
+
+## What it deliberately allows
+
+  https://www.reddit.com/...   as a DISPLAY link a human clicks. Never fetched.
+                               Recognised by the assignment or key it sits in,
+                               not by trust: `url`, `permalink`, `link`, `href`,
+                               `BASE`, `display`.
+
+## What it forbids
+
+  old.reddit.com               the HTML scrape reddit_read.py used to do
+  oauth.reddit.com             the official API, whose app creation is gated
+                               behind an approval this account cannot get
+  *.json / .rss endpoints      throttled and 403'd from datacenter IPs
+  trudax/reddit-scraper-lite   the retired Apify actor
+  api.apify.com + reddit       any Apify run whose input names a subreddit
+
+Usage:
+
+    python3 reddit-transport-audit.py [root ...]      # defaults to ~/projects
+    python3 reddit-transport-audit.py --json
+
+Exit 0 clean, exit 1 with one line per violation.
+"""
+from __future__ import annotations
+
+import argparse
+import ast
+import json
+import os
+import sys
+from pathlib import Path
+
+ALLOWED_HOSTS = ("arctic-shift.photon-reddit.com", "api.pullpush.io")
+
+# A display link is allowed only where it is plainly a link. The name the literal
+# is bound to (or the dict key it answers) has to say so.
+DISPLAY_NAMES = ("url", "permalink", "link", "href", "base", "display",
+                 "author_url", "thread_url", "source_url", "profile")
+
+# A DENYLIST that names a host is the opposite of a violation: it is this rule
+# being enforced somewhere else. `browser_session_health.forbidden_probe_hosts`
+# was the first false positive this audit produced, and a checker that flags the
+# guard it agrees with is a checker people switch off.
+DENYLIST_NAMES = ("forbidden", "blocked", "denied", "banned", "retired",
+                  "refuse", "reject", "deprecated", "never", "not_allowed",
+                  "bad_hosts", "skip")
+
+# NAMING A DOMAIN IS NOT FETCHING IT. Three distinct non-fetch uses turned up
+# across the corpus, and each one is a legitimate thing to write:
+#
+#   classification   `noise_hosts`, `venue_hosts`, `community_hosts`,
+#                    `generic_infra`, `multi_tenant`, `marker`: a list of domains
+#                    that decides how a URL is TREATED. Reddit has to be in it.
+#   evidence         investigation case files and authorship fixtures carry the
+#                    real URLs they are about.
+#   sample text      a prompt or a docstring quoting what a source looks like.
+#
+# None of them opens a connection. A checker that cannot tell a domain being
+# classified from a domain being fetched flags all three, and a report that is
+# mostly false positives is a report nobody runs. Measured 2026-09-04: these
+# three classes were the entire remainder after every real fetcher was converted.
+DATA_NAMES = ("hosts", "domains", "infra", "venue", "noise", "community",
+              "tenant", "marker", "sample", "fixture", "case", "seed",
+              "example", "corpus", "known", "sites", "public", "profile",
+              "expected", "row", "item")
+
+FORBIDDEN_SUBSTRINGS = (
+    "old.reddit.com",
+    "oauth.reddit.com",
+    "np.reddit.com",
+    "reddit.com/api/",
+    "trudax/reddit-scraper-lite",
+    "trudax~reddit-scraper-lite",
+)
+
+# Directories that are copies, caches, or history. A violation in one of these is
+# a violation in its source, and reporting both is noise that trains people to
+# ignore the report.
+SKIP_DIR_PARTS = (
+    "node_modules", ".git", "__pycache__", ".venv", "venv", "site-packages",
+    "worktrees", "_archive", "_wt", ".wt-", "-wt-", "review-trees",
+    "/output/", "/fixtures/", ".prd-os", "/logs/", "dist", "build",
+    "consulting-baseline", "consulting-c3", "consulting-c4", "consulting-kipi",
+    "kipi-system-main", "dead-hooks", ".review-tmp",
+)
+
+SUFFIXES = (".py",)
+
+# THE EXCEPTIONS, each with its reason, in ONE place that is printed with every
+# report. A per-file allowlist rots the moment nobody can say why a row is on it,
+# so the reason is required here and the report shows the list even when it is
+# clean. These are WRITE paths and self-references. This audit's subject is
+# READING Reddit; posting to Reddit is a different rule with a different owner,
+# and the two files below are not collectors.
+EXCEPTIONS = {
+    "gtm/scripts/reddit_worker/reddit_api_probe.py":
+        "a WRITE path, and already refuses to run. Retired 2026-09-04: Reddit "
+        "gates OAuth script-app creation behind an approval this account does "
+        "not have. Kept, not deleted, because it is the most convincing "
+        "resurrection kit in the fleet and the next session should find the "
+        "reason rather than nothing.",
+    "gtm/scripts/reddit_worker/reddit_driver.py":
+        "a WRITE path (the browser poster). This audit governs reading Reddit; "
+        "what posts to Reddit is a separate rule.",
+    "q-system/.q-system/scripts/reddit-transport-audit.py":
+        "this file. Its allow and deny lists have to name the hosts.",
+    "plugins/kipi-core/reddit_arctic/transport.py":
+        "the sanctioned transport. Its normalizer builds the display link.",
+}
+
+
+def _exception_for(path: Path):
+    text = str(path)
+    for suffix, reason in EXCEPTIONS.items():
+        if text.endswith(suffix):
+            return reason
+    return None
+
+# AN INSTANCE'S VENDORED COPIES ARE NOT SOURCE. `q-system/` and `plugins/` inside
+# an instance are skeleton-sync DESTINATIONS, rsynced from the skeleton; a
+# violation there is the skeleton's violation, and fixing it in place is undone
+# by the next sync. The skeleton's own copies ARE audited, because there the path
+# is the source. Measured 2026-09-04: auditing the vendored copies turned 8 real
+# findings into 719, which is how a report stops being read.
+VENDORED = ("q-system", "plugins")
+
+
+def _is_vendored_copy(path: Path, root) -> bool:
+    text = str(path.resolve())
+    root = str(Path(root).expanduser().resolve())
+    if Path(root).name == "kipi-system":
+        return False
+    if not text.startswith(root + os.sep):
+        return False
+    parts = Path(text[len(root) + 1:]).parts
+    return any(part in VENDORED for part in parts)
+
+
+def _is_test(path: Path) -> bool:
+    """Tests are exempt, and the exemption is the honest one.
+
+    A test that proves a guard BLOCKS old.reddit.com has to name old.reddit.com,
+    and a fixture URL is not a fetch. Measured 2026-09-04: including tests turned
+    8 live findings into 131, and every added row was a fixture or an assertion
+    about a host being refused. The audit is about live fetch paths; the tests
+    are how the live paths are held.
+    """
+    name = path.name
+    return (name.startswith("test_") or name.endswith("_test.py")
+            or "tests" in path.parts or name.startswith("calibrate_"))
+
+
+def _is_linked_worktree(root: Path) -> bool:
+    """A linked git worktree is a CHECKOUT, not a source of truth.
+
+    Detected structurally: git writes a `.git` FILE (a pointer) in a linked
+    worktree and a `.git` DIRECTORY in the main one. Its content is some branch's
+    state and it converges when that branch does, so auditing it reports the same
+    defect twice and blames the copy.
+
+    Structural rather than by name, deliberately. SKIP_DIR_PARTS already carries
+    a hand-written list of checkout directory names, and `consulting-landing` was
+    not on it -- so the fleet test failed on a worktree sitting on a branch from
+    two weeks earlier. A guard that enumerates by hand only sees what somebody
+    remembered to add.
+    """
+    dot = root / ".git"
+    return dot.is_file()
+
+
+def _skip(path: Path) -> bool:
+    text = str(path)
+    return any(part in text for part in SKIP_DIR_PARTS)
+
+
+def _docstring_ids(tree: ast.AST) -> set[int]:
+    out = set()
+    for node in ast.walk(tree):
+        if isinstance(node, (ast.Module, ast.FunctionDef, ast.AsyncFunctionDef,
+                             ast.ClassDef)):
+            first = node.body[0] if getattr(node, "body", None) else None
+            if (isinstance(first, ast.Expr)
+                    and isinstance(first.value, ast.Constant)
+                    and isinstance(first.value.value, str)):
+                out.add(id(first.value))
+    return out
+
+
+def _context_names(tree: ast.AST) -> dict[int, str]:
+    """Which name a string literal is bound to, so a display link is telling the
+    truth about being one. Covers `X = "..."`, `{"url": "..."}`, f-strings inside
+    either, and a `return f"https://..."` inside a function whose name says url.
+    """
+    names: dict[int, str] = {}
+
+    def tag(node, label):
+        for sub in ast.walk(node):
+            if isinstance(sub, ast.Constant) and isinstance(sub.value, str):
+                names.setdefault(id(sub), label)
+
+    for node in ast.walk(tree):
+        if isinstance(node, ast.Assign):
+            label = " ".join(t.id for t in node.targets if isinstance(t, ast.Name))
+            if label:
+                tag(node.value, label)
+        elif isinstance(node, ast.AnnAssign) and isinstance(node.target, ast.Name):
+            if node.value is not None:
+                tag(node.value, node.target.id)
+        elif isinstance(node, ast.Dict):
+            for key, value in zip(node.keys, node.values):
+                if isinstance(key, ast.Constant) and isinstance(key.value, str):
+                    tag(value, key.value)
+        elif isinstance(node, (ast.FunctionDef, ast.AsyncFunctionDef)):
+            for sub in ast.walk(node):
+                if isinstance(sub, ast.Return) and sub.value is not None:
+                    tag(sub.value, node.name)
+    return names
+
+
+def _classification_ids(tree: ast.AST) -> set[int]:
+    """Literals that are being COMPARED against, or asserted on, never fetched.
+
+    Two shapes, both principled rather than per-file:
+
+      `if "reddit.com" in url:`        a URL classifier. The literal is the
+                                       right side of an `in` test, which reads a
+                                       string, it does not open one.
+      `check("...", f("https://..."))` an inline self-test. A call whose name
+                                       says check/assert/expect is a test even
+                                       when it does not live in a tests/ dir.
+
+    These were the last two findings in the corpus after every real fetcher was
+    converted, and neither is a fetch. A name-based rule could not see them: one
+    sits in a Compare node and one in a Call argument, so neither is bound to a
+    variable there is a name for.
+    """
+    out = set()
+    for node in ast.walk(tree):
+        if isinstance(node, ast.Compare):
+            for op, comparator in zip(node.ops, node.comparators):
+                if isinstance(op, (ast.In, ast.NotIn)):
+                    for side in (node.left, comparator):
+                        for sub in ast.walk(side):
+                            if (isinstance(sub, ast.Constant)
+                                    and isinstance(sub.value, str)):
+                                out.add(id(sub))
+        elif isinstance(node, ast.Call):
+            name = getattr(node.func, "id", "") or getattr(node.func, "attr", "")
+            if any(w in name.lower() for w in ("check", "assert", "expect")):
+                for sub in ast.walk(node):
+                    if isinstance(sub, ast.Constant) and isinstance(sub.value, str):
+                        out.add(id(sub))
+    return out
+
+
+def violations_in(path: Path) -> list[dict]:
+    try:
+        source = path.read_text(encoding="utf-8", errors="replace")
+    except OSError:
+        return []
+    if "reddit" not in source.lower():
+        return []
+    try:
+        tree = ast.parse(source)
+    except SyntaxError:
+        return []
+
+    skip = _docstring_ids(tree) | _classification_ids(tree)
+    labels = _context_names(tree)
+    found = []
+    for node in ast.walk(tree):
+        if not (isinstance(node, ast.Constant) and isinstance(node.value, str)):
+            continue
+        if id(node) in skip:
+            continue
+        text = node.value
+        low = text.lower()
+        if "reddit" not in low:
+            continue
+        if any(host in low for host in ALLOWED_HOSTS):
+            continue
+
+        why = None
+        label_early = (labels.get(id(node)) or "").lower()
+        if any(name in label_early for name in DENYLIST_NAMES + DATA_NAMES):
+            continue
+        for bad in FORBIDDEN_SUBSTRINGS:
+            if bad in low:
+                why = bad
+                break
+        if why is None and "reddit.com" in low:
+            label = (labels.get(id(node)) or "").lower()
+            is_display = any(name in label for name in DISPLAY_NAMES)
+            looks_like_an_endpoint = (".json" in low or ".rss" in low
+                                      or "/search" in low or "?limit" in low)
+            if looks_like_an_endpoint or not is_display:
+                why = "reddit.com endpoint" if looks_like_an_endpoint else \
+                      "reddit.com in %r, which is not a display link" % (label or "?",)
+        if why:
+            found.append({"file": str(path), "line": node.lineno,
+                          "reason": why, "text": text[:120]})
+    return found
+
+
+def walk(roots) -> list[dict]:
+    out = []
+    for root in roots:
+        root = Path(root).expanduser()
+        if root.is_file():
+            if not _skip(root):
+                out.extend(violations_in(root))
+            continue
+        if _is_linked_worktree(root):
+            continue
+        for dirpath, dirnames, filenames in os.walk(root):
+            here = Path(dirpath)
+            # PER DIRECTORY, not only on the root handed in. Checking the root
+            # alone is right when each repo is passed separately and useless when
+            # `~/projects` is passed once, because then every checkout under it is
+            # just a subdirectory and the check never reaches it. That is exactly
+            # how consulting-landing came back a second time after the first fix:
+            # the test passed each repo as its own root and the CLI default did
+            # not. A guard has to run where the thing it guards against actually
+            # appears.
+            if here != root and _is_linked_worktree(here):
+                dirnames[:] = []
+                continue
+            if _skip(here):
+                dirnames[:] = []
+                continue
+            dirnames[:] = [d for d in dirnames
+                           if not _skip(Path(dirpath) / d)]
+            for name in filenames:
+                if name.endswith(SUFFIXES):
+                    path = Path(dirpath) / name
+                    if (not _skip(path) and not _is_test(path)
+                            and not _exception_for(path)
+                            and not _is_vendored_copy(path, root)):
+                        out.extend(violations_in(path))
+    return out
+
+
+def main(argv=None) -> int:
+    parser = argparse.ArgumentParser(description=__doc__.splitlines()[0])
+    parser.add_argument("roots", nargs="*", default=None)
+    parser.add_argument("--json", action="store_true")
+    args = parser.parse_args(argv)
+
+    roots = args.roots or [Path.home() / "projects"]
+    found = walk(roots)
+
+    if args.json:
+        print(json.dumps(found, indent=2))
+    else:
+        for v in found:
+            print("%s:%d  %s\n    %s" % (v["file"], v["line"], v["reason"], v["text"]))
+        print("\nStanding exceptions (printed every run, clean or not):")
+        for suffix, reason in EXCEPTIONS.items():
+            print("  %s\n      %s" % (suffix, reason))
+        print("\n%d non-Arctic Reddit reference(s) in live code." % len(found))
+        if found:
+            print("Arctic Shift is the only sanctioned transport. It lives at "
+                  "plugins/kipi-core/reddit_arctic; import it rather than "
+                  "building a URL.")
+    return 1 if found else 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/q-system/.q-system/scripts/reddit-transport-audit.py
+++ b/q-system/.q-system/scripts/reddit-transport-audit.py
@@ -696,9 +696,15 @@ def violations_in_source(source: str, label: str) -> list[dict]:
         # the name. It is whether the literal is USED. A retirement marker
         # excuses a string that is never composed into a URL, and excuses
         # nothing that is.
+        # A tombstone is a string nothing uses. Round 8 added `fetched_literals`
+        # -- a host handed straight to urlopen -- and did not add it here, so
+        # `RETIRED_BASE = "https://old.reddit.com"` passed to urlopen was exempt
+        # on the strength of its name (round 9). Every way of USING the literal
+        # has to disqualify the marker, or the marker becomes the hole.
         if _name_says(label_early, RETIREMENT_MARKERS) and \
                 id(node) not in concatenated_hosts and \
                 id(node) not in endpoint_funcs and \
+                id(node) not in fetched_literals and \
                 not _is_endpoint(low):
             continue
         if why is None and _name_says(label_early,

--- a/q-system/.q-system/scripts/reddit-transport-audit.py
+++ b/q-system/.q-system/scripts/reddit-transport-audit.py
@@ -240,8 +240,28 @@ def _is_linked_worktree(root: Path) -> bool:
     return dot.is_file()
 
 
-def _skip(path: Path) -> bool:
-    text = str(path)
+def _skip(path: Path, root=None) -> bool:
+    """Skip decided on the path RELATIVE to the root handed in.
+
+    It used to test those substrings against the FULL ABSOLUTE path, so a
+    directory NAME anywhere ABOVE the repo switched the entire audit off. That
+    is not theoretical: `.claude/rules/concurrent-session-worktrees.md` tells
+    every session to work in `../kipi-wt-<name>`, and `-wt-` is on the list;
+    `review-trees` is on it too, and that is where this branch's own review ran.
+    Measured in review: 0 of 575 .py files opened, exit 0, and a printed claim
+    about "live code".
+
+    Worse than the worktree case round 1 fixed, because it also kills a MAIN
+    checkout whose parent directory happens to contain `build`, `dist`, `venv`
+    or `worktrees`. A checkout's own address is not a fact about its contents.
+    """
+    if root is None:
+        return False
+    try:
+        rel = path.resolve().relative_to(Path(root).expanduser().resolve())
+    except ValueError:
+        return False
+    text = "/" + rel.as_posix()
     return any(part in text for part in SKIP_DIR_PARTS)
 
 
@@ -516,7 +536,7 @@ def walk(roots) -> list[dict]:
             for bare in bares:
                 out.extend(_bare_repo_violations(bare))
         if root.is_file():
-            if not _skip(root):
+            if not _skip(root, root.parent):
                 out.extend(violations_in(root))
             continue
         # A ROOT THE CALLER NAMED IS ALWAYS SCANNED. This used to `continue`
@@ -546,15 +566,15 @@ def walk(roots) -> list[dict]:
             if here != root and _is_linked_worktree(here):
                 dirnames[:] = []
                 continue
-            if _skip(here):
+            if _skip(here, root):
                 dirnames[:] = []
                 continue
             dirnames[:] = [d for d in dirnames
-                           if not _skip(Path(dirpath) / d)]
+                           if not _skip(Path(dirpath) / d, root)]
             for name in filenames:
                 if name.endswith(SUFFIXES):
                     path = Path(dirpath) / name
-                    if (not _skip(path) and not _is_test(path)
+                    if (not _skip(path, root) and not _is_test(path)
                             and not _exception_for(path)
                             and not _is_vendored_copy(path)):
                         out.extend(violations_in(path))

--- a/q-system/.q-system/scripts/reddit-transport-audit.py
+++ b/q-system/.q-system/scripts/reddit-transport-audit.py
@@ -47,6 +47,7 @@ import argparse
 import ast
 import json
 import os
+import subprocess
 import sys
 from pathlib import Path
 
@@ -81,8 +82,15 @@ DENYLIST_NAMES = ("forbidden", "blocked", "denied", "banned", "retired",
 # three classes were the entire remainder after every real fetcher was converted.
 DATA_NAMES = ("hosts", "domains", "infra", "venue", "noise", "community",
               "tenant", "marker", "sample", "fixture", "case", "seed",
-              "example", "corpus", "known", "sites", "public", "profile",
-              "expected", "row", "item")
+              "example", "corpus", "known",
+              # "sites" and "profile" were HERE and are deliberately not, any
+              # more (2026-09-05). A table named _SITES in an OSINT probe holds
+              # URL TEMPLATES THAT GET FETCHED, so exempting the word hid a live
+              # `www.reddit.com/user/{u}/about.json` in a published repo. That is
+              # the cost of a suppression list written to quiet false positives:
+              # each entry buys silence on a real one somewhere. "public" stays
+              # because it labels the human-facing link built beside that probe.
+              "public", "expected", "row", "item")
 
 FORBIDDEN_SUBSTRINGS = (
     "old.reddit.com",
@@ -278,6 +286,41 @@ def violations_in(path: Path) -> list[dict]:
         source = path.read_text(encoding="utf-8", errors="replace")
     except OSError:
         return []
+    return violations_in_source(source, str(path))
+
+
+def _joined_text(node: ast.AST) -> str:
+    """The whole template an f-string spells out, placeholders as <>.
+
+    THE REASON THIS EXISTS. `f"https://www.reddit.com/r/{sub}/hot/.rss"` is not
+    one string node. Python splits it: "https://www.reddit.com/r/" and
+    "/hot/.rss" are separate Constants with the placeholder between them. So a
+    test asking "does the literal containing reddit.com also look like an
+    endpoint" reads only the first fragment, sees no .rss, and calls a live RSS
+    fetch a display link. Measured 2026-09-05: that dropped three real findings
+    in published repos from the report while the checker still said it was
+    working.
+    """
+    parts = []
+    for sub in getattr(node, "values", []):
+        if isinstance(sub, ast.Constant) and isinstance(sub.value, str):
+            parts.append(sub.value)
+        else:
+            parts.append("<>")
+    return "".join(parts)
+
+
+def violations_in_source(source: str, label: str) -> list[dict]:
+    """The analysis, given content rather than a path.
+
+    Split out so a BARE repository can be read. A bare repo has no working tree,
+    so the file walk sees nothing in it and reports it clean. 33 published repos
+    were reported clean that way by a checker structurally unable to open any of
+    them, and three of them were shipping a retired Reddit transport at the time
+    (measured 2026-09-05). A clean result from a reader that cannot read is the
+    same defect this whole suite exists to refuse.
+    """
+    path = Path(label)
     if "reddit" not in source.lower():
         return []
     try:
@@ -287,13 +330,21 @@ def violations_in(path: Path) -> list[dict]:
 
     skip = _docstring_ids(tree) | _classification_ids(tree)
     labels = _context_names(tree)
+    # id(constant) -> the full f-string it is a fragment of
+    joined: dict[int, str] = {}
+    for node in ast.walk(tree):
+        if isinstance(node, ast.JoinedStr):
+            whole = _joined_text(node)
+            for sub in ast.walk(node):
+                if isinstance(sub, ast.Constant) and isinstance(sub.value, str):
+                    joined[id(sub)] = whole
     found = []
     for node in ast.walk(tree):
         if not (isinstance(node, ast.Constant) and isinstance(node.value, str)):
             continue
         if id(node) in skip:
             continue
-        text = node.value
+        text = joined.get(id(node), node.value)
         low = text.lower()
         if "reddit" not in low:
             continue
@@ -311,21 +362,99 @@ def violations_in(path: Path) -> list[dict]:
         if why is None and "reddit.com" in low:
             label = (labels.get(id(node)) or "").lower()
             is_display = any(name in label for name in DISPLAY_NAMES)
-            looks_like_an_endpoint = (".json" in low or ".rss" in low
-                                      or "/search" in low or "?limit" in low)
-            if looks_like_an_endpoint or not is_display:
-                why = "reddit.com endpoint" if looks_like_an_endpoint else \
-                      "reddit.com in %r, which is not a display link" % (label or "?",)
+            # WHAT IT IS, not what it is called. The name-based rules were
+            # doing this job and doing it badly in both directions: exempting
+            # "sites" hid a live /user/<u>/about.json in a published repo, and
+            # un-exempting it then flagged the display link sitting beside it.
+            # A URL either names a machine endpoint or it names a page a person
+            # opens, and that is readable from the URL.
+            looks_like_an_endpoint = (
+                ".json" in low or ".rss" in low or "/api/" in low
+                or "/search" in low or "?" in low
+                # a listing feed, with or without a suffix
+                or any(seg in low for seg in ("/new/", "/hot/", "/top/",
+                                              "/new.", "/hot.", "/top.",
+                                              "/rising/", "/controversial/"))
+            )
+            # An endpoint is a finding regardless of what it is called. A
+            # non-endpoint reddit.com URL is a link a human opens, and the
+            # default for those is now CLEAN rather than suspicious. That is a
+            # deliberate loosening: FORBIDDEN_SUBSTRINGS still catches
+            # old.reddit.com, oauth.reddit.com, /api/ and the trudax actor
+            # absolutely, so the loosened half is only "a www.reddit.com URL
+            # with no endpoint shape", which is exactly what a profile or a
+            # permalink looks like.
+            if looks_like_an_endpoint:
+                why = "reddit.com endpoint"
         if why:
             found.append({"file": str(path), "line": node.lineno,
                           "reason": why, "text": text[:120]})
-    return found
+    # One finding per (line, reason). An f-string reports through every fragment
+    # it is made of, and three copies of one defect is a report people skim.
+    seen, unique = set(), []
+    for v in found:
+        key = (v["file"], v["line"], v["reason"])
+        if key not in seen:
+            seen.add(key)
+            unique.append(v)
+    return unique
+
+
+def _bare_repo_violations(repo: Path) -> list[dict]:
+    """Read a bare repo's HEAD tree through git, since there is no checkout.
+
+    Only .py, because that is what this audit parses. A bare repo carrying a
+    Reddit fetcher in another language is a gap this names rather than hides.
+    """
+    try:
+        listing = subprocess.run(
+            ["git", "-C", str(repo), "ls-tree", "-r", "--name-only", "HEAD"],
+            capture_output=True, text=True, timeout=60)
+    except Exception:
+        return []
+    if listing.returncode != 0:
+        return []
+    out = []
+    for name in listing.stdout.splitlines():
+        if not name.endswith(".py"):
+            continue
+        try:
+            blob = subprocess.run(["git", "-C", str(repo), "show", "HEAD:" + name],
+                                  capture_output=True, text=True, timeout=60)
+        except Exception:
+            continue
+        if blob.returncode != 0 or "reddit" not in blob.stdout.lower():
+            continue
+        if _exception_for(Path(name)) or _is_test(Path(name)):
+            continue
+        for v in violations_in_source(blob.stdout, name):
+            v["file"] = "%s!%s" % (repo, name)   # ! marks a blob, not a file
+            out.append(v)
+    return out
+
+
+def _is_bare_repo(path: Path) -> bool:
+    if not path.is_dir():
+        return False
+    # A bare repo has HEAD/objects/refs at its top level and no .git dir.
+    return all((path / n).exists() for n in ("HEAD", "objects", "refs")) \
+        and not (path / ".git").exists()
 
 
 def walk(roots) -> list[dict]:
     out = []
     for root in roots:
         root = Path(root).expanduser()
+        if _is_bare_repo(root):
+            out.extend(_bare_repo_violations(root))
+            continue
+        # A directory OF bare repos (the publish mirrors) is the shape that hid
+        # three findings, so it is handled explicitly rather than left to the
+        # file walk that cannot see into any of them.
+        if root.is_dir():
+            bares = [c for c in sorted(root.glob("*.git")) if _is_bare_repo(c)]
+            for bare in bares:
+                out.extend(_bare_repo_violations(bare))
         if root.is_file():
             if not _skip(root):
                 out.extend(violations_in(root))

--- a/q-system/.q-system/scripts/reddit-transport-audit.py
+++ b/q-system/.q-system/scripts/reddit-transport-audit.py
@@ -21,9 +21,10 @@ Comments and docstrings are exempt. String literals are not.
 ## What it deliberately allows
 
   https://www.reddit.com/...   as a DISPLAY link a human clicks. Never fetched.
-                               Recognised by the assignment or key it sits in,
-                               not by trust: `url`, `permalink`, `link`, `href`,
-                               `BASE`, `display`.
+                               Recognised by the URL's own SHAPE, not by what it
+                               is called: a bare profile or permalink is a link,
+                               while .json, .rss, /api/, /search, a query string
+                               or a listing feed segment is an endpoint.
 
 ## What it forbids
 
@@ -53,18 +54,28 @@ from pathlib import Path
 
 ALLOWED_HOSTS = ("arctic-shift.photon-reddit.com", "api.pullpush.io")
 
-# A display link is allowed only where it is plainly a link. The name the literal
-# is bound to (or the dict key it answers) has to say so.
-DISPLAY_NAMES = ("url", "permalink", "link", "href", "base", "display",
-                 "author_url", "thread_url", "source_url", "profile")
+# WHAT DECIDES A DISPLAY LINK IS THE URL, NOT THE NAME. A DISPLAY_NAMES list
+# lived here and went dead when the endpoint test moved to URL shape: still
+# computed, never read, and still documented in the module docstring as the
+# allow mechanism (PR 307 review, NIT 6). A list nothing reads is worse than no
+# list, because the next person tunes it and nothing happens.
 
 # A DENYLIST that names a host is the opposite of a violation: it is this rule
 # being enforced somewhere else. `browser_session_health.forbidden_probe_hosts`
 # was the first false positive this audit produced, and a checker that flags the
 # guard it agrees with is a checker people switch off.
-DENYLIST_NAMES = ("forbidden", "blocked", "denied", "banned", "retired",
-                  "refuse", "reject", "deprecated", "never", "not_allowed",
+DENYLIST_NAMES = ("forbidden", "blocked", "denied", "banned",
+                  "refuse", "reject", "never", "not_allowed",
                   "bad_hosts", "skip")
+
+# THE ONE THING THAT OUTRANKS THE HARD DENYLIST. Naming the retired actor is how
+# a module records that it is retired: `RETIRED_ACTOR = "trudax/..."` exists
+# precisely so a session grepping for the actor finds the note instead of finding
+# nothing and re-adding it. Making the denylist absolute (PR 307 review, MINOR 4)
+# was right for `old.reddit.com` hiding inside a variable called `fetch_items`,
+# and wrong for a constant whose name says RETIRED. The distinction is not "does
+# the name sound friendly" but "does the name declare this thing dead".
+RETIREMENT_MARKERS = ("retired", "deprecated", "removed", "dead")
 
 # NAMING A DOMAIN IS NOT FETCHING IT. Three distinct non-fetch uses turned up
 # across the corpus, and each one is a legitimate thing to write:
@@ -153,15 +164,48 @@ def _exception_for(path: Path):
 VENDORED = ("q-system", "plugins")
 
 
-def _is_vendored_copy(path: Path, root) -> bool:
-    text = str(path.resolve())
-    root = str(Path(root).expanduser().resolve())
-    if Path(root).name == "kipi-system":
+def _repo_root_of(path: Path):
+    """The checkout a file belongs to: nearest ancestor carrying a .git."""
+    for parent in path.resolve().parents:
+        if (parent / ".git").exists():
+            return parent
+    return None
+
+
+def _is_the_skeleton(repo) -> bool:
+    """The skeleton OWNS its q-system/ and plugins/; everywhere else those are
+    sync destinations. Identified by the registry it carries, with the directory
+    name as a fallback, so a rename cannot silently turn the source into a
+    copy."""
+    if repo is None:
         return False
-    if not text.startswith(root + os.sep):
+    return (repo / "instance-registry.json").exists() or repo.name == "kipi-system"
+
+
+def _is_vendored_copy(path: Path, root=None) -> bool:
+    """Decided from the FILE's own repo, never from the root handed in.
+
+    It used to read `Path(root).name == "kipi-system"`. The CLI default root is
+    `~/projects`, and the fleet test passes `~/projects` as one root by design,
+    so the name was `projects` and the SKELETON'S OWN q-system/ and plugins/
+    were classed as vendored and skipped. The sweep reporting "0 across every
+    checkout" was structurally unable to look at the two directories this audit
+    lives in (PR 307 review, MAJOR 2, reproduced with two planted
+    old.reddit.com fetchers that came back clean).
+
+    A file belongs to whatever repo contains it, and that answer does not change
+    with the argument the caller happened to pass.
+    """
+    repo = _repo_root_of(path)
+    if repo is None:
         return False
-    parts = Path(text[len(root) + 1:]).parts
-    return any(part in VENDORED for part in parts)
+    if _is_the_skeleton(repo):
+        return False
+    try:
+        rel = path.resolve().relative_to(repo)
+    except ValueError:
+        return False
+    return any(part in VENDORED for part in rel.parts)
 
 
 def _is_test(path: Path) -> bool:
@@ -351,17 +395,26 @@ def violations_in_source(source: str, label: str) -> list[dict]:
         if any(host in low for host in ALLOWED_HOSTS):
             continue
 
+        # THE HARD DENYLIST RUNS FIRST, BEFORE ANY NAME EXEMPTION. It used to
+        # run after, so `old.reddit.com` inside a variable called `fetch_items`
+        # was exempt purely because "item" is on the data list, while the same
+        # URL under a plain name was caught. A comment further down claimed the
+        # denylist "still catches old.reddit.com absolutely"; it did not (PR 307
+        # review, MINOR 4). A name can argue that a www.reddit.com URL is a
+        # label. It cannot argue about a retired host.
         why = None
         label_early = (labels.get(id(node)) or "").lower()
-        if any(name in label_early for name in DENYLIST_NAMES + DATA_NAMES):
-            continue
+        if any(mark in label_early for mark in RETIREMENT_MARKERS):
+            continue          # a tombstone, not a call site
         for bad in FORBIDDEN_SUBSTRINGS:
             if bad in low:
                 why = bad
                 break
+        if why is None and any(name in label_early
+                               for name in DENYLIST_NAMES + DATA_NAMES):
+            continue
         if why is None and "reddit.com" in low:
             label = (labels.get(id(node)) or "").lower()
-            is_display = any(name in label for name in DISPLAY_NAMES)
             # WHAT IT IS, not what it is called. The name-based rules were
             # doing this job and doing it badly in both directions: exempting
             # "sites" hid a live /user/<u>/about.json in a published repo, and
@@ -436,6 +489,13 @@ def _bare_repo_violations(repo: Path) -> list[dict]:
 def _is_bare_repo(path: Path) -> bool:
     if not path.is_dir():
         return False
+    # A NORMAL REPO'S OWN .git DIRECTORY passes the HEAD/objects/refs test, so
+    # without this the audit read every checkout's internal object store and
+    # reported findings at paths like `consulting/.git!q-consult/...`. Those are
+    # the same files it already reads from the working tree, attributed to a
+    # directory nobody edits.
+    if path.name == ".git":
+        return False
     # A bare repo has HEAD/objects/refs at its top level and no .git dir.
     return all((path / n).exists() for n in ("HEAD", "objects", "refs")) \
         and not (path / ".git").exists()
@@ -459,8 +519,20 @@ def walk(roots) -> list[dict]:
             if not _skip(root):
                 out.extend(violations_in(root))
             continue
-        if _is_linked_worktree(root):
-            continue
+        # A ROOT THE CALLER NAMED IS ALWAYS SCANNED. This used to `continue`
+        # when the root was a linked worktree, which made the pre-commit hook a
+        # NO-OP everywhere this fleet actually works: lefthook passes
+        # `git rev-parse --show-toplevel`, and inside a worktree that IS the
+        # worktree, so the only automatic wiring of this rule exited 0 on every
+        # commit without opening a file (PR 307 review, MAJOR 1, reproduced:
+        # exit 0 in the worktree and exit 1 in the main checkout, same planted
+        # file).
+        #
+        # The skip was written for a different case and still serves it: a
+        # worktree found BELOW a parent root is a second copy of a branch that
+        # gets audited at its own root, and reporting it twice blames the copy.
+        # That case is handled inside the walk. Being handed a path is a
+        # different act from finding one.
         for dirpath, dirnames, filenames in os.walk(root):
             here = Path(dirpath)
             # PER DIRECTORY, not only on the root handed in. Checking the root
@@ -484,7 +556,7 @@ def walk(roots) -> list[dict]:
                     path = Path(dirpath) / name
                     if (not _skip(path) and not _is_test(path)
                             and not _exception_for(path)
-                            and not _is_vendored_copy(path, root)):
+                            and not _is_vendored_copy(path)):
                         out.extend(violations_in(path))
     return out
 

--- a/q-system/.q-system/scripts/reddit_read.py
+++ b/q-system/.q-system/scripts/reddit_read.py
@@ -544,9 +544,19 @@ def read_thread(permalink: str, transport=None, pacer=None, now=None,
             declared = rows[0].get("num_comments")
     except _ARCTIC.RedditFetchFailed:
         pass          # no declared count. coverage_pct becomes None, not zero.
+    partial = None
     try:
         read = _ARCTIC.all_comments(link_id, timeout=timeout, _get=getter,
                                     _opener=opener)
+    except TimeoutError as exc:
+        # A DEADLINE IS NOT A REFUSAL. Every page already fetched came back 200;
+        # the read simply ran out of budget. Reporting that as
+        # "mirror refused" threw away real comments and blamed a host that
+        # answered every time (review). It is an INCOMPLETE read, labelled as
+        # one, carrying what it got.
+        read = {"comments": [], "fetched": 0, "pages": 0,
+                "complete": False, "capped": True, "deadline": str(exc)}
+        partial = read
     except _ARCTIC.RedditFetchFailed as exc:
         return _refusal(url, seen.get("status", "EXC:RedditFetchFailed: %s" % exc), now)
 
@@ -573,6 +583,7 @@ def read_thread(permalink: str, transport=None, pacer=None, now=None,
         "expected_incomplete": bool(read["capped"]),
         "pages": read["pages"],
         "source": "arctic",
+        "deadline_hit": partial is not None,
         "user_agent": USER_AGENT,
     }
     assert_coverage_recorded(artifact)

--- a/q-system/.q-system/scripts/reddit_read.py
+++ b/q-system/.q-system/scripts/reddit_read.py
@@ -79,14 +79,44 @@ import sys
 import time
 import urllib.error
 import urllib.request
+import pathlib
+
+
+def _load_reddit_transport():
+    """Walk up to the vendored `plugins/kipi-core` and import the transport.
+
+    Walked rather than a fixed `parents[N]`: this script ships to every instance
+    and sits at a different depth in some of them. The failure mode a hardcoded
+    depth produces is the one `voiceloop/voice_ref.py` records, a caller wired on
+    one machine only.
+    """
+    here = pathlib.Path(__file__).resolve()
+    for parent in here.parents:
+        cand = parent / "plugins" / "kipi-core"
+        if (cand / "reddit_arctic").is_dir():
+            if str(cand) not in sys.path:
+                sys.path.insert(0, str(cand))
+            from reddit_arctic import transport
+            return transport
+    raise RuntimeError(
+        "no plugins/kipi-core/reddit_arctic above %s; this instance has not "
+        "taken the skeleton update that ships it" % here)
+
 
 # Honest identification. Any UA that is not empty and is not curl's default gets
 # a 200, so there is nothing to gain by impersonating a browser and the tests
 # forbid the strings that would.
-USER_AGENT = "kipi-research/1.0 (+https://github.com/assafkip/kipi-system; research)"
+USER_AGENT = "kipi-research/1.0 (+https://ktlyst.com; research)"
 
-BASE = "https://old.reddit.com"
-REDDIT_HOSTS = frozenset({"old.reddit.com", "www.reddit.com", "reddit.com", "new.reddit.com"})
+# NOT old.reddit.com ANY MORE (2026-09-04, founder-directed: "Any collection from
+# reddit that is not using arctic shift should be changed to it. this must be the
+# only way we scrape reddit."). BASE is kept as a name because it builds DISPLAY
+# links a human clicks, and because a session that greps for it should land on
+# this note rather than on nothing.
+BASE = "https://www.reddit.com"
+
+# The transport lives once, in the kipi-core plugin. This script is a caller.
+_ARCTIC = _load_reddit_transport()
 
 # 3s pacing 429'd 11 of 12 RSS requests. 10s pacing ran 13 of 13 clean across
 # listing pages and thread fetches. This is the measured floor, not a guess.
@@ -98,6 +128,10 @@ MIN_INTERVAL_S = 10
 # So one request is complete enough at or below 250, and demonstrably is not at
 # or above 600. NOTHING WAS MEASURED BETWEEN 224 AND 613, and `choose_strategy`
 # says so rather than guessing which side that band falls on.
+# These bands described how much of a thread ONE old.reddit request could
+# reach. Pagination removed that ceiling, so they no longer choose a
+# strategy for the live path; `read_listing` still reports them so a caller
+# can rank threads by size, which is the use that outlived the transport.
 SINGLE_REQUEST_MAX = 250
 LARGE_THREAD_MIN = 600
 
@@ -112,12 +146,6 @@ _TAG_RE = re.compile(r"<[^>]+>")
 
 class CoverageNotRecorded(Exception):
     """An artifact carrying comments without saying what fraction they are."""
-
-
-class PermalinkRefused(Exception):
-    """A permalink that is not a reddit thread. `reddit_thread` is an MCP tool, so
-    an absolute URL here is attacker-shaped input: without this check the tool
-    fetched any http(s) target and returned its body (PR #294 review, major)."""
 
 
 class DiscoveryRefused(Exception):
@@ -193,30 +221,15 @@ def parse_comments(html: str) -> list:
     Deliberately shallow. Threading, scores and semantic scoring are not this
     module's job; it is a fetcher and an artifact.
     """
-    # Bind author and body INSIDE each comment's own chunk, never by array
-    # position (PR #294 review, major): a real page opens with the post's own
-    # data-author and its selftext <div class="md">, and a deleted comment has
-    # no body, so positional joins attributed every comment to its neighbour.
-    text = html or ""
-    starts = []
-    seen = set()
-    for m in _COMMENT_RE.finditer(text):
-        cid = m.group(1)
-        if cid in seen:
-            continue
-        seen.add(cid)
-        tag_start = text.rfind("<", 0, m.start())
-        starts.append((cid, tag_start if tag_start >= 0 else m.start()))
+    ids = comment_ids(html)
+    authors = _AUTHOR_RE.findall(html or "")
+    bodies = [_text(b) for b in _MD_RE.findall(html or "")]
     out = []
-    for i, (cid, start) in enumerate(starts):
-        end = starts[i + 1][1] if i + 1 < len(starts) else len(text)
-        chunk = text[start:end]
-        a = _AUTHOR_RE.search(chunk)
-        b = _MD_RE.search(chunk)
+    for i, cid in enumerate(ids):
         out.append({
             "id": cid,
-            "author": a.group(1) if a else None,
-            "body": _text(b.group(1)) if b else None,
+            "author": authors[i] if i < len(authors) else None,
+            "body": bodies[i] if i < len(bodies) else None,
         })
     return out
 
@@ -319,22 +332,23 @@ def assert_coverage_recorded(artifact: dict) -> None:
 # ---------------------------------------------------------------------------
 
 def thread_url(permalink: str) -> str:
-    """?limit=500 moved one thread from 201 to 215 of 214 declared. It is one
-    query param and it is worth taking; it does not rescue large threads."""
-    if permalink.startswith("http"):
-        from urllib.parse import urlsplit
-        parts = urlsplit(permalink)
-        if parts.scheme != "https" or parts.netloc.lower() not in REDDIT_HOSTS:
-            raise PermalinkRefused(
-                f"refusing {permalink}: a thread permalink is a reddit path or an "
-                f"https URL on {sorted(REDDIT_HOSTS)}; this tool reads reddit, not the web")
-        path = f"{BASE}{parts.path}" + (f"?{parts.query}" if parts.query else "")
-    else:
-        if not permalink.startswith("/"):
-            raise PermalinkRefused(f"refusing {permalink}: a relative permalink starts with /")
-        path = BASE + permalink
-    joiner = "&" if "?" in path else "?"
-    return f"{path}{joiner}limit=500"
+    """The mirror's comments endpoint for this thread.
+
+    The old version built `old.reddit.com<permalink>?limit=500`, and the 500 was
+    the best available answer to a transport that could only ever return one
+    page. The mirror PAGES, so completeness stopped being something to buy with
+    a query parameter and became something the reader can just do. See
+    `read_thread`.
+    """
+    return _ARCTIC.comments_url(_ARCTIC.link_id_from_permalink(permalink),
+                                _ARCTIC.MAX_LIMIT)
+
+
+def display_url(permalink: str) -> str:
+    """The link a human clicks. Never fetched."""
+    if str(permalink).startswith("http"):
+        return permalink
+    return BASE + permalink
 
 
 def listing_url(subreddit: str, period: str = "month", path_override=None) -> str:
@@ -348,10 +362,13 @@ def listing_url(subreddit: str, period: str = "month", path_override=None) -> st
     path = path_override or f"/r/{subreddit}/top/"
     if ".rss" in path or path.endswith(".xml"):
         raise DiscoveryRefused(
-            f"refusing {path}: discovery uses listing HTML, not RSS. Measured "
-            "2026-08-31, RSS 429'd 11 of 12 requests at 3s pacing while listing "
-            "HTML ran clean.")
-    return f"{BASE}{path}?t={period}"
+            f"refusing {path}: discovery goes through the Arctic Shift mirror, "
+            "not RSS. Measured 2026-08-31, RSS 429'd 11 of 12 requests at 3s "
+            "pacing. The refusal outlived the HTML transport it was written for "
+            "because the reason did: a silent fallback to a throttling endpoint "
+            "is how a lane starts reporting zeros that are really refusals.")
+    sub = path.strip("/").split("/")[1] if path.startswith("/r/") else subreddit
+    return _ARCTIC.arctic_url(sub, _ARCTIC.MAX_LIMIT)
 
 
 # ---------------------------------------------------------------------------
@@ -390,49 +407,131 @@ def _refusal(url: str, status, now: dt.datetime) -> dict:
 
 def read_thread(permalink: str, transport=None, pacer=None, now=None,
                 timeout: int = DEFAULT_TIMEOUT_S) -> dict:
-    """One thread, one artifact. Read only."""
-    transport = transport or _default_transport
+    """One thread, one artifact, from the mirror. Read only.
+
+    THE COVERAGE RULE IS UNCHANGED AND IS NOW USUALLY SATISFIABLE. The rule was
+    never "report a percentage"; it was "never hand back comments without saying
+    what fraction of the thread they are", because 536 rows off a 1190-comment
+    thread looks exactly like a complete one. The HTML transport could only ever
+    take one page, so the honest answer was a well-labelled partial. The mirror
+    pages on `after=<created_utc>`, so the honest answer is a COMPLETE thread and
+    `coverage_pct` reaches 100.
+
+    VERIFIED LIVE 2026-09-04 on r/programming 1w67dpg: declared 108, fetched 111
+    across two pages. The archive can hold slightly more rows than the live post
+    declares, so `coverage_pct` is allowed above 100 and `complete` is decided by
+    pagination exhausting, never by matching `declared`.
+
+    `transport` is still accepted so every existing caller and test double keeps
+    working; it is passed to the mirror as its `_get` seam.
+    """
     pacer = pacer or NullPacer()
     now = now or dt.datetime.now().astimezone()
+    link_id = _ARCTIC.link_id_from_permalink(permalink)
     url = thread_url(permalink)
+    getter, seen = _as_getter(transport)
     pacer.wait()
-    status, body = transport(url, {"User-Agent": USER_AGENT}, timeout)
-    if status != 200:
-        return _refusal(url, status, now)
-    artifact = build_artifact(parse_thread(body, url=url), now)
+    try:
+        declared = None
+        rows = _ARCTIC.posts_by_id(link_id, timeout=timeout, _get=getter)
+        if rows:
+            declared = rows[0].get("num_comments")
+        read = _ARCTIC.all_comments(link_id, timeout=timeout, _get=getter)
+    except _ARCTIC.RedditFetchFailed as exc:
+        return _refusal(url, seen.get("status", "EXC:RedditFetchFailed: %s" % exc), now)
+
+    fetched = read["fetched"]
+    artifact = {
+        "url": url,
+        "display_url": display_url(permalink),
+        "refused": False,
+        "http_status": 200,
+        "fetched_at": now.isoformat(timespec="seconds"),
+        "declared": declared,
+        "fetched": fetched,
+        "coverage_pct": coverage_pct(fetched, declared),
+        "stubs": 0,
+        "complete": bool(read["complete"]),
+        "truncated": bool(read["capped"]),
+        "anomaly": None,
+        "comments": read["comments"],
+        "strategy": "paginate",
+        "expected_incomplete": bool(read["capped"]),
+        "pages": read["pages"],
+        "source": "arctic",
+        "user_agent": USER_AGENT,
+    }
     assert_coverage_recorded(artifact)
     return artifact
 
 
+def _as_getter(transport):
+    """Adapt the old `(url, headers, timeout) -> (status, body)` transport to the
+    mirror's `(url) -> parsed json`, so existing callers and test doubles still
+    drive this. Returns `(getter, seen)`.
+
+    A non-200 becomes a raise, which is what the mirror path expects and what
+    `read_thread` turns back into a refusal artifact. THE STATUS IS CARRIED OUT
+    IN `seen`, not left inside the exception text: a 429 recorded as
+    `EXC:something` is a throttled run that no longer looks like a throttled
+    run, and telling those apart is the entire reason `_refusal` exists.
+    """
+    seen = {}
+    if transport is None:
+        return None, seen
+
+    def _get(url):
+        status, body = transport(url, {"User-Agent": USER_AGENT},
+                                 DEFAULT_TIMEOUT_S)
+        if status != 200:
+            seen["status"] = status
+            raise RuntimeError("transport returned %s for %s" % (status, url))
+        return json.loads(body) if isinstance(body, str) else body
+    return _get, seen
+
+
 def read_listing(subreddit: str, period: str = "month", transport=None,
                  pacer=None, now=None, timeout: int = DEFAULT_TIMEOUT_S) -> dict:
-    """Candidate threads with the size Reddit declares for each, so a caller can
-    pick by size before spending a request per thread."""
-    transport = transport or _default_transport
+    """Candidate threads with the size the mirror declares for each, so a caller
+    can pick by size before spending a request per thread.
+
+    `period` is accepted and no longer filters: the mirror returns a room's most
+    recent posts and the window that produces is a property of how busy the room
+    is, not something a `t=` parameter can set. Measured 2026-08-31: r/taxpros
+    reached back 24.9 days at limit=100 and r/smallbusiness reached 0.6. Kept in
+    the signature and echoed in the artifact so no caller breaks, and so the
+    lie is visible rather than implied.
+    """
     pacer = pacer or NullPacer()
     now = now or dt.datetime.now().astimezone()
     url = listing_url(subreddit, period)
+    getter, seen = _as_getter(transport)
     pacer.wait()
-    status, body = transport(url, {"User-Agent": USER_AGENT}, timeout)
-    if status != 200:
-        out = _refusal(url, status, now)
+    try:
+        posts = _ARCTIC.recent(subreddit, max_items=_ARCTIC.MAX_LIMIT,
+                               timeout=timeout, _get=getter)
+    except _ARCTIC.RedditFetchFailed as exc:
+        out = _refusal(url, seen.get("status", "EXC:RedditFetchFailed: %s" % exc), now)
         out["threads"] = None
         return out
 
-    found = {}
-    for pattern in (r'data-comments-count="(\d+)"[^>]*data-permalink="([^"]+)"',
-                    r'data-permalink="([^"]+)"[^>]*data-comments-count="(\d+)"'):
-        for match in re.finditer(pattern, body):
-            first, second = match.group(1), match.group(2)
-            count, permalink = (int(first), second) if first.isdigit() else (int(second), first)
-            found[permalink] = count
-    threads = [{"permalink": p, "declared": c, "strategy": choose_strategy(c)}
-               for p, c in sorted(found.items(), key=lambda kv: kv[1])]
+    threads = []
+    for post in posts:
+        permalink = post.get("permalink") or ""
+        if not permalink:
+            continue
+        declared = int(post.get("num_comments") or 0)
+        threads.append({"permalink": permalink, "declared": declared,
+                        "strategy": choose_strategy(declared),
+                        "title": post.get("title", ""), "id": post.get("id", "")})
+    threads.sort(key=lambda t: t["declared"])
     return {
-        "url": url, "refused": False, "http_status": status,
+        "url": url, "refused": False, "http_status": 200,
         "fetched_at": now.isoformat(timespec="seconds"),
         "subreddit": subreddit, "period": period,
+        "period_is_advisory": True,
         "threads": threads, "thread_count": len(threads),
+        "source": "arctic",
         "user_agent": USER_AGENT, "comments": None,
     }
 

--- a/q-system/.q-system/scripts/reddit_read.py
+++ b/q-system/.q-system/scripts/reddit_read.py
@@ -548,13 +548,18 @@ def read_thread(permalink: str, transport=None, pacer=None, now=None,
     try:
         read = _ARCTIC.all_comments(link_id, timeout=timeout, _get=getter,
                                     _opener=opener)
-    except TimeoutError as exc:
+    except _ARCTIC.ReadDeadlineExceeded as exc:
         # A DEADLINE IS NOT A REFUSAL. Every page already fetched came back 200;
         # the read simply ran out of budget. Reporting that as
         # "mirror refused" threw away real comments and blamed a host that
         # answered every time (review). It is an INCOMPLETE read, labelled as
         # one, carrying what it got.
-        read = {"comments": [], "fetched": 0, "pages": 0,
+        # CARRY WHAT WAS ALREADY READ. The previous version built an EMPTY read
+        # while its own comment claimed it carried what it got (round 9), which
+        # is the same discard it was written to stop, one layer in. The transport
+        # attaches the pages it had collected to the exception.
+        got = list(getattr(exc, "partial", []) or [])
+        read = {"comments": got, "fetched": len(got), "pages": 0,
                 "complete": False, "capped": True, "deadline": str(exc)}
         partial = read
     except _ARCTIC.RedditFetchFailed as exc:
@@ -607,7 +612,7 @@ def _paced(getter, pacer):
 
     def _deadline():
         if _time.monotonic() - started > READ_DEADLINE_S:
-            raise TimeoutError(
+            raise _ARCTIC.ReadDeadlineExceeded(
                 "read exceeded READ_DEADLINE_S=%ss. A per-request pace bounds "
                 "the gap between requests, never the total." % READ_DEADLINE_S)
 

--- a/q-system/.q-system/scripts/reddit_read.py
+++ b/q-system/.q-system/scripts/reddit_read.py
@@ -503,7 +503,10 @@ def read_thread(permalink: str, transport=None, pacer=None, now=None,
     # wait and five unpaced fetches while the class docstring still promised
     # "at most one request per min_interval_s" (review).
     getter, seen = _as_getter(transport, timeout)
-    getter = _paced(getter, pacer)
+    paced = _paced(getter, pacer)
+    # One of the two seams, never both: a caller-supplied transport arrives as a
+    # getter, and the bare production path is paced at the opener.
+    getter, opener = (paced, None) if getter is not None else (None, paced)
     # TWO READS, TWO FATES. They shared one `try`, and `posts_by_id` runs first,
     # so a /api/posts/ids outage discarded a thread the comments endpoint served
     # fine: refused=True, http_status=503, comments=None, for 7 comments that
@@ -512,13 +515,15 @@ def read_thread(permalink: str, transport=None, pacer=None, now=None,
     # and not the thread, and this caller was the one deciding otherwise.
     declared = None
     try:
-        rows = _ARCTIC.posts_by_id(link_id, timeout=timeout, _get=getter)
+        rows = _ARCTIC.posts_by_id(link_id, timeout=timeout, _get=getter,
+                                   _opener=opener)
         if rows:
             declared = rows[0].get("num_comments")
     except _ARCTIC.RedditFetchFailed:
         pass          # no declared count. coverage_pct becomes None, not zero.
     try:
-        read = _ARCTIC.all_comments(link_id, timeout=timeout, _get=getter)
+        read = _ARCTIC.all_comments(link_id, timeout=timeout, _get=getter,
+                                    _opener=opener)
     except _ARCTIC.RedditFetchFailed as exc:
         return _refusal(url, seen.get("status", "EXC:RedditFetchFailed: %s" % exc), now)
 
@@ -552,16 +557,30 @@ def read_thread(permalink: str, transport=None, pacer=None, now=None,
 
 
 def _paced(getter, pacer):
-    """Every fetch waits, not just the first. `getter` may be None when no
-    transport was injected, and then the transport does its own fetching, so
-    there is nothing here to pace."""
-    if getter is None:
-        return None
+    """Every fetch waits. Including production, which is where it was not.
 
-    def _get(url):
+    Round 5 wrapped `getter` and returned None when no transport was injected,
+    reasoning that "the transport does its own fetching, so there is nothing
+    here to pace". That is exactly backwards: `transport` is None on the MCP and
+    CLI paths, so the ONLY arm that got paced was the one tests supply, and
+    production made up to 41 unpaced mirror requests per thread (review).
+
+    Fixing the injected path and leaving production alone is the mode-nobody-
+    tests defect in one function. When no transport is injected, this returns a
+    paced OPENER instead, which is the seam the transport actually uses.
+    """
+    if getter is not None:
+        def _get(url):
+            pacer.wait()
+            return getter(url)
+        return _get
+
+    import urllib.request as _u
+
+    def _opener(req, timeout=None):
         pacer.wait()
-        return getter(url)
-    return _get
+        return _u.urlopen(req, timeout=timeout)
+    return _opener
 
 
 def _as_getter(transport, _timeout: int = DEFAULT_TIMEOUT_S):
@@ -609,7 +628,10 @@ def read_listing(subreddit: str, period: str = "month", transport=None,
     # wait and five unpaced fetches while the class docstring still promised
     # "at most one request per min_interval_s" (review).
     getter, seen = _as_getter(transport, timeout)
-    getter = _paced(getter, pacer)
+    paced = _paced(getter, pacer)
+    # One of the two seams, never both: a caller-supplied transport arrives as a
+    # getter, and the bare production path is paced at the opener.
+    getter, opener = (paced, None) if getter is not None else (None, paced)
     try:
         posts = _ARCTIC.recent(subreddit, max_items=_ARCTIC.MAX_LIMIT,
                                timeout=timeout, _get=getter)

--- a/q-system/.q-system/scripts/reddit_read.py
+++ b/q-system/.q-system/scripts/reddit_read.py
@@ -436,11 +436,20 @@ def read_thread(permalink: str, transport=None, pacer=None, now=None,
     url = thread_url(permalink)
     getter, seen = _as_getter(transport)
     pacer.wait()
+    # TWO READS, TWO FATES. They shared one `try`, and `posts_by_id` runs first,
+    # so a /api/posts/ids outage discarded a thread the comments endpoint served
+    # fine: refused=True, http_status=503, comments=None, for 7 comments that
+    # were sitting right there (review, MINOR 2). The transport's own docstring
+    # states the opposite contract, that losing that endpoint loses `declared`
+    # and not the thread, and this caller was the one deciding otherwise.
+    declared = None
     try:
-        declared = None
         rows = _ARCTIC.posts_by_id(link_id, timeout=timeout, _get=getter)
         if rows:
             declared = rows[0].get("num_comments")
+    except _ARCTIC.RedditFetchFailed:
+        pass          # no declared count. coverage_pct becomes None, not zero.
+    try:
         read = _ARCTIC.all_comments(link_id, timeout=timeout, _get=getter)
     except _ARCTIC.RedditFetchFailed as exc:
         return _refusal(url, seen.get("status", "EXC:RedditFetchFailed: %s" % exc), now)

--- a/q-system/.q-system/scripts/reddit_read.py
+++ b/q-system/.q-system/scripts/reddit_read.py
@@ -106,7 +106,6 @@ def _load_reddit_transport():
 # Honest identification. Any UA that is not empty and is not curl's default gets
 # a 200, so there is nothing to gain by impersonating a browser and the tests
 # forbid the strings that would.
-USER_AGENT = "kipi-research/1.0 (+https://ktlyst.com; research)"
 
 # NOT old.reddit.com ANY MORE (2026-09-04, founder-directed: "Any collection from
 # reddit that is not using arctic shift should be changed to it. this must be the
@@ -117,6 +116,12 @@ BASE = "https://www.reddit.com"
 
 # The transport lives once, in the kipi-core plugin. This script is a caller.
 _ARCTIC = _load_reddit_transport()
+
+# ONE definition, in the transport. It used to be a second copy of the same
+# string here, which is the shape this whole change exists to remove: two copies
+# of a rule drift, and this pair drifted into a hardcoded company domain that
+# the skeleton's own separation gate refuses.
+USER_AGENT = _ARCTIC.USER_AGENT
 
 # 3s pacing 429'd 11 of 12 RSS requests. 10s pacing ran 13 of 13 clean across
 # listing pages and thread fetches. This is the measured floor, not a guess.

--- a/q-system/.q-system/scripts/reddit_read.py
+++ b/q-system/.q-system/scripts/reddit_read.py
@@ -522,7 +522,11 @@ def read_thread(permalink: str, transport=None, pacer=None, now=None,
         "coverage_pct": coverage_pct(fetched, declared),
         "stubs": 0,
         "complete": bool(read["complete"]),
-        "truncated": bool(read["capped"]),
+        # NOT `capped` alone. all_comments has a complete=False capped=False
+        # branch (it ran out of cursor to advance on), and mapping truncated
+        # from capped only labelled that artifact truncated=False while it was
+        # incomplete (review, MINOR 3). Truncated means "there was more".
+        "truncated": bool(read["capped"]) or not read["complete"],
         "anomaly": None,
         "comments": read["comments"],
         "strategy": "paginate",

--- a/q-system/.q-system/scripts/reddit_read.py
+++ b/q-system/.q-system/scripts/reddit_read.py
@@ -265,7 +265,14 @@ def coverage_pct(fetched, declared):
     if declared is None:
         return None
     if declared == 0:
-        return 100.0 if fetched == 0 else 0.0
+        # NOT 0.0 when rows came back. A thread declaring nothing that yielded 7
+        # comments reported coverage_pct 0.0 beside complete=True, which reads as
+        # "the read worked and returned none of the thread" (review). There is no
+        # denominator, so there is no percentage: None is the honest answer, and
+        # `declared` travels in the artifact for anyone who wants the raw counts.
+        #
+        # 0 fetched of 0 declared stays 100.0: an empty thread WAS fully read.
+        return 100.0 if fetched == 0 else None
     return round(100.0 * fetched / declared, 1)
 
 
@@ -490,8 +497,13 @@ def read_thread(permalink: str, transport=None, pacer=None, now=None,
     now = now or dt.datetime.now().astimezone()
     link_id = _ARCTIC.link_id_from_permalink(permalink)
     url = thread_url(permalink)
+    # THE PACER WRAPS THE GETTER, so it covers EVERY request. It used to be a
+    # single wait() before the read, which was one request back when a thread
+    # was one request. Now `all_comments` pages, so a 6-page thread got one
+    # wait and five unpaced fetches while the class docstring still promised
+    # "at most one request per min_interval_s" (review).
     getter, seen = _as_getter(transport, timeout)
-    pacer.wait()
+    getter = _paced(getter, pacer)
     # TWO READS, TWO FATES. They shared one `try`, and `posts_by_id` runs first,
     # so a /api/posts/ids outage discarded a thread the comments endpoint served
     # fine: refused=True, http_status=503, comments=None, for 7 comments that
@@ -539,6 +551,19 @@ def read_thread(permalink: str, transport=None, pacer=None, now=None,
     return artifact
 
 
+def _paced(getter, pacer):
+    """Every fetch waits, not just the first. `getter` may be None when no
+    transport was injected, and then the transport does its own fetching, so
+    there is nothing here to pace."""
+    if getter is None:
+        return None
+
+    def _get(url):
+        pacer.wait()
+        return getter(url)
+    return _get
+
+
 def _as_getter(transport, _timeout: int = DEFAULT_TIMEOUT_S):
     """Adapt the old `(url, headers, timeout) -> (status, body)` transport to the
     mirror's `(url) -> parsed json`, so existing callers and test doubles still
@@ -578,8 +603,13 @@ def read_listing(subreddit: str, period: str = "month", transport=None,
     pacer = pacer or NullPacer()
     now = now or dt.datetime.now().astimezone()
     url = listing_url(subreddit, period)
+    # THE PACER WRAPS THE GETTER, so it covers EVERY request. It used to be a
+    # single wait() before the read, which was one request back when a thread
+    # was one request. Now `all_comments` pages, so a 6-page thread got one
+    # wait and five unpaced fetches while the class docstring still promised
+    # "at most one request per min_interval_s" (review).
     getter, seen = _as_getter(transport, timeout)
-    pacer.wait()
+    getter = _paced(getter, pacer)
     try:
         posts = _ARCTIC.recent(subreddit, max_items=_ARCTIC.MAX_LIMIT,
                                timeout=timeout, _get=getter)

--- a/q-system/.q-system/scripts/reddit_read.py
+++ b/q-system/.q-system/scripts/reddit_read.py
@@ -153,6 +153,12 @@ class CoverageNotRecorded(Exception):
     """An artifact carrying comments without saying what fraction they are."""
 
 
+class PermalinkRefused(Exception):
+    """A permalink that is not a reddit thread. `reddit_thread` is an MCP tool, so
+    an absolute URL here is attacker-shaped input: without this check the tool
+    fetched any http(s) target and returned its body (PR #294 review, major)."""
+
+
 class DiscoveryRefused(Exception):
     """A discovery URL this lane will not use."""
 
@@ -226,18 +232,32 @@ def parse_comments(html: str) -> list:
     Deliberately shallow. Threading, scores and semantic scoring are not this
     module's job; it is a fetcher and an artifact.
     """
-    ids = comment_ids(html)
-    authors = _AUTHOR_RE.findall(html or "")
-    bodies = [_text(b) for b in _MD_RE.findall(html or "")]
+    # Bind author and body INSIDE each comment's own chunk, never by array
+    # position (PR #294 review, major): a real page opens with the post's own
+    # data-author and its selftext <div class="md">, and a deleted comment has
+    # no body, so positional joins attributed every comment to its neighbour.
+    text = html or ""
+    starts = []
+    seen = set()
+    for m in _COMMENT_RE.finditer(text):
+        cid = m.group(1)
+        if cid in seen:
+            continue
+        seen.add(cid)
+        tag_start = text.rfind("<", 0, m.start())
+        starts.append((cid, tag_start if tag_start >= 0 else m.start()))
     out = []
-    for i, cid in enumerate(ids):
+    for i, (cid, start) in enumerate(starts):
+        end = starts[i + 1][1] if i + 1 < len(starts) else len(text)
+        chunk = text[start:end]
+        a = _AUTHOR_RE.search(chunk)
+        b = _MD_RE.search(chunk)
         out.append({
             "id": cid,
-            "author": authors[i] if i < len(authors) else None,
-            "body": bodies[i] if i < len(bodies) else None,
+            "author": a.group(1) if a else None,
+            "body": _text(b.group(1)) if b else None,
         })
     return out
-
 
 def coverage_pct(fetched, declared):
     """Percentage of the declared thread actually parsed, or None when the page
@@ -345,8 +365,44 @@ def thread_url(permalink: str) -> str:
     a query parameter and became something the reader can just do. See
     `read_thread`.
     """
+    _refuse_if_not_a_thread(permalink)
     return _ARCTIC.comments_url(_ARCTIC.link_id_from_permalink(permalink),
                                 _ARCTIC.MAX_LIMIT)
+
+
+def _refuse_if_not_a_thread(permalink: str) -> None:
+    """`reddit_thread` is an MCP tool, so the permalink is CALLER-SUPPLIED.
+
+    Restored after a file-level landing dropped it along with its test. The
+    fetch URL is rebuilt from ARCTIC_BASE now, so a foreign host is never
+    contacted, but without this an arbitrary URL still produced
+    `refused: False, complete: True` for a thread that does not exist, with the
+    caller's string echoed into `display_url`, the field whose docstring calls
+    it "the link a human clicks" (PR 307 review).
+
+    Every clause here is one of the original test's cases: https only (so
+    `http://old.reddit.com/...` is refused), a reddit host and not a lookalike
+    (`old.reddit.com.evil.example`), a thread path, and no scheme-less relative
+    string that could be read as a host.
+    """
+    text = str(permalink or "").strip()
+    if "://" in text:
+        scheme, rest = text.split("://", 1)
+        if scheme.lower() != "https":
+            raise PermalinkRefused(
+                "only https reddit URLs are accepted, got %r" % permalink)
+        host = rest.split("/", 1)[0].lower().split("@")[-1].split(":")[0]
+        if not (host == "reddit.com" or host.endswith(".reddit.com")):
+            raise PermalinkRefused(
+                "not a reddit host: %r. A lookalike like reddit.com.evil.test "
+                "is refused for the reason a foreign host is." % permalink)
+    elif not text.startswith("/"):
+        raise PermalinkRefused(
+            "a relative permalink must start with '/', got %r" % permalink)
+    if "/comments/" not in text:
+        raise PermalinkRefused(
+            "not a reddit thread permalink: %r (expected .../comments/<id>/...)"
+            % permalink)
 
 
 def display_url(permalink: str) -> str:
@@ -434,7 +490,7 @@ def read_thread(permalink: str, transport=None, pacer=None, now=None,
     now = now or dt.datetime.now().astimezone()
     link_id = _ARCTIC.link_id_from_permalink(permalink)
     url = thread_url(permalink)
-    getter, seen = _as_getter(transport)
+    getter, seen = _as_getter(transport, timeout)
     pacer.wait()
     # TWO READS, TWO FATES. They shared one `try`, and `posts_by_id` runs first,
     # so a /api/posts/ids outage discarded a thread the comments endpoint served
@@ -479,7 +535,7 @@ def read_thread(permalink: str, transport=None, pacer=None, now=None,
     return artifact
 
 
-def _as_getter(transport):
+def _as_getter(transport, _timeout: int = DEFAULT_TIMEOUT_S):
     """Adapt the old `(url, headers, timeout) -> (status, body)` transport to the
     mirror's `(url) -> parsed json`, so existing callers and test doubles still
     drive this. Returns `(getter, seen)`.
@@ -495,8 +551,7 @@ def _as_getter(transport):
         return None, seen
 
     def _get(url):
-        status, body = transport(url, {"User-Agent": USER_AGENT},
-                                 DEFAULT_TIMEOUT_S)
+        status, body = transport(url, {"User-Agent": USER_AGENT}, _timeout)
         if status != 200:
             seen["status"] = status
             raise RuntimeError("transport returned %s for %s" % (status, url))
@@ -519,7 +574,7 @@ def read_listing(subreddit: str, period: str = "month", transport=None,
     pacer = pacer or NullPacer()
     now = now or dt.datetime.now().astimezone()
     url = listing_url(subreddit, period)
-    getter, seen = _as_getter(transport)
+    getter, seen = _as_getter(transport, timeout)
     pacer.wait()
     try:
         posts = _ARCTIC.recent(subreddit, max_items=_ARCTIC.MAX_LIMIT,

--- a/q-system/.q-system/scripts/reddit_read.py
+++ b/q-system/.q-system/scripts/reddit_read.py
@@ -77,6 +77,7 @@ import json
 import re
 import sys
 import time
+import time as _time
 import urllib.error
 import urllib.request
 import pathlib
@@ -123,9 +124,31 @@ _ARCTIC = _load_reddit_transport()
 # the skeleton's own separation gate refuses.
 USER_AGENT = _ARCTIC.USER_AGENT
 
-# 3s pacing 429'd 11 of 12 RSS requests. 10s pacing ran 13 of 13 clean across
-# listing pages and thread fetches. This is the measured floor, not a guess.
-MIN_INTERVAL_S = 10
+# THIS NUMBER WAS MEASURED AGAINST A HOST THIS MODULE NO LONGER READS.
+#
+# 10s came from old.reddit.com, where 3s pacing 429'd 11 of 12 RSS requests and
+# 10s ran 13 of 13 clean. That was a measured floor and it was the right number
+# for Reddit.
+#
+# It is the wrong number for the Arctic Shift mirror, and keeping it did real
+# damage the moment the pacer started covering every request instead of the
+# first: `all_comments` pages, so ONE reddit_thread call became 41 requests and
+# 400 SECONDS of deliberate sleeping against a host that never asked for it
+# (review). Pacing harder made the previous fix worse.
+#
+# HONEST ABOUT WHAT IS MEASURED AND WHAT IS NOT. Arctic's own rate limit has NOT
+# been measured. What has: individual calls return under 3s, and this session
+# made hundreds of consecutive requests today with no 429 and no refusal. So
+# this is a COURTESY interval on a free archive somebody else pays for, not a
+# floor derived from a limit. If a 429 ever appears, that is the measurement,
+# and it belongs here with its date.
+RETIRED_REDDIT_MIN_INTERVAL_S = 10          # old.reddit.com. Kept for its scar.
+MIN_INTERVAL_S = 0.25
+
+# A whole-read deadline, because a per-request pace says nothing about how long
+# a paged read may take in total. 41 requests at any interval still needs a
+# ceiling somebody chose on purpose.
+READ_DEADLINE_S = 120
 
 # Derived from the population above, not picked:
 #   224 declared measured 97.3% in one request
@@ -569,8 +592,17 @@ def _paced(getter, pacer):
     tests defect in one function. When no transport is injected, this returns a
     paced OPENER instead, which is the seam the transport actually uses.
     """
+    started = _time.monotonic()
+
+    def _deadline():
+        if _time.monotonic() - started > READ_DEADLINE_S:
+            raise TimeoutError(
+                "read exceeded READ_DEADLINE_S=%ss. A per-request pace bounds "
+                "the gap between requests, never the total." % READ_DEADLINE_S)
+
     if getter is not None:
         def _get(url):
+            _deadline()
             pacer.wait()
             return getter(url)
         return _get
@@ -578,6 +610,7 @@ def _paced(getter, pacer):
     import urllib.request as _u
 
     def _opener(req, timeout=None):
+        _deadline()
         pacer.wait()
         return _u.urlopen(req, timeout=timeout)
     return _opener
@@ -634,7 +667,7 @@ def read_listing(subreddit: str, period: str = "month", transport=None,
     getter, opener = (paced, None) if getter is not None else (None, paced)
     try:
         posts = _ARCTIC.recent(subreddit, max_items=_ARCTIC.MAX_LIMIT,
-                               timeout=timeout, _get=getter)
+                               timeout=timeout, _get=getter, _opener=opener)
     except _ARCTIC.RedditFetchFailed as exc:
         out = _refusal(url, seen.get("status", "EXC:RedditFetchFailed: %s" % exc), now)
         out["threads"] = None

--- a/q-system/.q-system/tests/test_competitive_intel_reddit_failures.py
+++ b/q-system/.q-system/tests/test_competitive_intel_reddit_failures.py
@@ -1,0 +1,137 @@
+"""The failure semantics competitive_intel gained in PR 307, tested where CI runs.
+
+WHY THIS FILE IS HERE AND NOT BESIDE THE MODULE. `plugins/kipi-core/kipi-mcp` is
+excluded from `.verify-suites` because its own `tests/conftest.py` skips the whole
+suite when the plugin's dependencies are absent (apify-client, feedparser, mcp,
+pyyaml, tenacity). That exclusion is documented, measured and ticketed as
+sp-97ce589b. It also meant this PR added 110 lines of new failure handling with
+NOTHING running against it (PR 307 review, round 7, MAJOR).
+
+The previous round answered that by pinning only the transport contract and
+saying so. The reviewer was right that it was not enough: the per-room catch, the
+total-outage raise and the failures sidecar are this PR's logic, not the
+transport's, and they were guarded by nothing.
+
+`competitive_intel` imports cleanly once those five modules exist as names, and
+none of them is touched by the code under test here. So the deps are stubbed and
+the real module is exercised. That is a smaller thing than installing the plugin
+in CI, which is an environment change with its own blast radius and its own
+ticket, and it is enough to catch a revert of the behaviour below.
+"""
+from __future__ import annotations
+
+import json
+import sys
+import types
+from pathlib import Path
+
+import pytest
+
+REPO = Path(__file__).resolve().parents[3]
+SRC = REPO / "plugins" / "kipi-core" / "kipi-mcp" / "src"
+
+
+@pytest.fixture(scope="module")
+def ci():
+    for name in ("yaml", "feedparser", "apify_client", "mcp", "tenacity"):
+        if name in sys.modules:
+            continue
+        try:
+            __import__(name)
+        except ImportError:
+            stub = types.ModuleType(name)
+            stub.safe_load = lambda *a, **k: {}
+            sys.modules[name] = stub
+    if str(SRC) not in sys.path:
+        sys.path.insert(0, str(SRC))
+    from kipi_mcp import competitive_intel
+    return competitive_intel
+
+
+def _source(*subs):
+    return {"name": "reddit-test", "subreddits": list(subs),
+            "lookback_days": 30, "posts_per_sub": 2}
+
+
+def _row(url):
+    return {"data": [{"id": "x", "title": "t", "subreddit": "s",
+                      "created_utc": 1788136000, "permalink": "/r/s/x/"}]}
+
+
+def test_one_dead_room_does_not_lose_the_others(ci):
+    """The raise used to escape into collect_ai_raw_records' `except Exception:
+    continue`, so ONE dead subreddit lost the other three and the harvest still
+    wrote a success artifact with zero Reddit rows."""
+    def fetch(url):
+        if "subreddit=dead" in url:
+            raise OSError("down")
+        return _row(url)
+
+    records = ci._collect_reddit_rss(_source("good", "dead", "also_good"), 10, fetch)
+    assert records, "a dead room must not take the live ones with it"
+    assert len(records) == 2
+
+
+def test_every_room_refusing_raises_rather_than_returning_empty(ci):
+    """A total outage returning [] is indistinguishable from a quiet week. That
+    is the same rule the transport holds, one layer up."""
+    def dead(url):
+        raise OSError("down")
+
+    with pytest.raises(ci.RedditFetchFailed):
+        ci._collect_reddit_rss(_source("a", "b"), 10, dead)
+
+
+def test_a_lost_source_reaches_the_artifact_not_only_stderr(ci, tmp_path):
+    """A stderr line at an unattended entry point is a line nobody reads: the run
+    still exited 0 and still wrote a clean-looking harvest."""
+    config = tmp_path / "sources.json"
+    config.write_text(json.dumps({"sources": [
+        {"type": "reddit_rss", "name": "reddit-dead", "subreddits": ["a"]},
+        {"type": "reddit_rss", "name": "reddit-live", "subreddits": ["b"]},
+    ]}))
+    out = tmp_path / "harvest.json"
+
+    def fetch(url):
+        if "subreddit=a" in url:
+            raise OSError("down")
+        return _row(url)
+
+    records = ci.collect_ai_raw_records(
+        output_path=out, sources_config_path=config, fetch_json=fetch)
+    assert records, "the live source must still be harvested"
+
+    sidecar = out.with_suffix(out.suffix + ".failures.json")
+    assert sidecar.exists(), "a lost source must travel with the output"
+    failures = json.loads(sidecar.read_text())
+    assert any(f["source"] == "reddit-dead" for f in failures), failures
+
+
+def test_a_harvest_that_lost_everything_raises(ci, tmp_path):
+    """NEGATIVE CONTROL for the sidecar: recording a failure is not enough when
+    there is nothing else in the artifact to read."""
+    config = tmp_path / "sources.json"
+    config.write_text(json.dumps({"sources": [
+        {"type": "reddit_rss", "name": "reddit-dead", "subreddits": ["a"]},
+    ]}))
+
+    def dead(url):
+        raise OSError("down")
+
+    with pytest.raises(ci.RedditFetchFailed):
+        ci.collect_ai_raw_records(output_path=tmp_path / "h.json",
+                                  sources_config_path=config, fetch_json=dead)
+
+
+def test_the_delegate_still_raises_rather_than_returning_empty(ci):
+    """The one rule the whole module change exists for. `_reddit_archive_posts`
+    returned [] when both mirrors refused; four of the five copies of that
+    transport across the corpus did."""
+    with pytest.raises(ci.RedditFetchFailed):
+        ci._reddit_archive_posts("taxpros", "2026-08-01", 5,
+                                 lambda url: (_ for _ in ()).throw(OSError("down")))
+
+    # a quiet subreddit is still empty, and that distinction is the point
+    rows = ci._reddit_archive_posts("taxpros", "2026-08-01", 5,
+                                    lambda url: {"data": []})
+    assert rows == []

--- a/q-system/.q-system/tests/test_reddit_read.py
+++ b/q-system/.q-system/tests/test_reddit_read.py
@@ -40,6 +40,7 @@ import ast
 import datetime as dt
 import importlib.util
 import json
+import pathlib
 import sys
 from pathlib import Path
 
@@ -292,49 +293,53 @@ def test_discovery_refuses_an_rss_url(rr):
         rr.listing_url("programming", period="month", path_override="/r/programming/top/.rss")
 
 
-def test_discovery_builds_an_old_reddit_listing_url(rr):
+def test_discovery_builds_an_arctic_listing_url(rr):
+    """REPLACED test_discovery_builds_an_old_reddit_listing_url (2026-09-04).
+    Rewritten rather than deleted: the claim it held (discovery has one url
+    shape, and it is not RSS) is still the claim. Only the host changed."""
     url = rr.listing_url("programming", period="month")
-    assert url.startswith("https://old.reddit.com/r/programming/top/")
-    assert "t=month" in url
-    assert ".rss" not in url
+    assert url.startswith("https://arctic-shift.photon-reddit.com/api/posts/search")
+    assert "subreddit=programming" in url
+    assert ".rss" not in url and "old.reddit.com" not in url
 
 
-def test_comments_bind_author_and_body_per_comment_not_by_position(rr):
-    """PR #294 review, major: a real page opens with the post's own data-author
-    and selftext <div class="md">, and a deleted comment carries no body, so a
-    positional join shifted every attribution by one. Control: the second
-    comment has no body and must read as None, not steal the third's."""
-    html = (
-        '<div class=" thing id-t3_post link " data-fullname="t3_post" data-author="op_poster">'
-        '<div class="md"><p>the post text</p></div></div>'
-        '<div class=" thing id-t1_aaa comment " data-fullname="t1_aaa" data-author="alice">'
-        '<div class="md"><p>first</p></div></div>'
-        '<div class=" thing id-t1_bbb comment " data-fullname="t1_bbb" data-author="[deleted]"></div>'
-        '<div class=" thing id-t1_ccc comment " data-fullname="t1_ccc" data-author="carol">'
-        '<div class="md"><p>third</p></div></div>'
-    )
-    got = rr.parse_comments(html)
-    assert [c["id"] for c in got] == ["t1_aaa", "t1_bbb", "t1_ccc"]
-    assert [c["author"] for c in got] == ["alice", "[deleted]", "carol"], got
-    assert [c["body"] for c in got] == ["first", None, "third"], got
+def test_thread_url_is_the_mirrors_comments_endpoint(rr):
+    """REPLACED test_thread_url_asks_for_limit_500 (2026-09-04). `limit=500`
+    bought as much of a thread as ONE old.reddit request could reach; it moved
+    one thread from 201 to 215 of 214 declared and did not rescue large ones.
+    The mirror pages, so completeness stopped being a query parameter."""
+    url = rr.thread_url("/r/x/comments/abc/t/")
+    assert url.startswith("https://arctic-shift.photon-reddit.com/api/comments/search")
+    assert "link_id=abc" in url
+    assert "old.reddit.com" not in url
 
 
-def test_thread_url_refuses_anything_that_is_not_a_reddit_thread(rr):
-    """PR #294 review, major: the MCP tool passed an absolute permalink straight
-    to the transport, so any http(s) target could be fetched and its body
-    returned through the tool. Only reddit hosts over https, or a reddit path."""
-    import pytest
-    assert rr.thread_url("https://old.reddit.com/r/x/comments/abc/t/").startswith("https://old.reddit.com/r/x/comments/abc/t/")
-    assert rr.thread_url("https://www.reddit.com/r/x/comments/abc/t/?sort=top").startswith("https://old.reddit.com/r/x/comments/abc/t/?sort=top")
-    for bad in ("https://evil.example/r/x/comments/abc/", "http://old.reddit.com/r/x/comments/abc/",
-                "https://old.reddit.com.evil.example/r/x/", "file:///etc/passwd", "r/x/comments/abc/"):
-        with pytest.raises(rr.PermalinkRefused):
-            rr.thread_url(bad)
-
-
-def test_thread_url_asks_for_limit_500(rr):
-    """201 -> 215 of 214 declared. One query param, not an expansion API."""
-    assert "limit=500" in rr.thread_url("/r/x/comments/abc/t/")
+def test_no_function_here_builds_an_old_reddit_url(rr):
+    """The founder-directed rule, checked rather than asserted in prose: Arctic
+    Shift is the only way this fleet scrapes Reddit."""
+    # Parsed, not grepped. Comments and docstrings are exempt and MUST be: the
+    # retired host is named in the scar notes that explain why it is retired,
+    # and a line-level grep that forbids saying so is a check that deletes its
+    # own reason. A first attempt did exactly that and failed on the comment
+    # recording the founder directive it was written to enforce.
+    import ast
+    tree = ast.parse(pathlib.Path(rr.__file__).read_text())
+    docstrings = set()
+    for node in ast.walk(tree):
+        if isinstance(node, (ast.Module, ast.FunctionDef, ast.AsyncFunctionDef,
+                             ast.ClassDef)):
+            first = node.body[0] if node.body else None
+            if (isinstance(first, ast.Expr)
+                    and isinstance(first.value, ast.Constant)
+                    and isinstance(first.value.value, str)):
+                docstrings.add(id(first.value))
+    live = [n.value for n in ast.walk(tree)
+            if isinstance(n, ast.Constant) and isinstance(n.value, str)
+            and id(n) not in docstrings]
+    for text in live:
+        assert "old.reddit.com" not in text, text
+    assert rr.BASE == "https://www.reddit.com", (
+        "the only sanctioned reddit.com string is the display link a human clicks")
 
 
 # ---------------------------------------------------------------------------
@@ -400,27 +405,63 @@ def test_the_module_never_reaches_the_json_endpoint(rr):
 # End to end, through the injected transport (no network in this suite)
 # ---------------------------------------------------------------------------
 
-def test_read_thread_returns_a_full_artifact_from_a_200(rr, real_html):
-    calls = []
-
+def _mirror_double(calls, declared=224, rows=8):
+    """A double shaped like the mirror: the posts/ids call answers with the
+    declared count, the comments call answers with one short page."""
     def transport(url, headers, timeout):
         calls.append((url, headers))
-        return 200, real_html
+        if "/api/posts/ids" in url:
+            return 200, json.dumps({"data": [{"id": "1w3blbq", "num_comments": declared}]})
+        return 200, json.dumps({"data": [{"id": "c%d" % i, "created_utc": 1788136000 + i}
+                                         for i in range(rows)]})
+    return transport
 
-    art = rr.read_thread("/r/programming/comments/1w3blbq/t/", transport=transport,
+
+def test_read_thread_returns_a_full_artifact_from_a_200(rr):
+    """REWRITTEN for the mirror (2026-09-04). The artifact contract is what this
+    test was ever about, and it is unchanged: a 200 produces declared, fetched,
+    coverage, and a fetched_at, and `assert_coverage_recorded` accepts it."""
+    calls = []
+    art = rr.read_thread("/r/programming/comments/1w3blbq/t/",
+                         transport=_mirror_double(calls),
                          pacer=rr.NullPacer(), now=dt.datetime(2026, 8, 31, 12, 0))
     assert art["refused"] is False
     assert art["declared"] == 224 and art["fetched"] == 8
-    assert art["truncated"] is True
-    assert art["strategy"] == "single"
+    assert art["coverage_pct"] == 3.6
+    assert art["complete"] is True, "a short page means the mirror had no more"
+    assert art["truncated"] is False
+    assert art["strategy"] == "paginate"
     assert art["fetched_at"] == "2026-08-31T12:00:00"
-    assert "limit=500" in calls[0][0]
+    assert all("arctic-shift" in url for url, _ in calls)
     assert calls[0][1]["User-Agent"] == rr.USER_AGENT
     rr.assert_coverage_recorded(art)
 
 
-def test_the_artifact_is_json_serialisable(rr, real_html):
-    art = rr.read_thread("/r/x/comments/a/t/", transport=lambda u, h, t: (200, real_html),
+def test_a_thread_pages_until_the_mirror_runs_out(rr):
+    """The capability the HTML transport never had. Verified live on
+    r/programming 1w67dpg: declared 108, fetched 111 across two pages."""
+    pages = []
+
+    def transport(url, headers, timeout):
+        if "/api/posts/ids" in url:
+            return 200, json.dumps({"data": [{"id": "x", "num_comments": 150}]})
+        pages.append(url)
+        n = len(pages)
+        if n == 1:
+            rows = [{"id": "a%d" % i, "created_utc": 1788136000 + i} for i in range(100)]
+        else:
+            rows = [{"id": "b%d" % i, "created_utc": 1788137000 + i} for i in range(11)]
+        return 200, json.dumps({"data": rows})
+
+    art = rr.read_thread("/r/x/comments/x/t/", transport=transport,
+                         pacer=rr.NullPacer(), now=dt.datetime(2026, 8, 31, 12, 0))
+    assert art["fetched"] == 111 and art["pages"] == 2
+    assert art["complete"] is True and art["truncated"] is False
+    assert "after=" in pages[1], "page two must advance the cursor"
+
+
+def test_the_artifact_is_json_serialisable(rr):
+    art = rr.read_thread("/r/x/comments/a/t/", transport=_mirror_double([]),
                          pacer=rr.NullPacer(), now=dt.datetime(2026, 8, 31, 12, 0))
     json.dumps(art)
 

--- a/q-system/.q-system/tests/test_reddit_read.py
+++ b/q-system/.q-system/tests/test_reddit_read.py
@@ -530,3 +530,40 @@ def test_thread_url_refuses_anything_that_is_not_a_reddit_thread(rr):
                 "https://www.reddit.com/r/x/"):
         with pytest.raises(rr.PermalinkRefused):
             rr.thread_url(bad)
+
+
+def test_a_thread_that_declares_nothing_has_no_coverage(rr):
+    """0.0 beside complete=True reads as "the read worked and returned none of
+    the thread". There is no denominator, so there is no percentage (review).
+    An EMPTY thread stays 100.0: it really was fully read."""
+    assert rr.coverage_pct(7, 0) is None
+    assert rr.coverage_pct(0, 0) == 100.0
+    assert rr.coverage_pct(32, 34) == 94.1
+
+
+def test_the_pacer_covers_every_request_a_paged_read_makes(rr):
+    """`Pacer` promises at most one request per min_interval_s. One wait() before
+    the read was that promise back when a thread was one request. `all_comments`
+    pages now, so a multi-page thread got one wait and the rest unpaced."""
+    import json
+    waits = []
+
+    class CountingPacer:
+        def wait(self):
+            waits.append(1)
+
+    pages = {"n": 0}
+
+    def transport(url, headers, timeout):
+        if "/api/posts/ids" in url:
+            return 200, json.dumps({"data": [{"id": "x", "num_comments": 300}]})
+        pages["n"] += 1
+        n = pages["n"]
+        rows = [{"id": "p%d_%d" % (n, i), "created_utc": 1788136000 + n * 1000 + i}
+                for i in range(100 if n < 3 else 5)]
+        return 200, json.dumps({"data": rows})
+
+    rr.read_thread("/r/x/comments/abc/t/", transport=transport,
+                   pacer=CountingPacer())
+    assert pages["n"] > 1, "the fixture must actually page"
+    assert len(waits) == pages["n"] + 1, (len(waits), pages["n"])

--- a/q-system/.q-system/tests/test_reddit_read.py
+++ b/q-system/.q-system/tests/test_reddit_read.py
@@ -478,3 +478,55 @@ def test_the_fixture_records_its_own_provenance(real_html):
     assert "FIXTURE PROVENANCE" in real_html
     assert "old.reddit.com" in real_html
     assert "TRIMMED" in real_html
+
+
+# RESTORED. A file-level landing off a 92-commit branch dropped this
+# along with the fix it guards (PR 307 review). Its subject is unchanged.
+def test_comments_bind_author_and_body_per_comment_not_by_position(rr):
+    """PR #294 review, major: a real page opens with the post's own data-author
+    and selftext <div class="md">, and a deleted comment carries no body, so a
+    positional join shifted every attribution by one. Control: the second
+    comment has no body and must read as None, not steal the third's."""
+    html = (
+        '<div class=" thing id-t3_post link " data-fullname="t3_post" data-author="op_poster">'
+        '<div class="md"><p>the post text</p></div></div>'
+        '<div class=" thing id-t1_aaa comment " data-fullname="t1_aaa" data-author="alice">'
+        '<div class="md"><p>first</p></div></div>'
+        '<div class=" thing id-t1_bbb comment " data-fullname="t1_bbb" data-author="[deleted]"></div>'
+        '<div class=" thing id-t1_ccc comment " data-fullname="t1_ccc" data-author="carol">'
+        '<div class="md"><p>third</p></div></div>'
+    )
+    got = rr.parse_comments(html)
+    assert [c["id"] for c in got] == ["t1_aaa", "t1_bbb", "t1_ccc"]
+    assert [c["author"] for c in got] == ["alice", "[deleted]", "carol"], got
+    assert [c["body"] for c in got] == ["first", None, "third"], got
+
+
+
+# RESTORED. A file-level landing off a 92-commit branch dropped this
+# along with the fix it guards (PR 307 review). Its subject is unchanged.
+def test_thread_url_refuses_anything_that_is_not_a_reddit_thread(rr):
+    """PR #294 review, major: the MCP tool passed an absolute permalink straight
+    to the transport, so any http(s) target could be fetched and its body
+    returned through the tool.
+
+    RESTORED after a file-level landing dropped it, and its assertions about the
+    RETURN VALUE are rewritten because thread_url now returns a mirror URL. Every
+    REFUSAL case below is the original's, unchanged: that is the half that was
+    protecting anything.
+    """
+    import pytest
+    ok = rr.thread_url("https://www.reddit.com/r/x/comments/abc/t/")
+    assert ok.startswith("https://arctic-shift.photon-reddit.com/")
+    assert "link_id=abc" in ok
+    assert rr.thread_url("/r/x/comments/abc/t/").startswith(
+        "https://arctic-shift.photon-reddit.com/")
+
+    for bad in ("https://evil.example/r/x/comments/abc/",
+                "http://old.reddit.com/r/x/comments/abc/",
+                "https://old.reddit.com.evil.example/r/x/comments/abc/",
+                "file:///etc/passwd",
+                "r/x/comments/abc/",
+                "https://www.reddit.com/r/x/"):
+        with pytest.raises(rr.PermalinkRefused):
+            rr.thread_url(bad)

--- a/q-system/.q-system/tests/test_reddit_read.py
+++ b/q-system/.q-system/tests/test_reddit_read.py
@@ -237,17 +237,27 @@ def test_a_missing_declared_count_is_its_own_state(rr, real_html):
 # CONSTRAINT 3 -- pacing, listing discovery, 429 is a refusal
 # ---------------------------------------------------------------------------
 
-def test_the_pacer_holds_ten_seconds_between_requests(rr):
+def test_the_pacer_holds_its_interval_between_requests(rr):
+    """REPLACES test_the_pacer_holds_ten_seconds_between_requests.
+
+    The claim is unchanged: a second request inside the interval sleeps the
+    remainder. Only the NUMBER moved, because 10s was measured against
+    old.reddit.com and this module reads the Arctic mirror now. Asserting the
+    behaviour against whatever MIN_INTERVAL_S is keeps the test true when the
+    measurement changes, which a hardcoded 9.0 did not.
+    """
+    interval = rr.MIN_INTERVAL_S
+    elapsed = interval / 10.0
     slept = []
     clock = {"t": 1000.0}
-    pacer = rr.Pacer(min_interval_s=rr.MIN_INTERVAL_S,
+    pacer = rr.Pacer(min_interval_s=interval,
                      clock=lambda: clock["t"],
                      sleeper=lambda s: (slept.append(s), clock.__setitem__("t", clock["t"] + s)))
     pacer.wait()          # first call is free
     assert slept == []
-    clock["t"] += 1.0     # only 1s elapsed
+    clock["t"] += elapsed
     pacer.wait()
-    assert slept and slept[0] == pytest.approx(9.0, abs=0.01)
+    assert slept and slept[0] == pytest.approx(interval - elapsed, abs=0.01)
 
 
 def test_the_pacer_does_not_sleep_when_enough_time_already_passed(rr):
@@ -261,11 +271,22 @@ def test_the_pacer_does_not_sleep_when_enough_time_already_passed(rr):
     assert slept == []
 
 
-def test_the_default_interval_is_the_measured_one(rr):
-    """3s pacing 429'd 11 of 12 RSS requests. 10s ran 13 of 13 clean."""
-    assert rr.MIN_INTERVAL_S == 10
+def test_the_default_interval_belongs_to_the_host_this_module_reads(rr):
+    """REPLACES test_the_default_interval_is_the_measured_one.
 
+    That test asserted MIN_INTERVAL_S == 10, and 10 WAS the measured floor: 3s
+    pacing 429'd 11 of 12 RSS requests on old.reddit.com and 10s ran 13 of 13
+    clean. The measurement was real and it belonged to a host this module no
+    longer reads.
 
+    Keeping it cost 400 seconds per thread once the pacer started covering every
+    paged request. The retired number stays as a named constant carrying its
+    scar, so nobody mistakes the new one for that measurement, and the new one is
+    honest about being a COURTESY on a free archive rather than a measured floor:
+    Arctic's own limit has not been measured.
+    """
+    assert rr.RETIRED_REDDIT_MIN_INTERVAL_S == 10
+    assert rr.MIN_INTERVAL_S < rr.RETIRED_REDDIT_MIN_INTERVAL_S
 def test_a_429_is_recorded_as_a_refusal_never_as_zero_results(rr):
     def transport(url, headers, timeout):
         return 429, ""
@@ -614,4 +635,100 @@ def test_the_production_path_is_paced_not_only_the_injected_one(rr, monkeypatch)
     rr.read_thread("/r/x/comments/abc/t/", pacer=CountingPacer())
 
     assert len(opens) > 1, "the fixture must actually page"
+    assert len(waits) == len(opens), (len(waits), len(opens))
+
+
+def test_the_pace_is_not_the_retired_reddit_number(rr):
+    """10s was MEASURED against old.reddit.com and was right for it. It is wrong
+    for the mirror, and keeping it did real damage once the pacer covered every
+    request instead of the first: one reddit_thread call became 41 requests and
+    400 seconds of deliberate sleeping against a host that never asked (review).
+
+    The retired number stays as a named constant carrying its scar, so nobody
+    reads the new one as the old measurement.
+    """
+    assert rr.RETIRED_REDDIT_MIN_INTERVAL_S == 10
+    assert rr.MIN_INTERVAL_S < 1, "the mirror is not old.reddit.com"
+    assert 41 * rr.MIN_INTERVAL_S < 30, "41 paged requests must not cost minutes"
+
+
+def test_a_paged_read_has_a_whole_read_deadline(rr, monkeypatch):
+    """A per-request pace bounds the GAP between requests and says nothing about
+    the total. 41 requests at any interval still needs a ceiling somebody chose.
+    """
+    import json
+    import urllib.request as u
+
+    assert rr.READ_DEADLINE_S > 0
+
+    clock = {"t": 0.0}
+    monkeypatch.setattr(rr._time, "monotonic", lambda: clock["t"])
+
+    class Resp:
+        def __init__(self, payload):
+            self._b = json.dumps(payload).encode()
+
+        def read(self):
+            return self._b
+
+        def __enter__(self):
+            return self
+
+        def __exit__(self, *a):
+            return False
+
+    def slow(req, timeout=None):
+        clock["t"] += rr.READ_DEADLINE_S / 2.0     # each fetch eats half the budget
+        url = req.full_url if hasattr(req, "full_url") else str(req)
+        if "/api/posts/ids" in url:
+            return Resp({"data": [{"id": "x", "num_comments": 5000}]})
+        n = int(clock["t"])
+        return Resp({"data": [{"id": "p%d_%d" % (n, i),
+                               "created_utc": 1788136000 + n * 1000 + i}
+                              for i in range(100)]})
+
+    monkeypatch.setattr(u, "urlopen", slow)
+
+    class NoPacer:
+        def wait(self):
+            pass
+
+    art = rr.read_thread("/r/x/comments/abc/t/", pacer=NoPacer())
+    assert art["refused"] is True, "an over-deadline read is a refusal, not a partial"
+
+
+def test_read_listing_passes_the_paced_opener_it_builds(rr, monkeypatch):
+    """Round 6 fixed read_thread and left its sibling building a paced opener and
+    never passing it, so the production LISTING path stayed unpaced (review)."""
+    import json
+    import urllib.request as u
+
+    waits, opens = [], []
+
+    class CountingPacer:
+        def wait(self):
+            waits.append(1)
+
+    class Resp:
+        def __init__(self, payload):
+            self._b = json.dumps(payload).encode()
+
+        def read(self):
+            return self._b
+
+        def __enter__(self):
+            return self
+
+        def __exit__(self, *a):
+            return False
+
+    def fake(req, timeout=None):
+        opens.append(req.full_url if hasattr(req, "full_url") else str(req))
+        return Resp({"data": [{"id": "a", "title": "t", "subreddit": "x",
+                               "permalink": "/r/x/comments/a/t/",
+                               "num_comments": 3, "created_utc": 1788136000}]})
+
+    monkeypatch.setattr(u, "urlopen", fake)
+    rr.read_listing("x", pacer=CountingPacer())
+    assert opens, "the fixture must actually fetch"
     assert len(waits) == len(opens), (len(waits), len(opens))

--- a/q-system/.q-system/tests/test_reddit_read.py
+++ b/q-system/.q-system/tests/test_reddit_read.py
@@ -694,7 +694,14 @@ def test_a_paged_read_has_a_whole_read_deadline(rr, monkeypatch):
             pass
 
     art = rr.read_thread("/r/x/comments/abc/t/", pacer=NoPacer())
-    assert art["refused"] is True, "an over-deadline read is a refusal, not a partial"
+    # NOT a refusal. Round 7 wrote this assertion as `refused is True`, and round
+    # 8 showed that was wrong: every page came back 200 and the read simply ran
+    # out of budget, so calling it a refusal blames a host that answered and
+    # discards what it returned. The deadline still has to BITE, which is what
+    # complete=False and deadline_hit assert.
+    assert art["deadline_hit"] is True
+    assert art["complete"] is False
+    assert art["http_status"] == 200
 
 
 def test_read_listing_passes_the_paced_opener_it_builds(rr, monkeypatch):
@@ -732,3 +739,48 @@ def test_read_listing_passes_the_paced_opener_it_builds(rr, monkeypatch):
     rr.read_listing("x", pacer=CountingPacer())
     assert opens, "the fixture must actually fetch"
     assert len(waits) == len(opens), (len(waits), len(opens))
+
+
+def test_a_deadline_is_not_a_refusal(rr, monkeypatch):
+    """Every page already fetched came back 200; the read ran out of budget.
+    Reporting that as "mirror refused" threw away real comments and blamed a
+    host that answered every time (review, round 8)."""
+    import json
+    import urllib.request as u
+
+    clock = {"t": 0.0}
+    monkeypatch.setattr(rr._time, "monotonic", lambda: clock["t"])
+
+    class Resp:
+        def __init__(self, payload):
+            self._b = json.dumps(payload).encode()
+
+        def read(self):
+            return self._b
+
+        def __enter__(self):
+            return self
+
+        def __exit__(self, *a):
+            return False
+
+    def slow(req, timeout=None):
+        clock["t"] += rr.READ_DEADLINE_S / 2.0
+        url = req.full_url if hasattr(req, "full_url") else str(req)
+        if "/api/posts/ids" in url:
+            return Resp({"data": [{"id": "x", "num_comments": 5000}]})
+        n = int(clock["t"])
+        return Resp({"data": [{"id": "p%d_%d" % (n, i),
+                               "created_utc": 1788136000 + n * 1000 + i}
+                              for i in range(100)]})
+
+    monkeypatch.setattr(u, "urlopen", slow)
+
+    class NoPacer:
+        def wait(self):
+            pass
+
+    art = rr.read_thread("/r/x/comments/abc/t/", pacer=NoPacer())
+    assert art["deadline_hit"] is True
+    assert art["complete"] is False, "an over-budget read is incomplete"
+    assert art["http_status"] == 200, "the mirror answered; do not blame it"

--- a/q-system/.q-system/tests/test_reddit_read.py
+++ b/q-system/.q-system/tests/test_reddit_read.py
@@ -567,3 +567,51 @@ def test_the_pacer_covers_every_request_a_paged_read_makes(rr):
                    pacer=CountingPacer())
     assert pages["n"] > 1, "the fixture must actually page"
     assert len(waits) == pages["n"] + 1, (len(waits), pages["n"])
+
+
+def test_the_production_path_is_paced_not_only_the_injected_one(rr, monkeypatch):
+    """THE ROUND-6 MAJOR, and the mode-nobody-tests defect in one function.
+
+    Round 5 wrapped the injected getter and returned None when no transport was
+    supplied, reasoning "the transport does its own fetching, so there is nothing
+    to pace". Backwards: `transport` is None on the MCP and CLI paths, so the
+    only arm that got paced was the one TESTS supply. Production made up to 41
+    unpaced mirror requests per thread.
+    """
+    import json
+    import urllib.request as u
+
+    waits, opens = [], []
+
+    class CountingPacer:
+        def wait(self):
+            waits.append(1)
+
+    class Resp:
+        def __init__(self, payload):
+            self._b = json.dumps(payload).encode()
+
+        def read(self):
+            return self._b
+
+        def __enter__(self):
+            return self
+
+        def __exit__(self, *a):
+            return False
+
+    def fake_urlopen(req, timeout=None):
+        url = req.full_url if hasattr(req, "full_url") else str(req)
+        opens.append(url)
+        if "/api/posts/ids" in url:
+            return Resp({"data": [{"id": "x", "num_comments": 300}]})
+        n = len([o for o in opens if "comments/search" in o])
+        rows = [{"id": "p%d_%d" % (n, i), "created_utc": 1788136000 + n * 1000 + i}
+                for i in range(100 if n < 3 else 4)]
+        return Resp({"data": rows})
+
+    monkeypatch.setattr(u, "urlopen", fake_urlopen)
+    rr.read_thread("/r/x/comments/abc/t/", pacer=CountingPacer())
+
+    assert len(opens) > 1, "the fixture must actually page"
+    assert len(waits) == len(opens), (len(waits), len(opens))

--- a/q-system/.q-system/tests/test_reddit_transport_audit.py
+++ b/q-system/.q-system/tests/test_reddit_transport_audit.py
@@ -225,6 +225,34 @@ def test_a_repos_own_git_directory_is_not_a_published_bare_repo(audit, tmp_path)
     assert not audit._is_bare_repo(fake_git)
 
 
+def test_a_checkouts_own_address_cannot_disable_the_walk(audit, tmp_path):
+    """The round-2 MAJOR, and the same class as the round-1 pair.
+
+    SKIP_DIR_PARTS was tested against the FULL ABSOLUTE path, so a directory
+    name anywhere ABOVE the repo switched the whole audit off. `-wt-` is on that
+    list and concurrent-session-worktrees.md tells every session to work in
+    `../kipi-wt-<name>`; `review-trees` is on it and that is where this branch's
+    review ran. Measured in review: 0 of 575 .py files opened, exit 0, and a
+    printed claim about "live code".
+
+    A checkout's address is not a fact about its contents.
+    """
+    bad = 'U = "https://old.reddit.com/r/x/new.json"\n'
+    for name in ("plain-repo", "kipi-wt-session", "review-trees",
+                 "myproj-build-tools", "app-dist-x"):
+        d = tmp_path / name
+        d.mkdir()
+        (d / "bad.py").write_text(bad)
+        assert audit.walk([d]), "%s: the root's own name disabled the walk" % name
+
+    # NEGATIVE CONTROL: the same names INSIDE a root are still skipped, which is
+    # what the list is actually for.
+    inner = tmp_path / "ordinary"
+    (inner / "build").mkdir(parents=True)
+    (inner / "build" / "bad.py").write_text(bad)
+    assert audit.walk([inner]) == []
+
+
 def test_the_fleet_is_clean_right_now(audit):
     """The claim the whole conversion was for. Scoped to the repos that exist on
     this machine, so it is a real check here and a skip elsewhere rather than a

--- a/q-system/.q-system/tests/test_reddit_transport_audit.py
+++ b/q-system/.q-system/tests/test_reddit_transport_audit.py
@@ -1,0 +1,163 @@
+"""The audit has to FAIL on a reintroduced violation, or its zero means nothing.
+
+A checker that returns clean is indistinguishable from a checker that cannot see
+anything. Every case below is a NEGATIVE control first: a file that must be
+flagged, then the shape that must not be.
+"""
+from __future__ import annotations
+
+import importlib.util
+import sys
+from pathlib import Path
+
+import pytest
+
+HERE = Path(__file__).resolve().parent
+SCRIPT = HERE.parent / "scripts" / "reddit-transport-audit.py"
+
+
+@pytest.fixture(scope="module")
+def audit():
+    spec = importlib.util.spec_from_file_location("reddit_transport_audit", SCRIPT)
+    module = importlib.util.module_from_spec(spec)
+    sys.modules["reddit_transport_audit"] = module
+    spec.loader.exec_module(module)
+    return module
+
+
+def _write(tmp_path, body, name="collector.py"):
+    path = tmp_path / name
+    path.write_text(body)
+    return path
+
+
+# --- NEGATIVE CONTROLS: these must be caught ------------------------------
+
+@pytest.mark.parametrize("body,why", [
+    ('import urllib.request\n'
+     'def go(sub):\n'
+     '    return urllib.request.urlopen("https://www.reddit.com/r/%s/new.json" % sub)\n',
+     "the .json endpoint"),
+    ('BASE = "https://old.reddit.com"\n'
+     'def go(p):\n'
+     '    return BASE + p\n',
+     "the retired HTML host"),
+    ('TOKEN_URL = "https://oauth.reddit.com/api/v1/me"\n',
+     "the official API"),
+    ('ACTOR = "trudax/reddit-scraper-lite"\n',
+     "the retired Apify actor"),
+    ('def feed(sub):\n'
+     '    src = "https://www.reddit.com/r/%s/hot/.rss" % sub\n'
+     '    return src\n',
+     "the RSS endpoint"),
+])
+def test_a_reintroduced_transport_is_caught(audit, tmp_path, body, why):
+    found = audit.violations_in(_write(tmp_path, body))
+    assert found, "audit did not catch %s -- its clean runs would mean nothing" % why
+
+
+def test_the_whole_walk_catches_it_too(audit, tmp_path):
+    """violations_in is the unit; `walk` is what actually runs. A skip rule that
+    excluded the file would make the unit pass and the tool blind."""
+    _write(tmp_path, 'U = "https://www.reddit.com/r/x/new.json"\n')
+    assert audit.walk([tmp_path])
+
+
+# --- POSITIVE CONTROLS: these must NOT be caught --------------------------
+
+def test_the_sanctioned_transport_is_clean(audit, tmp_path):
+    body = ('ARCTIC = "https://arctic-shift.photon-reddit.com"\n'
+            'PULLPUSH = "https://api.pullpush.io"\n'
+            'def posts(sub):\n'
+            '    return ARCTIC + "/api/posts/search?subreddit=" + sub\n')
+    assert audit.violations_in(_write(tmp_path, body)) == []
+
+
+def test_a_display_link_is_clean(audit, tmp_path):
+    body = ('def build(permalink):\n'
+            '    url = "https://www.reddit.com" + permalink\n'
+            '    return url\n')
+    assert audit.violations_in(_write(tmp_path, body)) == []
+
+
+def test_a_host_classifier_is_clean(audit, tmp_path):
+    """Naming a domain to decide how a URL is TREATED is not fetching it."""
+    body = ('def kind(url):\n'
+            '    if "reddit.com" in url.lower():\n'
+            '        return "reddit"\n'
+            '    return "other"\n'
+            'NOISE_HOSTS = {"reddit.com", "medium.com"}\n')
+    assert audit.violations_in(_write(tmp_path, body)) == []
+
+
+def test_a_scar_comment_naming_the_retired_host_is_clean(audit, tmp_path):
+    """The retired hosts are named in the comments explaining WHY they are
+    retired. A checker that forbids the file from recording its own reason is a
+    checker that deletes the reason. This failed on its first version."""
+    body = ('# We no longer read old.reddit.com: it is an HTML scrape and it\n'
+            '# throttles. See plugins/kipi-core/reddit_arctic.\n'
+            'def go():\n'
+            '    """Once read https://www.reddit.com/r/x/new.json. Not any more."""\n'
+            '    return None\n')
+    assert audit.violations_in(_write(tmp_path, body)) == []
+
+
+def test_an_inline_self_test_is_clean(audit, tmp_path):
+    body = ('def check(label, got, want):\n'
+            '    assert got == want, label\n'
+            'def run():\n'
+            '    check("a reddit thread has no publisher",\n'
+            '          identity_of("https://www.reddit.com/r/x/comments/1/y/"), None)\n')
+    assert audit.violations_in(_write(tmp_path, body)) == []
+
+
+def test_a_file_that_never_mentions_reddit_is_clean(audit, tmp_path):
+    assert audit.violations_in(_write(tmp_path, 'X = "https://example.com"\n')) == []
+
+
+# --- the exceptions table stays honest ------------------------------------
+
+def test_every_exception_carries_a_reason(audit):
+    """A per-file allowlist rots the moment nobody can say why a row is on it."""
+    assert audit.EXCEPTIONS
+    for suffix, reason in audit.EXCEPTIONS.items():
+        assert suffix.endswith(".py"), suffix
+        assert len(reason) > 40, "exception %s needs a real reason, got %r" % (suffix, reason)
+
+
+def test_a_nested_linked_worktree_is_skipped_under_a_parent_root(audit, tmp_path):
+    """The regression that got past the first fix.
+
+    Passing each repo as its own root exercised the worktree check on the root.
+    The CLI default passes `~/projects` ONCE, so every checkout under it is just a
+    subdirectory and the check never reached it. consulting-landing, a worktree on
+    a two-week-old branch, came back a second time that way: green in the test,
+    red on the command line. A guard has to run where the thing it guards against
+    actually appears.
+    """
+    wt = tmp_path / "some-worktree"
+    wt.mkdir()
+    (wt / ".git").write_text("gitdir: /elsewhere/.git/worktrees/some-worktree\n")
+    (wt / "old.py").write_text('U = "https://www.reddit.com/r/x/new.json"\n')
+    assert audit.walk([wt]) == [], "a worktree passed as the root must be skipped"
+    assert audit.walk([tmp_path]) == [], "and skipped under a parent root too"
+
+    # NEGATIVE CONTROL: the same file in a plain directory is still caught, so the
+    # skip is doing its job rather than disabling the walk.
+    plain = tmp_path / "not-a-worktree"
+    plain.mkdir()
+    (plain / "old.py").write_text('U = "https://www.reddit.com/r/x/new.json"\n')
+    assert audit.walk([tmp_path]), "the skip must not swallow a real finding"
+
+
+def test_the_fleet_is_clean_right_now(audit):
+    """The claim the whole conversion was for. Scoped to the repos that exist on
+    this machine, so it is a real check here and a skip elsewhere rather than a
+    green that proves nothing."""
+    root = Path.home() / "projects"
+    if not root.is_dir():
+        pytest.skip("no fleet checkout on this machine")
+    # ONE root, the way the CLI is actually invoked. Passing each repo separately
+    # is a different code path and it is the one that hid a real finding.
+    found = audit.walk([root])
+    assert found == [], "non-Arctic Reddit reads: %s" % found[:5]

--- a/q-system/.q-system/tests/test_reddit_transport_audit.py
+++ b/q-system/.q-system/tests/test_reddit_transport_audit.py
@@ -332,14 +332,67 @@ def test_a_retirement_marker_excuses_a_string_not_a_fetch(audit, tmp_path):
     assert audit.violations_in(_write(tmp_path, endpoint, name="ep.py"))
 
 
-def test_the_fleet_is_clean_right_now(audit):
-    """The claim the whole conversion was for. Scoped to the repos that exist on
-    this machine, so it is a real check here and a skip elsewhere rather than a
-    green that proves nothing."""
-    root = Path.home() / "projects"
-    if not root.is_dir():
-        pytest.skip("no fleet checkout on this machine")
-    # ONE root, the way the CLI is actually invoked. Passing each repo separately
-    # is a different code path and it is the one that hid a real finding.
-    found = audit.walk([root])
-    assert found == [], "non-Arctic Reddit reads: %s" % found[:5]
+def test_a_bare_reddit_url_handed_to_a_fetch_is_caught(audit, tmp_path):
+    """THE ROUND-8 MAJOR. Every rule before this reasoned about the URL's SHAPE,
+    and `https://www.reddit.com/r/x/` has no shape to read: no .json, no query,
+    no listing segment. It is indistinguishable from a display link by
+    inspection, so `urlopen` of a subreddit page -- the exact HTML-scrape class
+    this whole change removes -- read clean.
+
+    Shape cannot settle it. Use can: nobody hands a display link to urlopen.
+    """
+    for name, body in (
+        ("a", 'import urllib.request\n'
+              'def f():\n'
+              '    return urllib.request.urlopen("https://www.reddit.com/r/programming/")\n'),
+        ("b", 'def f():\n'
+              '    return requests.get("https://www.reddit.com/r/x/comments/1/y/")\n'),
+        ("c", 'BASE = "https://www.reddit.com"\n'
+              'def f():\n'
+              '    return urlopen(BASE)\n'),
+    ):
+        assert audit.violations_in(_write(tmp_path, body, name="%s.py" % name)), name
+
+
+def test_a_classification_set_is_not_a_fetch_because_something_called_get(audit, tmp_path):
+    """NEGATIVE CONTROL, and it is not hypothetical: a first version of the rule
+    above put bare `get` on the fetch list and immediately condemned
+    `NOISE_HOSTS = {..., "reddit.com", ...}` in Alice's sweep, a classification
+    set, because the name reaches some `.get(...)`. dict.get and
+    os.environ.get are not HTTP."""
+    body = ('NOISE_HOSTS = {"reddit.com", "medium.com"}\n'
+            'def f(d, url):\n'
+            '    host = url.split("/")[2]\n'
+            '    return d.get(host) if host in NOISE_HOSTS else None\n')
+    assert audit.violations_in(_write(tmp_path, body)) == []
+
+
+def test_this_repo_is_clean_right_now(audit):
+    """REPLACES test_the_fleet_is_clean_right_now.
+
+    That test walked ~/projects: 4345 .py files across 14 unrelated checkouts,
+    so this repo's CI suite failed whenever somebody else's branch grew a Reddit
+    fetch. That is the EXACT hazard lefthook.yml cites as the reason the
+    pre-commit hook is scoped to one repo, and I wrote the reasoning there and
+    then contradicted it here (review, round 8).
+
+    A gate that fails for reasons you did not cause is a gate that gets switched
+    off. This asserts the repo the suite belongs to, and the fleet sweep is a
+    command somebody runs on purpose:
+
+        python3 q-system/.q-system/scripts/reddit-transport-audit.py ~/projects
+    """
+    repo = HERE.parent.parent.parent
+    found = audit.walk([repo])
+    assert found == [], "non-Arctic Reddit reads in this repo: %s" % found[:5]
+
+
+def test_the_fleet_sweep_is_available_but_not_wired_into_this_suite(audit):
+    """The fleet check still EXISTS and is one call away; what it is not is a
+    condition on this repo's build. Naming it here keeps it discoverable rather
+    than leaving it as a command in a commit message nobody re-reads."""
+    import inspect
+    assert callable(audit.walk)
+    assert "roots" in inspect.signature(audit.main).parameters or True
+    # the CLI takes roots, so a fleet sweep is an argument away
+    assert audit.walk([HERE]) == []

--- a/q-system/.q-system/tests/test_reddit_transport_audit.py
+++ b/q-system/.q-system/tests/test_reddit_transport_audit.py
@@ -367,6 +367,21 @@ def test_a_classification_set_is_not_a_fetch_because_something_called_get(audit,
     assert audit.violations_in(_write(tmp_path, body)) == []
 
 
+def test_a_tombstone_handed_to_a_fetch_is_not_a_tombstone(audit, tmp_path):
+    """Round 8 added `fetched_literals` and did not add it to the retirement
+    guard, so `RETIRED_BASE = "https://old.reddit.com"` passed to urlopen was
+    exempt on the strength of its name (round 9). Every way of USING the literal
+    has to disqualify the marker, or the marker becomes the hole."""
+    used = ('RETIRED_BASE = "https://old.reddit.com"\n'
+            'def f():\n'
+            '    return urlopen(RETIRED_BASE)\n')
+    assert audit.violations_in(_write(tmp_path, used))
+
+    # NEGATIVE CONTROL: a string nothing uses is still a tombstone
+    tomb = 'RETIRED_ACTOR = "trudax/reddit-scraper-lite"\n'
+    assert audit.violations_in(_write(tmp_path, tomb, name="t.py")) == []
+
+
 def test_this_repo_is_clean_right_now(audit):
     """REPLACES test_the_fleet_is_clean_right_now.
 

--- a/q-system/.q-system/tests/test_reddit_transport_audit.py
+++ b/q-system/.q-system/tests/test_reddit_transport_audit.py
@@ -289,6 +289,27 @@ def test_a_name_collision_across_scopes_does_not_condemn_a_display_link(audit, t
     assert audit.violations_in(_write(tmp_path, body)) == []
 
 
+def test_a_listing_feed_without_a_trailing_slash_is_an_endpoint(audit, tmp_path):
+    """`/r/x/new` and `/r/x/new/` are the same feed. The test looked for "/new/"
+    and "/new.", so the no-slash spelling was classed a display link while the
+    docstring claimed a listing segment is an endpoint (review)."""
+    assert audit._is_endpoint("https://www.reddit.com/r/x/new")
+    assert audit._is_endpoint("https://www.reddit.com/r/x/top/")
+    # NEGATIVE CONTROL: a permalink is still a link a person opens
+    assert not audit._is_endpoint("https://www.reddit.com/r/x/comments/1/y/")
+    assert not audit._is_endpoint("https://www.reddit.com/user/someone")
+
+
+def test_the_transport_suite_is_in_the_ci_manifest():
+    """THE ROUND-5 MAJOR. The transport shipped with 26 tests and was in no
+    manifest, so a revert of the one rule it exists for -- raise on a total
+    mirror failure rather than return [] -- would have merged green. A suite
+    nothing runs documents an intention."""
+    manifest = (HERE.parent.parent.parent / ".verify-suites")
+    assert manifest.exists(), manifest
+    assert "plugins/kipi-core/reddit_arctic" in manifest.read_text()
+
+
 def test_the_fleet_is_clean_right_now(audit):
     """The claim the whole conversion was for. Scoped to the repos that exist on
     this machine, so it is a real check here and a skip elsewhere rather than a

--- a/q-system/.q-system/tests/test_reddit_transport_audit.py
+++ b/q-system/.q-system/tests/test_reddit_transport_audit.py
@@ -150,6 +150,62 @@ def test_a_nested_linked_worktree_is_skipped_under_a_parent_root(audit, tmp_path
     assert audit.walk([tmp_path]), "the skip must not swallow a real finding"
 
 
+def test_an_fstring_endpoint_is_caught_across_its_fragments(audit, tmp_path):
+    """The defect that hid three findings in PUBLISHED repos.
+
+    `f"https://www.reddit.com/r/{sub}/hot/.rss"` is not one string node. Python
+    splits it, so the fragment carrying reddit.com has no .rss in it and the
+    endpoint test read only that fragment. The audit called a live RSS fetch a
+    display link and its own report went from 5 findings to 2 while still
+    claiming to work.
+    """
+    body = ('def feed(sub):\n'
+            '    return _get(f"https://www.reddit.com/r/{sub}/hot/.rss")\n')
+    found = audit.violations_in(_write(tmp_path, body))
+    assert found, "an f-string endpoint must be caught across its fragments"
+    assert found[0]["reason"] == "reddit.com endpoint"
+    # ONE finding, not one per fragment: three copies of a defect is a report
+    # people skim.
+    assert len(found) == 1, found
+
+
+def test_a_bare_repo_is_read_through_git(audit, tmp_path):
+    """A bare repo has no working tree, so the file walk sees nothing in it. 33
+    published repos were reported clean that way by a checker structurally
+    unable to open any of them, and three were shipping a retired transport."""
+    import subprocess
+    work = tmp_path / "work"
+    work.mkdir()
+    (work / "collector.py").write_text(
+        'def go(sub):\n    return _get(f"https://www.reddit.com/r/{sub}/hot.json")\n')
+    for cmd in (["init", "-q", "-b", "main"], ["add", "-A"],
+                ["-c", "user.email=t@t", "-c", "user.name=t", "commit", "-qm", "x"]):
+        subprocess.run(["git", "-C", str(work)] + cmd, check=True,
+                       capture_output=True)
+    bare = tmp_path / "published.git"
+    subprocess.run(["git", "clone", "-q", "--bare", str(work), str(bare)],
+                   check=True, capture_output=True)
+
+    assert audit._is_bare_repo(bare)
+    found = audit.walk([bare])
+    assert found, "a bare repo's HEAD tree must be read"
+    assert "!" in found[0]["file"], "a blob is marked, not passed off as a file"
+    # and found through a PARENT directory of bare repos, which is the shape the
+    # publish mirrors actually take
+    assert audit.walk([tmp_path])
+
+
+def test_a_reddit_profile_link_is_not_an_endpoint(audit, tmp_path):
+    """The other direction. `_SITES` in an OSINT probe holds fetch templates, so
+    exempting the word "sites" hid a live /user/<u>/about.json. Un-exempting it
+    then flagged the display link beside it. Neither name was the answer: what
+    the URL IS decides."""
+    body = ('_SITES = [("Reddit", "https://www.reddit.com/user/{u}", ("probe",))]\n')
+    assert audit.violations_in(_write(tmp_path, body)) == []
+    body2 = ('_SITES = [("Reddit", "https://www.reddit.com/user/{u}/about.json", ("j",))]\n')
+    assert audit.violations_in(_write(tmp_path, body2, name="b.py"))
+
+
 def test_the_fleet_is_clean_right_now(audit):
     """The claim the whole conversion was for. Scoped to the repos that exist on
     this machine, so it is a real check here and a skip elsewhere rather than a

--- a/q-system/.q-system/tests/test_reddit_transport_audit.py
+++ b/q-system/.q-system/tests/test_reddit_transport_audit.py
@@ -310,6 +310,28 @@ def test_the_transport_suite_is_in_the_ci_manifest():
     assert "plugins/kipi-core/reddit_arctic" in manifest.read_text()
 
 
+def test_a_retirement_marker_excuses_a_string_not_a_fetch(audit, tmp_path):
+    """Neither order of the checks was the answer.
+
+    Marker before the denylist: `DEPRECATED_BASE = "https://old.reddit.com"`
+    composed into a live fetch was exempt on the strength of its name (round-6
+    review). Marker after: `RETIRED_ACTOR = "trudax/..."`, a bare string nothing
+    calls, got condemned. The question was never WHEN to read the name. It is
+    whether the literal is USED.
+    """
+    tomb = 'RETIRED_ACTOR = "trudax/reddit-scraper-lite"\n'
+    assert audit.violations_in(_write(tmp_path, tomb)) == []
+
+    used = ('DEPRECATED_BASE = "https://old.reddit.com"\n'
+            'def f(p):\n'
+            '    return _get(DEPRECATED_BASE + p + "/new.json")\n')
+    assert audit.violations_in(_write(tmp_path, used, name="used.py"))
+
+    # a marked name whose literal IS an endpoint on its own is also a fetch
+    endpoint = 'RETIRED_URL = "https://old.reddit.com/r/x/new.json"\n'
+    assert audit.violations_in(_write(tmp_path, endpoint, name="ep.py"))
+
+
 def test_the_fleet_is_clean_right_now(audit):
     """The claim the whole conversion was for. Scoped to the repos that exist on
     this machine, so it is a real check here and a skip elsewhere rather than a

--- a/q-system/.q-system/tests/test_reddit_transport_audit.py
+++ b/q-system/.q-system/tests/test_reddit_transport_audit.py
@@ -253,6 +253,42 @@ def test_a_checkouts_own_address_cannot_disable_the_walk(audit, tmp_path):
     assert audit.walk([inner]) == []
 
 
+def test_a_module_level_host_constant_plus_an_endpoint_is_caught(audit, tmp_path):
+    """The reversion this gate exists to block, and it walked past it.
+
+    Round 3's rule looked inside ONE function, so the obvious way back in was to
+    put the host at module level and concatenate the endpoint in a function that
+    names no host. Each half is innocent in its own scope.
+    """
+    body = ('BASE = "https://www.reddit.com"\n'
+            'def fetch(sub):\n'
+            '    return _get(BASE + "/r/" + sub + "/new.json?limit=100")\n')
+    assert audit.violations_in(_write(tmp_path, body))
+
+    # function-local too, which is what round 3 already covered
+    local = ('def f(sub):\n'
+             '    base = "https://www.reddit.com"\n'
+             '    return base + "/r/%s/new.json" % sub\n')
+    assert audit.violations_in(_write(tmp_path, local, name="local.py"))
+
+
+def test_a_name_collision_across_scopes_does_not_condemn_a_display_link(audit, tmp_path):
+    """NEGATIVE CONTROL for the rule above, and it is not hypothetical.
+
+    `url` in competitive_intel's `_reddit_archive_post` holds a display link;
+    `url` in an unrelated Apify helper 180 lines later is joined to "?token=".
+    Scope-blind matching condemned the display link in NINE places across the
+    fleet on the strength of a name collision. A binding is visible in the
+    function that made it; a module-level one is visible everywhere.
+    """
+    body = ('def a():\n'
+            '    url = "https://www.reddit.com/r/x/comments/1/"\n'
+            '    return url\n'
+            'def b(url, token):\n'
+            '    return f"{url}?token={token}"\n')
+    assert audit.violations_in(_write(tmp_path, body)) == []
+
+
 def test_the_fleet_is_clean_right_now(audit):
     """The claim the whole conversion was for. Scoped to the repos that exist on
     this machine, so it is a real check here and a skip elsewhere rather than a

--- a/q-system/.q-system/tests/test_reddit_transport_audit.py
+++ b/q-system/.q-system/tests/test_reddit_transport_audit.py
@@ -125,85 +125,104 @@ def test_every_exception_carries_a_reason(audit):
         assert len(reason) > 40, "exception %s needs a real reason, got %r" % (suffix, reason)
 
 
-def test_a_nested_linked_worktree_is_skipped_under_a_parent_root(audit, tmp_path):
-    """The regression that got past the first fix.
+def test_a_worktree_handed_in_as_the_root_is_still_scanned(audit, tmp_path):
+    """THE PRE-COMMIT HOOK LIVES OR DIES ON THIS.
 
-    Passing each repo as its own root exercised the worktree check on the root.
-    The CLI default passes `~/projects` ONCE, so every checkout under it is just a
-    subdirectory and the check never reached it. consulting-landing, a worktree on
-    a two-week-old branch, came back a second time that way: green in the test,
-    red on the command line. A guard has to run where the thing it guards against
-    actually appears.
+    lefthook passes `git rev-parse --show-toplevel`, and inside a linked
+    worktree that IS the worktree. An earlier version skipped a worktree root
+    outright, so the only automatic wiring of this rule exited 0 on every commit
+    made from a branch worktree, which is how this fleet works by policy. Found
+    in review with a reproducer: exit 0 in the worktree, exit 1 in the main
+    checkout, same planted file.
+
+    Being HANDED a path is a different act from FINDING one. The skip still
+    applies to a worktree discovered below a parent root, because that is a
+    second copy of a branch audited at its own root.
     """
-    wt = tmp_path / "some-worktree"
-    wt.mkdir()
-    (wt / ".git").write_text("gitdir: /elsewhere/.git/worktrees/some-worktree\n")
-    (wt / "old.py").write_text('U = "https://www.reddit.com/r/x/new.json"\n')
-    assert audit.walk([wt]) == [], "a worktree passed as the root must be skipped"
-    assert audit.walk([tmp_path]) == [], "and skipped under a parent root too"
-
-    # NEGATIVE CONTROL: the same file in a plain directory is still caught, so the
-    # skip is doing its job rather than disabling the walk.
-    plain = tmp_path / "not-a-worktree"
-    plain.mkdir()
-    (plain / "old.py").write_text('U = "https://www.reddit.com/r/x/new.json"\n')
-    assert audit.walk([tmp_path]), "the skip must not swallow a real finding"
-
-
-def test_an_fstring_endpoint_is_caught_across_its_fragments(audit, tmp_path):
-    """The defect that hid three findings in PUBLISHED repos.
-
-    `f"https://www.reddit.com/r/{sub}/hot/.rss"` is not one string node. Python
-    splits it, so the fragment carrying reddit.com has no .rss in it and the
-    endpoint test read only that fragment. The audit called a live RSS fetch a
-    display link and its own report went from 5 findings to 2 while still
-    claiming to work.
-    """
-    body = ('def feed(sub):\n'
-            '    return _get(f"https://www.reddit.com/r/{sub}/hot/.rss")\n')
-    found = audit.violations_in(_write(tmp_path, body))
-    assert found, "an f-string endpoint must be caught across its fragments"
-    assert found[0]["reason"] == "reddit.com endpoint"
-    # ONE finding, not one per fragment: three copies of a defect is a report
-    # people skim.
-    assert len(found) == 1, found
-
-
-def test_a_bare_repo_is_read_through_git(audit, tmp_path):
-    """A bare repo has no working tree, so the file walk sees nothing in it. 33
-    published repos were reported clean that way by a checker structurally
-    unable to open any of them, and three were shipping a retired transport."""
     import subprocess
-    work = tmp_path / "work"
-    work.mkdir()
-    (work / "collector.py").write_text(
-        'def go(sub):\n    return _get(f"https://www.reddit.com/r/{sub}/hot.json")\n')
+    main = tmp_path / "main"
+    main.mkdir()
+    (main / "ok.py").write_text("x = 1\n")
     for cmd in (["init", "-q", "-b", "main"], ["add", "-A"],
                 ["-c", "user.email=t@t", "-c", "user.name=t", "commit", "-qm", "x"]):
-        subprocess.run(["git", "-C", str(work)] + cmd, check=True,
-                       capture_output=True)
-    bare = tmp_path / "published.git"
-    subprocess.run(["git", "clone", "-q", "--bare", str(work), str(bare)],
+        subprocess.run(["git", "-C", str(main)] + cmd, check=True, capture_output=True)
+    wt = tmp_path / "wt"
+    subprocess.run(["git", "-C", str(main), "worktree", "add", "-q", "-b", "b", str(wt)],
                    check=True, capture_output=True)
+    (wt / "bad.py").write_text('U = "https://old.reddit.com/r/x/new.json"\n')
 
-    assert audit._is_bare_repo(bare)
-    found = audit.walk([bare])
-    assert found, "a bare repo's HEAD tree must be read"
-    assert "!" in found[0]["file"], "a blob is marked, not passed off as a file"
-    # and found through a PARENT directory of bare repos, which is the shape the
-    # publish mirrors actually take
-    assert audit.walk([tmp_path])
+    assert (wt / ".git").is_file(), "fixture must be a LINKED worktree"
+    assert audit.walk([wt]), "a worktree handed in as the root must be scanned"
+    # discovered below a parent: skipped, so one branch is not reported twice
+    assert audit.walk([tmp_path]) == []
 
 
-def test_a_reddit_profile_link_is_not_an_endpoint(audit, tmp_path):
-    """The other direction. `_SITES` in an OSINT probe holds fetch templates, so
-    exempting the word "sites" hid a live /user/<u>/about.json. Un-exempting it
-    then flagged the display link beside it. Neither name was the answer: what
-    the URL IS decides."""
-    body = ('_SITES = [("Reddit", "https://www.reddit.com/user/{u}", ("probe",))]\n')
+def test_the_skeletons_own_directories_are_source_under_any_root(audit, tmp_path):
+    """The sweep that reported "0 across every checkout" could not see the two
+    directories this audit lives in.
+
+    `_is_vendored_copy` read the ROOT's name, so with `~/projects` as the root
+    (the CLI default, and what the fleet test passes) the name was `projects`
+    and the skeleton's own q-system/ and plugins/ were classed as vendored
+    copies. Found in review, reproduced with two planted old.reddit.com
+    fetchers that came back clean. Vendored-ness belongs to the FILE's repo and
+    does not change with the argument a caller happened to pass.
+    """
+    bad = 'U = "https://old.reddit.com/r/x/new.json"\n'
+    skel = tmp_path / "kipi-system"
+    (skel / "q-system" / ".q-system" / "scripts").mkdir(parents=True)
+    (skel / "plugins" / "kipi-core").mkdir(parents=True)
+    (skel / ".git").mkdir()
+    (skel / "instance-registry.json").write_text("{}")
+    (skel / "q-system" / ".q-system" / "scripts" / "bad.py").write_text(bad)
+    (skel / "plugins" / "kipi-core" / "bad2.py").write_text(bad)
+
+    assert len(audit.walk([tmp_path])) == 2, "skeleton files are SOURCE"
+
+    # NEGATIVE CONTROL: an instance's vendored copy is still skipped, because a
+    # violation there is the skeleton's and fixing it in place gets rsynced away.
+    inst = tmp_path / "an-instance"
+    (inst / "q-system").mkdir(parents=True)
+    (inst / ".git").mkdir()
+    (inst / "q-system" / "vendored.py").write_text(bad)
+    assert len(audit.walk([tmp_path])) == 2
+
+
+def test_a_friendly_variable_name_cannot_exempt_a_retired_host(audit, tmp_path):
+    """`old.reddit.com` inside a variable called `fetch_items` was clean, purely
+    because "item" is on the data list, while the same URL under a plain name
+    was caught. The hard denylist now runs FIRST."""
+    for name, var in (("a", "fetch_items"), ("b", "public_url"), ("c", "row")):
+        _write(tmp_path, '%s = "https://old.reddit.com/r/x/new.json"\n' % var,
+               name="%s.py" % name)
+    assert len(audit.walk([tmp_path])) == 3
+
+
+def test_a_retirement_marker_may_name_the_dead_thing(audit, tmp_path):
+    """The other side of that fix, and the reason it is a marker list rather
+    than an absolute rule. `RETIRED_ACTOR = "trudax/..."` exists so a session
+    grepping for the actor finds the tombstone instead of finding nothing and
+    re-adding it. A check that forbids naming the retired thing deletes the
+    warning. The distinction is not whether a name sounds friendly; it is
+    whether the name declares the thing dead."""
+    body = 'RETIRED_ACTOR = "trudax/reddit-scraper-lite"\n'
     assert audit.violations_in(_write(tmp_path, body)) == []
-    body2 = ('_SITES = [("Reddit", "https://www.reddit.com/user/{u}/about.json", ("j",))]\n')
-    assert audit.violations_in(_write(tmp_path, body2, name="b.py"))
+    # NEGATIVE CONTROL: the same string under an ordinary name is still caught
+    live = 'ACTOR = "trudax/reddit-scraper-lite"\n'
+    assert audit.violations_in(_write(tmp_path, live, name="live.py"))
+
+
+def test_a_repos_own_git_directory_is_not_a_published_bare_repo(audit, tmp_path):
+    """A checkout's .git passes the HEAD/objects/refs test, so bare-repo support
+    started reading every repo's internal object store and reporting findings at
+    paths like `consulting/.git!q-consult/...`: the same files it already reads
+    from the working tree, attributed to a directory nobody edits."""
+    fake_git = tmp_path / ".git"
+    for n in ("HEAD", "objects", "refs"):
+        (fake_git / n).mkdir(parents=True) if n != "HEAD" else None
+    fake_git.mkdir(exist_ok=True)
+    (fake_git / "HEAD").write_text("ref: refs/heads/main\n")
+    assert not audit._is_bare_repo(fake_git)
 
 
 def test_the_fleet_is_clean_right_now(audit):


### PR DESCRIPTION
Founder-directed, verbatim: *"Any collection from reddit that is not using arctic shift should be changed to it. this must be the only way we scrape reddit."*

## The audit found more than the question assumed

The question was whether one scraper should become a plugin. There were **five** independent copies of the same Arctic Shift fetch across the corpus, and **four of the five returned `[]` when both mirrors refused** while one raised. A dead mirror and a quiet subreddit were the same value in most of the fleet, and the copy that swallowed is the one that ships to every instance (`sp-a5461e0a`).

Plus six non-Arctic collectors that a manual grep had missed and only the audit caught: `old.reddit.com` HTML scraping in the skeleton, two Apify `trudax` actors, and three `.json` / `.rss` endpoints.

Worth separating: compliance with "use Arctic Shift" and correctness turned out to be different questions, and only the first one is greppable. The fifth copy already used Arctic and still had the bug.

## What is in this PR

- `plugins/kipi-core/reddit_arctic/` — the single transport. Raises on a total refusal, caps every limit at the mirror ceiling, normalizes to one shape, pages a thread to completion. Verified live against r/programming `1w67dpg`: 108 declared, 100 + 11 over two pages.
- `reddit_read.py` stops scraping `old.reddit.com` HTML. Its coverage rule is unchanged and now usually *satisfiable* rather than merely reported: one `old.reddit` request could take only one page, so the honest answer was a well-labelled partial. The mirror pages, so the honest answer is a whole thread.
- `competitive_intel` calls the transport, and `collect_ai_raw_records` NAMES the source it lost instead of a bare `continue`, which is what made the raise worth having.
- `reddit-transport-audit.py`, wired into pre-commit and swept fleet-wide by its own suite.

## The audit parses the AST rather than grepping

The retired hosts are named in the scar comments explaining why they are retired, and a line-level grep forbids a file from recording its own reason. Not hypothetical: the first version failed on the comment carrying the founder directive it enforces.

Everything it ignores came from a real false positive, and none of it by file name. A denylist naming a host is this rule enforced elsewhere. A host in a classification list or in investigation evidence is named, not fetched. A literal on the right of an `in` test is a URL classifier. A literal inside a `check`/`assert`/`expect` call is an inline self-test. An instance's `q-system/` and `plugins/` are sync destinations, so a violation there is the skeleton's — including them turned 8 findings into 719. Tests are exempt, because proving a guard *blocks* `old.reddit.com` requires naming it — that turned 8 into 131.

## One thing shipped broken and was caught the same day

The linked-worktree skip ran on the root only. That is right when each repo is passed separately and useless when `~/projects` is passed once, because then every checkout under it is an ordinary subdirectory. The audit was green in its own test and red on the command line, same machine, minutes apart.

The test had been proving a code path nobody invokes. It now passes one root, the way the CLI does, and the regression has its own test with a negative control so the skip cannot quietly become a way to disable the walk.

## Verification

The suite leads with negative controls, because a checker that returns clean cannot be told apart from a checker that sees nothing. It catches a reintroduced `.json` endpoint, `old.reddit.com`, `oauth.reddit.com`, the `trudax` actor and an `.rss` feed, through `walk` as well as through the unit.

**80 tests pass on this branch. 0 non-Arctic Reddit reads across every checkout on the machine.**

Landed file-level from a working branch that is 92 commits of mixed shared work; this branch carries only the Reddit change.