### PR TITLE
docs: README leads with knowledge supply, seven diagrams, governance as the trust layer

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,63 +1,290 @@
-# The Kipi System
+# Kipi
 
-**Your AI brain. Externalized.**
+**Give your AI the right knowledge, at the moment it needs it.**
 
-It remembers everything you do. Then it becomes whatever you need.
+Kipi turns the scattered knowledge around your work into context that follows you across AI sessions: decisions, conversations, projects, people, commitments, lessons, documents, history.
 
-Today it might run as your chief of staff. Tomorrow your lawyer. Next week your investigator. Same system, different role, because it remembers every decision, every conversation, every project you've ever brought it.
+You do not have to remember which file holds something, or tell Claude what to read. Ask a question. Kipi works out what you are asking about, reads the sources that matter for that kind of question, and puts the evidence in front of the model before it answers. Then it tells you what it found, which file and line each piece came from, which sources were empty, and which ones it could not read.
 
-Most AI tools handle one job. This one handles every job you used to do yourself.
+The result is an AI that does not start from zero every conversation. Your brain, externalized, with the plumbing that gets the right memory into active thought.
 
-It runs in Claude Code. Plain markdown all the way down. No vector database, no embeddings, no black box. You read it with `cat`, search it with `rg`, version it with `git`.
-
----
-
-## What it actually does
-
-Three things, repeatedly.
-
-**Remembers.** Every conversation, decision, debrief, and artifact lives in plain markdown files. A new session reads them. The system arrives with full context of what you've been doing.
-
-**Reasons across.** Connections between projects, people, decisions, and patterns get logged in a knowledge graph (JSONL). When you ask a question, the system pulls from the right files automatically. Insights from one project apply to another without you wiring it.
-
-**Becomes any role.** The same skeleton can run as a chief of staff, a lawyer, a PM, an investigator, a content operator, a researcher. You configure what role each instance plays through a `canonical/` directory. The system adapts its behavior, voice, and outputs to the role.
+It runs in Claude Code. Plain markdown all the way down. No vector database, no black box. You can open every fact with `cat` and diff it with `git`.
 
 ---
 
-## Six real deployments
+## Memory is not useful if the AI never receives it
 
-Six instances running across one person's work right now. All six share the same skeleton. They differ only in their canonical content.
+Saving information is the easy part. The hard part is getting the right information to the model when it matters.
+
+Kipi's own history is the proof. Every store in the system had a writer and a hook guarding it. The fact graph refused to close a session if it had fallen behind. The commitment ledger dropped any promise it could not quote verbatim. The decision log refused an entry without a tag saying who decided. And nothing read any of it when a question arrived. A question naming a client got none of the client's facts. Careful storage, zero delivery.
+
+So Kipi treats knowledge as a supply chain. Capture. Organize. Retrieve. Deliver. Prove what was delivered.
+
+```mermaid
+flowchart LR
+    subgraph capture ["Capture"]
+        C1["a debrief after a conversation"]
+        C2["a handoff at session end"]
+        C3["a mistake, and why it happened"]
+    end
+    subgraph organize ["Organize"]
+        O1[("canonical: positioning, decisions, objections")]
+        O2[("a dated fact graph: people, companies, pushback")]
+        O3[("commitments, meetings, open follow-ups")]
+        O4[("lessons, shared across every copy")]
+    end
+    subgraph retrieve ["Retrieve"]
+        R["your question names a person,<br/>a project, or a kind of work"]
+    end
+    subgraph deliver ["Deliver"]
+        D["verbatim lines, each with<br/>file, line, date and status"]
+    end
+    subgraph prove ["Prove"]
+        P["a receipt per source: read, empty,<br/>unreadable or skipped.<br/>First line: FULL or PARTIAL"]
+    end
+    C1 --> O1
+    C1 --> O2
+    C2 --> O3
+    C3 --> O4
+    O1 --> R
+    O2 --> R
+    O3 --> R
+    O4 --> R
+    R --> D --> P
+```
+
+Ask about a person, and Kipi pulls their relationship history, the decisions that involved them, the commitments made to them, recent meetings, and the open follow-ups. Ask about a project, and a different set of sources becomes relevant. Ask it to build something, and the lessons from previous failures are placed in front of it before it starts.
+
+The model never has to remember to go looking.
+
+---
+
+## It knows when it does not know
+
+An empty search result is not proof that nothing exists. Most retrieval treats it that way.
+
+Kipi's supply step writes a receipt. Every source the question needed is recorded as read, empty, unreadable, or not searched because time ran out. The first line of what the model receives says `COVERAGE: FULL` or `COVERAGE: PARTIAL` and names what is missing.
+
+```mermaid
+flowchart TB
+    Q["ask about a client"] --> S{"each source the question needs"}
+    S -->|"read, has lines"| A["supplied verbatim, with file and line"]
+    S -->|"read, nothing there"| B["recorded: searched, empty"]
+    S -->|"file missing or corrupt"| C["recorded: could not read"]
+    S -->|"time ran out"| D["recorded: not searched"]
+    A --> F["COVERAGE: FULL"]
+    B --> F
+    C --> P["COVERAGE: PARTIAL, missing sources named"]
+    D --> P
+```
+
+So there is a difference between these two sentences, and the system says which one is true.
+
+"We searched the relevant sources and found nothing."
+
+"We could not read two of the sources that might hold the answer."
+
+Those should not produce the same confidence. Now they cannot.
+
+---
+
+## Why this is not search-and-paste
+
+Technical readers will file this under retrieval-augmented generation. The retrieval is the boring half. What Kipi cares about is what the retrieval knew.
+
+- Every excerpt is verbatim, with its file and line. There is no summarize step, because a summary is a copy that goes stale while the source moves.
+- Every fact carries a status: known, stale, conflicting, or unvalidated. The newest fact on a subject wins. The older one is marked stale, never deleted.
+- Every question leaves a receipt naming what was searched and what was not.
+- Every name in a question that the index could not resolve goes to a misses ledger. That ledger is the data the next improvement runs on.
+- Everything is a file. Open it, grep it, diff it, delete it.
+
+---
+
+## The more you work with it, the more useful its knowledge becomes
+
+It learns in two ways.
+
+**It learns about your world.** People, projects, decisions, preferences, relationships, commitments, terminology, history. A debrief after a conversation writes the facts. A handoff at the end of a session writes what tomorrow needs. Both are files, so both survive.
+
+**It learns from what went wrong.** When the system makes a mistake and you work out why, the lesson becomes durable knowledge supplied to future work. Kipi used to show the model a list of lesson titles and hope it opened one. It did not. It hit the exact failure one of those titles described. Now the relevant lesson bodies are placed in the prompt before the work starts. And where a script can catch the mistake, the lesson becomes a check that refuses it.
+
+```mermaid
+flowchart LR
+    subgraph world ["It learns about your world"]
+        DB["a debrief after a conversation"] --> G["a dated fact graph,<br/>newest fact wins"]
+        E["end of session"] --> HO["a handoff note, every claim<br/>labelled measured, stated or guessed"]
+    end
+    subgraph wrong ["It learns from what went wrong"]
+        M["a mistake, and why it happened"] --> L["a lesson, shared across every copy,<br/>client data scrubbed"]
+        M -. "when a script can catch it" .-> K["a check that refuses<br/>the same mistake"]
+    end
+    G -->|"a question naming someone"| S["the next session"]
+    HO -->|"session start"| S
+    L -->|"a request to build something"| S
+    K -->|"every action"| S
+```
+
+It grades itself too. A newer fact supersedes an older one. A handoff line says whether it was measured, stated or guessed. A memory that never gets opened stops being trusted. A source that could not be read is recorded, never assumed empty.
+
+Honest boundary: the lessons path proves the lesson entered the context. It cannot prove the model read it, or that it changed the work that followed. It is stronger than a promise, because a promise leaves no artifact. It is weaker than proof of application, and nothing here claims otherwise.
+
+---
+
+## What makes the knowledge trustworthy
+
+Everything above rests on one thing: the model receives files it cannot talk its way past. That takes machinery. Here is the machinery.
+
+```mermaid
+flowchart LR
+    F(["You"]) -->|"type"| CC["Claude Code session"]
+    CC <-->|"small scripts run on every action"| H["Guardrails"]
+    CC <-->|"reads and writes"| K[("Your knowledge:<br/>plain files on disk")]
+    CC <-->|"deterministic tools"| M["Local tool server"]
+    CC -->|"opens"| G["Pull requests + Linear issues"]
+    J["Scheduled jobs on your machine"] -->|"review, merge, report"| G
+    J --> K
+    S[("One template repo")] -->|"one command"| I["Many copies,<br/>one per project"]
+    I -. "each one is" .-> CC
+```
+
+You type into a Claude Code session. Before, during and after every action, small scripts
+called hooks run. They add context the AI would otherwise forget, they block actions that
+would break a rule, and they record what happened. The session reads and writes plain
+files that hold what you know. A local tool server gives the AI checks that return the
+same answer every time. Work leaves through pull requests and issues, where scheduled jobs
+review, merge and report without you in the loop. All of it lives in one template
+repository and is copied to every project you run.
+
+### The ideas underneath
+
+**1. Assume the AI is unreliable.** It invents facts, forgets what it read, agrees with
+whoever is talking, and says "done" before anything ran. Nothing here makes it accurate.
+Everything here makes its mistakes findable, so a wrong answer leaves a trail and a right
+one carries its evidence.
+
+**2. Files are receipts.** A chat transcript is folklore with a timestamp. A file can be
+opened tomorrow, searched by a script, diffed, and dated. If you told the system something
+and it did not make it into a file, it does not exist the next morning.
+
+**3. Guardrails, not reminders.** A reminder is a sentence the AI is supposed to remember.
+A guardrail is a script that runs whether or not anyone remembers. Anything a script can
+check is checked by a script that can say no.
+
+**4. You are never the next step.** Engineering signals go to a queue an agent drains. You
+decide three things: publish, spend, delete. Everything else has a machine that owns it.
+
+**5. One skeleton, many instances.** Improvements are made once and fanned out. Each copy
+keeps its own facts; the template owns the machinery.
+
+### What happens in one turn
+
+```mermaid
+sequenceDiagram
+    participant Y as You
+    participant S as Session
+    participant H as Hooks
+    participant A as AI
+    Y->>S: open a session
+    H-->>S: yesterday's handoff, open follow-ups, lessons learned, memories to doubt
+    Y->>S: ask a question
+    H-->>S: the facts behind any person or client you named, with a coverage line
+    H-->>S: your writing voice if you are drafting, the relevant lessons if you are building
+    S->>A: question plus that context
+    A->>S: wants to edit a file or run a command
+    alt a rule would break
+        H-->>A: refused, with the reason
+    else allowed
+        S->>S: the tool runs
+        H-->>A: findings on what was written, or nothing
+    end
+    A->>S: finishes
+    H-->>A: refused if the answer claims something never checked
+    H-->>S: commit the work, score the memories, log the effort
+```
+
+When you open a session, hooks put yesterday's handoff, your open follow-ups and the
+lessons the whole fleet has learned in front of the AI. When you ask something, they add
+the facts behind anyone you named, your writing voice if you are drafting, and the relevant
+lessons if you are building. Before a tool runs, a hook can refuse it. After a file is
+written, checks run on it. When the AI finishes, a last check can refuse the answer itself
+if it asserts something it never opened. Then the work is committed and the session is
+scored.
+
+### How work leaves without you
+
+```mermaid
+sequenceDiagram
+    participant D as A detector, or you
+    participant L as Linear
+    participant W as Worker
+    participant R as Reviewer
+    participant M as Merge
+    D->>L: an issue is filed and labelled
+    L->>L: triaged as worked, parked, or voided, with the reason recorded
+    W->>L: claims a ready issue, one agent at a time
+    W->>R: opens a pull request
+    R->>R: a fresh-eyes review, verdict posted as a status
+    alt changes requested
+        R-->>W: findings, each reproduced
+        W->>R: fixes, each with a test that fails without it
+    else approved
+        M->>M: checks green, merged automatically
+    end
+    M-->>L: issue closed with the command that proves it
+```
+
+Issues arrive from detectors or from you and are labelled so a machine-filed issue is
+distinguishable from a human one. A triage pass records a decision on each so the board
+does not only grow. A worker claims an issue under a lock, does the work on a branch and
+opens a pull request. A reviewer that has never seen the code reads the diff and posts a
+verdict. Fixes carry a test that fails without them. When every check is green, it merges
+itself. Red states have machine consumers. When they cannot cope, a ticket says so in an
+agent's queue, not yours.
+
+### One template, many copies
+
+```mermaid
+flowchart LR
+    SK[("kipi-system: the template")] -->|"kipi update"| U{"the updater"}
+    REG["a registry of every copy"] --> U
+    U -->|"preview first, approve once"| I1["Copy A: your chief of staff"]
+    U --> I2["Copy B: a client engagement"]
+    U --> I3["Copy C: an investigation"]
+    U -. "never touches" .-> OWN["each copy's own facts, contacts, memory"]
+    I1 -->|"git commit before and after"| RB["one-command rollback"]
+    I2 --> RB
+    I3 --> RB
+```
+
+Every project is a full copy with its own facts and the same machinery. The updater
+previews exactly what would be copied and removed per copy, waits for one approval, then
+fans the machinery out and leaves each copy's facts untouched. It commits before and after
+so any sync can be reverted alone. A copy with uncommitted work refuses the sync rather
+than committing someone else's changes.
+
+---
+
+## The roles it runs today
+
+Every copy shares the same skeleton and differs only in what it knows. Six roles are live right now.
 
 - **Chief of staff.** Tracks conversations, talk tracks, decisions, positioning. Drafts updates, debriefs, follow-ups.
 - **PM for a client engagement.** Coordinates multiple projects, logs every decision, drafts deliverables, tracks stakeholder context.
 - **Lawyer.** Generates separation packages, contract redlines, compliance memos. Citations to relevant code on every position.
-- **Investigator.** Manages active OSINT cases, evidence artifacts, published intel reports. Cross-platform source orchestration.
+- **Investigator.** Manages active OSINT cases, evidence artifacts, published intel reports.
 - **Operator for a consulting business.** Pipeline tracking, content cadence, deliverable production.
 - **Architect for itself.** Manages its own PRDs, issues, reviews. The system builds the system.
 
 ---
 
-## How memory compounds
+## The full explanation
 
-Three layers, time-aware.
-
-| Layer | What it holds | Lifecycle |
-|---|---|---|
-| **Working** | Active session notes, scratch work | Auto-cleaned after 48h |
-| **Canonical** | Decisions, positioning, frameworks that persist | Updated on every conversation, never auto-deleted |
-| **Graph** | Who/what/when triples linking entities across projects | Append-only |
-
-Insights flow upward. A pattern noticed in scratch notes gets promoted to weekly. A repeated weekly pattern becomes canonical. The system gets sharper the longer you run it.
-
----
-
-## Cross-instance memory
-
-Each deployment is its own instance with its own directory, canonical files, and graph. But instances can share state through a bridge directory.
-
-A real example: an investigation instance pulled positioning context from a separate strategy instance mid-task, and produced a synthesized advisory across two projects that had never been connected manually.
-
-That's not storage. That's compounding across role-specific deployments.
+A handbook is in review as [PR #306](https://github.com/assafkip/kipi-system/pull/306): six short pages for anyone, each with a
+drawing and a "what this means for you" section; fifteen deeper pages, one per part of the
+system, each with two drawings and every script listed with what it does and the mistake
+that made it exist; generated catalogs of every tool, hook, job and rule; and a coverage
+check that fails, naming the gap, if any part of the code is missing from the docs. It
+lands at `docs/README.md` when that review closes.
 
 ---
 
@@ -83,32 +310,10 @@ Optional. Most usage is just talking to the system in Claude Code.
 | `/q-draft` | Quick email, DM, or content draft in your voice |
 | `/q-engage` | Generate engagement on someone else's post |
 | `/q-research` | Citation-only research mode |
-| `/q-morning` | Build a daily action plan (full routine, optional) |
+| `/q-morning` | The day brief: one message with your calendar, mail needing an answer, and your board |
 | `/q-wrap` | End-of-day health check |
 | `/q-handoff` | Save context for next session |
-
----
-
-## Architecture
-
-```
-kipi-system/
-├── canonical/              # Source of truth, updated by every conversation
-│   ├── decisions.md
-│   ├── positioning.md
-│   ├── insights.md
-│   └── ...
-├── memory/
-│   ├── working/            # 48h scratch
-│   ├── weekly/             # 7-day rollups
-│   ├── monthly/            # Persistent
-│   └── graph.jsonl         # Entity-relationship triples
-├── output/                 # Generated artifacts (drafts, reports, schedules)
-├── plugins/                # MCP tools, hooks, skills
-└── .claude/                # Agents, rules, settings
-```
-
-Each instance you spin up has its own copy of this structure.
+| `/wiring-check` | End-of-task gate: prove every change is connected |
 
 ---
 
@@ -121,8 +326,8 @@ Works standalone with local files. Each integration adds capability.
 | Notion | CRM, project tracking |
 | Google Calendar | Meeting detection, auto-prep |
 | Gmail | Email monitoring |
-| Linear | Issue tracking, PRD workflow |
-| Slack | Notifications |
+| Linear | Issue tracking, the autonomous work queue |
+| Slack | The morning brief |
 | Chrome (DevTools MCP) | Web automation, LinkedIn |
 | Apify | X/Twitter scraping |
 | Reddit | Search and post tracking |
@@ -137,30 +342,12 @@ If you don't, you still get an AI that doesn't make you decide who to contact, w
 
 ---
 
-## How the AI stays focused
-
-The AI running this system has the same context-loss problems a human brain does. Research calls it "Lost in the Middle." In long conversations, LLMs forget instructions from earlier context, skip middle steps, and self-report completion without verifying.
-
-The system has guardrails for that.
-
-**Verification gates.** Scripts check output before claiming done.
-
-**Re-injected step requirements.** Each step's instructions get fresh context.
-
-**No self-authorized skipping.** The AI cannot decide on its own to skip steps.
-
-**Structured logs.** What was actually produced, not just "completed."
-
-Research basis: "Lost in the Middle" (Stanford), "LLMs Get Lost in Multi-Turn Conversation" (Laban et al. 2025).
-
----
-
 ## Security
 
 - `.env`, credentials, and key files blocked from read/write
 - PreToolUse hooks intercept dangerous operations
 - No secrets in committed files
-- `rm -rf`, `sudo`, `git push --force` denied by default
+- `rm -rf`, `sudo`, `git push --force` denied by default; the fleet-wide sync needs an out-of-band approval
 
 ---
 
@@ -170,4 +357,4 @@ I'm [Assaf Kipnis](https://www.linkedin.com/in/assafkipnis/). 12 years in threat
 
 Running a company solo with ADHD meant my brain couldn't hold everything it needed to hold. So I built a second one. It manages my work, writes in my voice, remembers what I forget, and compounds what I learn.
 
-Right now it runs as six different roles across my work. This repo is the general-purpose version. Fork it and teach it yours.
+Right now it runs as six roles across every copy of my work. This repo is the general-purpose version. Fork it and teach it yours.


### PR DESCRIPTION
## What

The public README, rewritten from the founder's feedback: lead with the thing people want (an AI that knows their work), then the hard problem (getting the right knowledge into the model on time), then the differentiator (a receipt naming what was searched, what was empty, what could not be read, FULL or PARTIAL), then the machinery that makes it true. Seven mermaid diagrams.

## Why a separate PR

main has zero diagrams. They lived on the handbook branch (PR #306), whose docs tooling is in its third review round with two majors parked as spillover (sp-c1c0464c, sp-c4d26576). The front page does not depend on that tooling. The handbook section here points at #306 and lands at `docs/README.md` when that closes.

## Evidence

- All 7 mermaid blocks parsed and rendered with mermaid 11 in a browser harness (playwright) before commit.
- Every claim traces to code on main: `knowledge_supply.py` (verbatim excerpts with path and line, per-source receipt, FULL/PARTIAL verdict, misses ledger) and `lessons-inject.py` (bodies on the prompt path, the titles scar).
- Six roles, not a deployment count the registry contradicts (Codex on #306, round 1).
- prompt-only-enforcement guard green; no emdashes; no corporate vocabulary; pre-commit verify green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_016hwuTe4dLJR465y74JSwmo