### PR TITLE
fix(updater): the rename hook never rewrites a path the skeleton ships

### DIFF
--- a/kipi-update-voiceloop-migrate.py
+++ b/kipi-update-voiceloop-migrate.py
@@ -60,12 +60,17 @@ file carrying the name that cannot be parsed refuses the instance rather than
 being swapped blind. The other REWRITE_EXTS have no such classifier and keep
 the blanket swap, comments included.
 
-A path the SKELETON ships is never rewritten, whatever its extension: the rsync
-this script runs ahead of delivers the skeleton's copy of it seconds later, so
+A path the SYNC DELIVERS is never rewritten, whatever its extension: the rsync
+this script runs ahead of writes the skeleton's copy over it seconds later, so
 the rewrite is churn at best and a refused commit at worst (2026-09-06: the
-engine's own __init__.py documents the rename in a why-comment that names the
-old package on purpose; see SKELETON_ROOT). Instance-only files, including ones
-that live inside q-system/, do not exist in the skeleton and are migrated.
+engine's own __init__.py documents the rename in its docstring, naming the old
+package on purpose). Delivered means the skeleton's q-system/ tree mapped
+through the instance's subtree_prefix minus INSTANCE_OWNED_SUBTREES, plus the
+skeleton's plugins/<name>/ trees minus PLUGIN_COPY_EXCLUDES, both arrays read
+from kipi-update.sh itself (see SKELETON_ROOT). Everything else the instance
+holds, including a file the skeleton ships as a template under an owned
+subtree, a file at the skeleton root, or its merged .claude/settings.json, is
+the instance's and is migrated.
 """
 from __future__ import annotations
 
@@ -156,14 +161,35 @@ SKIP_PATH_PARTS = (os.path.join("tests", "fixtures") + os.sep,)
 #     commit, this script reported "migration failed", and the rsync it exists
 #     to prepare never started (sp-b0389e48, sp-2c1bcc3f's neighbour).
 #
-# The test is exact, not a path heuristic: if the same relative path exists in
-# the skeleton tree, it is the skeleton's. An instance-only file INSIDE q-system/
-# (the updater preserves those) does not exist in the skeleton and is still
-# migrated. The package MOVE (step 1 of apply) is untouched by this rule: the
-# old package name never exists in the skeleton, so its files are seen at their
-# pre-move paths and the move proceeds; after the move they sit at paths the
-# skeleton ships and the rsync delivers the real ones.
+# THE SET IS WHAT THE SYNC DELIVERS, NOT WHAT THE SKELETON CONTAINS. "Exists in
+# the skeleton" was the first cut and the reviewer of PR #312 named where the
+# two sets differ: a path under an INSTANCE_OWNED_SUBTREES dir (my-project/,
+# memory/, .q-system/data/ ...) that the skeleton happens to ship as a template
+# is never overwritten, the sync excludes it; a file at the skeleton ROOT
+# (kipi-update.sh, lefthook.yml, README.md) is never copied anywhere; the
+# instance's .claude/settings.json is MERGED from a template, its own hook
+# entries survive, so a stale path there is the instance's to migrate. Exempting
+# any of those leaves the old name in place forever and reports verified=True.
+# And the instance keeps its q-system under `subtree_prefix` (null for one
+# registered instance), so the skeleton's q-system/<x> lands at <prefix>/<x>.
+#
+# So the exemption is derived, per file, from the same three facts the rsync
+# uses: the skeleton's q-system/ tree minus INSTANCE_OWNED_SUBTREES, mapped
+# through the instance's subtree_prefix; and the skeleton's plugins/<name>/
+# trees minus PLUGIN_COPY_EXCLUDES. Both arrays are read from kipi-update.sh
+# itself, the file that will run the rsync, so this script cannot drift from
+# it (the deletion guard keeps a hand copy and a test to compare; this one
+# reads the owner). If the arrays cannot be read, nothing is exempt and the
+# plan says so under `warnings`: rewriting a file the sync would have replaced
+# is churn, skipping one it would not have is a stranded import.
+#
+# The package MOVE (step 1 of apply) is untouched: the old package name is never
+# a delivered path, so its files are seen at their pre-move paths and the move
+# proceeds; after the move they sit where the rsync delivers the real ones.
 SKELETON_ROOT = os.path.dirname(SELF_PATH)
+UPDATER_NAME = "kipi-update.sh"
+REGISTRY_NAME = "instance-registry.json"
+DEFAULT_PREFIX = "q-system"
 
 
 def _resolve_skeleton(repo: str, skeleton: str | None) -> str | None:
@@ -176,8 +202,90 @@ def _resolve_skeleton(repo: str, skeleton: str | None) -> str | None:
     return root
 
 
-def _shipped_by_skeleton(rel: str, skeleton: str | None) -> bool:
-    return skeleton is not None and os.path.lexists(os.path.join(skeleton, rel))
+def _bash_array(text: str, name: str) -> list[str]:
+    """The literal elements of `NAME=( ... )` as bash reads them: one element
+    per whitespace-separated word, double quotes stripped with the four
+    backslash escapes bash honours inside them (dollar, quote, backslash,
+    backtick) unescaped, `#` comments dropped. Enough for the two arrays this
+    reads, which are literal lists by design (ASK-772)."""
+    m = re.search(r"^%s=\(\s*\n(.*?)^\)" % re.escape(name), text, re.S | re.M)
+    if not m:
+        return []
+    out: list[str] = []
+    for raw in m.group(1).splitlines():
+        line = raw.strip()
+        if not line or line.startswith("#"):
+            continue
+        for word in re.findall(r'"(?:[^"\\]|\\.)*"|\S+', line):
+            if word.startswith("#"):
+                break
+            if word.startswith('"') and word.endswith('"') and len(word) >= 2:
+                word = re.sub(r'\\([$"\\`])', r"\1", word[1:-1])
+            out.append(word)
+    return out
+
+
+def _updater_lists(skeleton: str) -> tuple[list[str], list[re.Pattern]]:
+    """(INSTANCE_OWNED_SUBTREES, PLUGIN_COPY_EXCLUDES regexes) from the
+    kipi-update.sh that will run the rsync: the one beside the delivered tree,
+    or the one beside this script."""
+    for root in (skeleton, SKELETON_ROOT):
+        updater = os.path.join(root, UPDATER_NAME)
+        if os.path.isfile(updater):
+            break
+    else:
+        raise ValueError(f"{UPDATER_NAME} not found beside the skeleton or this script")
+    text = open(updater, encoding="utf-8").read()
+    owned = _bash_array(text, "INSTANCE_OWNED_SUBTREES")
+    excl = [e.split("::", 1)[1] for e in _bash_array(text, "PLUGIN_COPY_EXCLUDES") if "::" in e]
+    if not owned or not excl:
+        raise ValueError(f"could not read INSTANCE_OWNED_SUBTREES / PLUGIN_COPY_EXCLUDES from {updater}")
+    return owned, [re.compile(r) for r in excl]
+
+
+def _instance_prefix(repo: str, skeleton: str) -> str:
+    """The instance's subtree_prefix from the registry beside the skeleton (or
+    beside this script); DEFAULT_PREFIX for a repo the registry does not know,
+    which is every fixture and the only layout the updater creates."""
+    for root in (skeleton, SKELETON_ROOT):
+        reg = os.path.join(root, REGISTRY_NAME)
+        if not os.path.isfile(reg):
+            continue
+        try:
+            rows = json.load(open(reg, encoding="utf-8")).get("instances") or []
+        except (OSError, ValueError):
+            continue
+        for row in rows:
+            path = row.get("path") if isinstance(row, dict) else None
+            if path and os.path.realpath(os.path.expanduser(path)) == os.path.realpath(repo):
+                return (row.get("subtree_prefix") or "").strip("/")
+        break
+    return DEFAULT_PREFIX
+
+
+def _delivered_by_sync(rel: str, skeleton: str | None, prefix: str,
+                       owned: list[str], plugin_excl: list[re.Pattern]) -> bool:
+    """Would the next sync write the skeleton's copy over this instance path?"""
+    if skeleton is None:
+        return False
+    # q-system half: skeleton q-system/<sub> lands at <prefix>/<sub>, minus the
+    # anchored instance-owned excludes.
+    if prefix:
+        sub = rel[len(prefix) + 1:] if rel.startswith(prefix + "/") else None
+    else:
+        sub = rel
+    if sub and not any(sub == o or sub.startswith(o + "/") for o in owned) \
+            and os.path.lexists(os.path.join(skeleton, "q-system", sub)):
+        return True
+    # plugins half: skeleton plugins/<name>/ lands at plugins/<name>/, minus
+    # PLUGIN_COPY_EXCLUDES (--delete-excluded).
+    parts = rel.split("/")
+    if len(parts) >= 3 and parts[0] == "plugins" \
+            and os.path.isdir(os.path.join(skeleton, "plugins", parts[1])) \
+            and os.path.lexists(os.path.join(skeleton, rel)) \
+            and not any(r.search("/".join(parts[2:])) for r in plugin_excl):
+        return True
+    return False
 
 
 def _exempt(path: str) -> bool:
@@ -320,13 +428,30 @@ def rewrite_text(text: str, ext: str) -> str:
     return _swap_outside(lines, spans)
 
 
-def plan(repo: str, skeleton: str | None = None) -> dict:
+def plan(repo: str, skeleton: str | None = None, prefix: str | None = None) -> dict:
     """Read-only. What this instance needs, without touching a byte.
 
     `skeleton` is the tree the sync delivers (default: the one this script sits
-    in); a path it ships is skipped entirely, see SKELETON_ROOT above."""
+    in); a path the sync would overwrite is skipped entirely, see SKELETON_ROOT
+    above. `prefix` is the instance's subtree_prefix (default: the registry's
+    answer, else DEFAULT_PREFIX)."""
     repo = os.path.abspath(repo)
     delivered = _resolve_skeleton(repo, skeleton)
+    warnings: list[str] = []
+    owned: list[str] = []
+    plugin_excl: list[re.Pattern] = []
+    if delivered is not None:
+        try:
+            owned, plugin_excl = _updater_lists(delivered)
+        except ValueError as exc:
+            warnings.append(f"no path is exempt: {exc}")
+            delivered = None
+    if prefix is not None:
+        sub_prefix = prefix.strip("/")
+    elif delivered is not None:
+        sub_prefix = _instance_prefix(repo, delivered)
+    else:
+        sub_prefix = DEFAULT_PREFIX
     old_pkg = os.path.join(repo, PLUGIN_PARENT, OLD)
     new_pkg = os.path.join(repo, PLUGIN_PARENT, NEW)
     has_old = os.path.isdir(old_pkg)
@@ -346,7 +471,7 @@ def plan(repo: str, skeleton: str | None = None) -> dict:
         if _exempt(path):
             continue
         rel = os.path.relpath(path, repo)
-        if _shipped_by_skeleton(rel, delivered):
+        if _delivered_by_sync(rel, delivered, sub_prefix, owned, plugin_excl):
             shipped.append(rel)
             continue
         base = os.path.basename(path)
@@ -432,10 +557,12 @@ def plan(repo: str, skeleton: str | None = None) -> dict:
     return {
         "repo": repo,
         "skeleton": delivered,
+        "prefix": sub_prefix,
+        "warnings": warnings,
         "package_action": package_action,
         "rewrite": sorted(rewrite),
         "renames": sorted(renames),
-        "shipped_by_skeleton": sorted(shipped),
+        "delivered_by_sync": sorted(shipped),
         "unparseable": sorted(unparseable),
         "history_left": sorted(history),
         "staged_migration": staged_migration,
@@ -489,9 +616,10 @@ def _dirty_tracked(repo: str, rels: list) -> list:
     return sorted(set(out))
 
 
-def apply(repo: str, commit: bool = True, skeleton: str | None = None) -> dict:
+def apply(repo: str, commit: bool = True, skeleton: str | None = None,
+          prefix: str | None = None) -> dict:
     repo = os.path.abspath(repo)
-    p = plan(repo, skeleton)
+    p = plan(repo, skeleton, prefix)
     result = {**p, "moved": False, "rewritten": [], "renamed": [], "committed": False,
               "errors": [], "left_untracked": [], "backed_up": []}
     # Snapshot tracked-ness BEFORE any write, because `git mv` and the rewrites
@@ -551,7 +679,7 @@ def apply(repo: str, commit: bool = True, skeleton: str | None = None) -> dict:
     # pre-move relative paths are stale. Re-reading is cheap; acting on a stale
     # path list is the "validate the mutant applied" failure -- an edit that
     # silently lands nowhere.
-    p2 = plan(repo, skeleton)
+    p2 = plan(repo, skeleton, prefix)
     for rel in p2["rewrite"]:
         path = os.path.join(repo, rel)
         try:
@@ -613,7 +741,7 @@ def apply(repo: str, commit: bool = True, skeleton: str | None = None) -> dict:
         result["renamed"].append(f"{rel} -> {dst_rel}")
 
     # --- step 3: prove it, against the tree we just wrote --------------------
-    after = plan(repo, skeleton)
+    after = plan(repo, skeleton, prefix)
     if after["package_action"] == "move":
         result["errors"].append("package still named voicekit after apply")
     if after["rewrite"]:

--- a/kipi-update-voiceloop-migrate.py
+++ b/kipi-update-voiceloop-migrate.py
@@ -52,6 +52,14 @@ than an oversight: .json here is config the engine reads (voice-channels.json
 names `voiceloop/validate.py`, a path that genuinely moved), .jsonl is an
 append-only ledger.
 
+Prose is never rewritten. In a .py file a comment or a docstring that names the
+old package is documenting the rename (the engine's own module docstring, the
+exporter's RENAMES note) and must keep the name; Python's tokenizer and parser
+tell that prose from the code and string literals that genuinely migrate. A .py
+file carrying the name that cannot be parsed refuses the instance rather than
+being swapped blind. The other REWRITE_EXTS have no such classifier and keep
+the blanket swap, comments included.
+
 A path the SKELETON ships is never rewritten, whatever its extension: the rsync
 this script runs ahead of delivers the skeleton's copy of it seconds later, so
 the rewrite is churn at best and a refused commit at worst (2026-09-06: the
@@ -62,7 +70,10 @@ that live inside q-system/, do not exist in the skeleton and are migrated.
 from __future__ import annotations
 
 import argparse
+import ast
+import io
 import json
+import tokenize
 import os
 import re
 import shutil
@@ -83,7 +94,8 @@ NEW = "voiceloop"
 # word boundary would miss every one of them. This is the same rule
 # consulting's automation/export_voice_loop.py has applied to its public mirror
 # since 2026-08-20, which is the evidence that a blanket token swap is safe on
-# this corpus.
+# CODE. It is not safe on prose: see rewrite_text, which keeps comments and
+# docstrings out of the swap for .py files (2026-09-06).
 CASE_FORMS = (
     ("voicekit", "voiceloop"),
     ("Voicekit", "Voiceloop"),
@@ -213,6 +225,101 @@ def has_token(text: str) -> bool:
     return any(before in text for before, _ in CASE_FORMS)
 
 
+# PROSE IS NEVER REWRITTEN. A why-comment that documents the rename has to name
+# the old package, or it documents nothing: the engine's own module docstring
+# says "this package was called `voicekit` here and the exporter renamed it to
+# `voiceloop`", and the exporter's RENAMES table carries "the pair (voicekit ->
+# voiceloop) lived here until the rename" as a # comment. The blanket swap
+# turned both into an identity pair described as a rename (2026-09-06, the
+# fleet sync refused on the one instance whose commit gate compares the engine
+# to its public mirror; the same run rewrote and STAGED the exporter's comment
+# in the instance's own automation/ and abandoned the checkout that way).
+#
+# "Skip comments" by regex cannot tell a comment that documents the old name
+# from a string that is a module path, and the module path is exactly what a
+# migration must rewrite. Python's own tokenizer and parser can: a COMMENT
+# token is prose, and a STRING that is the first statement of a module, class
+# or function is a docstring (the rule ast.get_docstring uses). Everything else,
+# NAME tokens (`from voicekit import`), STRING literals (`"voicekit/validate.py"`)
+# and filenames, is code and migrates as before. Only .py gets this: nothing
+# here can classify a shell comment against a shell string, so the other
+# REWRITE_EXTS keep the blanket swap, documented in the module docstring.
+#
+# A .py file that carries the token and cannot be parsed is NOT swapped
+# blindly: that would restore the defect for exactly the file nobody looked at.
+# It is reported and apply() refuses the instance, the same posture the updater
+# takes on a dirty tree (a-gate-that-cannot-run-must-not-pass).
+PROSE_EXTS = {".py"}
+
+
+def _char_col(line: str, byte_col: int) -> int:
+    """ast reports columns in UTF-8 bytes; tokenize and str slicing use
+    characters. Same value on ASCII lines, different after a non-ASCII char."""
+    return len(line.encode("utf-8")[:byte_col].decode("utf-8", "replace"))
+
+
+def _prose_spans(text: str, lines: list[str]) -> list[tuple[int, int, int, int]]:
+    """(start_line, start_col, end_line, end_col), 1-based lines, character
+    columns, end exclusive: every COMMENT token and every docstring."""
+    spans: list[tuple[int, int, int, int]] = []
+    tree = ast.parse(text)
+    holders = [tree] + [n for n in ast.walk(tree)
+                        if isinstance(n, (ast.ClassDef, ast.FunctionDef, ast.AsyncFunctionDef))]
+    for node in holders:
+        body = getattr(node, "body", None)
+        if not body:
+            continue
+        first = body[0]
+        if isinstance(first, ast.Expr) and isinstance(first.value, ast.Constant) \
+                and isinstance(first.value.value, str):
+            v = first.value
+            spans.append((v.lineno, _char_col(lines[v.lineno - 1], v.col_offset),
+                          v.end_lineno, _char_col(lines[v.end_lineno - 1], v.end_col_offset)))
+    for tok in tokenize.generate_tokens(io.StringIO(text).readline):
+        if tok.type == tokenize.COMMENT:
+            spans.append((tok.start[0], tok.start[1], tok.end[0], tok.end[1]))
+    return spans
+
+
+def _swap_outside(lines: list[str], spans: list[tuple[int, int, int, int]]) -> str:
+    """The token swap applied to every character that is not inside a span."""
+    protected: dict[int, list[tuple[int, int]]] = {}
+    for l1, c1, l2, c2 in spans:
+        for ln in range(l1, l2 + 1):
+            start = c1 if ln == l1 else 0
+            end = c2 if ln == l2 else len(lines[ln - 1])
+            protected.setdefault(ln, []).append((start, end))
+    out = []
+    for i, line in enumerate(lines, start=1):
+        ranges = sorted(protected.get(i, ()))
+        if not ranges:
+            out.append(swap_tokens(line))
+            continue
+        pos, parts = 0, []
+        for start, end in ranges:
+            parts.append(swap_tokens(line[pos:start]))
+            parts.append(line[start:end])
+            pos = max(pos, end)
+        parts.append(swap_tokens(line[pos:]))
+        out.append("".join(parts))
+    return "".join(out)
+
+
+def rewrite_text(text: str, ext: str) -> str:
+    """The migrated text for a file of this extension. Raises ValueError for a
+    prose-aware extension whose file cannot be classified."""
+    if ext not in PROSE_EXTS:
+        return swap_tokens(text)
+    if "\r" in text.replace("\r\n", ""):
+        raise ValueError("lone CR line endings: ast and tokenize would disagree on line numbers")
+    lines = io.StringIO(text).readlines()
+    try:
+        spans = _prose_spans(text, lines)
+    except (SyntaxError, ValueError, tokenize.TokenError) as exc:
+        raise ValueError(f"cannot classify prose from code: {type(exc).__name__}: {exc}") from exc
+    return _swap_outside(lines, spans)
+
+
 def plan(repo: str, skeleton: str | None = None) -> dict:
     """Read-only. What this instance needs, without touching a byte.
 
@@ -234,7 +341,7 @@ def plan(repo: str, skeleton: str | None = None) -> dict:
     else:
         package_action = "absent"
 
-    rewrite, renames, history, shipped = [], [], [], []
+    rewrite, renames, history, shipped, unparseable = [], [], [], [], []
     for path in iter_source_files(repo):
         if _exempt(path):
             continue
@@ -266,8 +373,15 @@ def plan(repo: str, skeleton: str | None = None) -> dict:
             text = open(path, encoding="utf-8", errors="strict").read()
         except (OSError, UnicodeError):
             continue
-        if has_token(text):
-            rewrite.append(rel)
+        if not has_token(text):
+            continue
+        # The same function apply() writes with decides whether there is
+        # anything to write, so plan and apply cannot disagree about prose.
+        try:
+            if rewrite_text(text, ext) != text:
+                rewrite.append(rel)
+        except ValueError as exc:
+            unparseable.append(f"{rel}: {exc}")
 
     # STAGED-BUT-UNCOMMITTED MIGRATION WORK IS UNFINISHED WORK, and reading the
     # disk alone cannot see that. Measured 2026-08-30 on one instance: its own
@@ -322,13 +436,14 @@ def plan(repo: str, skeleton: str | None = None) -> dict:
         "rewrite": sorted(rewrite),
         "renames": sorted(renames),
         "shipped_by_skeleton": sorted(shipped),
+        "unparseable": sorted(unparseable),
         "history_left": sorted(history),
         "staged_migration": staged_migration,
         "staged_rewrites": staged_rewrites,
         # The one line a caller can branch on. `already`/`absent` with nothing to
         # rewrite AND nothing staged is a finished instance.
         "needs_work": (package_action in ("move", "both_present")
-                       or bool(rewrite) or bool(renames)
+                       or bool(rewrite) or bool(renames) or bool(unparseable)
                        or bool(staged_migration) or bool(staged_rewrites)),
     }
 
@@ -400,6 +515,13 @@ def apply(repo: str, commit: bool = True, skeleton: str | None = None) -> dict:
     #
     # Checked ONCE, here, against the PRE-MOVE paths. After `git mv` the package's
     # own files read as staged renames and would false-trip this.
+    if p["unparseable"]:
+        result["errors"].append(
+            "refusing to migrate: %d .py file(s) carry the old name and cannot be "
+            "classified into code and prose; fix the file or move it out of the "
+            "tree and re-run: %s" % (len(p["unparseable"]), "; ".join(p["unparseable"][:3])))
+        result["verified"] = False
+        return result
     blocked = _dirty_tracked(repo, p["rewrite"] + p["renames"])
     if blocked:
         result["errors"].append(
@@ -437,7 +559,11 @@ def apply(repo: str, commit: bool = True, skeleton: str | None = None) -> dict:
         except (OSError, UnicodeError) as exc:
             result["errors"].append(f"read {rel}: {exc}")
             continue
-        new_text = swap_tokens(text)
+        try:
+            new_text = rewrite_text(text, os.path.splitext(rel)[1].lower())
+        except ValueError as exc:
+            result["errors"].append(f"classify {rel}: {exc}")
+            continue
         if new_text == text:
             continue
         # NOTHING RESTORES WHAT WAS NEVER TRACKED. Codex BLOCKER on PR #292:

--- a/kipi-update-voiceloop-migrate.py
+++ b/kipi-update-voiceloop-migrate.py
@@ -51,6 +51,13 @@ counted and reported as `history_left`, never edited.
 than an oversight: .json here is config the engine reads (voice-channels.json
 names `voiceloop/validate.py`, a path that genuinely moved), .jsonl is an
 append-only ledger.
+
+A path the SKELETON ships is never rewritten, whatever its extension: the rsync
+this script runs ahead of delivers the skeleton's copy of it seconds later, so
+the rewrite is churn at best and a refused commit at worst (2026-09-06: the
+engine's own __init__.py documents the rename in a why-comment that names the
+old package on purpose; see SKELETON_ROOT). Instance-only files, including ones
+that live inside q-system/, do not exist in the skeleton and are migrated.
 """
 from __future__ import annotations
 
@@ -119,6 +126,47 @@ SKIP_DIR_PREFIXES = (".wt-",)
 SELF_PATH = os.path.realpath(__file__)
 SKIP_PATH_PARTS = (os.path.join("tests", "fixtures") + os.sep,)
 
+# A FILE THE SKELETON SHIPS IS THE SYNC'S TO DELIVER, NEVER THIS SCRIPT'S TO
+# REWRITE. This script lives at the skeleton root and kipi-update.sh runs it
+# right before the rsync that copies the skeleton's q-system/ .claude/ plugins/
+# over the instance. Any path the skeleton itself carries is therefore
+# overwritten seconds later with the skeleton's bytes, so rewriting it here is
+# at best a churn commit and at worst a refused one:
+#
+#   * The skeleton's own plugins/kipi-core/voiceloop/__init__.py names the old
+#     package in a why-comment ("this package was called `voicekit` here"),
+#     deliberately, as history. Measured 2026-09-06 across the fleet: every sync
+#     rewrote that comment in every instance, committed it, and the rsync put the
+#     skeleton's copy back, forever ("rewritten=1" on all 22 instances, 7 on the
+#     one that also carried six skeleton-shipped q-system scripts and tests).
+#   * On the instance whose pre-commit compares the engine to a public mirror,
+#     that one-line rewrite is a diff against the mirror, the gate refused the
+#     commit, this script reported "migration failed", and the rsync it exists
+#     to prepare never started (sp-b0389e48, sp-2c1bcc3f's neighbour).
+#
+# The test is exact, not a path heuristic: if the same relative path exists in
+# the skeleton tree, it is the skeleton's. An instance-only file INSIDE q-system/
+# (the updater preserves those) does not exist in the skeleton and is still
+# migrated. The package MOVE (step 1 of apply) is untouched by this rule: the
+# old package name never exists in the skeleton, so its files are seen at their
+# pre-move paths and the move proceeds; after the move they sit at paths the
+# skeleton ships and the rsync delivers the real ones.
+SKELETON_ROOT = os.path.dirname(SELF_PATH)
+
+
+def _resolve_skeleton(repo: str, skeleton: str | None) -> str | None:
+    """The tree whose files the sync delivers, or None when there is none to
+    compare against (the script run over the skeleton itself, or a caller that
+    passed the instance as its own skeleton)."""
+    root = SKELETON_ROOT if skeleton is None else os.path.abspath(skeleton)
+    if os.path.realpath(root) == os.path.realpath(repo):
+        return None
+    return root
+
+
+def _shipped_by_skeleton(rel: str, skeleton: str | None) -> bool:
+    return skeleton is not None and os.path.lexists(os.path.join(skeleton, rel))
+
 
 def _exempt(path: str) -> bool:
     if os.path.realpath(path) == SELF_PATH:
@@ -165,9 +213,13 @@ def has_token(text: str) -> bool:
     return any(before in text for before, _ in CASE_FORMS)
 
 
-def plan(repo: str) -> dict:
-    """Read-only. What this instance needs, without touching a byte."""
+def plan(repo: str, skeleton: str | None = None) -> dict:
+    """Read-only. What this instance needs, without touching a byte.
+
+    `skeleton` is the tree the sync delivers (default: the one this script sits
+    in); a path it ships is skipped entirely, see SKELETON_ROOT above."""
     repo = os.path.abspath(repo)
+    delivered = _resolve_skeleton(repo, skeleton)
     old_pkg = os.path.join(repo, PLUGIN_PARENT, OLD)
     new_pkg = os.path.join(repo, PLUGIN_PARENT, NEW)
     has_old = os.path.isdir(old_pkg)
@@ -182,11 +234,14 @@ def plan(repo: str) -> dict:
     else:
         package_action = "absent"
 
-    rewrite, renames, history = [], [], []
+    rewrite, renames, history, shipped = [], [], [], []
     for path in iter_source_files(repo):
         if _exempt(path):
             continue
         rel = os.path.relpath(path, repo)
+        if _shipped_by_skeleton(rel, delivered):
+            shipped.append(rel)
+            continue
         base = os.path.basename(path)
         ext = os.path.splitext(base)[1].lower()
         # A FILENAME follows the same record/source split as file CONTENT, and
@@ -262,9 +317,11 @@ def plan(repo: str) -> dict:
 
     return {
         "repo": repo,
+        "skeleton": delivered,
         "package_action": package_action,
         "rewrite": sorted(rewrite),
         "renames": sorted(renames),
+        "shipped_by_skeleton": sorted(shipped),
         "history_left": sorted(history),
         "staged_migration": staged_migration,
         "staged_rewrites": staged_rewrites,
@@ -317,9 +374,9 @@ def _dirty_tracked(repo: str, rels: list) -> list:
     return sorted(set(out))
 
 
-def apply(repo: str, commit: bool = True) -> dict:
+def apply(repo: str, commit: bool = True, skeleton: str | None = None) -> dict:
     repo = os.path.abspath(repo)
-    p = plan(repo)
+    p = plan(repo, skeleton)
     result = {**p, "moved": False, "rewritten": [], "renamed": [], "committed": False,
               "errors": [], "left_untracked": [], "backed_up": []}
     # Snapshot tracked-ness BEFORE any write, because `git mv` and the rewrites
@@ -372,7 +429,7 @@ def apply(repo: str, commit: bool = True) -> dict:
     # pre-move relative paths are stale. Re-reading is cheap; acting on a stale
     # path list is the "validate the mutant applied" failure -- an edit that
     # silently lands nowhere.
-    p2 = plan(repo)
+    p2 = plan(repo, skeleton)
     for rel in p2["rewrite"]:
         path = os.path.join(repo, rel)
         try:
@@ -430,7 +487,7 @@ def apply(repo: str, commit: bool = True) -> dict:
         result["renamed"].append(f"{rel} -> {dst_rel}")
 
     # --- step 3: prove it, against the tree we just wrote --------------------
-    after = plan(repo)
+    after = plan(repo, skeleton)
     if after["package_action"] == "move":
         result["errors"].append("package still named voicekit after apply")
     if after["rewrite"]:

--- a/kipi-update-voiceloop-migrate.py
+++ b/kipi-update-voiceloop-migrate.py
@@ -881,13 +881,19 @@ def main(argv=None) -> int:
     else:
         name = os.path.basename(os.path.abspath(args.repo))
         if not args.apply:
+            # Every input to needs_work is printed beside it, so a plan that says
+            # work is needed also says WHICH kind: kipi-update.sh --dry pipes
+            # this line through sed, and `unparseable` was the one input it could
+            # not name (PR #312 review round 2).
             print(f"{name}: package={out['package_action']} "
                   f"rewrite={len(out['rewrite'])} rename={len(out['renames'])} "
+                  f"unparseable={len(out['unparseable'])} "
                   f"history_left={len(out['history_left'])} "
                   f"needs_work={out['needs_work']}")
         else:
             print(f"{name}: moved={out['moved']} "
                   f"rewritten={len(out['rewritten'])} renamed={len(out['renamed'])} "
+                  f"unparseable={len(out['unparseable'])} "
                   f"committed={out['committed']} verified={out['verified']}")
             for e in out["errors"]:
                 print("  ERROR: " + e, file=sys.stderr)

--- a/q-system/.q-system/scripts/test_voiceloop_migrate.py
+++ b/q-system/.q-system/scripts/test_voiceloop_migrate.py
@@ -108,7 +108,7 @@ class EngineTest(unittest.TestCase):
         p = mig.plan(r, skeleton=sk)
         self.assertEqual(p["rewrite"], ["q-consult/pipeline/voice.py",
                                         "q-system/.q-system/scripts/mine.py"])
-        self.assertEqual(p["shipped_by_skeleton"], ["plugins/kipi-core/" + NEW + "/__init__.py",
+        self.assertEqual(p["delivered_by_sync"], ["plugins/kipi-core/" + NEW + "/__init__.py",
                                                     "q-system/.q-system/scripts/tool.py"])
         out = mig.apply(r, commit=False, skeleton=sk)
         self.assertTrue(out["verified"], out["errors"])
@@ -129,7 +129,7 @@ class EngineTest(unittest.TestCase):
         empty = os.path.join(self.tmp, "empty-skeleton")
         os.makedirs(empty)
         p = mig.plan(r, skeleton=empty)
-        self.assertEqual(p["shipped_by_skeleton"], [])
+        self.assertEqual(p["delivered_by_sync"], [])
         self.assertIn("q-system/.q-system/scripts/tool.py", p["rewrite"])
         self.assertNotIn("plugins/kipi-core/" + NEW + "/__init__.py", p["rewrite"])
         mig.apply(r, commit=False, skeleton=empty)
@@ -231,7 +231,7 @@ class EngineTest(unittest.TestCase):
         _, r = self._skeleton_and_instance()
         p = mig.plan(r, skeleton=r)
         self.assertIsNone(p["skeleton"])
-        self.assertEqual(p["shipped_by_skeleton"], [])
+        self.assertEqual(p["delivered_by_sync"], [])
         self.assertIn("q-consult/pipeline/voice.py", p["rewrite"])
 
     def test_the_move_still_happens_under_a_skeleton_that_ships_the_package(self):
@@ -250,6 +250,100 @@ class EngineTest(unittest.TestCase):
         self.assertNotIn(OLD, moved_core)
         self.assertIn("plugins/kipi-core/" + NEW + "/core.py", out["rewritten"])
         self.assertNotIn("plugins/kipi-core/" + NEW + "/__init__.py", out["rewritten"])
+
+    def test_exclude_lists_derive_from_the_updater_and_match_bash(self):
+        """The owned subtrees and plugin excludes are read from kipi-update.sh,
+        the file that runs the rsync. Floor: non-empty. Bound: equal to what
+        bash itself evaluates the two arrays to."""
+        owned, excl = mig._updater_lists(REPO)
+        self.assertTrue(owned and excl)
+        script = (
+            'eval "$(sed -n \'/^INSTANCE_OWNED_SUBTREES=(/,/^)/p\' "$1")"; '
+            'eval "$(sed -n \'/^PLUGIN_COPY_EXCLUDES=(/,/^)/p\' "$1")"; '
+            'printf "O %s\\n" "${INSTANCE_OWNED_SUBTREES[@]}"; '
+            'printf "P %s\\n" "${PLUGIN_COPY_EXCLUDES[@]}"')
+        out = subprocess.run(["bash", "-c", script, "_", UPDATER], capture_output=True, text=True, check=True).stdout
+        bash_owned = [l[2:] for l in out.splitlines() if l.startswith("O ")]
+        bash_excl = [l[2:].split("::", 1)[1] for l in out.splitlines() if l.startswith("P ")]
+        self.assertEqual(owned, bash_owned)
+        self.assertEqual([r.pattern for r in excl], bash_excl)
+        self.assertIn("my-project", owned)
+
+    def test_an_owned_subtree_a_root_file_and_settings_are_the_instances_even_when_the_skeleton_has_them(self):
+        """Round 1 major: the sync never writes these, so a stale import there
+        must still migrate. Skeleton presence is not delivery."""
+        sk, r = self._skeleton_and_instance()
+        cases = [
+            ("q-system/memory/tools/probe.py", "from " + OLD + " import x\n"),      # owned subtree
+            ("q-system/.q-system/data/hook.py", "from " + OLD + " import x\n"),     # owned subtree, dotted
+            ("lefthook.py", "from " + OLD + " import x\n"),                          # skeleton root
+            (".claude/settings.json", '{"hooks": ["' + OLD + '/lint.py"]}\n'),      # merged, not copied
+            ("plugins/kipi-core/.env.py", "from " + OLD + " import x\n"),          # PLUGIN_COPY_EXCLUDES
+        ]
+        for rel, body in cases:
+            for root in (sk, r):
+                path = os.path.join(root, rel)
+                os.makedirs(os.path.dirname(path), exist_ok=True)
+                open(path, "w").write(body)
+        p = mig.plan(r, skeleton=sk)
+        for rel, _ in cases:
+            self.assertIn(rel, p["rewrite"], rel)
+            self.assertNotIn(rel, p["delivered_by_sync"], rel)
+        self.assertIn("q-system/.q-system/scripts/tool.py", p["delivered_by_sync"])
+        out = mig.apply(r, commit=False, skeleton=sk)
+        self.assertTrue(out["verified"], out["errors"])
+        for rel, _ in cases:
+            self.assertNotIn(OLD, open(os.path.join(r, rel)).read(), rel)
+
+    def test_a_null_prefix_instance_maps_the_skeleton_q_system_onto_its_root(self):
+        """Round 1 minor: with subtree_prefix null the skeleton's q-system/<x>
+        lands at <x>, so that is where delivery is judged, owned subtrees
+        included."""
+        sk = os.path.join(self.tmp, "skeleton")
+        for rel, body in [("q-system/.q-system/scripts/tool.py", "import " + OLD + ".core\n"),
+                          ("q-system/memory/tools/probe.py", "from " + OLD + " import x\n")]:
+            path = os.path.join(sk, rel)
+            os.makedirs(os.path.dirname(path), exist_ok=True)
+            open(path, "w").write(body)
+        r = build_instance(os.path.join(self.tmp, "flat"), package=NEW, extra=[
+            (".q-system/scripts/tool.py", "import " + OLD + ".core\n"),
+            ("memory/tools/probe.py", "from " + OLD + " import x\n"),
+            ("q-system/.q-system/scripts/tool.py", "import " + OLD + ".core\n"),
+        ])
+        p = mig.plan(r, skeleton=sk, prefix="")
+        self.assertEqual(p["prefix"], "")
+        self.assertEqual(p["delivered_by_sync"], [".q-system/scripts/tool.py"])
+        self.assertIn("memory/tools/probe.py", p["rewrite"])
+        # under a null prefix the nested q-system/ copy is NOT where the sync writes
+        self.assertIn("q-system/.q-system/scripts/tool.py", p["rewrite"])
+
+    def test_the_prefix_comes_from_the_registry_beside_the_skeleton(self):
+        sk, r = self._skeleton_and_instance()
+        import json
+        json.dump({"instances": [{"name": "i", "path": r, "subtree_prefix": None}]},
+                  open(os.path.join(sk, "instance-registry.json"), "w"))
+        self.assertEqual(mig.plan(r, skeleton=sk)["prefix"], "")
+        json.dump({"instances": [{"name": "i", "path": r, "subtree_prefix": "q-system"}]},
+                  open(os.path.join(sk, "instance-registry.json"), "w"))
+        self.assertEqual(mig.plan(r, skeleton=sk)["prefix"], "q-system")
+        os.unlink(os.path.join(sk, "instance-registry.json"))
+        self.assertEqual(mig.plan(r, skeleton=sk)["prefix"], mig.DEFAULT_PREFIX)
+
+    def test_unreadable_exclude_lists_exempt_nothing_and_say_so(self):
+        """Fail toward migrating: a skeleton whose updater cannot be read
+        exempts no path and the plan carries a warning, so the miss is churn,
+        never a stranded import."""
+        sk, r = self._skeleton_and_instance()
+        real = mig._updater_lists
+        mig._updater_lists = lambda skeleton: (_ for _ in ()).throw(ValueError("no updater here"))
+        try:
+            p = mig.plan(r, skeleton=sk)
+        finally:
+            mig._updater_lists = real
+        self.assertIsNone(p["skeleton"])
+        self.assertEqual(p["delivered_by_sync"], [])
+        self.assertTrue(any("no path is exempt" in w for w in p["warnings"]), p["warnings"])
+        self.assertIn("q-system/.q-system/scripts/tool.py", p["rewrite"])
 
     def test_both_present_never_deletes_either_package(self):
         """A half-synced instance is reported, not resolved by removal.

--- a/q-system/.q-system/scripts/test_voiceloop_migrate.py
+++ b/q-system/.q-system/scripts/test_voiceloop_migrate.py
@@ -345,6 +345,24 @@ class EngineTest(unittest.TestCase):
         self.assertTrue(any("no path is exempt" in w for w in p["warnings"]), p["warnings"])
         self.assertIn("q-system/.q-system/scripts/tool.py", p["rewrite"])
 
+    def test_the_plan_line_names_every_input_to_needs_work(self):
+        """kipi-update.sh --dry pipes the human-readable plan line through sed,
+        so a plan that says needs_work=True has to say which input made it so;
+        `unparseable` was the one it could not name (PR #312 round 2)."""
+        r = build_instance(os.path.join(self.tmp, "i"), package=NEW, extra=[
+            ("automation/broken.py", "x = (" + OLD + "\n"),
+        ])
+        env = {**os.environ, "PYTHONDONTWRITEBYTECODE": "1"}
+        out = subprocess.run([sys.executable, MIGRATE, "--repo", r], capture_output=True, text=True, env=env)
+        line = out.stdout.strip().splitlines()[-1]
+        self.assertIn("unparseable=1", line)
+        self.assertIn("needs_work=True", line)
+        out = subprocess.run([sys.executable, MIGRATE, "--repo", r, "--apply", "--no-commit"],
+                             capture_output=True, text=True, env=env)
+        self.assertEqual(out.returncode, 1)
+        self.assertIn("unparseable=1", out.stdout)
+        self.assertIn("verified=False", out.stdout)
+
     def test_both_present_never_deletes_either_package(self):
         """A half-synced instance is reported, not resolved by removal.
 

--- a/q-system/.q-system/scripts/test_voiceloop_migrate.py
+++ b/q-system/.q-system/scripts/test_voiceloop_migrate.py
@@ -75,6 +75,92 @@ class EngineTest(unittest.TestCase):
         self.assertFalse(out["moved"])
         self.assertEqual(out["rewritten"], [])
 
+    def _skeleton_and_instance(self, *, package=NEW, instance_carries_shipped=True):
+        """A fake skeleton that ships the engine init with the rename comment
+        plus one q-system script, and an instance carrying the same two files
+        (unless it is still on the old package: then the new package must not
+        exist yet or the move is a `both_present` refusal), an instance-only
+        script INSIDE q-system/, and its own pipeline import."""
+        why = "# why: this package was called `" + OLD + "` here, renamed on export\nVERSION = 2\n"
+        tool = "# " + OLD + " era helper, the skeleton's\n"
+        shipped = [("plugins/kipi-core/" + NEW + "/__init__.py", why),
+                   ("q-system/.q-system/scripts/tool.py", tool)]
+        sk = os.path.join(self.tmp, "skeleton")
+        for rel, body in shipped:
+            p = os.path.join(sk, rel)
+            os.makedirs(os.path.dirname(p), exist_ok=True)
+            open(p, "w").write(body)
+        carried = shipped if instance_carries_shipped else []
+        r = build_instance(os.path.join(self.tmp, "i"), package=package, extra=carried + [
+            ("q-system/.q-system/scripts/mine.py", "from " + OLD + " import x\n"),
+            ("q-consult/pipeline/voice.py", "from " + OLD + " import x\n"),
+        ])
+        return sk, r
+
+    def test_a_path_the_skeleton_ships_is_the_syncs_not_the_migrations(self):
+        """2026-09-06: the engine's own __init__.py documents the rename in a
+        why-comment that names the old package on purpose. Rewriting it made
+        every sync commit churn on 22 instances and made the one instance whose
+        pre-commit compares the engine to a public mirror refuse the commit, so
+        the rsync never started (sp-b0389e48)."""
+        sk, r = self._skeleton_and_instance()
+        p = mig.plan(r, skeleton=sk)
+        self.assertEqual(p["rewrite"], ["q-consult/pipeline/voice.py",
+                                        "q-system/.q-system/scripts/mine.py"])
+        self.assertEqual(p["shipped_by_skeleton"], ["plugins/kipi-core/" + NEW + "/__init__.py",
+                                                    "q-system/.q-system/scripts/tool.py"])
+        out = mig.apply(r, commit=False, skeleton=sk)
+        self.assertTrue(out["verified"], out["errors"])
+        self.assertEqual(sorted(out["rewritten"]), p["rewrite"])
+        init = open(os.path.join(r, "plugins/kipi-core", NEW, "__init__.py")).read()
+        self.assertIn("called `" + OLD + "` here", init)
+        self.assertIn(OLD, open(os.path.join(r, "q-system/.q-system/scripts/tool.py")).read())
+        self.assertNotIn(OLD, open(os.path.join(r, "q-system/.q-system/scripts/mine.py")).read())
+        self.assertNotIn(OLD, open(os.path.join(r, "q-consult/pipeline/voice.py")).read())
+        self.assertFalse(mig.plan(r, skeleton=sk)["needs_work"])
+
+    def test_without_the_skeleton_the_same_comment_is_rewritten(self):
+        """Negative self-test: an empty skeleton ships nothing, and then the
+        why-comment IS rewritten into nonsense. The exemption is what holds the
+        line, not the shape of the comment."""
+        _, r = self._skeleton_and_instance()
+        empty = os.path.join(self.tmp, "empty-skeleton")
+        os.makedirs(empty)
+        p = mig.plan(r, skeleton=empty)
+        self.assertEqual(p["shipped_by_skeleton"], [])
+        self.assertIn("plugins/kipi-core/" + NEW + "/__init__.py", p["rewrite"])
+        mig.apply(r, commit=False, skeleton=empty)
+        init = open(os.path.join(r, "plugins/kipi-core", NEW, "__init__.py")).read()
+        self.assertNotIn(OLD, init)
+        self.assertIn("called `" + NEW + "` here", init)
+
+    def test_an_instance_is_never_its_own_skeleton(self):
+        """A caller passing the instance as its skeleton would exempt every file
+        and report a clean no-op on an unmigrated tree. Same path resolves to
+        no skeleton at all, and the migration runs in full."""
+        _, r = self._skeleton_and_instance()
+        p = mig.plan(r, skeleton=r)
+        self.assertIsNone(p["skeleton"])
+        self.assertEqual(p["shipped_by_skeleton"], [])
+        self.assertIn("q-consult/pipeline/voice.py", p["rewrite"])
+
+    def test_the_move_still_happens_under_a_skeleton_that_ships_the_package(self):
+        """The old package name never exists in the skeleton, so the move is
+        planned from pre-move paths and proceeds; after it, the init the skeleton
+        ships is left for the rsync and an instance-only module inside the
+        package is still migrated."""
+        sk, r = self._skeleton_and_instance(package=OLD, instance_carries_shipped=False)
+        core = os.path.join(r, "plugins/kipi-core", OLD, "core.py")
+        open(core, "w").write("from " + OLD + " import __init__ as _\n")
+        out = mig.apply(r, commit=False, skeleton=sk)
+        self.assertTrue(out["moved"])
+        self.assertTrue(out["verified"], out["errors"])
+        self.assertFalse(os.path.isdir(os.path.join(r, "plugins/kipi-core", OLD)))
+        moved_core = open(os.path.join(r, "plugins/kipi-core", NEW, "core.py")).read()
+        self.assertNotIn(OLD, moved_core)
+        self.assertIn("plugins/kipi-core/" + NEW + "/core.py", out["rewritten"])
+        self.assertNotIn("plugins/kipi-core/" + NEW + "/__init__.py", out["rewritten"])
+
     def test_both_present_never_deletes_either_package(self):
         """A half-synced instance is reported, not resolved by removal.
 

--- a/q-system/.q-system/scripts/test_voiceloop_migrate.py
+++ b/q-system/.q-system/scripts/test_voiceloop_migrate.py
@@ -81,8 +81,9 @@ class EngineTest(unittest.TestCase):
         (unless it is still on the old package: then the new package must not
         exist yet or the move is a `both_present` refusal), an instance-only
         script INSIDE q-system/, and its own pipeline import."""
-        why = "# why: this package was called `" + OLD + "` here, renamed on export\nVERSION = 2\n"
-        tool = "# " + OLD + " era helper, the skeleton's\n"
+        why = ('"""engine.\n\nwhy the name changed: this package was called `' + OLD
+               + '` here and the\nexporter renamed it on the way out.\n"""\nVERSION = 2\n')
+        tool = "import " + OLD + ".core as core  # the skeleton's own helper, code not prose\n"
         shipped = [("plugins/kipi-core/" + NEW + "/__init__.py", why),
                    ("q-system/.q-system/scripts/tool.py", tool)]
         sk = os.path.join(self.tmp, "skeleton")
@@ -114,25 +115,114 @@ class EngineTest(unittest.TestCase):
         self.assertEqual(sorted(out["rewritten"]), p["rewrite"])
         init = open(os.path.join(r, "plugins/kipi-core", NEW, "__init__.py")).read()
         self.assertIn("called `" + OLD + "` here", init)
-        self.assertIn(OLD, open(os.path.join(r, "q-system/.q-system/scripts/tool.py")).read())
+        self.assertIn("import " + OLD + ".core", open(os.path.join(r, "q-system/.q-system/scripts/tool.py")).read())
         self.assertNotIn(OLD, open(os.path.join(r, "q-system/.q-system/scripts/mine.py")).read())
         self.assertNotIn(OLD, open(os.path.join(r, "q-consult/pipeline/voice.py")).read())
         self.assertFalse(mig.plan(r, skeleton=sk)["needs_work"])
 
-    def test_without_the_skeleton_the_same_comment_is_rewritten(self):
-        """Negative self-test: an empty skeleton ships nothing, and then the
-        why-comment IS rewritten into nonsense. The exemption is what holds the
-        line, not the shape of the comment."""
+    def test_without_the_skeleton_shipped_code_is_rewritten_and_prose_still_survives(self):
+        """Negative self-test for the skeleton rule: an empty skeleton ships
+        nothing, so the skeleton's CODE helper is rewritten like any instance
+        file. The docstring in the init survives on the prose rule alone, which
+        the next test takes away in turn."""
         _, r = self._skeleton_and_instance()
         empty = os.path.join(self.tmp, "empty-skeleton")
         os.makedirs(empty)
         p = mig.plan(r, skeleton=empty)
         self.assertEqual(p["shipped_by_skeleton"], [])
-        self.assertIn("plugins/kipi-core/" + NEW + "/__init__.py", p["rewrite"])
+        self.assertIn("q-system/.q-system/scripts/tool.py", p["rewrite"])
+        self.assertNotIn("plugins/kipi-core/" + NEW + "/__init__.py", p["rewrite"])
         mig.apply(r, commit=False, skeleton=empty)
+        self.assertNotIn(OLD, open(os.path.join(r, "q-system/.q-system/scripts/tool.py")).read())
+        init = open(os.path.join(r, "plugins/kipi-core", NEW, "__init__.py")).read()
+        self.assertIn("called `" + OLD + "` here", init)
+
+    def test_without_the_prose_rule_the_docstring_is_rewritten(self):
+        """Negative self-test for the prose rule: with span detection taken
+        away, the same docstring IS rewritten into an identity rename. The
+        classifier is what holds the line, not the shape of the text."""
+        _, r = self._skeleton_and_instance()
+        empty = os.path.join(self.tmp, "empty-skeleton")
+        os.makedirs(empty)
+        real = mig._prose_spans
+        mig._prose_spans = lambda text, lines: []
+        try:
+            p = mig.plan(r, skeleton=empty)
+            self.assertIn("plugins/kipi-core/" + NEW + "/__init__.py", p["rewrite"])
+            mig.apply(r, commit=False, skeleton=empty)
+        finally:
+            mig._prose_spans = real
         init = open(os.path.join(r, "plugins/kipi-core", NEW, "__init__.py")).read()
         self.assertNotIn(OLD, init)
         self.assertIn("called `" + NEW + "` here", init)
+
+    def test_prose_in_an_instance_file_survives_and_its_code_migrates(self):
+        """The exporter shape from the aborted 2026-09-06 run: a docstring and
+        two # comments that document the rename, next to an import and a path
+        literal that must migrate. Exact text, both directions."""
+        before = ('"""Exporter.\n\nThe pair (' + OLD + ' -> ' + NEW + ') lived here until the rename.\n"""\n'
+                  'import ' + OLD + '.core  # ' + OLD + ' was the name\n'
+                  'RENAMES = [("' + OLD + '/validate.py", "' + NEW + '/validate.py")]\n'
+                  '# test_' + OLD + '.py went with it\n')
+        after = ('"""Exporter.\n\nThe pair (' + OLD + ' -> ' + NEW + ') lived here until the rename.\n"""\n'
+                 'import ' + NEW + '.core  # ' + OLD + ' was the name\n'
+                 'RENAMES = [("' + NEW + '/validate.py", "' + NEW + '/validate.py")]\n'
+                 '# test_' + OLD + '.py went with it\n')
+        r = build_instance(os.path.join(self.tmp, "i"), package=NEW, extra=[
+            ("automation/export.py", before),
+        ])
+        out = mig.apply(r, commit=False, skeleton=os.path.join(self.tmp, "nothing-shipped"))
+        self.assertTrue(out["verified"], out["errors"])
+        self.assertEqual(open(os.path.join(r, "automation/export.py")).read(), after)
+        self.assertFalse(mig.plan(r, skeleton=os.path.join(self.tmp, "nothing-shipped"))["needs_work"])
+
+    def test_a_docstring_only_file_is_not_work(self):
+        """A file whose only mention is prose is not a rewrite candidate, so an
+        already-migrated instance reports needs_work=False and never commits."""
+        r = build_instance(os.path.join(self.tmp, "i"), package=NEW, extra=[
+            ("automation/notes.py", '"""' + OLD + ' was the old name."""\n# and ' + OLD + ' again\nX = 1\n'),
+        ])
+        p = mig.plan(r, skeleton=os.path.join(self.tmp, "nothing-shipped"))
+        self.assertEqual(p["rewrite"], [])
+        self.assertFalse(p["needs_work"])
+
+    def test_columns_survive_non_ascii_text_before_the_docstring_end(self):
+        """ast counts bytes, tokenize counts characters; the conversion is what
+        keeps a docstring ending after a non-ASCII char protected while the code
+        on the next line still migrates."""
+        body = ('"""Résumé: café ' + OLD + ' é"""\n'
+                'from ' + OLD + ' import x  # ' + OLD + '\n')
+        r = build_instance(os.path.join(self.tmp, "i"), package=NEW, extra=[("automation/u.py", body)])
+        mig.apply(r, commit=False, skeleton=os.path.join(self.tmp, "nothing-shipped"))
+        got = open(os.path.join(r, "automation/u.py"), encoding="utf-8").read()
+        self.assertEqual(got, '"""Résumé: café ' + OLD + ' é"""\nfrom ' + NEW + ' import x  # ' + OLD + '\n')
+
+    def test_a_file_that_cannot_be_classified_refuses_the_instance(self):
+        """No blanket fallback: a .py that carries the old name and does not
+        parse is reported, apply refuses, and nothing else is written."""
+        r = build_instance(os.path.join(self.tmp, "i"), package=NEW, extra=[
+            ("automation/broken.py", "x = (" + OLD + "\n"),
+            ("q-consult/pipeline/voice.py", "from " + OLD + " import x\n"),
+        ])
+        p = mig.plan(r, skeleton=os.path.join(self.tmp, "nothing-shipped"))
+        self.assertEqual(len(p["unparseable"]), 1)
+        self.assertTrue(p["unparseable"][0].startswith("automation/broken.py: "))
+        self.assertTrue(p["needs_work"])
+        out = mig.apply(r, commit=False, skeleton=os.path.join(self.tmp, "nothing-shipped"))
+        self.assertFalse(out["verified"])
+        self.assertTrue(any("cannot be classified" in e for e in out["errors"]), out["errors"])
+        self.assertEqual(out["rewritten"], [])
+        self.assertIn(OLD, open(os.path.join(r, "q-consult/pipeline/voice.py")).read())
+
+    def test_non_python_files_keep_the_blanket_swap(self):
+        """Pinned on purpose: nothing here can tell a shell comment from a shell
+        string, so .sh (and the rest of REWRITE_EXTS) still swap everything."""
+        r = build_instance(os.path.join(self.tmp, "i"), package=NEW, extra=[
+            ("automation/run.sh", "# " + OLD + " era\nexport PKG=" + OLD + "\n"),
+        ])
+        mig.apply(r, commit=False, skeleton=os.path.join(self.tmp, "nothing-shipped"))
+        self.assertEqual(open(os.path.join(r, "automation/run.sh")).read(),
+                         "# " + NEW + " era\nexport PKG=" + NEW + "\n")
 
     def test_an_instance_is_never_its_own_skeleton(self):
         """A caller passing the instance as its skeleton would exempt every file

--- a/q-system/output/rca/rca-rename-hook-rewrites-prose-2026-09-06.md
+++ b/q-system/output/rca/rca-rename-hook-rewrites-prose-2026-09-06.md
@@ -1,0 +1,87 @@
+# RCA: the fleet sync refused one instance after a rename hook rewrote the comment that documents the rename
+
+**Date:** 2026-09-06
+**Trigger:** the founder's `kipi-update.sh --only ASK_AI_consultant` run at 13:37 PDT exited `Failed: 1`; the instance's own pre-commit gate refused the hook's commit (log `~/.config/kipi/consulting-sync-.log`, lines 6-69)
+**Surface-fix commit:** edfce56c (PR #312, first commit)
+**Structural-fix commit:** 9612a4ce and 65b227bd (PR #312, second and third commits)
+
+## What happened
+
+The pre-rsync rename hook `kipi-update-voiceloop-migrate.py` swaps the old voice-engine package name for the new one in every source file of an instance before the skeleton sync copies `q-system/`, `.claude/` and `plugins/` over it. The engine's own `plugins/kipi-core/voiceloop/__init__.py` names the old package on purpose, in the docstring that documents the rename. Every fleet sync rewrote that docstring in every instance, committed it, and the rsync put the skeleton's copy back, so 22 instances carried a churn commit per sync and nobody saw it. On the one instance whose pre-commit compares the engine to its public mirror, the rewrite was a one-line diff against the mirror, the gate refused the commit, the hook reported `voiceloop migration failed; rsync not started`, and that instance stayed off the sync a second time in one day. The same run had already rewritten and staged the instance's own `automation/export_voice_loop.py`, whose two comments document the same rename.
+
+## Surface symptom
+
+```
+voice-loop mirror is STALE: 1 file(s) differ from plugins/kipi-core/voiceloop
+  --- mirror/voiceloop/__init__.py
+  +++ source/voiceloop/__init__.py
+  -why the name changed (2026-08-29): this package was called `voicekit` here and the
+  +why the name changed (2026-08-29): this package was called `voiceloop` here and the
+consulting: moved=False rewritten=7 renamed=0 committed=False verified=False
+  ERROR: voiceloop migration failed; rsync not started
+  Updated: 0
+  Failed:  1
+```
+
+Fleet-wide, the same defect read as `rewritten=1` on every instance in every sync log (fleet-apply-20260906-113342.log.apply), a commit the next rsync undid.
+
+## Surface root cause
+
+`swap_tokens()` at kipi-update-voiceloop-migrate.py:160 (main f7e42353) is a plain `str.replace` over the whole file, applied to every path under the instance except the hook itself and `tests/fixtures/`. It has no notion of prose versus code and no notion of which paths the sync is about to overwrite anyway. The engine's docstring and the exporter's comments carried the old name as documentation, and the swap turned "called `voicekit` here and the exporter renamed it to `voiceloop`" into an identity rename.
+
+## Structural root cause
+
+### Root cause #1
+
+`type: code-defect`
+
+A token rewrite that cannot tell prose from code will erase the record of the rename it performs, because the record has to name the old token. "Skip comments" by regex cannot fix it: the old name legitimately appears in string literals that are module paths, which is exactly what must migrate. The classifier has to be the language's own tokenizer and parser (COMMENT tokens, first-statement STRING docstrings), and the hook did not have one.
+
+### Root cause #2
+
+`type: implicit-contract`
+
+The hook ran ahead of an rsync that overwrites a known set of paths, and rewrote those same paths. Nothing stated the contract "a path the sync delivers is the sync's, not the migration's", so the hook did work the next step undid on every run, fleet-wide, and reported it as success. The first fix keyed that set on "exists in the skeleton", which the reviewer showed differs from the delivered set at `INSTANCE_OWNED_SUBTREES`, the skeleton root, the merged `.claude/settings.json` and `PLUGIN_COPY_EXCLUDES`. The delivered set has to be derived from the updater's own arrays and the instance's `subtree_prefix`.
+
+### Root cause #3
+
+`type: missing-test`
+
+The hook's tests built fixtures whose engine init contained no token (`VERSION = 1`) and whose q-system tree was empty, so "already migrated instance is untouched" passed while the real engine init carried the old name in its docstring. No test ran the hook over a tree shaped like the skeleton it ships with, and no fleet-side check noticed a per-sync commit that the next sync reverted.
+
+## Verification
+
+- Ran `python3 -m pytest -q q-system/.q-system/scripts/test_voiceloop_migrate.py` on 65b227bd: 38 passed. Ran the three updater test files together: 53 passed.
+- Ran a mutation with `_delivered_by_sync` forced to `False` in a scratch copy: exactly the three delivery tests failed, 30 passed; with `_prose_spans` removed (in-suite negative test), the docstring IS rewritten into the identity rename, so the classifier is what holds the line.
+- Ran plan mode (read-only, the same `--repo` call the updater makes) of main's hook and of 65b227bd over the live refused instance after its exporter was restored: main wants 8 rewrites (the engine init, six skeleton-delivered q-system files, the exporter); 65b227bd wants 0, `needs_work` False, 1165 paths reported as delivered, no warnings, instance tree untouched by both runs (`git status` before and after identical).
+- Ran the shadow check on the hook: 10 findings, identical to main; one new parameter rebind caught and renamed before the first commit.
+- Confirmed the array parse against the owner: the test evaluates `INSTANCE_OWNED_SUBTREES` and `PLUGIN_COPY_EXCLUDES` with bash and got the same seven and seven entries the Python parser reads.
+
+## Contributing factors
+
+- The refusal was visible on exactly one instance: the other 22 have no gate that compares the engine to anything, so the churn commit passed everywhere and the defect surfaced only where a mirror gate existed.
+- The updater removes `.git/index.lock` unconditionally before every sync and abandons an instance with its staged rewrites in place (sp-2c1bcc3f, sp-9ec528aa), so the aborted run left the exporter's corrupted rewrite staged for thirteen minutes and the first two readings of "nothing was written" were wrong.
+- The hook's `staged_rewrites` recovery reads a staged edit that removes the token as its own interrupted work, so the leftover would have been committed by the next apply under the migration's message.
+- The migration commit runs the instance's full pre-commit (`verify.sh --staged`, ~50 s), so each refused attempt cost a founder-minted token and a round trip.
+
+## Fixes shipped
+
+- Surface fix: a path the skeleton ships is never rewritten (edfce56c). Stopped the churn and the refusal for the engine init on the instance measured, and turned out to be the wrong set (see root cause #2).
+- Structural fix: prose in a `.py` file is classified with the tokenizer and parser and never rewritten; an unparseable `.py` carrying the token refuses the instance instead of being swapped blind (9612a4ce). The exemption is the set the sync delivers, derived from the updater's own two exclude arrays and the instance's registry prefix, with a test that compares the derivation with bash's evaluation (65b227bd).
+
+## Action items
+
+- [x] Prose-aware swap for `.py`, with the exporter shape as an exact-text test — owner: this PR — type: code
+- [x] Delivered-set exemption derived from `kipi-update.sh`'s arrays and the registry prefix — owner: this PR — type: code
+- [x] Fixtures mirror the real collisions (docstring in the shipped init, code in the shipped helper) and a negative twin for each rule — owner: this PR — type: test
+- [ ] The updater never deletes a `.git/*.lock` younger than the instance's pre-commit budget and refuses the instance instead (sp-2c1bcc3f) — owner: sana — type: gate
+- [ ] An abandoned instance is left with nothing staged by the updater (sp-9ec528aa) — owner: sana — type: code
+- [ ] A fleet-side check that a per-sync commit is not reverted by the same sync's rsync (the churn signature `rewritten=N` every run) — owner: sana — type: test
+- [ ] Blanket swap on the non-`.py` REWRITE_EXTS: decide whether shell comments get a classifier or stay as documented — owner: sana — type: code
+
+## Lessons
+
+- A rename tool that rewrites prose erases the record of the rename; the record has to name the old token, so the classifier must be the language's own parser, not a regex over comments.
+- A migration that runs ahead of a sync must exempt exactly the set the sync delivers, derived from the sync's own exclude lists, never from "exists upstream": the two sets differ where instance-owned templates, root files and merged configs live.
+- A per-run commit that the next run reverts is a defect with a silent signature (`rewritten=1` forever); a gate on one instance was the only thing that turned it into an error.
+- "Nothing was written" needs `git status` over the whole tree, not over the paths the dirty rule watches; the aborted run's write sat in `automation/`.


### PR DESCRIPTION
## What

`kipi-update-voiceloop-migrate.py` (the pre-rsync rename hook) no longer rewrites any path the sync is about to deliver, and never rewrites prose in a `.py` file. Three commits, each answering a measured gap: (1) skeleton-delivered paths are the sync's; (2) comments and docstrings are prose; (3) reviewer round 1: "delivered" is derived from the updater's own exclude arrays and the instance's `subtree_prefix`, not from skeleton presence.

## Why (measured 2026-09-06)

- The skeleton's own `plugins/kipi-core/voiceloop/__init__.py` names the old package on purpose, in the why-comment that documents the rename. The hook's plain token swap turned it into "this package was called `voiceloop` here and the exporter renamed it to `voiceloop`". Every fleet sync rewrote it in every instance, committed it, and the rsync put the skeleton's copy back (`rewritten=1` on all 22 instances, 7 on the one that also carried six skeleton-shipped q-system scripts and tests). sp-b0389e48.
- On the one instance whose pre-commit compares the engine to its public mirror, that one-line rewrite was a diff against the mirror, the gate refused the commit, the hook reported `migration failed`, and the rsync never started. Log: the founder's `--only` run at 13:37 PDT.
- "Skip comments" cannot work: the word legitimately appears in prose that must keep it, and a regex cannot tell a comment that documents the old name from one that uses it. Rewording the comment would widen the gate.

## Verification (ran, not assumed)

- `test_voiceloop_migrate.py`: 27 pass (4 new). Reproducer uses the real comment shape; its negative twin runs under an EMPTY skeleton and asserts the comment IS rewritten into nonsense, so the exemption is what holds the line. Self-skeleton guard: `plan(r, skeleton=r)` exempts nothing. Move case: package still moves, shipped init left for the rsync, instance-only module inside the package still migrated.
- Mutation: `_shipped_by_skeleton` forced to `False` in a scratch copy: reproducer RED, the other three GREEN.
- Shadow check: 10 findings, identical to main (one new parameter rebind caught and renamed before commit).
- Production caller shape, read-only `--json` plan over the live refused instance: main's hook `rewrite=7`; this hook `rewrite=0`, all 7 listed under `shipped_by_skeleton` (1274 shipped paths), instance tree untouched.
- `test-propagation-entrypoints.py` + `separation/test_update_propagation.py`: 15 pass here and on main.


## Second commit: prose in a .py file is never rewritten

The aborted run wrote one more file than the log showed: the instance's own `automation/export_voice_loop.py`, rewritten and left STAGED, its RENAMES why-comment turned into an identity pair described as a rename. Instance-owned, so the skeleton-shipped rule does not reach it. The two collisions are different token types: the engine's `__init__.py` names the old package inside its module DOCSTRING; the exporter names it in two COMMENT tokens. A regex cannot tell either from a string literal that is a module path, which is exactly what must migrate. Python's tokenizer and parser can.

- For `.py`, `rewrite_text` skips every COMMENT token and every docstring (first-statement STRING, the `ast.get_docstring` rule) and still rewrites NAME tokens, string literals and filenames. `plan()` and `apply()` both go through it, so they cannot disagree about prose. ast columns are bytes, tokenize columns are characters; converted, and tested on a non-ASCII line.
- A `.py` that carries the old name and cannot be parsed is NOT swapped blind: `plan()` reports it under `unparseable`, `apply()` refuses the instance (the updater's dirty-tree posture).
- The other REWRITE_EXTS have no classifier and keep the blanket swap; a test pins that boundary.

Verification after the second commit: 33 tests (fixtures now mirror the real shapes: docstring in the shipped init, code in the shipped helper; the negative twin for the prose rule removes span detection and watches the docstring get rewritten); mutation with the skeleton rule disabled leaves only its reproducer red; shadow check at main's 10; plan mode over the live refused instance after its exporter was restored: main's hook wants 8 rewrites, this branch wants 0 with `needs_work` False and `unparseable` empty, tree untouched.


## Third commit: the exemption is what the sync delivers (reviewer round 1, major + minor)

"Exists in the skeleton" was a proxy for "the sync will overwrite it". Where they differ: a template under an `INSTANCE_OWNED_SUBTREES` dir, a file at the skeleton root, the instance's merged `.claude/settings.json`, a path matching `PLUGIN_COPY_EXCLUDES`. Exempting those left the old name in place with `verified=True`. And the skeleton's `q-system/<x>` lands at `<subtree_prefix>/<x>`, null for one registered instance.

- `_delivered_by_sync` judges each path from the three facts the rsync uses: skeleton `q-system/` mapped through the prefix minus `INSTANCE_OWNED_SUBTREES`; skeleton `plugins/<name>/` minus `PLUGIN_COPY_EXCLUDES`.
- Both arrays are read from `kipi-update.sh` itself by `_bash_array`, which reads the literal list the way bash does; `test_exclude_lists_derive_from_the_updater_and_match_bash` compares the parse with bash's own evaluation (floor non-empty, bound equal). No hand copy.
- The prefix comes from `instance-registry.json` beside the skeleton (`DEFAULT_PREFIX` for an unknown repo). Unreadable arrays exempt nothing and the plan warns: the miss is churn, never a stranded import.
- Plan key renamed `delivered_by_sync`; `prefix` and `warnings` added.

Verification: 38 tests; mutation with `_delivered_by_sync` forced False leaves exactly the three delivery tests red; shadow check 10 = main; live plan over the refused instance: main 8 rewrites, this branch 0, 1165 delivered paths, prefix `q-system`, no warnings, tree untouched; the three updater test files together: 53 pass.

## Out of scope, captured

- The hook still reads a staged edit that removes the token as its own interrupted rewrite (`staged_rewrites`) and would sweep it into its commit. Pre-existing. The one live case was the hook's own leftover from the abort, restored to HEAD by its owner.
- The abandoned-instance cleanup (staged leftovers outside the dirty-rule paths after a refused pre-sync commit) is its own item; the sync owner is capturing it.
- `kipi-update.sh:1642` deletes `.git/*.lock` unconditionally before every sync: sp-2c1bcc3f.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01JQZrCCPLpc8Wr4t8aSB1V9
