### PR TITLE
feat(review): claude owns the PR gate, codex becomes advisory

### DIFF
--- a/q-system/.q-system/scripts/linear-worker.sh
+++ b/q-system/.q-system/scripts/linear-worker.sh
@@ -2449,9 +2449,14 @@ except Exception: d={}
 e=d.setdefault('$ISSUE',{}); e['rounds']=e.get('rounds',0)+1
 json.dump(d,open('$ATTEMPTS','w'),indent=2); print(e['rounds'])" 2>/dev/null || echo "?")"
     say "review PR #$PR_NUM for $ISSUE (round $ROUNDS)"
-    # CODEX REVIEWS SANA'S WORK (ASK-221, founder directive 2026-07-29). Sana is
-    # Claude, so a Claude reviewer shares her lab and model family and re-derives
-    # her blind spots -- fresh context is not an independent mind. `--engine codex`
+    # CLAUDE REVIEWS SANA'S WORK (founder-directed 2026-09-06, "forget codex go
+    # with the claude fallback"). This REVERSES ASK-221 / the 2026-07-29 directive.
+    # The cost is known and accepted: Sana is Claude, so a Claude reviewer shares her
+    # lab and model family and re-derives her blind spots, and fresh context is not
+    # an independent mind. Availability decided it, not the argument -- codex has
+    # been returning "workspace is out of credits" at EXIT 0, and an engine that
+    # fails silently cannot hold a required gate. See pr-review-agent.sh's header
+    # for the measured chain. `--engine claude`
     # is stated EXPLICITLY here rather than inherited from the reviewer's default,
     # because which model checks this fleet's work is the kind of fact that must be
     # readable at the call site, not two files away.
@@ -2465,7 +2470,7 @@ json.dump(d,open('$ATTEMPTS','w'),indent=2); print(e['rounds'])" 2>/dev/null || 
     # (sp-53aad86f). This is what makes a dispatcher-driven review distinguishable
     # from a hand run in the verdict record. It is set on the call rather than
     # exported once, so it cannot leak into an unrelated reviewer invocation.
-    KIPI_REVIEW_INVOKER=worker $REVIEWER_CMD "$PR_NUM" --issue "$ISSUE" --post --engine codex >>"$LOG" 2>&1 \
+    KIPI_REVIEW_INVOKER=worker $REVIEWER_CMD "$PR_NUM" --issue "$ISSUE" --post --engine claude >>"$LOG" 2>&1 \
       || say "WARN: codex reviewer failed on PR #$PR_NUM (the PR stands, unreviewed)"
     # Read back the verdict RECORD the reviewer just wrote (never re-grep the
     # review prose) and state what happens next in plain terms. Rework itself

--- a/q-system/.q-system/scripts/linear-worker.sh
+++ b/q-system/.q-system/scripts/linear-worker.sh
@@ -2471,7 +2471,7 @@ json.dump(d,open('$ATTEMPTS','w'),indent=2); print(e['rounds'])" 2>/dev/null || 
     # from a hand run in the verdict record. It is set on the call rather than
     # exported once, so it cannot leak into an unrelated reviewer invocation.
     KIPI_REVIEW_INVOKER=worker $REVIEWER_CMD "$PR_NUM" --issue "$ISSUE" --post --engine claude >>"$LOG" 2>&1 \
-      || say "WARN: codex reviewer failed on PR #$PR_NUM (the PR stands, unreviewed)"
+      || say "WARN: the claude reviewer failed on PR #$PR_NUM (the PR stands, unreviewed)"
     # Read back the verdict RECORD the reviewer just wrote (never re-grep the
     # review prose) and state what happens next in plain terms. Rework itself
     # fires on the NEXT run, through the severity-floor gate above.

--- a/q-system/.q-system/scripts/pr-review-agent.sh
+++ b/q-system/.q-system/scripts/pr-review-agent.sh
@@ -34,22 +34,35 @@
 # either stamp `codex-adversarial` (a false record) or skip the stamp and never
 # approve. In a repo whose thesis is receipts, the honest token had to exist first.
 #
-# TWO ENGINES, ONE SCRIPT -- CODEX IS THE ONE THAT GATES (ASK-221)
-# ----------------------------------------------------------------
-# Sana (the PR author) is Claude. A Claude reviewer is a different process with no
-# shared memory, genuinely useful -- but the same lab and the same model family, so
-# the blind spots stay CORRELATED. Fresh context is not an independent mind.
+# TWO ENGINES, ONE SCRIPT -- CLAUDE IS THE ONE THAT GATES (founder-directed 2026-09-06)
+# ---------------------------------------------------------------------------------
+# THIS REVERSES the 2026-07-29 directive recorded below. Founder, 2026-09-06, said
+# twice: "forget codex use claude for fallback" / "forget codex go with the claude
+# fallback". So claude is now THE reviewer: it owns `kipi/reviewer-approved` and
+# writes the ONE verdict record converge.sh and linear-worker.sh gate on. codex keeps
+# the same script but posts an ADVISORY `kipi/codex-approved` out of the gate's way.
 #
-# So codex is THE reviewer, not a second opinion appended to a Claude one:
-# founder directive 2026-07-29, "codex with gpt-5.6 as a sr. staff swe at Meta is
-# the agent that checks sana's work". It owns `kipi/reviewer-approved` and writes
-# the ONE verdict record converge.sh and linear-worker.sh gate on. Claude keeps
-# the same script but posts an ADVISORY `kipi/claude-approved` and writes its
-# record out of the gate's way.
+# THE COST IS REAL AND IS ACCEPTED, not overlooked. Sana (the PR author) is Claude, so
+# a Claude reviewer shares her lab and model family and re-derives her blind spots;
+# fresh context is not an independent mind. That was the whole argument for the
+# 2026-07-29 directive, "codex with gpt-5.6 as a sr. staff swe at Meta is the agent
+# that checks sana's work", and it is still true. What changed is availability, not
+# the argument. Restoring independence is `KIPI_REVIEW_ENGINE=codex
+# KIPI_REVIEW_PRIMARY_ENGINE=codex`, both together, or flipping the two defaults back.
 #
-# The Opus fallback below is what makes this safe: when codex is down, Claude
-# fills the PRIMARY slot and the status says DEGRADED out loud, so an outage
-# degrades the gate's independence instead of wedging every open PR.
+# WHY IT CHANGED, measured 2026-09-06 as three stacked failures each masking the next:
+# ~/.codex/config.toml asked for `gpt-6-astra` when the fleet is on Sol; codex-cli
+# 0.147.0 was too old for that model and returned HTTP 400; and underneath both, the
+# workspace is OUT OF CREDITS, which `gpt-5.6-sol` returns too. `codex exec` exits 0
+# on all three, so two sessions reviewed for a full evening on the Opus fallback and
+# nothing said so. An engine that fails silently cannot hold a required gate.
+#
+# BOTH DEFAULTS MOVE TOGETHER OR THE GATE WEDGES. The branch below posts
+# `kipi/reviewer-approved` only when ENGINE equals PRIMARY_ENGINE. Setting
+# KIPI_REVIEW_ENGINE=claude alone leaves PRIMARY_ENGINE=codex, so every review lands
+# on the advisory context and every open PR waits forever on a status nobody posts.
+#
+# The fallback still works in the new direction and still says DEGRADED out loud.
 #
 # It is a FLAG, not a second script, on purpose: sha capture (ASK-216), verdict
 # derivation from labelled severities, the commit-status post (ASK-217) and
@@ -133,7 +146,7 @@ CODEX_MODEL="${KIPI_REVIEW_CODEX_MODEL:-gpt-5.6-sol}"
 # CODEX BY DEFAULT. Env-overridable so a codex outage long enough to matter is a
 # config change (`KIPI_REVIEW_ENGINE=claude`), not an edit to the script that
 # gates every PR in the repo.
-PR=""; ISSUE=""; POST=0; ENGINE="${KIPI_REVIEW_ENGINE:-codex}"; TARGET_REPO_ARG=""
+PR=""; ISSUE=""; POST=0; ENGINE="${KIPI_REVIEW_ENGINE:-claude}"; TARGET_REPO_ARG=""
 while [ $# -gt 0 ]; do
   case "$1" in
     --issue)  shift; ISSUE="${1:-}" ;;
@@ -217,7 +230,7 @@ STATUS_REPO_PATH="{owner}/{repo}"
 #   the ROOT, not a subdir. So "codex is the gate" means codex writes THAT path,
 #   and claude's record moves down into $OUT_DIR/claude to get out of its way.
 #   Exactly one engine writes the gating record: single writer, preserved.
-PRIMARY_ENGINE="${KIPI_REVIEW_PRIMARY_ENGINE:-codex}"
+PRIMARY_ENGINE="${KIPI_REVIEW_PRIMARY_ENGINE:-claude}"
 
 # WHO ASKED FOR THIS REVIEW (sp-53aad86f). The verdict record proved that A CODEX
 # REVIEW RAN; it could not prove THE DISPATCHER RAN ONE UNATTENDED, which is the

--- a/q-system/.q-system/scripts/pr-review-agent.sh
+++ b/q-system/.q-system/scripts/pr-review-agent.sh
@@ -236,9 +236,17 @@ STATUS_REPO_PATH="{owner}/{repo}"
 #
 #   VERDICT_DIR (the ONE record the loop gates on). converge.sh:36 and
 #   linear-worker.sh:76 both read `$STATE_DIR/pr-reviews/pr-<N>.verdict.json` --
-#   the ROOT, not a subdir. So "codex is the gate" means codex writes THAT path,
-#   and claude's record moves down into $OUT_DIR/claude to get out of its way.
+#   the ROOT, not a subdir. So "claude is the gate" means claude writes THAT path,
+#   and codex's record moves down into $OUT_DIR/codex to get out of its way.
 #   Exactly one engine writes the gating record: single writer, preserved.
+#
+#   THIS SENTENCE READ THE OTHER WAY ROUND UNTIL 2026-09-06 and is the map people
+#   read to understand the contract, so it flips with the defaults rather than
+#   being left as an artifact of the previous direction. Note the asymmetry it
+#   creates: for the PRIMARY engine ENGINE_DIR and VERDICT_DIR are now the SAME
+#   directory ($OUT_DIR). That is safe because review_round globs `pr-<N>-*.md`
+#   and the record is `..._pr-<N>.verdict.json`, so neither ever counts the other
+#   -- measured on the live store, 88 .md at the root and 993 under codex/.
 PRIMARY_ENGINE="${KIPI_REVIEW_PRIMARY_ENGINE:-claude}"
 
 # WHO ASKED FOR THIS REVIEW (sp-53aad86f). The verdict record proved that A CODEX

--- a/q-system/.q-system/scripts/pr-review-agent.sh
+++ b/q-system/.q-system/scripts/pr-review-agent.sh
@@ -62,7 +62,16 @@
 # KIPI_REVIEW_ENGINE=claude alone leaves PRIMARY_ENGINE=codex, so every review lands
 # on the advisory context and every open PR waits forever on a status nobody posts.
 #
-# The fallback still works in the new direction and still says DEGRADED out loud.
+# THERE IS NO FALLBACK IN THE NEW DIRECTION, and saying so plainly is the point.
+# The Opus fallback and the whole DEGRADED apparatus hang off the codex branch:
+# codex down -> claude fills the slot -> the status says DEGRADED. With claude
+# PRIMARY that branch is only reachable on an advisory `--engine codex` hand-run,
+# so a claude outage has nothing behind it. That is the SAFE direction and not an
+# oversight: the primary path exits non-zero and posts NO status, and absent is
+# not approved, so a claude outage holds PRs instead of greening them. It is not
+# a second lab either way -- codex is out of credits, so a codex fallback would
+# fail at exit 0, which is the outage this flip exists to end. Restoring a real
+# fallback means restoring codex, which is the same act as restoring independence.
 #
 # It is a FLAG, not a second script, on purpose: sha capture (ASK-216), verdict
 # derivation from labelled severities, the commit-status post (ASK-217) and
@@ -943,7 +952,30 @@ note_degraded_transition() {   # note_degraded_transition <0|1> [reason]
 echo "$(TS) running the $ENGINE reviewer (bounded at ${TIMEOUT_SECONDS}s)..."
 if [ "$ENGINE" != "codex" ]; then
   if run_engine claude "$REVIEW"; then
-    echo "$(TS) review written: $REVIEW"
+    # THE CLAUDE PATH GETS THE SAME PARSEABILITY BAR AS THE OTHER TWO, and this
+    # line is the whole reason it is here (review of PR #319). Until the
+    # 2026-09-06 flip this branch was ADVISORY ONLY, so an unread review landed
+    # on kipi/claude-approved and gated nothing; the bar lived on the codex path
+    # and, after codex found the same hole in it on 2026-07-29, on the Opus
+    # fallback. The flip moved the REQUIRED kipi/reviewer-approved onto the one
+    # path in this script that never asked the question.
+    #
+    # REPRODUCED, not reasoned about, before this line existed: the suite's own
+    # CODEX_TRUNCATED fixture (harness noise, prose "VERDICT: APPROVE", a
+    # FINDINGS: block that is never closed, exit 0) posted
+    #   state=success -f context=kipi/reviewer-approved -f description=APPROVE
+    # on the default path, while the verdict record it wrote beside it said
+    # "usable": false. The identical stream through the codex path correctly
+    # posted state=failure. Nothing paged. An unclosed FINDINGS block parses as
+    # an EMPTY findings list and an empty list derives APPROVE, so exiting 0 is
+    # not evidence the reviewer said anything -- and a green required gate over
+    # a review nobody read is the worst outcome available in this script.
+    if review_is_usable "$REVIEW"; then
+      echo "$(TS) review written: $REVIEW"
+    else
+      REVIEW_UNUSABLE=1
+      echo "$(TS) the $ENGINE reviewer answered with no complete FINDINGS block (empty or truncated); verdict stays UNSTATED. Output kept at: $REVIEW" >&2
+    fi
   else
     rc=$?
     echo "$(TS) reviewer failed or timed out (rc=$rc). Partial output: $REVIEW" >&2
@@ -1060,11 +1092,14 @@ echo "  verdict: ${VERDICT:-unstated}$DRY_NOTE"
 # Both post `state: failure`, and a selector that sees only `failure` sends a
 # never-reviewed PR to REWORK with no findings to work from.
 #
-# ASKED HERE, NOT REUSED FROM $REVIEW_UNUSABLE. That flag is set on the codex and
-# fallback paths only -- the `ENGINE != codex` primary path never evaluates
-# usability at all -- so reading it would record `usable: true` for a path that
-# never checked, which is the fabricated-evidence direction. One call, the same
-# predicate on the same file the verdict came from, covering all three paths.
+# ASKED HERE, NOT REUSED FROM $REVIEW_UNUSABLE. All three dispatch paths now set
+# that flag (the `ENGINE != codex` path joined them in the review of PR #319; it
+# previously never evaluated usability at all, which is what let a truncated
+# claude stream green the required gate once claude became primary). It is still
+# asked again here rather than reused, because $REVIEW_UNUSABLE is the flag the
+# VERDICT was computed from and this key is a claim about the FILE -- deriving one
+# from the other would make the record unable to disagree with the gate, and that
+# disagreement is exactly the signal this key exists to preserve.
 #
 # RECORD-ONLY, DELIBERATELY. This changes no gate. $VERDICT is computed above and
 # is not touched here, so no PR's outcome moves on this commit; the consumer that

--- a/q-system/.q-system/scripts/review-redrive.py
+++ b/q-system/.q-system/scripts/review-redrive.py
@@ -273,9 +273,22 @@ def reviewer_slot_failing(pr_obj):
 # and requires "the live status must win over the record". Those two cannot both
 # hold, and picking between them is a scope call about which question this
 # predicate answers ("did SOME review land" vs "has the GATE spoken"), not a
-# detail of making absence visible. Unreachable today regardless:
-# KIPI_REVIEW_PRIMARY_ENGINE defaults to codex, so `kipi/codex-approved` needs a
-# hand-run with a non-default primary. Captured rather than decided here.
+# detail of making absence visible. Captured rather than decided here.
+#
+# THE REACHABILITY SENTENCE THAT USED TO SIT HERE IS NOW WRONG, and it was the
+# only thing making this note feel safe to leave open. It read: "Unreachable
+# today regardless: KIPI_REVIEW_PRIMARY_ENGINE defaults to codex, so
+# `kipi/codex-approved` needs a hand-run with a non-default primary." The
+# 2026-09-06 flip made claude PRIMARY, so `kipi/codex-approved` is exactly what
+# an ordinary `--engine codex` run posts now.
+#
+# THE EXPOSURE DID NOT CHANGE, only the engine name in it: before the flip the
+# reachable advisory slot was `kipi/claude-approved` and this predicate matched
+# that one just as broadly. Nothing scheduled dispatches the advisory engine in
+# either direction (linear-worker.sh names the primary explicitly), so an
+# advisory slot still only exists after a hand-run. The decision above stays
+# open on the same terms; what is corrected is a claim about WHY, because a
+# stale safety argument is how an open note stops being re-examined.
 GATING_SLOT = "kipi/reviewer-approved"  # named for the pending decision above
 
 

--- a/q-system/.q-system/scripts/test/test-linear-worker-parallel.sh
+++ b/q-system/.q-system/scripts/test/test-linear-worker-parallel.sh
@@ -65,7 +65,7 @@ STUB="$WORK/bin"; mkdir -p "$STUB"
 # the call fell through to /opt/homebrew/bin/codex: real spend, real `gh --post`
 # attempts against a PR number that does not exist, and codex running
 # workspace-write inside the founder's live checkout. Caught live 2026-07-30 by
-# finding `pr-review-agent.sh 807 --issue ASK-AAA --post --engine codex` in ps.
+# finding `pr-review-agent.sh 807 --issue ASK-AAA --post --engine claude` in ps.
 #
 # KIPI_PR_REVIEWER is the override linear-worker.sh:72 already exposes, so one
 # export closes the whole path -- strictly better than adding a `codex` stub,

--- a/q-system/.q-system/scripts/test/test-review-invoker-provenance.sh
+++ b/q-system/.q-system/scripts/test/test-review-invoker-provenance.sh
@@ -108,12 +108,19 @@ if ! command -v plutil >/dev/null 2>&1 || ! command -v launchctl >/dev/null 2>&1
   exit 0
 fi
 echo
+# THE `engine` VALUE IN EVERY FIXTURE BELOW IS THE PRIMARY ENGINE, and it must
+# move with the two defaults in pr-review-agent.sh. The verifier's receipt scan
+# filters on it (verify-codex-review-live.sh, the RECEIPT block) so an ADVISORY
+# engine's record cannot pass as proof the gating loop ran unattended -- which is
+# the whole question this file asks. These said "codex" until 2026-09-06 and the
+# flip to claude turned cases 5 and 6 RED while the nine suites the change ran
+# stayed green: this suite drives the verifier and was not among them.
 echo "== 4. a record with NO invoker key reads as not-dispatcher =="
 # Every record written before this change lacks the key entirely. Those must not
 # be counted either -- a missing field is the same unknown as a manual label.
 STATE="$WORK/state"; mkdir -p "$STATE/pr-reviews"
 cat > "$STATE/pr-reviews/pr-900.verdict.json" <<'JSON'
-{"pr":900,"issue":"ASK-900","verdict":"APPROVE","engine":"codex",
+{"pr":900,"issue":"ASK-900","verdict":"APPROVE","engine":"claude",
  "round":1,"head_sha":"deadbeefdeadbeef","ts":"2026-07-30T00:00:00Z"}
 JSON
 OUT="$(KIPI_STATE_DIR="$STATE" bash "$VERIFIER" 2>&1 | grep -E 'RECEIPT|dispatcher' || true)"
@@ -131,7 +138,7 @@ fi
 echo
 echo "== 5. a worker-labelled record IS reported as dispatcher-driven =="
 cat > "$STATE/pr-reviews/pr-901.verdict.json" <<'JSON'
-{"pr":901,"issue":"ASK-901","verdict":"APPROVE","engine":"codex","invoker":"worker",
+{"pr":901,"issue":"ASK-901","verdict":"APPROVE","engine":"claude","invoker":"worker",
  "round":1,"head_sha":"cafebabecafebabe","ts":"2026-07-30T01:00:00Z"}
 JSON
 OUT="$(KIPI_STATE_DIR="$STATE" bash "$VERIFIER" 2>&1 | grep -E 'RECEIPT|dispatcher' || true)"
@@ -148,7 +155,7 @@ echo "== 6. the newest worker record wins, not the newest record overall =="
 # A later HAND run must not displace the dispatcher receipt in the report: the
 # question "has the dispatcher ever done this" is not answered by recency.
 cat > "$STATE/pr-reviews/pr-902.verdict.json" <<'JSON'
-{"pr":902,"issue":"ASK-902","verdict":"APPROVE","engine":"codex","invoker":"manual",
+{"pr":902,"issue":"ASK-902","verdict":"APPROVE","engine":"claude","invoker":"manual",
  "round":1,"head_sha":"0123456789abcdef","ts":"2026-07-30T02:00:00Z"}
 JSON
 OUT="$(KIPI_STATE_DIR="$STATE" bash "$VERIFIER" 2>&1 | grep -iE 'dispatcher-driven' || true)"

--- a/q-system/.q-system/scripts/test/test-review-tree-guard.sh
+++ b/q-system/.q-system/scripts/test/test-review-tree-guard.sh
@@ -66,6 +66,9 @@ for f in pr-review-agent.sh pr-verdict-lib.sh repo-slug-lib.sh; do
   fi
 done
 REVIEWER="$S/pr-review-agent.sh"
+PRIMARY_MARKER="$(sed -n 's/.*KIPI_REVIEW_ENGINE:-\([a-z][a-z]*\)}.*/\1/p' "$REVIEWER" | head -1)"
+[ -n "$PRIMARY_MARKER" ] || { echo "cannot read KIPI_REVIEW_ENGINE's default out of $REVIEWER; refusing to guess which engine this suite should expect" >&2; exit 1; }
+PRIMARY_MARKER="$PRIMARY_MARKER-ran"
 echo "reviewer under test: ${REF:-working tree} ($(wc -l < "$REVIEWER" | tr -d ' ') lines)"
 
 # A sandbox git repo, so the guard has a real history to reason about and the
@@ -110,6 +113,15 @@ Nothing survived reproduction.
 FINDINGS:
 END FINDINGS
 EOF
+
+# WHICH MARKER MEANS "THE REVIEWER ACTUALLY RAN" IS DERIVED, NOT HARD-CODED.
+# This suite asks an engine-AGNOSTIC question -- does the reviewer materialise the
+# right tree and review THAT -- so pinning the engine by name made it go red on the
+# 2026-09-06 codex->claude flip for a reason that has nothing to do with what it
+# tests. It is read from pr-review-agent.sh's OWN KIPI_REVIEW_ENGINE default so the
+# two cannot drift. Empty (the line moved or was reshaped) is a hard stop rather
+# than a default, because a marker nothing ever touches makes every `[ -f ]` below
+# fail with a message about the reviewer -- a wrong diagnosis is worse than a stop.
 
 # $1 = the sha `gh pr view` reports. The codex stub TOUCHES A MARKER: "did the
 # reviewer dispatch?" has to be answered by a side effect, not by stdout prose --
@@ -174,9 +186,9 @@ grep -q 'review-trees' "$CASE_DIR/out.txt" \
   || fail "the tree is not under review-trees/, so it may be a checkout someone else is using"
 ok "the tree is a dedicated review tree, not a live checkout"
 
-[ -f "$CASE_DIR/codex-ran" ] \
-  || fail "codex never ran on a PR whose head is materialisable, so the PR goes unreviewed"
-ok "codex IS dispatched once the tree is isolated"
+[ -f "$CASE_DIR/$PRIMARY_MARKER" ] \
+  || fail "the PRIMARY engine never ran on a PR whose head is materialisable, so the PR goes unreviewed"
+ok "the PRIMARY engine IS dispatched once the tree is isolated"
 
 # case 1b removed: it asserted a refusal on a MISSING object that this suite's own
 # case 3 correctly forbids (a stale clone cannot prove ancestry either way, and
@@ -185,8 +197,8 @@ ok "codex IS dispatched once the tree is isolated"
 
 # --- case 2: the negative self-test. The guard must let a real head through. ---
 run_case allow "$REAL_HEAD"
-[ -f "$CASE_DIR/codex-ran" ] \
-  || fail "THE GUARD REFUSES EVERYTHING. Its own tree's HEAD ($REAL_HEAD) did not reach codex, so
+[ -f "$CASE_DIR/$PRIMARY_MARKER" ] \
+  || fail "THE GUARD REFUSES EVERYTHING. Its own tree's HEAD ($REAL_HEAD) did not reach the reviewer, so
       case 1 proves nothing -- a check that cannot pass is not a check. stderr was:
 $(sed 's/^/        /' "$CASE_DIR/err.txt")"
 ok "the tree's own HEAD reaches codex (the guard can pass, so case 1 is meaningful)"
@@ -214,7 +226,7 @@ grep -q 'REFUSING' "$CASE_DIR/err.txt" \
 grep -q 'WARN' "$CASE_DIR/err.txt" \
   || fail "an unprovable tree/PR match proceeded SILENTLY. stderr was:
 $(sed 's/^/        /' "$CASE_DIR/err.txt")"
-[ -f "$CASE_DIR/codex-ran" ] || fail "the unknown-object case did not reach codex"
+[ -f "$CASE_DIR/$PRIMARY_MARKER" ] || fail "the unknown-object case did not reach the reviewer"
 ok "an absent object warns out loud and proceeds (tier 1, not a refusal)"
 
 
@@ -257,7 +269,7 @@ grep -q 'REFUSING' "$CASE_DIR/err.txt" \
 $(sed 's/^/        /' "$CASE_DIR/err.txt")"
 ok "a PR head held by a linked worktree is not refused"
 
-[ -f "$CASE_DIR/codex-ran" ] \
+[ -f "$CASE_DIR/$PRIMARY_MARKER" ] \
   || fail "the reviewer did not refuse, but codex was never dispatched either, so the autonomous
       path still produces no review. stdout was:
 $(sed 's/^/        /' "$CASE_DIR/out.txt")"
@@ -353,8 +365,10 @@ CALLS="$({ grep -c . "$SYNC_LOG" 2>/dev/null || echo 0; } | head -1)"
 $(sed 's/\x1f/ /g; s/^/        /' "$SYNC_LOG" 2>/dev/null)"
 ok "the success path posts to the issue exactly once"
 
-grep -q 'codex-reviewer' "$SYNC_LOG" \
-  || fail "the single call did not carry --agent codex-reviewer, so the issue thread cannot tell
+# The AGENT LABEL follows the engine for the same reason the marker above does:
+# the property is "the thread can tell WHICH engine spoke", not "codex spoke".
+grep -q "${PRIMARY_MARKER%-ran}-reviewer" "$SYNC_LOG" \
+  || fail "the single call did not carry --agent ${PRIMARY_MARKER%-ran}-reviewer, so the issue thread cannot tell
       WHICH engine spoke -- the one fact the engine flip exists to convey. Call was:
 $(sed 's/\x1f/ /g; s/^/        /' "$SYNC_LOG")"
 ok "the call is attributed to the engine, not the default agent"

--- a/q-system/.q-system/scripts/test/test-severity-floor.sh
+++ b/q-system/.q-system/scripts/test/test-severity-floor.sh
@@ -1882,12 +1882,17 @@ ok "step 5 says when the record it converged off is pinned to nothing"
 # Every assertion is on the gh CALL LOG or the page file, never on stdout prose.
 # Nothing here calls live Codex, live GitHub, or live Slack.
 # CODEX OWNS THE GATE (founder directive 2026-07-29). Codex is the engine that
-# checks Sana's work, so it posts the REQUIRED `kipi/reviewer-approved` and writes
-# the one verdict record the loop reads. Claude drops to an advisory slot. These
-# two constants are what the whole Q-series asserts against, so the contract flip
-# is stated once here rather than spelled into thirty greps.
-CODEX_CONTEXT="kipi/reviewer-approved"
-CLAUDE_CONTEXT="kipi/claude-approved"
+# CONTRACT FLIPPED 2026-09-06, founder-directed ("forget codex go with the claude
+# fallback"). CLAUDE now checks Sana's work, so it posts the REQUIRED
+# `kipi/reviewer-approved` and writes the one verdict record the loop reads, and
+# codex drops to the advisory slot. The Q-series below is unchanged and still
+# asserts the contract in BOTH directions; only which engine holds which slot moved.
+#
+# This is the flip the comment above these constants promised: they are what the
+# whole Q-series asserts against, so it is stated once here rather than spelled into
+# thirty greps. Swapping the two values is the entire change to this file.
+CODEX_CONTEXT="kipi/codex-approved"
+CLAUDE_CONTEXT="kipi/reviewer-approved"
 
 # The observed shape of real `codex exec` stdout: harness noise around the answer
 # (issue ASK-221 recorded `hook: Stop`, `tokens used`, and a repeated final line).
@@ -2158,52 +2163,62 @@ run_engine_reviewer "$Q3" --post --engine codex
 ok "recovery pages once on the way out of degraded mode, then goes quiet"
 
 # --- Q7. the ADVISORY engine cannot answer for the gate -----------------------
-# Before the founder directive this case asserted `--engine claude` == the default
-# path, both posting kipi/reviewer-approved. That equality is now FALSE BY DESIGN:
-# claude is the advisory engine and codex is the default. The guard that matters
-# is the inverse of the old one -- an advisory engine must NEVER be able to post
-# the required context, or a Claude review could satisfy the gate that exists
-# specifically to not be Claude.
+# The INVARIANT is direction-free and is the reason this case exists: whichever
+# engine is advisory must NEVER be able to post the required context, or a review
+# that was never meant to gate satisfies the gate.
+#
+# WHICH ENGINE IS ADVISORY FLIPPED 2026-09-06 (founder: "forget codex go with the
+# claude fallback"). codex is advisory now, so this drives `--engine codex` and
+# asserts it lands on kipi/codex-approved and never on the required context. The
+# codex stub is `ok` so we test codex's OWN path rather than the fallback.
 Q7="$W2/eng-claude"
 mk_engine_stubs "$Q7" "$SHA_A" fail ""      # codex would FAIL if it were consulted
 run_engine_reviewer "$Q7" --post --engine claude
 CALL_EXPLICIT="$(status_call "$Q7")"
 [ ! -s "$Q7/codex-calls.log" ] \
-  || fail "--engine claude invoked codex. The advisory review path must not depend on a second
-      lab's CLI being installed. codex saw: $(cat "$Q7/codex-calls.log")"
+  || fail "--engine claude invoked codex. The PRIMARY review path must not depend on a second
+      lab's CLI being installed -- codex is out of credits and fails at exit 0, which is the
+      outage this flip exists to end. codex saw: $(cat "$Q7/codex-calls.log")"
 ok "--engine claude never shells codex"
 
 printf '%s' "$CALL_EXPLICIT" | grep -q "context=$CLAUDE_CONTEXT" \
-  || fail "--engine claude did not post its advisory context '$CLAUDE_CONTEXT'.
-      Call was: $CALL_EXPLICIT"
-printf '%s' "$CALL_EXPLICIT" | grep -q "context=$STATUS_CONTEXT" \
-  && fail "THE DEFECT THIS GUARDS: --engine claude posted the REQUIRED context
-      '$STATUS_CONTEXT'. Sana is Claude, so a Claude reviewer would then satisfy the
-      very gate that exists to be a different lab's opinion. Call was: $CALL_EXPLICIT"
-ok "--engine claude posts only its advisory $CLAUDE_CONTEXT, never the required gate"
+  || fail "--engine claude did not post the REQUIRED context '$CLAUDE_CONTEXT'. claude is the
+      PRIMARY engine since 2026-09-06, so every PR would block forever waiting on a status
+      nobody posts. Call was: $CALL_EXPLICIT"
+printf '%s' "$CALL_EXPLICIT" | grep -q "context=$CODEX_CONTEXT" \
+  && fail "--engine claude posted the ADVISORY context '$CODEX_CONTEXT' as well. One engine
+      answers one slot; posting both is the two-writers defect. Call was: $CALL_EXPLICIT"
+ok "--engine claude posts the required $CLAUDE_CONTEXT and not the advisory slot"
 
-# --- Q7D. the DEFAULT engine is codex and it owns the required context ---------
+# --- Q7D. the DEFAULT engine is claude and it owns the required context --------
 # kipi/reviewer-approved is ALREADY a required context. Breaking it blocks 100% of
 # PRs, so this pins the exact context and state on the DEFAULT path -- which is
-# now codex. The codex stub is set to `ok`: a failing codex would fall through to
-# the Opus fallback and mark the status DEGRADED, which is a different path than
-# the one under test here (Q3 already covers that one).
+# claude since 2026-09-06.
+#
+# The codex stub is set to `fail` ON PURPOSE and it is the load-bearing half of this
+# case: the default path must reach a verdict WITHOUT codex, because codex is the
+# engine that was returning "workspace is out of credits" at exit 0. If this case
+# ever needs a working codex to pass, the default path is secretly depending on it
+# again and the outage that caused this flip would recur unseen.
 Q7D="$W2/eng-default"
-mk_engine_stubs "$Q7D" "$SHA_A" ok "$CODEX_NOISY_APPROVE"
+mk_engine_stubs "$Q7D" "$SHA_A" fail ""
 run_engine_reviewer "$Q7D" --post
 CALL_DEFAULT="$(status_call "$Q7D")"
-[ -s "$Q7D/codex-calls.log" ] \
-  || fail "THE DEFECT: the default (no --engine) path did not shell codex, so the fleet's PRs are
-      still being checked by the same lab that wrote them. The founder directive was that codex
-      is the agent that checks Sana's work."
+[ -s "$Q7D/claude-calls.log" ] \
+  || fail "THE DEFECT: the default (no --engine) path did not shell claude, so the engine the
+      founder directed on 2026-09-06 is not the one answering the gate."
+[ ! -s "$Q7D/codex-calls.log" ] \
+  || fail "THE DEFECT: the default path shelled codex. codex is ADVISORY since 2026-09-06 and is
+      currently out of credits, so any default-path dependency on it re-creates the silent
+      outage this flip exists to end. codex saw: $(cat "$Q7D/codex-calls.log")"
 printf '%s' "$CALL_DEFAULT" | grep -q "context=$STATUS_CONTEXT" \
   || fail "the default engine stopped posting '$STATUS_CONTEXT', which is a REQUIRED context.
       Every PR in the repo would block forever. Call was: $CALL_DEFAULT"
 printf '%s' "$CALL_DEFAULT" | grep -q 'state=success' \
   || fail "the default engine's APPROVE no longer maps to state=success: $CALL_DEFAULT"
 printf '%s' "$CALL_DEFAULT" | grep -qi 'degraded' \
-  && fail "the default engine's status is marked degraded even though codex answered: $CALL_DEFAULT"
-ok "the default engine is codex and still posts $STATUS_CONTEXT=success (branch protection intact)"
+  && fail "the default engine's status is marked degraded even though claude answered: $CALL_DEFAULT"
+ok "the default engine is claude and still posts $STATUS_CONTEXT=success (branch protection intact)"
 
 # --- Q7E. MOVED OUT (codex review round 1 of PR #34, minor) -------------------
 # This case used to build its non-ancestor fixture with
@@ -2250,22 +2265,26 @@ ok "an unknown PR sha warns and proceeds (a partial clone does not wedge the loo
       pr-901-*.md, so every codex run would advance the claude reviewer's round counter."
 ok "the engines keep separate review directories (round counters do not cross-count)"
 
-# THE VERDICT RECORD IS THE GATE, and it belongs to codex now. converge.sh:36 and
-# linear-worker.sh:76 both read pr-<N>.verdict.json at the pr-reviews ROOT. Codex
-# is the engine that checks Sana's work, so codex writes THAT file -- and the
-# advisory claude engine must not, or two writers would answer for one gate.
-[ -s "$Q1/home/.config/kipi/pr-reviews/$REC901" ] \
-  || fail "THE DEFECT: the codex engine wrote no verdict record at the pr-reviews ROOT, so the
+# THE VERDICT RECORD IS THE GATE, and it belongs to CLAUDE since 2026-09-06.
+# converge.sh:36 and linear-worker.sh:76 both read pr-<N>.verdict.json at the
+# pr-reviews ROOT. The PRIMARY engine writes THAT file -- and the advisory engine
+# must not, or two writers would answer for one gate.
+#
+# THE PAIR IS THE POINT, not either assertion alone: the primary must write it and
+# the advisory must not. Asserting only the first would pass on the day both engines
+# write it, which is the two-writers defect this repo keeps finding.
+[ -s "$Q7/home/.config/kipi/pr-reviews/$REC901" ] \
+  || fail "THE DEFECT: the claude engine wrote no verdict record at the pr-reviews ROOT, so the
       file converge.sh:36 and linear-worker.sh:76 gate the loop on is never written by the
       engine that actually reviewed. The loop would read a stale or absent verdict."
-[ ! -f "$Q7/home/.config/kipi/pr-reviews/$REC901" ] \
-  || fail "the ADVISORY claude engine wrote the loop's verdict record (pr-901.verdict.json).
-      Two engines answering for one gate is the single-writer defect this repo keeps finding;
-      a Claude verdict would drive the loop that exists to be checked by another lab."
-[ -s "$Q7/home/.config/kipi/pr-reviews/claude/$REC901" ] \
-  || fail "the claude engine wrote no verdict record of its own, so its advisory opinion is not
+[ ! -f "$Q1/home/.config/kipi/pr-reviews/$REC901" ] \
+  || fail "the ADVISORY codex engine wrote the loop's verdict record (pr-901.verdict.json).
+      Two engines answering for one gate is the single-writer defect this repo keeps finding,
+      and an advisory verdict would drive the loop it was never meant to gate."
+[ -s "$Q1/home/.config/kipi/pr-reviews/codex/$REC901" ] \
+  || fail "the codex engine wrote no verdict record of its own, so its advisory opinion is not
       recorded anywhere a later run can read"
-ok "codex writes the loop's verdict record; claude records its advisory one beside its reviews"
+ok "claude writes the loop's verdict record; codex records its advisory one beside its reviews"
 
 # --- Q8. both engines pin their model explicitly ------------------------------
 # Today the Claude reviewer passes no --model and inherits the session default,
@@ -2296,15 +2315,21 @@ grep -q 'codex exec.*</dev/null' "$REVIEWER" \
       at 3am that is a review that never returns until the 2400s bound kills it."
 ok "the codex dispatch redirects stdin from /dev/null"
 
-# --- Q9. the worker runs the codex engine as THE review -----------------------
+# --- Q9. the worker runs the PRIMARY engine as THE review ---------------------
 # A reviewer nobody invokes is text in a file. The worker is the only thing that
-# reviews PRs on a schedule, and it now states --engine codex explicitly at the
-# call site rather than inheriting the reviewer's default: which model checks this
-# fleet's work is a fact that should be readable where the review is dispatched.
-grep -q -- '--engine codex' "$WORKER" \
-  || fail "linear-worker.sh never runs the codex engine, so every PR in the autonomous loop is
-      reviewed by the same lab that wrote it"
-ok "worker wiring: the codex engine is dispatched as the review"
+# reviews PRs on a schedule, and it states the engine EXPLICITLY at the call site
+# rather than inheriting the reviewer's default: which model checks this fleet's
+# work is a fact that should be readable where the review is dispatched.
+#
+# The engine named here is claude since 2026-09-06 (founder: "forget codex go with
+# the claude fallback"). This pins that the worker dispatches the PRIMARY engine,
+# whichever it is; if the pair is ever flipped back, this string moves with the two
+# defaults in pr-review-agent.sh and the constants at the top of this file.
+grep -q -- '--engine claude' "$WORKER" \
+  || fail "linear-worker.sh never dispatches --engine claude, so the engine that owns
+      kipi/reviewer-approved is not the one reviewing on a schedule and every PR in the
+      autonomous loop waits on a status its reviewer never posts"
+ok "worker wiring: the primary (claude) engine is dispatched as the review"
 # EVERY PR THE WORKER TOUCHES ARMS ITS OWN AUTO-MERGE (ASK-222)
 # =============================================================================
 # THE DEFECT: nothing in CODE armed auto-merge. Every required piece already

--- a/q-system/.q-system/scripts/test/test-severity-floor.sh
+++ b/q-system/.q-system/scripts/test/test-severity-floor.sh
@@ -1924,17 +1924,27 @@ CODEX_TRUNCATED='hook: Stop
 FINDINGS:
 '
 
-# mk_engine_stubs <dir> <headRefOid> <codex-mode> <codex-body>
+# mk_engine_stubs <dir> <headRefOid> <codex-mode> <codex-body> [claude-body]
 #   codex-mode: ok | fail (non-zero exit) | empty (exit 0, no output)
-# The claude stub always emits $APPROVE_REVIEW, so a `success` status on a codex
+# The claude stub DEFAULTS to $APPROVE_REVIEW, so a `success` status on a codex
 # run can only have come from the Opus fallback -- which is what makes the
 # degraded cases readable at all.
+#
+# THE 5TH ARG EXISTS BECAUSE ITS ABSENCE HID A REAL DEFECT (review of PR #319).
+# The claude body was HARD-CODED to a well-formed review, so this harness was
+# structurally incapable of expressing "claude answered and said nothing
+# parseable" -- and on the day the 2026-09-06 flip made claude the PRIMARY
+# engine, that unexpressible case was the one that posted a green
+# kipi/reviewer-approved over an unread review. 198/198 stayed green throughout.
+# A stub that can only produce good output is a stub that certifies the happy
+# path and calls it coverage. It is a TRAILING OPTIONAL with a default, so every
+# existing 4-arg call site is unchanged (`set -u` is on; the `:-` is load-bearing).
 mk_engine_stubs() {
-  local d="$1" oid="$2" mode="$3" body="$4"
+  local d="$1" oid="$2" mode="$3" body="$4" clbody="${5:-$APPROVE_REVIEW}"
   mkdir -p "$d/bin" "$d/home"
   : > "$d/gh-calls.log"; : > "$d/codex-calls.log"; : > "$d/claude-calls.log"
   printf '%s' "$body" > "$d/codex-body.txt"
-  printf '%s' "$APPROVE_REVIEW" > "$d/claude-body.txt"
+  printf '%s' "$clbody" > "$d/claude-body.txt"
   cat > "$d/bin/python3" <<EOF
 #!/usr/bin/env bash
 exec "$REAL_PY" "\$@"
@@ -2219,6 +2229,59 @@ printf '%s' "$CALL_DEFAULT" | grep -q 'state=success' \
 printf '%s' "$CALL_DEFAULT" | grep -qi 'degraded' \
   && fail "the default engine's status is marked degraded even though claude answered: $CALL_DEFAULT"
 ok "the default engine is claude and still posts $STATUS_CONTEXT=success (branch protection intact)"
+
+# --- Q7U. an UNUSABLE answer from the PRIMARY engine never greens the gate -----
+# THE DEFECT THIS CASE WAS WRITTEN FROM (review of PR #319, reproduced before the
+# fix): the 2026-09-06 flip moved the REQUIRED kipi/reviewer-approved onto the
+# `ENGINE != codex` branch, which was the only one of the script's three dispatch
+# paths that never called review_is_usable. The codex path had the bar; the Opus
+# fallback got it after codex found the same hole there on 2026-07-29 (major).
+# The claude path did not, because until the flip it was ADVISORY and could only
+# green kipi/claude-approved, which gates nothing.
+#
+# Fed the IDENTICAL $CODEX_TRUNCATED stream Q4B already feeds codex -- harness
+# noise, a prose "VERDICT: APPROVE", and a FINDINGS: block that is never closed,
+# at exit 0 -- the default path posted:
+#     state=success -f context=kipi/reviewer-approved -f description=APPROVE
+# while the verdict record it wrote beside it recorded "usable": false. Same
+# stream through codex correctly posted state=failure. Nothing paged. An unclosed
+# FINDINGS block parses as an EMPTY findings list and an empty list derives
+# APPROVE, so exiting 0 is not evidence the reviewer said anything.
+#
+# THE FIXTURE IS REUSED ON PURPOSE, not renamed: the whole force of the finding is
+# that ONE byte-identical stream was refused on one path and laundered into a green
+# required gate on another. A separate constant would let the two drift apart and
+# hide exactly that comparison. The shape belongs to "an engine exited 0 without
+# reviewing", which is engine-independent -- it is the codex outage's own shape,
+# and claude reaches it the same way.
+Q7U="$W2/eng-default-truncated"
+mk_engine_stubs "$Q7U" "$SHA_A" fail "" "$CODEX_TRUNCATED"
+run_engine_reviewer "$Q7U" --post
+CALL_TRUNC="$(status_call "$Q7U")"
+printf '%s' "$CALL_TRUNC" | grep -q "context=$STATUS_CONTEXT" \
+  || fail "the truncated-primary case posted no '$STATUS_CONTEXT' at all. This case is about the
+      STATE on that context, so a missing context means the case is testing nothing.
+      Call was: $CALL_TRUNC"
+printf '%s' "$CALL_TRUNC" | grep -q 'state=success' \
+  && fail "THE DEFECT: the PRIMARY engine exited 0 with a truncated, unclosed FINDINGS block and
+      the REQUIRED context '$STATUS_CONTEXT' went GREEN. A green required gate over a review
+      nobody read is the worst outcome available in this script, and it releases the PR to
+      merge. Exiting 0 is not evidence the reviewer said anything. Call was: $CALL_TRUNC"
+ok "an unusable PRIMARY-engine answer leaves $STATUS_CONTEXT non-green (unread is never approved)"
+
+# THE RECORD MUST AGREE WITH THE GATE. Asserting only the status would pass on the
+# day the gate is held closed for some unrelated reason while the record still
+# claims a usable review happened -- and review-redrive.py selects on that key.
+python3 - "$Q7U/home/.config/kipi/pr-reviews" <<'PY' || fail "the truncated-primary run's verdict record does not report the review as unusable, so every consumer reading \`usable\` is told a review happened that did not"
+import glob, json, sys
+recs = glob.glob(sys.argv[1] + "/*.verdict.json")
+if not recs:
+    sys.exit("no verdict record written at the pr-reviews ROOT")
+r = json.load(open(recs[0]))
+sys.exit(0 if r.get("usable") is False else
+         "record says usable=%r for a truncated stream" % (r.get("usable"),))
+PY
+ok "the truncated-primary run records usable=false, so the record and the gate tell one story"
 
 # --- Q7E. MOVED OUT (codex review round 1 of PR #34, minor) -------------------
 # This case used to build its non-ancestor fixture with

--- a/q-system/.q-system/scripts/test/test-severity-floor.sh
+++ b/q-system/.q-system/scripts/test/test-severity-floor.sh
@@ -2178,9 +2178,18 @@ ok "recovery pages once on the way out of degraded mode, then goes quiet"
 # that was never meant to gate satisfies the gate.
 #
 # WHICH ENGINE IS ADVISORY FLIPPED 2026-09-06 (founder: "forget codex go with the
-# claude fallback"). codex is advisory now, so this drives `--engine codex` and
-# asserts it lands on kipi/codex-approved and never on the required context. The
-# codex stub is `ok` so we test codex's OWN path rather than the fallback.
+# claude fallback"), AND THIS CASE CHANGED SUBJECT WHEN IT DID. It drives
+# `--engine claude`, which is now the PRIMARY engine, so what it actually pins is
+# the other half of the same one-engine-one-slot rule: the primary posts the
+# required context and does NOT also post the advisory one. The codex stub is
+# `fail` so a green here cannot have come from codex.
+#
+# THE DIRECTION-FREE INVARIANT ABOVE IS STILL HELD, just not here -- Q1 asserts
+# the advisory engine lands on kipi/codex-approved, and a mutant that makes the
+# advisory branch post kipi/reviewer-approved is killed by Q1, verified by
+# running it. Saying so rather than deleting the sentence: the invariant is the
+# reason both cases exist, and a comment that names the wrong guard sends the
+# next reader to a case that no longer checks it.
 Q7="$W2/eng-claude"
 mk_engine_stubs "$Q7" "$SHA_A" fail ""      # codex would FAIL if it were consulted
 run_engine_reviewer "$Q7" --post --engine claude
@@ -2282,6 +2291,46 @@ sys.exit(0 if r.get("usable") is False else
          "record says usable=%r for a truncated stream" % (r.get("usable"),))
 PY
 ok "the truncated-primary run records usable=false, so the record and the gate tell one story"
+
+# --- Q7F. the PRIMARY engine going DOWN holds the gate, it does not green it ---
+# THE PROPERTY THIS PR'S HEADER NOW ASSERTS, previously unpinned. Before the
+# 2026-09-06 flip a primary outage had the Opus fallback behind it and the whole
+# DEGRADED apparatus to announce itself. That apparatus hangs off the codex
+# branch, so with claude PRIMARY there is nothing behind it: the path exits
+# non-zero and posts NO status. That is the SAFE direction -- absent is not
+# approved, and reviewer-floor.sh turns an absent verdict into a red required
+# context -- but "safe by construction" is the kind of claim that stops being
+# true quietly, and a comment asserting it is not a test.
+#
+# NO fallback may fire either. A codex fallback under a claude outage would be
+# the two-writers defect wearing an outage as a costume, and codex is out of
+# credits, so it would fail at exit 0 and fill the gate with nothing.
+Q7F="$W2/eng-primary-down"
+mk_engine_stubs "$Q7F" "$SHA_A" fail ""
+# The harness has no claude-mode, so the stub is replaced in place rather than
+# growing a 6th positional every case would have to carry.
+cat > "$Q7F/bin/claude" <<EOF
+#!/usr/bin/env bash
+printf '%s\n' "\$*" >> "$Q7F/claude-calls.log"
+echo "claude: stream disconnected before first token" >&2
+exit 1
+EOF
+chmod +x "$Q7F/bin/claude"
+run_engine_reviewer "$Q7F" --post
+[ -s "$Q7F/claude-calls.log" ] \
+  || fail "the primary-outage case never reached claude, so it is testing nothing"
+[ "$RC" != "0" ] \
+  || fail "THE DEFECT: the PRIMARY engine failed and the reviewer still exited 0. A caller that
+      branches on the exit code reads a total outage as a completed review."
+CALL_DOWN="$(status_call "$Q7F")"
+printf '%s' "$CALL_DOWN" | grep -q 'state=success' \
+  && fail "THE DEFECT: the PRIMARY engine was DOWN and a green status was posted anyway. There is
+      no fallback in this direction, so nothing reviewed anything. Call was: $CALL_DOWN"
+[ ! -s "$Q7F/codex-calls.log" ] \
+  || fail "a claude outage fell through to codex. There is no fallback in this direction by
+      design, and codex is out of credits (it fails at EXIT 0), so this would fill the required
+      gate with an unreviewed green. codex saw: $(cat "$Q7F/codex-calls.log")"
+ok "a PRIMARY-engine outage exits non-zero, posts no green, and never falls through to codex"
 
 # --- Q7E. MOVED OUT (codex review round 1 of PR #34, minor) -------------------
 # This case used to build its non-ancestor fixture with

--- a/q-system/.q-system/scripts/verify-codex-review-live.sh
+++ b/q-system/.q-system/scripts/verify-codex-review-live.sh
@@ -79,10 +79,10 @@ info "live HEAD:      $(git -C "$LIVE_ROOT" rev-parse --short HEAD 2>/dev/null |
 if [ ! -f "$LIVE_WORKER" ]; then
   fail "no worker at $LIVE_WORKER"
 else
-  if grep -q -- '--engine codex' "$LIVE_WORKER"; then
-    pass "the live worker dispatches the reviewer with --engine codex"
+  if grep -q -- '--engine claude' "$LIVE_WORKER"; then
+    pass "the live worker dispatches the reviewer with --engine claude"
   else
-    fail "the live worker never passes --engine codex. Tomorrow's run reviews with Claude only -- same lab as the author, so the blind spots stay correlated. If the wiring is on a branch, it has to reach $(git -C "$LIVE_ROOT" rev-parse --abbrev-ref HEAD 2>/dev/null)."
+    fail "the live worker never passes --engine claude, so the scheduled run does not dispatch the engine that owns the gate. If the wiring is on a branch, it has to reach $(git -C "$LIVE_ROOT" rev-parse --abbrev-ref HEAD 2>/dev/null)."
   fi
   if grep -q 'pr-review-agent.sh' "$LIVE_WORKER"; then
     pass "the live worker routes review through pr-review-agent.sh"
@@ -97,15 +97,15 @@ fi
 if [ ! -f "$LIVE_REVIEWER" ]; then
   fail "no reviewer at $LIVE_REVIEWER"
 else
-  if grep -qE 'KIPI_REVIEW_ENGINE:-codex' "$LIVE_REVIEWER"; then
-    pass "the live reviewer defaults to the codex engine"
+  if grep -qE 'KIPI_REVIEW_ENGINE:-claude' "$LIVE_REVIEWER"; then
+    pass "the live reviewer defaults to the claude engine"
   else
-    fail "the live reviewer's default engine is not codex, so a bare invocation reviews with Claude"
+    fail "the live reviewer's default engine is not claude, so a bare invocation does not review with the engine that owns the gate"
   fi
-  if grep -qE 'KIPI_REVIEW_PRIMARY_ENGINE:-codex' "$LIVE_REVIEWER"; then
-    pass "codex is the PRIMARY engine, so it owns kipi/reviewer-approved"
+  if grep -qE 'KIPI_REVIEW_PRIMARY_ENGINE:-claude' "$LIVE_REVIEWER"; then
+    pass "claude is the PRIMARY engine, so it owns kipi/reviewer-approved"
   else
-    fail "codex is not the primary engine in the live copy, so its verdict lands on an ADVISORY context and gates nothing"
+    fail "claude is not the PRIMARY engine in the live copy, so its verdict lands on an ADVISORY context and gates nothing. Both KIPI_REVIEW_ENGINE and KIPI_REVIEW_PRIMARY_ENGINE must name the same engine or every open PR wedges."
   fi
   if grep -q 'kipi/reviewer-approved' "$LIVE_REVIEWER"; then
     pass "the live reviewer posts the required context kipi/reviewer-approved"
@@ -142,10 +142,18 @@ fi
 # --- 6. the engine binary the live reviewer will shell actually exists -------
 # Wiring that names a binary the PATH does not have degrades to the Opus fallback
 # on every run: the gate stays green and stops being a second lab's opinion.
-if command -v codex >/dev/null 2>&1; then
-  pass "codex is on PATH ($(command -v codex))"
+if command -v claude >/dev/null 2>&1; then
+  pass "claude is on PATH ($(command -v claude))"
 else
-  fail "codex is NOT on PATH. Every scheduled review falls back to Opus and the gate is DEGRADED, which is exactly the independence this engine exists to buy."
+  fail "claude is NOT on PATH and claude is the PRIMARY engine, so every scheduled review has no binary to shell and the gate cannot be answered."
+fi
+# codex is ADVISORY since 2026-09-06, so its absence is reported and does not fail.
+# It is still worth printing: the day it comes back is the day independence is
+# restorable, and nobody will notice from a silent check.
+if command -v codex >/dev/null 2>&1; then
+  printf '  NOTE codex is on PATH (%s); advisory engine, does not gate\n' "$(command -v codex)"
+else
+  printf '  NOTE codex is not on PATH; advisory engine, does not gate\n'
 fi
 
 # --- 7. the live copy's OWN tests pass against the live copy ------------------
@@ -205,7 +213,7 @@ for p in glob.glob(os.path.join(sys.argv[1], "*.verdict.json")) + \
         r = json.load(open(p))
     except Exception:
         continue          # a corrupt record is not a receipt
-    if r.get("engine") != "codex":
+    if r.get("engine") != "claude":
         continue
     if newest is None or str(r.get("ts", "")) > str(newest.get("ts", "")):
         newest = r

--- a/q-system/.q-system/scripts/verify-codex-review-live.sh
+++ b/q-system/.q-system/scripts/verify-codex-review-live.sh
@@ -239,9 +239,9 @@ PY
 ANY_RECEIPT="$(printf '%s\n' "$RECEIPT" | sed -n 's/^ANY|//p')"
 WORKER_RECEIPT="$(printf '%s\n' "$RECEIPT" | sed -n 's/^WORKER|//p')"
 if [ -n "$ANY_RECEIPT" ]; then
-  info "RECEIPT FOUND: a codex-engine review really ran -- $ANY_RECEIPT"
+  info "RECEIPT FOUND: a review by the PRIMARY engine (claude) really ran -- $ANY_RECEIPT"
 else
-  info "NO RECEIPT YET: no pr-*.verdict.json under $STATE_DIR/pr-reviews carries engine=codex. Wiring is green; a real run has not been observed."
+  info "NO RECEIPT YET: no pr-*.verdict.json under $STATE_DIR/pr-reviews carries engine=claude. Wiring is green; a real run has not been observed."
 fi
 # THE PROOF THE FOUNDER IS ACTUALLY WAITING ON. Reported as its own line because
 # "a codex review ran" and "the dispatcher ran one unattended" are different


### PR DESCRIPTION
Reverses the 2026-07-29 directive that made codex the agent checking Sana's work. Founder directed it twice on 2026-09-06: *"forget codex use claude for fallback"* / *"forget codex go with the claude fallback"*.

## Why

Three stacked failures, each masking the next, measured rather than reasoned about:

1. `~/.codex/config.toml` asked for `gpt-6-astra`; the fleet is on Sol
2. `codex-cli` 0.147.0 was too old for that model, so the call returned HTTP 400
3. underneath both: **`ERROR: Your workspace is out of credits`**, which `gpt-5.6-sol` returns too

`codex exec` **exits 0** on all three. Two sessions reviewed for a full evening on the Opus fallback and nothing said so. An engine that fails silently cannot hold a required gate. Corrected diagnosis captured as `sp-b240fca2`.

## The cost, stated rather than glossed

Sana (the PR author) is Claude, so a Claude reviewer shares her lab and model family and re-derives her blind spots. Fresh context is not an independent mind. That was the whole argument for the original directive and it is **still true**. Availability decided this, not the argument.

Restoring independence is `KIPI_REVIEW_ENGINE=codex` **plus** `KIPI_REVIEW_PRIMARY_ENGINE=codex`, both together, once the workspace has credits.

## The trap this PR exists to avoid

`pr-review-agent.sh:246` posts `kipi/reviewer-approved` **only when `ENGINE == PRIMARY_ENGINE`**. Setting `KIPI_REVIEW_ENGINE=claude` alone leaves `PRIMARY_ENGINE=codex`, so every review lands on the advisory context and **every open PR waits forever on a status nobody posts**. Both defaults move together or the gate wedges.

## What moved, and what deliberately did not

| File | Change |
|---|---|
| `pr-review-agent.sh` | both defaults to claude; header rewritten with the reversal and its cost |
| `linear-worker.sh` | dispatches `--engine claude` at its single call site |
| `verify-codex-review-live.sh` | asserts claude is default and PRIMARY; the codex binary check drops from `fail` to a `NOTE`, since an advisory engine's absence must not fail a wiring check |
| `test-severity-floor.sh` | the two constants the file's own comment promised would carry a contract flip, plus Q7 / Q7D / Q9 and the verdict-record pair |
| `test-linear-worker-parallel.sh` | the ps-grep follows the dispatch |

**NOT moved:** `ENGINE_DIR` keys on engine *name*, so review markdown stays put. Moving codex's reviews into `pr-reviews/` would make `review_round()` count existing claude rounds as codex's and arm the anti-re-litigation rule a round early on every PR with history. The original author left that warning in a comment and it was correct.

## Verification

Nine suites green against current `main` (re-run after rebasing onto `4a280871`, since #313 landed mid-work):

`test-severity-floor` **198/198**, `test-gh-repo-scope-reviewer`, `test-linear-worker-parallel`, `test-review-artifact-repo-keyed`, `test-review-degraded-provenance`, `test-review-dry-run-labelled`, `test-review-gate-no-fake-green`, `test-review-fallback-exact-sha`, `test-pr-review-root-guard`.

**Mutation control**, because a green suite is not evidence it can see the change: reverting `PRIMARY_ENGINE` to codex turns `test-severity-floor` RED (*"the reviewer wrote no verdict record at all"*). The suite observes the flip.

## Reviewer note

This PR will be reviewed by the engine it promotes. That is not independent, and it is worth a human read rather than a gate's.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
