### PR TITLE
knowledge-supply: every project reads its own folder; each 4_points case is its own knowledge base

### DIFF
--- a/q-system/.q-system/knowledge-sources.investigation.json
+++ b/q-system/.q-system/knowledge-sources.investigation.json
@@ -4,6 +4,8 @@
   "_why": "Founder-directed 2026-09-05 (plan knowledge-supply-project-folders-2026-09-05): 4_points had 45 cases and 1,475 markdown files no source class covered, and every receipt there read PARTIAL for absent consulting stores.",
   "ceiling_chars": 8000,
   "doc_max_bytes": 524288,
+  "_skip_dirs_why": "Directories under a docs folder that are never read by the docs class, DECLARED here so the receipt can count them and the header can say so (PR #308 review round 11: a hardcoded skip of raw-collections and exports had no record anywhere under FULL). exports and screenshots are renders of other files; raw-collections is collected evidence, not the founder's writing.",
+  "skip_dirs": ["exports", "screenshots", "raw-collections"],
   "entity_kinds_that_fire_alone": ["store", "target", "noun", "slug", "client"],
   "state_predicates": ["status", "state", "stage", "phase", "works_at", "role", "role_is", "is", "is-a", "located_in", "title", "reports_to", "assigned_to", "controls", "operates", "hosted_at", "registered_to"],
   "stores": [{"name": "case", "glob": "investigations/case-*"}],

--- a/q-system/.q-system/knowledge-sources.investigation.json
+++ b/q-system/.q-system/knowledge-sources.investigation.json
@@ -1,0 +1,57 @@
+{
+  "_version": 2,
+  "_description": "The investigation-shaped manifest for knowledge_supply.py. An instance whose work is cases (4_points, kipi-investigations) copies this to <qdir>/.q-system/data/knowledge-sources.json (an instance-owned subtree, untouched by kipi update). Every 'investigations/case-*' directory is its own knowledge base: its canonical, memory, findings, targets, timelines and outputs. Nothing consulting-shaped (commitments.jsonl, granola-cache.json, relationships.md) is required, because an investigation instance does not carry those and a permanent PARTIAL is noise, not information.",
+  "_why": "Founder-directed 2026-09-05 (plan knowledge-supply-project-folders-2026-09-05): 4_points had 45 cases and 1,475 markdown files no source class covered, and every receipt there read PARTIAL for absent consulting stores.",
+  "ceiling_chars": 8000,
+  "doc_max_bytes": 524288,
+  "entity_kinds_that_fire_alone": ["store", "target", "noun", "slug", "client"],
+  "state_predicates": ["status", "state", "stage", "phase", "works_at", "role", "role_is", "is", "is-a", "located_in", "title", "reports_to", "assigned_to", "controls", "operates", "hosted_at", "registered_to"],
+  "stores": [{"name": "case", "glob": "investigations/case-*"}],
+  "folders": ["investigation", "output", "memory", "research", "inputs", "notes", "docs"],
+  "entity_dirs": ["targets", "entities", "people", "subjects"],
+  "classes": {
+    "entity_lookup": {
+      "sources": {
+        "graph": {"required": true, "cap": 12},
+        "canonical": {"required": true, "cap": 6},
+        "docs": {"required": true, "cap": 8},
+        "decisions": {"required": false, "cap": 4},
+        "loops": {"required": false, "fresh_days": 30, "cap": 4},
+        "handoff": {"required": false, "fresh_days": 30, "cap": 3}
+      }
+    },
+    "temporal_event": {
+      "sources": {
+        "docs": {"required": true, "cap": 8},
+        "handoff": {"required": false, "fresh_days": 30, "cap": 4},
+        "loops": {"required": false, "fresh_days": 30, "cap": 6},
+        "graph": {"required": false, "cap": 6}
+      }
+    },
+    "commitment": {
+      "sources": {
+        "docs": {"required": true, "cap": 8},
+        "graph": {"required": false, "cap": 8},
+        "canonical": {"required": false, "cap": 4},
+        "loops": {"required": false, "fresh_days": 60, "cap": 6},
+        "handoff": {"required": false, "fresh_days": 30, "cap": 3}
+      }
+    },
+    "writing": {
+      "sources": {
+        "graph": {"required": true, "cap": 10},
+        "canonical": {"required": true, "cap": 6},
+        "docs": {"required": true, "cap": 6},
+        "decisions": {"required": false, "cap": 4},
+        "loops": {"required": false, "fresh_days": 30, "cap": 3}
+      }
+    },
+    "capability": {
+      "sources": {
+        "capability": {"required": true, "cap": 8},
+        "decisions": {"required": false, "cap": 4},
+        "canonical": {"required": false, "cap": 4}
+      }
+    }
+  }
+}

--- a/q-system/.q-system/knowledge-sources.json
+++ b/q-system/.q-system/knowledge-sources.json
@@ -1,10 +1,15 @@
 {
-  "_version": 1,
+  "_version": 2,
   "_description": "The declared source set per task class for knowledge_supply.py. This file is the coverage contract and the budget contract in one place: a class lists the source classes it needs, each required or optional, with a freshness bound in days for event sources and a per-class excerpt cap. Coverage is FULL only when every required class resolved to a readable source. Instance override: <qroot>/.q-system/data/knowledge-sources.json (an instance-owned subtree, untouched by kipi update).",
   "_why": "2026-09-04 knowledge-supply plan, section C. A declared input set as data is what lets the assembler assert that every declared source contributed or was recorded absent (lesson: assert what went into a composed artifact). A reader with no declaration cannot tell 'not found' from 'never searched'.",
   "ceiling_chars": 8000,
   "_entity_kinds_that_fire_alone_why": "Which index entity kinds fire on a single whole-word match. Only kinds the index actually produces belong here: slug (commitments.jsonl) and client (granola-cache.json keys). Contacts and graph names have their own rules in resolve_entities. Codex round 1 on PR #302: loop and capability were listed but no code produces those kinds, and a hardcoded list in the resolver overrode this knob; both are gone.",
-  "entity_kinds_that_fire_alone": ["slug", "client"],
+  "entity_kinds_that_fire_alone": ["slug", "client", "store", "target", "noun"],
+  "_project_folders_why": "Founder-directed 2026-09-05 (plan knowledge-supply-project-folders-2026-09-05): every project reads its OWN folder, and each 4_points investigation is its own knowledge base. `stores` globs name sub-directories that are knowledge bases with the qroot layout (a glob that matches nothing costs nothing). `folders` are the markdown folders the `docs` class greps, under the qroot and under each store. `entity_dirs` are directories whose markdown stems name a subject (fires alone). canonical/proper-nouns.txt (the voice lint's curated list) contributes `noun` entities. Headings never index: the census across every 4_points case file was section labels.",
+  "stores": [{"name": "case", "glob": "investigations/case-*"}],
+  "folders": ["output", "research", "inputs", "investigation", "build", "docs", "notes", "memory"],
+  "entity_dirs": ["targets", "clients", "people", "contacts", "entities"],
+  "doc_max_bytes": 524288,
   "_state_predicates_why": "Supersession (older triple marked STALE by a newer one with the same subject and predicate) is only true for predicates that describe a STATE. Accumulative predicates (owns, confirmed, discovered) hold many objects at once; measured on the largest instance 2026-09-04, 'owns merging PR #19' wrongly superseded 'owns merged PR #8'. Grouping is per project as well, so the same name in two projects never supersedes itself.",
   "state_predicates": ["status", "state", "stage", "phase", "works_at", "role", "role_is", "is", "is-a", "located_in", "title", "reports_to", "assigned_to"],
   "classes": {
@@ -17,7 +22,8 @@
         "commitments": {"required": false, "fresh_days": 45, "cap": 6},
         "meetings": {"required": false, "fresh_days": 45, "cap": 4},
         "loops": {"required": false, "fresh_days": 30, "cap": 4},
-        "handoff": {"required": false, "fresh_days": 14, "cap": 3}
+        "handoff": {"required": false, "fresh_days": 14, "cap": 3},
+        "docs": {"required": false, "cap": 6}
       }
     },
     "temporal_event": {
@@ -26,7 +32,8 @@
         "commitments": {"required": true, "fresh_days": 45, "cap": 8},
         "loops": {"required": false, "fresh_days": 30, "cap": 6},
         "handoff": {"required": false, "fresh_days": 14, "cap": 3},
-        "graph": {"required": false, "cap": 6}
+        "graph": {"required": false, "cap": 6},
+        "docs": {"required": false, "cap": 6}
       }
     },
     "commitment": {
@@ -36,7 +43,8 @@
         "loops": {"required": false, "fresh_days": 60, "cap": 6},
         "graph": {"required": false, "cap": 8},
         "relationships": {"required": false, "cap": 1},
-        "canonical": {"required": false, "cap": 4}
+        "canonical": {"required": false, "cap": 4},
+        "docs": {"required": false, "cap": 6}
       }
     },
     "writing": {
@@ -46,14 +54,16 @@
         "canonical": {"required": true, "cap": 6},
         "commitments": {"required": false, "fresh_days": 60, "cap": 4},
         "meetings": {"required": false, "fresh_days": 45, "cap": 3},
-        "loops": {"required": false, "fresh_days": 30, "cap": 3}
+        "loops": {"required": false, "fresh_days": 30, "cap": 3},
+        "docs": {"required": false, "cap": 4}
       }
     },
     "capability": {
       "sources": {
         "capability": {"required": true, "cap": 8},
         "decisions": {"required": false, "cap": 4},
-        "canonical": {"required": false, "cap": 4}
+        "canonical": {"required": false, "cap": 4},
+        "docs": {"required": false, "cap": 4}
       }
     }
   }

--- a/q-system/.q-system/knowledge-sources.json
+++ b/q-system/.q-system/knowledge-sources.json
@@ -10,6 +10,8 @@
   "folders": ["output", "research", "inputs", "investigation", "build", "docs", "notes", "memory"],
   "entity_dirs": ["targets", "clients", "people", "contacts", "entities"],
   "doc_max_bytes": 524288,
+  "_skip_dirs_why": "Directories under a docs folder that are never read by the docs class, DECLARED here so the receipt can count them and the header can say so (PR #308 review round 11: a hardcoded skip of raw-collections and exports had no record anywhere under FULL). exports and screenshots are renders of other files; raw-collections is collected evidence, not the founder's writing.",
+  "skip_dirs": ["exports", "screenshots", "raw-collections"],
   "_state_predicates_why": "Supersession (older triple marked STALE by a newer one with the same subject and predicate) is only true for predicates that describe a STATE. Accumulative predicates (owns, confirmed, discovered) hold many objects at once; measured on the largest instance 2026-09-04, 'owns merging PR #19' wrongly superseded 'owns merged PR #8'. Grouping is per project as well, so the same name in two projects never supersedes itself.",
   "state_predicates": ["status", "state", "stage", "phase", "works_at", "role", "role_is", "is", "is-a", "located_in", "title", "reports_to", "assigned_to"],
   "classes": {

--- a/q-system/.q-system/scripts/knowledge_supply.py
+++ b/q-system/.q-system/scripts/knowledge_supply.py
@@ -1146,8 +1146,11 @@ def grep_binary() -> str | None:
 HIT_RE = re.compile(r"^(?P<path>.+?):(?P<n>\d+):(?P<text>.*)$")
 
 
+GREP_ERR_RE = re.compile(r"^grep: (?P<path>.+?): (?P<err>.+)$")
+
+
 def _grep(files: list[Path], patterns: list[str], *, ignore_case: bool, word: bool,
-          deadline: float) -> tuple[list[tuple[Path, int, str]], str] | None:
+          deadline: float, failed: list[Path] | None = None) -> tuple[list[tuple[Path, int, str]], str] | None:
     """One fixed-string grep over the files, chunked. None when grep is not on
     PATH (the caller falls back to the Python scan). BSD grep 2.6 and GNU grep
     share every flag used here. The timeout is the remaining deadline, so a
@@ -1155,7 +1158,10 @@ def _grep(files: list[Path], patterns: list[str], *, ignore_case: bool, word: bo
     binary = grep_binary()
     if binary is None or not files or not patterns:
         return None if binary is None else ([], "grep")
-    args = [binary, "-n", "-H", "-I", "-F", "-m", str(GREP_MAX_PER_FILE)] + (["-i"] if ignore_case else []) + (["-w"] if word else [])
+    # -m is the cap PLUS ONE: a file that yields cap+1 lines was truncated, a file
+    # that yields exactly cap was read to its end (PR #308 review round 7: the
+    # cap fired at exactly 200 matches and reported PARTIAL for nothing unread).
+    args = [binary, "-n", "-H", "-I", "-F", "-m", str(GREP_MAX_PER_FILE + 1)] + (["-i"] if ignore_case else []) + (["-w"] if word else [])
     for pat in patterns:
         args += ["-e", pat]
     args.append("--")
@@ -1174,23 +1180,36 @@ def _grep(files: list[Path], patterns: list[str], *, ignore_case: bool, word: bo
             return hits, "grep (timeout)"
         except OSError:
             return None
+        # grep reports a file it could not open on stderr ("grep: <path>: No such
+        # file or directory") and exits 2. Those files were enumerated and never
+        # read; they go to the caller's `failed` list, the same read accounting
+        # every other class has (PR #308 review round 7: the docs class was the
+        # one required class with no read-failure path, and a file deleted
+        # between enumeration and the grep reported "searched, 0 hits").
+        if failed is not None and cp.returncode == 2 and cp.stderr:
+            for eline in cp.stderr.splitlines():
+                em = GREP_ERR_RE.match(eline.strip())
+                if em:
+                    failed.append(Path(em.group("path")))
         for line in cp.stdout.splitlines():
             m = HIT_RE.match(line)
             if m:
-                hits.append((Path(m.group("path")), int(m.group("n")), m.group("text")))
                 per_file[m.group("path")] = per_file.get(m.group("path"), 0) + 1
-                if per_file[m.group("path")] >= GREP_MAX_PER_FILE:
-                    # -m stopped reading that file: lines past the cap were never
-                    # looked at, which is a truncation like any other (PR #308
-                    # review round 4: the cap was silent and the receipt said FULL).
+                if per_file[m.group("path")] > GREP_MAX_PER_FILE:
+                    # the cap+1-th line: -m stopped reading that file, lines past
+                    # the cap were never looked at (PR #308 review round 4). The
+                    # extra line is not kept, so both engines return exactly cap.
                     engine = "grep (file cap)"
+                    continue
+                hits.append((Path(m.group("path")), int(m.group("n")), m.group("text")))
                 if len(hits) >= MAX_DOC_HITS:
                     return hits, "grep (hit cap)"
     return hits, engine
 
 
 def _pyscan(files: list[Path], patterns: list[str], *, ignore_case: bool, word: bool,
-            deadline: float, budget_bytes: int = DOC_SCAN_BUDGET_BYTES) -> tuple[list[tuple[Path, int, str]], str]:
+            deadline: float, budget_bytes: int = DOC_SCAN_BUDGET_BYTES,
+            failed: list[Path] | None = None) -> tuple[list[tuple[Path, int, str]], str]:
     """The grep-less path: same substring / whole-word semantics, bounded by a
     byte budget and the deadline, both reported in the engine string."""
     alts = "|".join(re.escape(p) for p in patterns)
@@ -1204,18 +1223,20 @@ def _pyscan(files: list[Path], patterns: list[str], *, ignore_case: bool, word: 
         try:
             data = f.read_text(encoding="utf-8", errors="replace")
         except OSError:
+            if failed is not None:
+                failed.append(f)   # counted, never swallowed (PR #308 review round 7)
             continue
         used += len(data)
         in_file = 0
         for n, line in enumerate(data.splitlines(), start=1):
             if pat.search(line):
-                hits.append((f, n, line))
                 in_file += 1
+                if in_file > GREP_MAX_PER_FILE:
+                    engine = "python (file cap)"   # parity with grep -m cap+1, and the same receipt
+                    break
+                hits.append((f, n, line))
                 if len(hits) >= MAX_DOC_HITS:
                     return hits, "python (hit cap)"
-                if in_file >= GREP_MAX_PER_FILE:
-                    engine = "python (file cap)"   # parity with grep -m, and the same receipt
-                    break
         if used > budget_bytes:
             return hits, "python (budget)"
     return hits, engine
@@ -1239,12 +1260,13 @@ def class_search_state(stopped_cold: bool, truncated: str | None) -> bool | str:
 
 
 def search_docs(files: list[Path], patterns: list[str], *, ignore_case: bool, word: bool,
-                deadline: float) -> tuple[list[tuple[Path, int, str]], str]:
+                deadline: float, failed: list[Path] | None = None) -> tuple[list[tuple[Path, int, str]], str]:
+    """`failed` collects the enumerated files the engine could not read."""
     if not files or not patterns:
         return [], "none"
-    r = _grep(files, patterns, ignore_case=ignore_case, word=word, deadline=deadline)
+    r = _grep(files, patterns, ignore_case=ignore_case, word=word, deadline=deadline, failed=failed)
     if r is None:
-        return _pyscan(files, patterns, ignore_case=ignore_case, word=word, deadline=deadline)
+        return _pyscan(files, patterns, ignore_case=ignore_case, word=word, deadline=deadline, failed=failed)
     return r
 
 
@@ -1331,7 +1353,25 @@ def resolve_docs(entities: list[dict], search_stores: list[dict], root: Path,
             for v in pattern_variants(nm):
                 if v not in patterns:
                     patterns.append(v)
-    hits, engine = search_docs(files, patterns, ignore_case=True, word=False, deadline=deadline)
+    failed: list[Path] = []
+    hits, engine = search_docs(files, patterns, ignore_case=True, word=False, deadline=deadline, failed=failed)
+    # The same read accounting every file class has: per store, the files the
+    # engine was asked to read and the ones it could not. A store whose every
+    # doc failed is unreadable (degrades the class); one failed among readable
+    # ones is a recorded problem (PR #304, sp-ca1769db). Counted whether or not
+    # the entity had a hit there: the engine was asked to read them all.
+    by_store_files: dict[str, set[str]] = {}
+    for f_s, st_name in file_store.items():
+        by_store_files.setdefault(st_name, set()).add(f_s)
+    for st in search_stores:
+        st_files = by_store_files.get(st["name"], set())
+        if not st_files:
+            continue
+        rs = st.setdefault("read_stats", {}).setdefault("docs", {"files": set(), "failed": set()})
+        rs["files"] |= st_files
+        rs["failed"] |= {str(f) for f in failed if str(f) in st_files}
+        if rs["failed"]:
+            st["problems"]["docs"] = f"{len(rs['failed'])} of {len(rs['files'])} doc file(s) unreadable"
     mtimes: dict[str, str | None] = {}
     mtimes_ns: dict[str, int] = {}
 
@@ -1550,6 +1590,7 @@ def render_header(bundle: dict) -> str:
     else:
         miss = "; ".join(f"{m} ({bundle['coverage']['missing_paths'].get(m, 'absent')})" for m in cov["missing"])
         line = f"[knowledge-supply] COVERAGE: {cov['verdict']}. missing: {miss}."
+    line += scope_note(cov)
     def suffix(e: dict) -> str:
         if e.get("kind") == "store" and e.get("stores"):
             return f" [{', '.join(e['stores'])}]"
@@ -1573,7 +1614,17 @@ def render_header(bundle: dict) -> str:
             "This layer never infers; anything you add beyond these lines is INFERRED and yours to label.")
 
 
+def scope_note(cov: dict) -> str:
+    """One clause naming what a named case left out of the search."""
+    if cov.get("scope"):
+        n = len(cov.get("stores_excluded") or [])
+        return f" scope: {', '.join(cov['scope'])} + project ({n} other store{'s' if n != 1 else ''} not searched)."
+    return ""
+
+
 def render(bundle: dict) -> str:
+    if bundle.get("note") and not bundle["items"]:
+        return bundle["note"]
     if not bundle["items"]:
         # An entity resolved and every declared store was searched and held
         # nothing: one line, not an 800-char header. Codex round 3 on PR #302.
@@ -1582,7 +1633,7 @@ def render(bundle: dict) -> str:
         cov = bundle["coverage"]
         ents = ", ".join(e["name"] for e in bundle["entities"]) or "none"
         miss = f" missing: {', '.join(cov['missing'])}." if cov["missing"] else ""
-        return (f"[knowledge-supply] COVERAGE: {cov['verdict']}. task={bundle['task_class']} entities={ents}. "
+        return (f"[knowledge-supply] COVERAGE: {cov['verdict']}.{scope_note(cov)} task={bundle['task_class']} entities={ents}. "
                 f"Searched, nothing recorded.{miss}{deadline_note(bundle)} receipt={bundle['receipt_path']}")
     parts = [render_header(bundle)]
     current = None
@@ -1738,22 +1789,32 @@ def supply(root: Path, prompt: str, *, session_id: str, now: dt.date | None = No
     # it plus the project level; naming none searches every store.
     named_stores = {s for e in entities if e.get("kind") == "store" for s in (e.get("stores") or [])}
     search_stores = [project] + [s for s in substores if not named_stores or s["name"] in named_stores]
+    # What the scope left out is a fact on the wire, not only in the receipt:
+    # "payment fraud" in a prompt matched case-031-payment-fraud and silently
+    # dropped three cases that held the answer, under FULL (PR #308 review
+    # round 7). FULL now reads "FULL within case-031-...; N stores not searched".
+    stores_excluded = sorted(s["name"] for s in substores if named_stores and s["name"] not in named_stores)
     # Prompt-driven candidates against the project's own documents: what makes a
     # project with no graph and no relationships.md answer from its folder.
     candidate_hits: dict[str, list] = {}
     candidate_engine = "none"
+    candidate_pass_cut: str | None = None
     candidates_dropped: list[dict] = []
     docs_declared = any("docs" in (c.get("sources") or {}) for c in (manifest.get("classes") or {}).values())
     if docs_declared and not truncated:
         cands = doc_candidates(scan, entities, index)
         if cands:
             candidate_hits, candidate_engine = search_docs_for_candidates(cands, search_stores, root, deadline=t_deadline)
+            candidate_pass_cut = truncation_of(candidate_engine)
             for cand in cands:
                 hits = candidate_hits.get(cand) or []
                 if not hits:
                     continue
                 n_stores = len({h[3] for h in hits})
-                if n_stores > MAX_CANDIDATE_STORES:
+                # A store count over a hit set the engine cut short is not a
+                # count (PR #308 review round 7): the rule is then not applied,
+                # the candidate is admitted, and candidate_rule says why.
+                if n_stores > MAX_CANDIDATE_STORES and not candidate_pass_cut:
                     candidates_dropped.append({"candidate": cand, "stores": n_stores})
                     candidate_hits.pop(cand, None)
                     continue
@@ -1767,6 +1828,20 @@ def supply(root: Path, prompt: str, *, session_id: str, now: dt.date | None = No
     if task_class == "none":
         if record:
             _record_misses(qroot, prompt, scan, truncated, entities, ts, session_id, candidates_dropped)
+        if candidates_dropped:
+            # Searched, found everywhere, not injected: still a line, never zero
+            # bytes (PR #308 review round 7). "I did not find it" and "I found it
+            # in 6 of 45 cases and held it back" are different sentences.
+            names = ", ".join(f"{d['candidate']} ({d['stores']} stores)" for d in candidates_dropped)
+            return {"task_class": "none", "window": None, "entities": [], "items": [],
+                    "coverage": {"verdict": "NONE", "missing": [], "missing_paths": {}},
+                    "conflicts": 0, "budget": {"ceiling": 0, "used": 0, "cut": 0},
+                    "delegated": {"lessons": "lessons-inject", "voice": "voice-dna-loader"},
+                    "receipt_path": rel(receipts_path, root), "deadline_hit": None, "entities_dropped": [],
+                    "note": (f"[knowledge-supply] searched the docs for {names}: corpus-common (more than "
+                             f"{MAX_CANDIDATE_STORES} stores), not injected; name a case to scope it. "
+                             f"receipt={rel(qroot / 'memory' / MISSES_NAME, root)}"),
+                    "receipt": {"task_class": "none", "candidates_dropped": candidates_dropped}}
         return None
 
     declared = (manifest.get("classes") or {}).get(task_class, {}).get("sources") or {}
@@ -1974,7 +2049,8 @@ def supply(root: Path, prompt: str, *, session_id: str, now: dt.date | None = No
     bundle = {
         "task_class": task_class, "window": window,
         "entities": [{k: v for k, v in e.items() if k != "project"} | {"project": e.get("project")} for e in entities],
-        "coverage": {"verdict": verdict, "missing": missing, "missing_paths": missing_paths},
+        "coverage": {"verdict": verdict, "missing": missing, "missing_paths": missing_paths,
+                     "scope": sorted(named_stores), "stores_excluded": stores_excluded},
         "items": [], "conflicts": conflicts,
         "budget": {"ceiling": ceiling, "used": 0, "cut": 0},
         "delegated": {"lessons": "lessons-inject", "voice": "voice-dna-loader"},
@@ -1990,6 +2066,7 @@ def supply(root: Path, prompt: str, *, session_id: str, now: dt.date | None = No
         "ts": ts, "session_id": session_id, "task_class": task_class, "prompt_hash": _hash(prompt),
         "entities": [e["name"] for e in entities], "window": window,
         "sources": source_rows, "declared_missing": missing, "coverage": verdict,
+        "scope": sorted(named_stores), "stores_excluded": stores_excluded,
         "conflicts": conflicts, "ceiling_hit": ceiling_hit, "overflow": overflow,
         "prompt_chars": len(prompt), "prompt_truncated": truncated,
         "deadline_hit": deadline_hit, "entities_dropped": entities_dropped,
@@ -2001,8 +2078,11 @@ def supply(root: Path, prompt: str, *, session_id: str, now: dt.date | None = No
         # most files by design (measured 2026-09-05: one instance's client hit
         # 97 lines across its research and output), and dropping it would be
         # dropping the subject.
-        "candidate_rule": {"max_stores": MAX_CANDIDATE_STORES, "applicable": bool(substores),
-                           "note": None if substores else "single store: rule cannot run"},
+        "candidate_rule": {"max_stores": MAX_CANDIDATE_STORES,
+                           "applicable": bool(substores) and not candidate_pass_cut,
+                           "note": (None if (substores and not candidate_pass_cut)
+                                    else f"candidate pass truncated ({candidate_pass_cut}): rule not applied"
+                                    if substores else "single store: rule cannot run")},
         "items": len(kept), "bytes": bundle["budget"]["used"], "elapsed_ms": int((time.time() - t0) * 1000),
         "manifest": rel(manifest_path, root) if manifest_path else None,
     }

--- a/q-system/.q-system/scripts/knowledge_supply.py
+++ b/q-system/.q-system/scripts/knowledge_supply.py
@@ -1376,7 +1376,10 @@ def resolve_docs(entities: list[dict], search_stores: list[dict], root: Path,
             for v in pattern_variants(nm):
                 if v not in patterns:
                     patterns.append(v)
-    failed: list[Path] = []
+    # Readability is accounted for EVERY enumerated file before any search, so an
+    # index of 0 (no patterns, early return inside search_docs) cannot leave an
+    # unreadable store invisible under FULL (PR #308 review round 10).
+    failed: list[Path] = [f for f in files if not os.access(f, os.R_OK)]
     hits, engine = search_docs(files, patterns, ignore_case=True, word=False, deadline=deadline, failed=failed)
     # The same read accounting every file class has: per store, the files the
     # engine was asked to read and the ones it could not. A store whose every
@@ -1423,6 +1426,8 @@ def resolve_docs(entities: list[dict], search_stores: list[dict], root: Path,
             continue
         store = file_store.get(str(f), PROJECT_STORE)
         for e in index_ents:
+            if not store_in_scope_of(e, store):
+                continue
             if entity_matches(e, text, store):
                 out.setdefault(norm(e["name"]), {}).setdefault(store, []).append(
                     _item(e["name"], "doc", s, f, n, t_of(f), root, status=status_for_line(text)))
@@ -1616,6 +1621,18 @@ def _assemble(items: list[dict], entities: list[dict], ceiling: int, header_len:
     return kept, cut, ceiling_hit
 
 
+def store_in_scope_of(entity: dict, store_name: str) -> bool:
+    """A target entity's items come from the cases that declared it, plus the
+    project level; every other entity reads every store in scope."""
+    if entity.get("kind") != "target" or not entity.get("stores"):
+        return True
+    return store_name == PROJECT_STORE or store_name in entity["stores"]
+
+
+def stores_for(entity: dict, search_stores: list[dict]) -> list[dict]:
+    return [st for st in search_stores if store_in_scope_of(entity, st["name"])]
+
+
 def store_recency(items: list[dict]) -> dict[str, str]:
     """store -> the newest item date it carries. The project store always ranks
     first; the cases rank newest first, never by directory name: PR #308 review
@@ -1786,6 +1803,9 @@ def append_jsonl(path: Path, row: dict) -> None:
 
 MISS_CAP_PER_PROMPT = 20
 MISS_LEDGER_MAX_BYTES = 256 * 1024
+# A receipt row grows with the store count (3.4 KB at 45 stores, measured by the
+# PR #308 round 10 reviewer: 124 MB/year at 100 prompts/day unbounded).
+RECEIPT_LEDGER_MAX_BYTES = 2 * 1024 * 1024
 
 
 def miss_candidates(prompt: str, entities: list[dict]) -> list[dict]:
@@ -1815,8 +1835,8 @@ def miss_candidates(prompt: str, entities: list[dict]) -> list[dict]:
 
 def append_bounded(path: Path, row: dict, max_bytes: int = MISS_LEDGER_MAX_BYTES) -> None:
     """append_jsonl, then keep the file under max_bytes by dropping the oldest
-    half of its lines (atomic rewrite). The receipts ledger is small per row and
-    one per firing; the misses ledger is the one that can balloon."""
+    half of its lines (atomic rewrite). Both ledgers go through it: the misses
+    ledger balloons per paste, the receipts ledger per store count."""
     append_jsonl(path, row)
     try:
         if path.stat().st_size <= max_bytes:
@@ -1904,13 +1924,13 @@ def supply(root: Path, prompt: str, *, session_id: str, now: dt.date | None = No
     entities = resolve_entities(scan, index, fire_alone)
     # Naming a sub-store (a 4_points case) scopes every other entity's search to
     # it plus the project level; naming none searches every store.
-    # A case the founder NAMED is the scope. A target's declaring cases scope the
-    # search only when no case was named: a target shared by 45 cases must not
-    # drag them all back in behind "in subject7, ..." (PR #308 review round 9,
-    # which the round 8 union did).
-    store_named = {s for e in entities if e.get("kind") == "store" for s in (e.get("stores") or [])}
-    target_named = {s for e in entities if e.get("kind") == "target" for s in (e.get("stores") or [])}
-    named_stores = store_named or target_named
+    # A case name the founder TYPED is the scope. A filename inside one case is
+    # not: a targets/ stem narrows only its own entity's items to the cases that
+    # declared it (stores_for), never the whole prompt. PR #308 review rounds 8,
+    # 9 and 10 each found a prompt-level target scope wrong on a different
+    # input (bypassed the corpus-common rule; unioned past the named case;
+    # hijacked an unrelated fully-indexed subject).
+    named_stores = {s for e in entities if e.get("kind") == "store" for s in (e.get("stores") or [])}
     search_stores = [project] + [s for s in substores if not named_stores or s["name"] in named_stores]
     # What the scope left out is a fact on the wire, not only in the receipt:
     # "payment fraud" in a prompt matched case-031-payment-fraud and silently
@@ -2036,7 +2056,7 @@ def supply(root: Path, prompt: str, *, session_id: str, now: dt.date | None = No
             for ent in entities:
                 if deadline_hit is not None:
                     break
-                for st in search_stores:
+                for st in stores_for(ent, search_stores):
                     if time.time() > t_deadline:
                         deadline_hit = {"at_class": cls, "at_entity": ent["name"],
                                         "elapsed_ms": int((time.time() - t0) * 1000)}
@@ -2217,7 +2237,7 @@ def supply(root: Path, prompt: str, *, session_id: str, now: dt.date | None = No
     }
     bundle["receipt"] = receipt
     if record:
-        append_jsonl(receipts_path, receipt)
+        append_bounded(receipts_path, receipt, RECEIPT_LEDGER_MAX_BYTES)
         _record_misses(qroot, prompt, scan, truncated, entities, ts, session_id, candidates_dropped)
         _record_recall(bundle, session_id, recall_path)
     return bundle

--- a/q-system/.q-system/scripts/knowledge_supply.py
+++ b/q-system/.q-system/scripts/knowledge_supply.py
@@ -402,7 +402,13 @@ def build_index(stores: dict, substores: list[dict] | None = None) -> dict[str, 
         for key in st.get("client_keys") or []:
             _add(index, key, "client")
         for name in st.get("target_names") or []:
-            _add(index, name, "target")
+            ent = _add(index, name, "target")
+            # A targets/ file is one case's declaration of a subject; asking about
+            # it means that case unless another is named. Without this, a target
+            # stem that is also a common word ("miami") fired alone across every
+            # case and bypassed the corpus-common rule (PR #308 review round 8).
+            if ent is not None and st.get("name") and st["name"] != PROJECT_STORE:
+                ent.stores.add(st["name"])
         for name in st.get("noun_names") or []:
             _add(index, name, "noun")
         if st.get("name") and st["name"] != PROJECT_STORE:
@@ -1123,7 +1129,10 @@ def resolve_handoff(entity: dict, stores: dict, root: Path, window: dict | None)
     path = stores["paths"]["handoff"]
     if not path.is_file():
         return []
-    items = resolve_canonical(entity, stores, root, kind="handoff", files=[path])
+    # cls="handoff": the read failure lands under the handoff class, never under
+    # canonical's read_stats (PR #308 review round 8, pre-existing from #302).
+    items = resolve_canonical(entity, stores, root, kind="handoff", files=[path],
+                              errors=stores.get("problems"), cls="handoff")
     return [i for i in items if in_window(i["t"], window)]
 
 
@@ -1261,12 +1270,25 @@ def class_search_state(stopped_cold: bool, truncated: str | None) -> bool | str:
 
 def search_docs(files: list[Path], patterns: list[str], *, ignore_case: bool, word: bool,
                 deadline: float, failed: list[Path] | None = None) -> tuple[list[tuple[Path, int, str]], str]:
-    """`failed` collects the enumerated files the engine could not read."""
+    """`failed` collects the enumerated files the engine could not read. The
+    readability check is made HERE, before either engine runs, so it does not
+    depend on how a given grep reports an unreadable file (PR #308 review round
+    7 fix reported it on BSD grep and CI's GNU grep stayed silent): a file that
+    vanished or lost read permission between enumeration and the search is
+    recorded and never handed to the engine."""
     if not files or not patterns:
         return [], "none"
-    r = _grep(files, patterns, ignore_case=ignore_case, word=word, deadline=deadline, failed=failed)
+    readable: list[Path] = []
+    for f in files:
+        if os.access(f, os.R_OK):
+            readable.append(f)
+        elif failed is not None:
+            failed.append(f)
+    if not readable:
+        return [], "grep" if grep_binary() else "python"
+    r = _grep(readable, patterns, ignore_case=ignore_case, word=word, deadline=deadline, failed=failed)
     if r is None:
-        return _pyscan(files, patterns, ignore_case=ignore_case, word=word, deadline=deadline, failed=failed)
+        return _pyscan(readable, patterns, ignore_case=ignore_case, word=word, deadline=deadline, failed=failed)
     return r
 
 
@@ -1488,6 +1510,19 @@ def capability_hits(prompt: str, cap_index: dict) -> list[tuple[str, list]]:
 # ------------------------------------------------------------------ assembly
 
 def assemble(items: list[dict], entities: list[dict], ceiling: int, header_len: int) -> tuple[list[dict], int, bool]:
+    """Two passes at most: if the first leaves a store with nothing, the note
+    that names it is on the wire, so the second pass pays for the note up
+    front (PR #308 review round 8: the note pushed the render 128 chars past
+    the ceiling with every remaining line pinned and nothing left to drop)."""
+    kept, cut, ceiling_hit = _assemble(items, entities, ceiling, header_len)
+    cut_stores = stores_cut_by_ceiling(items, kept)
+    if cut_stores:
+        reserve = len(ceiling_note_text(cut_stores)) + 8
+        kept, cut, ceiling_hit = _assemble(items, entities, ceiling - reserve, header_len)
+    return kept, cut, ceiling_hit
+
+
+def _assemble(items: list[dict], entities: list[dict], ceiling: int, header_len: int) -> tuple[list[dict], int, bool]:
     """Order, dedupe, and cut to the ceiling. The newest graph item per entity is
     pinned first so a cut can never drop the one fact most likely to be current."""
     order = {norm(e["name"]): i for i, e in enumerate(entities)}
@@ -1506,7 +1541,8 @@ def assemble(items: list[dict], entities: list[dict], ceiling: int, header_len: 
             continue
         seen.add(key)
         deduped.append(it)
-    deduped.sort(key=item_order(order))  # stable: resolver order survives inside a tier (open commitments first, newest first)
+    recency = store_recency(deduped)
+    deduped.sort(key=item_order(order, recency))  # stable: resolver order survives inside a tier (open commitments first, newest first)
     pinned: set[int] = set()
     seen_ent: set[str] = set()
     for idx, it in enumerate(deduped):
@@ -1515,6 +1551,18 @@ def assemble(items: list[dict], entities: list[dict], ceiling: int, header_len: 
             seen_ent.add(norm(it["entity"]))
     used = header_len
     kept, cut, ceiling_hit = [], 0, False
+    blocks: set[tuple[str, str]] = set()
+
+    def cost_of(it: dict) -> tuple[int, tuple[str, str]]:
+        # A block heading ("== name [store] ==") is on the wire too. Uncounted, 40
+        # case headings put the rendered text 1,553 chars past the ceiling while
+        # the budget said it fit (PR #308 review round 8, measured).
+        key = (norm(it["entity"]), it.get("store") or PROJECT_STORE)
+        c = len(render_item(it)) + 1
+        if key not in blocks:
+            c += len(f"== {block_label(it)} ==") + 1
+        return c, key
+
     # Pins are reserved FIRST and always kept, so their cost sits inside `used`
     # before the fill starts. If the pins alone overrun the ceiling, that is
     # REPORTED (ceiling_hit, overflow), never hidden: Codex round 2 on PR #302
@@ -1522,10 +1570,32 @@ def assemble(items: list[dict], entities: list[dict], ceiling: int, header_len: 
     for idx, it in enumerate(deduped):
         it["pinned"] = idx in pinned
     for idx in sorted(pinned):
-        used += len(render_item(deduped[idx])) + 1
+        c, key = cost_of(deduped[idx])
+        used += c
+        blocks.add(key)
         kept.append(deduped[idx])
     if used > ceiling:
         ceiling_hit = True
+    # Then one line per (entity, store), newest store first, WHILE IT FITS: a
+    # store with a hit is never dropped whole because a newer store had more to
+    # say; a store that gets no line is named on the wire (stores_cut). PR #308
+    # review round 8: the fill kept case-001..006 by directory name and cut the
+    # case that held the answer.
+    seen_store: set[tuple[str, str]] = {(norm(deduped[i]["entity"]), deduped[i].get("store") or PROJECT_STORE) for i in pinned}
+    for idx, it in enumerate(deduped):
+        if idx in pinned:
+            continue
+        key = (norm(it["entity"]), it.get("store") or PROJECT_STORE)
+        if key in seen_store:
+            continue
+        seen_store.add(key)
+        c, _ = cost_of(it)
+        if not ceiling_hit and used + c <= ceiling:
+            pinned.add(idx)
+            it["pinned"] = True
+            blocks.add(key)
+            used += c
+            kept.append(it)
     # The first cut ends the fill for everything else. A per-item check would
     # let a short low-tier line slip into the gap left after a higher-tier cut,
     # which reorders priority by accident (measured: the pin mutation survived
@@ -1533,26 +1603,51 @@ def assemble(items: list[dict], entities: list[dict], ceiling: int, header_len: 
     for idx, it in enumerate(deduped):
         if idx in pinned:
             continue
-        cost = len(render_item(it)) + 1
-        if not ceiling_hit and used + cost <= ceiling:
+        c, key = cost_of(it)
+        if not ceiling_hit and used + c <= ceiling:
             kept.append(it)
-            used += cost
+            blocks.add(key)
+            used += c
         else:
             cut += 1
             ceiling_hit = True
-    kept.sort(key=item_order(order))  # stable: resolver order survives inside a tier (open commitments first, newest first)
+    kept.sort(key=item_order(order, recency))  # stable: resolver order survives inside a tier (open commitments first, newest first)
     return kept, cut, ceiling_hit
 
 
-def item_order(order: dict[str, int]):
-    """Entity, then the project block before each case block, then tier. A name
-    carried by two cases is two blocks, never one identity: PR #308 review
-    round 2 showed two different people called the same thing in two cases
-    rendering as one heading with contradictory KNOWN facts."""
+def store_recency(items: list[dict]) -> dict[str, str]:
+    """store -> the newest item date it carries. The project store always ranks
+    first; the cases rank newest first, never by directory name: PR #308 review
+    round 8 measured the ceiling keeping case-001..006 and cutting the case that
+    held the answer because "case-040" sorts last."""
+    newest: dict[str, str] = {}
+    for it in items:
+        st = it.get("store") or PROJECT_STORE
+        t = it.get("t") or ""
+        if t > newest.get(st, ""):
+            newest[st] = t
+    return newest
+
+
+def item_order(order: dict[str, int], recency: dict[str, str] | None = None):
+    """Entity, then the project block, then each case block newest first, then
+    tier. A name carried by two cases is two blocks, never one identity (PR #308
+    review round 2)."""
+    rec = recency or {}
+
     def key(i: dict):
         store = i.get("store") or PROJECT_STORE
-        return (order.get(norm(i["entity"]), 99), 0 if store == PROJECT_STORE else 1, store, TIER.get(i["kind"], 9))
-    return key
+        return (order.get(norm(i["entity"]), 99), 0 if store == PROJECT_STORE else 1,
+                "" if store == PROJECT_STORE else rec.get(store, ""), store, TIER.get(i["kind"], 9))
+
+    def wrapped(i: dict):
+        k = key(i)
+        # Newest date first, and on a tie the HIGHER case number first: in a
+        # case-NNN scheme the number grows with time, and a fresh checkout gives
+        # every doc one date (PR #308 review round 8). Both descend by sorting on
+        # the negated code points.
+        return (k[0], k[1], tuple(-ord(c) for c in k[2]), tuple(-ord(c) for c in k[3]), k[4])
+    return wrapped
 
 
 def block_label(it: dict) -> str:
@@ -1580,7 +1675,16 @@ def deadline_note(bundle: dict) -> str:
     dropped = bundle.get("entities_dropped") or []
     if dropped:
         parts.append(f" ENTITIES DROPPED (cap {MAX_ENTITIES}): {', '.join(dropped)}.")
+    cut_stores = (bundle.get("budget") or {}).get("stores_cut") or []
+    if cut_stores:
+        parts.append(ceiling_note_text(cut_stores))
     return "".join(parts)
+
+
+def ceiling_note_text(cut_stores: list[str]) -> str:
+    """Bounded: six names and a count, so the disclosure never eats the budget."""
+    shown = ", ".join(cut_stores[:6]) + (f" and {len(cut_stores) - 6} more" if len(cut_stores) > 6 else "")
+    return f" CEILING: {len(cut_stores)} store(s) with hits reached you with nothing: {shown} (full list in the receipt)."
 
 
 def render_header(bundle: dict) -> str:
@@ -1594,6 +1698,8 @@ def render_header(bundle: dict) -> str:
     def suffix(e: dict) -> str:
         if e.get("kind") == "store" and e.get("stores"):
             return f" [{', '.join(e['stores'])}]"
+        if e.get("kind") == "target" and e.get("stores"):
+            return f" [target of {', '.join(e['stores'])}]"
         if e.get("kind") == "docs_hit":
             return " [docs]"
         out = ""
@@ -1615,10 +1721,14 @@ def render_header(bundle: dict) -> str:
 
 
 def scope_note(cov: dict) -> str:
-    """One clause naming what a named case left out of the search."""
+    """One clause naming what a named case left out of the search. The verdict
+    word is relative to the scope and the clause says so, because the engine
+    cannot tell "in jennica pounds, ..." from an incidental "post it on
+    Facebook" matching case-005-facebook (PR #308 review rounds 7 and 8)."""
     if cov.get("scope"):
         n = len(cov.get("stores_excluded") or [])
-        return f" scope: {', '.join(cov['scope'])} + project ({n} other store{'s' if n != 1 else ''} not searched)."
+        return (f" WITHIN SCOPE {', '.join(cov['scope'])} + project only; {n} other store{'s' if n != 1 else ''} "
+                f"not searched (name a different case, or none, to widen).")
     return ""
 
 
@@ -1787,7 +1897,7 @@ def supply(root: Path, prompt: str, *, session_id: str, now: dt.date | None = No
     entities = resolve_entities(scan, index, fire_alone)
     # Naming a sub-store (a 4_points case) scopes every other entity's search to
     # it plus the project level; naming none searches every store.
-    named_stores = {s for e in entities if e.get("kind") == "store" for s in (e.get("stores") or [])}
+    named_stores = {s for e in entities if e.get("kind") in ("store", "target") for s in (e.get("stores") or [])}
     search_stores = [project] + [s for s in substores if not named_stores or s["name"] in named_stores]
     # What the scope left out is a fact on the wire, not only in the receipt:
     # "payment fraud" in a prompt matched case-031-payment-fraud and silently
@@ -2061,13 +2171,19 @@ def supply(root: Path, prompt: str, *, session_id: str, now: dt.date | None = No
     kept, cut, ceiling_hit = assemble(items, entities, ceiling, header_len)
     bundle["items"] = kept
     source_cut = sum(r["cut"] for r in source_rows)
+    # The cut-stores note is on the wire, so it is set BEFORE the exact fit and
+    # the fit pays for it; recomputed after, since the fit never drops a pinned
+    # line and so never cuts another store whole (PR #308 review round 8).
+    bundle["budget"]["stores_cut"] = stores_cut_by_ceiling(items, bundle["items"])
     cut, ceiling_hit, overflow = fit_to_ceiling(bundle, ceiling, cut, source_cut, ceiling_hit)
+    bundle["budget"]["stores_cut"] = stores_cut_by_ceiling(items, bundle["items"])
     receipt = {
         "ts": ts, "session_id": session_id, "task_class": task_class, "prompt_hash": _hash(prompt),
         "entities": [e["name"] for e in entities], "window": window,
         "sources": source_rows, "declared_missing": missing, "coverage": verdict,
         "scope": sorted(named_stores), "stores_excluded": stores_excluded,
         "conflicts": conflicts, "ceiling_hit": ceiling_hit, "overflow": overflow,
+        "stores_cut": bundle["budget"]["stores_cut"],
         "prompt_chars": len(prompt), "prompt_truncated": truncated,
         "deadline_hit": deadline_hit, "entities_dropped": entities_dropped,
         "candidates_dropped": candidates_dropped,
@@ -2120,6 +2236,15 @@ def fit_to_ceiling(bundle: dict, ceiling: int, cut: int, source_cut: int,
     overflow = max(0, bundle["budget"]["used"] - ceiling)
     bundle["budget"]["overflow"] = overflow   # chars the pins alone ran past the ceiling; 0 when honest
     return cut, ceiling_hit, overflow
+
+
+def stores_cut_by_ceiling(all_items: list[dict], kept: list[dict]) -> list[str]:
+    """Stores that had a hit and reached the model with nothing. With one pin per
+    (entity, store) this is empty unless the pins alone overran the ceiling,
+    and then it is named on the wire (PR #308 review round 8)."""
+    had = {it.get("store") or PROJECT_STORE for it in all_items}
+    have = {it.get("store") or PROJECT_STORE for it in kept}
+    return sorted(had - have)
 
 
 def _record_recall(bundle: dict, session_id: str, recall_path: Path | None) -> None:

--- a/q-system/.q-system/scripts/knowledge_supply.py
+++ b/q-system/.q-system/scripts/knowledge_supply.py
@@ -563,7 +563,10 @@ def resolve_entities(prompt: str, index: dict[str, Entity], fire_alone: set[str]
     out.sort(key=lambda e: -len(e["name"]))
     kept: list[dict] = []
     for e in out:
-        if any(norm(e["name"]) != norm(k["name"]) and phrase_in(e["name"], norm(k["name"])) for k in kept):
+        # A store name that is a substring of another resolved name ("zeta" in
+        # "Zeta Holdings") is still the scope the founder named; dropping it
+        # silently widened the search to every case (PR #308 review round 6).
+        if e.get("kind") != "store" and any(norm(e["name"]) != norm(k["name"]) and phrase_in(e["name"], norm(k["name"])) for k in kept):
             continue
         kept.append(e)
     kept.sort(key=lambda e: prompt.casefold().find(e["name"].casefold()) if e["name"].casefold() in prompt.casefold() else 10**6)
@@ -801,7 +804,9 @@ def load_stores(qroot: Path, root: Path, manifest: dict | None = None,
     # its own call, and the project's rglob("*") over 4_points was 57,081
     # entries and 318 ms per prompt (measured 2026-09-05).
     exclude = {path for _, path in discover_stores(qroot, manifest or {})} if name == PROJECT_STORE else set()
-    stores["doc_files"] = enumerate_docs(qroot, folders, max_bytes, exclude) if folders else []
+    skipped: list[Path] = []
+    stores["doc_files"] = enumerate_docs(qroot, folders, max_bytes, exclude, skipped) if folders else []
+    stores["doc_skipped_oversize"] = skipped
     # A markdown file directly under a `targets`-style directory names a subject
     # of the work (4_points: investigation/targets/<subject>.md). Its stem is an
     # entity that fires alone; a finding or note file's stem never does.
@@ -847,7 +852,7 @@ def walk_dirs(base: Path, exclude: set[Path], max_depth: int):
 
 
 def enumerate_docs(store_dir: Path, folders: list[str], max_bytes: int,
-                   exclude: set[Path] | None = None) -> list[Path]:
+                   exclude: set[Path] | None = None, skipped: list[Path] | None = None) -> list[Path]:
     """The markdown files of a store's declared folders, in a stable order. Dot
     dirs, DOC_SKIP_DIRS, sub-store roots, dot files, files over max_bytes and
     last-handoff.md (the handoff class owns it) are skipped; the receipt's
@@ -868,6 +873,12 @@ def enumerate_docs(store_dir: Path, folders: list[str], max_bytes: int,
                 f = Path(dirpath) / fn
                 try:
                     if f.stat().st_size > max_bytes:
+                        # A declared exclusion (manifest doc_max_bytes), not a
+                        # truncation, so coverage stays FULL; the receipt counts
+                        # it so a reader can see what was never opened (PR #308
+                        # review round 6).
+                        if skipped is not None:
+                            skipped.append(f)
                         continue
                 except OSError:
                     continue
@@ -1370,11 +1381,18 @@ def resolve_docs(entities: list[dict], search_stores: list[dict], root: Path,
                 per_file[it["abs_src"]] = per_file.get(it["abs_src"], 0) + 1
             lst.sort(key=lambda i: (-mtimes_ns.get(i["abs_src"], 0), -per_file[i["abs_src"]],
                                     i["abs_src"], int(i["src"].rsplit(":", 1)[-1] or 0)))
+    # `stop` is the truth the class state reads; the engine string is display.
+    # Each pass is inspected on its own, so a composed label can never hide a
+    # stop: PR #308 review round 6 found "grep (candidates file cap)", built
+    # here in round 3, which the marker parser could not read, and a required
+    # docs class went FULL with 100 lines never looked at. Fourth path for the
+    # same class; the fix is a field, not another string format.
+    stop = truncation_of(engine) or truncation_of(candidate_engine)
     if engine == "none" and candidate_hits:
         engine = candidate_engine   # only the candidate pass ran (an index of 0)
     elif truncation_of(candidate_engine) and not truncation_of(engine):
-        engine += f" (candidates {truncation_of(candidate_engine)})"
-    return out, {"files": len(files), "engine": engine}
+        engine += f" (candidates: {candidate_engine})"
+    return out, {"files": len(files), "engine": engine, "stop": stop}
 
 
 def capability_index(root: Path) -> dict[str, list[tuple[Path, int, str]]]:
@@ -1440,7 +1458,10 @@ def assemble(items: list[dict], entities: list[dict], ceiling: int, header_len: 
             # Graph triples only: a relationship block is a 12-line excerpt by
             # design and was being cut at 600 (PR #304 review).
             it["text"] = it["text"][:ITEM_MAX_CHARS] + f" [cut at {ITEM_MAX_CHARS} chars; open src]"
-        key = (norm(it["entity"]), it["kind"], norm(it["text"]))   # sp-1b3ef442: a shared line stays under each named entity
+        # sp-1b3ef442: a shared line stays under each named entity; PR #308 review
+        # round 6: and under each STORE, or an identical line in two cases collapsed
+        # to one while the receipt said both stores hit and the footer said cut=0.
+        key = (norm(it["entity"]), it["kind"], norm(it["text"]), it.get("store"))
         if key in seen:
             continue
         seen.add(key)
@@ -1889,7 +1910,7 @@ def supply(root: Path, prompt: str, *, session_id: str, now: dt.date | None = No
         cut_reason = None
         if present and not stopped_cold:
             if cls == "docs":
-                cut_reason = truncation_of(docs_meta.get("engine"))
+                cut_reason = docs_meta.get("stop")   # the field, never the display string
             elif deadline_hit and deadline_hit["at_class"] == cls:
                 cut_reason = "deadline"
         searched_state = class_search_state(stopped_cold, cut_reason)
@@ -1945,6 +1966,7 @@ def supply(root: Path, prompt: str, *, session_id: str, now: dt.date | None = No
         if cls == "docs":
             row["files"] = docs_meta.get("files", sum(len(s.get("doc_files") or []) for s in search_stores))
             row["engine"] = docs_meta.get("engine")
+            row["files_skipped_oversize"] = sum(len(s.get("doc_skipped_oversize") or []) for s in search_stores)
         source_rows.append(row)
 
     verdict = "FULL" if not missing else ("NONE" if all(not r["present"] for r in source_rows) else "PARTIAL")

--- a/q-system/.q-system/scripts/knowledge_supply.py
+++ b/q-system/.q-system/scripts/knowledge_supply.py
@@ -604,7 +604,12 @@ def is_initial_position(text: str, pos: int) -> bool:
 def entity_matches(entity: dict, text: str, store: str | None = None) -> bool:
     """Content-side match. The name matches anywhere; an alias matches only
     content in a store that asserted it (or anywhere, when the project store
-    asserted it, or when the caller has no store to name)."""
+    asserted it, or when the caller has no store to name). A prompt-driven
+    candidate was admitted case-sensitively and whole-word; it is matched the
+    same way by EVERY resolver, or a capitalized common word pulls unrelated
+    lowercase lines labelled KNOWN (PR #308 review round 5)."""
+    if entity.get("case_sensitive"):
+        return word_in_exact(entity["name"], text)
     if phrase_in(entity["name"], norm(text)):
         return True
     scopes = entity.get("alias_stores") or {}
@@ -1733,7 +1738,7 @@ def supply(root: Path, prompt: str, *, session_id: str, now: dt.date | None = No
                     continue
                 entities.append({"name": cand, "kind": "docs_hit", "resolved_from": "docs",
                                  "ambiguous": False, "project": None, "orgs": [], "aliases": [],
-                                 "stores": [], "via_alias": None, "alias_stores": {}})
+                                 "stores": [], "via_alias": None, "alias_stores": {}, "case_sensitive": True})
     entities_dropped = [e["name"] for e in entities[MAX_ENTITIES:]]
     entities = entities[:MAX_ENTITIES]
     cap_hits = capability_hits(scan, capability_index(root)) if (CAPABILITY_RE.search(scan) and not entities) else []
@@ -1894,6 +1899,35 @@ def supply(root: Path, prompt: str, *, session_id: str, now: dt.date | None = No
                                   else f"{path_s or cls} partially searched ({cut_reason})")
         src_path = Path(root) / path_s if path_s and cls not in ("canonical", "capability", "docs") else None
         store_problems = "; ".join(f"{s['name']}: {s['problems'][cls]}" for s in search_stores if cls in s["problems"]) or None
+        # present_of() asks "does ANY store in scope carry this class", which is
+        # the right question for ABSENT (a case with no graph.jsonl must not hide
+        # the project's). UNREADABLE is a different fact: a copy that exists and
+        # failed to parse was never searched, so the class is degraded no matter
+        # how many other copies read cleanly. PR #308 review round 5: a truncated
+        # graph in the one case that held the answer reported FULL because the
+        # project's graph parsed. The receipt carried the problem; the header,
+        # the only channel the model reads, did not.
+        # "Unreadable" means a store's WHOLE copy of the class: a parse failure on
+        # its ledger, or every file of the class in that store failing to read.
+        # One unreadable file among readable ones in a store stays a problem in
+        # the receipt and never a PARTIAL (PR #304 review, sp-ca1769db, pinned by
+        # test_unreadable_is_every_file_not_zero_hits).
+        # For a file-per-class store (canonical, handoff, relationships, decisions)
+        # the resolver records a per-FILE read error under the same problems key,
+        # so the ledger rule (a key in problems) applies only to the ledger
+        # classes; the file classes use read_stats and the all-failed test.
+        ledger_classes = ("graph", "commitments", "meetings", "loops")
+        unreadable_in = [s["name"] for s in search_stores if cls in ledger_classes and cls in s["problems"]]
+        for s in search_stores:
+            rs_s = s.get("read_stats", {}).get(cls)
+            if rs_s and rs_s["files"] and rs_s["failed"] >= rs_s["files"] and s["name"] not in unreadable_in:
+                unreadable_in.append(s["name"])
+        if present and unreadable_in:
+            if searched_state is True:
+                searched_state = "partial"
+            if spec.get("required") and cls not in missing:
+                missing.append(cls)
+                missing_paths[cls] = f"{path_s or cls} unreadable in {', '.join(unreadable_in)}"
         row = {
             "class": cls, "path": path_s, "present": present, "required": bool(spec.get("required")),
             "mtime": mtime_date(src_path) if src_path and src_path.exists() else None,

--- a/q-system/.q-system/scripts/knowledge_supply.py
+++ b/q-system/.q-system/scripts/knowledge_supply.py
@@ -129,7 +129,7 @@ MAX_DOC_HITS = 20000
 # and, for a required class, a missing entry; PR #308 review rounds 1 and 2
 # found the same defect on two paths (deadline before the class, then grep
 # timeout / byte budget inside it), which is the signal for one rule, not two.
-TRUNCATION_MARKERS = ("(deadline)", "(timeout)", "(budget)", "(hit cap)")
+TRUNCATION_MARKERS = ("(deadline)", "(timeout)", "(budget)", "(hit cap)", "(file cap)")
 # A prompt word that hits in more than this many stores is a word this corpus
 # uses everywhere (Facebook, Miami across 27 of 43 cases, measured 2026-09-05),
 # not a subject. It is dropped and named in the receipt; naming a case first
@@ -1145,6 +1145,7 @@ def _grep(files: list[Path], patterns: list[str], *, ignore_case: bool, word: bo
     args.append("--")
     hits: list[tuple[Path, int, str]] = []
     engine = "grep"
+    per_file: dict[str, int] = {}
     for i in range(0, len(files), GREP_CHUNK):
         remaining = deadline - time.time()
         if remaining <= 0.05:
@@ -1161,6 +1162,12 @@ def _grep(files: list[Path], patterns: list[str], *, ignore_case: bool, word: bo
             m = HIT_RE.match(line)
             if m:
                 hits.append((Path(m.group("path")), int(m.group("n")), m.group("text")))
+                per_file[m.group("path")] = per_file.get(m.group("path"), 0) + 1
+                if per_file[m.group("path")] >= GREP_MAX_PER_FILE:
+                    # -m stopped reading that file: lines past the cap were never
+                    # looked at, which is a truncation like any other (PR #308
+                    # review round 4: the cap was silent and the receipt said FULL).
+                    engine = "grep (file cap)"
                 if len(hits) >= MAX_DOC_HITS:
                     return hits, "grep (hit cap)"
     return hits, engine
@@ -1183,11 +1190,16 @@ def _pyscan(files: list[Path], patterns: list[str], *, ignore_case: bool, word: 
         except OSError:
             continue
         used += len(data)
+        in_file = 0
         for n, line in enumerate(data.splitlines(), start=1):
             if pat.search(line):
                 hits.append((f, n, line))
+                in_file += 1
                 if len(hits) >= MAX_DOC_HITS:
                     return hits, "python (hit cap)"
+                if in_file >= GREP_MAX_PER_FILE:
+                    engine = "python (file cap)"   # parity with grep -m, and the same receipt
+                    break
         if used > budget_bytes:
             return hits, "python (budget)"
     return hits, engine
@@ -1305,11 +1317,16 @@ def resolve_docs(entities: list[dict], search_stores: list[dict], root: Path,
                     patterns.append(v)
     hits, engine = search_docs(files, patterns, ignore_case=True, word=False, deadline=deadline)
     mtimes: dict[str, str | None] = {}
+    mtimes_ns: dict[str, int] = {}
 
     def t_of(f: Path) -> str | None:
         k = str(f)
         if k not in mtimes:
             mtimes[k] = mtime_date(f)
+            try:
+                mtimes_ns[k] = f.stat().st_mtime_ns
+            except OSError:
+                mtimes_ns[k] = 0
         return mtimes[k]
 
     out: dict[str, dict[str, list[dict]]] = {}
@@ -1336,9 +1353,18 @@ def resolve_docs(entities: list[dict], search_stores: list[dict], root: Path,
         for f, n, text, store in candidate_hits.get(e["name"], []):
             out.setdefault(norm(e["name"]), {}).setdefault(store, []).append(
                 _item(e["name"], "doc", text.strip(), f, n, t_of(f), root, status=status_for_line(text)))
+    # Order inside one entity and store: newest FILE first by full mtime (the
+    # displayed t is a date, and every file of a fresh checkout shares one), then
+    # the file that mentions the entity most, then path and line ascending. PR #308
+    # review round 4: a plain reverse sort on "date, src" kept the alphabetically
+    # last filler files and dropped the one answer file under a "newest first" header.
     for by_store in out.values():
         for lst in by_store.values():
-            lst.sort(key=lambda i: (i["t"] or "", i["src"]), reverse=True)
+            per_file: dict[str, int] = {}
+            for it in lst:
+                per_file[it["abs_src"]] = per_file.get(it["abs_src"], 0) + 1
+            lst.sort(key=lambda i: (-mtimes_ns.get(i["abs_src"], 0), -per_file[i["abs_src"]],
+                                    i["abs_src"], int(i["src"].rsplit(":", 1)[-1] or 0)))
     if engine == "none" and candidate_hits:
         engine = candidate_engine   # only the candidate pass ran (an index of 0)
     elif truncation_of(candidate_engine) and not truncation_of(engine):

--- a/q-system/.q-system/scripts/knowledge_supply.py
+++ b/q-system/.q-system/scripts/knowledge_supply.py
@@ -730,9 +730,13 @@ def load_stores(qroot: Path, root: Path, manifest: dict | None = None,
             for line in read_lines(paths["relationships"]):
                 if line.startswith("### "):
                     head = line[4:].split("<!--")[0]
-                    name = re.split(r"\s+[—–-]\s+", head, maxsplit=1)[0].strip()
-                    if name and not name.startswith("["):
-                        contact_names.append(name)
+                    # `contact`, never `name`: that is this function's store-name
+                    # parameter, and rebinding it here made the sub-store exclusion
+                    # below compare against the last contact heading instead
+                    # (PR #308 review round 3).
+                    contact = re.split(r"\s+[—–-]\s+", head, maxsplit=1)[0].strip()
+                    if contact and not contact.startswith("["):
+                        contact_names.append(contact)
         except OSError as exc:
             problems["relationships"] = str(exc)
     stores["contact_names"] = contact_names
@@ -1264,8 +1268,13 @@ def search_docs_for_candidates(cands: list[str], search_stores: list[dict], root
     hits, engine = search_docs(files, cands, ignore_case=False, word=True, deadline=deadline)
     out: dict[str, list[tuple[Path, int, str, str]]] = {}
     for i, (f, n, text) in enumerate(hits):
-        if i % 500 == 0 and time.time() > deadline and not truncation_of(engine):
-            engine += " (deadline)"
+        # The deadline ALWAYS ends the fold; the suffix is only added when the
+        # engine string does not already carry a stop reason. PR #308 review
+        # round 3: with the guard on the whole condition, a search that had
+        # already hit the cap ran the fold unbounded past the hook timeout.
+        if i % 500 == 0 and time.time() > deadline:
+            if not truncation_of(engine):
+                engine += " (deadline)"
             break
         s = text.strip()
         if not s or s.startswith("#"):
@@ -1305,8 +1314,13 @@ def resolve_docs(entities: list[dict], search_stores: list[dict], root: Path,
 
     out: dict[str, dict[str, list[dict]]] = {}
     for i, (f, n, text) in enumerate(hits):
-        if i % 500 == 0 and time.time() > deadline and not truncation_of(engine):
-            engine += " (deadline)"
+        # The deadline ALWAYS ends the fold; the suffix is only added when the
+        # engine string does not already carry a stop reason. PR #308 review
+        # round 3: with the guard on the whole condition, a search that had
+        # already hit the cap ran the fold unbounded past the hook timeout.
+        if i % 500 == 0 and time.time() > deadline:
+            if not truncation_of(engine):
+                engine += " (deadline)"
             break
         s = text.strip()
         if not s:

--- a/q-system/.q-system/scripts/knowledge_supply.py
+++ b/q-system/.q-system/scripts/knowledge_supply.py
@@ -44,6 +44,19 @@ WHY STATUS LABELS COME FROM provenance-vocabulary.json: that file is the ONE
 vocabulary, loaded at runtime by two lints already. A second table here would
 drift the way the first two did on 2026-07-28 (the scar recorded in that file).
 
+WHY STORES, DOCS AND PROMPT-DRIVEN CANDIDATES (founder-directed 2026-09-05, plan
+knowledge-supply-project-folders-2026-09-05): "every project reads its own folder,
+and each 4_points investigation is its own knowledge base." Measured before this:
+4_points had 45 investigation folders and 1,475 markdown files that no source
+class covered (index: 40 graph entities); a consulting instance had 83 files and an index of 0, so the reader never woke up there. Three additions, all declared as data in
+the manifest: `stores` (a glob of sub-directories, each a knowledge base with the
+qroot layout; naming one in the prompt scopes the search to it), a `docs` class
+(the project's own markdown folders, one grep pass per prompt, Python fallback),
+and prompt-driven candidates (a capitalized word the index cannot resolve is
+searched case-sensitively in the docs; a hit makes it an entity, a miss stays a
+miss). Headings never index: the heading census across every case file was
+section labels (Notes, Summary, Integrity), not names.
+
 Contract: pure functions over paths. supply() writes only the receipt and misses
 ledgers under <qroot>/memory/, both untracked jsonl like graph.jsonl, through
 one append function. record=False writes nothing (replay and tests). Any store
@@ -58,6 +71,8 @@ import importlib.util
 import json
 import os
 import re
+import shutil
+import subprocess
 import sys
 import time
 from pathlib import Path
@@ -87,7 +102,27 @@ DROP_STATES = ("voided", "misattributed")
 # Render order inside one entity. Canonical and decisions first (the founder's
 # curated truth), then the graph newest-first, then event stores by recency.
 TIER = {"canonical": 0, "decision": 0, "capability": 0, "relationship": 1, "graph": 2,
-        "commitment": 3, "meeting": 4, "loop": 5, "handoff": 6}
+        "commitment": 3, "meeting": 4, "loop": 5, "handoff": 6, "doc": 7}
+
+# The project-level store's name in receipts and items; sub-stores carry their
+# directory name (case-023-shinyhunters), which the src path shows anyway.
+PROJECT_STORE = "project"
+# A store directory's entity name drops a `case-023-` style prefix: the founder
+# says "shinyhunters", never "case-023-shinyhunters".
+STORE_PREFIX_RE = re.compile(r"^[a-z]+-\d+-", re.IGNORECASE)
+DOC_SKIP_DIRS = {"node_modules", "exports", "screenshots", "__pycache__", "raw-collections"}
+DOC_MAX_BYTES_DEFAULT = 512 * 1024
+# Python fallback budget when grep is unavailable: past this many bytes the
+# scan stops and the receipt engine says "python (budget)".
+DOC_SCAN_BUDGET_BYTES = 3 * 1024 * 1024
+GREP_CHUNK = 400
+MAX_DOC_CANDIDATES = 6
+# A prompt word that hits in more than this many stores is a word this corpus
+# uses everywhere (Facebook, Miami across 27 of 43 cases, measured 2026-09-05),
+# not a subject. It is dropped and named in the receipt; naming a case first
+# scopes the count to that case, so the same word works inside one.
+MAX_CANDIDATE_STORES = 4
+ENTITY_DIR_MAX_DEPTH = 4
 
 STOPWORDS = {
     "that", "this", "with", "from", "have", "will", "would", "should", "could", "there",
@@ -267,16 +302,17 @@ def status_for_line(line: str) -> str:
 # ------------------------------------------------------------------ entity index
 
 class Entity:
-    __slots__ = ("name", "kind", "aliases", "orgs")
+    __slots__ = ("name", "kind", "aliases", "orgs", "store")
 
     def __init__(self, name: str, kind: str):
         self.name = name
-        self.kind = kind          # graph | contact | slug | client | capability
+        self.kind = kind          # graph | contact | slug | client | store | target | noun | capability
         self.aliases: set[str] = set()
         self.orgs: dict[str, str | None] = {}   # org -> project, from works_at rows
+        self.store: str | None = None            # the sub-store directory a `store` entity names
 
     def as_dict(self) -> dict:
-        return {"name": self.name, "kind": self.kind, "aliases": sorted(self.aliases)}
+        return {"name": self.name, "kind": self.kind, "aliases": sorted(self.aliases), "store": self.store}
 
 
 def _add(index: dict[str, Entity], name: str, kind: str) -> Entity | None:
@@ -288,14 +324,17 @@ def _add(index: dict[str, Entity], name: str, kind: str) -> Entity | None:
     if ent is None:
         ent = Entity(name, kind)
         index[key] = ent
-    elif kind in ("contact", "client", "slug") and ent.kind == "graph":
+    elif kind in ("contact", "client", "slug", "store", "target", "noun") and ent.kind == "graph":
         ent.kind = kind   # a curated source outranks a graph mention for the fire rule
     return ent
 
 
-def build_index(stores: dict) -> dict[str, Entity]:
+def build_index(stores: dict, substores: list[dict] | None = None) -> dict[str, Entity]:
+    """One index over the project store and every sub-store. Curated kinds (a
+    store's own name, a target file, a proper noun) outrank a graph mention."""
     index: dict[str, Entity] = {}
-    graph_rows = stores.get("graph_rows") or []
+    all_stores = [stores] + list(substores or [])
+    graph_rows = [r for st in all_stores for r in (st.get("graph_rows") or [])]
     for row in graph_rows:
         s, p, o = row.get("s"), row.get("p"), row.get("o")
         if not isinstance(s, str) or not isinstance(o, str):
@@ -314,13 +353,27 @@ def build_index(stores: dict) -> dict[str, Entity]:
                 index.pop(norm(o), None)
         if p in ORG_PREDICATES and es is not None:
             es.orgs[normalize_ws(o)] = row.get("project")
-    for name in stores.get("contact_names") or []:
-        _add(index, name, "contact")
-    for slug in stores.get("slugs") or []:
-        _add(index, slug, "slug")
-    for key in stores.get("client_keys") or []:
-        _add(index, key, "client")
+    for st in all_stores:
+        for name in st.get("contact_names") or []:
+            _add(index, name, "contact")
+        for slug in st.get("slugs") or []:
+            _add(index, slug, "slug")
+        for key in st.get("client_keys") or []:
+            _add(index, key, "client")
+        for name in st.get("target_names") or []:
+            _add(index, name, "target")
+        for name in st.get("noun_names") or []:
+            _add(index, name, "noun")
+        if st.get("name") and st["name"] != PROJECT_STORE:
+            ent = _add(index, store_entity_name(st["name"]), "store")
+            if ent is not None:
+                ent.kind = "store"
+                ent.store = st["name"]
     return index
+
+
+def store_entity_name(dirname: str) -> str:
+    return normalize_ws(STORE_PREFIX_RE.sub("", dirname).replace("-", " ").replace("_", " "))
 
 
 def prompt_tokens(pn: str) -> set[str]:
@@ -431,7 +484,7 @@ def resolve_entities(prompt: str, index: dict[str, Entity], fire_alone: set[str]
         found[key] = {"name": ent.name, "kind": ent.kind,
                       "resolved_from": "alias" if hit_via == "alias" else ent.kind,
                       "ambiguous": ambiguous, "project": scoped_project,
-                      "orgs": sorted(ent.orgs), "aliases": sorted(ent.aliases)}
+                      "orgs": sorted(ent.orgs), "aliases": sorted(ent.aliases), "store": ent.store}
     # First-name expansion, measured not guessed. Replay of 2,131 real prompts
     # (2026-09-04) showed the founder names people by bare first name; the top
     # misses were exactly those. A capitalized token that is NOT sentence-initial
@@ -458,7 +511,7 @@ def resolve_entities(prompt: str, index: dict[str, Entity], fire_alone: set[str]
                 ent = index[keys[0]]
                 found[keys[0]] = {"name": ent.name, "kind": ent.kind, "resolved_from": "first_name",
                                   "ambiguous": len(ent.orgs) >= 2, "project": None,
-                                  "orgs": sorted(ent.orgs), "aliases": sorted(ent.aliases)}
+                                  "orgs": sorted(ent.orgs), "aliases": sorted(ent.aliases), "store": ent.store}
     # Longest name wins when one resolved name contains another ("Dana Okafor" vs "Okafor Co").
     out = list(found.values())
     out.sort(key=lambda e: -len(e["name"]))
@@ -558,11 +611,16 @@ def in_window(t: str | None, window: dict | None) -> bool:
 
 # ------------------------------------------------------------------ store loading
 
-def load_stores(qroot: Path, root: Path) -> tuple[dict, dict]:
+def load_stores(qroot: Path, root: Path, manifest: dict | None = None,
+                name: str = PROJECT_STORE) -> tuple[dict, dict]:
     """Read every store once. Returns (stores, problems). A store that fails to
-    parse lands in problems and counts as present-but-unreadable in the receipt."""
-    stores: dict = {"paths": {}}
+    parse lands in problems and counts as present-but-unreadable in the receipt.
+    The same loader reads the project qroot and every sub-store directory (a
+    4_points case folder has the same layout), so a case's own graph, canonical,
+    handoff and documents are read the way the project's are."""
+    stores: dict = {"paths": {}, "name": name, "dir": qroot}
     problems: dict = {}
+    stores["problems"] = problems
     paths = {
         "graph": qroot / "memory" / "graph.jsonl",
         "relationships": qroot / "my-project" / "relationships.md",
@@ -670,7 +728,109 @@ def load_stores(qroot: Path, root: Path) -> tuple[dict, dict]:
         except (OSError, ValueError) as exc:
             problems["loops"] = str(exc)
     stores["loops"] = [l for l in loops if isinstance(l, dict)]
+
+    folders = list((manifest or {}).get("folders") or [])
+    max_bytes = int((manifest or {}).get("doc_max_bytes") or DOC_MAX_BYTES_DEFAULT)
+    # The project walk never enters a sub-store root: each case is loaded by
+    # its own call, and the project's rglob("*") over 4_points was 57,081
+    # entries and 318 ms per prompt (measured 2026-09-05).
+    exclude = {path for _, path in discover_stores(qroot, manifest or {})} if name == PROJECT_STORE else set()
+    stores["doc_files"] = enumerate_docs(qroot, folders, max_bytes, exclude) if folders else []
+    # A markdown file directly under a `targets`-style directory names a subject
+    # of the work (4_points: investigation/targets/<subject>.md). Its stem is an
+    # entity that fires alone; a finding or note file's stem never does.
+    target_names = []
+    entity_dirs = set((manifest or {}).get("entity_dirs") or [])
+    if entity_dirs:
+        for d in walk_dirs(qroot, exclude, ENTITY_DIR_MAX_DEPTH):
+            if d.name not in entity_dirs:
+                continue
+            for f in sorted(d.glob("*.md")):
+                if not f.name.startswith("_") and not f.name.startswith("."):
+                    target_names.append(normalize_ws(f.stem.replace("-", " ").replace("_", " ")))
+    stores["target_names"] = target_names
+    # canonical/proper-nouns.txt is the voice lint's curated name list (its own
+    # header says to keep common words out), which makes it a safe fire-alone
+    # index source for a project with no graph yet (a consulting instance with no graph, 2026-09-05).
+    nouns = []
+    pn = qroot / "canonical" / "proper-nouns.txt"
+    if pn.is_file():
+        try:
+            for line in read_lines(pn):
+                s = line.strip()
+                if s and not s.startswith("#"):
+                    nouns.append(s)
+        except OSError as exc:
+            problems["nouns"] = str(exc)
+    stores["noun_names"] = nouns
     return stores, problems
+
+
+def walk_dirs(base: Path, exclude: set[Path], max_depth: int):
+    """Pruned directory walk: dot dirs, DOC_SKIP_DIRS and `exclude` (sub-store
+    roots) are never entered, and nothing below max_depth is."""
+    base_depth = len(base.parts)
+    for dirpath, dirnames, _ in os.walk(base):
+        cur = Path(dirpath)
+        if len(cur.parts) - base_depth >= max_depth:
+            dirnames[:] = []
+        else:
+            dirnames[:] = sorted(d for d in dirnames if not d.startswith(".") and d not in DOC_SKIP_DIRS
+                                 and (cur / d) not in exclude)
+        yield cur
+
+
+def enumerate_docs(store_dir: Path, folders: list[str], max_bytes: int,
+                   exclude: set[Path] | None = None) -> list[Path]:
+    """The markdown files of a store's declared folders, in a stable order. Dot
+    dirs, DOC_SKIP_DIRS, sub-store roots, dot files, files over max_bytes and
+    last-handoff.md (the handoff class owns it) are skipped; the receipt's
+    `files` is this count."""
+    out: list[Path] = []
+    exclude = exclude or set()
+    for folder in folders:
+        base = store_dir / folder
+        if not base.is_dir():
+            continue
+        for dirpath, dirnames, filenames in os.walk(base):
+            cur = Path(dirpath)
+            dirnames[:] = sorted(d for d in dirnames if not d.startswith(".") and d not in DOC_SKIP_DIRS
+                                 and (cur / d) not in exclude)
+            for fn in sorted(filenames):
+                if not fn.endswith(".md") or fn.startswith(".") or fn == "last-handoff.md":
+                    continue
+                f = Path(dirpath) / fn
+                try:
+                    if f.stat().st_size > max_bytes:
+                        continue
+                except OSError:
+                    continue
+                out.append(f)
+    return out
+
+
+def discover_stores(qroot: Path, manifest: dict) -> list[tuple[str, Path]]:
+    """(dirname, path) for every directory a manifest `stores` glob matches.
+    A glob that matches nothing costs nothing, so the default ships it fleet-wide."""
+    out: list[tuple[str, Path]] = []
+    seen: set[Path] = set()
+    for spec in manifest.get("stores") or []:
+        glob = spec.get("glob") if isinstance(spec, dict) else None
+        if not glob or ".." in glob:
+            continue
+        for d in sorted(qroot.glob(glob)):
+            if d.is_dir() and d not in seen and not d.name.startswith("."):
+                seen.add(d)
+                out.append((d.name, d))
+    return out
+
+
+def load_all_stores(qroot: Path, root: Path, manifest: dict) -> tuple[dict, list[dict], dict]:
+    """The project store plus every sub-store. Problems of the project store come
+    back as before; a sub-store's live on that store dict under `problems`."""
+    project, problems = load_stores(qroot, root, manifest, PROJECT_STORE)
+    subs = [load_stores(path, root, manifest, name)[0] for name, path in discover_stores(qroot, manifest)]
+    return project, subs, problems
 
 
 # ------------------------------------------------------------------ resolvers
@@ -887,6 +1047,202 @@ def resolve_handoff(entity: dict, stores: dict, root: Path, window: dict | None)
     return [i for i in items if in_window(i["t"], window)]
 
 
+def pattern_variants(name: str) -> list[str]:
+    """The spellings a name takes on disk: the name, and its `-` and `_` joins
+    (the phrase rule folds those to spaces on the prompt side; grep -F does not)."""
+    n = normalize_ws(name)
+    if len(n) < 4:
+        return []   # a short initialism over a corpus is noise (alias "DO", PR #302 round 1)
+    out = [n]
+    if " " in n:
+        out += [n.replace(" ", "-"), n.replace(" ", "_")]
+    return out
+
+
+def grep_binary() -> str | None:
+    return shutil.which("grep")
+
+
+HIT_RE = re.compile(r"^(?P<path>.+?):(?P<n>\d+):(?P<text>.*)$")
+
+
+def _grep(files: list[Path], patterns: list[str], *, ignore_case: bool, word: bool,
+          deadline: float) -> tuple[list[tuple[Path, int, str]], str] | None:
+    """One fixed-string grep over the files, chunked. None when grep is not on
+    PATH (the caller falls back to the Python scan). BSD grep 2.6 and GNU grep
+    share every flag used here. The timeout is the remaining deadline, so a
+    killed hook still returns what it gathered plus a receipt naming the stop."""
+    binary = grep_binary()
+    if binary is None or not files or not patterns:
+        return None if binary is None else ([], "grep")
+    args = [binary, "-n", "-H", "-I", "-F"] + (["-i"] if ignore_case else []) + (["-w"] if word else [])
+    for pat in patterns:
+        args += ["-e", pat]
+    args.append("--")
+    hits: list[tuple[Path, int, str]] = []
+    engine = "grep"
+    for i in range(0, len(files), GREP_CHUNK):
+        remaining = deadline - time.time()
+        if remaining <= 0.05:
+            return hits, "grep (deadline)"
+        chunk = [str(f) for f in files[i:i + GREP_CHUNK]]
+        try:
+            cp = subprocess.run(args + chunk, capture_output=True, text=True, errors="replace",
+                                timeout=max(0.2, remaining))
+        except subprocess.TimeoutExpired:
+            return hits, "grep (timeout)"
+        except OSError:
+            return None
+        for line in cp.stdout.splitlines():
+            m = HIT_RE.match(line)
+            if m:
+                hits.append((Path(m.group("path")), int(m.group("n")), m.group("text")))
+    return hits, engine
+
+
+def _pyscan(files: list[Path], patterns: list[str], *, ignore_case: bool, word: bool,
+            deadline: float, budget_bytes: int = DOC_SCAN_BUDGET_BYTES) -> tuple[list[tuple[Path, int, str]], str]:
+    """The grep-less path: same substring / whole-word semantics, bounded by a
+    byte budget and the deadline, both reported in the engine string."""
+    alts = "|".join(re.escape(p) for p in patterns)
+    body = f"(?<!\\w)(?:{alts})(?!\\w)" if word else f"(?:{alts})"
+    pat = re.compile(body, re.IGNORECASE if ignore_case else 0)
+    hits: list[tuple[Path, int, str]] = []
+    used, engine = 0, "python"
+    for f in files:
+        if time.time() > deadline:
+            return hits, "python (deadline)"
+        try:
+            data = f.read_text(encoding="utf-8", errors="replace")
+        except OSError:
+            continue
+        used += len(data)
+        for n, line in enumerate(data.splitlines(), start=1):
+            if pat.search(line):
+                hits.append((f, n, line))
+        if used > budget_bytes:
+            return hits, "python (budget)"
+    return hits, engine
+
+
+def search_docs(files: list[Path], patterns: list[str], *, ignore_case: bool, word: bool,
+                deadline: float) -> tuple[list[tuple[Path, int, str]], str]:
+    if not files or not patterns:
+        return [], "none"
+    r = _grep(files, patterns, ignore_case=ignore_case, word=word, deadline=deadline)
+    if r is None:
+        return _pyscan(files, patterns, ignore_case=ignore_case, word=word, deadline=deadline)
+    return r
+
+
+def doc_candidates(scan: str, entities: list[dict], index: dict[str, Entity]) -> list[str]:
+    """What the prompt names that the index cannot resolve, in proper-noun shape:
+    capitalized bigrams (the misses ledger's rule) and capitalized single words
+    of 4+ letters that are not sentence-, line- or bullet-initial (through
+    single_token_hit, the one chokepoint). A word that is the first token of an
+    index entity is left to the first-name rule, which owns that ambiguity."""
+    resolved = [norm(e["name"]) for e in entities] + [norm(a) for e in entities for a in e.get("aliases", [])]
+    first_tokens = {ent.name.split()[0].casefold() for ent in index.values() if ent.name.split()}
+    out: list[str] = []
+    seen: set[str] = set()
+    for m in CAP_BIGRAM_RE.finditer(scan):
+        a, b = m.group(1), m.group(2)
+        if a.casefold() in STOPWORDS or b.casefold() in STOPWORDS or a.casefold() in MISS_OPENERS:
+            continue
+        cand = f"{a} {b}"
+        cn = norm(cand)
+        if cn in seen or any(cn in r or r in cn for r in resolved):
+            continue
+        seen.add(cn)
+        out.append(cand)
+    for m in re.finditer(r"\b([A-Z][a-z]{3,})\b", scan):
+        tok = m.group(1)
+        tn = tok.casefold()
+        if tn in seen or tn in STOPWORDS or tn in MISS_OPENERS or tn in first_tokens:
+            continue
+        if any(tn in r.split() for r in resolved) or any(tn in s.split() for s in seen):
+            continue
+        if not single_token_hit(tok, scan, "contact"):
+            continue
+        seen.add(tn)
+        out.append(tok)
+    return out[:MAX_DOC_CANDIDATES]
+
+
+def search_docs_for_candidates(cands: list[str], search_stores: list[dict], root: Path,
+                               deadline: float) -> tuple[dict[str, list[tuple[Path, int, str, str]]], str]:
+    """Case-sensitive, whole-word, headings excluded: a heading is a section label
+    (the 2026-09-05 census over every 4_points case: Notes, Summary, Integrity),
+    so "Next Steps" in a prompt never resolves to the heading that says so.
+    Each hit carries its store so the caller can apply MAX_CANDIDATE_STORES."""
+    file_store: dict[str, str] = {}
+    for st in search_stores:
+        for f in st.get("doc_files") or []:
+            file_store[str(f)] = st["name"]
+    files = [Path(f) for f in file_store]
+    hits, engine = search_docs(files, cands, ignore_case=False, word=True, deadline=deadline)
+    out: dict[str, list[tuple[Path, int, str, str]]] = {}
+    for f, n, text in hits:
+        s = text.strip()
+        if not s or s.startswith("#"):
+            continue
+        for c in cands:
+            if word_in_exact(c, text):
+                out.setdefault(c, []).append((f, n, text, file_store.get(str(f), PROJECT_STORE)))
+    return out, engine
+
+
+def resolve_docs(entities: list[dict], search_stores: list[dict], root: Path,
+                 candidate_hits: dict[str, list[tuple[Path, int, str, str]]],
+                 deadline: float, candidate_engine: str = "none") -> tuple[dict[str, dict[str, list[dict]]], dict]:
+    """entity key -> store name -> items, newest file first. One grep over every
+    document of the stores in scope for the index entities; the candidates'
+    hits were gathered before classification and are folded in here."""
+    file_store: dict[str, str] = {}
+    for st in search_stores:
+        for f in st.get("doc_files") or []:
+            file_store[str(f)] = st["name"]
+    files = [Path(f) for f in file_store]
+    index_ents = [e for e in entities if e.get("kind") != "docs_hit"]
+    patterns: list[str] = []
+    for e in index_ents:
+        for nm in [e["name"], *e.get("aliases", [])]:
+            for v in pattern_variants(nm):
+                if v not in patterns:
+                    patterns.append(v)
+    hits, engine = search_docs(files, patterns, ignore_case=True, word=False, deadline=deadline)
+    mtimes: dict[str, str | None] = {}
+
+    def t_of(f: Path) -> str | None:
+        k = str(f)
+        if k not in mtimes:
+            mtimes[k] = mtime_date(f)
+        return mtimes[k]
+
+    out: dict[str, dict[str, list[dict]]] = {}
+    for f, n, text in hits:
+        s = text.strip()
+        if not s:
+            continue
+        store = file_store.get(str(f), PROJECT_STORE)
+        for e in index_ents:
+            if entity_matches(e, text):
+                out.setdefault(norm(e["name"]), {}).setdefault(store, []).append(
+                    _item(e["name"], "doc", s, f, n, t_of(f), root, status=status_for_line(text)))
+    for e in entities:
+        if e.get("kind") != "docs_hit":
+            continue
+        for f, n, text, store in candidate_hits.get(e["name"], []):
+            out.setdefault(norm(e["name"]), {}).setdefault(store, []).append(
+                _item(e["name"], "doc", text.strip(), f, n, t_of(f), root, status=status_for_line(text)))
+    for by_store in out.values():
+        for lst in by_store.values():
+            lst.sort(key=lambda i: (i["t"] or "", i["src"]), reverse=True)
+    if engine == "none" and candidate_hits:
+        engine = candidate_engine   # only the candidate pass ran (an index of 0)
+    return out, {"files": len(files), "engine": engine}
+
+
 def capability_index(root: Path) -> dict[str, list[tuple[Path, int, str]]]:
     """name -> [(path, line, description)] over the repo's own commands, skills,
     rules and scripts. Built only when the prompt has capability phrasing."""
@@ -1023,8 +1379,13 @@ def render_header(bundle: dict) -> str:
     else:
         miss = "; ".join(f"{m} ({bundle['coverage']['missing_paths'].get(m, 'absent')})" for m in cov["missing"])
         line = f"[knowledge-supply] COVERAGE: {cov['verdict']}. missing: {miss}."
-    ents = ", ".join(e["name"] + (" (ambiguous: " + " | ".join(e["orgs"]) + ")" if e["ambiguous"] else "")
-                     for e in bundle["entities"]) or "none"
+    def suffix(e: dict) -> str:
+        if e.get("kind") == "store" and e.get("store"):
+            return f" [{e['store']}]"
+        if e.get("kind") == "docs_hit":
+            return " [docs]"
+        return " (ambiguous: " + " | ".join(e["orgs"]) + ")" if e["ambiguous"] else ""
+    ents = ", ".join(e["name"] + suffix(e) for e in bundle["entities"]) or "none"
     win = bundle.get("window")
     win_s = f" window={win['from']}..{win['to']}" if win else ""
     win_s += deadline_note(bundle)
@@ -1141,10 +1502,13 @@ SUPPLY_DEADLINE_S = float(os.environ.get("KNOWLEDGE_SUPPLY_DEADLINE_S", "3.5"))
 
 
 def _record_misses(qroot: Path, prompt: str, scan: str, truncated: bool,
-                   entities: list[dict], ts: str, session_id: str) -> None:
+                   entities: list[dict], ts: str, session_id: str,
+                   candidates_dropped: list[dict] | None = None) -> None:
     """One bounded write per prompt. A truncated prompt (a paste) gets ONE row
     saying so instead of its candidates: the founder did not name those things,
-    the pasted text did."""
+    the pasted text did. A candidate dropped as corpus-common is a row too: it
+    was named, searched, found everywhere, and is the data for a per-instance
+    stopword list if that ever earns its cost."""
     path = qroot / "memory" / MISSES_NAME
     h = _hash(prompt)
     if truncated:
@@ -1153,6 +1517,9 @@ def _record_misses(qroot: Path, prompt: str, scan: str, truncated: bool,
         return
     for miss in miss_candidates(scan, entities):
         append_bounded(path, {"ts": ts, "session_id": session_id, "prompt_hash": h, **miss})
+    for d in candidates_dropped or []:
+        append_bounded(path, {"ts": ts, "session_id": session_id, "prompt_hash": h,
+                              "candidate": d["candidate"], "shape": "corpus_common", "stores": d["stores"]})
 
 
 # ------------------------------------------------------------------ entry point
@@ -1177,8 +1544,9 @@ def supply(root: Path, prompt: str, *, session_id: str, now: dt.date | None = No
                                          "looked_at": str(manifest_path) if manifest_path else None})
         return None
 
-    stores, problems = load_stores(qroot, root)
-    index = build_index(stores)
+    project, substores, problems = load_all_stores(qroot, root, manifest)
+    stores = project
+    index = build_index(project, substores)
     # Absent key: the shipped default. Present but empty: a deliberate quiet.
     fire_alone = set(manifest["entity_kinds_that_fire_alone"]
                      if "entity_kinds_that_fire_alone" in manifest else ["slug", "client"])
@@ -1187,13 +1555,38 @@ def supply(root: Path, prompt: str, *, session_id: str, now: dt.date | None = No
     scan = prompt[:PROMPT_SCAN_CHARS]
     truncated = len(prompt) > PROMPT_SCAN_CHARS
     entities = resolve_entities(scan, index, fire_alone)
+    # Naming a sub-store (a 4_points case) scopes every other entity's search to
+    # it plus the project level; naming none searches every store.
+    named_stores = {e["store"] for e in entities if e.get("kind") == "store" and e.get("store")}
+    search_stores = [project] + [s for s in substores if not named_stores or s["name"] in named_stores]
+    # Prompt-driven candidates against the project's own documents: what makes a
+    # project with no graph and no relationships.md answer from its folder.
+    candidate_hits: dict[str, list] = {}
+    candidate_engine = "none"
+    candidates_dropped: list[dict] = []
+    docs_declared = any("docs" in (c.get("sources") or {}) for c in (manifest.get("classes") or {}).values())
+    if docs_declared and not truncated:
+        cands = doc_candidates(scan, entities, index)
+        if cands:
+            candidate_hits, candidate_engine = search_docs_for_candidates(cands, search_stores, root, deadline=t_deadline)
+            for cand in cands:
+                hits = candidate_hits.get(cand) or []
+                if not hits:
+                    continue
+                n_stores = len({h[3] for h in hits})
+                if n_stores > MAX_CANDIDATE_STORES:
+                    candidates_dropped.append({"candidate": cand, "stores": n_stores})
+                    candidate_hits.pop(cand, None)
+                    continue
+                entities.append({"name": cand, "kind": "docs_hit", "resolved_from": "docs",
+                                 "ambiguous": False, "project": None, "orgs": [], "aliases": [], "store": None})
     entities_dropped = [e["name"] for e in entities[MAX_ENTITIES:]]
     entities = entities[:MAX_ENTITIES]
     cap_hits = capability_hits(scan, capability_index(root)) if (CAPABILITY_RE.search(scan) and not entities) else []
     task_class, window = classify(scan, entities, cap_hits, now)
     if task_class == "none":
         if record:
-            _record_misses(qroot, prompt, scan, truncated, entities, ts, session_id)
+            _record_misses(qroot, prompt, scan, truncated, entities, ts, session_id, candidates_dropped)
         return None
 
     declared = (manifest.get("classes") or {}).get(task_class, {}).get("sources") or {}
@@ -1204,19 +1597,27 @@ def supply(root: Path, prompt: str, *, session_id: str, now: dt.date | None = No
     missing_paths: dict[str, str] = {}
     paths = stores["paths"]
 
+    folders = list(manifest.get("folders") or [])
+
     def present_of(cls: str) -> tuple[bool, str | None]:
         if cls == "canonical":
-            return bool(stores["canonical_files"]), rel(qroot / "canonical", root)
+            return any(s["canonical_files"] for s in search_stores), rel(qroot / "canonical", root)
+        if cls == "docs":
+            return any(s.get("doc_files") for s in search_stores), f"{rel(qroot, root)}/{{{','.join(folders)}}}"
         if cls == "capability":
             return bool(cap_hits), "repo capability index"
-        p = paths.get(cls if cls != "relationship" else "relationships")
+        key = cls if cls != "relationship" else "relationships"
+        p = paths.get(key)
         if p is None:
             return False, None
-        return (p.is_file() and cls not in problems), rel(p, root)
+        ok = any(s["paths"][key].is_file() and key not in s["problems"] for s in search_stores)
+        return ok, rel(p, root)
 
     for cls, spec in declared.items():
         present, path_s = present_of(cls)
         cls_items: list[dict] = []
+        stores_hit: set[str] = set()
+        docs_meta: dict = {}
         if deadline_hit is not None:
             # Past the deadline: this class was never searched, and the receipt
             # and the coverage line both say so. Never "present, 0 hits".
@@ -1225,7 +1626,8 @@ def supply(root: Path, prompt: str, *, session_id: str, now: dt.date | None = No
                 missing_paths[cls] = f"{path_s or cls} not searched (deadline)"
             source_rows.append({"class": cls, "path": path_s, "present": present, "required": bool(spec.get("required")),
                                 "searched": False, "mtime": None, "fresh_days": spec.get("fresh_days"),
-                                "hits": 0, "cut": 0, "bytes": 0, "bad_lines": 0, "problem": "not searched (deadline)"})
+                                "hits": 0, "cut": 0, "bytes": 0, "bad_lines": 0, "problem": "not searched (deadline)",
+                                "stores_searched": 0, "stores_hit": []})
             continue
         # The cap is N per class PER ENTITY, applied to each resolver result
         # before the lists are joined. Codex round 1 on PR #302: a cap applied
@@ -1233,36 +1635,64 @@ def supply(root: Path, prompt: str, *, session_id: str, now: dt.date | None = No
         # header named three people and the body carried facts about one.
         cap = spec.get("cap")
         cut_here = 0
-        if present:
+        if present and cls == "docs":
+            if time.time() > t_deadline:
+                deadline_hit = {"at_class": cls, "at_entity": entities[0]["name"] if entities else "",
+                                "elapsed_ms": int((time.time() - t0) * 1000)}
+            else:
+                by_ent, docs_meta = resolve_docs(entities, search_stores, root, candidate_hits,
+                                                 deadline=t_deadline, candidate_engine=candidate_engine)
+                for ent in entities:
+                    for store_name, got in (by_ent.get(norm(ent["name"])) or {}).items():
+                        if cap is not None and len(got) > cap:
+                            cut_here += len(got) - cap
+                            got = got[:cap]
+                        if got:
+                            stores_hit.add(store_name)
+                        for it in got:
+                            it["store"] = store_name
+                        cls_items += got
+        elif present:
             for ent in entities:
-                if time.time() > t_deadline:
-                    deadline_hit = {"at_class": cls, "at_entity": ent["name"],
-                                    "elapsed_ms": int((time.time() - t0) * 1000)}
+                if deadline_hit is not None:
                     break
-                if cls == "graph":
-                    got, c = resolve_graph(ent, stores, root, window,
-                                           set(manifest.get("state_predicates") or []))
-                    conflicts += c
-                elif cls == "canonical":
-                    got = resolve_canonical(ent, stores, root, errors=problems, cls=cls)
-                elif cls == "relationships":
-                    got = resolve_blocks(ent, paths["relationships"], root, "relationship", 12, errors=problems, cls=cls, stores=stores)
-                elif cls == "decisions":
-                    got = resolve_blocks(ent, paths["decisions"], root, "decision", 8, errors=problems, cls=cls, stores=stores)
-                elif cls == "commitments":
-                    got = resolve_commitments(ent, stores, root, window)
-                elif cls == "meetings":
-                    got = resolve_meetings(ent, stores, root, window)
-                elif cls == "loops":
-                    got = resolve_loops(ent, stores, root, window)
-                elif cls == "handoff":
-                    got = resolve_handoff(ent, stores, root, window)
-                else:
-                    got = []
-                if cap is not None and len(got) > cap:
-                    cut_here += len(got) - cap
-                    got = got[:cap]
-                cls_items += got
+                for st in search_stores:
+                    if time.time() > t_deadline:
+                        deadline_hit = {"at_class": cls, "at_entity": ent["name"],
+                                        "elapsed_ms": int((time.time() - t0) * 1000)}
+                        break
+                    st_paths = st["paths"]
+                    st_problems = st["problems"]
+                    if cls == "graph":
+                        got, c = resolve_graph(ent, st, root, window,
+                                               set(manifest.get("state_predicates") or []))
+                        conflicts += c
+                    elif cls == "canonical":
+                        got = resolve_canonical(ent, st, root, errors=st_problems, cls=cls)
+                    elif cls == "relationships":
+                        got = resolve_blocks(ent, st_paths["relationships"], root, "relationship", 12, errors=st_problems, cls=cls, stores=st)
+                    elif cls == "decisions":
+                        got = resolve_blocks(ent, st_paths["decisions"], root, "decision", 8, errors=st_problems, cls=cls, stores=st)
+                    elif cls == "commitments":
+                        got = resolve_commitments(ent, st, root, window)
+                    elif cls == "meetings":
+                        got = resolve_meetings(ent, st, root, window)
+                    elif cls == "loops":
+                        got = resolve_loops(ent, st, root, window)
+                    elif cls == "handoff":
+                        got = resolve_handoff(ent, st, root, window)
+                    else:
+                        got = []
+                    # The cap is N per class PER ENTITY PER STORE (a case is its
+                    # own knowledge base and keeps its own budget).
+                    if cap is not None and len(got) > cap:
+                        cut_here += len(got) - cap
+                        got = got[:cap]
+                    if got:
+                        stores_hit.add(st["name"])
+                    for it in got:
+                        it["store"] = st["name"]
+                    cls_items += got
             if cls == "capability":
                 for name, entries in cap_hits:
                     got = [_item(name, "capability", desc or path.name, path, line,
@@ -1279,22 +1709,29 @@ def supply(root: Path, prompt: str, *, session_id: str, now: dt.date | None = No
                 if it["status"] == KNOWN and (d is None or (now - d).days > fresh_days):
                     it["status"] = STALE
         items += cls_items
-        rs = stores.get("read_stats", {}).get(cls)
-        if present and rs and rs["failed"] and rs["failed"] >= rs["files"]:
+        read = [s.get("read_stats", {}).get(cls) for s in search_stores]
+        read = [r for r in read if r and r["files"]]
+        if present and read and all(r["failed"] and r["failed"] >= r["files"] for r in read):
             present = False   # EVERY file of the class failed to read: unreadable, not empty (sp-ca1769db)
         if not present and spec.get("required"):
             missing.append(cls)
             missing_paths[cls] = f"{path_s or cls} {'unreadable' if cls in problems else 'absent'}"
-        src_path = Path(root) / path_s if path_s and cls not in ("canonical", "capability") else None
-        source_rows.append({
+        src_path = Path(root) / path_s if path_s and cls not in ("canonical", "capability", "docs") else None
+        store_problems = "; ".join(f"{s['name']}: {s['problems'][cls]}" for s in search_stores if cls in s["problems"]) or None
+        row = {
             "class": cls, "path": path_s, "present": present, "required": bool(spec.get("required")),
             "mtime": mtime_date(src_path) if src_path and src_path.exists() else None,
             "fresh_days": fresh_days, "hits": len(cls_items) + cut_here, "cut": cut_here,
             "bytes": sum(len(i["text"]) for i in cls_items),
-            "bad_lines": stores["bad_lines"].get(cls, 0),
-            "problem": problems.get(cls),
+            "bad_lines": sum(s["bad_lines"].get(cls, 0) for s in search_stores),
+            "problem": store_problems,
             "searched": "partial" if (deadline_hit and deadline_hit["at_class"] == cls) else True,
-        })
+            "stores_searched": len(search_stores), "stores_hit": sorted(stores_hit),
+        }
+        if cls == "docs":
+            row["files"] = docs_meta.get("files", sum(len(s.get("doc_files") or []) for s in search_stores))
+            row["engine"] = docs_meta.get("engine")
+        source_rows.append(row)
 
     verdict = "FULL" if not missing else ("NONE" if all(not r["present"] for r in source_rows) else "PARTIAL")
     ceiling = int(manifest.get("ceiling_chars") or 8000)
@@ -1320,13 +1757,14 @@ def supply(root: Path, prompt: str, *, session_id: str, now: dt.date | None = No
         "conflicts": conflicts, "ceiling_hit": ceiling_hit, "overflow": overflow,
         "prompt_chars": len(prompt), "prompt_truncated": truncated,
         "deadline_hit": deadline_hit, "entities_dropped": entities_dropped,
+        "candidates_dropped": candidates_dropped,
         "items": len(kept), "bytes": bundle["budget"]["used"], "elapsed_ms": int((time.time() - t0) * 1000),
         "manifest": rel(manifest_path, root) if manifest_path else None,
     }
     bundle["receipt"] = receipt
     if record:
         append_jsonl(receipts_path, receipt)
-        _record_misses(qroot, prompt, scan, truncated, entities, ts, session_id)
+        _record_misses(qroot, prompt, scan, truncated, entities, ts, session_id, candidates_dropped)
         _record_recall(bundle, session_id, recall_path)
     return bundle
 
@@ -1405,7 +1843,9 @@ if __name__ == "__main__":  # manual probe: python3 knowledge_supply.py "<prompt
             if m is None:
                 print(f"(no supply) reason=manifest_missing qroot={q} looked_at={mp}")
             else:
-                st, pr = load_stores(q, root)
-                ents = resolve_entities(prompt, build_index(st), set(m.get("entity_kinds_that_fire_alone") or []))
-                print(f"(no supply) reason=no_entities_or_class qroot={q} index_size={len(build_index(st))} "
+                st, subs, pr = load_all_stores(q, root, m)
+                idx = build_index(st, subs)
+                ents = resolve_entities(prompt, idx, set(m.get("entity_kinds_that_fire_alone") or []))
+                print(f"(no supply) reason=no_entities_or_class qroot={q} index_size={len(idx)} "
+                      f"stores={[s['name'] for s in subs]} docs={sum(len(s['doc_files']) for s in [st] + subs)} "
                       f"entities={[e['name'] for e in ents]} problems={pr}")

--- a/q-system/.q-system/scripts/knowledge_supply.py
+++ b/q-system/.q-system/scripts/knowledge_supply.py
@@ -1259,11 +1259,12 @@ def truncation_of(engine: str | None) -> str | None:
     return None
 
 
-def class_search_state(stopped_cold: bool, truncated: str | None) -> bool | str:
+def class_search_state(stopped_cold: bool, truncated: str | None, present: bool = True) -> bool | str:
     """THE one place that says how far a class was searched: False (never
-    started), "partial" (started and cut short, for any reason), True. A class
-    that is not True never counts toward FULL."""
-    if stopped_cold:
+    started, which includes a class that is absent), "partial" (started and
+    cut short, for any reason), True. A class that is not True never counts
+    toward FULL. PR #308 review round 9: an absent class read searched=True."""
+    if stopped_cold or not present:
         return False
     return "partial" if truncated else True
 
@@ -1695,11 +1696,14 @@ def render_header(bundle: dict) -> str:
         miss = "; ".join(f"{m} ({bundle['coverage']['missing_paths'].get(m, 'absent')})" for m in cov["missing"])
         line = f"[knowledge-supply] COVERAGE: {cov['verdict']}. missing: {miss}."
     line += scope_note(cov)
+    def bounded(names: list[str]) -> str:
+        return ", ".join(names[:6]) + (f" and {len(names) - 6} more" if len(names) > 6 else "")
+
     def suffix(e: dict) -> str:
         if e.get("kind") == "store" and e.get("stores"):
-            return f" [{', '.join(e['stores'])}]"
+            return f" [{bounded(e['stores'])}]"
         if e.get("kind") == "target" and e.get("stores"):
-            return f" [target of {', '.join(e['stores'])}]"
+            return f" [target of {bounded(e['stores'])}]"
         if e.get("kind") == "docs_hit":
             return " [docs]"
         out = ""
@@ -1725,11 +1729,14 @@ def scope_note(cov: dict) -> str:
     word is relative to the scope and the clause says so, because the engine
     cannot tell "in jennica pounds, ..." from an incidental "post it on
     Facebook" matching case-005-facebook (PR #308 review rounds 7 and 8)."""
-    if cov.get("scope"):
-        n = len(cov.get("stores_excluded") or [])
-        return (f" WITHIN SCOPE {', '.join(cov['scope'])} + project only; {n} other store{'s' if n != 1 else ''} "
+    excluded = cov.get("stores_excluded") or []
+    if cov.get("scope") and excluded:
+        scope = cov["scope"]
+        shown = ", ".join(scope[:6]) + (f" and {len(scope) - 6} more" if len(scope) > 6 else "")
+        n = len(excluded)
+        return (f" WITHIN SCOPE {shown} + project only; {n} other store{'s' if n != 1 else ''} "
                 f"not searched (name a different case, or none, to widen).")
-    return ""
+    return ""   # nothing excluded: nothing to disclose, and no budget spent saying so (round 9 minor 2)
 
 
 def render(bundle: dict) -> str:
@@ -1897,7 +1904,13 @@ def supply(root: Path, prompt: str, *, session_id: str, now: dt.date | None = No
     entities = resolve_entities(scan, index, fire_alone)
     # Naming a sub-store (a 4_points case) scopes every other entity's search to
     # it plus the project level; naming none searches every store.
-    named_stores = {s for e in entities if e.get("kind") in ("store", "target") for s in (e.get("stores") or [])}
+    # A case the founder NAMED is the scope. A target's declaring cases scope the
+    # search only when no case was named: a target shared by 45 cases must not
+    # drag them all back in behind "in subject7, ..." (PR #308 review round 9,
+    # which the round 8 union did).
+    store_named = {s for e in entities if e.get("kind") == "store" for s in (e.get("stores") or [])}
+    target_named = {s for e in entities if e.get("kind") == "target" for s in (e.get("stores") or [])}
+    named_stores = store_named or target_named
     search_stores = [project] + [s for s in substores if not named_stores or s["name"] in named_stores]
     # What the scope left out is a fact on the wire, not only in the receipt:
     # "payment fraud" in a prompt matched case-031-payment-fraud and silently
@@ -2098,7 +2111,7 @@ def supply(root: Path, prompt: str, *, session_id: str, now: dt.date | None = No
                 cut_reason = docs_meta.get("stop")   # the field, never the display string
             elif deadline_hit and deadline_hit["at_class"] == cls:
                 cut_reason = "deadline"
-        searched_state = class_search_state(stopped_cold, cut_reason)
+        searched_state = class_search_state(stopped_cold, cut_reason, present)
         if searched_state is not True and present and spec.get("required") and cls not in missing:
             missing.append(cls)
             missing_paths[cls] = (f"{path_s or cls} not searched (deadline)" if stopped_cold
@@ -2142,7 +2155,7 @@ def supply(root: Path, prompt: str, *, session_id: str, now: dt.date | None = No
             "bad_lines": sum(s["bad_lines"].get(cls, 0) for s in search_stores),
             "problem": store_problems,
             "searched": searched_state,
-            "stores_searched": 0 if stopped_cold else len(search_stores), "stores_hit": sorted(stores_hit),
+            "stores_searched": 0 if (stopped_cold or not present) else len(search_stores), "stores_hit": sorted(stores_hit),
         }
         if stopped_cold:
             row["problem"] = "not searched (deadline)"

--- a/q-system/.q-system/scripts/knowledge_supply.py
+++ b/q-system/.q-system/scripts/knowledge_supply.py
@@ -302,17 +302,29 @@ def status_for_line(line: str) -> str:
 # ------------------------------------------------------------------ entity index
 
 class Entity:
-    __slots__ = ("name", "kind", "aliases", "orgs", "store")
+    __slots__ = ("name", "kind", "aliases", "orgs", "stores", "alias_stores")
 
     def __init__(self, name: str, kind: str):
         self.name = name
         self.kind = kind          # graph | contact | slug | client | store | target | noun | capability
         self.aliases: set[str] = set()
         self.orgs: dict[str, str | None] = {}   # org -> project, from works_at rows
-        self.store: str | None = None            # the sub-store directory a `store` entity names
+        # Every sub-store directory a `store` entity names. A SET, not one value:
+        # PR #308 review round 1 found case-010-lapsus and case-041-lapsus collapsing
+        # to one entity whose last writer won, so the other case vanished from the
+        # search with no receipt. A recurring subject across cases is the normal
+        # shape of investigation work, not an edge.
+        self.stores: set[str] = set()
+        # alias -> the stores whose graph asserted it. An alias_of edge is one
+        # case's knowledge; applied to another case's content it rewrote identity
+        # there (PR #308 review round 1, major 2). The project store's aliases
+        # apply instance-wide.
+        self.alias_stores: dict[str, set[str]] = {}
 
     def as_dict(self) -> dict:
-        return {"name": self.name, "kind": self.kind, "aliases": sorted(self.aliases), "store": self.store}
+        return {"name": self.name, "kind": self.kind, "aliases": sorted(self.aliases),
+                "stores": sorted(self.stores),
+                "alias_stores": {a: sorted(s) for a, s in self.alias_stores.items()}}
 
 
 def _add(index: dict[str, Entity], name: str, kind: str) -> Entity | None:
@@ -335,24 +347,40 @@ def build_index(stores: dict, substores: list[dict] | None = None) -> dict[str, 
     index: dict[str, Entity] = {}
     all_stores = [stores] + list(substores or [])
     graph_rows = [r for st in all_stores for r in (st.get("graph_rows") or [])]
+    # Which stores contributed each name on their own (as a subject or object).
+    # An alias edge may only remove a name from the index when no OTHER store
+    # contributed it: case-020's "Widget Corp" is case-020's entity even when
+    # case-010 says Widget Corp is an alias of Zeta Holdings.
+    contributors: dict[str, set[str]] = {}
+    alias_rows: list[dict] = []
     for row in graph_rows:
         s, p, o = row.get("s"), row.get("p"), row.get("o")
         if not isinstance(s, str) or not isinstance(o, str):
             continue
+        st_name = row.get("_store") or PROJECT_STORE
         es = _add(index, s, "graph")
+        if es is not None:
+            contributors.setdefault(norm(s), set()).add(st_name)
         if len(o.split()) <= 4:
-            _add(index, o, "graph")
+            if _add(index, o, "graph") is not None:
+                contributors.setdefault(norm(o), set()).add(st_name)
         if p in ALIAS_PREDICATES and es is not None:
-            if ALIAS_PREDICATES[p] == "s_is_alias":
-                canonical = _add(index, o, "graph")
-                if canonical is not None:
-                    canonical.aliases.add(normalize_ws(s))
-                    index.pop(norm(s), None)
-            else:
-                es.aliases.add(normalize_ws(o))
-                index.pop(norm(o), None)
+            alias_rows.append(row)
         if p in ORG_PREDICATES and es is not None:
             es.orgs[normalize_ws(o)] = row.get("project")
+    for row in alias_rows:
+        s, p, o = row["s"], row["p"], row["o"]
+        st_name = row.get("_store") or PROJECT_STORE
+        if ALIAS_PREDICATES[p] == "s_is_alias":
+            canonical, alias = _add(index, o, "graph"), normalize_ws(s)
+        else:
+            canonical, alias = index.get(norm(s)), normalize_ws(o)
+        if canonical is None or norm(alias) == norm(canonical.name):
+            continue
+        canonical.aliases.add(alias)
+        canonical.alias_stores.setdefault(alias, set()).add(st_name)
+        if contributors.get(norm(alias), set()) <= {st_name}:
+            index.pop(norm(alias), None)
     for st in all_stores:
         for name in st.get("contact_names") or []:
             _add(index, name, "contact")
@@ -368,7 +396,7 @@ def build_index(stores: dict, substores: list[dict] | None = None) -> dict[str, 
             ent = _add(index, store_entity_name(st["name"]), "store")
             if ent is not None:
                 ent.kind = "store"
-                ent.store = st["name"]
+                ent.stores.add(st["name"])
     return index
 
 
@@ -447,7 +475,7 @@ def resolve_entities(prompt: str, index: dict[str, Entity], fire_alone: set[str]
     found: dict[str, dict] = {}
     for key in candidate_keys(index, ptoks):
         ent = index[key]
-        hit_via = None
+        hit_via, hit_name = None, None
         names = [(ent.name, "self")] + [(a, "alias") for a in ent.aliases]
         for name, via in names:
             toks = name.split()
@@ -470,6 +498,7 @@ def resolve_entities(prompt: str, index: dict[str, Entity], fire_alone: set[str]
                     if single_token_hit(tok, prompt, "contact"):
                         hit_via = via
             if hit_via:
+                hit_name = name
                 break
         if not hit_via:
             continue
@@ -484,7 +513,9 @@ def resolve_entities(prompt: str, index: dict[str, Entity], fire_alone: set[str]
         found[key] = {"name": ent.name, "kind": ent.kind,
                       "resolved_from": "alias" if hit_via == "alias" else ent.kind,
                       "ambiguous": ambiguous, "project": scoped_project,
-                      "orgs": sorted(ent.orgs), "aliases": sorted(ent.aliases), "store": ent.store}
+                      "orgs": sorted(ent.orgs), "aliases": sorted(ent.aliases),
+                      "stores": sorted(ent.stores), "via_alias": hit_name if hit_via == "alias" else None,
+                      "alias_stores": {a: sorted(s) for a, s in ent.alias_stores.items()}}
     # First-name expansion, measured not guessed. Replay of 2,131 real prompts
     # (2026-09-04) showed the founder names people by bare first name; the top
     # misses were exactly those. A capitalized token that is NOT sentence-initial
@@ -511,7 +542,9 @@ def resolve_entities(prompt: str, index: dict[str, Entity], fire_alone: set[str]
                 ent = index[keys[0]]
                 found[keys[0]] = {"name": ent.name, "kind": ent.kind, "resolved_from": "first_name",
                                   "ambiguous": len(ent.orgs) >= 2, "project": None,
-                                  "orgs": sorted(ent.orgs), "aliases": sorted(ent.aliases), "store": ent.store}
+                                  "orgs": sorted(ent.orgs), "aliases": sorted(ent.aliases),
+                                  "stores": sorted(ent.stores), "via_alias": None,
+                                  "alias_stores": {a: sorted(s) for a, s in ent.alias_stores.items()}}
     # Longest name wins when one resolved name contains another ("Dana Okafor" vs "Okafor Co").
     out = list(found.values())
     out.sort(key=lambda e: -len(e["name"]))
@@ -555,10 +588,20 @@ def is_initial_position(text: str, pos: int) -> bool:
     return not before or before[-1] in ".!?:;"
 
 
-def entity_matches(entity: dict, text: str) -> bool:
+def entity_matches(entity: dict, text: str, store: str | None = None) -> bool:
+    """Content-side match. The name matches anywhere; an alias matches only
+    content in a store that asserted it (or anywhere, when the project store
+    asserted it, or when the caller has no store to name)."""
     if phrase_in(entity["name"], norm(text)):
         return True
-    return any(alias_in_text(a, text) for a in entity.get("aliases", []))
+    scopes = entity.get("alias_stores") or {}
+    for a in entity.get("aliases", []):
+        allowed = scopes.get(a)
+        if store is not None and allowed and store not in allowed and PROJECT_STORE not in allowed:
+            continue
+        if alias_in_text(a, text):
+            return True
+    return False
 
 
 # ------------------------------------------------------------------ router
@@ -648,6 +691,7 @@ def load_stores(qroot: Path, root: Path, manifest: dict | None = None,
                     row = json.loads(line)
                     if isinstance(row, dict):
                         row["_line"] = n
+                        row["_store"] = name
                         rows.append(row)
                     else:
                         bad += 1
@@ -853,9 +897,10 @@ def resolve_graph(entity: dict, stores: dict, root: Path, window: dict | None,
     manifest (state_predicates), never a table here."""
     path = stores["paths"]["graph"]
     state_predicates = {norm(p) for p in (state_predicates or ())}
+    st_name = stores.get("name")
     rows = [r for r in stores["graph_rows"]
             if isinstance(r.get("s"), str) and isinstance(r.get("o"), str)
-            and (entity_matches(entity, r["s"]) or entity_matches(entity, r["o"]))
+            and (entity_matches(entity, r["s"], st_name) or entity_matches(entity, r["o"], st_name))
             and r.get("p") not in ALIAS_PREDICATES]
     if entity.get("project"):
         rows = [r for r in rows if r.get("project") in (entity["project"], None, "all")]
@@ -919,7 +964,7 @@ def resolve_canonical(entity: dict, stores: dict, root: Path, kind: str = "canon
                 continue
             if in_fence or not line.strip():
                 continue
-            if entity_matches(entity, line):
+            if entity_matches(entity, line, stores.get("name")):
                 items.append(_item(entity["name"], kind, line.strip(), path, n, t, root,
                                    status=status_for_line(line)))
     items.sort(key=lambda i: (i["t"] or ""), reverse=True)
@@ -961,7 +1006,8 @@ def resolve_blocks(entity: dict, path: Path, root: Path, kind: str, max_lines: i
         body = [l for l in block if l.strip()]
         joined = "\n".join(body)
         target = body[0] if kind == "relationship" else joined
-        if not entity_matches(entity, target if kind == "relationship" else joined):
+        if not entity_matches(entity, target if kind == "relationship" else joined,
+                              (stores or {}).get("name")):
             continue
         if kind == "decision":
             decision = next((l for l in body if "**Decision:**" in l), "")
@@ -986,7 +1032,7 @@ def resolve_commitments(entity: dict, stores: dict, root: Path, window: dict | N
         promise, slug, state = str(r.get("promise") or ""), str(r.get("slug") or ""), str(r.get("state") or "")
         if state in DROP_STATES:
             continue
-        if not (entity_matches(entity, slug) or entity_matches(entity, promise)):
+        if not (entity_matches(entity, slug, stores.get("name")) or entity_matches(entity, promise, stores.get("name"))):
             continue
         t = (r.get("extracted_at") or "")[:10] or None
         if not in_window(t, window):
@@ -1003,13 +1049,14 @@ def resolve_commitments(entity: dict, stores: dict, root: Path, window: dict | N
 def resolve_meetings(entity: dict, stores: dict, root: Path, window: dict | None) -> list[dict]:
     path = stores["paths"]["meetings"]
     items = []
+    st_name = stores.get("name")
     for key, rows in stores["meetings"].items():
-        key_hit = entity_matches(entity, key)
+        key_hit = entity_matches(entity, key, st_name)
         for r in rows:
             if not isinstance(r, dict):
                 continue
             title, summary = str(r.get("title") or ""), str(r.get("summary") or "")
-            if not (key_hit or entity_matches(entity, title) or entity_matches(entity, summary)):
+            if not (key_hit or entity_matches(entity, title, st_name) or entity_matches(entity, summary, st_name)):
                 continue
             t = (r.get("date") or "")[:10] or None
             if not in_window(t, window):
@@ -1028,7 +1075,7 @@ def resolve_loops(entity: dict, stores: dict, root: Path, window: dict | None) -
         if l.get("status") != "open":
             continue
         title, nxt = str(l.get("title") or ""), str(l.get("next_action") or "")
-        if not (entity_matches(entity, title) or entity_matches(entity, nxt)):
+        if not (entity_matches(entity, title, stores.get("name")) or entity_matches(entity, nxt, stores.get("name"))):
             continue
         t = (l.get("added") or "")[:10] or None
         if not in_window(t, window):
@@ -1226,7 +1273,7 @@ def resolve_docs(entities: list[dict], search_stores: list[dict], root: Path,
             continue
         store = file_store.get(str(f), PROJECT_STORE)
         for e in index_ents:
-            if entity_matches(e, text):
+            if entity_matches(e, text, store):
                 out.setdefault(norm(e["name"]), {}).setdefault(store, []).append(
                     _item(e["name"], "doc", s, f, n, t_of(f), root, status=status_for_line(text)))
     for e in entities:
@@ -1380,11 +1427,18 @@ def render_header(bundle: dict) -> str:
         miss = "; ".join(f"{m} ({bundle['coverage']['missing_paths'].get(m, 'absent')})" for m in cov["missing"])
         line = f"[knowledge-supply] COVERAGE: {cov['verdict']}. missing: {miss}."
     def suffix(e: dict) -> str:
-        if e.get("kind") == "store" and e.get("store"):
-            return f" [{e['store']}]"
+        if e.get("kind") == "store" and e.get("stores"):
+            return f" [{', '.join(e['stores'])}]"
         if e.get("kind") == "docs_hit":
             return " [docs]"
-        return " (ambiguous: " + " | ".join(e["orgs"]) + ")" if e["ambiguous"] else ""
+        out = ""
+        via = e.get("via_alias")
+        if via:
+            asserted = (e.get("alias_stores") or {}).get(via) or []
+            out += f" (via alias {via}" + (f": {', '.join(asserted)}" if asserted else "") + ")"
+        if e["ambiguous"]:
+            out += " (ambiguous: " + " | ".join(e["orgs"]) + ")"
+        return out
     ents = ", ".join(e["name"] + suffix(e) for e in bundle["entities"]) or "none"
     win = bundle.get("window")
     win_s = f" window={win['from']}..{win['to']}" if win else ""
@@ -1557,7 +1611,7 @@ def supply(root: Path, prompt: str, *, session_id: str, now: dt.date | None = No
     entities = resolve_entities(scan, index, fire_alone)
     # Naming a sub-store (a 4_points case) scopes every other entity's search to
     # it plus the project level; naming none searches every store.
-    named_stores = {e["store"] for e in entities if e.get("kind") == "store" and e.get("store")}
+    named_stores = {s for e in entities if e.get("kind") == "store" for s in (e.get("stores") or [])}
     search_stores = [project] + [s for s in substores if not named_stores or s["name"] in named_stores]
     # Prompt-driven candidates against the project's own documents: what makes a
     # project with no graph and no relationships.md answer from its folder.
@@ -1579,7 +1633,8 @@ def supply(root: Path, prompt: str, *, session_id: str, now: dt.date | None = No
                     candidate_hits.pop(cand, None)
                     continue
                 entities.append({"name": cand, "kind": "docs_hit", "resolved_from": "docs",
-                                 "ambiguous": False, "project": None, "orgs": [], "aliases": [], "store": None})
+                                 "ambiguous": False, "project": None, "orgs": [], "aliases": [],
+                                 "stores": [], "via_alias": None, "alias_stores": {}})
     entities_dropped = [e["name"] for e in entities[MAX_ENTITIES:]]
     entities = entities[:MAX_ENTITIES]
     cap_hits = capability_hits(scan, capability_index(root)) if (CAPABILITY_RE.search(scan) and not entities) else []
@@ -1635,11 +1690,13 @@ def supply(root: Path, prompt: str, *, session_id: str, now: dt.date | None = No
         # header named three people and the body carried facts about one.
         cap = spec.get("cap")
         cut_here = 0
+        searched_any = False
         if present and cls == "docs":
             if time.time() > t_deadline:
                 deadline_hit = {"at_class": cls, "at_entity": entities[0]["name"] if entities else "",
                                 "elapsed_ms": int((time.time() - t0) * 1000)}
             else:
+                searched_any = True
                 by_ent, docs_meta = resolve_docs(entities, search_stores, root, candidate_hits,
                                                  deadline=t_deadline, candidate_engine=candidate_engine)
                 for ent in entities:
@@ -1661,6 +1718,7 @@ def supply(root: Path, prompt: str, *, session_id: str, now: dt.date | None = No
                         deadline_hit = {"at_class": cls, "at_entity": ent["name"],
                                         "elapsed_ms": int((time.time() - t0) * 1000)}
                         break
+                    searched_any = True
                     st_paths = st["paths"]
                     st_problems = st["problems"]
                     if cls == "graph":
@@ -1716,6 +1774,14 @@ def supply(root: Path, prompt: str, *, session_id: str, now: dt.date | None = No
         if not present and spec.get("required"):
             missing.append(cls)
             missing_paths[cls] = f"{path_s or cls} {'unreadable' if cls in problems else 'absent'}"
+        # The deadline landed on this class before ANY store was read: that is
+        # "not searched", never "partial", and a required class goes to missing.
+        # PR #308 review round 1 minor 3: the investigation manifest lists docs
+        # first and alone under temporal_event, so this one row decided FULL.
+        stopped_cold = bool(deadline_hit and deadline_hit["at_class"] == cls and present and not searched_any)
+        if stopped_cold and spec.get("required") and cls not in missing:
+            missing.append(cls)
+            missing_paths[cls] = f"{path_s or cls} not searched (deadline)"
         src_path = Path(root) / path_s if path_s and cls not in ("canonical", "capability", "docs") else None
         store_problems = "; ".join(f"{s['name']}: {s['problems'][cls]}" for s in search_stores if cls in s["problems"]) or None
         row = {
@@ -1725,9 +1791,11 @@ def supply(root: Path, prompt: str, *, session_id: str, now: dt.date | None = No
             "bytes": sum(len(i["text"]) for i in cls_items),
             "bad_lines": sum(s["bad_lines"].get(cls, 0) for s in search_stores),
             "problem": store_problems,
-            "searched": "partial" if (deadline_hit and deadline_hit["at_class"] == cls) else True,
-            "stores_searched": len(search_stores), "stores_hit": sorted(stores_hit),
+            "searched": False if stopped_cold else ("partial" if (deadline_hit and deadline_hit["at_class"] == cls) else True),
+            "stores_searched": 0 if stopped_cold else len(search_stores), "stores_hit": sorted(stores_hit),
         }
+        if stopped_cold:
+            row["problem"] = "not searched (deadline)"
         if cls == "docs":
             row["files"] = docs_meta.get("files", sum(len(s.get("doc_files") or []) for s in search_stores))
             row["engine"] = docs_meta.get("engine")
@@ -1758,6 +1826,15 @@ def supply(root: Path, prompt: str, *, session_id: str, now: dt.date | None = No
         "prompt_chars": len(prompt), "prompt_truncated": truncated,
         "deadline_hit": deadline_hit, "entities_dropped": entities_dropped,
         "candidates_dropped": candidates_dropped,
+        # The corpus-common rule counts STORES, so on a project with no sub-stores
+        # it cannot fire and an empty candidates_dropped would read as "nothing
+        # was common" (PR #308 review round 1 minor 4). Say so. A file-count rule
+        # is not the fix: on a single-store project the main client's name is in
+        # most files by design (measured 2026-09-05: one instance's client hit
+        # 97 lines across its research and output), and dropping it would be
+        # dropping the subject.
+        "candidate_rule": {"max_stores": MAX_CANDIDATE_STORES, "applicable": bool(substores),
+                           "note": None if substores else "single store: rule cannot run"},
         "items": len(kept), "bytes": bundle["budget"]["used"], "elapsed_ms": int((time.time() - t0) * 1000),
         "manifest": rel(manifest_path, root) if manifest_path else None,
     }

--- a/q-system/.q-system/scripts/knowledge_supply.py
+++ b/q-system/.q-system/scripts/knowledge_supply.py
@@ -110,7 +110,12 @@ PROJECT_STORE = "project"
 # A store directory's entity name drops a `case-023-` style prefix: the founder
 # says "shinyhunters", never "case-023-shinyhunters".
 STORE_PREFIX_RE = re.compile(r"^[a-z]+-\d+-", re.IGNORECASE)
-DOC_SKIP_DIRS = {"node_modules", "exports", "screenshots", "__pycache__", "raw-collections"}
+# Never knowledge, never disclosed: tooling dirs. Everything else a store keeps
+# out of the docs class is DECLARED in the manifest (skip_dirs) and counted in
+# the receipt, the way doc_max_bytes skips are (PR #308 review round 11: the
+# hardcoded raw-collections/exports skip had no record anywhere under FULL).
+HARD_SKIP_DIRS = {"node_modules", "__pycache__"}
+DEFAULT_SKIP_DIRS = ["exports", "screenshots", "raw-collections"]
 DOC_MAX_BYTES_DEFAULT = 512 * 1024
 # Python fallback budget when grep is unavailable: past this many bytes the
 # scan stops and the receipt engine says "python (budget)".
@@ -810,16 +815,19 @@ def load_stores(qroot: Path, root: Path, manifest: dict | None = None,
     # its own call, and the project's rglob("*") over 4_points was 57,081
     # entries and 318 ms per prompt (measured 2026-09-05).
     exclude = {path for _, path in discover_stores(qroot, manifest or {})} if name == PROJECT_STORE else set()
+    skip_dirs = set((manifest or {}).get("skip_dirs") if (manifest or {}).get("skip_dirs") is not None else DEFAULT_SKIP_DIRS)
     skipped: list[Path] = []
-    stores["doc_files"] = enumerate_docs(qroot, folders, max_bytes, exclude, skipped) if folders else []
+    skipped_dirs: list[Path] = []
+    stores["doc_files"] = enumerate_docs(qroot, folders, max_bytes, exclude, skipped, skip_dirs, skipped_dirs) if folders else []
     stores["doc_skipped_oversize"] = skipped
+    stores["doc_skipped_dirs"] = skipped_dirs
     # A markdown file directly under a `targets`-style directory names a subject
     # of the work (4_points: investigation/targets/<subject>.md). Its stem is an
     # entity that fires alone; a finding or note file's stem never does.
     target_names = []
     entity_dirs = set((manifest or {}).get("entity_dirs") or [])
     if entity_dirs:
-        for d in walk_dirs(qroot, exclude, ENTITY_DIR_MAX_DEPTH):
+        for d in walk_dirs(qroot, exclude, ENTITY_DIR_MAX_DEPTH, skip_dirs):
             if d.name not in entity_dirs:
                 continue
             for f in sorted(d.glob("*.md")):
@@ -843,36 +851,48 @@ def load_stores(qroot: Path, root: Path, manifest: dict | None = None,
     return stores, problems
 
 
-def walk_dirs(base: Path, exclude: set[Path], max_depth: int):
-    """Pruned directory walk: dot dirs, DOC_SKIP_DIRS and `exclude` (sub-store
-    roots) are never entered, and nothing below max_depth is."""
+def walk_dirs(base: Path, exclude: set[Path], max_depth: int, skip_dirs: set[str] | None = None):
+    """Pruned directory walk: dot dirs, tooling dirs, declared skip dirs and
+    `exclude` (sub-store roots) are never entered, and nothing below max_depth is."""
     base_depth = len(base.parts)
+    skips = HARD_SKIP_DIRS | set(skip_dirs or ())
     for dirpath, dirnames, _ in os.walk(base):
         cur = Path(dirpath)
         if len(cur.parts) - base_depth >= max_depth:
             dirnames[:] = []
         else:
-            dirnames[:] = sorted(d for d in dirnames if not d.startswith(".") and d not in DOC_SKIP_DIRS
+            dirnames[:] = sorted(d for d in dirnames if not d.startswith(".") and d not in skips
                                  and (cur / d) not in exclude)
         yield cur
 
 
 def enumerate_docs(store_dir: Path, folders: list[str], max_bytes: int,
-                   exclude: set[Path] | None = None, skipped: list[Path] | None = None) -> list[Path]:
+                   exclude: set[Path] | None = None, skipped: list[Path] | None = None,
+                   skip_dirs: set[str] | None = None, skipped_dirs: list[Path] | None = None) -> list[Path]:
     """The markdown files of a store's declared folders, in a stable order. Dot
-    dirs, DOC_SKIP_DIRS, sub-store roots, dot files, files over max_bytes and
-    last-handoff.md (the handoff class owns it) are skipped; the receipt's
-    `files` is this count."""
+    dirs, tooling dirs, sub-store roots, dot files and last-handoff.md (the
+    handoff class owns it) are skipped silently; a DECLARED skip (a manifest
+    skip_dirs name, a file over doc_max_bytes) is recorded in `skipped_dirs` /
+    `skipped` so the receipt and the header can say so."""
     out: list[Path] = []
-    exclude = exclude or set()
+    excl = exclude or set()
+    declared = set(skip_dirs or ())
     for folder in folders:
         base = store_dir / folder
         if not base.is_dir():
             continue
         for dirpath, dirnames, filenames in os.walk(base):
             cur = Path(dirpath)
-            dirnames[:] = sorted(d for d in dirnames if not d.startswith(".") and d not in DOC_SKIP_DIRS
-                                 and (cur / d) not in exclude)
+            keep = []
+            for d in sorted(dirnames):
+                if d.startswith(".") or d in HARD_SKIP_DIRS or (cur / d) in excl:
+                    continue
+                if d in declared:
+                    if skipped_dirs is not None:
+                        skipped_dirs.append(cur / d)
+                    continue
+                keep.append(d)
+            dirnames[:] = keep
             for fn in sorted(filenames):
                 if not fn.endswith(".md") or fn.startswith(".") or fn == "last-handoff.md":
                     continue
@@ -1303,6 +1323,7 @@ def doc_candidates(scan: str, entities: list[dict], index: dict[str, Entity]) ->
     first_tokens = {ent.name.split()[0].casefold() for ent in index.values() if ent.name.split()}
     out: list[str] = []
     seen: set[str] = set()
+    consumed: set[str] = set()
     for m in CAP_BIGRAM_RE.finditer(scan):
         a, b = m.group(1), m.group(2)
         if a.casefold() in STOPWORDS or b.casefold() in STOPWORDS or a.casefold() in MISS_OPENERS:
@@ -1310,13 +1331,18 @@ def doc_candidates(scan: str, entities: list[dict], index: dict[str, Entity]) ->
         cand = f"{a} {b}"
         cn = norm(cand)
         if cn in seen or any(cn in r or r in cn for r in resolved):
+            # A bigram the resolver already covers ("ShinyHunters Crew" behind
+            # the store shinyhunters) takes BOTH its halves out of the single-word
+            # pass, or the generic half ("Crew") becomes a subject on its own
+            # and pulls unrelated lines labelled KNOWN (PR #308 review round 11).
+            consumed.update({a.casefold(), b.casefold()})
             continue
         seen.add(cn)
         out.append(cand)
     for m in re.finditer(r"\b([A-Z][a-z]{3,})\b", scan):
         tok = m.group(1)
         tn = tok.casefold()
-        if tn in seen or tn in STOPWORDS or tn in MISS_OPENERS or tn in first_tokens:
+        if tn in seen or tn in consumed or tn in STOPWORDS or tn in MISS_OPENERS or tn in first_tokens:
             continue
         if any(tn in r.split() for r in resolved) or any(tn in s.split() for s in seen):
             continue
@@ -1547,6 +1573,7 @@ def _assemble(items: list[dict], entities: list[dict], ceiling: int, header_len:
             continue
         seen.add(key)
         deduped.append(it)
+    deduped = collapse_identical_blocks(deduped, entities)
     recency = store_recency(deduped)
     deduped.sort(key=item_order(order, recency))  # stable: resolver order survives inside a tier (open commitments first, newest first)
     pinned: set[int] = set()
@@ -1670,7 +1697,36 @@ def item_order(order: dict[str, int], recency: dict[str, str] | None = None):
 
 def block_label(it: dict) -> str:
     store = it.get("store") or PROJECT_STORE
-    return it["entity"] if store == PROJECT_STORE else f"{it['entity']} [{store}]"
+    name = ", ".join([it["entity"], *it.get("co_entities", [])])
+    return name if store == PROJECT_STORE else f"{name} [{store}]"
+
+
+def collapse_identical_blocks(items: list[dict], entities: list[dict]) -> list[dict]:
+    """Two entities whose blocks in one store carry the SAME set of lines are one
+    block under one heading naming both. A line naming two people still renders
+    under each of them when their blocks differ (sp-1b3ef442); only a byte-identical
+    second block is dropped, because it spends the cap twice and reads like two
+    sources corroborating one claim (PR #308 review round 11)."""
+    order = {norm(e["name"]): i for i, e in enumerate(entities)}
+    blocks: dict[tuple[str, str], list[dict]] = {}
+    for it in items:
+        blocks.setdefault((norm(it["entity"]), it.get("store") or PROJECT_STORE), []).append(it)
+    signature: dict[tuple[str, str], tuple] = {k: tuple(sorted((i["kind"], norm(i["text"])) for i in v)) for k, v in blocks.items()}
+    dropped: set[tuple[str, str]] = set()
+    keys = sorted(blocks, key=lambda k: (k[1], order.get(k[0], 99)))
+    for i, a in enumerate(keys):
+        if a in dropped:
+            continue
+        for b in keys[i + 1:]:
+            if b in dropped or b[1] != a[1] or signature[a] != signature[b]:
+                continue
+            dropped.add(b)
+            name_b = blocks[b][0]["entity"]
+            for it in blocks[a]:
+                it.setdefault("co_entities", [])
+                if name_b not in it["co_entities"]:
+                    it["co_entities"].append(name_b)
+    return [it for it in items if (norm(it["entity"]), it.get("store") or PROJECT_STORE) not in dropped]
 
 
 def render_item(it: dict) -> str:
@@ -1696,6 +1752,12 @@ def deadline_note(bundle: dict) -> str:
     cut_stores = (bundle.get("budget") or {}).get("stores_cut") or []
     if cut_stores:
         parts.append(ceiling_note_text(cut_stores))
+    sk = bundle.get("declared_skips") or {}
+    if sk.get("files") or sk.get("dirs"):
+        # A declared exclusion keeps FULL, but the model reads only the header,
+        # so the header says what was never opened (PR #308 review round 11).
+        parts.append(f" SKIPPED (declared): {sk.get('files', 0)} file(s) over doc_max_bytes, "
+                     f"{sk.get('dirs', 0)} dir(s) in skip_dirs; the receipt lists them.")
     return "".join(parts)
 
 
@@ -1988,6 +2050,7 @@ def supply(root: Path, prompt: str, *, session_id: str, now: dt.date | None = No
         return None
 
     declared = (manifest.get("classes") or {}).get(task_class, {}).get("sources") or {}
+    declared_skips: dict = {"files": 0, "dirs": 0}
     items: list[dict] = []
     conflicts = 0
     source_rows: list[dict] = []
@@ -2185,6 +2248,10 @@ def supply(root: Path, prompt: str, *, session_id: str, now: dt.date | None = No
             row["files"] = docs_meta.get("files", sum(len(s.get("doc_files") or []) for s in search_stores))
             row["engine"] = docs_meta.get("engine")
             row["files_skipped_oversize"] = sum(len(s.get("doc_skipped_oversize") or []) for s in search_stores)
+            skipped_dirs_all = [rel(d, root) for s in search_stores for d in (s.get("doc_skipped_dirs") or [])]
+            row["dirs_skipped"] = len(skipped_dirs_all)
+            row["dirs_skipped_sample"] = skipped_dirs_all[:6]
+            declared_skips = {"files": row["files_skipped_oversize"], "dirs": row["dirs_skipped"]}
         source_rows.append(row)
 
     verdict = "FULL" if not missing else ("NONE" if all(not r["present"] for r in source_rows) else "PARTIAL")
@@ -2208,6 +2275,7 @@ def supply(root: Path, prompt: str, *, session_id: str, now: dt.date | None = No
     # the fit pays for it; recomputed after, since the fit never drops a pinned
     # line and so never cuts another store whole (PR #308 review round 8).
     bundle["budget"]["stores_cut"] = stores_cut_by_ceiling(items, bundle["items"])
+    bundle["declared_skips"] = declared_skips
     cut, ceiling_hit, overflow = fit_to_ceiling(bundle, ceiling, cut, source_cut, ceiling_hit)
     bundle["budget"]["stores_cut"] = stores_cut_by_ceiling(items, bundle["items"])
     receipt = {

--- a/q-system/.q-system/scripts/knowledge_supply.py
+++ b/q-system/.q-system/scripts/knowledge_supply.py
@@ -117,6 +117,19 @@ DOC_MAX_BYTES_DEFAULT = 512 * 1024
 DOC_SCAN_BUDGET_BYTES = 3 * 1024 * 1024
 GREP_CHUNK = 400
 MAX_DOC_CANDIDATES = 6
+# Bounds on the docs pass. grep -m caps matches PER FILE; MAX_DOC_HITS caps the
+# lines the fold will look at at all. PR #308 review round 2: an entity with a
+# hit on most lines of a large corpus ran the fold for 8.46 s and 1.1 GB, past
+# both the 3.5 s deadline and the 5 s hook timeout, because every bound sat
+# BEFORE the fold and none inside it.
+GREP_MAX_PER_FILE = 200
+MAX_DOC_HITS = 20000
+# Every way a search can stop early, as the suffix the engine string carries.
+# ONE chokepoint (class_search_state) turns any of them into searched=partial
+# and, for a required class, a missing entry; PR #308 review rounds 1 and 2
+# found the same defect on two paths (deadline before the class, then grep
+# timeout / byte budget inside it), which is the signal for one rule, not two.
+TRUNCATION_MARKERS = ("(deadline)", "(timeout)", "(budget)", "(hit cap)")
 # A prompt word that hits in more than this many stores is a word this corpus
 # uses everywhere (Facebook, Miami across 27 of 43 cases, measured 2026-09-05),
 # not a subject. It is dropped and named in the receipt; naming a case first
@@ -1122,7 +1135,7 @@ def _grep(files: list[Path], patterns: list[str], *, ignore_case: bool, word: bo
     binary = grep_binary()
     if binary is None or not files or not patterns:
         return None if binary is None else ([], "grep")
-    args = [binary, "-n", "-H", "-I", "-F"] + (["-i"] if ignore_case else []) + (["-w"] if word else [])
+    args = [binary, "-n", "-H", "-I", "-F", "-m", str(GREP_MAX_PER_FILE)] + (["-i"] if ignore_case else []) + (["-w"] if word else [])
     for pat in patterns:
         args += ["-e", pat]
     args.append("--")
@@ -1144,6 +1157,8 @@ def _grep(files: list[Path], patterns: list[str], *, ignore_case: bool, word: bo
             m = HIT_RE.match(line)
             if m:
                 hits.append((Path(m.group("path")), int(m.group("n")), m.group("text")))
+                if len(hits) >= MAX_DOC_HITS:
+                    return hits, "grep (hit cap)"
     return hits, engine
 
 
@@ -1167,9 +1182,28 @@ def _pyscan(files: list[Path], patterns: list[str], *, ignore_case: bool, word: 
         for n, line in enumerate(data.splitlines(), start=1):
             if pat.search(line):
                 hits.append((f, n, line))
+                if len(hits) >= MAX_DOC_HITS:
+                    return hits, "python (hit cap)"
         if used > budget_bytes:
             return hits, "python (budget)"
     return hits, engine
+
+
+def truncation_of(engine: str | None) -> str | None:
+    """The reason a docs pass stopped early, or None when it ran to the end."""
+    for marker in TRUNCATION_MARKERS:
+        if marker in (engine or ""):
+            return marker.strip("()")
+    return None
+
+
+def class_search_state(stopped_cold: bool, truncated: str | None) -> bool | str:
+    """THE one place that says how far a class was searched: False (never
+    started), "partial" (started and cut short, for any reason), True. A class
+    that is not True never counts toward FULL."""
+    if stopped_cold:
+        return False
+    return "partial" if truncated else True
 
 
 def search_docs(files: list[Path], patterns: list[str], *, ignore_case: bool, word: bool,
@@ -1229,7 +1263,10 @@ def search_docs_for_candidates(cands: list[str], search_stores: list[dict], root
     files = [Path(f) for f in file_store]
     hits, engine = search_docs(files, cands, ignore_case=False, word=True, deadline=deadline)
     out: dict[str, list[tuple[Path, int, str, str]]] = {}
-    for f, n, text in hits:
+    for i, (f, n, text) in enumerate(hits):
+        if i % 500 == 0 and time.time() > deadline and not truncation_of(engine):
+            engine += " (deadline)"
+            break
         s = text.strip()
         if not s or s.startswith("#"):
             continue
@@ -1267,7 +1304,10 @@ def resolve_docs(entities: list[dict], search_stores: list[dict], root: Path,
         return mtimes[k]
 
     out: dict[str, dict[str, list[dict]]] = {}
-    for f, n, text in hits:
+    for i, (f, n, text) in enumerate(hits):
+        if i % 500 == 0 and time.time() > deadline and not truncation_of(engine):
+            engine += " (deadline)"
+            break
         s = text.strip()
         if not s:
             continue
@@ -1287,6 +1327,8 @@ def resolve_docs(entities: list[dict], search_stores: list[dict], root: Path,
             lst.sort(key=lambda i: (i["t"] or "", i["src"]), reverse=True)
     if engine == "none" and candidate_hits:
         engine = candidate_engine   # only the candidate pass ran (an index of 0)
+    elif truncation_of(candidate_engine) and not truncation_of(engine):
+        engine += f" (candidates {truncation_of(candidate_engine)})"
     return out, {"files": len(files), "engine": engine}
 
 
@@ -1358,7 +1400,7 @@ def assemble(items: list[dict], entities: list[dict], ceiling: int, header_len: 
             continue
         seen.add(key)
         deduped.append(it)
-    deduped.sort(key=lambda i: (order.get(norm(i["entity"]), 99), TIER.get(i["kind"], 9)))  # stable: resolver order survives inside a tier (open commitments first, newest first)
+    deduped.sort(key=item_order(order))  # stable: resolver order survives inside a tier (open commitments first, newest first)
     pinned: set[int] = set()
     seen_ent: set[str] = set()
     for idx, it in enumerate(deduped):
@@ -1392,8 +1434,24 @@ def assemble(items: list[dict], entities: list[dict], ceiling: int, header_len: 
         else:
             cut += 1
             ceiling_hit = True
-    kept.sort(key=lambda i: (order.get(norm(i["entity"]), 99), TIER.get(i["kind"], 9)))  # stable: resolver order survives inside a tier (open commitments first, newest first)
+    kept.sort(key=item_order(order))  # stable: resolver order survives inside a tier (open commitments first, newest first)
     return kept, cut, ceiling_hit
+
+
+def item_order(order: dict[str, int]):
+    """Entity, then the project block before each case block, then tier. A name
+    carried by two cases is two blocks, never one identity: PR #308 review
+    round 2 showed two different people called the same thing in two cases
+    rendering as one heading with contradictory KNOWN facts."""
+    def key(i: dict):
+        store = i.get("store") or PROJECT_STORE
+        return (order.get(norm(i["entity"]), 99), 0 if store == PROJECT_STORE else 1, store, TIER.get(i["kind"], 9))
+    return key
+
+
+def block_label(it: dict) -> str:
+    store = it.get("store") or PROJECT_STORE
+    return it["entity"] if store == PROJECT_STORE else f"{it['entity']} [{store}]"
 
 
 def render_item(it: dict) -> str:
@@ -1463,8 +1521,9 @@ def render(bundle: dict) -> str:
     parts = [render_header(bundle)]
     current = None
     for it in bundle["items"]:
-        if it["entity"] != current:
-            current = it["entity"]
+        label = block_label(it)
+        if label != current:
+            current = label
             parts.append(f"== {current} ==")
         parts.append(render_item(it))
     d = bundle["delegated"]
@@ -1779,9 +1838,20 @@ def supply(root: Path, prompt: str, *, session_id: str, now: dt.date | None = No
         # PR #308 review round 1 minor 3: the investigation manifest lists docs
         # first and alone under temporal_event, so this one row decided FULL.
         stopped_cold = bool(deadline_hit and deadline_hit["at_class"] == cls and present and not searched_any)
-        if stopped_cold and spec.get("required") and cls not in missing:
+        # `cut_reason`, never `truncated`: that name is the PROMPT truncation
+        # flag in this scope, and shadowing it blanked the receipt's prompt
+        # fields (caught by test_large_paste_against_big_index_is_fast_and_truncated).
+        cut_reason = None
+        if present and not stopped_cold:
+            if cls == "docs":
+                cut_reason = truncation_of(docs_meta.get("engine"))
+            elif deadline_hit and deadline_hit["at_class"] == cls:
+                cut_reason = "deadline"
+        searched_state = class_search_state(stopped_cold, cut_reason)
+        if searched_state is not True and present and spec.get("required") and cls not in missing:
             missing.append(cls)
-            missing_paths[cls] = f"{path_s or cls} not searched (deadline)"
+            missing_paths[cls] = (f"{path_s or cls} not searched (deadline)" if stopped_cold
+                                  else f"{path_s or cls} partially searched ({cut_reason})")
         src_path = Path(root) / path_s if path_s and cls not in ("canonical", "capability", "docs") else None
         store_problems = "; ".join(f"{s['name']}: {s['problems'][cls]}" for s in search_stores if cls in s["problems"]) or None
         row = {
@@ -1791,11 +1861,13 @@ def supply(root: Path, prompt: str, *, session_id: str, now: dt.date | None = No
             "bytes": sum(len(i["text"]) for i in cls_items),
             "bad_lines": sum(s["bad_lines"].get(cls, 0) for s in search_stores),
             "problem": store_problems,
-            "searched": False if stopped_cold else ("partial" if (deadline_hit and deadline_hit["at_class"] == cls) else True),
+            "searched": searched_state,
             "stores_searched": 0 if stopped_cold else len(search_stores), "stores_hit": sorted(stores_hit),
         }
         if stopped_cold:
             row["problem"] = "not searched (deadline)"
+        elif cut_reason:
+            row["problem"] = f"partially searched ({cut_reason})"
         if cls == "docs":
             row["files"] = docs_meta.get("files", sum(len(s.get("doc_files") or []) for s in search_stores))
             row["engine"] = docs_meta.get("engine")

--- a/q-system/.q-system/scripts/test_knowledge_supply.py
+++ b/q-system/.q-system/scripts/test_knowledge_supply.py
@@ -1209,6 +1209,58 @@ def test_receipt_says_when_the_corpus_common_rule_cannot_run(tmp_path):
     assert b2["receipt"]["candidate_rule"]["applicable"] is True
 
 
+# PR #308 review round 2: truncation is one rule, the docs fold is bounded, one block per case.
+
+def test_truncated_docs_search_is_partial_never_full(tmp_path, monkeypatch):
+    root, q = make_instance(tmp_path)
+    (q / ".q-system" / "data").mkdir()
+    shutil.copy(INVESTIGATION_MANIFEST, q / ".q-system" / "data" / "knowledge-sources.json")
+    add_store(q, "case-001-foo-bar", "scope", "Dana Okafor briefed the Foo Bar victim list.")
+    for reason in ("grep (timeout)", "grep (deadline)", "python (budget)", "grep (hit cap)"):
+        monkeypatch.setattr(ks, "search_docs", lambda files, patterns, **kw: ([], reason))
+        b = run(root, "what do we know about Dana Okafor")
+        row = receipt_row(b, "docs")
+        assert row["searched"] == "partial" and row["problem"].startswith("partially searched ("), (reason, row)
+        assert b["coverage"]["verdict"] != "FULL" and "docs" in b["coverage"]["missing"], (reason, b["coverage"])
+        assert "partially searched" in b["coverage"]["missing_paths"]["docs"]
+
+
+def test_docs_hit_cap_bounds_the_fold(tmp_path, monkeypatch):
+    root, q = make_instance(tmp_path)
+    (q / "output" / "flood.md").write_text("".join(f"Dana Okafor line {i}\n" for i in range(3000)))
+    monkeypatch.setattr(ks, "MAX_DOC_HITS", 40)
+    b = run(root, "what do we know about Dana Okafor")
+    row = receipt_row(b, "docs")
+    assert "(hit cap)" in row["engine"] and row["searched"] == "partial", row
+    assert len(items_of(b, kind="doc")) <= 40
+    monkeypatch.setattr(ks.shutil, "which", lambda name: None)
+    b2 = run(root, "what do we know about Dana Okafor")
+    assert "(hit cap)" in receipt_row(b2, "docs")["engine"]
+
+
+def test_same_name_in_two_cases_renders_one_block_per_case(tmp_path):
+    root, q = make_instance(tmp_path)
+    a = add_store(q, "case-010-alpha", "scope", "alpha")
+    b_ = add_store(q, "case-020-bravo", "scope", "bravo")
+    _graph(a / "memory" / "graph.jsonl", [{"s": "John Smith", "p": "role", "o": "the victim in alpha", "t": "2026-09-01"}])
+    _graph(b_ / "memory" / "graph.jsonl", [{"s": "John Smith", "p": "role", "o": "the suspect in bravo", "t": "2026-09-02"}])
+    b = run(root, "what do we know about John Smith")
+    out = ks.render(b)
+    assert "== John Smith [case-010-alpha] ==" in out and "== John Smith [case-020-bravo] ==" in out
+    assert "\n== John Smith ==\n" not in out, "no project-level block when the project has nothing"
+    alpha = out.index("[case-010-alpha] ==")
+    bravo = out.index("[case-020-bravo] ==")
+    assert out.index("the victim in alpha") > alpha and out.index("the victim in alpha") < bravo
+    assert all(i["status"] == "KNOWN" for i in items_of(b, kind="graph")), "a case never supersedes another case"
+
+
+def test_project_block_comes_before_case_blocks(tmp_path):
+    root, q = make_instance(tmp_path)
+    add_store(q, "case-001-foo-bar", "scope", "Dana Okafor briefed the Foo Bar victim list.")
+    out = ks.render(run(root, "what do we know about Dana Okafor"))
+    assert out.index("== Dana Okafor ==") < out.index("== Dana Okafor [case-001-foo-bar] ==")
+
+
 # ---------------------------------------------------------------- the hook
 
 def run_hook(root: Path, prompt: str, extra_env: dict | None = None) -> subprocess.CompletedProcess:

--- a/q-system/.q-system/scripts/test_knowledge_supply.py
+++ b/q-system/.q-system/scripts/test_knowledge_supply.py
@@ -903,6 +903,233 @@ def test_missing_manifest_is_observable_not_silent(tmp_path):
     assert r["error"] == "manifest_missing"
 
 
+# ---------------------------------------------------------------- project folders
+# Founder-directed 2026-09-05 (plan knowledge-supply-project-folders-2026-09-05):
+# every project reads its OWN folder, and each 4_points investigation is its own
+# knowledge base. Reproducer: 4_points had 1,475 case files and an index of 40;
+# a consulting instance had 83 files and an index of 0, so the reader never woke up.
+
+INVESTIGATION_MANIFEST = HERE.parent / "knowledge-sources.investigation.json"
+
+
+def add_store(q: Path, name: str, scope_line: str, finding_line: str) -> Path:
+    s = q / "investigations" / name
+    (s / "canonical").mkdir(parents=True)
+    (s / "memory").mkdir()
+    (s / "investigation" / "findings").mkdir(parents=True)
+    (s / "investigation" / "targets").mkdir(parents=True)
+    (s / "canonical" / "scope.md").write_text(f"# Investigation Scope\n\n## Primary Question\n\n{scope_line}\n")
+    (s / "investigation" / "findings" / "finding-001.md").write_text(
+        f"# Finding 001\n\n## Summary\n\n{finding_line}\n\n## Next Steps\n\n- none\n")
+    return s
+
+
+def make_bare_instance(tmp: Path) -> tuple[Path, Path]:
+    """A project with NO graph, relationships, commitments or meetings: documents only.
+    a consulting instance's shape on 2026-09-05."""
+    root = tmp / "bare"
+    q = root / "q-bare"
+    for d in ("canonical", "memory", "output", ".q-system"):
+        (q / d).mkdir(parents=True)
+    shutil.copy(MANIFEST, q / ".q-system" / "knowledge-sources.json")
+    (q / "canonical" / "client-profile.md").write_text("# Client\n\nThe client sells gold coins.\n")
+    (q / "output" / "brief-2026-08-14.md").write_text(
+        "# Brief\n\nBluepeak asked for a name column on the intake form.\n\n## Next Steps\n\n- reply to the carrier\n")
+    return root, q
+
+
+def receipt_row(bundle, cls):
+    return next(r for r in bundle["receipt"]["sources"] if r["class"] == cls)
+
+
+def test_store_named_in_prompt_scopes_to_that_store(tmp_path):
+    root, q = make_instance(tmp_path)
+    add_store(q, "case-001-foo-bar", "Why does Foo Bar keep getting breached?", "Dana Okafor briefed the Foo Bar victim list.")
+    add_store(q, "case-002-other-thing", "What is Other Thing?", "Dana Okafor also appears in the Other Thing case.")
+    b = run(root, "what do we know about foo bar")
+    assert b is not None
+    ents = {e["name"]: e for e in b["entities"]}
+    assert "foo bar" in ents and ents["foo bar"]["kind"] == "store" and ents["foo bar"]["store"] == "case-001-foo-bar"
+    srcs = [i["src"] for i in b["items"]]
+    assert any("investigations/case-001-foo-bar/canonical/scope.md:5" in s for s in srcs), srcs
+    assert any("investigations/case-001-foo-bar/investigation/findings/finding-001.md:5" in s for s in srcs), srcs
+    assert not any("case-002-other-thing" in s for s in srcs), srcs
+
+
+def test_store_plus_person_never_leaks_the_other_store(tmp_path):
+    root, q = make_instance(tmp_path)
+    add_store(q, "case-001-foo-bar", "scope", "Dana Okafor briefed the Foo Bar victim list.")
+    add_store(q, "case-002-other-thing", "scope", "Dana Okafor also appears in the Other Thing case.")
+    b = run(root, "in foo bar, what did Dana Okafor brief")
+    dana = items_of(b, entity="Dana Okafor")
+    assert any("case-001-foo-bar" in i["src"] for i in dana), [i["src"] for i in dana]
+    assert not any("case-002-other-thing" in i["src"] for i in b["items"]), [i["src"] for i in b["items"]]
+    assert any(i["kind"] == "graph" for i in dana)   # project-level stores are always in scope
+
+
+def test_no_store_named_searches_every_store(tmp_path):
+    root, q = make_instance(tmp_path)
+    add_store(q, "case-001-foo-bar", "scope", "Dana Okafor briefed the Foo Bar victim list.")
+    add_store(q, "case-002-other-thing", "scope", "Dana Okafor also appears in the Other Thing case.")
+    b = run(root, "what do we know about Dana Okafor")
+    srcs = [i["src"] for i in items_of(b, kind="doc")]
+    assert any("case-001-foo-bar" in s for s in srcs) and any("case-002-other-thing" in s for s in srcs), srcs
+    row = receipt_row(b, "docs")
+    assert row["stores_searched"] == 3 and sorted(row["stores_hit"]) == ["case-001-foo-bar", "case-002-other-thing"]
+    assert receipt_row(b, "canonical")["stores_searched"] == 3
+
+
+def test_target_file_stem_fires_alone_but_a_finding_stem_does_not(tmp_path):
+    root, q = make_instance(tmp_path)
+    s = add_store(q, "case-003-x-case", "scope", "finding")
+    (s / "investigation" / "targets" / "acme-corp.md").write_text("# acme-corp\n\nacme-corp runs the fake exchange.\n")
+    (s / "investigation" / "findings" / "weird-note.md").write_text("# weird-note\n\nweird-note is a finding file.\n")
+    b = run(root, "pull everything on acme-corp")
+    assert b is not None and any(e["kind"] == "target" and e["name"] == "acme corp" for e in b["entities"])
+    assert any(i["text"] == "acme-corp runs the fake exchange." for i in items_of(b, kind="doc"))
+    b2 = run(root, "pull everything on weird-note")
+    assert b2 is None or not any(e["name"] == "weird note" for e in b2["entities"])
+
+
+def test_proper_nouns_file_indexes_curated_names_only(tmp_path):
+    root, q = make_instance(tmp_path)
+    (q / "canonical" / "proper-nouns.txt").write_text("# names kept OUT of common words\n\nMarilyn\nBlue Peak\n")
+    (q / "output" / "call-2026-09-01.md").write_text("# Call\n\nMarilyn asked for the pay sheet by Friday.\n")
+    b = run(root, "what did Marilyn ask for")
+    assert b is not None and any(e["kind"] == "noun" and e["name"] == "Marilyn" for e in b["entities"])
+    docs = items_of(b, kind="doc", entity="Marilyn")
+    assert docs and docs[0]["text"] == "Marilyn asked for the pay sheet by Friday."
+    assert docs[0]["src"].endswith("output/call-2026-09-01.md:3")
+    manifest, _ = ks.load_manifest(q, root)
+    assert ks.load_stores(q, root, manifest)[0]["noun_names"] == ["Marilyn", "Blue Peak"], "comment and blank lines never index"
+
+
+def test_docs_class_returns_verbatim_line_after_graph_and_canonical(tmp_path):
+    root, q = make_instance(tmp_path)
+    (q / "output" / "notes-2026-09-01.md").write_text("# Notes\n\nDana Okafor asked for the runbook in writing.\n")
+    b = run(root, "what do we know about Dana Okafor")
+    docs = items_of(b, kind="doc", entity="Dana Okafor")
+    assert docs and docs[0]["text"] == "Dana Okafor asked for the runbook in writing."
+    assert docs[0]["src"].endswith("output/notes-2026-09-01.md:3")
+    kinds = [i["kind"] for i in b["items"] if i["entity"] == "Dana Okafor"]
+    assert kinds.index("doc") > kinds.index("graph") and kinds.index("doc") > kinds.index("canonical")
+    row = receipt_row(b, "docs")
+    assert row["engine"] == "grep" and row["files"] >= 1 and row["present"] is True
+
+
+def test_docs_python_fallback_matches_grep(tmp_path, monkeypatch):
+    root, q = make_instance(tmp_path)
+    (q / "output" / "notes.md").write_text("Dana Okafor asked for the runbook in writing.\n")
+    a = run(root, "what do we know about Dana Okafor")
+    monkeypatch.setattr(ks.shutil, "which", lambda name: None)
+    b = run(root, "what do we know about Dana Okafor")
+    assert [i["src"] for i in items_of(a, kind="doc")] == [i["src"] for i in items_of(b, kind="doc")]
+    assert receipt_row(a, "docs")["engine"] == "grep" and receipt_row(b, "docs")["engine"] == "python"
+
+
+def test_prompt_proper_noun_with_doc_hits_becomes_entity(tmp_path):
+    root, q = make_bare_instance(tmp_path)
+    b = run(root, "what did Bluepeak ask for")
+    assert b is not None, "an index of 0 must not mean the reader never wakes up"
+    e = b["entities"][0]
+    assert e["name"] == "Bluepeak" and e["resolved_from"] == "docs" and e["kind"] == "docs_hit"
+    assert any(i["text"] == "Bluepeak asked for a name column on the intake form." for i in items_of(b, kind="doc"))
+    assert b["coverage"]["verdict"] in ("FULL", "PARTIAL")
+
+
+def test_prompt_proper_noun_without_hits_lowercase_or_initial_never_fires(tmp_path):
+    root, q = make_bare_instance(tmp_path)
+    assert run(root, "what did Nobody ask for") is None
+    assert run(root, "what did bluepeak ask for") is None
+    assert run(root, "Bluepeak asked for what") is None
+    assert run(root, "- Bluepeak asked for what") is None
+
+
+def test_headings_never_become_entities(tmp_path):
+    root, q = make_bare_instance(tmp_path)
+    assert run(root, "what are the next steps") is None
+    assert run(root, "what are the Next Steps here") is None
+
+
+def test_docs_skip_big_hidden_and_node_modules(tmp_path):
+    root, q = make_instance(tmp_path)
+    (q / "output" / "big.md").write_text("Dana Okafor big\n" + "x" * 600_000)
+    (q / "output" / ".hidden").mkdir()
+    (q / "output" / ".hidden" / "h.md").write_text("Dana Okafor hidden\n")
+    (q / "output" / "node_modules").mkdir()
+    (q / "output" / "node_modules" / "n.md").write_text("Dana Okafor node\n")
+    (q / "output" / "ok.md").write_text("Dana Okafor ok\n")
+    b = run(root, "what do we know about Dana Okafor")
+    texts = [i["text"] for i in items_of(b, kind="doc")]
+    assert "Dana Okafor ok" in texts
+    assert not any(t in texts for t in ("Dana Okafor big", "Dana Okafor hidden", "Dana Okafor node"))
+    assert receipt_row(b, "docs")["files"] == 1
+
+
+def test_docs_items_are_verbatim_and_dated_by_file(tmp_path):
+    root, q = make_instance(tmp_path)
+    add_store(q, "case-001-foo-bar", "scope", "Dana Okafor briefed the Foo Bar victim list.")
+    b = run(root, "what do we know about Dana Okafor")
+    for it in items_of(b, kind="doc"):
+        text = Path(it["abs_src"]).read_text()
+        for piece in ks.verbatim_pieces(it):
+            assert piece in text
+        assert it["t"] is not None
+
+
+def test_shipped_manifests_declare_project_folders():
+    m = json.loads(MANIFEST.read_text())
+    assert m["_version"] >= 2
+    assert any(s["glob"] == "investigations/case-*" for s in m["stores"])
+    assert {"output", "investigation", "research"} <= set(m["folders"])
+    assert {"targets", "clients"} <= set(m["entity_dirs"])
+    assert {"store", "target", "noun"} <= set(m["entity_kinds_that_fire_alone"])
+    for cls, spec in m["classes"].items():
+        assert "docs" in spec["sources"], cls
+    inv = json.loads(INVESTIGATION_MANIFEST.read_text())
+    lookup = inv["classes"]["entity_lookup"]["sources"]
+    assert lookup["graph"]["required"] and lookup["canonical"]["required"] and lookup["docs"]["required"]
+    for cls, spec in inv["classes"].items():
+        for name in ("commitments", "meetings", "relationships"):
+            assert not spec["sources"].get(name, {}).get("required"), (cls, name)
+
+
+def test_investigation_manifest_loads_as_instance_override(tmp_path):
+    root, q = make_instance(tmp_path)
+    (q / ".q-system" / "data").mkdir()
+    shutil.copy(INVESTIGATION_MANIFEST, q / ".q-system" / "data" / "knowledge-sources.json")
+    for p in ("my-project/commitments.jsonl", "output/granola-cache.json", "my-project/relationships.md"):
+        (q / p).unlink()
+    add_store(q, "case-001-foo-bar", "scope", "Dana Okafor briefed the Foo Bar victim list.")
+    b = run(root, "what is still outstanding on Dana Okafor")
+    assert b is not None and b["task_class"] == "commitment"
+    assert b["coverage"]["verdict"] == "FULL", b["coverage"]
+    assert b["receipt"]["manifest"].endswith(".q-system/data/knowledge-sources.json")
+
+
+def test_corpus_common_word_is_dropped_unless_a_store_is_named(tmp_path):
+    root, q = make_instance(tmp_path)
+    for i in range(1, 7):
+        add_store(q, f"case-00{i}-thing-{i}", "scope", f"Facebook profile checked in case {i}.")
+    assert run(root, "update on the Facebook profiles", record=True) is None, "a word in 6 of 6 cases is not a subject"
+    rows = [json.loads(l) for l in (q / "memory" / ".knowledge-supply-misses.jsonl").read_text().splitlines()]
+    assert any(r["candidate"] == "Facebook" and r["shape"] == "corpus_common" and r["stores"] == 6 for r in rows), rows
+    b = run(root, "in thing 2, what did the Facebook profiles show")
+    names = {e["name"]: e for e in b["entities"]}
+    assert "Facebook" in names and names["Facebook"]["resolved_from"] == "docs"
+    srcs = [i["src"] for i in items_of(b, entity="Facebook")]
+    assert srcs and all("case-002-thing-2" in s for s in srcs), srcs
+
+
+def test_dropped_candidates_are_named_in_the_receipt(tmp_path):
+    root, q = make_instance(tmp_path)
+    for i in range(1, 7):
+        add_store(q, f"case-00{i}-thing-{i}", "scope", f"Facebook profile checked in case {i}.")
+    b = run(root, "what do we know about Dana Okafor and the Facebook profiles")
+    assert b is not None and not any(e["name"] == "Facebook" for e in b["entities"])
+    assert b["receipt"]["candidates_dropped"] == [{"candidate": "Facebook", "stores": 6}]
+
+
 # ---------------------------------------------------------------- the hook
 
 def run_hook(root: Path, prompt: str, extra_env: dict | None = None) -> subprocess.CompletedProcess:

--- a/q-system/.q-system/scripts/test_knowledge_supply.py
+++ b/q-system/.q-system/scripts/test_knowledge_supply.py
@@ -1085,6 +1085,7 @@ def test_docs_skip_big_hidden_and_node_modules(tmp_path):
     assert "Dana Okafor ok" in texts
     assert not any(t in texts for t in ("Dana Okafor big", "Dana Okafor hidden", "Dana Okafor node"))
     assert receipt_row(b, "docs")["files"] == 1
+    assert receipt_row(b, "docs")["files_skipped_oversize"] == 1, "a declared skip is counted, never silent"
 
 
 def test_docs_items_are_verbatim_and_dated_by_file(tmp_path):
@@ -1370,6 +1371,48 @@ def test_docs_candidate_stays_case_sensitive_in_every_resolver(tmp_path):
     texts = [i["text"] for i in b["items"]]
     assert "Bluepeak asked for a name column on the intake form." in texts
     assert not any("bluepeak channel" in t for t in texts), texts
+
+
+# PR #308 review round 6: the stop reason is a field; dedupe keeps stores apart; a store name survives.
+
+def test_candidate_pass_truncation_is_partial_without_monkeypatch(tmp_path):
+    """The reviewer's fixture: the index pass (Dana Okafor) finishes clean, the
+    candidate pass (Bluepeak, 300 lines) hits grep -m. No monkeypatch, so a
+    composed engine string cannot hide the stop the way it did in round 6."""
+    root, q = make_instance(tmp_path)
+    (q / ".q-system" / "data").mkdir()
+    shutil.copy(INVESTIGATION_MANIFEST, q / ".q-system" / "data" / "knowledge-sources.json")
+    (q / "output" / "flood.md").write_text("".join(f"Bluepeak asked line {i}\n" for i in range(300)))
+    b = run(root, "what did Bluepeak ask Dana Okafor about")
+    assert any(e["name"] == "Bluepeak" and e["kind"] == "docs_hit" for e in b["entities"])
+    row = receipt_row(b, "docs")
+    assert row["searched"] == "partial", row
+    assert "file cap" in row["problem"] and "candidates" in row["engine"], row
+    assert b["coverage"]["verdict"] != "FULL" and "docs" in b["coverage"]["missing"], b["coverage"]
+
+
+def test_identical_line_in_two_cases_keeps_both(tmp_path):
+    root, q = make_instance(tmp_path)
+    add_store(q, "case-010-alpha", "scope", "Dana Okafor reused the same bulletproof host.")
+    add_store(q, "case-041-beta", "scope", "Dana Okafor reused the same bulletproof host.")
+    b = run(root, "what do we know about Dana Okafor")
+    docs = [i for i in items_of(b, kind="doc") if "bulletproof" in i["text"]]
+    assert sorted(i["store"] for i in docs) == ["case-010-alpha", "case-041-beta"], [i["src"] for i in docs]
+    out = ks.render(b)
+    assert "[case-010-alpha] ==" in out and "[case-041-beta] ==" in out
+    assert b["budget"]["cut"] == 0
+
+
+def test_named_store_survives_the_longest_name_rule(tmp_path):
+    root, q = make_instance(tmp_path)
+    a = add_store(q, "case-010-zeta", "scope", "zeta finding")
+    b_ = add_store(q, "case-020-other", "scope", "other finding")
+    _graph(a / "memory" / "graph.jsonl", [{"s": "Zeta Holdings", "p": "status", "o": "sanctioned", "t": "2026-09-05"}])
+    _graph(b_ / "memory" / "graph.jsonl", [{"s": "Zeta Holdings", "p": "status", "o": "clean", "t": "2026-09-05"}])
+    b = run(root, "in zeta, what do we know about Zeta Holdings")
+    assert any(e["kind"] == "store" and e["stores"] == ["case-010-zeta"] for e in b["entities"]), b["entities"]
+    srcs = [i["src"] for i in b["items"]]
+    assert srcs and not any("case-020-other" in s for s in srcs), srcs
 
 
 # ---------------------------------------------------------------- the hook

--- a/q-system/.q-system/scripts/test_knowledge_supply.py
+++ b/q-system/.q-system/scripts/test_knowledge_supply.py
@@ -1261,6 +1261,39 @@ def test_project_block_comes_before_case_blocks(tmp_path):
     assert out.index("== Dana Okafor ==") < out.index("== Dana Okafor [case-001-foo-bar] ==")
 
 
+# PR #308 review round 3: the fold's deadline always ends it; the project walk never enters a case.
+
+def test_docs_fold_stops_at_the_deadline_even_after_a_hit_cap(tmp_path, monkeypatch):
+    import time as _time
+    root, q = make_instance(tmp_path)
+    (q / "output" / "one.md").write_text("Dana Okafor line\n")
+    manifest, _ = ks.load_manifest(q, root)
+    project, subs, _ = ks.load_all_stores(q, root, manifest)
+    ent = {"name": "Dana Okafor", "kind": "contact", "aliases": [], "alias_stores": {}, "stores": []}
+    f = q / "output" / "one.md"
+    flood = [(f, 1, "Dana Okafor line")] * 200_000
+    for engine_in in ("grep (hit cap)", "grep"):
+        monkeypatch.setattr(ks, "search_docs", lambda files, patterns, **kw: (flood, engine_in))
+        t0 = _time.time()
+        out, meta = ks.resolve_docs([ent], [project] + subs, root, {}, deadline=_time.time() - 1)
+        assert _time.time() - t0 < 1.0, "the fold must end at the deadline, not after 200,000 hits"
+        assert sum(len(v) for by in out.values() for v in by.values()) <= 500
+        assert "(deadline)" in meta["engine"] or "(hit cap)" in meta["engine"]
+        if engine_in == "grep (hit cap)":
+            assert meta["engine"] == "grep (hit cap)", "an existing stop reason is kept, not doubled"
+
+
+def test_project_store_never_indexes_a_substore_target(tmp_path):
+    root, q = make_instance(tmp_path)   # relationships.md present: the loop that used to rebind `name`
+    s = add_store(q, "case-003-x-case", "scope", "finding")
+    (s / "investigation" / "targets" / "acme-corp.md").write_text("# acme-corp\n")
+    manifest, _ = ks.load_manifest(q, root)
+    project, subs, _ = ks.load_all_stores(q, root, manifest)
+    assert project["name"] == "project" and "acme corp" not in project["target_names"], project["target_names"]
+    assert subs[0]["target_names"] == ["acme corp"]
+    assert not any("case-003-x-case" in str(f) for f in project["doc_files"])
+
+
 # ---------------------------------------------------------------- the hook
 
 def run_hook(root: Path, prompt: str, extra_env: dict | None = None) -> subprocess.CompletedProcess:

--- a/q-system/.q-system/scripts/test_knowledge_supply.py
+++ b/q-system/.q-system/scripts/test_knowledge_supply.py
@@ -1554,8 +1554,9 @@ def test_target_stem_scopes_to_the_declaring_case(tmp_path):
     b = run(root, "what do we know about miami")
     ent = next(e for e in b["entities"] if e["kind"] == "target")
     assert ent["stores"] == ["case-001-alpha1"]
-    assert b["coverage"]["scope"] == ["case-001-alpha1"] and len(b["coverage"]["stores_excluded"]) == 5
-    assert all("case-001-alpha1" in i["src"] or "/q-fix/" in i["src"] for i in b["items"]), [i["src"] for i in b["items"]]
+    assert b["coverage"]["scope"] == [] and b["coverage"]["stores_excluded"] == [], "a filename is never a prompt scope"
+    miami = items_of(b, entity="miami")
+    assert miami and all(i.get("store") in ("case-001-alpha1", "project") for i in miami), [i["src"] for i in miami]
     assert "[target of case-001-alpha1]" in ks.render(b).splitlines()[0]
 
 
@@ -1607,11 +1608,28 @@ def test_target_shared_by_many_cases_scopes_to_all_of_them_when_none_is_named(tm
     root, q = make_instance(tmp_path)
     _three_cases_sharing_a_target(q)
     b = run(root, "what did acme do")
-    assert b["coverage"]["scope"] == ["case-001-alpha", "case-002-beta", "case-003-gamma"]
-    assert b["coverage"]["stores_excluded"] == []
-    assert "WITHIN SCOPE" not in ks.render(b), "nothing excluded, nothing disclosed, no budget spent"
+    assert b["coverage"]["scope"] == [] and b["coverage"]["stores_excluded"] == []
+    assert "WITHIN SCOPE" not in ks.render(b)
     texts = [i["text"] for i in b["items"]]
     assert all(any(k in t for t in texts) for k in ("ALPHA-ONLY", "BETA-ONLY", "GAMMA-ONLY"))
+
+
+def test_target_never_narrows_another_entity(tmp_path):
+    """The round 10 reproducer: 'Orbit Holdings and the miami accounts' with
+    miami a target of one case must still deliver every Orbit Holdings fact."""
+    root, q = make_instance(tmp_path)
+    with open(q / "memory" / "graph.jsonl", "a") as f:   # a fully-indexed subject, as in the reviewer's repro
+        f.write(json.dumps({"s": "Orbit Holdings", "p": "is", "o": "a shell company", "t": "2026-09-01"}) + "\n")
+    for i in range(1, 6):
+        s = add_store(q, f"case-00{i}-thing{i}", "scope", f"Orbit Holdings fact {i}.")
+        if i == 3:
+            (s / "investigation" / "targets" / "miami.md").write_text("# miami\n\nmiami target notes\n")
+    b = run(root, "what do we have on Orbit Holdings and the miami accounts")
+    assert b["coverage"]["scope"] == [] and b["coverage"]["stores_excluded"] == []
+    orbit = items_of(b, entity="Orbit Holdings")
+    assert {i["store"] for i in orbit} >= {f"case-00{i}-thing{i}" for i in range(1, 6)}, sorted({i["store"] for i in orbit})
+    miami = items_of(b, entity="miami")
+    assert miami and all(i["store"] in ("case-003-thing3", "project") for i in miami)
 
 
 def test_scope_note_is_bounded(tmp_path):
@@ -1620,13 +1638,18 @@ def test_scope_note_is_bounded(tmp_path):
         s = add_store(q, f"case-00{i}-thing{i}", "scope", f"Acme in case {i}")
         if i <= 8:
             (s / "investigation" / "targets" / "acme.md").write_text("# acme\n")
-    b = run(root, "what did acme do")
+    named = ", ".join(f"thing{i}" for i in range(1, 9))
+    b = run(root, f"in {named}: what did acme do")
     assert len(b["coverage"]["scope"]) == 8 and b["coverage"]["stores_excluded"] == ["case-009-thing9"]
     head = ks.render(b).splitlines()[0]
     assert "and 2 more + project only; 1 other store not searched" in head, head
     scope_clause = head.split("WITHIN SCOPE", 1)[1].split("+ project", 1)[0]
     assert scope_clause.count("case-00") == 6, scope_clause
     assert "[target of case-001-thing1, case-002-thing2, case-003-thing3, case-004-thing4, case-005-thing5, case-006-thing6 and 2 more]" in head, head
+    # every store named: a scope with nothing excluded discloses nothing
+    b2 = run(root, "in " + ", ".join(f"thing{i}" for i in range(1, 10)) + ": what did acme do")
+    assert len(b2["coverage"]["scope"]) == 9 and b2["coverage"]["stores_excluded"] == []
+    assert "WITHIN SCOPE" not in ks.render(b2).splitlines()[0]
 
 
 def test_absent_class_is_never_searched_in_the_receipt(tmp_path):
@@ -1635,6 +1658,36 @@ def test_absent_class_is_never_searched_in_the_receipt(tmp_path):
     for cls in ("graph", "commitments", "meetings", "loops"):
         row = receipt_row(b, cls)
         assert row["present"] is False and row["searched"] is False and row["stores_searched"] == 0, row
+
+
+# PR #308 review round 10: an index of 0 still accounts for unreadable docs; the receipts ledger is bounded.
+
+def test_unreadable_store_is_seen_with_an_index_of_zero(tmp_path):
+    root, q = make_bare_instance(tmp_path)
+    (q / ".q-system" / "data").mkdir()
+    shutil.copy(INVESTIGATION_MANIFEST, q / ".q-system" / "data" / "knowledge-sources.json")
+    s = add_store(q, "case-001-alpha", "scope", "Bluepeak asked here too.")
+    only = s / "investigation" / "findings" / "finding-001.md"
+    only.chmod(0)
+    try:
+        b = run(root, "what did Bluepeak ask for")
+    finally:
+        only.chmod(0o644)
+    assert b is not None and any(e["kind"] == "docs_hit" for e in b["entities"])
+    row = receipt_row(b, "docs")
+    assert "case-001-alpha: 1 of 1 doc file(s) unreadable" in (row["problem"] or ""), row
+    assert row["searched"] == "partial" and b["coverage"]["verdict"] != "FULL", b["coverage"]
+
+
+def test_receipts_ledger_is_bounded(tmp_path, monkeypatch):
+    root, q = make_instance(tmp_path)
+    monkeypatch.setattr(ks, "RECEIPT_LEDGER_MAX_BYTES", 4000)
+    for _ in range(12):
+        run(root, "what do we know about Dana Okafor", record=True)
+    path = q / "memory" / ".knowledge-supply-receipts.jsonl"
+    assert path.stat().st_size <= 4000 * 2, path.stat().st_size   # one row may land before the trim
+    rows = [json.loads(l) for l in path.read_text().splitlines()]
+    assert 1 <= len(rows) < 12 and all("sources" in r for r in rows)
 
 
 # ---------------------------------------------------------------- the hook

--- a/q-system/.q-system/scripts/test_knowledge_supply.py
+++ b/q-system/.q-system/scripts/test_knowledge_supply.py
@@ -1027,6 +1027,27 @@ def test_docs_python_fallback_matches_grep(tmp_path, monkeypatch):
     assert receipt_row(a, "docs")["engine"] == "grep" and receipt_row(b, "docs")["engine"] == "python"
 
 
+def test_docs_engines_agree_on_the_per_file_cap_and_both_report_it(tmp_path, monkeypatch):
+    """PR #308 review round 4: grep -m capped a file at 200 silently while the
+    Python scan returned 300, under searched=True. The one way the engines could
+    differ is the one this fixture exercises."""
+    root, q = make_instance(tmp_path)
+    (q / "output" / "flood.md").write_text("".join(f"Dana Okafor line {i}\n" for i in range(300)))
+    manifest, _ = ks.load_manifest(q, root)
+    project, subs, _ = ks.load_all_stores(q, root, manifest)
+    files = project["doc_files"]
+    g_hits, g_engine = ks.search_docs(files, ["Dana Okafor"], ignore_case=True, word=False, deadline=dt.datetime.now().timestamp() + 5)
+    monkeypatch.setattr(ks.shutil, "which", lambda name: None)
+    p_hits, p_engine = ks.search_docs(files, ["Dana Okafor"], ignore_case=True, word=False, deadline=dt.datetime.now().timestamp() + 5)
+    assert len(g_hits) == len(p_hits) == ks.GREP_MAX_PER_FILE
+    assert [h[1] for h in g_hits] == [h[1] for h in p_hits]
+    assert g_engine == "grep (file cap)" and p_engine == "python (file cap)"
+    monkeypatch.undo()
+    b = run(root, "what do we know about Dana Okafor")
+    row = receipt_row(b, "docs")
+    assert row["searched"] == "partial" and "file cap" in row["problem"], row
+
+
 def test_prompt_proper_noun_with_doc_hits_becomes_entity(tmp_path):
     root, q = make_bare_instance(tmp_path)
     b = run(root, "what did Bluepeak ask for")
@@ -1292,6 +1313,30 @@ def test_project_store_never_indexes_a_substore_target(tmp_path):
     assert project["name"] == "project" and "acme corp" not in project["target_names"], project["target_names"]
     assert subs[0]["target_names"] == ["acme corp"]
     assert not any("case-003-x-case" in str(f) for f in project["doc_files"])
+
+
+# PR #308 review round 4: order inside a store is by file time, then mentions, never by name.
+
+def test_docs_order_is_file_time_then_mentions_never_path(tmp_path):
+    import os as _os
+    root, q = make_instance(tmp_path)
+    same = 1_700_000_000
+    for i in range(1, 10):
+        f = q / "output" / f"z-noise-{i}.md"
+        f.write_text("Dana Okafor filler.\n")
+        _os.utime(f, ns=(same * 10**9, same * 10**9))
+    ans = q / "output" / "a-the-answer.md"
+    ans.write_text("Dana Okafor ANSWER one.\nDana Okafor ANSWER two.\nDana Okafor ANSWER three.\n")
+    _os.utime(ans, ns=(same * 10**9, same * 10**9))
+    b = run(root, "what do we know about Dana Okafor")
+    docs = items_of(b, kind="doc")
+    assert docs and "a-the-answer.md" in docs[0]["src"], [i["src"] for i in docs]
+    assert [i["src"].rsplit(":", 1)[-1] for i in docs[:3]] == ["1", "2", "3"], "lines of one file stay in file order"
+    newer = q / "output" / "b-newer.md"
+    newer.write_text("Dana Okafor newer.\n")
+    _os.utime(newer, ns=((same + 60) * 10**9, (same + 60) * 10**9))
+    b2 = run(root, "what do we know about Dana Okafor")
+    assert "b-newer.md" in items_of(b2, kind="doc")[0]["src"], "a file one minute newer on the same date wins"
 
 
 # ---------------------------------------------------------------- the hook

--- a/q-system/.q-system/scripts/test_knowledge_supply.py
+++ b/q-system/.q-system/scripts/test_knowledge_supply.py
@@ -949,7 +949,7 @@ def test_store_named_in_prompt_scopes_to_that_store(tmp_path):
     b = run(root, "what do we know about foo bar")
     assert b is not None
     ents = {e["name"]: e for e in b["entities"]}
-    assert "foo bar" in ents and ents["foo bar"]["kind"] == "store" and ents["foo bar"]["store"] == "case-001-foo-bar"
+    assert "foo bar" in ents and ents["foo bar"]["kind"] == "store" and ents["foo bar"]["stores"] == ["case-001-foo-bar"]
     srcs = [i["src"] for i in b["items"]]
     assert any("investigations/case-001-foo-bar/canonical/scope.md:5" in s for s in srcs), srcs
     assert any("investigations/case-001-foo-bar/investigation/findings/finding-001.md:5" in s for s in srcs), srcs
@@ -1128,6 +1128,85 @@ def test_dropped_candidates_are_named_in_the_receipt(tmp_path):
     b = run(root, "what do we know about Dana Okafor and the Facebook profiles")
     assert b is not None and not any(e["name"] == "Facebook" for e in b["entities"])
     assert b["receipt"]["candidates_dropped"] == [{"candidate": "Facebook", "stores": 6}]
+
+
+# PR #308 review round 1: the reviewer's executed reproducers, kept as tests.
+
+def test_same_subject_in_two_cases_searches_both(tmp_path):
+    root, q = make_instance(tmp_path)
+    add_store(q, "case-010-lapsus", "scope", "LAPSUS first engagement: server in Rio.")
+    add_store(q, "case-041-lapsus", "scope", "LAPSUS second engagement: server in Oslo.")
+    b = run(root, "what do we know about lapsus")
+    ent = next(e for e in b["entities"] if e["kind"] == "store")
+    assert ent["stores"] == ["case-010-lapsus", "case-041-lapsus"]
+    srcs = [i["src"] for i in b["items"]]
+    assert any("case-010-lapsus" in s for s in srcs) and any("case-041-lapsus" in s for s in srcs), srcs
+    assert receipt_row(b, "docs")["stores_searched"] == 3
+    assert "case-010-lapsus, case-041-lapsus" in ks.render(b).splitlines()[0]
+
+
+def _graph(path: Path, rows: list[dict]) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    with open(path, "w") as f:
+        for r in rows:
+            f.write(json.dumps(r) + "\n")
+
+
+def test_alias_asserted_in_one_case_never_rewrites_another(tmp_path):
+    root, q = make_instance(tmp_path)
+    a = add_store(q, "case-010-alpha", "scope", "alpha finding")
+    b_ = add_store(q, "case-020-bravo", "scope", "bravo finding")
+    _graph(a / "memory" / "graph.jsonl", [
+        {"s": "Widget Corp", "p": "alias_of", "o": "Zeta Holdings", "t": "2026-09-01"},
+        {"s": "Zeta Holdings", "p": "status", "o": "under sanctions", "t": "2026-09-02"},
+    ])
+    _graph(b_ / "memory" / "graph.jsonl", [
+        {"s": "Widget Corp", "p": "status", "o": "clean, no findings", "t": "2026-09-03"},
+    ])
+    b = run(root, "what do we know about Widget Corp")
+    names = {e["name"]: e for e in b["entities"]}
+    assert "Widget Corp" in names, "a name another case contributed on its own survives the alias edge"
+    assert "Zeta Holdings" in names and names["Zeta Holdings"]["via_alias"] == "Widget Corp"
+    assert names["Zeta Holdings"]["alias_stores"] == {"Widget Corp": ["case-010-alpha"]}
+    widget = items_of(b, entity="Widget Corp")
+    zeta = items_of(b, entity="Zeta Holdings")
+    assert widget and all("case-020-bravo" in i["src"] for i in widget), [i["src"] for i in widget]
+    assert zeta and all("case-010-alpha" in i["src"] for i in zeta), [i["src"] for i in zeta]
+    assert not any("clean, no findings" in i["text"] for i in zeta), "case-020's line never lands under Zeta"
+    assert "(via alias Widget Corp: case-010-alpha)" in ks.render(b).splitlines()[0]
+
+
+def test_project_level_alias_still_applies_everywhere(tmp_path):
+    root, q = make_instance(tmp_path)   # the fixture graph has "DO alias_of Dana Okafor" at the project level
+    add_store(q, "case-001-foo-bar", "DO briefed the Foo Bar victim list.", "finding")
+    b = run(root, "what do we know about Dana Okafor")
+    hits = [i for i in items_of(b, kind="canonical", entity="Dana Okafor") if "case-001-foo-bar" in i["src"]]
+    assert hits and hits[0]["text"] == "DO briefed the Foo Bar victim list.", "a project-level alias reaches every case"
+
+
+def test_deadline_on_the_first_required_class_is_not_full(tmp_path):
+    root, q = make_instance(tmp_path)
+    (q / ".q-system" / "data").mkdir()
+    shutil.copy(INVESTIGATION_MANIFEST, q / ".q-system" / "data" / "knowledge-sources.json")
+    add_store(q, "case-001-foo-bar", "scope", "Dana Okafor briefed the Foo Bar victim list yesterday.")
+    b = run(root, "what happened yesterday with Dana Okafor", deadline_s=0)
+    assert b is not None and b["task_class"] == "temporal_event"
+    assert b["coverage"]["verdict"] != "FULL", b["coverage"]
+    assert "docs" in b["coverage"]["missing"]
+    row = receipt_row(b, "docs")
+    assert row["searched"] is False and row["stores_searched"] == 0 and row["problem"] == "not searched (deadline)"
+
+
+def test_receipt_says_when_the_corpus_common_rule_cannot_run(tmp_path):
+    root, q = make_bare_instance(tmp_path)
+    for i in range(8):
+        (q / "output" / f"r{i}.md").write_text("Bluepeak again.\n")
+    b = run(root, "what did Bluepeak ask for")
+    assert b["receipt"]["candidate_rule"] == {"max_stores": 4, "applicable": False, "note": "single store: rule cannot run"}
+    root2, q2 = make_instance(tmp_path)
+    add_store(q2, "case-001-foo-bar", "scope", "x")
+    b2 = run(root2, "what do we know about Dana Okafor")
+    assert b2["receipt"]["candidate_rule"]["applicable"] is True
 
 
 # ---------------------------------------------------------------- the hook

--- a/q-system/.q-system/scripts/test_knowledge_supply.py
+++ b/q-system/.q-system/scripts/test_knowledge_supply.py
@@ -1339,6 +1339,39 @@ def test_docs_order_is_file_time_then_mentions_never_path(tmp_path):
     assert "b-newer.md" in items_of(b2, kind="doc")[0]["src"], "a file one minute newer on the same date wins"
 
 
+# PR #308 review round 5: unreadable anywhere in scope is never FULL; a candidate stays case-sensitive.
+
+def test_unreadable_copy_in_one_store_is_never_full(tmp_path):
+    root, q = make_instance(tmp_path)
+    s = add_store(q, "case-045-zeta", "scope", "finding")
+    _graph(s / "memory" / "graph.jsonl", [{"s": "Dana Okafor", "p": "status", "o": "sanctioned in zeta", "t": "2026-09-05"}])
+    ok = run(root, "what do we know about Dana Okafor")
+    assert ok["coverage"]["verdict"] == "FULL", "control: a readable case graph is FULL"
+    (s / "memory" / "graph.jsonl").write_text('{"s": "Dana Okafor", "p": "status", "o": "sanct\n')   # a killed writer
+    b = run(root, "what do we know about Dana Okafor")
+    assert b["coverage"]["verdict"] != "FULL", b["coverage"]
+    assert b["coverage"]["missing_paths"]["graph"].endswith("unreadable in case-045-zeta")
+    row = receipt_row(b, "graph")
+    assert row["present"] is True and row["searched"] == "partial" and "case-045-zeta: unreadable" in row["problem"]
+    assert "unreadable in case-045-zeta" in ks.render(b).splitlines()[0], "the header, not only the receipt, says it"
+    # the mirror image: the PROJECT graph corrupt, one healthy case, still never FULL
+    (s / "memory" / "graph.jsonl").write_text(json.dumps({"s": "Dana Okafor", "p": "owns", "o": "zeta", "t": "2026-09-05"}) + "\n")
+    (q / "memory" / "graph.jsonl").write_text("{not json\n{still not\n")
+    b2 = run(root, "what do we know about Dana Okafor")
+    assert b2["coverage"]["verdict"] != "FULL" and "unreadable in project" in b2["coverage"]["missing_paths"]["graph"]
+
+
+def test_docs_candidate_stays_case_sensitive_in_every_resolver(tmp_path):
+    root, q = make_bare_instance(tmp_path)
+    (q / "canonical" / "client-profile.md").write_text("# Client\n\nthe bluepeak channel is closed for now.\n")
+    b = run(root, "what did Bluepeak ask for")
+    ent = next(e for e in b["entities"] if e["name"] == "Bluepeak")
+    assert ent["case_sensitive"] is True
+    texts = [i["text"] for i in b["items"]]
+    assert "Bluepeak asked for a name column on the intake form." in texts
+    assert not any("bluepeak channel" in t for t in texts), texts
+
+
 # ---------------------------------------------------------------- the hook
 
 def run_hook(root: Path, prompt: str, extra_env: dict | None = None) -> subprocess.CompletedProcess:

--- a/q-system/.q-system/scripts/test_knowledge_supply.py
+++ b/q-system/.q-system/scripts/test_knowledge_supply.py
@@ -1285,7 +1285,8 @@ def test_same_name_in_two_cases_renders_one_block_per_case(tmp_path):
     assert "\n== John Smith ==\n" not in out, "no project-level block when the project has nothing"
     alpha = out.index("[case-010-alpha] ==")
     bravo = out.index("[case-020-bravo] ==")
-    assert out.index("the victim in alpha") > alpha and out.index("the victim in alpha") < bravo
+    assert bravo < alpha, "the newer case (2026-09-02) renders first (PR #308 review round 8)"
+    assert out.index("the victim in alpha") > alpha and out.index("the suspect in bravo") > bravo and out.index("the suspect in bravo") < alpha
     assert all(i["status"] == "KNOWN" for i in items_of(b, kind="graph")), "a case never supersedes another case"
 
 
@@ -1470,7 +1471,7 @@ def test_scoped_search_names_what_it_left_out(tmp_path):
     assert b["coverage"]["scope"] == ["case-031-payment-fraud"]
     assert b["coverage"]["stores_excluded"] == ["case-001-thing-1", "case-002-thing-2", "case-003-thing-3"]
     head = ks.render(b).splitlines()[0]
-    assert "scope: case-031-payment-fraud + project (3 other stores not searched)" in head, head
+    assert "WITHIN SCOPE case-031-payment-fraud + project only; 3 other stores not searched" in head, head
     assert b["receipt"]["stores_excluded"] == b["coverage"]["stores_excluded"]
     b2 = run(root, "what do we know about Dana Okafor")
     assert b2["coverage"]["scope"] == [] and "scope:" not in ks.render(b2).splitlines()[0]
@@ -1488,6 +1489,98 @@ def test_corpus_common_rule_declares_itself_inapplicable_when_the_candidate_pass
     assert rule["applicable"] is False and "candidate pass truncated" in rule["note"], rule
     assert b["receipt"]["candidates_dropped"] == [], "a count over a cut hit set is not a count"
     assert any(e["name"] == "Wachovia Trust" for e in b["entities"]), "admitted, and the receipt says the rule did not run"
+
+
+# PR #308 review round 8: no store is dropped whole by the ceiling; cases order newest first; a target scopes.
+
+def test_every_store_with_a_hit_keeps_one_line_under_the_ceiling(tmp_path):
+    """A newest store with a lot to say cannot starve the others of their one line."""
+    root, q = make_instance(tmp_path)
+    big = add_store(q, "case-003-charlie", "scope", "nothing about anyone")
+    # inside the per-store caps (12 graph, 6 docs) and still past the ceiling on its own
+    _graph(big / "memory" / "graph.jsonl", [{"s": "Satoshi Nakamoto", "p": "owns", "o": f"thing {k} " + "x" * 540, "t": "2026-09-03"} for k in range(12)])
+    (big / "investigation" / "findings" / "flood.md").write_text("".join(f"Satoshi Nakamoto note {k} " + "y" * 420 + "\n" for k in range(6)))
+    for i in (1, 2):
+        s = add_store(q, f"case-00{i}-alpha{i}", "scope", "nothing about anyone")
+        _graph(s / "memory" / "graph.jsonl", [{"s": "Satoshi Nakamoto", "p": "owns", "o": f"older thing {i}", "t": f"2026-08-0{i}"}])
+    b = run(root, "what do we know about Satoshi Nakamoto")
+    assert b["budget"]["cut"] > 0, "the ceiling must actually bite for this test to mean anything"
+    assert {i.get("store") for i in b["items"]} >= {"case-001-alpha1", "case-002-alpha2", "case-003-charlie"}
+    assert b["budget"]["stores_cut"] == [] and "CEILING:" not in ks.render(b)
+    assert ks.render(b).splitlines()[2] == "== Satoshi Nakamoto [case-003-charlie] ==", "newest store first"
+    assert len(ks.render(b)) <= 8000, "block headings are inside the budget now"
+
+
+def test_ceiling_keeps_the_newest_stores_and_names_the_cut(tmp_path):
+    """The reviewer's shape: 60 cases mention the subject, the answer is the only
+    line in the newest one. Under the ceiling the newest cases survive, the
+    oldest are cut, and the cut ones are named on the wire."""
+    root, q = make_instance(tmp_path)
+    for i in range(1, 60):
+        s = add_store(q, f"case-{i:03d}-alpha{i:02d}", "scope", "nothing about anyone")
+        day = f"2026-{7 + i // 28:02d}-{i % 28 + 1:02d}"
+        _graph(s / "memory" / "graph.jsonl", [{"s": "Satoshi Nakamoto", "p": "owns", "o": f"thing {i} " + "x" * 90, "t": day}])
+    add_store(q, "case-060-alpha60", "scope", "Satoshi Nakamoto ANSWER lives here.")
+    b = run(root, "what do we know about Satoshi Nakamoto")
+    assert any("ANSWER lives here" in i["text"] for i in b["items"]), "the newest case reaches the model"
+    assert ks.render(b).splitlines()[2] == "== Satoshi Nakamoto [case-060-alpha60] =="
+    cut_stores = b["budget"]["stores_cut"]
+    assert cut_stores, "60 lines of this size cannot fit 8,000 chars; something must be cut"
+    kept_nums = {int(i["store"].split("-")[1]) for i in b["items"] if i.get("store", "").startswith("case-")}
+    cut_nums = {int(s.split("-")[1]) for s in cut_stores}
+    assert max(cut_nums) < min(kept_nums), (sorted(cut_nums)[-3:], sorted(kept_nums)[:3])
+    assert f"CEILING: {len(cut_stores)} store(s) with hits reached you with nothing: " in ks.render(b)
+    assert b["receipt"]["stores_cut"] == cut_stores and len(ks.render(b)) <= 8000
+
+
+def test_a_store_cut_by_the_ceiling_is_named(tmp_path, monkeypatch):
+    root, q = make_instance(tmp_path)
+    for i in range(1, 4):
+        s = add_store(q, f"case-00{i}-alpha{i}", "scope", "Dana Okafor " + "y" * 300 + f" {i}.")
+    b = run(root, "what do we know about Dana Okafor")
+    bundle_items = list(b["items"])
+    kept = [i for i in bundle_items if (i.get("store") or "project") != "case-003-alpha3"]
+    assert ks.stores_cut_by_ceiling(bundle_items, kept) == ["case-003-alpha3"]
+    b["budget"]["stores_cut"] = ["case-003-alpha3"]
+    assert "CEILING: 1 store(s) with hits reached you with nothing: case-003-alpha3" in ks.render(b)
+
+
+def test_target_stem_scopes_to_the_declaring_case(tmp_path):
+    root, q = make_instance(tmp_path)
+    for i in range(1, 7):
+        add_store(q, f"case-00{i}-alpha{i}", "scope", f"Miami appears in case {i}.")
+    t = q / "investigations" / "case-001-alpha1" / "investigation" / "targets" / "miami.md"
+    t.write_text("# miami\n\nMiami target notes.\n")
+    b = run(root, "what do we know about miami")
+    ent = next(e for e in b["entities"] if e["kind"] == "target")
+    assert ent["stores"] == ["case-001-alpha1"]
+    assert b["coverage"]["scope"] == ["case-001-alpha1"] and len(b["coverage"]["stores_excluded"]) == 5
+    assert all("case-001-alpha1" in i["src"] or "/q-fix/" in i["src"] for i in b["items"]), [i["src"] for i in b["items"]]
+    assert "[target of case-001-alpha1]" in ks.render(b).splitlines()[0]
+
+
+def test_unreadable_handoff_is_filed_under_handoff(tmp_path):
+    root, q = make_instance(tmp_path)
+    (q / "memory" / "last-handoff.md").chmod(0)
+    try:
+        b = run(root, "what do we know about Dana Okafor")
+    finally:
+        (q / "memory" / "last-handoff.md").chmod(0o644)
+    row = receipt_row(b, "handoff")
+    assert row["problem"] and "last-handoff" in row["problem"] and row["present"] is False, row   # unreadable, the way a ledger is
+    assert receipt_row(b, "canonical")["problem"] is None and receipt_row(b, "canonical")["present"] is True
+
+
+def test_store_recency_beats_case_number(tmp_path):
+    """An older-numbered case with newer activity renders before a newer-numbered
+    quiet one; the case number is only the tie-break for a fresh checkout."""
+    root, q = make_instance(tmp_path)
+    a = add_store(q, "case-001-alpha", "scope", "nothing")
+    b_ = add_store(q, "case-050-bravo", "scope", "nothing")
+    _graph(a / "memory" / "graph.jsonl", [{"s": "Satoshi Nakamoto", "p": "owns", "o": "fresh work", "t": "2026-09-01"}])
+    _graph(b_ / "memory" / "graph.jsonl", [{"s": "Satoshi Nakamoto", "p": "owns", "o": "old work", "t": "2026-07-01"}])
+    heads = [l for l in ks.render(run(root, "what do we know about Satoshi Nakamoto")).splitlines() if l.startswith("== ")]
+    assert heads[0] == "== Satoshi Nakamoto [case-001-alpha] ==", heads
 
 
 # ---------------------------------------------------------------- the hook

--- a/q-system/.q-system/scripts/test_knowledge_supply.py
+++ b/q-system/.q-system/scripts/test_knowledge_supply.py
@@ -1583,6 +1583,60 @@ def test_store_recency_beats_case_number(tmp_path):
     assert heads[0] == "== Satoshi Nakamoto [case-001-alpha] ==", heads
 
 
+# PR #308 review round 9: a named case wins over a shared target; the scope note is bounded; absent = never searched.
+
+def _three_cases_sharing_a_target(q):
+    for name, line in (("case-001-alpha", "Acme wired ALPHA-ONLY to the shell company"),
+                       ("case-002-beta", "Acme wired BETA-ONLY to the shell company"),
+                       ("case-003-gamma", "Acme wired GAMMA-ONLY to the shell company")):
+        s = add_store(q, name, "scope", line)
+        (s / "investigation" / "targets" / "acme.md").write_text("# acme\n")
+
+
+def test_named_case_wins_over_a_target_shared_by_other_cases(tmp_path):
+    root, q = make_instance(tmp_path)
+    _three_cases_sharing_a_target(q)
+    b = run(root, "in beta, what did acme do")
+    assert b["coverage"]["scope"] == ["case-002-beta"], b["coverage"]
+    assert b["coverage"]["stores_excluded"] == ["case-001-alpha", "case-003-gamma"]
+    texts = [i["text"] for i in b["items"]]
+    assert any("BETA-ONLY" in t for t in texts) and not any("ALPHA-ONLY" in t or "GAMMA-ONLY" in t for t in texts), texts
+
+
+def test_target_shared_by_many_cases_scopes_to_all_of_them_when_none_is_named(tmp_path):
+    root, q = make_instance(tmp_path)
+    _three_cases_sharing_a_target(q)
+    b = run(root, "what did acme do")
+    assert b["coverage"]["scope"] == ["case-001-alpha", "case-002-beta", "case-003-gamma"]
+    assert b["coverage"]["stores_excluded"] == []
+    assert "WITHIN SCOPE" not in ks.render(b), "nothing excluded, nothing disclosed, no budget spent"
+    texts = [i["text"] for i in b["items"]]
+    assert all(any(k in t for t in texts) for k in ("ALPHA-ONLY", "BETA-ONLY", "GAMMA-ONLY"))
+
+
+def test_scope_note_is_bounded(tmp_path):
+    root, q = make_instance(tmp_path)
+    for i in range(1, 10):
+        s = add_store(q, f"case-00{i}-thing{i}", "scope", f"Acme in case {i}")
+        if i <= 8:
+            (s / "investigation" / "targets" / "acme.md").write_text("# acme\n")
+    b = run(root, "what did acme do")
+    assert len(b["coverage"]["scope"]) == 8 and b["coverage"]["stores_excluded"] == ["case-009-thing9"]
+    head = ks.render(b).splitlines()[0]
+    assert "and 2 more + project only; 1 other store not searched" in head, head
+    scope_clause = head.split("WITHIN SCOPE", 1)[1].split("+ project", 1)[0]
+    assert scope_clause.count("case-00") == 6, scope_clause
+    assert "[target of case-001-thing1, case-002-thing2, case-003-thing3, case-004-thing4, case-005-thing5, case-006-thing6 and 2 more]" in head, head
+
+
+def test_absent_class_is_never_searched_in_the_receipt(tmp_path):
+    root, q = make_bare_instance(tmp_path)
+    b = run(root, "what did Bluepeak ask for")
+    for cls in ("graph", "commitments", "meetings", "loops"):
+        row = receipt_row(b, cls)
+        assert row["present"] is False and row["searched"] is False and row["stores_searched"] == 0, row
+
+
 # ---------------------------------------------------------------- the hook
 
 def run_hook(root: Path, prompt: str, extra_env: dict | None = None) -> subprocess.CompletedProcess:

--- a/q-system/.q-system/scripts/test_knowledge_supply.py
+++ b/q-system/.q-system/scripts/test_knowledge_supply.py
@@ -1046,6 +1046,17 @@ def test_docs_engines_agree_on_the_per_file_cap_and_both_report_it(tmp_path, mon
     b = run(root, "what do we know about Dana Okafor")
     row = receipt_row(b, "docs")
     assert row["searched"] == "partial" and "file cap" in row["problem"], row
+    # exactly the cap is NOT a truncation (PR #308 review round 7 minor 4)
+    (q / "output" / "flood.md").write_text("".join(f"Dana Okafor line {i}\n" for i in range(ks.GREP_MAX_PER_FILE)))
+    project2, subs2, _ = ks.load_all_stores(q, root, manifest)
+    g2, e2 = ks.search_docs(project2["doc_files"], ["Dana Okafor"], ignore_case=True, word=False, deadline=dt.datetime.now().timestamp() + 5)
+    assert len(g2) == ks.GREP_MAX_PER_FILE and e2 == "grep", (len(g2), e2)
+    monkeypatch.setattr(ks.shutil, "which", lambda name: None)
+    p2, pe2 = ks.search_docs(project2["doc_files"], ["Dana Okafor"], ignore_case=True, word=False, deadline=dt.datetime.now().timestamp() + 5)
+    assert len(p2) == ks.GREP_MAX_PER_FILE and pe2 == "python", (len(p2), pe2)
+    monkeypatch.undo()
+    b2 = run(root, "what do we know about Dana Okafor")
+    assert receipt_row(b2, "docs")["searched"] is True
 
 
 def test_prompt_proper_noun_with_doc_hits_becomes_entity(tmp_path):
@@ -1133,7 +1144,9 @@ def test_corpus_common_word_is_dropped_unless_a_store_is_named(tmp_path):
     root, q = make_instance(tmp_path)
     for i in range(1, 7):
         add_store(q, f"case-00{i}-thing-{i}", "scope", f"Facebook profile checked in case {i}.")
-    assert run(root, "update on the Facebook profiles", record=True) is None, "a word in 6 of 6 cases is not a subject"
+    b0 = run(root, "update on the Facebook profiles", record=True)
+    assert b0 is not None and b0["items"] == [] and "corpus-common" in ks.render(b0) and "Facebook (6 stores)" in ks.render(b0), \
+        "a word in 6 of 6 cases is not a subject, and the hook still says it searched (round 7 minor 5)"
     rows = [json.loads(l) for l in (q / "memory" / ".knowledge-supply-misses.jsonl").read_text().splitlines()]
     assert any(r["candidate"] == "Facebook" and r["shape"] == "corpus_common" and r["stores"] == 6 for r in rows), rows
     b = run(root, "in thing 2, what did the Facebook profiles show")
@@ -1413,6 +1426,68 @@ def test_named_store_survives_the_longest_name_rule(tmp_path):
     assert any(e["kind"] == "store" and e["stores"] == ["case-010-zeta"] for e in b["entities"]), b["entities"]
     srcs = [i["src"] for i in b["items"]]
     assert srcs and not any("case-020-other" in s for s in srcs), srcs
+
+
+# PR #308 review round 7: docs read failures are counted; a scoped search says so; the rule declares itself.
+
+def test_unreadable_doc_files_are_counted_and_an_all_failed_store_degrades(tmp_path, monkeypatch):
+    root, q = make_instance(tmp_path)
+    (q / ".q-system" / "data").mkdir()
+    shutil.copy(INVESTIGATION_MANIFEST, q / ".q-system" / "data" / "knowledge-sources.json")
+    s = add_store(q, "case-001-foo-bar", "scope", "Dana Okafor briefed the Foo Bar victim list.")
+    (q / "output" / "ok.md").write_text("Dana Okafor ok\n")
+    only = s / "investigation" / "findings" / "finding-001.md"
+    for engine_off in (False, True):
+        if engine_off:
+            monkeypatch.setattr(ks.shutil, "which", lambda name: None)
+        only.chmod(0)
+        try:
+            b = run(root, "what do we know about Dana Okafor")
+        finally:
+            only.chmod(0o644)
+        row = receipt_row(b, "docs")
+        assert row["problem"] and "1 of 1 doc file(s) unreadable" in row["problem"], row
+        assert row["searched"] == "partial" and "case-001-foo-bar" in b["coverage"]["missing_paths"].get("docs", ""), b["coverage"]
+        assert b["coverage"]["verdict"] != "FULL"
+    # one unreadable among readable ones in the SAME store: recorded, never PARTIAL
+    (q / "output" / "bad.md").write_text("Dana Okafor bad\n")
+    (q / "output" / "bad.md").chmod(0)
+    only.chmod(0o644)
+    try:
+        b2 = run(root, "what do we know about Dana Okafor")
+    finally:
+        (q / "output" / "bad.md").chmod(0o644)
+    row2 = receipt_row(b2, "docs")
+    assert "1 of 2 doc file(s) unreadable" in (row2["problem"] or "") and row2["searched"] is True, row2
+
+
+def test_scoped_search_names_what_it_left_out(tmp_path):
+    root, q = make_instance(tmp_path)
+    for i in (1, 2, 3):
+        add_store(q, f"case-00{i}-thing-{i}", "scope", f"Dana Okafor fact {i}.")
+    add_store(q, "case-031-payment-fraud", "scope", "nothing here")
+    b = run(root, "for the payment fraud workstream, what do we know about Dana Okafor")
+    assert b["coverage"]["scope"] == ["case-031-payment-fraud"]
+    assert b["coverage"]["stores_excluded"] == ["case-001-thing-1", "case-002-thing-2", "case-003-thing-3"]
+    head = ks.render(b).splitlines()[0]
+    assert "scope: case-031-payment-fraud + project (3 other stores not searched)" in head, head
+    assert b["receipt"]["stores_excluded"] == b["coverage"]["stores_excluded"]
+    b2 = run(root, "what do we know about Dana Okafor")
+    assert b2["coverage"]["scope"] == [] and "scope:" not in ks.render(b2).splitlines()[0]
+
+
+def test_corpus_common_rule_declares_itself_inapplicable_when_the_candidate_pass_truncated(tmp_path, monkeypatch):
+    root, q = make_instance(tmp_path)
+    for i in range(1, 7):
+        add_store(q, f"case-00{i}-thing-{i}", "scope", "Wachovia Trust checked here.")
+    # Six stores, one line each, cap five: the cut hit set still spans five stores,
+    # so a rule applied over it WOULD drop the candidate; the correct code does not.
+    monkeypatch.setattr(ks, "MAX_DOC_HITS", 5)
+    b = run(root, "what do we know about Wachovia Trust and Dana Okafor")
+    rule = b["receipt"]["candidate_rule"]
+    assert rule["applicable"] is False and "candidate pass truncated" in rule["note"], rule
+    assert b["receipt"]["candidates_dropped"] == [], "a count over a cut hit set is not a count"
+    assert any(e["name"] == "Wachovia Trust" for e in b["entities"]), "admitted, and the receipt says the rule did not run"
 
 
 # ---------------------------------------------------------------- the hook

--- a/q-system/.q-system/scripts/test_knowledge_supply.py
+++ b/q-system/.q-system/scripts/test_knowledge_supply.py
@@ -161,7 +161,8 @@ def items_of(bundle, kind=None, entity=None):
     if kind:
         out = [i for i in out if i["kind"] == kind]
     if entity:
-        out = [i for i in out if i["entity"] == entity]
+        # a merged heading ("== A, B ==") carries B in co_entities (round 11)
+        out = [i for i in out if i["entity"] == entity or entity in (i.get("co_entities") or [])]
     return out
 
 
@@ -1116,6 +1117,8 @@ def test_shipped_manifests_declare_project_folders():
     assert any(s["glob"] == "investigations/case-*" for s in m["stores"])
     assert {"output", "investigation", "research"} <= set(m["folders"])
     assert {"targets", "clients"} <= set(m["entity_dirs"])
+    assert {"exports", "screenshots", "raw-collections"} <= set(m["skip_dirs"]), "skips are declared, never hardcoded"
+    assert set(inv_skip := json.loads(INVESTIGATION_MANIFEST.read_text())["skip_dirs"]) >= {"raw-collections"}
     assert {"store", "target", "noun"} <= set(m["entity_kinds_that_fire_alone"])
     for cls, spec in m["classes"].items():
         assert "docs" in spec["sources"], cls
@@ -1688,6 +1691,53 @@ def test_receipts_ledger_is_bounded(tmp_path, monkeypatch):
     assert path.stat().st_size <= 4000 * 2, path.stat().st_size   # one row may land before the trim
     rows = [json.loads(l) for l in path.read_text().splitlines()]
     assert 1 <= len(rows) < 12 and all("sources" in r for r in rows)
+
+
+# PR #308 review round 11: consumed bigram halves; declared skips disclosed; identical blocks collapse.
+
+def test_suppressed_bigram_half_is_never_a_candidate(tmp_path):
+    root, q = make_instance(tmp_path)
+    add_store(q, "case-023-shinyhunters", "scope", "ShinyHunters hit the CRM vendor.")
+    (q / "output" / "others.md").write_text("The Lapsus Crew was dormant all quarter.\nA different Crew filed the takedown request.\n")
+    b = run(root, "what do we know about ShinyHunters Crew")
+    names = [e["name"] for e in b["entities"]]
+    assert "shinyhunters" in names and "Crew" not in names, names
+    assert not any("Lapsus" in i["text"] or "takedown" in i["text"] for i in b["items"]), [i["text"] for i in b["items"]]
+
+
+def test_declared_skips_are_counted_and_disclosed(tmp_path):
+    root, q = make_instance(tmp_path)
+    s = add_store(q, "case-001-foo-bar", "scope", "Dana Okafor briefed the Foo Bar victim list.")
+    (s / "investigation" / "raw-collections").mkdir()
+    (s / "investigation" / "raw-collections" / "dump.md").write_text("Dana Okafor controls the wallet.\n")
+    (q / "output" / "big.md").write_text("Dana Okafor pilot is cancelled\n" + "x" * 600_000)
+    b = run(root, "what do we know about Dana Okafor")
+    row = receipt_row(b, "docs")
+    assert row["files_skipped_oversize"] == 1 and row["dirs_skipped"] == 1
+    assert row["dirs_skipped_sample"] == ["q-fix/investigations/case-001-foo-bar/investigation/raw-collections"]
+    head = ks.render(b).splitlines()[0]
+    assert "SKIPPED (declared): 1 file(s) over doc_max_bytes, 1 dir(s) in skip_dirs; the receipt lists them." in head, head
+    assert b["coverage"]["verdict"] == "FULL", "a declared exclusion is not a truncation"
+    texts = [i["text"] for i in b["items"]]
+    assert not any("controls the wallet" in t or "pilot is cancelled" in t for t in texts)
+    # tooling dirs stay silent
+    (q / "output" / "node_modules").mkdir()
+    (q / "output" / "node_modules" / "n.md").write_text("Dana Okafor node\n")
+    b2 = run(root, "what do we know about Dana Okafor")
+    assert receipt_row(b2, "docs")["dirs_skipped"] == 1
+
+
+def test_identical_blocks_collapse_into_one_heading(tmp_path):
+    root, q = make_instance(tmp_path)
+    _graph(q / "memory" / "graph.jsonl", GRAPH_ROWS + [
+        {"s": "Priya Raman", "p": "met", "o": "Tomas Lind", "t": "2026-08-20", "project": "v"},
+    ])
+    b = run(root, "what do we know about Priya Raman and Tomas Lind")
+    out = ks.render(b)
+    assert "== Priya Raman, Tomas Lind ==" in out, out
+    assert "== Tomas Lind ==" not in out
+    assert out.count("Priya Raman met Tomas Lind") == 1
+    assert [e["name"] for e in b["entities"]] == ["Priya Raman", "Tomas Lind"], "both still resolved"
 
 
 # ---------------------------------------------------------------- the hook


### PR DESCRIPTION
## What

Founder-directed 2026-09-05: every consulting project's reader reads that project's OWN folder, and each 4_points investigation is its own knowledge base. Measured before this: 4_points had 45 case folders and 1,475 markdown files no source class covered (index: 40 graph entities); one consulting instance had 83 files and an index of 0, so the reader never woke up there.

## How (all declared as data in `knowledge-sources.json`, version 2)

- **stores**: a glob of sub-directories, each a knowledge base with the qroot layout (default `investigations/case-*`). Naming one in the prompt scopes every other entity's search to it plus the project level; naming none searches all of them. Each excerpt's path names its case.
- **docs class**: the project's own markdown folders (`output`, `research`, `inputs`, `investigation`, `build`, `docs`, `notes`, `memory`), one BSD/GNU grep pass per prompt, Python fallback with a byte budget, verified by the same phrase rule the index uses. Renders last (graph beats canonical beats notes).
- **prompt-driven candidates**: a capitalized word the index cannot resolve is searched case-sensitively in the docs; a hit makes it an entity, a word found in more than four stores is corpus-common and dropped (named in the receipt and the misses ledger). Headings never index: the census across every 4_points case file was section labels.
- **index sources added**: the store's own name (`case-023-shinyhunters` -> `shinyhunters`), markdown stems under `targets/`-style dirs, `canonical/proper-nouns.txt` (the voice lint's curated list).
- **`knowledge-sources.investigation.json`**: the instance override for investigation-shaped instances; nothing consulting-shaped required, so the permanent PARTIAL stops. Copied to 4_points at `q-investigate/.q-system/data/knowledge-sources.json` (an instance-owned subtree the fleet updater never touches).

## Ran, not assumed

- `pytest test_knowledge_supply.py`: 71 passed (55 before, 16 new).
- Mutation pass, 8 deliberate breaks (no store scoping, heading skip off, grep never used, target stems from every dir, proper-noun comments indexed, big files not skipped, corpus-common rule off, lowercase accepted by both layers): caught 8 of 8.
- Live probes, `record=False`, on the real instances: 4_points "what do we know about shinyhunters" -> FULL, 17 items all from case-023, 176 ms cold / 76 ms warm (the first cut was 2.2 s: `rglob("*")` over 57,081 entries, replaced by a pruned walk). "in jennica pounds, what did we find about the Miami address" -> scoped to case-013, 742 ms. A consulting instance with no graph: "what did Marilyn ask for" -> 12 items via its proper-noun list, 45 ms. Another with documents only: resolved through the document search, 36 ms. The largest instance: unchanged FULL, graph first.
- Real hook path (`knowledge-inject.py`, `CLAUDE_PROJECT_DIR` = 4_points, no env overrides): FULL, manifest = the instance override, 188 ms.
- Deadline still honoured: `KNOWLEDGE_SUPPLY_DEADLINE_S=0.001` returns a bundle with `deadline_hit` after 59 ms.

## Not in this PR

- Consulting root (`ASK_AI_consultant`) stays out of the fleet sync until ASK-1238; it gets this on the next sync after that.
- Plan: `q-system/output/plans/knowledge-supply-project-folders-2026-09-05.md` (instance-local).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01E2ztwemKp2NXMK1hELmsBS
