### PR TITLE
feat(updater): report every file a sync would overwrite whose instance copy the skeleton never shipped, with --refuse-instance-ahead (sp-1ad08728)

### DIFF
--- a/kipi-update-instance-ahead.py
+++ b/kipi-update-instance-ahead.py
@@ -1,0 +1,71 @@
+#!/usr/bin/env python3
+"""Describe how an instance's copy of a synced file is ahead of the skeleton's.
+
+Called by kipi-update.sh's instance_ahead_scan for one file the rsync would
+overwrite whose instance bytes are not any blob the skeleton ever shipped for
+that path. The scan decides WHETHER a file is ahead (fleet_authored_blob, git
+history); this script only says HOW, for the log line:
+
+    .py    -> "+defs: name, name" (defs and classes the instance has and the
+              skeleton lacks) or, when the names are identical, the hunk count
+    other  -> "N hunks" from a unified diff
+
+Pure: no git, no writes. On 2026-09-06 the three instance-ahead hits were an
+engine (extra modules), a gate script (five extra defs, founder_typed_text
+among them) and a calibrated word list (two removed entries): the first two
+are the def line, the third is the hunk count, which is why both exist.
+
+usage: kipi-update-instance-ahead.py <instance_file> <skeleton_file>
+"""
+import ast
+import difflib
+import sys
+
+
+def top_level_names(text):
+    try:
+        tree = ast.parse(text)
+    except SyntaxError:
+        return None
+    names = set()
+    for node in tree.body:
+        if isinstance(node, (ast.FunctionDef, ast.AsyncFunctionDef, ast.ClassDef)):
+            names.add(node.name)
+    return names
+
+
+def hunk_count(instance_text, skeleton_text):
+    diff = difflib.unified_diff(
+        skeleton_text.splitlines(keepends=True),
+        instance_text.splitlines(keepends=True),
+        n=0,
+    )
+    return sum(1 for line in diff if line.startswith("@@"))
+
+
+def describe(instance_path, skeleton_path):
+    with open(instance_path, encoding="utf-8", errors="replace") as fh:
+        instance_text = fh.read()
+    with open(skeleton_path, encoding="utf-8", errors="replace") as fh:
+        skeleton_text = fh.read()
+    hunks = hunk_count(instance_text, skeleton_text)
+    if instance_path.endswith(".py"):
+        mine = top_level_names(instance_text)
+        theirs = top_level_names(skeleton_text)
+        if mine is not None and theirs is not None:
+            extra = sorted(mine - theirs)
+            if extra:
+                return "+defs: " + ", ".join(extra)
+    return f"{hunks} hunk{'' if hunks == 1 else 's'}"
+
+
+def main(argv):
+    if len(argv) != 3:
+        print(__doc__, file=sys.stderr)
+        return 2
+    print(describe(argv[1], argv[2]))
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main(sys.argv))

--- a/kipi-update.sh
+++ b/kipi-update.sh
@@ -21,9 +21,17 @@ SKELETON_BRANCH="main"
 # staged rollout is the only safe way to ship anything with this blast radius.
 DRY_RUN=""
 ONLY=""
+# --refuse-instance-ahead: abandon an instance BEFORE its pre-sync commit when
+# the run would overwrite a file whose instance copy the skeleton never shipped
+# (see instance_ahead_scan). Off by default: fleet-wide the hit is usually
+# hook churn, and a refusal that fires on 24 instances gets switched off. The
+# consulting run script passes it, because there "ahead" has meant real work
+# every time (2026-09-06, three times in one day).
+REFUSE_INSTANCE_AHEAD=0
 while [ $# -gt 0 ]; do
   case "$1" in
     --dry-run) DRY_RUN="--dry-run"; shift ;;
+    --refuse-instance-ahead) REFUSE_INSTANCE_AHEAD=1; shift ;;
     --only)
       ONLY="${2:-}"
       if [ -z "$ONLY" ]; then
@@ -34,7 +42,7 @@ while [ $# -gt 0 ]; do
       ;;
     *)
       echo "ERROR: unknown argument: $1" >&2
-      echo "Usage: kipi-update.sh [--dry-run] [--only <instance-name>]" >&2
+      echo "Usage: kipi-update.sh [--dry-run] [--only <instance-name>] [--refuse-instance-ahead]" >&2
       exit 1
       ;;
   esac
@@ -291,6 +299,101 @@ plugin_copy_rsync_flags() {
   local entry
   for entry in "${PLUGIN_COPY_EXCLUDES[@]}"; do
     printf -- '--exclude=%s\n' "${entry%%::*}"
+  done
+}
+
+# "Instance ahead of the skeleton" (sp-1ad08728): a file this run would
+# OVERWRITE whose instance copy is content the skeleton never shipped for that
+# path. Three times on 2026-09-06 the sync replaced exactly that and the
+# instance's own gates went red only after the rsync had landed: the voiceloop
+# engine (extra modules), voice-stop-gate.py (five extra defs, founder_typed_text
+# among them, port still on an open PR) and voice-lint's BANNED_WORDS (two
+# entries removed after measuring the founder's own corpus). Nothing in the
+# updater said so beforehand; the dry run listed the files as changes like any
+# other and the refusal came from a downstream gate with the damage done.
+#
+# The question is answered by fleet_authored_blob, the shipped-blob check the
+# updater already uses for authorship: bytes equal to ANY skeleton version of
+# the path are never "ahead" (a stale instance is behind, not ahead; a hook
+# that committed the updater's own bytes is neither). Only content the skeleton
+# never shipped counts, which is what makes this language-agnostic: a list, a
+# rule, a script all read the same way. The candidate set comes from the same
+# itemized rsync previews the real run uses, with the same excludes, so it
+# cannot drift from what the run would change.
+#
+# Report by default, one line per file, and again in the run summary next to
+# Updated/Failed, because a 1,100-line dry log hid rewritten=8 for a morning.
+# --refuse-instance-ahead turns a hit into an abandon BEFORE the pre-sync
+# commit: nothing staged, nothing deleted.
+INSTANCE_AHEAD_REPORT=""
+INSTANCE_AHEAD_TOTAL=0
+INSTANCE_AHEAD_HITS=0
+
+# $1 skeleton source dir for one scope, $2 the instance dir it lands in,
+# $3 the scope's skeleton-relative prefix (for fleet_authored_blob),
+# $4 the scope's instance-relative prefix ("" at the instance root),
+# $5 the instance root (for git ls-files), $6 the instance name,
+# $7.. the rsync flags the real run uses for this scope.
+instance_ahead_scan() {
+  local src="$1" dest="$2" skel_rel="$3" inst_rel="$4" root="$5" name="$6"
+  shift 6
+  [ -d "$src" ] && [ -d "$dest" ] || return 0
+  local line rel inst_file skel_file shown detail
+  while IFS= read -r line; do
+    case "$line" in
+      '>f+++++++++'*) continue ;;
+      '>f'*) ;;
+      *) continue ;;
+    esac
+    rel="${line#* }"
+    inst_file="$dest/$rel"
+    skel_file="$src/$rel"
+    [ -f "$inst_file" ] && [ -f "$skel_file" ] || continue
+    shown="$rel"
+    [ -n "$inst_rel" ] && shown="$inst_rel/$rel"
+    # Tracked only: an untracked or unstaged local edit is the dirty guard's
+    # business further down, and it refuses the whole instance.
+    git -C "$root" ls-files --error-unmatch -- "$shown" >/dev/null 2>&1 || continue
+    fleet_authored_blob "$skel_rel/$rel" "$inst_file" && continue
+    detail="$(python3 "$SCRIPT_DIR/kipi-update-instance-ahead.py" "$inst_file" "$skel_file" 2>/dev/null)" \
+      || detail="differs"
+    echo "  instance ahead: $shown ($detail)"
+    INSTANCE_AHEAD_HITS=$((INSTANCE_AHEAD_HITS + 1))
+    INSTANCE_AHEAD_TOTAL=$((INSTANCE_AHEAD_TOTAL + 1))
+    INSTANCE_AHEAD_REPORT="$INSTANCE_AHEAD_REPORT
+    - $name: $shown ($detail)"
+  done < <(rsync -ain "$src/" "$dest/" "$@" 2>/dev/null || true)
+}
+
+# Every scope the run writes, from the same sources: the skeleton's committed
+# q-system/ (git archive HEAD, as the real sync uses), each managed plugin from
+# the working tree (as the plugins rsync uses), and the three .claude/ md dirs
+# (copied per file). $1 instance path, $2 subtree prefix, $3 instance name.
+instance_ahead_preflight() {
+  local path="$1" prefix="$2" name="$3" src_tmp dest kind
+  INSTANCE_AHEAD_HITS=0
+  src_tmp="$(mktemp -d)"
+  if git -C "$SCRIPT_DIR" archive --format=tar HEAD -- q-system/ 2>/dev/null \
+      | tar -x -C "$src_tmp" 2>/dev/null; then
+    dest="$path"
+    [ -n "$prefix" ] && dest="$path/$prefix"
+    # shellcheck disable=SC2046
+    instance_ahead_scan "$src_tmp/q-system" "$dest" "q-system" "$prefix" "$path" "$name" \
+      $(rsync_owned_excludes)
+  else
+    echo "  WARN: instance-ahead scan skipped for q-system (archive export failed)"
+  fi
+  rm -r -- "$src_tmp"
+  if [ -d "$SKELETON_PLUGIN_ROOT" ]; then
+    while IFS= read -r -d '' plugin_name; do
+      # shellcheck disable=SC2046
+      instance_ahead_scan "$SKELETON_PLUGIN_ROOT/$plugin_name" "$path/plugins/$plugin_name" \
+        "plugins/$plugin_name" "plugins/$plugin_name" "$path" "$name" $(plugin_copy_rsync_flags)
+    done < <(managed_plugin_names)
+  fi
+  for kind in agents output-styles rules; do
+    instance_ahead_scan "$SCRIPT_DIR/.claude/$kind" "$path/.claude/$kind" ".claude/$kind" \
+      ".claude/$kind" "$path" "$name" --include='*.md' --exclude='*'
   done
 }
 
@@ -1783,6 +1886,15 @@ The file itself is untouched on disk." 2>/dev/null; then
       fi
     done < <(system_owned_paths_for_run)
 
+    # Before anything is committed or written: which files this run would
+    # overwrite carry content the skeleton never shipped (sp-1ad08728). Runs in
+    # every mode, so the plain dry run, the fleet dry sweep's model run and the
+    # apply all print the same lines.
+    instance_ahead_preflight "$path" "$prefix" "$name"
+    if [ "$REFUSE_INSTANCE_AHEAD" = "1" ] && [ "$INSTANCE_AHEAD_HITS" -gt 0 ]; then
+      abandon_instance "  ERROR: instance is ahead of the skeleton on $INSTANCE_AHEAD_HITS file(s); refusing (--refuse-instance-ahead), nothing staged, nothing written" && continue
+    fi
+
     # ASK-605. The list above is hand-maintained and names 3 paths. auto-commit.py's
     # classifier answers the SAME question -- "is this the system's own exhaust?" --
     # for the whole tree, and the two disagreed. `q-system/memory/open-loops.json`
@@ -2619,6 +2731,11 @@ fi
 echo "  Skipped: $SKIP"
 if [ -n "${GATE_FAIL:-}" ]; then
   echo "  CAPABILITY GATE RED in:$GATE_FAIL"
+fi
+# Repeated here on purpose: the per-instance line sits inside a section a
+# reader scrolls past, and the summary is what gets read.
+if [ "$INSTANCE_AHEAD_TOTAL" -gt 0 ]; then
+  echo "  INSTANCE AHEAD OF SKELETON ($INSTANCE_AHEAD_TOTAL file(s) whose instance content the skeleton never shipped; a sync overwrites them):$INSTANCE_AHEAD_REPORT"
 fi
 # In the summary, not only inline: a real run prints ~40 lines per instance and
 # the summary is what gets read. An ungoverned instance that only appears on

--- a/q-system/.q-system/capability/expected_tests/q-system__.q-system__scripts__test__test-kipi-update-instance-ahead.sh.json
+++ b/q-system/.q-system/capability/expected_tests/q-system__.q-system__scripts__test__test-kipi-update-instance-ahead.sh.json
@@ -1,0 +1,4 @@
+{
+ "path": "q-system/.q-system/scripts/test/test-kipi-update-instance-ahead.sh",
+ "runner": "bash"
+}

--- a/q-system/.q-system/scripts/test/test-kipi-update-instance-ahead.sh
+++ b/q-system/.q-system/scripts/test/test-kipi-update-instance-ahead.sh
@@ -1,0 +1,166 @@
+#!/usr/bin/env bash
+# The updater names every file it would overwrite whose instance copy the
+# skeleton never shipped, before it writes anything, and refuses on demand.
+#
+# 2026-09-06, three times in one day: the fleet sync replaced consulting's
+# voiceloop engine (extra modules), its voice-stop-gate.py (five extra defs) and
+# its calibrated voice-lint BANNED_WORDS (two entries removed after measuring
+# the founder's corpus), and each time the instance's own gate went red only
+# after the rsync had landed. The dry run listed those files as ordinary
+# changes. sp-1ad08728.
+#
+# "Ahead" is the shipped-blob question (fleet_authored_blob): bytes equal to
+# ANY skeleton version of the path are never ahead. So a skeleton with history
+# is part of the fixture: a file whose instance copy equals the skeleton's
+# OLDER version must stay quiet, or the report is a diff wearing a better name.
+set -euo pipefail
+ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/../../../.." && pwd)"
+fail() { echo "FAIL: $1" >&2; exit 1; }
+G() { git -c user.email=t@t.t -c user.name=test -c commit.gpgsign=false "$@"; }
+
+# ------------------------------------------------------------------ the fixture
+# Skeleton with TWO commits, so "older shipped version" exists, and one clean
+# instance carrying: an extra def in a synced .py (ahead), an edited list
+# (ahead), a file at the skeleton's OLDER version (not ahead), an edited
+# plugin file (ahead) and an edited rule (ahead).
+build() {
+  local work="$1" sk="$work/skel" inst="$work/inst"
+  mkdir -p "$sk/q-system/.q-system/scripts" "$sk/q-system/.q-system/state" \
+           "$sk/q-system/hooks" "$sk/plugins/demo" "$sk/.claude/rules"
+  for f in kipi-update.sh kipi-update-preserve-scan.py kipi-update-deletion-guard.py \
+           kipi-update-instance-ahead.py validate-separation.py; do
+    cp "$ROOT/$f" "$sk/$f"
+  done
+  for f in propagation-leak-gate.py containment-targets.py fleet-replica-divergence.py; do
+    if [ -f "$ROOT/q-system/.q-system/scripts/$f" ]; then
+      cp "$ROOT/q-system/.q-system/scripts/$f" "$sk/q-system/.q-system/scripts/$f"
+    fi
+  done
+  cp "$ROOT/q-system/hooks/auto-commit.py" "$sk/q-system/hooks/auto-commit.py"
+  cat > "$sk/q-system/.q-system/state/propagation-leak-baseline.json" <<'JSON'
+{
+  "schema_version": 1,
+  "blocking_classes": ["case_proof_gap", "client_identity", "dated_interaction",
+                       "pricing", "relationship", "source_identity",
+                       "sourced_interaction"],
+  "classifier_sha256": null,
+  "entries": []
+}
+JSON
+  # v1 of everything the instance will diverge on.
+  printf 'skeleton v1\n' > "$sk/q-system/tracked.md"
+  printf 'def shipped():\n    return 1\n' > "$sk/q-system/.q-system/scripts/gate.py"
+  printf 'alpha\nbeta\ngamma\n' > "$sk/q-system/.q-system/scripts/calibrated.txt"
+  printf 'plugin v1\n' > "$sk/plugins/demo/content.txt"
+  printf '# demo rule v1\n' > "$sk/.claude/rules/demo.md"
+  ( cd "$sk" && G init -q -b main && G add -A -f && G commit -qm skel-v1 )
+  # v2 = skeleton HEAD, the version the sync delivers.
+  printf 'skeleton v2\n' > "$sk/q-system/tracked.md"
+  printf 'def shipped():\n    return 2\n' > "$sk/q-system/.q-system/scripts/gate.py"
+  printf 'alpha\nbeta\ngamma\ndelta\n' > "$sk/q-system/.q-system/scripts/calibrated.txt"
+  printf 'plugin v2\n' > "$sk/plugins/demo/content.txt"
+  printf '# demo rule v2\n' > "$sk/.claude/rules/demo.md"
+  ( cd "$sk" && G add -A -f && G commit -qm skel-v2 )
+  printf '{"instances":[{"name":"testinst","path":"%s","subtree_prefix":"q-system","type":"subtree"}]}\n' \
+    "$inst" > "$sk/instance-registry.json"
+
+  mkdir -p "$inst/q-system/.q-system/scripts" "$inst/plugins/demo" "$inst/.claude/rules"
+  # NOT ahead: the skeleton's older version, byte for byte.
+  printf 'skeleton v1\n' > "$inst/q-system/tracked.md"
+  # Ahead: skeleton v2 plus a def the skeleton never shipped.
+  printf 'def shipped():\n    return 2\n\ndef founder_only():\n    return True\n' \
+    > "$inst/q-system/.q-system/scripts/gate.py"
+  # Ahead: the calibrated list, one entry removed.
+  printf 'alpha\ngamma\ndelta\n' > "$inst/q-system/.q-system/scripts/calibrated.txt"
+  # Ahead: a plugin file edited in the instance.
+  printf 'plugin v2 with a local fix\n' > "$inst/plugins/demo/content.txt"
+  # Ahead: a rule edited in the instance.
+  printf '# demo rule v2, tuned here\n' > "$inst/.claude/rules/demo.md"
+  ( cd "$inst" && G init -q -b main && G add -A -f && G commit -qm inst )
+}
+
+expect_report() {
+  local out="$1"
+  grep -q 'instance ahead: q-system/.q-system/scripts/gate.py (+defs: founder_only)' "$out" || \
+    fail "the extra def is not named: $(grep 'instance ahead' "$out" || echo none)"
+  grep -q 'instance ahead: q-system/.q-system/scripts/calibrated.txt (1 hunk)' "$out" || \
+    fail "the edited list is not named with its hunk count: $(grep 'instance ahead' "$out" || echo none)"
+  grep -q 'instance ahead: plugins/demo/content.txt (1 hunk)' "$out" || \
+    fail "the edited plugin file is not named: $(grep 'instance ahead' "$out" || echo none)"
+  grep -q 'instance ahead: .claude/rules/demo.md (1 hunk)' "$out" || \
+    fail "the edited rule is not named: $(grep 'instance ahead' "$out" || echo none)"
+  if grep -q 'instance ahead: q-system/tracked.md' "$out"; then
+    fail "a file at the skeleton's OLDER version was reported ahead; the check is a diff, not the shipped-blob question"
+  fi
+  grep -q 'INSTANCE AHEAD OF SKELETON (4 file(s)' "$out" || \
+    fail "the summary does not repeat the report with the right count: $(grep -A5 'Summary' "$out")"
+  grep -q -- '- testinst: q-system/.q-system/scripts/gate.py (+defs: founder_only)' "$out" || \
+    fail "the summary line does not name the instance and the file: $(grep -A8 'Summary' "$out")"
+}
+
+# ------------------------------------------------------------------ property 1
+assert_the_dry_run_names_every_ahead_file_and_only_those() {
+  local work sk; work="$(mktemp -d)"; sk="$work/skel"
+  build "$work"
+  bash "$sk/kipi-update.sh" --dry-run >"$work/out" 2>&1 || true
+  expect_report "$work/out"
+  echo "PASS: the dry run names the four ahead files with defs or hunks, stays quiet on the older shipped version, and repeats them in the summary"
+}
+
+# ------------------------------------------------------------------ property 2
+assert_the_refuse_flag_abandons_before_any_commit_or_write() {
+  local work sk inst; work="$(mktemp -d)"; sk="$work/skel"; inst="$work/inst"
+  build "$work"
+  bash "$sk/kipi-update.sh" --refuse-instance-ahead >"$work/out" 2>&1 || true
+  grep -q 'refusing (--refuse-instance-ahead)' "$work/out" || \
+    fail "the flag did not refuse: $(tail -n 15 "$work/out")"
+  grep -q 'Failed:  1' "$work/out" || fail "a refused instance was not counted as failed: $(tail -n 8 "$work/out")"
+  [ "$(G -C "$inst" log -1 --format=%s)" = "inst" ] || fail "a refusal left a commit behind: $(G -C "$inst" log --format=%s)"
+  G -C "$inst" diff --cached --quiet || fail "a refusal left something staged"
+  G -C "$inst" diff --quiet || fail "a refusal left the working tree modified"
+  grep -q 'founder_only' "$inst/q-system/.q-system/scripts/gate.py" || fail "a refusal overwrote the ahead file"
+  expect_report "$work/out"
+  echo "PASS: --refuse-instance-ahead abandons the instance before the pre-sync commit: nothing staged, nothing written, report still printed"
+}
+
+# ------------------------------------------------------------------ property 3
+assert_without_the_flag_the_sync_lands_and_the_summary_still_says_so() {
+  local work sk inst; work="$(mktemp -d)"; sk="$work/skel"; inst="$work/inst"
+  build "$work"
+  bash "$sk/kipi-update.sh" >"$work/out" 2>&1 || true
+  grep -q 'Updated: 1' "$work/out" || fail "the default did not sync: $(tail -n 15 "$work/out")"
+  expect_report "$work/out"
+  # The documented effect of continuing: the skeleton's copy lands.
+  if grep -q 'founder_only' "$inst/q-system/.q-system/scripts/gate.py"; then
+    fail "the sync ran but the ahead file kept its instance content; the report described a run that did not happen"
+  fi
+  echo "PASS: without the flag the sync lands, the report still names every ahead file, and the summary repeats it"
+}
+
+# ------------------------------------------------------------------ property 4
+# The mutant: make fleet_authored_blob answer "shipped" for everything. The
+# report must go silent; if it does not, the scan is not asking the shipped-blob
+# question and property 1 was passing for another reason.
+assert_the_report_depends_on_the_shipped_blob_check() {
+  local work sk; work="$(mktemp -d)"; sk="$work/skel"
+  build "$work"
+  python3 - "$sk/kipi-update.sh" <<'PY'
+import sys
+path = sys.argv[1]
+text = open(path, encoding="utf-8").read()
+needle = "while IFS='|' read -r name path prefix itype declared; do"
+assert text.count(needle) == 1, "main loop header moved; update the mutant"
+text = text.replace(needle, "fleet_authored_blob() { return 0; }\n" + needle)
+open(path, "w", encoding="utf-8").write(text)
+PY
+  bash "$sk/kipi-update.sh" --dry-run >"$work/out" 2>&1 || true
+  if grep -q 'instance ahead:' "$work/out"; then
+    fail "with fleet_authored_blob forced to 'shipped', the report still named files; the scan is not using the shipped-blob check"
+  fi
+  echo "PASS: forcing every blob to read as shipped silences the report (the shipped-blob check is load-bearing)"
+}
+
+assert_the_dry_run_names_every_ahead_file_and_only_those
+assert_the_refuse_flag_abandons_before_any_commit_or_write
+assert_without_the_flag_the_sync_lands_and_the_summary_still_says_so
+assert_the_report_depends_on_the_shipped_blob_check

--- a/q-system/.q-system/scripts/test/test-kipi-update-preservation-failure.sh
+++ b/q-system/.q-system/scripts/test/test-kipi-update-preservation-failure.sh
@@ -122,8 +122,16 @@ PY
     git_test commit -qm instance
   )
 
+  # A dry itemized rsync (-n / -ain) reads and writes nothing; the updater's
+  # instance-ahead preflight runs one before the preservation helper on
+  # purpose, so only a WRITING invocation counts as "rsync invoked".
   cat > "$fake_bin/rsync" <<'SH'
 #!/usr/bin/env bash
+for arg in "$@"; do
+  case "$arg" in
+    -n|--dry-run|-*n*) [ "${arg#--}" = "$arg" ] && exit 0 ;;
+  esac
+done
 printf 'rsync invoked\n' >> "$RSYNC_LOG"
 exit 0
 SH


### PR DESCRIPTION
## What broke

Three times on 2026-09-06 the fleet sync replaced a file the instance had improved past the skeleton, and each time the instance's own gate went red only after the rsync had landed:

- the voiceloop engine (extra modules, ported later by PR #311)
- `voice-stop-gate.py` with `founder_typed_text` and the route-receipt family (port on PR #313)
- voice-lint's calibrated `BANNED_WORDS`, two entries removed after measuring the founder's corpus (PR #315)

The dry run listed those files as ordinary changes. Nothing in the updater said "this instance carries content the skeleton never shipped for a path I am about to overwrite" (sp-1ad08728).

## What changed

`kipi-update.sh`
- `instance_ahead_scan`: for every existing-file update in the same itemized rsync preview the run uses (same excludes), the instance's tracked copy is "ahead" when `fleet_authored_blob` says the skeleton never shipped those bytes for that path. Bytes equal to any skeleton version are never ahead, so a stale instance and a hook that committed the updater's own bytes stay quiet. Language-agnostic by construction. One line per hit: `+defs: name` for `.py`, hunk count otherwise.
- `instance_ahead_preflight`: the q-system prefix (from `git archive HEAD`, as the sync uses), each managed plugin (working tree, as the plugins rsync uses), the three `.claude` md dirs. Runs before the pre-sync commit in every mode, so `--dry-run`, the fleet dry sweep's model run and the apply print the same lines.
- `--refuse-instance-ahead`: abandon the instance on any hit before the pre-sync commit, nothing staged, nothing written. Off by default (fleet-wide most hits would be hook churn); the consulting run script opts in.
- The summary repeats every line beside Updated/Failed, because a 1,100-line dry log hid `rewritten=8` for a morning.

`kipi-update-instance-ahead.py`: pure describe helper (ast def/class names only in the instance copy, else unified-diff hunk count).

## Verification

- `test-kipi-update-instance-ahead.sh` (registered): a skeleton with two commits so the older-shipped-version case exists. Dry run names the four ahead files (extra def, edited list, edited plugin file, edited rule) and not the file sitting at the skeleton's older version; the summary repeats them with the count. `--refuse-instance-ahead` refuses with HEAD, index and working tree untouched. Without the flag the sync lands and the report still prints. A mutant that makes `fleet_authored_blob` always succeed silences the report. 4/4.
- `test-kipi-update-preservation-failure.sh`: its rsync fake now ignores a dry itemized invocation (`-n`), which the preflight makes on purpose before the preservation helper; a writing rsync still counts.
- Other `test-kipi-update-*.sh`: 10/10; the three updater python tests pass.

## Cost

One `fleet_authored_blob` history walk per file the rsync would update and the instance already has; tens of files on a typical instance.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01KLwJz1CRif347aHf9xx5AU
