### PR TITLE
fix(brief): the mail section reads the consulting ledger's needs-reply, not a model over Gmail snippets (ASK-1323)

### DIFF
--- a/.prd-os/issues/ASK-1323.md
+++ b/.prd-os/issues/ASK-1323.md
@@ -1,7 +1,7 @@
 ---
 id: ASK-1323
 title: Morning brief: the mail section reads the CRM ledger's needs-reply, not a model over Gmail snippets
-status: in-progress
+status: closed
 priority: p1
 parent_prd: linear:ASK-1323
 allowed_files:
@@ -36,4 +36,19 @@ The 07:00 brief's "Mail needing an answer" section takes its rows from the consu
 ## Deliverables
 
 <!-- Check each box when it ships; close refuses until checked count equals deliverables_count (locked at issue-start). -->
-- [ ] Morning brief: the mail section reads the CRM ledger's needs-reply, not a model over Gmail snippets
+- [x] Morning brief: the mail section reads the CRM ledger's needs-reply, not a model over Gmail snippets
+
+## Amendments
+
+### 2026-09-07T02:04:03Z
+Reason: claude-review/claude-adversarial F1: test_consulting_board.py drove the model-era collector; its rewrite joins the scope and its suite joins required_checks
+
+Before:
+- allowed_files: ['q-system/.q-system/scripts/morning-brief.py', 'q-system/.q-system/scripts/consulting_board.py', 'ledger.py', 'test_boundary.py', 'q-system/.q-system/scripts/test/', 'test_morning_brief_mail.py', 'board_rows.py']
+- required_checks: ['python3 -m pytest q-system/.q-system/tests/test_morning_brief_mail.py -q', 'python3 -m pytest q-system/.q-system/tests/test_morning_brief.py -q']
+- disallowed_files: []
+
+After:
+- allowed_files: ['q-system/.q-system/scripts/morning-brief.py', 'q-system/.q-system/tests/test_consulting_board.py', 'q-system/.q-system/scripts/consulting_board.py', 'ledger.py', 'test_boundary.py', 'q-system/.q-system/scripts/test/', 'test_morning_brief_mail.py', 'board_rows.py']
+- required_checks: ['python3 -m pytest q-system/.q-system/tests/test_morning_brief_mail.py -q', 'python3 -m pytest q-system/.q-system/tests/test_morning_brief.py -q', 'python3 -m pytest q-system/.q-system/tests/test_consulting_board.py -q']
+- disallowed_files: []

--- a/.prd-os/issues/ASK-1323.md
+++ b/.prd-os/issues/ASK-1323.md
@@ -1,0 +1,39 @@
+---
+id: ASK-1323
+title: Morning brief: the mail section reads the CRM ledger's needs-reply, not a model over Gmail snippets
+status: in-progress
+priority: p1
+parent_prd: linear:ASK-1323
+allowed_files:
+  - q-system/.q-system/scripts/morning-brief.py
+  - q-system/.q-system/tests/test_consulting_board.py
+  - q-system/.q-system/scripts/consulting_board.py
+  - ledger.py
+  - test_boundary.py
+  - q-system/.q-system/scripts/test/
+  - test_morning_brief_mail.py
+  - board_rows.py
+disallowed_files: []
+required_checks:
+  - python3 -m pytest q-system/.q-system/tests/test_morning_brief_mail.py -q
+  - python3 -m pytest q-system/.q-system/tests/test_morning_brief.py -q
+  - python3 -m pytest q-system/.q-system/tests/test_consulting_board.py -q
+required_reviews: []
+deliverables_count: 1
+---
+<!-- generated-by: prd_split.py prd=linear:ASK-1323 finding=linear-dor at=2026-09-07T01:42:26Z -->
+
+# Morning brief: the mail section reads the CRM ledger's needs-reply, not a model over Gmail snippets
+
+## Context
+
+Parent PRD: `https://linear.app/ask-consulting/issue/ASK-1323`
+
+## Acceptance
+
+The 07:00 brief's "Mail needing an answer" section takes its rows from the consulting instance's `email-watch/ledger.py needs-reply --json` (the reader that applies the founder's 2026-08-18 rule: a thread surfaces only when the last inbound message carries an unanswered ask FOR HIM; acks, CC-only copies, calendar mail and forwards with no question read `waiting_on_them`). The model call over `mcp__claude_ai_Gmail__search_threads` leaves that section. The Kipi backlog "Inbox" view then holds only the threads the ledger says need him, and `board_rows` archives the rest on the next healthy run, because the mail scope reports healthy whenever the ledger answered (an empty answer is healthy). When the ledger cannot be read (instance missing, non-zero exit, unparseable JSON, timeout) the section prints COULD NOT READ and reports the scope unhealthy, so the painter KEEPS every row rather than archiving inside a blind scope.
+
+## Deliverables
+
+<!-- Check each box when it ships; close refuses until checked count equals deliverables_count (locked at issue-start). -->
+- [ ] Morning brief: the mail section reads the CRM ledger's needs-reply, not a model over Gmail snippets

--- a/.prd-os/reviews/ASK-1323-adversarial.md
+++ b/.prd-os/reviews/ASK-1323-adversarial.md
@@ -1,0 +1,148 @@
+# ASK-1323 adversarial review
+
+Reviewer: Claude (adversarial), 2026-09-06. Worktree: `/Users/assafkipnis/.config/kipi/worktrees/ask-1323` (detached, HEAD f8bcaf41 + the working-tree diff). Nothing committed, no tracked file edited. Throwaway drivers under `scratchpad/adv/`.
+
+## VERDICT: request-changes
+
+One blocker, three minors, three nits. The change itself does what the DoR says on every path I could drive. What stops it landing is a red suite in the same tests directory that the DoR's `required_checks` do not run: `test_consulting_board.py` still drives `collect_mail` with the model-era `{"threads": [...]}` runner and 4 of its tests fail against the new collector, two of them asserting the sender|subject collapse this diff deliberately removed. The file is outside the diff and outside `allowed_files`, but the change cannot land green without it, which the brief says is a blocker even when the fix is elsewhere.
+
+## What I ran, and what came back
+
+### Suites (as instructed)
+
+```
+python3 -m pytest q-system/.q-system/tests/test_morning_brief_mail.py q-system/.q-system/tests/test_morning_brief.py q-system/.q-system/tests/test_consulting_board.py -q -p no:cacheprovider
+  -> 4 failed, 212 passed in 1.48s
+  FAILED test_consulting_board.py::TestRound4::test_the_real_mail_producers_age_form_is_volatile
+  FAILED test_consulting_board.py::TestTwoThreadsAreNeverOneRow::test_two_indistinguishable_threads_become_one_row_that_SAYS_two
+  FAILED test_consulting_board.py::TestTwoThreadsAreNeverOneRow::test_a_real_thread_id_still_wins_and_stays_stable
+  FAILED test_consulting_board.py::TestTwoThreadsAreNeverOneRow::test_both_rows_reach_the_board
+q-system/.q-system/tests/test_board_rows.py            -> does not exist; skipped and saying so
+test_morning_brief_mail.py alone                       -> 18 passed
+test_morning_brief.py alone (KIPI_CONSULTING_ROOT=/nonexistent too) -> 63 passed
+KIPI_CONSULTING_ROOT=/nonexistent test_consulting_board.py -> 4 failed, 131 passed
+   (same 4; the assertion text changes from "ledger JSON is not a list" to
+    "consulting ledger not found at /nonexistent/... (set KIPI_CONSULTING_ROOT)")
+```
+
+The DoR's two `required_checks` are green. The repo's suite is not.
+
+### Attack 1: will the ten stale Gmail rows actually be archived on the first healthy run?
+
+Driver `adv/attack1_healthy_scope.py`: loads the worktree's `consulting_board.py`, `morning-brief.py`, `board_rows.py`, calls `consulting_board.buckets(NOW, sources, _paths(tmp))` with a tmp root (every card file absent, so `card_error` is set and the inbox loop still runs).
+
+```
+empty healthy   inbox:Gmail healthy? True   inbox rows=0
+error           inbox:Gmail healthy? False  inbox rows=1   (the COULD NOT READ row)
+absent key      inbox:Gmail healthy? False  inbox rows=0
+new rows        keys: ['mail:19ff4af34dbc0f56'] healthy? True  scope on row: inbox:Gmail
+_FALLBACK_KEY matches a hex thread id?             False
+_FALLBACK_KEY matches an OLD sender|subject key?   True
+old row scope read back: 'inbox:Gmail' -> in healthy set: True
+```
+
+Trace: `buckets()` line 752 `if not got: continue` sees the 2-tuple `([], None)` as truthy, `err` is None, `any(_FALLBACK_KEY.match(...) for r in [])` is False, so `healthy.add("inbox:Gmail")` runs on an EMPTY answer. New rows and old rows both carry `scope=inbox:Gmail` (the label lives in consulting_board, which the diff does not touch), `board_rows._scope_of` reads it back off Notes, and `paint()` line 597 archives an old page whose id is not in `wanted` and whose scope is in `healthy`. A thread that still needs him keeps its row because the key is the same Gmail thread id the old prompt was asked to copy verbatim. Result: the Outcome is achievable by this diff. Two observations outside the diff: (a) board_rows must be ON (token file present) for any archive to happen; (b) `launchctl list` shows `com.kipi.morning-brief` installed and `com.kipi.morning-inbox` NOT installed, so "the next healthy run" is 07:00 via `~/.config/kipi/bin/morning-brief-run.sh`, which fast-forwards `~/projects/kipi-system-main` to origin/main and execs `/usr/bin/python3 morning-brief.py`. That is another reason the red suite is a blocker: the code reaches production only through origin/main.
+
+### Attack 2: the login shell, quoting, exec, timeout, token
+
+```
+env -i HOME=$HOME USER=$USER LOGNAME=$USER PATH=/usr/bin:/bin /bin/zsh -l -c 'echo "token:${NOTION_TOKEN_ASK:+set}"'   -> token:set
+env -i ...                                                     /bin/zsh -c    'echo "token:${NOTION_TOKEN_ASK:+set}"'   -> token:set   (so it comes from ~/.zshenv, not a login-only file)
+env -i ... /usr/bin/python3 ledger.py needs-reply --json (no shell at all)  -> exit 1, stdout 0 bytes, stderr "NOTION_TOKEN_ASK is not set. Refusing to run. ..."
+env -i ... /bin/zsh -l -c 'exec /usr/bin/python3 -c "...write(\"X\")"' | xxd -> exactly 0x58; the login shell writes nothing to stdout or stderr
+```
+
+Driver `adv/attack2_shell.py` (outside pytest so `run_ledger` is not refused), script at `.../it's a dir/with space/led ger.py`:
+
+```
+quoting err: None
+argv round-trip: True ['needs-reply', '--json', 'a b', "it's", 'say "hi"', '$HOME']   ($HOME NOT expanded)
+token visible inside the child: True
+child ppid == this pid (exec replaced zsh): True  pid 91883 ppid 91881 me 91881
+timeout err: ledger timed out after 1s (1.0s)
+child still alive after timeout? False
+under env -i, token reaches the ledger child: True
+nonzero: None | ledger exit 1: NOTION_TOKEN_ASK is not set. Refusing to run.   (last stderr line survives)
+```
+
+`exec` works: zsh is replaced, so `subprocess.run`'s timeout kills the ledger itself and leaves no orphan. Passes.
+
+### Attack 3: can anything precede the JSON on stdout?
+
+- `ledger.py` lines 80-1672 (every helper on the `needs-reply` path: `load_config`, `notion_token`, `_notion_request`, `_http`, `query_all`, `read_ledger`): `awk 'NR>=80 && NR<=1672 && /print\(|sys.stdout|warnings\./'` -> no matches. `load_config` is `open` + `json.load`. `notion_token()` raises `SystemExit(str)`, which is exit 1 to stderr, i.e. the non-zero branch.
+- `cmd_needs_reply` with `--json` prints exactly one `json.dumps(rows, indent=2)` and returns. `main` returns `args.func(args) or 0`.
+- Real CLI, read-only, under the launchd shape: `env -i HOME USER LOGNAME PATH=/usr/bin:/bin /bin/zsh -l -c "exec /usr/bin/python3 .../ledger.py needs-reply --json"` -> exit 0, stdout 3 bytes, first byte `[`, last non-whitespace byte `]`, `json.loads` ok (list, 0 rows), stderr 0 bytes. Row content was not printed.
+- Encoding: `json.dumps` default `ensure_ascii=True`, so a non-ASCII subject cannot produce a non-ASCII byte for the parent's locale decode under a bare env. Passes.
+
+### Attack 4: the interpreter
+
+- `morning-brief-run.sh` execs `/usr/bin/python3`, which is 3.9.6. Homebrew `python3` on PATH is 3.14.6; either becomes `sys.executable`.
+- `/usr/bin/python3 ledger.py needs-reply --help` -> exit 0 (module imports and argparse under 3.9, no network).
+- `/usr/bin/python3 -c "from zoneinfo import ZoneInfo; print(ZoneInfo('America/Los_Angeles'))"` -> `America/Los_Angeles`.
+- `ledger.py` header: "stdlib only, on purpose". Nested imports (`slackio`, `sales_rules`) sit in other subcommands. `sys.executable` is correct. Passes.
+
+### Attack 5: timeouts
+
+`LEDGER_TIMEOUT_S=60 < FIXED_BUDGET_S=240.0`: the subprocess fires first and returns `([], "ledger timed out after 60s")`; the guard's backstop returns `([], "mail timed out (240.0s)")`. Neither loses the string. With `KIPI_BRIEF_LEDGER_TIMEOUT=600` the order inverts (measured: `subprocess fires first: False`), the guard abandons the daemon thread at 240s and the ledger child runs on until 600s. Nothing pins the pair, unlike `BUDGET_S < COLLECT_BUDGET_S` which test_consulting_board pins. Minor.
+
+### Attack 6: the tests
+
+- New file: `instance` fixture builds everything under `tmp_path`; `run_ledger` refuses under pytest and `test_run_ledger_refuses_under_pytest` asserts it. `Path.is_file` spy across the whole run: zero stats under `~/projects/consulting` from `test_morning_brief_mail.py` or `test_morning_brief.py`.
+- `monkeypatch.delenv("PYTEST_CURRENT_TEST")` in the two `run_ledger` tests: ordered runs `[login_shell, nonzero_exit, refuses]` -> 3 passed and `[refuses, login_shell, refuses]` -> passed; no leak.
+- Wrong-reason check: `test_mail_collector_reports_a_ledger_failure` asserts `"timed out" in error` where the runner itself returned "ledger timed out", so it proves pass-through only, which is what the docstring claims; acceptable. `test_the_model_read_is_gone_from_the_mail_section` uses `"d)" not in label`, a substring check that would also fire on "(unread)"; nit.
+- The spy DID catch live-path stats: 5 `is_file` calls on `/Users/assafkipnis/projects/consulting/q-consult/email-watch/ledger.py` from the 4 failing `test_consulting_board.py` tests (they call `brief.collect_mail` with no sibling swap, so `ledger_script()` resolves `consulting_root()` to the founder's real checkout). Their failure text is machine-dependent (see the two runs above).
+- `swapped()` uses `stem.rstrip(".py")`, a character-set strip; it happens to work for "consulting_board.py" because 'd' is not in the set. Nit.
+
+### Attack 7: old-code residue
+
+- Scripts: `grep -rn 'MAIL_PROMPT\|MAIL_TOOL\|MAIL_WINDOW_DAYS\|age_hours' q-system/.q-system/scripts/` -> nothing. `search_threads`/`run_claude` absent from the Section 2 slice (pinned by the new test). SECTIONS label is `"Mail needing an answer"`.
+- Tests: `test_consulting_board.py` lines 527-528, 678-680, 699-701, 707-709, 715-717 still build `{"threads": [...]}` payloads with `from`/`age_hours` (the 4 failures).
+- Docs inside the diff's own file that now contradict the code: line 39 "Why two `claude -p` calls and not one" (there is one), line 613 "Calendar and mail shell `claude -p` under CLAUDE_TIMEOUT" (the FIXED_BUDGET_S derivation), lines 776-778 "calendar and mail shell `claude -p` ... mail alone needs more than 20s". The file's own rule: "A number written twice is a number that will disagree." Minor.
+
+### Attack 8: `--inbox-only` and `--dry-run`
+
+Driver `adv/attack8_main_paths.py` (every collector stubbed, `_optional_module` -> None, `route_engineering` stubbed):
+
+```
+--inbox-only             healthy empty  exit=0  ['[mail] 0 row(s)']
+--inbox-only             two rows       exit=0  ['[mail] 2 row(s)']
+--inbox-only             error          exit=1  ['[mail] COULD NOT READ: ledger exit 1: NOTION_TOKEN_ASK is not set']
+--inbox-only --dry-run   (same three)   exit=0/0/1, same lines
+--dry-run                all three      exit=0  ['*Mail needing an answer*', '[dry-run] nothing sent, no receipt written']
+```
+
+Unchanged contract: `--inbox-only` is 1 only on a mail/groupme/board error, `--dry-run` returns 0 before `degraded` is consulted. Passes. Note the ledger IS executed under `--dry-run` (a read-only Notion query), the same class of side effect the old `claude -p` call had.
+
+## Findings
+
+### F1 (blocker) `q-system/.q-system/tests/test_consulting_board.py` lines 520-533 and 668-719: four tests drive the model-era producer and fail against the new collector
+
+`TestRound4::test_the_real_mail_producers_age_form_is_volatile`, `TestTwoThreadsAreNeverOneRow::{test_two_indistinguishable_threads_become_one_row_that_SAYS_two, test_a_real_thread_id_still_wins_and_stays_stable, test_both_rows_reach_the_board}` call `brief.collect_mail(None, lambda p, t: (json.dumps({"threads": [...]}), None))`. The new collector parses a JSON list, so the dict answers "ledger JSON is not a list" and every assertion fails (4 failed, 212 passed; same 4 under `KIPI_CONSULTING_ROOT=/nonexistent`). Two of them assert the sender|subject collapse into "N threads, same sender and subject", which this diff removes on purpose (the ledger always carries a thread id), so they cannot be patched to the new shape; they have to be replaced by the statement that now holds (one row per ledger row, key = `mail:<thread_id>`, a row without an id fails the whole read, which `test_morning_brief_mail.py` already pins). The other two can be re-pointed at a ledger-shaped runner with the `instance`-style sibling swap. As they stand they also stat the founder's live `~/projects/consulting/.../ledger.py` (5 stats measured). The DoR's `required_checks` do not run this file, so the author's gate is green while the repo suite is red; `morning-brief-run.sh` only ever runs origin/main, so nothing here reaches the 07:00 job until this is fixed. Suggested fix: rewrite the four against the ledger contract (or delete the two collapse tests with a note pointing at `test_rows_are_the_ledgers_rows_keyed_by_thread_id` and `test_one_bad_row_fails_the_whole_read`), and add `python3 -m pytest q-system/.q-system/tests/test_consulting_board.py -q` to the issue's `required_checks`.
+
+### F2 (minor) `q-system/.q-system/scripts/morning-brief.py` lines 39-52, 613, 776-778: three doc blocks still say mail shells `claude -p`
+
+The module docstring's "Why two `claude -p` calls and not one", the `FIXED_BUDGET_S` derivation comment, and `collect_all`'s docstring all describe the mail section as a `claude -p` call under `CLAUDE_TIMEOUT`. After this diff the mail bound is `LEDGER_TIMEOUT_S`, and `FIXED_BUDGET_S = CLAUDE_TIMEOUT + 60` is now justified by calendar alone. Shown by `grep -n "claude -p\|Calendar and mail\|mail shell" morning-brief.py`. Suggested fix: reword the three to name calendar as the one remaining model call and `LEDGER_TIMEOUT_S` as mail's own bound.
+
+### F3 (minor) `q-system/.q-system/scripts/morning-brief.py` line 247: `LEDGER_TIMEOUT_S` is env-tunable above `FIXED_BUDGET_S` with no pin
+
+`KIPI_BRIEF_LEDGER_TIMEOUT=600` makes `LEDGER_TIMEOUT_S < FIXED_BUDGET_S` False (measured). Then `_guarded` abandons the mail thread at 240s and reports "mail timed out", while the ledger child keeps running to 600s; the section's error string is intact but the "subprocess fires first" property the FIXED_BUDGET_S comment relies on is silently gone. Suggested fix: `LEDGER_TIMEOUT_S = min(int(env), int(FIXED_BUDGET_S) - 1)` or a test in `test_morning_brief_mail.py` asserting `brief.LEDGER_TIMEOUT_S < brief.FIXED_BUDGET_S`, mirroring the `BUDGET_S < COLLECT_BUDGET_S` pin.
+
+### F4 (nit) `q-system/.q-system/scripts/morning-brief.py` lines 232-236: the login-shell rationale names the wrong file
+
+"bare env + `zsh -l` prints `[]`; bare env alone prints the refusal" is true as measured, but the token is exported by `~/.zshenv` (set under `zsh -c` and `zsh -l -c` alike under `env -i`), so `-l` is not what carries it. Harmless, and matching `crm-run.sh`'s `#!/bin/zsh -l` is a fine reason to keep it. Suggested fix: say ".zshenv, which every zsh reads" so the next person who reorganises the dotfiles (enrich-run.sh records that happening twice in one day) knows which file the job depends on.
+
+### F5 (nit) `q-system/.q-system/tests/test_morning_brief_mail.py` line 62: `stem.rstrip(".py")` is a character-set strip
+
+Works for "consulting_board.py" only because 'd' is outside the set. Suggested fix: `stem[:-3] if stem.endswith(".py") else stem`, or reuse `_optional_module`'s own normalisation.
+
+### F6 (nit) `q-system/.q-system/tests/test_morning_brief_mail.py` line 224: `"d)" not in section[1]`
+
+A two-character substring stands in for "carries a day window". Suggested fix: `assert not re.search(r"\(\d+d\)", section[1])`.
+
+### Observation, no finding
+
+A ledger row with `status == needs_reply` and an empty Thread ID title (the `seed-registry-rows` subcommand creates blank rows) fails the whole read with "a ledger row has no thread id" until the Notion row is fixed. That is the documented fail-closed choice ("half a list would archive the other half's rows"), and the refusal names itself in the brief; recorded here only so the first time it fires nobody diagnoses it as a shell problem.
+
+## Verdict
+
+request-changes. F1 is the only blocker: the diff's own contract holds on every path driven above, and the ten stale rows will be archived on the first healthy 07:00 paint once it is on origin/main, but four tests in the same directory are red against it and the DoR's checks do not run them.

--- a/.prd-os/reviews/ASK-1323-standard.md
+++ b/.prd-os/reviews/ASK-1323-standard.md
@@ -1,0 +1,159 @@
+# ASK-1323 standard review (senior staff engineer)
+
+Issue: Morning brief: the mail section reads the CRM ledger's needs-reply, not a model over Gmail snippets.
+Worktree: /Users/assafkipnis/.config/kipi/worktrees/ask-1323 (detached, HEAD f8bcaf41).
+Reviewer scope: read-only on the worktree and on the consulting ledger file; the only file written is this one.
+
+## What changed (from `git status` and `git diff` in the worktree)
+
+```
+ M q-system/.q-system/scripts/morning-brief.py      (198 lines: +143/-115 across the two files)
+ M q-system/.q-system/tests/test_morning_brief.py
+?? q-system/.q-system/tests/test_morning_brief_mail.py   (new, 238 lines)
+?? .prd-os/issues/ASK-1323.md                            (the spec itself)
+```
+
+The scratch diff at `.../scratchpad/ask-1323.diff` differs from `git diff` only by carrying the untracked new test file, so the two agree.
+
+Hunks in morning-brief.py, in order: `import shlex`; `MAIL_TOOL` removed; Section 2 replaced (`MAIL_WINDOW_DAYS`, `MAIL_PROMPT`, the model-backed `collect_mail`, the group/collapse logic gone; `LEDGER_TIMEOUT_S`, `LOGIN_SHELL`, `LEDGER_RELATIVE`, `run_ledger`, `ledger_script`, `_mail_line`, the ledger-backed `collect_mail` added); the `SECTIONS` mail label loses its interpolated window. Nothing outside Section 2 changed except that label and the import. Scope discipline holds against the DoR's three files.
+
+## Commands run and their results
+
+1. The three suites the brief named:
+
+```
+$ python3 -m pytest q-system/.q-system/tests/test_morning_brief_mail.py \
+    q-system/.q-system/tests/test_morning_brief.py \
+    q-system/.q-system/tests/test_consulting_board.py -q -p no:cacheprovider
+FAILED q-system/.q-system/tests/test_consulting_board.py::TestRound4::test_the_real_mail_producers_age_form_is_volatile
+FAILED q-system/.q-system/tests/test_consulting_board.py::TestTwoThreadsAreNeverOneRow::test_two_indistinguishable_threads_become_one_row_that_SAYS_two
+FAILED q-system/.q-system/tests/test_consulting_board.py::TestTwoThreadsAreNeverOneRow::test_a_real_thread_id_still_wins_and_stays_stable
+FAILED q-system/.q-system/tests/test_consulting_board.py::TestTwoThreadsAreNeverOneRow::test_both_rows_reach_the_board
+4 failed, 212 passed in 1.51s
+```
+
+The two files the spec's `required_checks` name are green (every failure is in `test_consulting_board.py`). The failing four all drive the OLD producer: `runner = lambda p, t: (json.dumps({"threads": [...]}), None)` and then `brief.collect_mail(None, runner)`, asserting the sender|subject fallback, the "2 threads, same sender and subject" collapse row, and `[2h]` age volatility. The new collector calls `runner(argv, timeout)` and parses a JSON list, so those fixtures parse as "not a list" and return `([], error)`, and the assertions fail on empty rows (`AssertionError: []` at test_consulting_board.py:712).
+
+2. Is that file on a gate? `.verify-suites` at the repo root names `q-system/.q-system/tests` as a suite. `q-system/.q-system/verify.sh` reads that manifest for both `--staged` (lefthook pre-commit) and `--full`; `.github/workflows/verify.yml` runs `bash q-system/.q-system/verify.sh --full` on every pull_request. So the four failures stop the commit door and the merge door as the tree stands.
+
+3. The property that matters most, demonstrated rather than argued. Scratch probe `.../scratchpad/ask1323_archive_property.py` loads the modified morning-brief.py with a fake `consulting_board` whose `consulting_root()` is a tmp dir holding a stub `ledger.py`, injects the ledger runner, and pushes the result through the REAL `consulting_board.buckets` (tmp tree from the suite's `_tree`) and the REAL `board_rows.paint` with `existing_rows` and `_request` replaced in-process. Existing pages carry `scope=inbox:Gmail` in Notes, exactly as `_properties` has always written Gmail rows.
+
+```
+_FALLBACK_KEY.match('mail:19ff4af34dbc0f56') -> None  (healthy is not withheld)
+--- EXIT 1  ledger printed []
+    collect_mail -> rows=[] err=None
+    healthy_scopes=['card', 'card:alarm', 'gtm', 'inbox:Gmail', 'myside', 'week', 'week:gtm']
+    paint counts: archived=1 kept=0        archive PATCHes: ['/pages/p0']
+--- EXIT 2  ledger timed out
+    collect_mail -> rows=[] err='ledger timed out after 60s'
+    healthy_scopes=['card', 'card:alarm', 'gtm', 'myside', 'week', 'week:gtm']
+    inbox rows=[('Gmail:error', 'inbox:Gmail')]
+    paint counts: archived=0 kept=2        archive PATCHes: []
+--- EXIT 3  ledger printed one row
+    collect_mail -> rows=[('acme  Re: x  [since 2026-09-02]', 'mail:19ff4af34dbc0f56')] err=None
+    healthy_scopes=[..., 'inbox:Gmail', ...]
+    inbox rows=[('mail:19ff4af34dbc0f56', 'inbox:Gmail')]
+    paint counts: archived=1 kept=0 updated=1   archive PATCHes: ['/pages/p0']   (p1, the live thread, PATCHed in place)
+--- EXIT 2b ledger exit 1 (token refusal)      archived=0 kept=1
+--- EXIT 2c one row lacks thread_id            err='a ledger row has no thread id; ...'  archived=0 kept=1
+ALL PROBES PASSED
+```
+
+So: `([], None)` marks `inbox:Gmail` healthy and the stale model-era row is archived; `([], error)` leaves `inbox:Gmail` out of `healthy_scopes`, keeps every row, and paints the one `Gmail:error` alarm row. The SCOPE LABEL is unchanged: consulting_board.py is untouched by this diff, its loop is still keyed `("mail", "Gmail")` (lines 751 to 800), so new rows are written under `inbox:Gmail`, the same string the old rows carry in Notes, and the healthy set names that same string. The old rows will be archived on the first healthy run, which is the whole issue. `_FALLBACK_KEY` (`^[^|]+\|`) cannot match a `mail:<hex>` key, so healthy is never withheld for a ledger row.
+
+4. The chokepoint, unfixtured (this is what the `collect_all` tests in test_morning_brief.py actually hit on this machine):
+
+```
+$ PYTEST_CURRENT_TEST=probe python3 - <<EOF ... m.ledger_script(); m.collect_mail(None) ... EOF
+ledger_script -> /Users/assafkipnis/projects/consulting/q-consult/email-watch/ledger.py | None
+collect_mail(None) under pytest -> ([], 'run_ledger refused under pytest; inject a runner')
+LEDGER_TIMEOUT_S = 60  FIXED_BUDGET_S = 240.0  COLLECT_BUDGET_S = 20.0
+KIPI_CONSULTING_ROOT=unset
+```
+
+The real ledger is located (a read-only `is_file()` on the founder's instance path) and `run_ledger` refuses before any subprocess. No test in either file can reach the live Notion ledger. On a machine without the instance the same call returns `consulting ledger not found ...`; both are the error exit, and no engine test asserts on the mail error text via `collect_all` (lines 775, 795, 843 either monkeypatch the collector or assert on their own injected error), so the suite is machine-independent.
+
+5. The login-shell claims, measured (only set/unset is revealed):
+
+```
+$ env -i /bin/zsh -c    'test -n "$NOTION_TOKEN_ASK" && echo SET || echo UNSET'   -> SET
+$ env -i /bin/zsh -l -c 'test -n "$NOTION_TOKEN_ASK" && echo SET || echo UNSET'   -> SET
+$ grep -l NOTION_TOKEN_ASK ~/.zshenv ~/.zprofile ~/.zshrc ~/.zlogin              -> ~/.zshenv, ~/.zshrc
+$ head -1 /Users/assafkipnis/projects/consulting/q-consult/pipeline/crm-run.sh    -> #!/bin/zsh -l
+$ env -i HOME=.. USER=.. /bin/zsh -l -c 'exec /bin/echo "[]"' | od -c            -> exactly "[ ] \n"
+$ env -i HOME=.. USER=.. /bin/zsh -l -c 'echo shell=$$; exec /bin/sh -c "echo child=\$\$"'  -> shell=68252 child=68252
+```
+
+The comment's measurement ("bare env + zsh -l prints []") reproduces. `exec` does what the code relies on: the ledger process IS the shell's pid, so `subprocess.run(timeout=)` kills python, not an orphaning zsh. Nothing in the login profile writes to stdout, so the JSON parse is not at risk from a profile echo. One nuance is filed as a minor below.
+
+6. Static checks:
+   - `grep -rn "MAIL_TOOL\|MAIL_PROMPT\|MAIL_WINDOW_DAYS\|MAIL_ROW_CAP"` over the worktree (excluding .git): only the new test's tuple naming them as gone.
+   - `awk '/# Section 2/,/# Section 3/'` of morning-brief.py grepped for `search_threads|run_claude|MAIL_`: none. The only "Gmail" mentions in the section are the Row docstring ("the Gmail thread id") and the history sentence ("used to ask a model to search Gmail").
+   - `grep "(30d)\|(48h)\|Mail needing an answer"`: the label survives only at morning-brief.py:567 without a window; no other file asserted the old label.
+   - `grep sys.path` in morning-brief.py: none.
+   - The RCA the comment cites exists: `/Users/assafkipnis/projects/consulting/q-system/output/rca/rca-crm-evidence-invisible-2026-08-18.md`.
+   - Ledger row shape (read from `read_ledger`, ledger.py:1672): `thread_id`, `client`, `last_from`, `subject`, `needs_reply_since` are all real keys; `cmd_needs_reply --json` prints `json.dumps(rows, indent=2)`, a bare list, filtered to `status == needs_reply`, not ignored, not parked past today. The token refusal (ledger.py:61) is `raise SystemExit("NOTION_TOKEN_ASK is not set. Refusing to run. ...")`, which is exit 1 with that line on stderr, so `run_ledger` would report `ledger exit 1: NOTION_TOKEN_ASK is not set...`, the exact shape the parametrised test uses.
+
+## Code review of the two exits and the subprocess call
+
+- `collect_mail`: `ledger_script()` error, runner error, non-JSON stdout, JSON that is not a list, and any entry that is not a dict or lacks `thread_id` all return `([], <error>)`; only a parsed list with a thread id on every entry returns `(rows, None)`. Every failure lands on the keep-the-board exit. Correct, and fail-closed on the half-list case (one bad row refuses the whole read rather than archiving the good rows' neighbours), which the comment and `test_one_bad_row_fails_the_whole_read` both state.
+- `run_ledger`: refuses under pytest first; `shlex.quote` on every argv element; `exec` prefix; `/bin/zsh -l -c`; `capture_output`, `text`, `timeout`. `TimeoutExpired` and `OSError` are the only exceptions caught. A non-zero exit reports the last non-empty line of stderr (else stdout), truncated to 140 chars. `subprocess.run` with `capture_output=True` and no explicit `stdin` inherits stdin; the ledger CLI does not read stdin for `needs-reply`, so unlike `run_claude` this is not a hazard.
+- Timeout vs guard: `LEDGER_TIMEOUT_S` (60) is well under `FIXED_BUDGET_S` (240) and under the guard used in `collect_hourly`, so the subprocess timeout fires first and the section error names the ledger. There is no test pinning `LEDGER_TIMEOUT_S < FIXED_BUDGET_S` (nit 4).
+- Row key: `mail:<thread_id>` is the key consulting_board always received for an id-bearing model row, so a thread still needing him keeps its Notion page (probe EXIT 3: `updated=1`, no archive of p1).
+- Callers: `collect_hourly` (line 749) and `collect_all` (line 786) both call `collect_mail(now)` with no runner, so production takes `run_ledger`. The `--inbox-only` branch of `main` (lines 858 to 895) has no hunk in `git diff`; its behaviour (print `[mail] COULD NOT READ: ...` or `[mail] N row(s)`, return 1 on a mail error) is covered by the existing `test_morning_brief.py` cases at lines 1043 and 1056, which stub `collect_hourly` with `{"mail": ([], None)}` and `{"mail": ([], "gmail down")}` and passed in the run above.
+
+## The new comment block, sentence by sentence, against test_morning_brief_mail.py
+
+Each row names the pytest case in `q-system/.q-system/tests/test_morning_brief_mail.py` (or `test_morning_brief.py`) that checks the sentence, or says the sentence is dated history that no test can check and is labelled as such in the comment.
+
+| Sentence | pytest case, or dated history |
+|---|---|
+| The section used to ask a model for "a real person wrote and the founder has not replied" | History (dated). The old prompt is in the diff's minus lines. |
+| The ledger dropped direction-only on 2026-08-18, RCA named | History; RCA file exists at the cited name. |
+| 2026-09-06: ten rows on his Inbox view while `needs-reply --json` printed `[]` | Marked measured history. Not testable here by design. |
+| The 30-day window went with the prompt; the label carries none | `test_the_model_read_is_gone_from_the_mail_section` (`"d)" not in label`; `MAIL_WINDOW_DAYS` absent) |
+| The brief does not import the ledger; `test_the_brief_holds_no_ledger_import` keeps it so | That test (regex on import lines) |
+| Subprocess under a LOGIN shell, same as crm-run.sh, because launchd is bare and the token is in the profile | `test_run_ledger_goes_through_the_login_shell` pins `("/bin/zsh","-l","-c")` and the `exec` string; crm-run.sh shebang verified `#!/bin/zsh -l`. Mechanism nuance: minor 2. |
+| Measured 2026-09-06: bare env + zsh -l prints `[]`; bare env alone prints the refusal | Measured history; reproduced above (set/unset). |
+| `([], None)` = nothing needs him, clear stale rows | Collector side: `test_an_empty_ledger_answer_is_empty_and_healthy`. Board side: only the generic consulting_board/board_rows tests, plus my probe. No committed test couples the new collector to `healthy_scopes` (see blocker 1: the four tests that used to do that coupling are the ones now red). |
+| Every failure shape returns `([], error)`: no instance, non-zero exit, timeout, non-JSON, not a list, no thread id | `test_every_unreadable_shape_keeps_the_board` (7 cases), `test_a_missing_ledger_script_is_an_error_not_an_empty_section`, `test_no_consulting_board_sibling_is_an_error`, `test_run_ledger_reports_a_nonzero_exit_with_its_last_line` |
+| "prints COULD NOT READ and leaves the board exactly as it was" | `_section` is unchanged; board side per the probe. |
+
+Test isolation: the `instance` / `mail_instance` fixtures swap `_optional_module` for a `_FakeBoard` rooted at `tmp_path`; the shell test deletes `PYTEST_CURRENT_TEST` and replaces `brief.subprocess.run`, so no process is spawned; `test_run_ledger_refuses_under_pytest` asserts the chokepoint. No fixture names a live path.
+
+## Findings
+
+### 1. BLOCKER. Four tests in `q-system/.q-system/tests/test_consulting_board.py` are red on the merge gate.
+File: q-system/.q-system/tests/test_consulting_board.py, lines 521 to 535 and 676 to 721.
+Evidence: the pytest result line above (`4 failed, 212 passed`); `.verify-suites` names this directory; verify.yml runs `verify.sh --full` on pull_request and lefthook runs `--staged` at commit. The four tests exercise the producer that this change deletes (model-shaped runner, `{"threads": [...]}` payload, sender|subject fallback, the "2 threads" collapse row, `[2h]` age volatility). None of those behaviours exist any more: the ledger always supplies `thread_id`, and the rendered line carries `[since YYYY-MM-DD]`, not an age. They are not detecting a regression in the new code; they are asserting the old producer's shape.
+Suggested fix: rewrite them against the ledger shape rather than shimming the old runner signature. `TestRound4::test_the_real_mail_producers_age_form_is_volatile` becomes "two ledger answers for one thread with different `needs_reply_since` / subject render differently and hash to one board id" (the drag-stability property it was written for, still true). `TestTwoThreadsAreNeverOneRow` collapses to one case: "two ledger rows with different thread ids reach the board as two rows with two keys", plus a class docstring note that the id-less branch was retired with the model read on 2026-09-06 (ASK-1323). This is also the natural home for the coupling the comment claims and nothing yet pins: `sources={"mail": ([], None)}` puts `inbox:Gmail` in `healthy_scopes`; `sources={"mail": ([], "ledger timed out")}` does not and yields exactly one `Gmail:error` row. Note: the spec's `allowed_files` lists `q-system/.q-system/scripts/test/` and bare `board_rows.py`, but not `q-system/.q-system/tests/test_consulting_board.py`, so this needs an issue-amend before the fix can land inside the DSSE flow.
+
+### 2. MINOR. The login-shell comment states the right measurement with the wrong mechanism; the failure it would hide is fail-safe but permanent.
+File: q-system/.q-system/scripts/morning-brief.py, lines 235 to 239 and 248 to 250.
+Evidence: `env -i /bin/zsh -c` (no `-l`) already sees the token; `grep -l` finds the export in `~/.zshenv` (sourced by every zsh) and `~/.zshrc` (never sourced by a non-interactive `zsh -l -c`). So `-l` is not what carries the token today; `.zshenv` is. The consulting CLAUDE.md says the managed blocks live in `~/.zshrc`. If the export is ever consolidated there, `zsh -l -c` will not see it, `run_ledger` returns `ledger exit 1: NOTION_TOKEN_ASK is not set`, the section reads COULD NOT READ every morning and the board is kept forever (safe, but the issue's outcome silently stops).
+Suggested fix: one sentence in the comment naming the real file: "the export must live in ~/.zshenv or ~/.zprofile; ~/.zshrc is not sourced by a non-interactive login shell, so a token that lives only there is invisible here and to crm-run.sh alike." No code change.
+
+### 3. MINOR. Three in-scope comments still describe mail as a `claude -p` call.
+File: q-system/.q-system/scripts/morning-brief.py, lines 39 to 51 (module docstring "Why two `claude -p` calls and not one": "Calendar and Gmail live behind the claude_ai_* connectors ... each section gets its own call"), lines 613 to 616 (`FIXED_BUDGET_S`: "Calendar and mail shell `claude -p` under CLAUDE_TIMEOUT, so the thread bound sits one minute above it"), lines 776 to 780 (`collect_all` docstring: "calendar and mail shell `claude -p` under CLAUDE_TIMEOUT, and the first live dry-run ... showed mail alone needs more than 20s").
+Evidence: after this diff only calendar shells `claude -p`; mail shells the ledger under `LEDGER_TIMEOUT_S` (60) inside the same 240s guard. `test_the_model_read_is_gone_from_the_mail_section` deliberately scopes its grep to Section 2, so these are not caught, by design. The `FIXED_BUDGET_S` line is the one that matters: it is the guard's own justification and it is now wrong about one of the two collectors it bounds.
+Suggested fix: rewrite the three sentences: the module docstring keeps the "why two calls" history as dated history and says calendar is the one remaining `claude -p` call; `FIXED_BUDGET_S` says "calendar shells `claude -p` under CLAUDE_TIMEOUT and mail shells the ledger under LEDGER_TIMEOUT_S; the bound sits above both".
+
+### 4. NIT. No pin that `LEDGER_TIMEOUT_S` stays below the guard budget.
+File: q-system/.q-system/scripts/morning-brief.py, line 247.
+Evidence: `KIPI_BRIEF_LEDGER_TIMEOUT` is env-overridable; a value above 240 makes the guard fire first, the section error becomes the guard's `mail timed out (240.0s)` instead of the ledger's, and the abandoned subprocess keeps running (read-only, harmless). test_consulting_board already pins the analogous `board_rows.BUDGET_S < COLLECT_BUDGET_S`.
+Suggested fix: one assertion in test_morning_brief_mail.py: `assert brief.LEDGER_TIMEOUT_S < brief.FIXED_BUDGET_S`.
+
+### 5. NIT. Two small test-side shapes.
+File: q-system/.q-system/tests/test_morning_brief_mail.py, line 69 and line 238.
+Evidence: `stem.rstrip(".py")` strips a character SET, not a suffix (it happens to work for "consulting_board.py" because "d" is not in the set); `_optional_module` already accepts both spellings, so `stem.endswith("consulting_board") or stem.endswith("consulting_board.py")` says what is meant. Line 238's `assert "sys.path" not in src or "q-consult" not in src` is strict in effect (any `sys.path` mention fails, because "q-consult" is now in the source via `LEDGER_RELATIVE`), but the disjunction reads as a loophole; `assert "sys.path" not in src` is the check being made.
+Suggested fix: as described; no behaviour change.
+
+## Notes (outside the DoR's Files line; not findings)
+
+- consulting_board.py lines 114 to 116 and 763 to 770 still explain `_FALLBACK_KEY` as "when the model returned no id". After this change no producer emits a `|` key; the guard is dead-but-harmless defence. Worth a one-line note when that file is next touched, not a change here.
+- The engine tests that call `collect_all` (test_morning_brief.py lines 726 to 938) now reach the real `consulting_board.consulting_root()` and `is_file()` the founder's instance path before the chokepoint refuses. Read-only, no live data read, and the suite is machine-independent because the assertions never read the mail error text. Mentioned only so nobody later reads that stat as a live-path breach.
+- `ledger_script()` executes consulting_board.py once per call and the registry executes it again for "Your book"; two `exec_module` calls per run of a module with no import-time I/O. Cost is negligible; a shared loader would be an unrelated refactor.
+
+## Verdict
+
+request-changes. The design is right and the property the issue exists for is demonstrated end to end (empty answer archives inside `inbox:Gmail`, unreadable keeps everything, the scope label is unchanged so the model-era rows will clear on the first healthy run). What stops it is finding 1: four tests in the same suite directory now assert a producer that no longer exists, `.verify-suites` puts that directory on both the commit and the merge gate, and the rewrite is also where the missing collector-to-board coupling test belongs. Findings 2 and 3 are prose that should ride the same commit; 4 and 5 are optional.

--- a/q-system/.q-system/scripts/morning-brief.py
+++ b/q-system/.q-system/scripts/morning-brief.py
@@ -253,6 +253,19 @@ class Row(str):
 #: Same shell, same flag, so the two jobs cannot see two different environments.
 LOGIN_SHELL = ("/bin/zsh", "-l", "-c")
 LEDGER_RELATIVE = Path("q-consult") / "email-watch" / "ledger.py"
+#: EMPTY IS HEALTHY ONLY WHEN THE LEDGER IS FRESH (PR #318 reviewer, round 2, major).
+#: `needs-reply` reads the Notion ledger live, and the hourly consulting mail sweep is
+#: what writes it. A sweep that died leaves a readable ledger that never changes, so
+#: `[]` from it would still archive rows. The sweep's own log ends every successful
+#: run with `mail-sweep: stamped ok at <UTC>` (control.py heartbeat prints it when
+#: mail-sweep.sh stamps the Run Control board, and the log captures it); the last
+#: such line is the witness, read here with no network. Older than
+#: LEDGER_FRESH_HOURS, missing, or never stamped ok: the section
+#: is COULD NOT READ and the board is kept. Three hours because the sweep is hourly:
+#: one missed run does not blank his brief, two make it say so.
+SWEEP_LOG_RELATIVE = Path("q-consult") / "output" / "mail-sweep.log"
+LEDGER_FRESH_HOURS = 3
+_SWEEP_OK = re.compile(r"^mail-sweep: stamped ok at (\S+)\s*$")
 
 
 def run_ledger(argv: list, timeout=None):
@@ -291,6 +304,33 @@ def ledger_script():
     return script, None
 
 
+def ledger_freshness(root, now: dt.datetime):
+    """None when the mail sweep stamped ok within LEDGER_FRESH_HOURS of `now`, else
+    the error string the section prints. Reads the sweep log's tail only."""
+    log = Path(root) / SWEEP_LOG_RELATIVE
+    if not log.is_file():
+        return f"no mail-sweep log at {log}; the ledger's freshness cannot be shown"
+    stamped = None
+    for line in log.read_text(encoding="utf-8", errors="replace").splitlines():
+        m = _SWEEP_OK.match(line)
+        if m:
+            stamped = m.group(1)
+    if stamped is None:
+        return "mail-sweep has never stamped ok in its log; the ledger's freshness cannot be shown"
+    try:
+        at = dt.datetime.fromisoformat(stamped.replace("Z", "+00:00"))
+    except ValueError:
+        return f"mail-sweep stamp {stamped!r} is not a timestamp"
+    if at.tzinfo is None:
+        at = at.replace(tzinfo=dt.timezone.utc)
+    age = now - at
+    if age > dt.timedelta(hours=LEDGER_FRESH_HOURS):
+        hours = age.total_seconds() / 3600
+        return (f"mail-sweep last stamped ok {hours:.1f}h ago ({stamped}); older than "
+                f"{LEDGER_FRESH_HOURS}h, so an empty ledger cannot be trusted to clear rows")
+    return None
+
+
 def _mail_line(entry: dict) -> str:
     who = str(entry.get("client") or entry.get("last_from") or "unknown")[:40]
     subject = str(entry.get("subject") or "")[:70]
@@ -305,8 +345,12 @@ def collect_mail(now: dt.datetime, runner=None):
     `runner(argv, timeout)` returns (stdout, error). Production runs the CLI; tests
     inject a fake. Rows keep the `mail:<thread id>` key the board has always used, so
     a thread that still needs him keeps its row and whatever bucket he dragged it to.
-    `now` is unused and kept so every fixed collector has one signature."""
+    `now` dates the freshness check; None means the wall clock."""
     script, error = ledger_script()
+    if error:
+        return [], error
+    now = now or dt.datetime.now(dt.timezone.utc)
+    error = ledger_freshness(script.parents[2], now)
     if error:
         return [], error
     runner = runner or run_ledger

--- a/q-system/.q-system/scripts/morning-brief.py
+++ b/q-system/.q-system/scripts/morning-brief.py
@@ -36,9 +36,10 @@ which reads Slack's own answer out of the response body. Never `slack-notify.sh`
 that is the fleet ALERT path, it files a Linear ticket for Sana, it sends nothing
 to Slack, and it exits 0 either way.
 
-## Why two `claude -p` calls and not one
+## Why two `claude -p` calls and not one (dated 2026-08-30; since ASK-1323 only
+## calendar is a `claude -p` call, mail reads the consulting ledger, see section 2)
 
-Calendar and Gmail live behind the `claude_ai_*` connectors, which are MCP
+Calendar (and, until 2026-09-06, Gmail) lives behind the `claude_ai_*` connectors, MCP
 servers attached to the CLI, not an HTTP API a bare Python script can call.
 Measured 2026-08-30 in a stripped environment: a headless `claude -p` DOES reach
 them (`--allowedTools mcp__claude_ai_Google_Calendar__list_events` returned
@@ -61,6 +62,7 @@ import importlib.util
 import json
 import os
 import re
+import shlex
 import subprocess
 import sys
 import threading
@@ -79,7 +81,6 @@ BRIEF_MODEL = os.environ.get("KIPI_BRIEF_MODEL", "claude-opus-5")
 CLAUDE_TIMEOUT = int(os.environ.get("KIPI_BRIEF_CLAUDE_TIMEOUT", "180"))
 
 CAL_TOOL = "mcp__claude_ai_Google_Calendar__list_events"
-MAIL_TOOL = "mcp__claude_ai_Gmail__search_threads"
 
 MAX_ROWS = 15
 
@@ -215,106 +216,116 @@ class Row(str):
         return row
 
 
-#: How far back the mail sweep looks, and it is a CONSTANT because it was a hardcoded
-#: "48 hours" inside the prompt for weeks and nobody could see it.
+#: THE MODEL READ IS GONE (ASK-1323, 2026-09-06). This section used to ask a model to
+#: search Gmail for threads where "a real person wrote and the founder has not replied".
+#: That is the direction-only rule, and the consulting ledger dropped it on 2026-08-18
+#: (rca-crm-evidence-invisible-2026-08-18): direction alone called a thumbs-up, a
+#: CC-only copy and a calendar invitation "waiting on your reply", and the board
+#: repeated it to the founder. On 2026-09-06 his Inbox view carried ten such rows --
+#: case-file forwards, two "Accepted: 30 Min consultation" calendar mails, an intro he
+#: was CC'd on -- while `ledger.py needs-reply --json` printed `[]`, because
+#: `reply_debt` there reads each thread to its end and surfaces only an unanswered ask
+#: FOR HIM. The 30-day window that lived here (measured 2026-09-03 against two client
+#: threads a 48-hour window could not see) went with the prompt: the ledger has no
+#: window, and the label below no longer carries one.
 #:
-#: THE BUG THIS FIXES, measured 2026-09-03. The brief printed "Mail needing an answer:
-#: nothing" on 09-01, 09-02 and 09-03 while two client threads sat unanswered since
-#: 2026-08-11 and 2026-08-13. Both are real, both are named by
-#: `email-watch/ledger.py needs-reply`, and both are 3 weeks old, so a 48-hour window
-#: could not see either one. The section was not empty; it was blind, and it reported
-#: blindness as calm.
+#: So the rows come from that reader, through its own CLI, as a subprocess. The
+#: brief does not import it and does not read the Notion ledger itself (a second
+#: reader of one store is how the v1 CRM died); test_morning_brief_mail.py's
+#: `test_the_brief_holds_no_ledger_import` is the check that keeps it that way. The
+#: subprocess runs under zsh for the same reason the consulting CRM's crm-run.sh is
+#: `#!/bin/zsh -l`: launchd hands this job a bare environment, the ledger refuses
+#: without NOTION_TOKEN_ASK, and the export lives in the founder's ~/.zshenv, which
+#: every zsh reads. Measured 2026-09-06: bare env + zsh prints `[]`; bare env alone
+#: prints the refusal. `-l` is kept to match crm-run.sh, not because it carries the
+#: token: a token moved to ~/.zshrc alone would be invisible here AND to crm-run.sh,
+#: because a non-interactive login shell does not read ~/.zshrc (claude-review,
+#: ASK-1323). `test_run_ledger_goes_through_the_login_shell` pins the shell.
 #:
-#: 30 days because the oldest of the two is 23 days old and a window that only just
-#: covers today's example is a window that will fail next month. The prompt still
-#: excludes automated senders and still requires that HE has not replied, so widening
-#: the window does not widen the noise; it only stops hiding the old ones.
-#:
-#: The deterministic answer is `ledger.py needs-reply`, which has no window at all and
-#: knows which threads are clients. It is not wired here yet: it reads the Notion
-#: ledger live, so it is a cross-repo runtime dependency and its own piece of work.
-MAIL_WINDOW_DAYS = 30
-#: MAIL_ROW_CAP LIVED HERE AND IS DELETED (claude review, 2026-09-04, major).
-#: It trimmed the PRODUCER's rows to 15. Trimmed threads never entered
-#: `buckets["inbox"]`, yet `inbox:Gmail` still reported healthy (every remaining key
-#: was a real thread id), so the painter archived their board rows -- pins included --
-#: inside a healthy scope. An unanswered client thread disappeared off his board, which
-#: is the exact failure this board exists to prevent.
-#:
-#: The cap was also redundant. `_section` already trims DISPLAY to MAX_ROWS and prints
-#: "...and N more", so the Slack message was never going to be 50 lines. One cap for
-#: display, none for data: the brief stays short and the board sees every thread.
-#:
-#: Round 11 fixed this same class inside the painter with its `capped` set, on the
-#: rule that a cap is a write budget and not a statement that the work is finished.
-#: The rule is right; a second cap upstream of the producer routed around it.
+#: EMPTY IS HEALTHY, UNREADABLE IS NOT. board_rows archives inside a scope that
+#: reported healthy, so `([], None)` means "nothing needs him; clear the stale rows",
+#: and every failure -- no instance on this machine, a non-zero exit, a timeout, output
+#: that is not a JSON list, a row with no thread id -- returns `([], error)`, which
+#: prints COULD NOT READ and leaves the board exactly as it was.
 
-MAIL_PROMPT = """Call {tool} to find email threads from the last {days} days where a
-REAL PERSON wrote to the founder and the founder has not replied yet. Exclude
-newsletters, notifications, receipts, calendar invites, automated senders and
-no-reply addresses. Oldest first: a thread waiting three weeks matters more than
-one waiting an hour.
-Reply with ONE JSON object and nothing else, no prose, no code fence:
-{{"threads": [{{"id": "<the thread id the tool returned>", "from": "email or name", "subject": "...", "age_hours": <int>}}]}}
-`id` is the thread's own id from the tool result, copied verbatim. It is what keeps a
-board row stable while its age changes, so never invent or shorten it.
-If the tool call fails, reply with exactly: {{"error": "<what failed>"}}"""
+#: LEDGER_TIMEOUT_S is defined beside FIXED_BUDGET_S below, clamped under it.
+#: The consulting CRM's launchd runner is `#!/bin/zsh -l` for the token reason above.
+#: Same shell, same flag, so the two jobs cannot see two different environments.
+LOGIN_SHELL = ("/bin/zsh", "-l", "-c")
+LEDGER_RELATIVE = Path("q-consult") / "email-watch" / "ledger.py"
+
+
+def run_ledger(argv: list, timeout=None):
+    """(stdout, error). One bounded ledger CLI call under a login shell.
+
+    REFUSES UNDER PYTEST, the same chokepoint posture as the model seam above: a suite must
+    never read the founder's live Notion ledger by accident."""
+    if os.environ.get("PYTEST_CURRENT_TEST"):
+        return None, "run_ledger refused under pytest; inject a runner"
+    timeout = LEDGER_TIMEOUT_S if timeout is None else timeout
+    command = "exec " + " ".join(shlex.quote(str(a)) for a in argv)
+    try:
+        proc = subprocess.run([*LOGIN_SHELL, command], capture_output=True, text=True,
+                              timeout=timeout)
+    except subprocess.TimeoutExpired:
+        return None, f"ledger timed out after {timeout}s"
+    except OSError as exc:
+        return None, f"ledger could not start: {type(exc).__name__}: {str(exc)[:120]}"
+    if proc.returncode != 0:
+        lines = (proc.stderr or proc.stdout or "").strip().splitlines()
+        tail = lines[-1][:140] if lines else "no output"
+        return None, f"ledger exit {proc.returncode}: {tail}"
+    return proc.stdout, None
+
+
+def ledger_script():
+    """(path, error). The consulting instance is located by consulting_board's own
+    `consulting_root()`, so this section and "Your book" can never disagree about
+    where the instance is. No sibling, no location: an error, not a guess."""
+    board = _optional_module("consulting_board")
+    if board is None:
+        return None, "consulting_board.py absent beside this script; the instance cannot be located"
+    script = Path(board.consulting_root()) / LEDGER_RELATIVE
+    if not script.is_file():
+        return None, f"consulting ledger not found at {script} (set KIPI_CONSULTING_ROOT)"
+    return script, None
+
+
+def _mail_line(entry: dict) -> str:
+    who = str(entry.get("client") or entry.get("last_from") or "unknown")[:40]
+    subject = str(entry.get("subject") or "")[:70]
+    since = str(entry.get("needs_reply_since") or "")[:10]
+    since_text = f"  [since {since}]" if since else ""
+    return f"{who}  {subject}{since_text}"
 
 
 def collect_mail(now: dt.datetime, runner=None):
-    runner = runner or (lambda p, t: run_claude(p, t))
-    text, error = runner(MAIL_PROMPT.format(tool=MAIL_TOOL, days=MAIL_WINDOW_DAYS),
-                         [MAIL_TOOL])
+    """Threads the consulting ledger says are waiting on HIM: `needs-reply --json`.
+
+    `runner(argv, timeout)` returns (stdout, error). Production runs the CLI; tests
+    inject a fake. Rows keep the `mail:<thread id>` key the board has always used, so
+    a thread that still needs him keeps its row and whatever bucket he dragged it to.
+    `now` is unused and kept so every fixed collector has one signature."""
+    script, error = ledger_script()
     if error:
         return [], error
-    threads, parse_error = _parse_json_block(text, "threads")
-    if parse_error:
-        return [], parse_error
+    runner = runner or run_ledger
+    text, error = runner([sys.executable, str(script), "needs-reply", "--json"],
+                         LEDGER_TIMEOUT_S)
+    if error:
+        return [], error
+    try:
+        entries = json.loads(text or "")
+    except ValueError as exc:
+        return [], f"ledger printed something other than JSON: {str(exc)[:100]}"
+    if not isinstance(entries, list):
+        return [], "ledger JSON is not a list"
     rows = []
-    for th in threads:
-        if not isinstance(th, dict):
-            continue
-        age = th.get("age_hours")
-        age_text = f"  [{age}h]" if isinstance(age, int) else ""
-        sender = str(th.get("from", "unknown"))[:40]
-        subject = str(th.get("subject", ""))[:70]
-        # The thread id when the model returned one, else sender+subject. Both are
-        # stable while the AGE changes, which is what was minting new ids. Never the
-        # rendered line: that is the defect rounds 1-4 kept patching.
-        key = str(th.get("id") or "").strip() or f"{sender}|{subject}"
-        rows.append(Row(f"{sender}  {subject}{age_text}", f"mail:{key}"))
-
-    # A COLLAPSE IS NOT A DEDUPE. Codex, 2026-09-03: when the model omits thread ids,
-    # two different threads from one person with one subject ("Re: invoice", twice)
-    # produce one key, the board writes ONE row, and the second task is gone -- while
-    # read-back still says ok, because it compares what was written to what was
-    # wanted and both had already lost it. That is worse than the bug it replaced:
-    # rounds 1-4 lost a DRAG, this loses WORK.
-    #
-    # Nothing stable distinguishes them, so the choice is between dropping a task and
-    # keeping it under an id that may move. Keeping it wins, and it is not close: a
-    # row he never sees cannot be acted on at all, while a row whose id shifts costs
-    # him a position on the board. The suffix is ordinal and deliberately provisional.
-    # THE ORDINAL SUFFIX WAS WITHDRAWN (round 10, major). It numbered duplicates by
-    # POSITION, so when the first of two "Re: invoice" threads was answered and left
-    # the list, the second was renumbered onto the first one's key -- and inherited its
-    # board row, its Status and the bucket he had dragged it to. A thread wearing
-    # another thread's identity is worse than either failure the note above weighed.
-    #
-    # With no thread id there is nothing that tells two identical rows apart, so this
-    # stops pretending there is. The group becomes ONE row that SAYS it is a group.
-    # No task is hidden (the count is on the row), no id is invented, and the key is
-    # stable because it is the thing they have in common.
-    groups = {}
-    for row in rows:
-        groups.setdefault(row.key, []).append(row)
-    rows = []
-    for key, members in groups.items():
-        if len(members) == 1:
-            rows.append(members[0])
-            continue
-        rows.append(Row(f"{members[0]} ({len(members)} threads, same sender and "
-                        "subject)", key))
+    for entry in entries:
+        thread_id = str(entry.get("thread_id") or "").strip() if isinstance(entry, dict) else ""
+        if not thread_id:
+            return [], "a ledger row has no thread id; refusing to paint a row the board cannot key"
+        rows.append(Row(_mail_line(entry), f"mail:{thread_id}"))
     return rows, None
 
 
@@ -557,10 +568,8 @@ def _section(title, rows, error, cap=MAX_ROWS):
 # retire `notion_board`'s only input.
 SECTIONS = (
     ("calendar", "Today"),
-    # The window is INTERPOLATED, never typed. It read "(48h)" while the prompt also
-    # said 48 hours, so when the window was wrong the label agreed with it and the
-    # section looked correct. A number written twice is a number that will disagree.
-    ("mail", f"Mail needing an answer ({MAIL_WINDOW_DAYS}d)"),
+    # No window in the label: the ledger has none (ASK-1323).
+    ("mail", "Mail needing an answer"),
 )
 
 #: Collected, never rendered to him. One line each into Sana's queue, and only when the
@@ -606,10 +615,17 @@ COLLECT_BUDGET_S = 20.0
 # The fixed four are bounded too (PR #294 review, major: `fixed_budget_s=None`
 # meant one hung calendar or mail call held the 07:00 brief, its Slack send and
 # its receipt forever, and the 09:00 deadman was the first thing to notice).
-# Calendar and mail shell `claude -p` under CLAUDE_TIMEOUT, so the thread bound
-# sits one minute above it: the subprocess timeout fires first in the normal
+# Calendar shells `claude -p` under CLAUDE_TIMEOUT and mail shells the ledger under
+# LEDGER_TIMEOUT_S (clamped below it, ASK-1323), so the thread bound sits one minute
+# above the larger of the two: the subprocess timeout fires first in the normal
 # case and this is the backstop for a collector that hangs before or after it.
 FIXED_BUDGET_S = float(CLAUDE_TIMEOUT + 60)
+#: The ledger child's own bound (ASK-1323), clamped under the guard so the section's
+#: error is the ledger's own "ledger timed out after Ns" and the guard does not
+#: abandon the thread while the child runs on. Env-tunable, and the clamp is what a
+#: tuning cannot undo (claude-adversarial F3); test_morning_brief_mail.py pins it.
+LEDGER_TIMEOUT_S = min(int(os.environ.get("KIPI_BRIEF_LEDGER_TIMEOUT", "60")),
+                       int(FIXED_BUDGET_S) - 1)
 
 
 def _optional_module(stem: str):
@@ -769,9 +785,10 @@ def collect_hourly(now: dt.datetime, log_path=None, budget_s: float = COLLECT_BU
 def collect_all(now: dt.datetime, log_path=None, budget_s: float = COLLECT_BUDGET_S,
                 fixed_budget_s: float = None) -> dict:
     """`budget_s` bounds the OPTIONAL sections (the board's Notion round trip,
-    finding-4). The fixed four bound themselves: calendar and mail shell
-    `claude -p` under CLAUDE_TIMEOUT, and the first live dry-run of this code
-    (2026-09-01) showed mail alone needs more than 20s, so a shared 20s bound
+    finding-4). The fixed four bound themselves: calendar shells
+    `claude -p` under CLAUDE_TIMEOUT, mail shells the ledger under LEDGER_TIMEOUT_S
+    (ASK-1323), and the first live dry-run of this code (2026-09-01, when mail was
+    still a model call) showed it alone needs more than 20s, so a shared 20s bound
     would have cost the founder his mail every morning. `fixed_budget_s` exists
     so a test can prove the timeout path without waiting on a real collector."""
     log_path = log_path or ERROR_LOG

--- a/q-system/.q-system/tests/test_consulting_board.py
+++ b/q-system/.q-system/tests/test_consulting_board.py
@@ -512,213 +512,90 @@ def _brief():
     return mod
 
 
+class _FakeBoard:
+    def __init__(self, root):
+        self._root = root
+
+    def consulting_root(self):
+        return self._root
+
+
+def _ledger_brief(tmp_path):
+    """A fresh brief whose mail section is rooted at a throwaway instance (ASK-1323):
+    the ledger script exists there, and the runner is injected by each test, so no
+    process runs and nothing under the real home directory is read."""
+    ledger = tmp_path / "q-consult" / "email-watch" / "ledger.py"
+    ledger.parent.mkdir(parents=True, exist_ok=True)
+    ledger.write_text("# stand-in\n", encoding="utf-8")
+    mod = _brief()
+    original = mod._optional_module
+    mod._optional_module = (lambda stem: _FakeBoard(tmp_path)
+                            if "consulting_board" in stem else original(stem))
+    return mod
+
+
 class TestRound4:
     """The first real Codex read after rounds 2 and 3 ran on the Opus fallback. Both
     findings are the same shape: a fix that held for the fixture and not for the
     producer. So these tests drive the PRODUCER (collect_mail, collect) and not a
     hand-typed row."""
 
-    def test_the_real_mail_producers_age_form_is_volatile(self, tmp_path):
-        """collect_mail renders `[2h]`, not "2h ago". Round 2's regex never matched it,
-        so every age change replaced the Notion row and lost his drag."""
-        brief = _brief()
+    def test_the_real_mail_producers_since_form_is_volatile(self, tmp_path):
+        """The ledger-backed collect_mail (ASK-1323) renders `[since YYYY-MM-DD]`. The
+        rendered line moves when the ledger's date or subject moves; the board id is
+        the thread id and does not."""
+        brief = _ledger_brief(tmp_path)
 
-        def runner(age):
-            return lambda p, t: (json.dumps({"threads": [
-                {"from": "Alice", "subject": "Docs", "age_hours": age}]}), None)
+        def runner(since, subject):
+            return lambda argv, t: (json.dumps([
+                {"thread_id": "t-alice", "last_from": "Alice", "subject": subject,
+                 "needs_reply_since": since}]), None)
 
-        a_rows, _ = brief.collect_mail(None, runner(2))
-        b_rows, _ = brief.collect_mail(None, runner(3))
-        assert a_rows != b_rows, "the producer must actually render the age, or this proves nothing"
+        a_rows, _ = brief.collect_mail(None, runner("2026-09-01", "Docs"))
+        b_rows, _ = brief.collect_mail(None, runner("2026-09-03", "Re: Docs"))
+        assert a_rows != b_rows, "the producer must actually render the date, or this proves nothing"
         a = cb.buckets(NOW, {"mail": (a_rows, None)}, _tree(tmp_path))["inbox"][0]["key"]
         b = cb.buckets(NOW, {"mail": (b_rows, None)}, _tree(tmp_path))["inbox"][0]["key"]
-        assert a == b, f"an age change minted a new id: {a!r} != {b!r}"
+        assert a == b, f"a date change minted a new id: {a!r} != {b!r}"
 
-    def test_but_a_bracketed_number_that_is_not_an_age_stays(self, tmp_path):
-        brief = _brief()
-        a = cb.buckets(NOW, {"mail": ([brief.Row("Alice ticket [4021]", "mail:t1")], None)},
-                       _tree(tmp_path))["inbox"][0]["key"]
-        b = cb.buckets(NOW, {"mail": ([brief.Row("Alice ticket [4022]", "mail:t2")], None)},
-                       _tree(tmp_path))["inbox"][0]["key"]
-        assert a != b
-
-    @staticmethod
-    def _fake_db(slow_first_query_s: float):
-        """The database API, just enough of it. Records every call; the first query
-        sleeps past the budget so the worker is abandoned mid-paint."""
-        class Fake:
-            def __init__(self):
-                self.calls = []
-
-            def __call__(self, req, timeout):
-                method, url = req.get_method(), req.full_url
-                if "/databases/" in url and not self.calls:
-                    self.calls.append(("query-slow", timeout))
-                    time.sleep(slow_first_query_s)
-                    return io.BytesIO(b'{"results": [], "has_more": false}')
-                self.calls.append((method, url))
-                if "/databases/" in url:
-                    return io.BytesIO(b'{"results": [], "has_more": false}')
-                return io.BytesIO(b'{"id": "p1"}')
-        return Fake()
-
-    def test_no_write_lands_after_the_timeout_was_reported(self, tmp_path, monkeypatch):
-        """Codex round 4 (major): the guard abandoned the worker and it kept writing.
-        Now the budget is cancelled before the timeout is reported, so the worker's
-        next request refuses and the paint stops where it stood."""
-        (tmp_path / "tok").write_text("t")
-        (tmp_path / "db").write_text("db1")
-        monkeypatch.setattr(board_rows, "LOCK_FILE", tmp_path / "board.lock")
-        buckets = {"top_of_mind": [{"key": "k1", "title": "t", "detail": "d", "scope": "card"}],
-                   "this_week": [], "inbox": [], "healthy_scopes": {"card"}}
-        monkeypatch.setattr(board_rows.consulting_board, "buckets", lambda *a, **k: buckets)
-        fake = self._fake_db(slow_first_query_s=0.15)
-        rows, error = board_rows.collect(NOW, {}, opener=fake, token_file=tmp_path / "tok",
-                                         db_file=tmp_path / "db", budget_s=0.05)
-        assert rows == [] and "timed out" in error and "no further write" in error
-        time.sleep(0.4)                      # let the abandoned worker run on and try
-        writes = [c for c in fake.calls if c[0] in ("POST", "PATCH") and "/pages" in c[1]]
-        assert writes == [], f"writes landed after the timeout: {writes}"
-
-    def test_and_the_in_flight_call_is_capped_to_what_is_left(self, tmp_path, monkeypatch):
-        """A 10s HTTP timeout on a request that starts with 0.02s left would outlive
-        the budget. The request's own timeout is clipped to the remainder."""
-        seen = []
-
-        def opener(req, timeout):
-            seen.append(timeout)
-            return io.BytesIO(b'{"results": [], "has_more": false}')
-        budget = board_rows._Budget(0.05)
-        board_rows.existing_rows("t", "db", opener, budget=budget)
-        assert seen and seen[0] <= 0.05 < board_rows.TIMEOUT_S
-
-    def test_the_boards_own_budget_fires_before_the_briefs_guard(self):
-        """Two bounds, one ordering. If the brief's guard fired first the worker would
-        be abandoned with a live budget, which is exactly the round-4 defect."""
-        assert board_rows.BUDGET_S < _brief().COLLECT_BUDGET_S
-
-    def test_a_worker_that_ran_out_of_time_also_let_go_of_the_lock(self, tmp_path, monkeypatch):
-        (tmp_path / "tok").write_text("t")
-        (tmp_path / "db").write_text("db1")
-        monkeypatch.setattr(board_rows, "LOCK_FILE", tmp_path / "board.lock")
-        buckets = {"top_of_mind": [], "this_week": [], "inbox": [], "healthy_scopes": {"card"}}
-        monkeypatch.setattr(board_rows.consulting_board, "buckets", lambda *a, **k: buckets)
-        fake = self._fake_db(slow_first_query_s=0.15)
-        board_rows.collect(NOW, {}, opener=fake, token_file=tmp_path / "tok",
-                           db_file=tmp_path / "db", budget_s=0.05)
-        time.sleep(0.3)
-        with board_rows.exclusive(tmp_path / "board.lock"):
-            pass                                        # no BoardBusy: it was released
-
-
-class TestTheBoardLooksLikeTheOneHeAsked_For:
-    """Founder, 2026-09-03, with two screenshots of Bloom's board: *"This is what I
-    wanted my board to look like."* The schema already matched. Three things his
-    screenshots carry that this writer did not fill."""
-
-    def test_every_row_carries_a_priority(self, tmp_path):
-        """Bloom's board is scanned by P0-P3. A board that writes no Priority renders
-        an empty column, which is worse than no column: it looks like a field he
-        forgot to fill."""
-        b = cb.buckets(NOW, {"mail": ([_brief().Row("Portant: docs", "mail:t1")], None)},
-                       _tree(tmp_path))
-        rows = b["top_of_mind"] + b["this_week"] + b["inbox"]
-        assert rows, "fixture produced no rows, so this proves nothing"
-        missing = [r["title"] for r in rows if not r.get("priority")]
-        assert not missing, f"rows with no priority: {missing}"
-        assert all(r["priority"] in ("P0", "P1", "P2", "P3") for r in rows)
-
-    def test_priority_is_the_cards_verdict_translated_not_a_second_judgement(self):
-        """The mirror rule: one thing computes urgency. This table only renames it."""
-        assert cb.PRIORITY_BY_HEALTH["🔴"] == "P0"
-        assert cb.PRIORITY_BY_HEALTH["⚪"] == "P3"
-        src = pathlib.Path(cb.__file__).read_text(encoding="utf-8")
-        code = "\n".join(l for l in src.splitlines() if not l.lstrip().startswith("#"))
-        for invented in ("days_overdue", "score", "urgency"):
-            assert invented not in code, (
-                f"{invented!r} suggests this module started computing urgency itself; "
-                "the state card owns that verdict")
-
-    def test_every_row_carries_a_done_signal(self, tmp_path):
-        b = cb.buckets(NOW, {"mail": ([_brief().Row("Portant: docs", "mail:t1")], None)},
-                       _tree(tmp_path))
-        rows = b["top_of_mind"] + b["this_week"] + b["inbox"]
-        missing = [r["title"] for r in rows if not (r.get("done") or "").strip()]
-        assert not missing, f"rows with no done signal: {missing}"
-
-    def test_the_done_signal_reaches_notion_and_leads_the_note(self):
-        props = board_rows._properties(
-            {"title": "t", "scope": "card", "detail": "d", "done": "you sent it"},
-            "Top of Mind", "kipi-abc", True)
-        note = props["Notes"]["rich_text"][0]["text"]["content"]
-        assert note.startswith("Done signal: you sent it"), note
-        assert "scope=card" in note, "the painter still has to read its scope back"
-
-    def test_domain_is_the_producers_not_a_hardcoded_Consulting(self):
-        gtm = board_rows._properties({"title": "t", "domain": "GTM"}, "Top of Mind", "i", True)
-        assert gtm["Domain"]["multi_select"][0]["name"] == "GTM"
-        bare = board_rows._properties({"title": "t"}, "Top of Mind", "i", True)
-        assert bare["Domain"]["multi_select"][0]["name"] == "Consulting", "safe default"
-
-    def test_size_is_never_invented(self):
         """Bloom's board has XS/S/M. Nothing here knows effort, so the column stays
         empty rather than carrying a number that looks measured and is not."""
         props = board_rows._properties({"title": "t", "priority": "P0"}, "Inbox", "i", True)
         assert "Size" not in props
 
 
-class TestTwoThreadsAreNeverOneRow:
-    """Codex, 2026-09-03, on the fix for rounds 1-4: the `sender|subject` fallback
-    (used when the model returns no thread id) collapsed two distinct threads into one
-    Notion row. Read-back still passed, because `wanted` had already lost the second
-    one -- the same shape as the round-3 defect, one layer up."""
+class TestTwoThreadsAreTwoRows:
+    """Codex, 2026-09-03: the `sender|subject` fallback (used when the model returned
+    no thread id) collapsed two distinct threads into one Notion row. The id-less
+    branch retired with the model read (ASK-1323): every ledger row carries the
+    Gmail thread id, and a row without one fails the whole read rather than being
+    keyed by its text (test_morning_brief_mail.py::test_one_bad_row_fails_the_whole_read).
+    What remains to pin is the normal path and the two exits the painter reads."""
 
-    def test_two_indistinguishable_threads_become_one_row_that_SAYS_two(self):
-        brief = _brief()
-        runner = lambda p, t: (json.dumps({"threads": [
-            {"from": "Alice", "subject": "Re: invoice", "age_hours": 2},
-            {"from": "Alice", "subject": "Re: invoice", "age_hours": 9}]}), None)
+    def test_two_ledger_rows_reach_the_board_as_two_keys(self, tmp_path):
+        brief = _ledger_brief(tmp_path)
+        runner = lambda argv, t: (json.dumps([
+            {"thread_id": "t1", "last_from": "Alice", "subject": "Re: invoice"},
+            {"thread_id": "t2", "last_from": "Alice", "subject": "Re: invoice"}]), None)
         rows, err = brief.collect_mail(None, runner)
         assert err is None
-        # ROUND 10 REVERSED THE SHAPE OF THIS FIX, and the harm it was written against
-        # still governs. The first fix numbered duplicates by POSITION, so answering
-        # the first thread renumbered the second onto its key and handed it that row's
-        # Status and the bucket he had dragged it to. A thread wearing another
-        # thread's identity is worse than either outcome the original note weighed.
-        #
-        # With no thread id nothing tells these two apart, so the group is ONE row
-        # that says how many it stands for. The task is not silently gone, which is
-        # what this class exists to prevent: he can see there are two and open both.
-        assert len(rows) == 1
-        assert "2 threads" in str(rows[0]), str(rows[0])
-
-    def test_a_real_thread_id_still_wins_and_stays_stable(self):
-        """The suffix is only for the id-less case. A thread WITH an id must not pick
-        one up, or the age-stability the whole change exists for is undone."""
-        brief = _brief()
-        runner = lambda p, t: (json.dumps({"threads": [
-            {"id": "t1", "from": "Alice", "subject": "Re: invoice", "age_hours": 2},
-            {"id": "t2", "from": "Alice", "subject": "Re: invoice", "age_hours": 9}]}), None)
-        rows, _ = brief.collect_mail(None, runner)
         assert [r.key for r in rows] == ["mail:t1", "mail:t2"]
-
-    def test_both_rows_reach_the_board(self, tmp_path):
-        brief = _brief()
-        runner = lambda p, t: (json.dumps({"threads": [
-            {"from": "Alice", "subject": "Re: invoice", "age_hours": 2},
-            {"from": "Alice", "subject": "Re: invoice", "age_hours": 9}]}), None)
-        rows, _ = brief.collect_mail(None, runner)
         inbox = cb.buckets(NOW, {"mail": (rows, None)}, _tree(tmp_path))["inbox"]
-        assert len(inbox) == 1 and "2 threads" in inbox[0]["title"], inbox
-        # And the id-LESS case is the only one that collapses: with real ids the board
-        # still gets two rows. That is the normal path and it must not regress.
-        keyed = lambda p, t: (json.dumps({"threads": [
-            {"id": "t1", "from": "Alice", "subject": "Re: invoice", "age_hours": 2},
-            {"id": "t2", "from": "Alice", "subject": "Re: invoice", "age_hours": 9}]}),
-            None)
-        rows2, _ = brief.collect_mail(None, keyed)
-        inbox2 = cb.buckets(NOW, {"mail": (rows2, None)}, _tree(tmp_path))["inbox"]
-        assert len({i["key"] for i in inbox2}) == 2, "a real thread id stopped working"
+        assert len({i["key"] for i in inbox}) == 2, "two threads must never share one row"
+
+    def test_an_empty_healthy_mail_answer_lets_the_painter_clear_stale_rows(self, tmp_path):
+        """([], None) is 'nothing needs him': the Gmail scope is healthy, so board_rows
+        archives rows the ledger no longer names. This is the exit ASK-1323 exists for."""
+        res = cb.buckets(NOW, {"mail": ([], None)}, _tree(tmp_path))
+        assert "inbox:Gmail" in res["healthy_scopes"]
+        assert not [i for i in res["inbox"] if i["key"].startswith("mail:")]
+
+    def test_a_mail_error_keeps_the_gmail_scope_unhealthy(self, tmp_path):
+        """([], error) is 'could not read': the scope stays out of healthy_scopes, so
+        the painter keeps every row, and the board carries one row saying so."""
+        res = cb.buckets(NOW, {"mail": ([], "ledger timed out after 60s")}, _tree(tmp_path))
+        assert "inbox:Gmail" not in res["healthy_scopes"]
+        assert len(res["inbox"]) == 1, res["inbox"]
 
 
 class TestHisSideCarriesItsDates:

--- a/q-system/.q-system/tests/test_consulting_board.py
+++ b/q-system/.q-system/tests/test_consulting_board.py
@@ -558,6 +558,133 @@ class TestRound4:
         b = cb.buckets(NOW, {"mail": (b_rows, None)}, _tree(tmp_path))["inbox"][0]["key"]
         assert a == b, f"a date change minted a new id: {a!r} != {b!r}"
 
+    def test_but_a_bracketed_number_that_is_not_an_age_stays(self, tmp_path):
+        brief = _brief()
+        a = cb.buckets(NOW, {"mail": ([brief.Row("Alice ticket [4021]", "mail:t1")], None)},
+                       _tree(tmp_path))["inbox"][0]["key"]
+        b = cb.buckets(NOW, {"mail": ([brief.Row("Alice ticket [4022]", "mail:t2")], None)},
+                       _tree(tmp_path))["inbox"][0]["key"]
+        assert a != b
+
+    @staticmethod
+    def _fake_db(slow_first_query_s: float):
+        """The database API, just enough of it. Records every call; the first query
+        sleeps past the budget so the worker is abandoned mid-paint."""
+        class Fake:
+            def __init__(self):
+                self.calls = []
+
+            def __call__(self, req, timeout):
+                method, url = req.get_method(), req.full_url
+                if "/databases/" in url and not self.calls:
+                    self.calls.append(("query-slow", timeout))
+                    time.sleep(slow_first_query_s)
+                    return io.BytesIO(b'{"results": [], "has_more": false}')
+                self.calls.append((method, url))
+                if "/databases/" in url:
+                    return io.BytesIO(b'{"results": [], "has_more": false}')
+                return io.BytesIO(b'{"id": "p1"}')
+        return Fake()
+
+    def test_no_write_lands_after_the_timeout_was_reported(self, tmp_path, monkeypatch):
+        """Codex round 4 (major): the guard abandoned the worker and it kept writing.
+        Now the budget is cancelled before the timeout is reported, so the worker's
+        next request refuses and the paint stops where it stood."""
+        (tmp_path / "tok").write_text("t")
+        (tmp_path / "db").write_text("db1")
+        monkeypatch.setattr(board_rows, "LOCK_FILE", tmp_path / "board.lock")
+        buckets = {"top_of_mind": [{"key": "k1", "title": "t", "detail": "d", "scope": "card"}],
+                   "this_week": [], "inbox": [], "healthy_scopes": {"card"}}
+        monkeypatch.setattr(board_rows.consulting_board, "buckets", lambda *a, **k: buckets)
+        fake = self._fake_db(slow_first_query_s=0.15)
+        rows, error = board_rows.collect(NOW, {}, opener=fake, token_file=tmp_path / "tok",
+                                         db_file=tmp_path / "db", budget_s=0.05)
+        assert rows == [] and "timed out" in error and "no further write" in error
+        time.sleep(0.4)                      # let the abandoned worker run on and try
+        writes = [c for c in fake.calls if c[0] in ("POST", "PATCH") and "/pages" in c[1]]
+        assert writes == [], f"writes landed after the timeout: {writes}"
+
+    def test_and_the_in_flight_call_is_capped_to_what_is_left(self, tmp_path, monkeypatch):
+        """A 10s HTTP timeout on a request that starts with 0.02s left would outlive
+        the budget. The request's own timeout is clipped to the remainder."""
+        seen = []
+
+        def opener(req, timeout):
+            seen.append(timeout)
+            return io.BytesIO(b'{"results": [], "has_more": false}')
+        budget = board_rows._Budget(0.05)
+        board_rows.existing_rows("t", "db", opener, budget=budget)
+        assert seen and seen[0] <= 0.05 < board_rows.TIMEOUT_S
+
+    def test_the_boards_own_budget_fires_before_the_briefs_guard(self):
+        """Two bounds, one ordering. If the brief's guard fired first the worker would
+        be abandoned with a live budget, which is exactly the round-4 defect."""
+        assert board_rows.BUDGET_S < _brief().COLLECT_BUDGET_S
+
+    def test_a_worker_that_ran_out_of_time_also_let_go_of_the_lock(self, tmp_path, monkeypatch):
+        (tmp_path / "tok").write_text("t")
+        (tmp_path / "db").write_text("db1")
+        monkeypatch.setattr(board_rows, "LOCK_FILE", tmp_path / "board.lock")
+        buckets = {"top_of_mind": [], "this_week": [], "inbox": [], "healthy_scopes": {"card"}}
+        monkeypatch.setattr(board_rows.consulting_board, "buckets", lambda *a, **k: buckets)
+        fake = self._fake_db(slow_first_query_s=0.15)
+        board_rows.collect(NOW, {}, opener=fake, token_file=tmp_path / "tok",
+                           db_file=tmp_path / "db", budget_s=0.05)
+        time.sleep(0.3)
+        with board_rows.exclusive(tmp_path / "board.lock"):
+            pass                                        # no BoardBusy: it was released
+
+
+class TestTheBoardLooksLikeTheOneHeAsked_For:
+    """Founder, 2026-09-03, with two screenshots of Bloom's board: *"This is what I
+    wanted my board to look like."* The schema already matched. Three things his
+    screenshots carry that this writer did not fill."""
+
+    def test_every_row_carries_a_priority(self, tmp_path):
+        """Bloom's board is scanned by P0-P3. A board that writes no Priority renders
+        an empty column, which is worse than no column: it looks like a field he
+        forgot to fill."""
+        b = cb.buckets(NOW, {"mail": ([_brief().Row("Portant: docs", "mail:t1")], None)},
+                       _tree(tmp_path))
+        rows = b["top_of_mind"] + b["this_week"] + b["inbox"]
+        assert rows, "fixture produced no rows, so this proves nothing"
+        missing = [r["title"] for r in rows if not r.get("priority")]
+        assert not missing, f"rows with no priority: {missing}"
+        assert all(r["priority"] in ("P0", "P1", "P2", "P3") for r in rows)
+
+    def test_priority_is_the_cards_verdict_translated_not_a_second_judgement(self):
+        """The mirror rule: one thing computes urgency. This table only renames it."""
+        assert cb.PRIORITY_BY_HEALTH["🔴"] == "P0"
+        assert cb.PRIORITY_BY_HEALTH["⚪"] == "P3"
+        src = pathlib.Path(cb.__file__).read_text(encoding="utf-8")
+        code = "\n".join(l for l in src.splitlines() if not l.lstrip().startswith("#"))
+        for invented in ("days_overdue", "score", "urgency"):
+            assert invented not in code, (
+                f"{invented!r} suggests this module started computing urgency itself; "
+                "the state card owns that verdict")
+
+    def test_every_row_carries_a_done_signal(self, tmp_path):
+        b = cb.buckets(NOW, {"mail": ([_brief().Row("Portant: docs", "mail:t1")], None)},
+                       _tree(tmp_path))
+        rows = b["top_of_mind"] + b["this_week"] + b["inbox"]
+        missing = [r["title"] for r in rows if not (r.get("done") or "").strip()]
+        assert not missing, f"rows with no done signal: {missing}"
+
+    def test_the_done_signal_reaches_notion_and_leads_the_note(self):
+        props = board_rows._properties(
+            {"title": "t", "scope": "card", "detail": "d", "done": "you sent it"},
+            "Top of Mind", "kipi-abc", True)
+        note = props["Notes"]["rich_text"][0]["text"]["content"]
+        assert note.startswith("Done signal: you sent it"), note
+        assert "scope=card" in note, "the painter still has to read its scope back"
+
+    def test_domain_is_the_producers_not_a_hardcoded_Consulting(self):
+        gtm = board_rows._properties({"title": "t", "domain": "GTM"}, "Top of Mind", "i", True)
+        assert gtm["Domain"]["multi_select"][0]["name"] == "GTM"
+        bare = board_rows._properties({"title": "t"}, "Top of Mind", "i", True)
+        assert bare["Domain"]["multi_select"][0]["name"] == "Consulting", "safe default"
+
+    def test_size_is_never_invented(self):
         """Bloom's board has XS/S/M. Nothing here knows effort, so the column stays
         empty rather than carrying a number that looks measured and is not."""
         props = board_rows._properties({"title": "t", "priority": "P0"}, "Inbox", "i", True)

--- a/q-system/.q-system/tests/test_consulting_board.py
+++ b/q-system/.q-system/tests/test_consulting_board.py
@@ -527,6 +527,11 @@ def _ledger_brief(tmp_path):
     ledger = tmp_path / "q-consult" / "email-watch" / "ledger.py"
     ledger.parent.mkdir(parents=True, exist_ok=True)
     ledger.write_text("# stand-in\n", encoding="utf-8")
+    log = tmp_path / "q-consult" / "output" / "mail-sweep.log"
+    log.parent.mkdir(parents=True, exist_ok=True)
+    log.write_text("mail-sweep: stamped ok at "
+                   + dt.datetime.now(dt.timezone.utc).strftime("%Y-%m-%dT%H:%M:%SZ")
+                   + "\n", encoding="utf-8")
     mod = _brief()
     original = mod._optional_module
     mod._optional_module = (lambda stem: _FakeBoard(tmp_path)

--- a/q-system/.q-system/tests/test_morning_brief.py
+++ b/q-system/.q-system/tests/test_morning_brief.py
@@ -316,18 +316,42 @@ def test_calendar_empty_is_empty_not_an_error(brief):
     assert error is None
 
 
-def test_mail_collector_reports_a_model_failure(brief):
-    rows, error = brief.collect_mail(NOW, runner=lambda p, t: (None, "timeout"))
+class _FakeBoard:
+    def __init__(self, root):
+        self._root = root
+
+    def consulting_root(self):
+        return self._root
+
+
+@pytest.fixture
+def mail_instance(tmp_path, monkeypatch, brief):
+    """A throwaway consulting instance for the ledger-backed mail collector
+    (ASK-1323). The contract itself lives in test_morning_brief_mail.py; these
+    cases only keep the section's two exits visible from the engine suite."""
+    ledger = tmp_path / "q-consult" / "email-watch" / "ledger.py"
+    ledger.parent.mkdir(parents=True)
+    ledger.write_text("# stand-in\n", encoding="utf-8")
+    original = brief._optional_module
+    monkeypatch.setattr(brief, "_optional_module",
+                        lambda stem: _FakeBoard(tmp_path)
+                        if "consulting_board" in stem else original(stem))
+    return tmp_path
+
+
+def test_mail_collector_reports_a_ledger_failure(brief, mail_instance):
+    rows, error = brief.collect_mail(NOW, runner=lambda argv, t: (None, "ledger timed out"))
     assert rows == []
-    assert "timeout" in error
+    assert "timed out" in error
 
 
-def test_mail_collector_parses_threads(brief):
-    payload = json.dumps({"threads": [
-        {"from": "chris@pi.com", "subject": "SOW", "age_hours": 20}]})
-    rows, error = brief.collect_mail(NOW, runner=lambda p, t: (payload, None))
+def test_mail_collector_paints_the_ledgers_rows(brief, mail_instance):
+    payload = json.dumps([{"thread_id": "t1", "client": "all-points",
+                           "last_from": "chris@pi.com", "subject": "SOW",
+                           "needs_reply_since": "2026-08-13"}])
+    rows, error = brief.collect_mail(NOW, runner=lambda argv, t: (payload, None))
     assert error is None
-    assert any("chris@pi.com" in r for r in rows)
+    assert any("all-points" in r and "SOW" in r for r in rows)
 
 
 def test_owed_reports_a_linear_failure_without_hiding_the_loops(brief, tmp_path):
@@ -1045,25 +1069,25 @@ class TestNoCapUpstreamOfTheBoard:
     not a statement that the work is finished). A second cap upstream of the producer
     routed around that rule. Display is capped by `_section`; data is not capped."""
 
-    def test_every_thread_the_model_returns_reaches_the_caller(self, brief):
+    def test_every_thread_the_ledger_returns_reaches_the_caller(self, brief, mail_instance):
         n = 40
-        payload = json.dumps({"threads": [
-            {"id": f"t{i}", "from": f"p{i}@x.com", "subject": f"s{i}", "age_hours": i}
-            for i in range(n)]})
-        rows, error = brief.collect_mail(None, lambda p, t: (payload, None))
+        payload = json.dumps([
+            {"thread_id": f"t{i}", "last_from": f"p{i}@x.com", "subject": f"s{i}"}
+            for i in range(n)])
+        rows, error = brief.collect_mail(None, lambda argv, t: (payload, None))
         assert error is None
         assert len(rows) == n, (
             f"the producer dropped {n - len(rows)} threads; their board rows would be "
             "archived inside a healthy scope")
         assert len({r.key for r in rows}) == n
 
-    def test_no_synthetic_overflow_row_is_minted(self, brief):
+    def test_no_synthetic_overflow_row_is_minted(self, brief, mail_instance):
         """An overflow row needs a stable id and a scope. Inventing one puts a row on
         the board that no thread corresponds to."""
-        payload = json.dumps({"threads": [
-            {"id": f"t{i}", "from": "p@x.com", "subject": "s", "age_hours": 1}
-            for i in range(30)]})
-        rows, _ = brief.collect_mail(None, lambda p, t: (payload, None))
+        payload = json.dumps([
+            {"thread_id": f"t{i}", "last_from": "p@x.com", "subject": "s"}
+            for i in range(30)])
+        rows, _ = brief.collect_mail(None, lambda argv, t: (payload, None))
         assert not any("more unanswered" in str(r) for r in rows)
         assert all(getattr(r, "key", "").startswith("mail:t") for r in rows)
 

--- a/q-system/.q-system/tests/test_morning_brief.py
+++ b/q-system/.q-system/tests/test_morning_brief.py
@@ -332,6 +332,11 @@ def mail_instance(tmp_path, monkeypatch, brief):
     ledger = tmp_path / "q-consult" / "email-watch" / "ledger.py"
     ledger.parent.mkdir(parents=True)
     ledger.write_text("# stand-in\n", encoding="utf-8")
+    log = tmp_path / "q-consult" / "output" / "mail-sweep.log"
+    log.parent.mkdir(parents=True, exist_ok=True)
+    log.write_text("mail-sweep: stamped ok at "
+                   + dt.datetime.now(dt.timezone.utc).strftime("%Y-%m-%dT%H:%M:%SZ")
+                   + "\n", encoding="utf-8")
     original = brief._optional_module
     monkeypatch.setattr(brief, "_optional_module",
                         lambda stem: _FakeBoard(tmp_path)

--- a/q-system/.q-system/tests/test_morning_brief_mail.py
+++ b/q-system/.q-system/tests/test_morning_brief_mail.py
@@ -19,6 +19,7 @@ refusal, so no test here can read the founder's real Notion ledger by accident.
 """
 from __future__ import annotations
 
+import datetime as dt
 import importlib.util
 import json
 import os
@@ -63,6 +64,11 @@ def instance(tmp_path, monkeypatch, brief):
     ledger = tmp_path / "q-consult" / "email-watch" / "ledger.py"
     ledger.parent.mkdir(parents=True)
     ledger.write_text("# stand-in; the runner is injected\n", encoding="utf-8")
+    log = tmp_path / "q-consult" / "output" / "mail-sweep.log"
+    log.parent.mkdir(parents=True, exist_ok=True)
+    log.write_text("mail-sweep: stamped ok at "
+                   + dt.datetime.now(dt.timezone.utc).strftime("%Y-%m-%dT%H:%M:%SZ")
+                   + "\n", encoding="utf-8")
     original = brief._optional_module
 
     def swapped(stem):
@@ -143,6 +149,60 @@ def test_every_unreadable_shape_keeps_the_board(brief, instance, stdout, error, 
     rows, err = brief.collect_mail(None, runner=_runner(stdout, error))
     assert rows == []
     assert err and expect in err
+
+
+def _stamp(instance, when: str) -> None:
+    (instance / "q-consult" / "output" / "mail-sweep.log").write_text(
+        "=== 2026-09-07T01:25:01Z mail-sweep ===\nfiled 0\n"
+        f"mail-sweep: stamped ok at {when}\nmail-sweep: done\n", encoding="utf-8")
+
+
+NOW = dt.datetime(2026, 9, 7, 14, 0, tzinfo=dt.timezone.utc)
+
+
+def test_a_fresh_sweep_stamp_lets_an_empty_answer_be_healthy(brief, instance):
+    _stamp(instance, "2026-09-07T13:31:10Z")
+    rows, error = brief.collect_mail(NOW, runner=_runner("[]"))
+    assert (rows, error) == ([], None)
+
+
+def test_a_stale_sweep_stamp_keeps_the_board_and_never_runs_the_ledger(brief, instance):
+    """PR #318 reviewer, round 2: a sweep that died leaves a readable ledger that never
+    changes, and an empty answer from it would archive rows. Three hours is the line."""
+    _stamp(instance, "2026-09-07T10:31:10Z")
+    run = _runner("[]")
+    rows, error = brief.collect_mail(NOW, runner=run)
+    assert rows == []
+    assert "3.5h ago" in error and "older than 3h" in error
+    assert run.calls == [], "a stale ledger is not even asked"
+
+
+def test_the_last_stamp_counts_and_a_failed_run_after_it_does_not_refresh(brief, instance):
+    (instance / "q-consult" / "output" / "mail-sweep.log").write_text(
+        "mail-sweep: stamped ok at 2026-09-07T09:31:10Z\n"
+        "=== 2026-09-07T13:25:01Z mail-sweep ===\nmail-sweep: stamped failed at 2026-09-07T13:26:00Z\n",
+        encoding="utf-8")
+    rows, error = brief.collect_mail(NOW, runner=_runner("[]"))
+    assert rows == [] and "older than 3h" in error
+
+
+@pytest.mark.parametrize("log_text, expect", [
+    (None, "no mail-sweep log"),
+    ("=== 2026-09-07T13:25:01Z mail-sweep ===\nmail-sweep: done\n", "never stamped ok"),
+    ("mail-sweep: stamped ok at yesterday\n", "not a timestamp"),
+])
+def test_no_witness_is_an_error_not_a_quiet_empty(brief, instance, log_text, expect):
+    log = instance / "q-consult" / "output" / "mail-sweep.log"
+    if log_text is None:
+        log.unlink()
+    else:
+        log.write_text(log_text, encoding="utf-8")
+    rows, error = brief.collect_mail(NOW, runner=_runner("[]"))
+    assert rows == [] and expect in error
+
+
+def test_the_freshness_window_matches_an_hourly_sweep(brief):
+    assert brief.LEDGER_FRESH_HOURS == 3
 
 
 def test_one_bad_row_fails_the_whole_read(brief, instance):

--- a/q-system/.q-system/tests/test_morning_brief_mail.py
+++ b/q-system/.q-system/tests/test_morning_brief_mail.py
@@ -1,0 +1,250 @@
+#!/usr/bin/env python3
+"""The brief's mail section reads the consulting ledger, not a model (ASK-1323).
+
+RED FIRST: this file was written against the model-backed `collect_mail` and every
+case failed there (the old collector formatted a prompt and parsed `{"threads":...}`;
+these inject a ledger-shaped runner and a JSON list).
+
+## The property this file exists for
+
+`board_rows` archives rows inside a scope that reported healthy. So the collector's
+two exits must be different things: `([], None)` is "the ledger answered and nothing
+needs him" (clear the stale rows), and `([], error)` is "the ledger could not be read"
+(keep the board as it is). Every failure shape below lands on the second exit.
+
+## What this suite may NOT do
+
+No live data path. `run_ledger` refuses under pytest and one case asserts that
+refusal, so no test here can read the founder's real Notion ledger by accident.
+"""
+from __future__ import annotations
+
+import importlib.util
+import json
+import os
+import re
+import sys
+from pathlib import Path
+
+import pytest
+
+HERE = Path(__file__).resolve().parent
+SCRIPTS = HERE.parent / "scripts"
+BRIEF_PATH = SCRIPTS / "morning-brief.py"
+
+
+def _load(stem: str, filename: str):
+    spec = importlib.util.spec_from_file_location(stem, SCRIPTS / filename)
+    mod = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(mod)
+    return mod
+
+
+@pytest.fixture(scope="module")
+def brief():
+    return _load("morning_brief_mail_under_test", "morning-brief.py")
+
+
+class _FakeBoard:
+    """Stands in for consulting_board: the only thing collect_mail asks of it is
+    where the instance lives."""
+
+    def __init__(self, root: Path):
+        self._root = root
+
+    def consulting_root(self) -> Path:
+        return self._root
+
+
+@pytest.fixture
+def instance(tmp_path, monkeypatch, brief):
+    """A throwaway consulting instance with a ledger script present, and the brief's
+    sibling loader pointed at it. Nothing under the real home directory is read."""
+    ledger = tmp_path / "q-consult" / "email-watch" / "ledger.py"
+    ledger.parent.mkdir(parents=True)
+    ledger.write_text("# stand-in; the runner is injected\n", encoding="utf-8")
+    original = brief._optional_module
+
+    def swapped(stem):
+        bare = stem[:-3] if stem.endswith(".py") else stem
+        if bare.endswith("consulting_board"):
+            return _FakeBoard(tmp_path)
+        return original(stem)
+
+    monkeypatch.setattr(brief, "_optional_module", swapped)
+    return tmp_path
+
+
+LEDGER_ROWS = [
+    {"thread_id": "19ff4af34dbc0f56", "client": "silicon-docks",
+     "last_from": "john@silicondocks.vc", "subject": "Re: Intro: John + Assaf",
+     "needs_reply_since": "2026-09-02T16:27:46+00:00"},
+    {"thread_id": "1a01ae47d7ac6241", "client": "", "last_from": "csalgado@allpointsinv.com",
+     "subject": "Re: My one pager", "needs_reply_since": ""},
+]
+
+
+def _runner(stdout, error=None):
+    calls = []
+
+    def run(argv, timeout):
+        calls.append((list(argv), timeout))
+        return stdout, error
+    run.calls = calls
+    return run
+
+
+# ---------------------------------------------------------------------------
+# the healthy exits
+# ---------------------------------------------------------------------------
+
+def test_rows_are_the_ledgers_rows_keyed_by_thread_id(brief, instance):
+    rows, error = brief.collect_mail(None, runner=_runner(json.dumps(LEDGER_ROWS)))
+    assert error is None
+    assert [r.key for r in rows] == ["mail:19ff4af34dbc0f56", "mail:1a01ae47d7ac6241"]
+    assert "silicon-docks" in rows[0] and "Re: Intro: John + Assaf" in rows[0]
+    assert "[since 2026-09-02]" in rows[0]
+    # no client slug: the sender is the name; no since: no bracket at all
+    assert rows[1].startswith("csalgado@allpointsinv.com")
+    assert "[since" not in rows[1]
+
+
+def test_an_empty_ledger_answer_is_empty_and_healthy(brief, instance):
+    """The exit board_rows reads as "clear the stale rows". It must be reachable."""
+    rows, error = brief.collect_mail(None, runner=_runner("[]\n"))
+    assert rows == []
+    assert error is None
+
+
+def test_the_runner_is_asked_for_needs_reply_json_on_the_instances_ledger(brief, instance):
+    run = _runner("[]")
+    brief.collect_mail(None, runner=run)
+    (argv, timeout), = run.calls
+    assert argv[0] == sys.executable
+    assert argv[1] == str(instance / "q-consult" / "email-watch" / "ledger.py")
+    assert argv[2:] == ["needs-reply", "--json"]
+    assert timeout == brief.LEDGER_TIMEOUT_S
+
+
+# ---------------------------------------------------------------------------
+# every failure is an error, never a quiet empty
+# ---------------------------------------------------------------------------
+
+@pytest.mark.parametrize("stdout, error, expect", [
+    (None, "ledger exit 1: NOTION_TOKEN_ASK is not set", "NOTION_TOKEN_ASK"),
+    (None, "ledger timed out after 60s", "timed out"),
+    ("NOTION_TOKEN_ASK is not set. Refusing to run.", None, "other than JSON"),
+    ("", None, "other than JSON"),
+    (json.dumps({"rows": []}), None, "not a list"),
+    (json.dumps([{"client": "x", "subject": "no id"}]), None, "no thread id"),
+    (json.dumps(["not a dict"]), None, "no thread id"),
+])
+def test_every_unreadable_shape_keeps_the_board(brief, instance, stdout, error, expect):
+    rows, err = brief.collect_mail(None, runner=_runner(stdout, error))
+    assert rows == []
+    assert err and expect in err
+
+
+def test_one_bad_row_fails_the_whole_read(brief, instance):
+    """Half a list would archive the other half's rows inside a healthy scope."""
+    payload = json.dumps([LEDGER_ROWS[0], {"subject": "no id"}])
+    rows, err = brief.collect_mail(None, runner=_runner(payload))
+    assert rows == [] and err
+
+
+def test_a_missing_ledger_script_is_an_error_not_an_empty_section(brief, instance):
+    (instance / "q-consult" / "email-watch" / "ledger.py").unlink()
+    run = _runner("[]")
+    rows, err = brief.collect_mail(None, runner=run)
+    assert rows == []
+    assert "not found" in err and "KIPI_CONSULTING_ROOT" in err
+    assert run.calls == [], "nothing may run when the script is absent"
+
+
+def test_no_consulting_board_sibling_is_an_error(brief, monkeypatch):
+    monkeypatch.setattr(brief, "_optional_module", lambda stem: None)
+    rows, err = brief.collect_mail(None, runner=_runner("[]"))
+    assert rows == []
+    assert "consulting_board" in err
+
+
+# ---------------------------------------------------------------------------
+# the chokepoint, the shell, and what must not come back
+# ---------------------------------------------------------------------------
+
+def test_the_ledger_timeout_sits_under_the_guard_budget(brief, monkeypatch):
+    """Otherwise the guard abandons the mail thread while the ledger child runs on,
+    and the section's error is the guard's instead of the ledger's (F3)."""
+    assert brief.LEDGER_TIMEOUT_S < brief.FIXED_BUDGET_S
+    monkeypatch.setenv("KIPI_BRIEF_LEDGER_TIMEOUT", "600")
+    tuned = _load("morning_brief_mail_tuned", "morning-brief.py")
+    assert tuned.LEDGER_TIMEOUT_S < tuned.FIXED_BUDGET_S
+    assert tuned.LEDGER_TIMEOUT_S == int(tuned.FIXED_BUDGET_S) - 1
+
+
+def test_run_ledger_refuses_under_pytest(brief):
+    assert os.environ.get("PYTEST_CURRENT_TEST")
+    stdout, err = brief.run_ledger(["python3", "anything"])
+    assert stdout is None and "refused under pytest" in err
+
+
+def test_run_ledger_goes_through_the_login_shell(brief, monkeypatch):
+    """launchd hands the brief a bare environment; NOTION_TOKEN_ASK lives in the
+    founder's shell profile. Measured 2026-09-06: bare env + zsh -l prints [],
+    bare env alone prints the refusal. Same shell and flag as crm-run.sh."""
+    seen = {}
+
+    class _Proc:
+        returncode = 0
+        stdout = "[]"
+        stderr = ""
+
+    def fake_run(cmd, **kw):
+        seen["cmd"] = cmd
+        seen["timeout"] = kw.get("timeout")
+        return _Proc()
+
+    monkeypatch.delenv("PYTEST_CURRENT_TEST", raising=False)
+    monkeypatch.setattr(brief.subprocess, "run", fake_run)
+    stdout, err = brief.run_ledger(["/usr/bin/python3", "/x/ledger.py", "needs-reply", "--json"],
+                                   timeout=7)
+    assert (stdout, err) == ("[]", None)
+    assert tuple(seen["cmd"][:3]) == ("/bin/zsh", "-l", "-c")
+    assert seen["cmd"][3] == "exec /usr/bin/python3 /x/ledger.py needs-reply --json"
+    assert seen["timeout"] == 7
+
+
+def test_run_ledger_reports_a_nonzero_exit_with_its_last_line(brief, monkeypatch):
+    class _Proc:
+        returncode = 1
+        stdout = ""
+        stderr = "Traceback\nNOTION_TOKEN_ASK is not set. Refusing to run.\n"
+
+    monkeypatch.delenv("PYTEST_CURRENT_TEST", raising=False)
+    monkeypatch.setattr(brief.subprocess, "run", lambda *a, **k: _Proc())
+    stdout, err = brief.run_ledger(["x"])
+    assert stdout is None
+    assert err.startswith("ledger exit 1:") and "NOTION_TOKEN_ASK" in err
+
+
+def test_the_model_read_is_gone_from_the_mail_section(brief):
+    src = BRIEF_PATH.read_text(encoding="utf-8")
+    for gone in ("MAIL_PROMPT", "MAIL_WINDOW_DAYS", "MAIL_TOOL"):
+        assert gone not in src, f"{gone} came back"
+    # the module docstring may keep the connector's tool names as history; the
+    # SECTION may not reach for the Gmail search tool
+    section = src[src.index("# Section 2"):src.index("# Section 3")]
+    assert "search_threads" not in section
+    assert "run_claude" not in section
+    for section in getattr(brief, "SECTIONS", ()):
+        if section[0] == "mail":
+            assert not re.search(r"\(\d+d\)", section[1]), (
+                "the label carries a day window the ledger does not have")
+
+
+def test_the_brief_holds_no_ledger_import(brief):
+    """The ledger is a subprocess, never an import: the consulting package has its
+    own boundary test and this side keeps the same line."""
+    src = BRIEF_PATH.read_text(encoding="utf-8")
+    assert not re.search(r"^\s*(from|import)\s+.*\bledger\b", src, re.M)
+    assert "sys.path" not in src


### PR DESCRIPTION
## What

The morning brief's "Mail needing an answer" section reads the consulting ledger's `needs-reply --json` instead of asking a model to search Gmail. Linear: ASK-1323.

## Why

On 2026-09-06 the founder's Notion Inbox view (the Kipi backlog, painted by this brief) carried ten rows that did not need him: All Points case-file forwards, two "Accepted: 30 Min consultation" calendar mails, an intro he was CC'd on. The model prompt used the direction-only rule ("a real person wrote and you have not replied"), which the consulting ledger dropped on 2026-08-18 because it called acks, CC copies and calendar mail "waiting on you". The ledger's `reply_debt` reads each thread to its end and surfaces only an unanswered ask for him; `needs-reply --json` printed `[]` for the same morning. The section's own comment already named `ledger.py needs-reply` as the deterministic answer and said it was not wired.

## How

- `collect_mail` runs `python3 <consulting>/q-consult/email-watch/ledger.py needs-reply --json` as a subprocess, located through `consulting_board.consulting_root()` so the two sections cannot disagree about where the instance is. Never imported.
- The subprocess runs under `/bin/zsh -l -c "exec ..."`: launchd hands the brief a bare environment and the ledger refuses without `NOTION_TOKEN_ASK`, which lives in the founder's shell profile (the CRM's `crm-run.sh` is `#!/bin/zsh -l` for the same reason). Measured: bare env + login shell prints `[]`, bare env alone prints the refusal.
- Rows keep the `mail:<thread id>` key. `([], None)` is healthy, so `board_rows` archives the stale rows on the first run; a missing instance, a non-zero exit, a timeout, non-JSON output or a row without a thread id return `([], error)` and keep the board.
- `run_ledger` refuses under pytest, the same chokepoint posture as the model seam.
- **Freshness gate (reviewer round 2):** an empty answer counts as healthy only when the sweep log's last `mail-sweep: stamped ok at <UTC>` line is under 3 hours old (the sweep is hourly). Stale, missing, or never stamped ok: COULD NOT READ, board kept, ledger not asked.
- `MAIL_PROMPT`, `MAIL_TOOL`, `MAIL_WINDOW_DAYS` are gone; the section label carries no window.

## Proof

- The three suites (`test_morning_brief_mail.py`, `test_morning_brief.py`, `test_consulting_board.py`): 224 passed. The mail file was written red against the old collector (14 failed).
- Live, in the launchd shape (`env -i`, `/usr/bin/python3`, outside pytest): the collector returned `([], None)` in 0.6s; `ledger.py needs-reply --json` printed `[]`.
- Day-two proof is the morning after merge: the painter line in `~/.config/kipi/logs/morning-brief.out.log` should report the stale Gmail rows cleared and the Inbox view should match `needs-reply`.

## Reviews

PR reviewer round 1 (major): the test rewrite had cut eleven unrelated board_rows tests; rebuilt from main, fixed on f547c182. Round 2 (major): the freshness gate above.

DSSE standard and adversarial reviews ran as Claude subagents (codex is out of credits, sp-b240fca2) and are stamped `claude-review` / `claude-adversarial`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01HETchU5zbvka6TbqbLKNea
