### PR TITLE
fix(auto-commit): refuse while another commit holds git's locks

### DIFF
--- a/.github/workflows/verify.yml
+++ b/.github/workflows/verify.yml
@@ -13,6 +13,26 @@ jobs:
   verify:
     runs-on: ubuntu-latest
     steps:
+      # THE SAME MISSING IDENTITY validate.yml carries a scar for, in the other
+      # door. verify.sh runs q-system/hooks/test/test_auto_commit_run_marker.py,
+      # whose subject is a SUBPROCESS: run_hook spawns auto-commit.py, which runs
+      # its own `git commit`, and that child inherits the runner's identity, not
+      # the `git -c user.email=...` the test passes to its own commands. The
+      # ubuntu runner user has an empty gecos field so git cannot guess one and
+      # refuses with "Author identity unknown"; the failure then reads "the hook
+      # did not commit", as if the hook were broken. Measured 2026-09-07 from run
+      # 34123764623, the first run after that suite was named in .verify-suites.
+      # macOS cannot reproduce it -- its git guesses from the passwd gecos field,
+      # which is the same reason validate.yml's copy of this note exists.
+      #
+      # The test was ALSO made hermetic in the same change (it writes the
+      # identity into its own temp repo), so this step is the second of two
+      # independent fixes, not the only one holding it up.
+      - name: Configure git identity for tests that spawn git
+        run: |
+          git config --global user.name "kipi-ci"
+          git config --global user.email "ci@kipi.invalid"
+
       - uses: actions/checkout@v4
         with:
           # FULL HISTORY, not the default depth-1 shallow clone.

--- a/.verify-suites
+++ b/.verify-suites
@@ -80,6 +80,18 @@ rescued/memory-lifecycle
 q-system/.q-system/tests
 test_destructive_op_deny_anchor.py
 test_fleet_unblock.py
+# ROUND 5, and the same finding for the fifth time: a tracked, green, wholly
+# ungated suite. q-system/hooks/test/test_auto_commit_run_marker.py is the ONLY
+# pin on the auto-commit hook's fleet-updater handshake, and it appeared in no
+# entry above and in no written exclusion below, so this manifest's own claim
+# that "EVERY suite that can be named IS named" was false.
+#
+# It cost a red CI on PR #321: verify.sh ran 12/12 green locally while that file
+# sat unrun, and the capability gate then failed on it in Actions. Measured
+# 2026-09-07 before naming it: 6 tests, `Ran 6 tests ... OK`, collects clean from
+# the repo root. A file entry, because q-system/hooks/test/ holds one python test
+# file and one shell script.
+q-system/hooks/test/test_auto_commit_run_marker.py
 #
 # THE REMAINING FIVE, each measured, none silently dropped.
 #

--- a/q-system/.q-system/tests/test_auto_commit.py
+++ b/q-system/.q-system/tests/test_auto_commit.py
@@ -696,3 +696,38 @@ def test_a_worktree_still_refuses_on_its_own_lock(tmp_path):
     log = subprocess.run(["git", "log", "--oneline"], cwd=wt,
                          capture_output=True, text=True).stdout
     assert "chore" not in log, "it committed while holding its own lock"
+
+
+def test_the_lock_dir_resolves_against_PROJ_DIR_not_the_process_cwd(tmp_path):
+    """PR #321 review, minor. The SAME defect PR #314 round 2 fixed one guard up.
+
+    `git rev-parse --git-dir` answers RELATIVE to the cwd it ran in, and run()
+    executes in PROJ_DIR (CLAUDE_PROJECT_DIR), which is not this process's cwd.
+    Resolving the answer against os.getcwd() points at a path that does not exist
+    whenever the two differ, no lock is ever found, and the guard FAILS OPEN into
+    the exact pre-guard behaviour it was built to remove.
+
+    fleet_update_in_progress carries that scar in its own comment and has no test
+    for it either. Every other test in this file fires with cwd == PROJ_DIR, so
+    `os.path.abspath(git_dir)` in place of `os.path.abspath(join(PROJ_DIR, ...))`
+    passed all 43 of them. This is the one that can tell them apart.
+    """
+    root, run = _repo(tmp_path)
+    _write(root, "memory/MEMORY.md", "- note\n")
+    elsewhere = tmp_path / "elsewhere"
+    elsewhere.mkdir()
+    assert not (elsewhere / ".git").exists(), "the fixture must not be a repo"
+    lock = root / ".git" / "index.lock"
+    lock.write_text("held")
+    try:
+        out = subprocess.run(
+            [sys.executable, HOOK], capture_output=True, text=True,
+            cwd=str(elsewhere),
+            env=dict(os.environ, CLAUDE_PROJECT_DIR=str(root)))
+    finally:
+        lock.unlink()
+    assert "another commit is in flight" in (out.stdout + out.stderr), (
+        "with cwd outside PROJ_DIR the guard did not see PROJ_DIR's held lock. "
+        "The git-dir answer is being resolved against the process cwd.")
+    assert "chore" not in run("git", "log", "--oneline").stdout, \
+        "it committed while a lock was held in PROJ_DIR's git dir"

--- a/q-system/.q-system/tests/test_auto_commit.py
+++ b/q-system/.q-system/tests/test_auto_commit.py
@@ -747,7 +747,7 @@ def test_a_refusal_reaches_the_channel_the_fleet_wiring_keeps(tmp_path):
     """REVIEW ROUND 2, MAJOR. The refusal was on stderr, which is thrown away.
 
     settings-template.json wires this hook as `... auto-commit.py 2>/dev/null ||
-    true` (lines 380 and 406), and that is the copy the fleet updater installs on
+    true` (line 395), and that is the copy the fleet updater installs on
     every instance. The behaviour the lock guard replaced reported a collision on
     STDOUT via commit_group's `skipped:` line, which survived that redirect. A
     stderr-only refusal does not: an orphaned index.lock, which has no age bound

--- a/q-system/.q-system/tests/test_auto_commit.py
+++ b/q-system/.q-system/tests/test_auto_commit.py
@@ -716,8 +716,14 @@ def test_the_lock_dir_resolves_against_PROJ_DIR_not_the_process_cwd(tmp_path):
     whenever the two differ, no lock is ever found, and the guard FAILS OPEN into
     the exact pre-guard behaviour it was built to remove.
 
-    fleet_update_in_progress carries that scar in its own comment and has no test
-    for it either. Every other test in this file fires with cwd == PROJ_DIR, so
+    fleet_update_in_progress carries that scar in its own comment and IS pinned,
+    but in a DIFFERENT FILE this suite does not run:
+    q-system/hooks/test/test_auto_commit_run_marker.py::
+    test_live_marker_is_seen_when_cwd_is_not_the_project_dir. An earlier draft of
+    this docstring said it had no test either; that was wrong, and missing that
+    second file is also how a channel change here shipped past a green run of
+    this suite and reddened CI. Every other test in THIS file fires with
+    cwd == PROJ_DIR, so
     `os.path.abspath(git_dir)` in place of `os.path.abspath(join(PROJ_DIR, ...))`
     passed all 43 of them. This is the one that can tell them apart.
     """

--- a/q-system/.q-system/tests/test_auto_commit.py
+++ b/q-system/.q-system/tests/test_auto_commit.py
@@ -626,3 +626,73 @@ def test_it_still_commits_when_no_lock_is_held(tmp_path):
     _fire(root)
     log = run("git", "log", "--oneline").stdout
     assert "chore" in log, "the hook refused with no lock held, so it never commits"
+
+
+def _worktree(tmp_path):
+    """A linked worktree of a fresh repo, plus its main checkout.
+
+    Returns (main_root, wt_root, main_git_dir, wt_git_dir).
+    """
+    main, run = _repo(tmp_path)
+    wt = tmp_path / "wt"
+    run("git", "branch", "-q", "side")
+    run("git", "worktree", "add", "-q", str(wt), "side")
+    main_git = main / ".git"
+    wt_git = main_git / "worktrees" / "wt"
+    assert wt_git.is_dir(), f"the worktree fixture never linked: {wt_git}"
+    return main, wt, main_git, wt_git
+
+
+def test_a_worktree_does_not_refuse_on_the_main_checkouts_lock(tmp_path):
+    """THE MUTANT THIS EXISTS FOR: --git-common-dir in place of --git-dir.
+
+    It survives every other test in this file, because a plain repo's git dir IS
+    its common dir, so the two spellings are indistinguishable there. They are not
+    indistinguishable on this checkout, which carries a dozen linked worktrees.
+
+    MEASURED 2026-09-07, not reasoned: index.lock and HEAD.lock are PER-WORKTREE.
+    Holding `<main>/.git/index.lock` does not block a `git add` run from a linked
+    worktree (rc=0), and holding `<main>/.git/worktrees/<n>/index.lock` does not
+    block one run from the main checkout (rc=0). Only the worktree's own lock
+    stops it (rc=128, "Unable to create ... index.lock"). So `--git-dir`, which
+    answers the per-worktree dir, names exactly the lock that can stop THIS
+    checkout, and `--git-common-dir` names one that cannot.
+
+    The cost of getting it wrong is quiet and fleet-wide: a commit in the main
+    checkout holds index.lock for its whole pre-commit (445-497s measured), so a
+    common-dir read would silence the safety net in every linked worktree for
+    eight minutes at a time, for a lock none of them was ever going to contend.
+    Note that fleet_update_in_progress deliberately reads the OPPOSITE dir, and
+    is right to: a run marker is a claim on the whole checkout, a lock is not.
+    """
+    _main, wt, main_git, _wt_git = _worktree(tmp_path)
+    _write(wt, "memory/MEMORY.md", "- note\n")
+    lock = main_git / "index.lock"
+    lock.write_text("held by the main checkout")
+    try:
+        _fire(wt)
+    finally:
+        lock.unlink()
+    log = subprocess.run(["git", "log", "--oneline"], cwd=wt,
+                         capture_output=True, text=True).stdout
+    assert "chore" in log, (
+        "the worktree refused on a lock in the MAIN checkout's git dir, which "
+        "cannot block it. The guard is reading --git-common-dir, not --git-dir.")
+
+
+def test_a_worktree_still_refuses_on_its_own_lock(tmp_path):
+    """The other direction, so the test above cannot be satisfied by never
+    refusing at all. The per-worktree lock is the one that stops this checkout."""
+    _main, wt, _main_git, wt_git = _worktree(tmp_path)
+    _write(wt, "memory/MEMORY.md", "- note\n")
+    lock = wt_git / "index.lock"
+    lock.write_text("held by this worktree")
+    try:
+        out = _fire(wt)
+    finally:
+        lock.unlink()
+    assert "another commit is in flight" in (out.stdout + out.stderr), \
+        "a worktree fired into its OWN held index.lock instead of refusing"
+    log = subprocess.run(["git", "log", "--oneline"], cwd=wt,
+                         capture_output=True, text=True).stdout
+    assert "chore" not in log, "it committed while holding its own lock"

--- a/q-system/.q-system/tests/test_auto_commit.py
+++ b/q-system/.q-system/tests/test_auto_commit.py
@@ -555,3 +555,74 @@ def test_a_binary_file_degrades_instead_of_crashing(tmp_path):
     msg = _last_msg(run)
     assert rel in msg, f"the binary file was dropped from the message\n{msg}"
     assert "binary" in msg, f"the binary file was not marked as such\n{msg}"
+
+
+# --- the third writer (2026-09-06) -------------------------------------------------
+# fleet_update_in_progress coordinates with the one writer that leaves a marker. This
+# hook was the writer nobody could negotiate with: it fires at every turn end in every
+# session on a shared checkout and took no lock at all. Measured in one session that
+# night, three of five git operations died on "Unable to create .git/index.lock" and
+# every one of them EXITED 0.
+
+def test_it_refuses_while_another_commit_holds_index_lock(tmp_path):
+    """sp-4bff1b91. A commit in flight owns index.lock for its whole pre-commit,
+    measured at 447-497s on the consulting checkout. Firing into that either dies at
+    exit 0 or lands a commit nobody asked for."""
+    root, run = _repo(tmp_path)
+    _write(root, "memory/MEMORY.md", "- note\n")
+    lock = os.path.join(root, ".git", "index.lock")
+    with open(lock, "w", encoding="utf-8") as fh:
+        fh.write("")
+    try:
+        out = _fire(root)
+    finally:
+        os.remove(lock)
+    assert "another commit is in flight" in (out.stdout + out.stderr), \
+        "the hook fired into a held index.lock instead of refusing"
+    log = run("git", "log", "--oneline").stdout
+    assert "chore" not in log, "it committed while another writer held the lock"
+
+
+def test_it_refuses_on_head_lock_too(tmp_path):
+    """The ref lock, not the index lock, is the one that killed the prd-os ledger
+    sweep mid pre-commit (sp-d0ce1966). Both doors or neither."""
+    root, run = _repo(tmp_path)
+    _write(root, "memory/MEMORY.md", "- note\n")
+    lock = os.path.join(root, ".git", "HEAD.lock")
+    with open(lock, "w", encoding="utf-8") as fh:
+        fh.write("")
+    try:
+        out = _fire(root)
+    finally:
+        os.remove(lock)
+    assert "another commit is in flight" in (out.stdout + out.stderr)
+
+
+def test_it_does_not_delete_the_lock_it_refuses_on(tmp_path):
+    """THE CONTROL THAT MATTERS MOST. kipi-update.sh:1714 force-deletes these locks
+    with no pid, mtime or age test (sp-50119dec). Removing a lock that a live
+    8-minute pre-commit still owns corrupts that commit's index. Refusing is the
+    whole fix; deleting would be a worse bug wearing the same commit message."""
+    root, _ = _repo(tmp_path)
+    _write(root, "memory/MEMORY.md", "- note\n")
+    lock = os.path.join(root, ".git", "index.lock")
+    with open(lock, "w", encoding="utf-8") as fh:
+        fh.write("sentinel")
+    try:
+        _fire(root)
+        assert os.path.exists(lock), "the hook DELETED a lock it does not own"
+        with open(lock, encoding="utf-8") as fh:
+            assert fh.read() == "sentinel", "the hook rewrote a lock it does not own"
+    finally:
+        if os.path.exists(lock):
+            os.remove(lock)
+
+
+def test_it_still_commits_when_no_lock_is_held(tmp_path):
+    """The negative control. A guard that refuses always is not a guard, it is an
+    outage: the safety net exists so work survives a context loss."""
+    root, run = _repo(tmp_path)
+    _write(root, "memory/MEMORY.md", "- note\n")
+    _fire(root)
+    log = run("git", "log", "--oneline").stdout
+    assert "chore" in log, "the hook refused with no lock held, so it never commits"

--- a/q-system/.q-system/tests/test_auto_commit.py
+++ b/q-system/.q-system/tests/test_auto_commit.py
@@ -9,6 +9,7 @@ from __future__ import annotations
 import os
 import subprocess
 import sys
+import time
 
 import pytest
 
@@ -584,8 +585,16 @@ def test_it_refuses_while_another_commit_holds_index_lock(tmp_path):
 
 
 def test_it_refuses_on_head_lock_too(tmp_path):
-    """The ref lock, not the index lock, is the one that killed the prd-os ledger
-    sweep mid pre-commit (sp-d0ce1966). Both doors or neither."""
+    """HEAD.lock is a SEPARATE door, and this docstring named the wrong reason
+    for it. It said the ref lock killed the prd-os ledger sweep mid pre-commit
+    (sp-d0ce1966). Review round 2 measured that a commit on an attached branch
+    produces index.lock and `refs/heads/<branch>.lock` and NEVER HEAD.lock, and
+    an independent watch agrees: only index.lock appears through a slow
+    pre-commit. The check still earns its place -- HEAD.lock has real producers
+    (checkout, reset, merge, alongside the AUTO_MERGE / ORIG_HEAD / packed-refs
+    family) and dropping it reddens this test. What it does NOT cover is
+    `refs/heads/<branch>.lock`, which a commit really does take; that window is
+    sub-second and index.lock spans it, so it is deliberately not checked."""
     root, run = _repo(tmp_path)
     _write(root, "memory/MEMORY.md", "- note\n")
     lock = os.path.join(root, ".git", "HEAD.lock")
@@ -731,3 +740,53 @@ def test_the_lock_dir_resolves_against_PROJ_DIR_not_the_process_cwd(tmp_path):
         "The git-dir answer is being resolved against the process cwd.")
     assert "chore" not in run("git", "log", "--oneline").stdout, \
         "it committed while a lock was held in PROJ_DIR's git dir"
+
+
+
+def test_a_refusal_reaches_the_channel_the_fleet_wiring_keeps(tmp_path):
+    """REVIEW ROUND 2, MAJOR. The refusal was on stderr, which is thrown away.
+
+    settings-template.json wires this hook as `... auto-commit.py 2>/dev/null ||
+    true` (lines 380 and 406), and that is the copy the fleet updater installs on
+    every instance. The behaviour the lock guard replaced reported a collision on
+    STDOUT via commit_group's `skipped:` line, which survived that redirect. A
+    stderr-only refusal does not: an orphaned index.lock, which has no age bound
+    by design, would switch the safety net off on that checkout forever and print
+    nothing anywhere a human looks.
+
+    So this asserts the CHANNEL, not the wording. It fires the hook exactly the
+    way the fleet does, with stderr discarded, and fails if the reason vanishes.
+    """
+    root, _run = _repo(tmp_path)
+    _write(root, "memory/MEMORY.md", "- note\n")
+    lock = root / ".git" / "index.lock"
+    lock.write_text("held")
+    try:
+        out = subprocess.run(
+            [sys.executable, HOOK], capture_output=True, text=True, cwd=str(root),
+            env=dict(os.environ, CLAUDE_PROJECT_DIR=str(root)))
+    finally:
+        lock.unlink()
+    assert "another commit is in flight" in out.stdout, (
+        "the refusal did not reach STDOUT, so `2>/dev/null` in the shipped hook "
+        "wiring discards it and the safety net goes off in total silence.\n"
+        f"stdout={out.stdout!r}\nstderr={out.stderr!r}")
+
+
+def test_the_fleet_update_refusal_reaches_stdout_too(tmp_path):
+    """The sibling guard, hardened in the same breath. It had the identical
+    stderr-only shape and the identical consequence, and fixing one of two
+    guards that fail the same way is how this class comes back."""
+    root, _run = _repo(tmp_path)
+    _write(root, "memory/MEMORY.md", "- note\n")
+    marker = root / ".git" / "kipi-update.run"
+    marker.write_text(f"{os.getpid()} {time.strftime('%Y-%m-%dT%H:%M:%SZ', time.gmtime())}")
+    try:
+        out = subprocess.run(
+            [sys.executable, HOOK], capture_output=True, text=True, cwd=str(root),
+            env=dict(os.environ, CLAUDE_PROJECT_DIR=str(root)))
+    finally:
+        marker.unlink()
+    assert "fleet updater run in progress" in out.stdout, (
+        "the fleet-updater refusal did not reach STDOUT.\n"
+        f"stdout={out.stdout!r}\nstderr={out.stderr!r}")

--- a/q-system/hooks/auto-commit.py
+++ b/q-system/hooks/auto-commit.py
@@ -574,8 +574,13 @@ def main():
 
     # STDOUT, NOT STDERR, AND THAT IS THE WHOLE POINT (review round 2, major).
     # settings-template.json wires this hook as `... auto-commit.py 2>/dev/null
-    # || true` at lines 380 and 406, and that is the copy the fleet updater
-    # installs on every instance. So stderr is DISCARDED on all 22+ checkouts.
+    # || true` at line 395, the single wiring of it, and that is the copy the fleet
+    # updater installs on every instance. So stderr is DISCARDED on 22+ checkouts.
+    # (An earlier draft of this comment said "lines 380 and 406". Those came from
+    # a checkout with local edits to that file and point at unrelated hooks. A
+    # scar comment with a wrong pointer reads as coverage, which is the exact
+    # defect this PR was reviewed for; re-derive line numbers from the tree you
+    # are actually shipping.)
     # The behaviour these guards replaced reported a lock collision on STDOUT,
     # as commit_group's `skipped:` line naming the file and git's own error, and
     # that line survived the redirect. Returning early with a stderr-only

--- a/q-system/hooks/auto-commit.py
+++ b/q-system/hooks/auto-commit.py
@@ -111,10 +111,20 @@ def get_changed_files():
     if r.stdout.strip():
         files.update(r.stdout.strip().splitlines())
 
-    # Staged but not yet diffed against HEAD (new files)
-    r = run(["git", "diff", "--cached", "--name-only"])
-    if r.stdout.strip():
-        files.update(r.stdout.strip().splitlines())
+    # THE `--cached` READ IS GONE AS REDUNDANCY, AND THAT IS ALL IT WAS.
+    #
+    # MEASURED 2026-09-06 before removing it, because the obvious story was wrong.
+    # It was believed to be the line that swept another session's staged work into
+    # this hook's commit (sp-78728ff1). It is not. `git diff --name-only HEAD` on the
+    # line above ALREADY reports a staged-but-uncommitted new file: in a scratch repo,
+    # `git add b` on a new file makes `git diff --name-only HEAD` print `b`. So this
+    # read added nothing any other probe missed, and deleting it fixes nothing.
+    #
+    # sp-78728ff1 IS THEREFORE STILL OPEN and needs a different fix than deleting a
+    # line. Git cannot tell WHO staged a path, so the only honest lever is to treat
+    # "staged" as "a writer has claimed this" and skip it, reporting it as skipped.
+    # That trades away part of the safety net (work staged at session death would no
+    # longer be committed for you) and is a deliberate design call, not a cleanup.
 
     # Filter out empty strings and gitignored patterns
     return {f for f in files if f and not f.startswith("q-system/output/")}
@@ -460,6 +470,49 @@ def fleet_update_in_progress():
     return f"pid {pid}"
 
 
+def another_commit_in_flight():
+    """A reason string if git's own locks say someone is mid-commit, else None.
+
+    THE THIRD WRITER (sp-4bff1b91, sp-d0ce1966, sp-e06433b8, measured 2026-09-06).
+    `fleet_update_in_progress` above coordinates with the ONE writer that agreed to
+    leave a marker. This hook is the writer nobody can negotiate with: it fires at
+    every turn end in every session on the checkout, and it took no lock at all. Two
+    sessions can hold a ref window perfectly and still lose a commit to it.
+
+    Measured that night in one session: three of five git operations died on
+    `Unable to create '.git/index.lock'`, and EVERY ONE EXITED 0. A commit that
+    reports success while landing nothing is worse than one that refuses.
+
+    WE READ THE LOCKS, WE DO NOT REMOVE THEM. kipi-update.sh:1714 does
+    `rm -f` on HEAD.lock/index.lock with no pid, mtime or age test at all
+    (sp-50119dec), and deleting a lock a live 8-minute pre-commit still owns
+    corrupts that commit's index. Refusing costs one skipped auto-commit; the
+    next turn end picks the work up.
+
+    NO AGE BOUND ON PURPOSE, unlike the run marker. A commit here holds index.lock
+    for the length of its pre-commit, measured tonight at 447-497 seconds, and a
+    bound low enough to be useful against a crashed lock would fire constantly
+    against healthy ones. A truly orphaned lock is rare, visible, and a human's
+    call: "no process holds it AND every live hook's cwd is a worktree" is the test
+    that settled it by hand, and it needs `lsof`, which a Stop hook must not spend.
+    """
+    r = run(["git", "rev-parse", "--git-dir"])
+    if r.returncode != 0:
+        return None
+    git_dir = r.stdout.strip()
+    if not os.path.isabs(git_dir):
+        git_dir = os.path.abspath(os.path.join(PROJ_DIR, git_dir))
+    for name in ("index.lock", "HEAD.lock"):
+        path = os.path.join(git_dir, name)
+        if os.path.exists(path):
+            try:
+                age = int(time.time() - os.path.getmtime(path))
+                return f"{name} held {age}s"
+            except OSError:
+                return name
+    return None
+
+
 def main():
     # Check we're in a git repo
     r = run(["git", "rev-parse", "--is-inside-work-tree"])
@@ -470,6 +523,13 @@ def main():
     if live_run is not None:
         print(f"auto-commit: fleet updater run in progress ({live_run}); "
               "committing nothing", file=sys.stderr)
+        return
+
+    held = another_commit_in_flight()
+    if held is not None:
+        print(f"auto-commit: another commit is in flight ({held}); "
+              "committing nothing. The next turn end picks this work up.",
+              file=sys.stderr)
         return
 
     files = get_changed_files()

--- a/q-system/hooks/auto-commit.py
+++ b/q-system/hooks/auto-commit.py
@@ -111,14 +111,29 @@ def get_changed_files():
     if r.stdout.strip():
         files.update(r.stdout.strip().splitlines())
 
-    # THE `--cached` READ IS GONE AS REDUNDANCY, AND THAT IS ALL IT WAS.
+    # THE `--cached` READ IS GONE AS REDUNDANCY, FOR THE SHAPE THAT MOTIVATED IT.
     #
     # MEASURED 2026-09-06 before removing it, because the obvious story was wrong.
     # It was believed to be the line that swept another session's staged work into
     # this hook's commit (sp-78728ff1). It is not. `git diff --name-only HEAD` on the
     # line above ALREADY reports a staged-but-uncommitted new file: in a scratch repo,
-    # `git add b` on a new file makes `git diff --name-only HEAD` print `b`. So this
-    # read added nothing any other probe missed, and deleting it fixes nothing.
+    # `git add b` on a new file makes `git diff --name-only HEAD` print `b`. That is
+    # sp-78728ff1's shape, so deleting this line fixes nothing.
+    #
+    # IT IS NOT UNIVERSALLY REDUNDANT, and the first draft of this comment claimed it
+    # was ("added nothing any other probe missed"). Re-measured 2026-09-07 across six
+    # staging shapes: `--cached` names two paths that `diff --name-only HEAD` and
+    # `ls-files --others` both miss -- a file staged and then DELETED from the
+    # worktree, and a file staged and then edited back to its HEAD content.
+    #
+    # Removing it is still right, and that reason is measured too, not reasoned:
+    # commit_group runs a PATHSPEC commit, and `git commit -m x -- <path>` in BOTH of
+    # those shapes exits 1 with "nothing to commit" and writes no commit. (The first
+    # guess written here was that the delete shape would commit a DELETION of another
+    # writer's staged file. It does not; the staged entry survives untouched.) So the
+    # two extra paths only ever bought a spurious `skipped:` line. What this removal
+    # gets is a narrower changed-file set, not a bug fix. Do not re-add it expecting
+    # one, and do not cite it as coverage for sp-78728ff1.
     #
     # sp-78728ff1 IS THEREFORE STILL OPEN and needs a different fix than deleting a
     # line. Git cannot tell WHO staged a path, so the only honest lever is to treat
@@ -483,18 +498,46 @@ def another_commit_in_flight():
     `Unable to create '.git/index.lock'`, and EVERY ONE EXITED 0. A commit that
     reports success while landing nothing is worse than one that refuses.
 
-    WE READ THE LOCKS, WE DO NOT REMOVE THEM. kipi-update.sh:1714 does
-    `rm -f` on HEAD.lock/index.lock with no pid, mtime or age test at all
-    (sp-50119dec), and deleting a lock a live 8-minute pre-commit still owns
-    corrupts that commit's index. Refusing costs one skipped auto-commit; the
-    next turn end picks the work up.
+    WE READ THE LOCKS, WE DO NOT REMOVE THEM. Deleting a lock that a live 8-minute
+    pre-commit still owns corrupts that commit's index. kipi-update.sh still sweeps
+    HEAD.lock/index.lock/AUTO_MERGE.lock with an unconditional force-delete at the
+    top of its instance loop, no pid, mtime or age test at all (~L1915, sp-50119dec;
+    an earlier draft of this docstring cited L1714, which is unrelated env-var code).
+    Read that citation narrowly: the SAME file is also the one that already solved
+    this properly, at ~L1313-1400, where every index write it makes waits for the
+    lock to clear, bounded at 600s, with bounded retry and a loud error
+    (sp-523c1a25). A Stop hook cannot spend 600s at turn end, so it takes the other
+    half of that answer: refuse now, and the next turn end picks the work up.
 
     NO AGE BOUND ON PURPOSE, unlike the run marker. A commit here holds index.lock
-    for the length of its pre-commit, measured tonight at 447-497 seconds, and a
+    for the length of its pre-commit, measured at 447-497 seconds here and
+    independently at 445s in kipi-update.sh's own note from the same night, so a
     bound low enough to be useful against a crashed lock would fire constantly
     against healthy ones. A truly orphaned lock is rare, visible, and a human's
     call: "no process holds it AND every live hook's cwd is a worktree" is the test
     that settled it by hand, and it needs `lsof`, which a Stop hook must not spend.
+
+    AND THAT BOUND COSTS LESS THAN THE FIRST DRAFT OF THIS DOCSTRING CHARGED IT.
+    Measured 2026-09-07: git itself exits 128 on a held index.lock, and commit_group
+    turns ANY non-zero into a `skipped:` line while this hook exits 0. So an orphaned
+    lock ALREADY stopped this hook from committing, silently, before this guard
+    existed. The guard adds no new silent-outage mode; it replaces a failure found
+    after a 450s pre-commit with a refusal that costs nothing. The genuinely new
+    behaviour is the opposite one, and it is frequent rather than rare: a peer
+    session's `git status` holds index.lock for a fraction of a second, so some turn
+    ends now skip a commit they would have won. Work stays on disk either way.
+
+    --git-dir, NOT --git-common-dir, AND THE TWO GUARDS HERE DISAGREE ON PURPOSE.
+    fleet_update_in_progress above reads the COMMON dir because a run marker is a
+    claim on the whole checkout. A lock is not: index.lock and HEAD.lock are
+    per-worktree. Measured 2026-09-07 -- holding <main>/.git/index.lock does not
+    block a `git add` run from a linked worktree, and holding that worktree's own
+    lock does (rc=128). So this spelling names exactly the lock that can stop THIS
+    checkout. Harmonizing the two would silence the safety net in every linked
+    worktree for the eight minutes the main checkout spends inside a pre-commit,
+    over a lock none of them would ever contend. Pinned by
+    test_a_worktree_does_not_refuse_on_the_main_checkouts_lock, the only test in the
+    file that can tell the two spellings apart.
     """
     r = run(["git", "rev-parse", "--git-dir"])
     if r.returncode != 0:

--- a/q-system/hooks/auto-commit.py
+++ b/q-system/hooks/auto-commit.py
@@ -511,7 +511,14 @@ def another_commit_in_flight():
 
     NO AGE BOUND ON PURPOSE, unlike the run marker. A commit here holds index.lock
     for the length of its pre-commit, measured at 447-497 seconds here and
-    independently at 445s in kipi-update.sh's own note from the same night, so a
+    independently at 445s in kipi-update.sh's own note from the same night. Review
+    round 2 called that figure false, having measured ~12ms and no lock at all
+    during a pre-commit. RE-MEASURED 2026-09-07 over three command shapes against
+    a 5s pre-commit hook, and the figure stands: `git commit -m x -- <path>`,
+    which is exactly what commit_group runs, holds index.lock (plus a next-index
+    lock) for the WHOLE hook; `git commit -a` does too; only `git add` followed by
+    a bare `git commit` holds nothing, and that is the one shape this hook never
+    uses. Measure the pathspec form, or the number will look invented again. So a
     bound low enough to be useful against a crashed lock would fire constantly
     against healthy ones. A truly orphaned lock is rare, visible, and a human's
     call: "no process holds it AND every live hook's cwd is a worktree" is the test
@@ -521,8 +528,11 @@ def another_commit_in_flight():
     Measured 2026-09-07: git itself exits 128 on a held index.lock, and commit_group
     turns ANY non-zero into a `skipped:` line while this hook exits 0. So an orphaned
     lock ALREADY stopped this hook from committing, silently, before this guard
-    existed. The guard adds no new silent-outage mode; it replaces a failure found
-    after a 450s pre-commit with a refusal that costs nothing. The genuinely new
+    existed. It replaces a failure found after a 450s pre-commit with a refusal
+    that costs nothing. An earlier draft went further and said the guard adds NO
+    new silent-outage mode; review round 2 proved that false, and it is true now
+    only because of the fix it forced -- the refusal prints on stdout, because the
+    fleet wiring discards stderr. See the comment in main(). The genuinely new
     behaviour is the opposite one, and it is frequent rather than rare: a peer
     session's `git status` holds index.lock for a fraction of a second, so some turn
     ends now skip a commit they would have won. Work stays on disk either way.
@@ -562,17 +572,29 @@ def main():
     if r.returncode != 0:
         return
 
+    # STDOUT, NOT STDERR, AND THAT IS THE WHOLE POINT (review round 2, major).
+    # settings-template.json wires this hook as `... auto-commit.py 2>/dev/null
+    # || true` at lines 380 and 406, and that is the copy the fleet updater
+    # installs on every instance. So stderr is DISCARDED on all 22+ checkouts.
+    # The behaviour these guards replaced reported a lock collision on STDOUT,
+    # as commit_group's `skipped:` line naming the file and git's own error, and
+    # that line survived the redirect. Returning early with a stderr-only
+    # message made the safety net go quiet with literally zero output: an
+    # orphaned index.lock (no age bound, by design) would switch this hook off
+    # on that checkout forever and print nothing anywhere. The message is the
+    # only thing that tells a human to go look, so it has to reach the channel
+    # that survives. Pinned by
+    # test_a_refusal_reaches_the_channel_the_fleet_wiring_keeps.
     live_run = fleet_update_in_progress()
     if live_run is not None:
         print(f"auto-commit: fleet updater run in progress ({live_run}); "
-              "committing nothing", file=sys.stderr)
+              "committing nothing")
         return
 
     held = another_commit_in_flight()
     if held is not None:
         print(f"auto-commit: another commit is in flight ({held}); "
-              "committing nothing. The next turn end picks this work up.",
-              file=sys.stderr)
+              "committing nothing. The next turn end picks this work up.")
         return
 
     files = get_changed_files()

--- a/q-system/hooks/test/test_auto_commit_run_marker.py
+++ b/q-system/hooks/test/test_auto_commit_run_marker.py
@@ -63,6 +63,22 @@ class RunMarker(unittest.TestCase):
     def setUp(self):
         self.repo = tempfile.mkdtemp(prefix="auto-commit-marker-")
         git(self.repo, "init", "-q", "-b", "main")
+        # IDENTITY ON THE REPO, NOT ON OUR OWN `git -c` CALLS.
+        #
+        # `git()` above passes -c user.email/-c user.name, which covers the
+        # commands THIS FILE runs and nothing else. The subject under test is a
+        # subprocess -- run_hook spawns auto-commit.py, which runs its own
+        # `git commit` -- and that inherits whatever identity the RUNNER happens
+        # to have. Measured 2026-09-07: `validate.yml` sets a global identity and
+        # `verify.yml` does not, so the moment this suite was named in
+        # .verify-suites two cases went red in one job and stayed green in the
+        # other, with the failure reading "the hook did not commit" as if the
+        # hook were broken. Writing the identity into the repo config puts it
+        # where the child git will find it, and makes the suite hermetic instead
+        # of dependent on which workflow happens to run it.
+        git(self.repo, "config", "user.email", "t@t.t")
+        git(self.repo, "config", "user.name", "test")
+        git(self.repo, "config", "commit.gpgsign", "false")
         # A path the hook classifies as committable, so the "no marker" and
         # "stale marker" cases have something to commit and the live case has
         # something it must NOT commit.

--- a/q-system/hooks/test/test_auto_commit_run_marker.py
+++ b/q-system/hooks/test/test_auto_commit_run_marker.py
@@ -9,7 +9,15 @@ and did nothing (sp-9306036e). The updater now writes
 <git-common-dir>/kipi-update.run for the duration of one instance apply; this
 pins the hook's half of the handshake:
 
-  live marker  (pid alive)  -> exit 0, one stderr line, no commit, marker kept
+  live marker  (pid alive)  -> exit 0, one STDOUT line, no commit, marker kept
+
+  THE CHANNEL IS STDOUT, NOT STDERR (PR #321 review round 2, major). This file
+  asserted stderr, and it was the only thing pinning that. settings-template.json
+  wires the hook as `... auto-commit.py 2>/dev/null || true` (line 395), so the
+  copy the fleet updater installs on every instance THROWS STDERR AWAY. A refusal
+  nobody can see turns the safety net off in silence, which is the whole defect
+  PR #321 exists to remove. The positive assertions now read stdout; the negative
+  ones read BOTH channels, so they cannot pass merely because a message moved.
   stale marker (pid dead)   -> marker removed, hook proceeds as before
   no marker                 -> unchanged behaviour
 
@@ -76,7 +84,7 @@ class RunMarker(unittest.TestCase):
         before = head_count(self.repo)
         result = run_hook(self.repo)
         self.assertEqual(result.returncode, 0, result.stderr)
-        self.assertIn("fleet updater run in progress", result.stderr)
+        self.assertIn("fleet updater run in progress", result.stdout)
         self.assertEqual(head_count(self.repo), before, "the hook committed under a live marker")
         self.assertTrue(os.path.exists(self.marker), "the hook removed a LIVE marker")
 
@@ -85,7 +93,8 @@ class RunMarker(unittest.TestCase):
             fh.write(f"{dead_pid()} 2026-09-06T21:30:00Z\n")
         result = run_hook(self.repo)
         self.assertEqual(result.returncode, 0, result.stderr)
-        self.assertNotIn("fleet updater run in progress", result.stderr)
+        self.assertNotIn("fleet updater run in progress",
+                            result.stdout + result.stderr)
         self.assertFalse(os.path.exists(self.marker), "a stale marker survived")
 
     def test_live_marker_is_seen_when_cwd_is_not_the_project_dir(self):
@@ -97,7 +106,7 @@ class RunMarker(unittest.TestCase):
         before = head_count(self.repo)
         result = run_hook(self.repo, cwd=tempfile.gettempdir())
         self.assertEqual(result.returncode, 0, result.stderr)
-        self.assertIn("fleet updater run in progress", result.stderr)
+        self.assertIn("fleet updater run in progress", result.stdout)
         self.assertEqual(head_count(self.repo), before, "the guard failed open from a foreign cwd")
 
     def test_live_pid_with_an_old_stamp_is_stale(self):
@@ -108,7 +117,8 @@ class RunMarker(unittest.TestCase):
         before = head_count(self.repo)
         result = run_hook(self.repo)
         self.assertEqual(result.returncode, 0, result.stderr)
-        self.assertNotIn("fleet updater run in progress", result.stderr)
+        self.assertNotIn("fleet updater run in progress",
+                            result.stdout + result.stderr)
         self.assertFalse(os.path.exists(self.marker), "an old-stamp marker with a live pid survived")
         self.assertEqual(head_count(self.repo), before + 1, "the hook did not proceed past a stale marker")
 
@@ -117,14 +127,16 @@ class RunMarker(unittest.TestCase):
             fh.write("not-a-pid\n")
         result = run_hook(self.repo)
         self.assertEqual(result.returncode, 0, result.stderr)
-        self.assertNotIn("fleet updater run in progress", result.stderr)
+        self.assertNotIn("fleet updater run in progress",
+                            result.stdout + result.stderr)
         self.assertFalse(os.path.exists(self.marker))
 
     def test_no_marker_is_the_old_behaviour(self):
         before = head_count(self.repo)
         result = run_hook(self.repo)
         self.assertEqual(result.returncode, 0, result.stderr)
-        self.assertNotIn("fleet updater run in progress", result.stderr)
+        self.assertNotIn("fleet updater run in progress",
+                            result.stdout + result.stderr)
         # The floor that makes the live case meaningful: without a marker the
         # same dirty file DOES get committed, so "no commit" above is the marker's
         # doing and not the classifier's.


### PR DESCRIPTION
## The writer nobody could negotiate with

`fleet_update_in_progress` already coordinates with the one writer that leaves a marker. This hook fires at **every turn end in every session** on a shared checkout and took no lock at all, so two sessions can hold a ref window perfectly and still lose a commit to it.

Measured 2026-09-06 in a single session: **three of five git operations died** on `Unable to create '.git/index.lock'`, and **every one exited 0**. A commit that reports success while landing nothing is worse than one that refuses, because the next session reads the log and believes it.

## We read the locks, we do not remove them

`kipi-update.sh:1714` force-deletes `HEAD.lock`/`index.lock` with no pid, mtime or age test at all (`sp-50119dec`). Removing a lock that a live 8-minute pre-commit still owns corrupts that commit's index. Refusing costs one skipped auto-commit; the next turn end picks the work up.

**No age bound, deliberately**, unlike the run marker beside it. A commit here holds `index.lock` for its whole pre-commit — measured at **447–497s** on the consulting checkout — so a bound low enough to catch a crashed lock would fire constantly against healthy ones. A genuinely orphaned lock is a human's call: *"no process holds it AND every live hook's cwd is a worktree"* is the test that settled one by hand tonight, and it needs `lsof`, which a Stop hook must not spend.

## The part where I was wrong, and the test caught it

The `git diff --cached --name-only` read is removed as **redundancy, and the comment says plainly that this is all it is.**

It was believed — by the original spillover filer *and* by the triage that reviewed it — to be the line that swept another session's staged work into this hook's commit (`sp-78728ff1`). Measured before removing it, that is **false**: `git diff --name-only HEAD` one line above already reports a staged-but-uncommitted new file. In a scratch repo, `git add b` on a new file makes `git diff --name-only HEAD` print `b`.

I wrote the test for the claimed fix first, watched it go RED with the line removed, and **deleted the test rather than keep one built on a false premise.**

`sp-78728ff1` stays open, corrected as `sp-8d1e8836`. Git cannot tell *who* staged a path, so the real lever is to treat staged as claimed and skip it — which trades away part of the safety net and is a design call, not a line deletion.

## Verification (updated after review, 2026-09-07)

`test_auto_commit.py` **46 passed** (37 before, 9 new). The original body said 41 and 4;
review added five more tests across four rounds.

Mutation controls, each killing on its own message:

| Mutant | Result |
|---|---|
| disable the guard (`held = None`) | 3 tests RED |
| make the guard DELETE the lock it finds | the do-not-delete control RED |
| check `index.lock` only, drop `HEAD.lock` | the HEAD.lock test RED |
| `--git-common-dir` in place of `--git-dir` | both worktree tests RED |
| resolve the git dir against the process cwd | the PROJ_DIR pin RED |
| move the lock refusal back to stderr | the fleet-channel test RED |
| move the fleet-updater refusal back to stderr | its sibling test RED |

The last four mutants SURVIVED the original 41 tests and are what review added.
Gates run green on the branch: `verify.sh --full` 12/12, `test_verify_adversarial`
rc=0, `validate-separation.py 1 --verbose` rc=0, `capability-gate.py` GREEN (231
tests).

## What review changed

1. **`--git-dir` is correct and is now pinned.** Measured: `index.lock` and
   `HEAD.lock` are per-worktree. Holding `<main>/.git/index.lock` does not block a
   `git add` from a linked worktree (rc=0); only that worktree's own lock does
   (rc=128). The common-dir spelling would have silenced the safety net in every
   linked worktree for the ~450s a main-checkout pre-commit runs, and it passed
   all 41 tests.
2. **The resolution base was unpinned** (review round 1, minor). Resolving the
   git-dir answer against the process cwd instead of `PROJ_DIR` fails the guard
   OPEN whenever the two differ, and also passed all 43 tests. Same defect class
   as PR #314 round 2, one guard up in the same file.
3. **Three causal sentences were corrected against measurement**, not reasoning:
   the `--cached` read is not universally redundant (two staging shapes only it
   sees; removing it is still right because a pathspec commit is a no-op on both);
   `kipi-update.sh:1714` is unrelated code, the sweep is ~L1915 and that same file
   already solves this properly at ~L1313-1400 by waiting; and the no-age-bound
   trade was over-charged, since git already exits 128 on a held lock and this
   hook already turned that into a `skipped:` line at exit 0.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


