### PR TITLE
test(updater): the propagation fixture carries kipi-update-instance-ahead.py (main regression from #316)

### DIFF
--- a/q-system/.q-system/tests/separation/test_update_propagation.py
+++ b/q-system/.q-system/tests/separation/test_update_propagation.py
@@ -47,6 +47,10 @@ UPDATER_HELPERS = (
     "kipi-update-gitignore-block.py",
     "kipi-update-wip-check.py",
     "kipi-update-voiceloop-migrate.py",
+    # The instance-ahead describe helper (PR #316). Arrived on main with the
+    # report and was not added here, so the divergence test below went red on
+    # every PR merged against that main: the exact trap this list documents.
+    "kipi-update-instance-ahead.py",
     "settings-template.json",
 )
 


### PR DESCRIPTION
## What broke

PR #316 taught `kipi-update.sh` to invoke `kipi-update-instance-ahead.py` from its own directory. `q-system/.q-system/tests/separation/test_update_propagation.py` keeps `UPDATER_HELPERS`, the hand-kept list of such helpers, and its divergence test `test_the_fixture_carries_every_helper_the_updater_invokes` is the guard that list documents: a helper the updater invokes that the fixture never copies.

It went red on main the moment #316 merged (auto-merge requires `validate` and the reviewer status, not `verify`), and then on every PR's `verify` run since, because CI tests the head merged into main. PR #314's verify is the first casualty.

## What changed

One entry in `UPDATER_HELPERS`, with the note the list's own history asks for.

## Verification

`python3 -m pytest q-system/.q-system/tests/separation/test_update_propagation.py`: 6 passed. The pre-commit's `verify.sh --staged` ran the whole `q-system/.q-system/tests` suite green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01NALQTapH2TADG19pNkvWrd
