### PR TITLE
feat(voice-stop-gate): port the live route-receipt and founder-text behaviour into the skeleton (ASK-1197)

### DIFF
--- a/q-system/.q-system/capability/expected_tests/q-system__.q-system__tests__test_voice_stop_gate_founder_text.py.json
+++ b/q-system/.q-system/capability/expected_tests/q-system__.q-system__tests__test_voice_stop_gate_founder_text.py.json
@@ -1,0 +1,5 @@
+{
+ "path": "q-system/.q-system/tests/test_voice_stop_gate_founder_text.py",
+ "runner": "python3",
+ "timeout_s": 60
+}

--- a/q-system/.q-system/capability/expected_tests/q-system__.q-system__tests__test_voice_stop_gate_founder_text.py.json
+++ b/q-system/.q-system/capability/expected_tests/q-system__.q-system__tests__test_voice_stop_gate_founder_text.py.json
@@ -1,5 +1,5 @@
 {
- "path": "q-system/.q-system/tests/test_voice_stop_gate_founder_text.py",
- "runner": "python3",
- "timeout_s": 60
+  "path": "q-system/.q-system/tests/test_voice_stop_gate_founder_text.py",
+  "runner": "pytest",
+  "timeout_s": 120
 }

--- a/q-system/.q-system/scripts/voice-stop-gate.py
+++ b/q-system/.q-system/scripts/voice-stop-gate.py
@@ -642,6 +642,46 @@ def find_final_user_text(transcript_path):
     return text
 
 
+def request_is_current(transcript_path):
+    """True when the newest text put in front of the assistant was typed by HIM.
+
+    `find_final_user_text` walks back to his last words on purpose (a skill body
+    or a hook's feedback is never his request). The walk-back has a second edge
+    (PR #313 review, round 3): after a routed draft, a machine turn (a task
+    notification, a peer message, a command's stdout) made the assistant answer
+    the MACHINE, and the gate re-ran his previous request through the receipt
+    check, refusing every such reply until he typed again. Measured there: 579
+    of 837 user text records in 60 session logs are machine turns answered by
+    the assistant. A non-draft reply to machine text is not a completion of his
+    request, so the short path asks this first.
+
+    Shape rules, from the records the harness writes: a tool result carries no
+    text and is neither his nor a trigger; a flagged record right after his own
+    (a skill body) is a companion of his turn; a flagged record after the
+    assistant spoke (a Stop hook's feedback) is the machine's; unflagged machine
+    text (a notification, a peer message) is the machine's.
+    """
+    current = False
+    assistant_spoke = False
+    for record, message in _walk_transcript(transcript_path, want_record=True):
+        role = message.get("role")
+        if role == "assistant":
+            assistant_spoke = True
+            continue
+        if role != "user":
+            continue
+        text = _message_text(message)
+        if not text:
+            continue
+        if any(record.get(flag) is True for flag in _META_FLAGS):
+            if assistant_spoke:
+                current = False
+            continue
+        current = bool(founder_typed_text(text))
+        assistant_spoke = False
+    return current
+
+
 # A MISSING CHECK IS NOT A PASS. This returned (0, "") when its script was
 # absent, and 0 is the same value a clean draft produces, so a run on a machine
 # where voice-lint.py had moved was byte-for-byte indistinguishable from a run
@@ -978,11 +1018,18 @@ def main():
         # returned here -- so the ONE turn shape he uses most was the one shape
         # that never reached the scorer. The lint's scope is unchanged; the
         # measurement no longer rides on it.
-        try:
-            enforce_route_receipt(request, text)
-        except RouteBoundaryError as exc:
-            sys.stderr.write(f"voice-stop-gate: {exc}\n")
-            sys.exit(2)
+        #
+        # Only when HE just asked. A non-draft reply to machine text (a
+        # notification, a peer message, a hook's feedback) is an answer to the
+        # machine, not a completion of his routed request; see
+        # `request_is_current`. The framed-draft path below keeps its check
+        # whatever triggered it: a draft of a routed request needs its receipt.
+        if request_is_current(transcript_path):
+            try:
+                enforce_route_receipt(request, text)
+            except RouteBoundaryError as exc:
+                sys.stderr.write(f"voice-stop-gate: {exc}\n")
+                sys.exit(2)
         authorship_spool(extract_setoff_draft(text), text, request)
         finish_ok()
     # WHICH RULEBOOK. An instance with no registry resolves to None here and the two

--- a/q-system/.q-system/scripts/voice-stop-gate.py
+++ b/q-system/.q-system/scripts/voice-stop-gate.py
@@ -45,6 +45,117 @@ INSTANCE_ROOT = SCRIPTS_DIR.parents[2]
 
 MIN_TEXT_BYTES = 80
 
+
+# THE ROUTE-RECEIPT FAMILY, PORTED FROM THE ONE INSTANCE THAT RUNS IT (ASK-1197).
+#
+# consulting's copy of this file has carried these five defs since 2026-08, and
+# every fleet sync replaced them with a skeleton copy that had none, so that
+# checkout's pre-commit went red after every sync and the restore was undone by
+# the next one (2026-09-06, twice in one afternoon; sp-745f5962, sp-1ad08728).
+# What is ported is the behaviour the founder runs live, verbatim where it can
+# be, so the sync stops regressing it; the deeper rewrite (PR #295, 15 review
+# rounds, one open major) rebases onto this rather than blocking it.
+#
+# THE 24 INSTANCES WITHOUT A ROUTE LANE ARE SILENT. consulting's original
+# imported `pipeline` unguarded, which is fine there and an uncaught ImportError
+# everywhere else (a Stop hook that exits 1 fails OPEN). So: no `q-consult/
+# pipeline` directory means no lane, `_route_context` returns None and
+# `enforce_route_receipt` returns None. A lane directory that is present and
+# does not import is a BROKEN verifier, not an absent one, and holds the turn
+# (a-gate-that-cannot-run-must-not-pass). Three outcomes, on purpose.
+ROUTE_PIPELINE_REL = Path("q-consult") / "pipeline"
+
+
+class RouteBoundaryError(ValueError):
+    """A routed completion lacks a current shared route receipt."""
+
+
+def _route_context():
+    """The q-consult route modules, or None when this instance has no route lane."""
+    pipeline_dir = INSTANCE_ROOT / ROUTE_PIPELINE_REL
+    if not pipeline_dir.is_dir():
+        return None
+    sys.path.insert(0, str(INSTANCE_ROOT / "q-consult"))
+    try:
+        from pipeline import (audit_only_routes, route_classifier, route_contract,
+                              route_registry)
+    except Exception as exc:
+        raise RouteBoundaryError(
+            f"route lane is installed at {pipeline_dir} but did not import: {exc}"
+        ) from exc
+    return route_classifier, route_contract, audit_only_routes, route_registry
+
+
+def _route_draft(text):
+    marker = "=== DRAFT ==="
+    if marker not in text:
+        return extract_publishable(text)
+    return text.split(marker, 1)[1].strip()
+
+
+def _receipt_block(text):
+    marker = "=== ROUTE RECEIPT ==="
+    if marker not in text:
+        return None
+    payload = text.split(marker, 1)[1].lstrip()
+    try:
+        value, _end = json.JSONDecoder().raw_decode(payload)
+    except json.JSONDecodeError as exc:
+        raise RouteBoundaryError("route receipt block is not valid JSON") from exc
+    return value
+
+
+def enforce_route_receipt(request, assistant_text):
+    """Consume the producer receipt for a routed completion, or refuse it.
+
+    None when this instance has no route lane, or the request is not routed.
+    Raises RouteBoundaryError to hold the turn.
+    """
+    context = _route_context()
+    if context is None:
+        return None
+    classifier, contract, audit_only, registry = context
+    result = classifier.classify(request)
+    if result.status == classifier.NOT_ROUTED:
+        return None
+    if result.status != classifier.ROUTE:
+        raise RouteBoundaryError(
+            f"route request is {result.status}: {result.reason}")
+    try:
+        route = registry.resolve(result.surface, result.channel)
+    except registry.RouteRegistryError:
+        audit_routes = [candidate for candidate in audit_only.routes()
+                        if candidate.surface == result.surface and candidate.channel == result.channel]
+        if len(audit_routes) == 1:
+            try:
+                audit_only.deny(audit_routes[0])
+            except audit_only.AuditOnlyRouteError as exc:
+                raise RouteBoundaryError(str(exc)) from exc
+        raise RouteBoundaryError("route has no single registered active owner")
+    receipt = _receipt_block(assistant_text)
+    if not isinstance(receipt, dict):
+        raise RouteBoundaryError("routed completion has no route receipt")
+    # The identity is whatever the store matches on, read from the store, so
+    # a field added there (R9: loop_sha) is demanded here without a second
+    # hand-kept list.
+    required = set(contract.route_receipts.MATCH_FIELDS)
+    if not required <= receipt.keys():
+        raise RouteBoundaryError("route receipt identity is incomplete")
+    if (receipt["surface"], receipt["channel"]) != (result.surface, result.channel):
+        raise RouteBoundaryError("route receipt does not match the requested surface")
+    if contract.request_hash(request, result.surface, result.channel) != receipt["request_hash"]:
+        raise RouteBoundaryError("route receipt does not match the user request")
+    draft = _route_draft(assistant_text)
+    if contract.output_hash(draft, result.surface, result.channel) != receipt["output_hash"]:
+        raise RouteBoundaryError("route receipt does not match the assistant output")
+    identity = {key: receipt[key] for key in required}
+    try:
+        # R9: the contract recomputes the receipt's loop evidence against THIS
+        # draft and the corpus on disk before the row is consumed.
+        return contract.verify_and_consume(identity, draft=draft)
+    except Exception as exc:
+        raise RouteBoundaryError(f"route receipt was not accepted: {exc}") from exc
+
 # Explicit publish-intent framing — the only signal that a final chat message hands the
 # founder content meant for someone ELSE. Engineering/debug chat carries none of these,
 # so it's treated as conversational-to-founder and skipped (voice-enforcement.md).
@@ -321,7 +432,31 @@ def finish_ok():
     sys.exit(0)
 
 
-def _walk_transcript(transcript_path):
+# A record the HARNESS injected, not something a person typed. These are
+# top-level fields on the transcript record, and `_walk_transcript` used to
+# throw them away by yielding only `record["message"]` -- which is precisely why
+# the text filters below kept having to guess from prose.
+_META_FLAGS = ("isMeta", "turnCompanion")
+
+
+def _walk_transcript(transcript_path, want_record=False):
+    """Yield each message, or `(record, message)` when the caller needs the flags.
+
+    THE SCAR (2026-09-01, third occurrence of this deadlock). A skill loaded and
+    the harness wrote that skill's 16,584-character body as its OWN `user`
+    record, carrying `isMeta: true` and `turnCompanion: true` and NO command tags
+    at all. This walker dropped those flags, so `find_final_user_text` read the
+    skill's documentation as the founder's request. Two of that document's own
+    sentences classify UNSUPPORTED, and the gate then refused every completion in
+    the session -- including the turn reporting the block -- while his actual
+    message, "Explain this simply no tables", is correctly not-routed.
+
+    The two earlier rounds were fixed by enumerating carriers in a regex
+    (`_INJECTED_BLOCK`, then `cross-session-message`). That is the shape that
+    keeps failing: each round adds the carrier that just bit, and the next one is
+    invisible until it bites. The harness already labels these records. Read the
+    label.
+    """
     if not transcript_path or not Path(transcript_path).exists():
         return
     for line in Path(transcript_path).read_text(encoding="utf-8").splitlines():
@@ -331,7 +466,7 @@ def _walk_transcript(transcript_path):
             continue
         message = record.get("message", {})
         if isinstance(message, dict):
-            yield message
+            yield (record, message) if want_record else message
 
 
 def _message_text(message):
@@ -357,6 +492,83 @@ def find_final_assistant_text(transcript_path):
     return "\n\n".join(p for p in text_parts if p)
 
 
+# A `user` turn the FOUNDER did not type. The harness injects background-task
+# results, hook output and context reminders on the user role, so the newest
+# `user` message is often a machine's prose. 2026-08-31: a subagent's completion
+# report contained the token `reply-lane`, `_UNSUPPORTED_COMPOUND` matched it,
+# and `enforce_route_receipt` refused the turn with "surface format has no
+# registered generation route" -- a writing request nobody made, from a report
+# about the work being finished. Stripping the blocks is not enough: a
+# notification whose text sits OUTSIDE any tag would still read as his words,
+# so a turn that is entirely machine-injected is skipped whole.
+_INJECTED_BLOCK = re.compile(
+    # `cross-session-message` added 2026-08-31 (sp-23053db5): a peer Claude
+    # session's message arrives in a `user` turn, so without it this enumeration
+    # answered "the founder typed this" about another agent's words. Its prose
+    # classified AMBIGUOUS and deadlocked every turn in the session, including the
+    # one reporting the block. Adding it removes no coverage of his own text.
+    r"<(system-reminder|task-notification|command-name|command-message|"
+    r"command-args|local-command-stdout|function_results|user-prompt-submit-hook|"
+    r"cross-session-message)"
+    r"\b.*?</\1>",
+    re.I | re.S,
+)
+_INJECTED_OPENER = re.compile(
+    r"^\s*(?:<(?:system-reminder|task-notification|command-name|"
+    r"local-command-stdout|user-prompt-submit-hook|cross-session-message)\b"
+    r"|\[SYSTEM NOTIFICATION"
+    r"|(?:PreToolUse|PostToolUse|Stop|SessionStart|UserPromptSubmit)"
+    r"(?::\w+)?\s+hook\b)",
+    re.I,
+)
+# A SKILL or SLASH-COMMAND invocation injects its whole BODY as bare markdown
+# after these tags. The body is not wrapped in anything, so `_INJECTED_BLOCK`
+# removed the little tags and left thousands of words of documentation standing
+# as "what the founder typed".
+#
+# THE SCAR, and this is its THIRD occurrence (2026-09-01). The deterministic
+# blocker for it is `_META_FLAGS` plus the `want_record=True` walk above, held
+# by the executable tests in
+# q-system/.q-system/tests/test_voice_stop_gate_founder_text.py; the prose here
+# is the history, not the enforcement. The comment on `_INJECTED_BLOCK` above
+# records the second occurrence: a peer session's prose classified AMBIGUOUS and
+# deadlocked every turn in the session, including the one reporting the refusal.
+# This is the same failure with a skill body as the source. `/workflow-authoring`
+# loaded, and two of its own sentences, "compose novel harnesses when the task
+# calls for it" and "Write/Edit and re-invoke Workflow with scriptPath", classify
+# UNSUPPORTED, so every completion was held while the founder's actual message,
+# "Explain this simply no tables", is correctly not-routed.
+#
+# His typed words come FIRST and the injection follows, so the fix is a
+# truncation, not another tag to enumerate. Enumerating tags is what failed
+# twice: each round adds the one carrier that just bit, and the next carrier is
+# invisible until it does.
+_COMMAND_INJECTION_MARK = re.compile(
+    r"<(?:command-name|command-message|command-args|skill-format|"
+    r"local-command-stdout)\b",
+    re.I,
+)
+
+
+def founder_typed_text(candidate):
+    """Strip machine-injected prose from one `user` turn, or reject it entirely.
+
+    A command or skill invocation is a TRUNCATION, not a tag removal: his typed
+    words come first and the injected body follows unwrapped, so everything from
+    the first command marker onward is the machine's text. See the scar note on
+    `_COMMAND_INJECTION_MARK`.
+    """
+    if not candidate:
+        return ""
+    if _INJECTED_OPENER.search(candidate):
+        return ""
+    typed = candidate
+    mark = _COMMAND_INJECTION_MARK.search(typed)
+    if mark:
+        typed = typed[:mark.start()]
+    return _INJECTED_BLOCK.sub(" ", typed).strip()
+
+
 def find_final_user_text(transcript_path):
     """His last message. The trigger signal the model cannot get wrong.
 
@@ -364,12 +576,18 @@ def find_final_user_text(transcript_path):
     what the assistant hands over, and reading his request into that decision
     would gate his own words. It is used only to decide whether the draft is
     worth measuring.
+
+    Only text the FOUNDER typed counts. See `_INJECTED_BLOCK` for the scar.
     """
     text = ""
-    for message in _walk_transcript(transcript_path):
+    for record, message in _walk_transcript(transcript_path, want_record=True):
         if message.get("role") != "user":
             continue
-        candidate = _message_text(message)
+        # The harness labels its own injections. Trust the label over any
+        # attempt to recognise the prose; see `_walk_transcript`'s scar note.
+        if any(record.get(flag) is True for flag in _META_FLAGS):
+            continue
+        candidate = founder_typed_text(_message_text(message))
         if candidate:
             text = candidate
     return text
@@ -711,6 +929,11 @@ def main():
         # returned here -- so the ONE turn shape he uses most was the one shape
         # that never reached the scorer. The lint's scope is unchanged; the
         # measurement no longer rides on it.
+        try:
+            enforce_route_receipt(request, text)
+        except RouteBoundaryError as exc:
+            sys.stderr.write(f"voice-stop-gate: {exc}\n")
+            sys.exit(2)
         authorship_spool(extract_setoff_draft(text), text, request)
         finish_ok()
     # WHICH RULEBOOK. An instance with no registry resolves to None here and the two
@@ -813,6 +1036,12 @@ def main():
                 os.unlink(path)
             except OSError:
                 pass
+
+    try:
+        enforce_route_receipt(request, text)
+    except RouteBoundaryError as exc:
+        sys.stderr.write(f"voice-stop-gate: {exc}\n")
+        sys.exit(2)
 
     # THE CLEAN PATH. Score this draft (backgrounded, arrives next turn) and
     # surface whatever a previous turn's worker finished.

--- a/q-system/.q-system/scripts/voice-stop-gate.py
+++ b/q-system/.q-system/scripts/voice-stop-gate.py
@@ -110,10 +110,28 @@ def enforce_route_receipt(request, assistant_text):
 
     None when this instance has no route lane, or the request is not routed.
     Raises RouteBoundaryError to hold the turn.
+
+    ANY other exception out of the lane is also a hold. The lane is a verifier
+    (classifier, registry, receipt store), and a verifier that raises has not
+    verified: an uncaught error here exits the Stop hook with 1, which Claude
+    Code treats as a non-blocking failure, so the routed turn completed with
+    no receipt consumed (PR #313 review, round 2). Only the two callers in
+    main() catch RouteBoundaryError, so the conversion happens here, once.
     """
     context = _route_context()
     if context is None:
         return None
+    try:
+        return _verify_route_receipt(context, request, assistant_text)
+    except RouteBoundaryError:
+        raise
+    except Exception as exc:
+        raise RouteBoundaryError(
+            f"route lane raised {type(exc).__name__} instead of verifying: {exc}"
+        ) from exc
+
+
+def _verify_route_receipt(context, request, assistant_text):
     classifier, contract, audit_only, registry = context
     result = classifier.classify(request)
     if result.status == classifier.NOT_ROUTED:

--- a/q-system/.q-system/scripts/voice-stop-gate.py
+++ b/q-system/.q-system/scripts/voice-stop-gate.py
@@ -513,12 +513,19 @@ _INJECTED_BLOCK = re.compile(
     r"\b.*?</\1>",
     re.I | re.S,
 )
+# A turn that OPENS with an injected tag is machine text end to end. Two
+# alternatives left this list on 2026-09-06 (PR #313 review, findings 1 and 4):
+# `command-name`, because a slash-command turn is HIS turn and is rebuilt by
+# `_command_invocation` below; and the "<Event> hook" prose opener, because the
+# harness labels every hook-feedback record isMeta (measured over 30 session
+# logs in two projects: 251 of 251 such records carry the flag, which
+# `find_final_user_text` already honours), so the only text that alternative
+# ever matched was his own, "PostToolUse hook is refusing my edit again, why?",
+# which then read as an OLDER turn's request.
 _INJECTED_OPENER = re.compile(
-    r"^\s*(?:<(?:system-reminder|task-notification|command-name|"
+    r"^\s*(?:<(?:system-reminder|task-notification|"
     r"local-command-stdout|user-prompt-submit-hook|cross-session-message)\b"
-    r"|\[SYSTEM NOTIFICATION"
-    r"|(?:PreToolUse|PostToolUse|Stop|SessionStart|UserPromptSubmit)"
-    r"(?::\w+)?\s+hook\b)",
+    r"|\[SYSTEM NOTIFICATION)",
     re.I,
 )
 # A SKILL or SLASH-COMMAND invocation injects its whole BODY as bare markdown
@@ -539,34 +546,58 @@ _INJECTED_OPENER = re.compile(
 # UNSUPPORTED, so every completion was held while the founder's actual message,
 # "Explain this simply no tables", is correctly not-routed.
 #
-# His typed words come FIRST and the injection follows, so the fix is a
-# truncation, not another tag to enumerate. Enumerating tags is what failed
-# twice: each round adds the one carrier that just bit, and the next carrier is
-# invisible until it does.
+# His typed words come FIRST, or, for a slash command, INSIDE `<command-args>`,
+# and the injected body follows. Measured 2026-09-06 over 30 session logs in two
+# projects: 50 command turns, none flagged isMeta; 13 carry his words in
+# command-args, 37 are bare (a plugin command puts `<command-message>` before
+# `<command-name>`), and none has typed text before the first tag. Truncating
+# at the first marker therefore returned "" for every one of them, and
+# `find_final_user_text` answered with an OLDER turn (PR #313 review, finding
+# 1): the scorer and the route hasher were handed a request he did not type
+# this turn. So the invocation is REBUILT from the tags, never enumerated by
+# body: enumerating tags is what failed twice, each round adding the one
+# carrier that just bit, and the next carrier invisible until it does.
 _COMMAND_INJECTION_MARK = re.compile(
     r"<(?:command-name|command-message|command-args|skill-format|"
     r"local-command-stdout)\b",
     re.I,
 )
+_COMMAND_NAME = re.compile(r"<command-name>(.*?)</command-name>", re.I | re.S)
+_COMMAND_ARGS = re.compile(r"<command-args>(.*?)</command-args>", re.I | re.S)
+
+
+def _command_invocation(injected):
+    """What he typed to invoke a slash command, rebuilt from the harness tags.
+
+    His words are the `<command-args>` content. With no arguments the command
+    name itself is the request, so a bare `/q-morning` turn is still his turn
+    and never yields to a stale one. `<command-message>` is the command's own
+    label, never typed, and the skill body after the tags is the machine's.
+    """
+    args = _COMMAND_ARGS.search(injected)
+    if args and args.group(1).strip():
+        return args.group(1).strip()
+    name = _COMMAND_NAME.search(injected)
+    return name.group(1).strip() if name else ""
 
 
 def founder_typed_text(candidate):
     """Strip machine-injected prose from one `user` turn, or reject it entirely.
 
-    A command or skill invocation is a TRUNCATION, not a tag removal: his typed
-    words come first and the injected body follows unwrapped, so everything from
-    the first command marker onward is the machine's text. See the scar note on
-    `_COMMAND_INJECTION_MARK`.
+    A command or skill invocation is a TRUNCATION plus a REBUILD, not a tag
+    removal: anything he typed before the first command marker is his, the
+    invocation is read back out of the tags, and the unwrapped body after them
+    is the machine's. See the scar note on `_COMMAND_INJECTION_MARK`.
     """
     if not candidate:
         return ""
     if _INJECTED_OPENER.search(candidate):
         return ""
-    typed = candidate
-    mark = _COMMAND_INJECTION_MARK.search(typed)
-    if mark:
-        typed = typed[:mark.start()]
-    return _INJECTED_BLOCK.sub(" ", typed).strip()
+    mark = _COMMAND_INJECTION_MARK.search(candidate)
+    if not mark:
+        return _INJECTED_BLOCK.sub(" ", candidate).strip()
+    typed = _INJECTED_BLOCK.sub(" ", candidate[:mark.start()]).strip()
+    return typed or _command_invocation(candidate[mark.start():])
 
 
 def find_final_user_text(transcript_path):

--- a/q-system/.q-system/scripts/voice-stop-gate.py
+++ b/q-system/.q-system/scripts/voice-stop-gate.py
@@ -653,7 +653,10 @@ def request_is_current(transcript_path):
     check, refusing every such reply until he typed again. Measured there: 579
     of 837 user text records in 60 session logs are machine turns answered by
     the assistant. A non-draft reply to machine text is not a completion of his
-    request, so the short path asks this first.
+    request, so the short path asks this first, together with
+    `reply_carries_a_draft`: a DRAFT after machine text (a bare fence written
+    after the gate's own feedback, round 4 of the same review) is still a
+    completion of his routed request and keeps its receipt check.
 
     Shape rules, from the records the harness writes: a tool result carries no
     text and is neither his nor a trigger; a flagged record right after his own
@@ -680,6 +683,15 @@ def request_is_current(transcript_path):
         current = bool(founder_typed_text(text))
         assistant_spoke = False
     return current
+
+
+def reply_carries_a_draft(text):
+    """True when the assistant's reply contains draft-shaped content: a set-off
+    prose fence or blockquote, a `=== DRAFT ===` section, or a route receipt.
+    Such a reply is a completion of a routed request whatever triggered it, so
+    the receipt check applies; plain prose is not."""
+    return ("=== ROUTE RECEIPT ===" in text or "=== DRAFT ===" in text
+            or bool(extract_setoff_draft(text)))
 
 
 # A MISSING CHECK IS NOT A PASS. This returned (0, "") when its script was
@@ -1019,12 +1031,14 @@ def main():
         # that never reached the scorer. The lint's scope is unchanged; the
         # measurement no longer rides on it.
         #
-        # Only when HE just asked. A non-draft reply to machine text (a
-        # notification, a peer message, a hook's feedback) is an answer to the
-        # machine, not a completion of his routed request; see
-        # `request_is_current`. The framed-draft path below keeps its check
-        # whatever triggered it: a draft of a routed request needs its receipt.
-        if request_is_current(transcript_path):
+        # When HE just asked, or when the reply IS a draft. A prose reply to
+        # machine text (a notification, a peer message, a hook's feedback) is
+        # an answer to the machine, not a completion of his routed request; a
+        # draft after machine text still is one (a bare fence written after the
+        # gate's own feedback would otherwise complete with no receipt). See
+        # `request_is_current` and `reply_carries_a_draft`. The framed-draft
+        # path below keeps its check whatever triggered it, for the same reason.
+        if request_is_current(transcript_path) or reply_carries_a_draft(text):
             try:
                 enforce_route_receipt(request, text)
             except RouteBoundaryError as exc:

--- a/q-system/.q-system/tests/test_voice_stop_gate_founder_text.py
+++ b/q-system/.q-system/tests/test_voice_stop_gate_founder_text.py
@@ -12,6 +12,13 @@ content as a list of text blocks.
 The lane tests build a fake `q-consult/pipeline` package in a temp root and
 point the gate's INSTANCE_ROOT at it, so the three outcomes of `_route_context`
 (absent, broken, present) are each exercised without the real lane.
+
+Round 2 (PR #313 review): the slash-command and hook-opener cases use record
+text lifted verbatim from this fleet's own session logs (a `/goal` turn with his
+words in `<command-args>`, a plugin command with `<command-message>` first), and
+the receipt cases run against a fake `route_contract` that hashes with the
+producer's exact envelope, so each of the five verification branches in
+`enforce_route_receipt` is killed by at least one case (mutation-checked).
 """
 import importlib.util
 import json
@@ -46,6 +53,20 @@ PEER = (
     'from-name="voice loop" from-mode="bypass">\n'
     'If you add a `social-comment` surface, its pointers are now verified.\n'
     '</cross-session-message>'
+)
+# Verbatim from a 2026-09-06 session log: the harness's own shape for a slash
+# command, indentation included, and not flagged isMeta.
+GOAL_TURN = (
+    "<command-name>/goal</command-name>\n"
+    "            <command-message>goal</command-message>\n"
+    "            <command-args>ensure you know from the other projects tht you "
+    "know when you can go and then go</command-args>"
+)
+GOAL_ARGS = "ensure you know from the other projects tht you know when you can go and then go"
+# A plugin command: `<command-message>` comes FIRST, and there are no args.
+PLUGIN_COMMAND_TURN = (
+    "<command-message>kipi-core:wiring-check</command-message>\n"
+    "<command-name>/kipi-core:wiring-check</command-name>"
 )
 
 
@@ -145,9 +166,98 @@ def test_assistant_text_is_unaffected(transcript):
     assert "here is the draft" in vsg.find_final_assistant_text(path)
 
 
+# --- a slash command is HIS turn ------------------------------------------
+
+def test_a_slash_command_turn_is_his_arguments():
+    assert vsg.founder_typed_text(GOAL_TURN) == GOAL_ARGS
+
+
+def test_a_slash_command_turn_is_not_an_older_request(transcript):
+    """The PR #313 reproducer: truncating at the first tag returned "" and the
+    gate answered with the PREVIOUS turn, so the scorer and the route hasher
+    were handed words he did not type this turn."""
+    path = transcript([
+        _record("write me a linkedin post about the audit"),
+        _record(GOAL_TURN),
+    ])
+    assert vsg.find_final_user_text(path) == GOAL_ARGS
+
+
+def test_a_bare_command_is_still_his_turn(transcript):
+    assert vsg.founder_typed_text(PLUGIN_COMMAND_TURN) == "/kipi-core:wiring-check"
+    path = transcript([
+        _record("write me a linkedin post about the audit"),
+        _record(PLUGIN_COMMAND_TURN),
+    ])
+    assert vsg.find_final_user_text(path) == "/kipi-core:wiring-check"
+
+
+@pytest.mark.parametrize("typed", [
+    "PostToolUse hook is refusing my edit again, why?",
+    "Stop hook feedback is firing on every turn, fix it",
+    "SessionStart hook output looks wrong",
+])
+def test_his_message_about_a_hook_is_his_message(typed):
+    """He pastes hook errors as a workflow. The harness flags its OWN hook
+    feedback isMeta (251 of 251 records over 30 session logs), so prose that
+    opens with an event name is his, not the machine's."""
+    assert vsg.founder_typed_text(typed) == typed
+
+
 # --- the route lane: absent, broken, present ------------------------------
 
-def _fake_lane(root, broken=False, status="NOT_ROUTED"):
+# The contract half of the fake lane hashes with the PRODUCER's exact envelope
+# (route_contract._hash: NFC-normalised text, sorted compact JSON, sha256) and
+# matches on its MATCH_FIELDS, so a receipt minted here is refused or consumed
+# for the same reasons a real one is. An empty module here was PR #313's
+# finding 3: every verification branch survived deletion with the suite green.
+FAKE_CONTRACT = '''
+import hashlib, json, pathlib, unicodedata
+
+class route_receipts:
+    MATCH_FIELDS = {"attempt_id", "session_id", "origin_message_id",
+                    "completion_message_id", "request_hash", "surface",
+                    "channel", "output_hash", "loop_sha"}
+
+STORE = pathlib.Path(__file__).with_name("receipts.json")
+
+def normalize_text(text):
+    return unicodedata.normalize("NFC", str(text)).replace("\\r\\n", "\\n").replace("\\r", "\\n")
+
+def _hash(kind, text, surface, channel):
+    envelope = {"channel": channel, "kind": kind, "surface": surface, "text": normalize_text(text)}
+    encoded = json.dumps(envelope, ensure_ascii=False, sort_keys=True, separators=(",", ":"))
+    return hashlib.sha256(encoded.encode("utf-8")).hexdigest()
+
+def request_hash(request, surface, channel):
+    return _hash("request", request, surface, channel)
+
+def output_hash(output, surface, channel):
+    return _hash("output", output, surface, channel)
+
+def create_receipt(request, output, *, surface, channel, **overrides):
+    row = {"attempt_id": "attempt-1", "session_id": "session-1",
+           "origin_message_id": "origin-1", "completion_message_id": "completion-1",
+           "request_hash": request_hash(request, surface, channel),
+           "surface": surface, "channel": channel,
+           "output_hash": output_hash(output, surface, channel),
+           "loop_sha": "loop-1", "status": "pending"}
+    row.update(overrides)
+    STORE.write_text(json.dumps(row))
+    return row
+
+def verify_and_consume(identity, *, draft=None, **_):
+    row = json.loads(STORE.read_text()) if STORE.exists() else None
+    if row is None or row["status"] != "pending" or any(row.get(k) != v for k, v in identity.items()):
+        raise LookupError("no current receipt matches the identity")
+    row["status"] = "consumed"
+    row["draft"] = draft
+    STORE.write_text(json.dumps(row))
+    return row
+'''
+
+
+def _fake_lane(root, broken=False, status="NOT_ROUTED", owner=False):
     pkg = root / "q-consult" / "pipeline"
     pkg.mkdir(parents=True)
     (pkg / "__init__.py").write_text("")
@@ -164,18 +274,20 @@ def _fake_lane(root, broken=False, status="NOT_ROUTED"):
         def classify(request):
             return Result({status!r}, "linkedin_post", "linkedin", "fixture")
     """))
-    (pkg / "route_contract.py").write_text("")
+    (pkg / "route_contract.py").write_text(FAKE_CONTRACT)
     (pkg / "audit_only_routes.py").write_text(textwrap.dedent("""
         class AuditOnlyRouteError(Exception):
             pass
         def routes():
             return []
     """))
-    (pkg / "route_registry.py").write_text(textwrap.dedent("""
+    (pkg / "route_registry.py").write_text(textwrap.dedent(f"""
         class RouteRegistryError(Exception):
             pass
         def resolve(surface, channel):
-            raise RouteRegistryError("no owner in the fixture")
+            if not {owner!r}:
+                raise RouteRegistryError("no owner in the fixture")
+            return {{"surface": surface, "channel": channel, "owner": "fixture"}}
     """))
     return pkg
 
@@ -224,3 +336,73 @@ def test_a_receipt_block_must_be_json():
         vsg._receipt_block("=== ROUTE RECEIPT ===\nnot json")
     assert vsg._receipt_block("no marker here") is None
     assert vsg._receipt_block('=== ROUTE RECEIPT ===\n{"surface": "x"}') == {"surface": "x"}
+
+
+# --- the receipt: each verification branch refuses for its own reason ------
+
+REQUEST = "write me a linkedin post about the audit"
+DRAFT = "The audit found the gate green and the test never ran."
+
+
+def _routed_lane(lane_root):
+    """A present lane that ROUTES the request to an owner; returns its contract."""
+    _fake_lane(lane_root, status="ROUTE", owner=True)
+    return vsg._route_context()[1]
+
+
+def _assistant(receipt, draft=DRAFT):
+    return "=== ROUTE RECEIPT ===\n" + json.dumps(receipt) + "\n=== DRAFT ===\n" + draft
+
+
+def test_a_matching_receipt_passes_and_is_consumed(lane_root):
+    contract = _routed_lane(lane_root)
+    receipt = contract.create_receipt(REQUEST, DRAFT, surface="linkedin_post", channel="linkedin")
+    row = vsg.enforce_route_receipt(REQUEST, _assistant(receipt))
+    assert row["status"] == "consumed"
+    assert row["draft"] == DRAFT
+
+
+def test_a_routed_completion_with_no_receipt_is_refused(lane_root):
+    _routed_lane(lane_root)
+    with pytest.raises(vsg.RouteBoundaryError, match="has no route receipt"):
+        vsg.enforce_route_receipt(REQUEST, "=== DRAFT ===\n" + DRAFT)
+
+
+def test_an_incomplete_identity_is_refused(lane_root):
+    contract = _routed_lane(lane_root)
+    receipt = contract.create_receipt(REQUEST, DRAFT, surface="linkedin_post", channel="linkedin")
+    del receipt["loop_sha"]
+    with pytest.raises(vsg.RouteBoundaryError, match="identity is incomplete"):
+        vsg.enforce_route_receipt(REQUEST, _assistant(receipt))
+
+
+def test_a_receipt_for_another_surface_is_refused(lane_root):
+    contract = _routed_lane(lane_root)
+    receipt = contract.create_receipt(REQUEST, DRAFT, surface="reddit_post", channel="reddit")
+    with pytest.raises(vsg.RouteBoundaryError, match="requested surface"):
+        vsg.enforce_route_receipt(REQUEST, _assistant(receipt))
+
+
+def test_a_receipt_for_another_request_is_refused(lane_root):
+    contract = _routed_lane(lane_root)
+    receipt = contract.create_receipt("write me a linkedin post about another audit", DRAFT,
+                                      surface="linkedin_post", channel="linkedin")
+    with pytest.raises(vsg.RouteBoundaryError, match="does not match the user request"):
+        vsg.enforce_route_receipt(REQUEST, _assistant(receipt))
+
+
+def test_a_draft_edited_after_minting_is_refused(lane_root):
+    contract = _routed_lane(lane_root)
+    receipt = contract.create_receipt(REQUEST, DRAFT, surface="linkedin_post", channel="linkedin")
+    with pytest.raises(vsg.RouteBoundaryError, match="does not match the assistant output"):
+        vsg.enforce_route_receipt(REQUEST, _assistant(receipt, draft=DRAFT + " Edited."))
+
+
+def test_a_receipt_the_store_does_not_hold_is_refused(lane_root):
+    """A well-formed block whose row is gone (or already consumed) is not a
+    proof; the store's refusal is surfaced, never swallowed."""
+    contract = _routed_lane(lane_root)
+    receipt = contract.create_receipt(REQUEST, DRAFT, surface="linkedin_post", channel="linkedin")
+    contract.STORE.unlink()
+    with pytest.raises(vsg.RouteBoundaryError, match="was not accepted"):
+        vsg.enforce_route_receipt(REQUEST, _assistant(receipt))

--- a/q-system/.q-system/tests/test_voice_stop_gate_founder_text.py
+++ b/q-system/.q-system/tests/test_voice_stop_gate_founder_text.py
@@ -17,10 +17,18 @@ Round 2 (PR #313 review): the slash-command and hook-opener cases use record
 text lifted verbatim from this fleet's own session logs (a `/goal` turn with his
 words in `<command-args>`, a plugin command with `<command-message>` first), and
 the receipt cases run against a fake `route_contract` that hashes with the
-producer's exact envelope, so each of the five verification branches in
-`enforce_route_receipt` is killed by at least one case (mutation-checked).
+producer's exact envelope.
+
+Round 3: a lane that RAISES (not ImportError) holds the turn instead of exiting
+the hook with 1, the audit-only refusal is reached through a fake route that
+matches, and `main()` itself is driven on both paths (short draft, linted
+draft) so deleting either `enforce_route_receipt` call site goes red. The
+mutation harness beside this file (scratchpad, not shipped) replaces each of
+the five receipt checks, the two audit-only branches, the exception guard and
+each call site with a no-op; every mutant fails at least one case here.
 """
 import importlib.util
+import io
 import json
 import pathlib
 import textwrap
@@ -257,7 +265,15 @@ def verify_and_consume(identity, *, draft=None, **_):
 '''
 
 
-def _fake_lane(root, broken=False, status="NOT_ROUTED", owner=False):
+def _fake_lane(root, broken=False, status="NOT_ROUTED", owner=False,
+               raises=False, audit_surface=None):
+    """A q-consult/pipeline package with the four modules the gate imports.
+
+    `raises`: classify() raises RuntimeError, the shape of a lane whose store
+    or classifier is broken at call time rather than at import time.
+    `audit_surface`: audit_only_routes.routes() lists one audit-only route on
+    that surface (channel "linkedin"), and deny() refuses it by name.
+    """
     pkg = root / "q-consult" / "pipeline"
     pkg.mkdir(parents=True)
     (pkg / "__init__.py").write_text("")
@@ -272,14 +288,22 @@ def _fake_lane(root, broken=False, status="NOT_ROUTED", owner=False):
         ROUTE = "ROUTE"
         Result = collections.namedtuple("Result", "status surface channel reason")
         def classify(request):
+            if {raises!r}:
+                raise RuntimeError("classifier store is unreadable")
             return Result({status!r}, "linkedin_post", "linkedin", "fixture")
     """))
     (pkg / "route_contract.py").write_text(FAKE_CONTRACT)
-    (pkg / "audit_only_routes.py").write_text(textwrap.dedent("""
+    (pkg / "audit_only_routes.py").write_text(textwrap.dedent(f"""
+        import collections
+        Route = collections.namedtuple("Route", "surface channel route_id")
         class AuditOnlyRouteError(Exception):
             pass
         def routes():
-            return []
+            surface = {audit_surface!r}
+            return [Route(surface, "linkedin", "audit-1")] if surface else []
+        def deny(route):
+            raise AuditOnlyRouteError(
+                f"{{route.surface}} is audit-only; file the follow-up issue instead")
     """))
     (pkg / "route_registry.py").write_text(textwrap.dedent(f"""
         class RouteRegistryError(Exception):
@@ -329,6 +353,67 @@ def test_a_routed_request_with_no_owner_is_refused(lane_root):
     _fake_lane(lane_root, status="ROUTE")
     with pytest.raises(vsg.RouteBoundaryError, match="no single registered active owner"):
         vsg.enforce_route_receipt("write me a linkedin post", "a draft")
+
+
+def test_a_lane_that_raises_at_call_time_holds_the_turn(lane_root):
+    """Not an ImportError: the lane imports and then its classifier raises. An
+    uncaught exception exits the Stop hook with 1, which does not block, so the
+    routed turn would complete with no receipt consumed."""
+    _fake_lane(lane_root, status="ROUTE", raises=True)
+    with pytest.raises(vsg.RouteBoundaryError, match="raised RuntimeError"):
+        vsg.enforce_route_receipt("write me a linkedin post", "a draft")
+
+
+def test_an_audit_only_surface_is_refused_by_name(lane_root):
+    """No owner in the registry AND exactly one audit-only route on the
+    requested surface: the refusal names the audit-only rule, not the owner."""
+    _fake_lane(lane_root, status="ROUTE", audit_surface="linkedin_post")
+    with pytest.raises(vsg.RouteBoundaryError, match="is audit-only"):
+        vsg.enforce_route_receipt("write me a linkedin post", "a draft")
+
+
+def test_an_audit_only_route_on_another_surface_does_not_apply(lane_root):
+    _fake_lane(lane_root, status="ROUTE", audit_surface="reddit_post")
+    with pytest.raises(vsg.RouteBoundaryError, match="no single registered active owner"):
+        vsg.enforce_route_receipt("write me a linkedin post", "a draft")
+
+
+# --- the wiring: main() reaches the receipt check on both of its paths -----
+
+def _run_main(monkeypatch, transcript, assistant_text):
+    monkeypatch.setattr("sys.argv", ["voice-stop-gate.py"])
+    monkeypatch.setattr("sys.stdin", io.StringIO(json.dumps({"transcript_path": transcript})))
+    err = io.StringIO()
+    monkeypatch.setattr("sys.stderr", err)
+    with pytest.raises(SystemExit) as exit_info:
+        vsg.main()
+    return exit_info.value.code, err.getvalue()
+
+
+def test_main_holds_a_short_routed_reply_with_no_receipt(lane_root, transcript, monkeypatch):
+    """The first call site: the founder's most common turn shape is a post in a
+    fence with no framing sentence, which the lint declines to grade and which
+    used to return before any check. Deleting this call leaves every unit test
+    above green; only driving main() sees it."""
+    _fake_lane(lane_root, status="ROUTE", owner=True)
+    path = transcript([_record(REQUEST), _record("short reply", role="assistant")])
+    code, err = _run_main(monkeypatch, path, "short reply")
+    assert code == 2
+    assert "has no route receipt" in err
+
+
+def test_main_holds_a_linted_routed_draft_with_no_receipt(lane_root, transcript, monkeypatch):
+    """The second call site, after the voice lints. The lints are stubbed to
+    pass (run_check returns 0) and the draft is long enough to be graded, so
+    the only thing that can hold the turn is the receipt check."""
+    _fake_lane(lane_root, status="ROUTE", owner=True)
+    long_draft = "A graded draft. " * 12
+    monkeypatch.setattr(vsg, "extract_publishable", lambda text: long_draft)
+    monkeypatch.setattr(vsg, "run_check", lambda *args, **kwargs: (0, ""))
+    path = transcript([_record(REQUEST), _record(long_draft, role="assistant")])
+    code, err = _run_main(monkeypatch, path, long_draft)
+    assert code == 2
+    assert "has no route receipt" in err
 
 
 def test_a_receipt_block_must_be_json():

--- a/q-system/.q-system/tests/test_voice_stop_gate_founder_text.py
+++ b/q-system/.q-system/tests/test_voice_stop_gate_founder_text.py
@@ -76,6 +76,8 @@ PLUGIN_COMMAND_TURN = (
     "<command-message>kipi-core:wiring-check</command-message>\n"
     "<command-name>/kipi-core:wiring-check</command-name>"
 )
+REQUEST = "write me a linkedin post about the audit"
+DRAFT = "The audit found the gate green and the test never ran."
 
 
 def _record(text, role="user", **flags):
@@ -266,13 +268,15 @@ def verify_and_consume(identity, *, draft=None, **_):
 
 
 def _fake_lane(root, broken=False, status="NOT_ROUTED", owner=False,
-               raises=False, audit_surface=None):
+               raises=False, audit_surface=None, route_on=None):
     """A q-consult/pipeline package with the four modules the gate imports.
 
     `raises`: classify() raises RuntimeError, the shape of a lane whose store
     or classifier is broken at call time rather than at import time.
     `audit_surface`: audit_only_routes.routes() lists one audit-only route on
     that surface (channel "linkedin"), and deny() refuses it by name.
+    `route_on`: classify() routes only when this phrase is in the request, the
+    way the reviewer's reproducer classified on the words of the request.
     """
     pkg = root / "q-consult" / "pipeline"
     pkg.mkdir(parents=True)
@@ -290,7 +294,11 @@ def _fake_lane(root, broken=False, status="NOT_ROUTED", owner=False,
         def classify(request):
             if {raises!r}:
                 raise RuntimeError("classifier store is unreadable")
-            return Result({status!r}, "linkedin_post", "linkedin", "fixture")
+            status = {status!r}
+            route_on = {route_on!r}
+            if route_on is not None:
+                status = ROUTE if route_on in request.lower() else NOT_ROUTED
+            return Result(status, "linkedin_post", "linkedin", "fixture")
     """))
     (pkg / "route_contract.py").write_text(FAKE_CONTRACT)
     (pkg / "audit_only_routes.py").write_text(textwrap.dedent(f"""
@@ -402,6 +410,58 @@ def test_main_holds_a_short_routed_reply_with_no_receipt(lane_root, transcript, 
     assert "has no route receipt" in err
 
 
+# --- whose turn is it: the request must belong to THIS turn ---------------
+
+NOTIFICATION = "<task-notification>agent finished: 3 files</task-notification>"
+TOOL_RESULT = {
+    "type": "user", "isSidechain": False, "userType": "external",
+    "message": {"role": "user", "content": [{"type": "tool_result", "tool_use_id": "t1", "content": "ok"}]},
+}
+
+
+@pytest.mark.parametrize("records, expected", [
+    ([_record(REQUEST)], True),
+    ([_record(REQUEST), _record(SKILL_BODY, isMeta=True, turnCompanion=True)], True),
+    ([_record(REQUEST), _record("a draft", role="assistant"), TOOL_RESULT,
+      _record("done", role="assistant")], True),
+    ([_record(REQUEST), _record("a draft", role="assistant"),
+      _record("Stop hook feedback:\nvoice violations", isMeta=True)], False),
+    ([_record(REQUEST), _record("a draft", role="assistant"), _record(PEER)], False),
+    ([_record(REQUEST), _record("a draft", role="assistant"), _record(NOTIFICATION)], False),
+    ([_record(REQUEST), _record("a draft", role="assistant"), _record(NOTIFICATION),
+      _record("noted", role="assistant"), _record("thanks, park it")], True),
+], ids=["his-turn", "skill-body-companion", "tool-result-mid-turn", "hook-feedback",
+        "peer-message", "notification", "he-types-again"])
+def test_request_is_current_reads_who_spoke_last(transcript, records, expected):
+    assert vsg.request_is_current(transcript(records)) is expected
+
+
+def test_main_does_not_rerun_his_old_request_on_a_machine_turn(lane_root, transcript, monkeypatch):
+    """The reviewer's five-turn reproducer, driven through main() on one growing
+    transcript with a lane that routes on the words of the request. Before the
+    fix, turn 2 exited 2 ("has no route receipt") and so did every redraft after
+    it, until he typed again."""
+    _fake_lane(lane_root, owner=True, route_on="linkedin post")
+    contract = vsg._route_context()[1]
+    monkeypatch.setattr(vsg, "authorship_spool", lambda *args, **kwargs: None)
+    monkeypatch.setattr(vsg, "finish_ok", lambda: (_ for _ in ()).throw(SystemExit(0)))
+    monkeypatch.setattr(vsg, "run_check", lambda *args, **kwargs: (0, ""))
+    receipt = contract.create_receipt(REQUEST, DRAFT, surface="linkedin_post", channel="linkedin")
+    records = [_record(REQUEST), _record(_assistant(receipt), role="assistant")]
+    code, err = _run_main(monkeypatch, transcript(records), _assistant(receipt))
+    assert code == 0, err                                     # turn 1: routed draft + receipt
+    records += [_record(NOTIFICATION), _record("Noted, three files landed.", role="assistant")]
+    code, err = _run_main(monkeypatch, transcript(records), "Noted, three files landed.")
+    assert code == 0, err                                     # turn 2: prose reply to the machine
+    records += [_record("thanks, park it"), _record("Parked.", role="assistant")]
+    code, err = _run_main(monkeypatch, transcript(records), "Parked.")
+    assert code == 0, err                                     # turn 3: he types, not routed
+    records += [_record("write me a linkedin post about the audit, again"),
+                _record("Here it is.", role="assistant")]
+    code, err = _run_main(monkeypatch, transcript(records), "Here it is.")
+    assert code == 2 and "has no route receipt" in err        # turn 4: he asks, no receipt
+
+
 def test_main_holds_a_linted_routed_draft_with_no_receipt(lane_root, transcript, monkeypatch):
     """The second call site, after the voice lints. The lints are stubbed to
     pass (run_check returns 0) and the draft is long enough to be graded, so
@@ -424,10 +484,6 @@ def test_a_receipt_block_must_be_json():
 
 
 # --- the receipt: each verification branch refuses for its own reason ------
-
-REQUEST = "write me a linkedin post about the audit"
-DRAFT = "The audit found the gate green and the test never ran."
-
 
 def _routed_lane(lane_root):
     """A present lane that ROUTES the request to an owner; returns its contract."""

--- a/q-system/.q-system/tests/test_voice_stop_gate_founder_text.py
+++ b/q-system/.q-system/tests/test_voice_stop_gate_founder_text.py
@@ -436,6 +436,35 @@ def test_request_is_current_reads_who_spoke_last(transcript, records, expected):
     assert vsg.request_is_current(transcript(records)) is expected
 
 
+@pytest.mark.parametrize("text, expected", [
+    ("Noted, three files landed.", False),
+    ("```\n" + DRAFT + "\n```", True),
+    ("> " + DRAFT, True),
+    ("=== DRAFT ===\n" + DRAFT, True),
+    ('=== ROUTE RECEIPT ===\n{"surface": "x"}\n=== DRAFT ===\n' + DRAFT, True),
+], ids=["prose", "bare-fence", "blockquote", "draft-section", "receipt-block"])
+def test_reply_carries_a_draft_reads_the_shape_not_the_trigger(text, expected):
+    assert vsg.reply_carries_a_draft(text) is expected
+
+
+def test_main_holds_a_bare_fenced_draft_after_the_gates_own_feedback(lane_root, transcript, monkeypatch):
+    """Round 4's major: the gate refused a draft (exit 2, its feedback lands as
+    an isMeta user record), the assistant answered that MACHINE record with the
+    same routed draft in a bare fence and no framing, and a who-spoke-last rule
+    alone let it complete with no receipt consumed."""
+    _fake_lane(lane_root, owner=True, route_on="linkedin post")
+    fenced = "```\n" + DRAFT + "\n```"
+    records = [
+        _record(REQUEST),
+        _record(fenced, role="assistant"),
+        _record("Stop hook feedback:\nvoice-stop-gate: routed completion has no route receipt",
+                isMeta=True),
+        _record(fenced, role="assistant"),
+    ]
+    code, err = _run_main(monkeypatch, transcript(records), fenced)
+    assert code == 2 and "has no route receipt" in err
+
+
 def test_main_does_not_rerun_his_old_request_on_a_machine_turn(lane_root, transcript, monkeypatch):
     """The reviewer's five-turn reproducer, driven through main() on one growing
     transcript with a lane that routes on the words of the request. Before the

--- a/q-system/.q-system/tests/test_voice_stop_gate_founder_text.py
+++ b/q-system/.q-system/tests/test_voice_stop_gate_founder_text.py
@@ -1,0 +1,226 @@
+"""Only text the FOUNDER typed is his request, and a route lane is enforced only
+where one is installed.
+
+Ported 2026-09-06 from the one instance that ran these live
+(automation/test_harness_injection_is_not_the_founder.py and
+test_founder_typed_text_rejects_peer_messages.py there), because every fleet
+sync replaced that instance's gate with a skeleton copy that had none of this
+and its pre-commit went red until the next restore (sp-745f5962). The record
+shapes are the ones the harness actually writes: flags TOP-LEVEL on the record,
+content as a list of text blocks.
+
+The lane tests build a fake `q-consult/pipeline` package in a temp root and
+point the gate's INSTANCE_ROOT at it, so the three outcomes of `_route_context`
+(absent, broken, present) are each exercised without the real lane.
+"""
+import importlib.util
+import json
+import pathlib
+import textwrap
+
+import pytest
+
+REPO = pathlib.Path(__file__).resolve().parents[3]
+GATE = REPO / "q-system" / ".q-system" / "scripts" / "voice-stop-gate.py"
+
+
+def _load():
+    spec = importlib.util.spec_from_file_location("voice_stop_gate", GATE)
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module
+
+
+vsg = _load()
+
+FOUNDER_MESSAGE = "Explain simply no tables."
+SKILL_BODY = (
+    "# Workflow authoring reference\n\n"
+    "A workflow structures work across many agents.\n\n"
+    "compose novel harnesses when the task calls for it\n\n"
+    "To iterate on a workflow, edit that file with Write/Edit and re-invoke "
+    "Workflow with scriptPath instead of resending the full script.\n"
+)
+PEER = (
+    '<cross-session-message from="uds:/tmp/cc-socks/41361.sock" '
+    'from-name="voice loop" from-mode="bypass">\n'
+    'If you add a `social-comment` surface, its pointers are now verified.\n'
+    '</cross-session-message>'
+)
+
+
+def _record(text, role="user", **flags):
+    record = {
+        "type": "user",
+        "isSidechain": False,
+        "userType": "external",
+        "message": {"role": role, "content": [{"type": "text", "text": text}]},
+    }
+    record.update(flags)
+    return record
+
+
+@pytest.fixture
+def transcript(tmp_path):
+    def build(records):
+        path = tmp_path / "transcript.jsonl"
+        path.write_text("\n".join(json.dumps(r) for r in records), encoding="utf-8")
+        return str(path)
+    return build
+
+
+# --- the founder's words vs the harness's ---------------------------------
+
+def test_a_skill_body_is_not_the_founders_request(transcript):
+    path = transcript([
+        _record(FOUNDER_MESSAGE),
+        _record(SKILL_BODY, isMeta=True, turnCompanion=True),
+    ])
+    assert vsg.find_final_user_text(path) == FOUNDER_MESSAGE
+
+
+@pytest.mark.parametrize("flags", [
+    {"isMeta": True},
+    {"turnCompanion": True},
+    {"isMeta": True, "turnCompanion": True},
+])
+def test_either_flag_alone_is_enough(transcript, flags):
+    path = transcript([_record(FOUNDER_MESSAGE), _record(SKILL_BODY, **flags)])
+    assert vsg.find_final_user_text(path) == FOUNDER_MESSAGE
+
+
+def test_stop_hook_feedback_is_not_his_words_either(transcript):
+    path = transcript([
+        _record(FOUNDER_MESSAGE),
+        _record("Stop hook feedback:\nvoice-stop-gate: route request is unsupported",
+                isMeta=True),
+    ])
+    assert vsg.find_final_user_text(path) == FOUNDER_MESSAGE
+
+
+def test_an_unflagged_user_turn_is_still_read(transcript):
+    """The negative control: a filter that swallows his real messages is worse
+    than the bug, the gate would look green while measuring nothing."""
+    path = transcript([
+        _record("first message"),
+        _record(SKILL_BODY, isMeta=True, turnCompanion=True),
+        _record("write me a linkedin post about the audit"),
+    ])
+    assert vsg.find_final_user_text(path) == "write me a linkedin post about the audit"
+
+
+def test_flags_are_read_from_the_record_not_the_message(transcript):
+    """A flag INSIDE `message` must not count: that is not where the harness puts
+    it, and honouring it there lets a crafted message hide from the gate."""
+    record = _record(SKILL_BODY)
+    record["message"]["isMeta"] = True
+    path = transcript([_record(FOUNDER_MESSAGE), record])
+    assert vsg.find_final_user_text(path) == SKILL_BODY.strip()
+
+
+def test_a_cross_session_message_is_rejected_whole():
+    assert vsg.founder_typed_text(PEER) == ""
+
+
+def test_the_founders_own_words_still_survive():
+    typed = "write this as a linkedin comment with voice loop"
+    assert vsg.founder_typed_text(typed) == typed
+
+
+def test_a_peer_block_inside_a_turn_is_stripped_not_kept():
+    assert "social-comment" not in vsg.founder_typed_text("ok\n\n" + PEER)
+
+
+def test_a_command_invocation_is_truncated_at_the_marker():
+    typed = "make it shorter <command-name>/foo</command-name>\n# Foo\n\nlong skill body"
+    assert vsg.founder_typed_text(typed) == "make it shorter"
+
+
+def test_assistant_text_is_unaffected(transcript):
+    """`_walk_transcript` grew a parameter; its other caller must not change."""
+    path = transcript([
+        _record(FOUNDER_MESSAGE),
+        _record("here is the draft", role="assistant"),
+    ])
+    assert "here is the draft" in vsg.find_final_assistant_text(path)
+
+
+# --- the route lane: absent, broken, present ------------------------------
+
+def _fake_lane(root, broken=False, status="NOT_ROUTED"):
+    pkg = root / "q-consult" / "pipeline"
+    pkg.mkdir(parents=True)
+    (pkg / "__init__.py").write_text("")
+    if broken:
+        (pkg / "route_classifier.py").write_text("raise ImportError('half-installed lane')\n")
+        for name in ("route_contract", "audit_only_routes", "route_registry"):
+            (pkg / f"{name}.py").write_text("")
+        return pkg
+    (pkg / "route_classifier.py").write_text(textwrap.dedent(f"""
+        import collections
+        NOT_ROUTED = "NOT_ROUTED"
+        ROUTE = "ROUTE"
+        Result = collections.namedtuple("Result", "status surface channel reason")
+        def classify(request):
+            return Result({status!r}, "linkedin_post", "linkedin", "fixture")
+    """))
+    (pkg / "route_contract.py").write_text("")
+    (pkg / "audit_only_routes.py").write_text(textwrap.dedent("""
+        class AuditOnlyRouteError(Exception):
+            pass
+        def routes():
+            return []
+    """))
+    (pkg / "route_registry.py").write_text(textwrap.dedent("""
+        class RouteRegistryError(Exception):
+            pass
+        def resolve(surface, channel):
+            raise RouteRegistryError("no owner in the fixture")
+    """))
+    return pkg
+
+
+@pytest.fixture
+def lane_root(tmp_path, monkeypatch):
+    """A temp instance root the gate treats as its own, with `pipeline` evicted
+    from sys.modules so each test imports the package it built."""
+    import sys
+    for name in list(sys.modules):
+        if name == "pipeline" or name.startswith("pipeline."):
+            monkeypatch.delitem(sys.modules, name, raising=False)
+    monkeypatch.setattr(vsg, "INSTANCE_ROOT", tmp_path)
+    return tmp_path
+
+
+def test_no_lane_means_no_enforcement(lane_root):
+    """The 24-instance case: nothing under q-consult/pipeline, nothing to verify,
+    and no exception either (an uncaught ImportError in a Stop hook fails OPEN)."""
+    assert vsg._route_context() is None
+    assert vsg.enforce_route_receipt("write me a linkedin post", "a draft") is None
+
+
+def test_a_lane_that_does_not_import_holds_the_turn(lane_root):
+    """Present-but-broken is a broken verifier, not an absent one."""
+    _fake_lane(lane_root, broken=True)
+    with pytest.raises(vsg.RouteBoundaryError, match="did not import"):
+        vsg.enforce_route_receipt("write me a linkedin post", "a draft")
+
+
+def test_a_not_routed_request_passes_a_present_lane(lane_root):
+    _fake_lane(lane_root, status="NOT_ROUTED")
+    assert vsg.enforce_route_receipt("explain simply", "a reply") is None
+
+
+def test_a_routed_request_with_no_owner_is_refused(lane_root):
+    """Same words as the live gate: the route family is verbatim from the
+    instance, so its refusals read the same on every instance that grows a lane."""
+    _fake_lane(lane_root, status="ROUTE")
+    with pytest.raises(vsg.RouteBoundaryError, match="no single registered active owner"):
+        vsg.enforce_route_receipt("write me a linkedin post", "a draft")
+
+
+def test_a_receipt_block_must_be_json():
+    with pytest.raises(vsg.RouteBoundaryError, match="not valid JSON"):
+        vsg._receipt_block("=== ROUTE RECEIPT ===\nnot json")
+    assert vsg._receipt_block("no marker here") is None
+    assert vsg._receipt_block('=== ROUTE RECEIPT ===\n{"surface": "x"}') == {"surface": "x"}


### PR DESCRIPTION
## What

Ports the behaviour one instance's `voice-stop-gate.py` has run live since 2026-08 onto the skeleton's current file, verbatim: the route-receipt family (`_route_context`, `_route_draft`, `_receipt_block`, `enforce_route_receipt`, `RouteBoundaryError`), `founder_typed_text`, the harness-flag transcript walk (`_META_FLAGS`, `_walk_transcript(want_record=True)`), and the founder-only `find_final_user_text`. Main's channel-surface family stays. ASK-1197.

## Why (measured 2026-09-06)

Every fleet sync replaced that instance's gate with a skeleton copy that had none of this. Its own suite asserts it (`find_final_user_text` returns the founder's words, never the harness text injected around them), so its pre-commit went red after each sync, the restore was undone by the next sync (twice in one afternoon), and every commit in that checkout was blocked. sp-745f5962 is the carry; sp-1ad08728 is the class (an instance ahead of the skeleton on a synced path).

## The one thing the instance never needed

Its `_route_context` imports `pipeline` unguarded. That is fine there and an uncaught ImportError inside a Stop hook on the 24 instances without `q-consult/pipeline`, and a Stop hook that exits 1 fails OPEN. A straight copy of the five defs would have shipped that. Here: absent lane = `None`, silent; lane directory present but not importable = `RouteBoundaryError`, holds the turn; present lane = the instance's code path unchanged. The consulting session's own words on it: "the difference between a port and an outage."

## Verification (ran, not assumed)

- `test_voice_stop_gate_founder_text.py` (new, 17): the instance's arbiter cases byte for byte, plus peer-message rejection, command-body truncation, and the lane triple (absent / broken / present) on a fake `q-consult/pipeline` package in a temp root.
- The four stop-gate suites in the skeleton together: 67 pass, 1 skip.
- The instance's own two arbiter test files re-pointed at THIS file with its REAL route lane and classifier: 13 pass.
- `prompt-only-enforcement-guard.py` on the file: exit 0. Parameter-rebind check: 1 finding, equal to main.
- Capability manifest entry added for the new test file.

## Relationship to PR #295

#295 is the deeper route-receipt rewrite (15 review rounds, one open major on the refusal loop). It merges clean onto main but does not land today; it rebases onto this. This PR changes nothing #295 does not also carry, and carries nothing #295 would remove.

## After merge

The next consulting sync makes the two copies identical; the instance's `test_voice_stop_gate_propagation.py` (strict xfail on the drift) goes XPASS and its owner deletes the marker.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01DCaQcw6jqEpYyqyAznCHg9
