### PR TITLE
fix(reviewer): status before comment, refuse a duplicate head, cap concurrency, stop on a repeated file (sp-fa810306, sp-0a09e013, sp-46726f79)

### DIFF
--- a/q-system/.q-system/capability/expected_tests/q-system__.q-system__scripts__test__test-review-run-safety.sh.json
+++ b/q-system/.q-system/capability/expected_tests/q-system__.q-system__scripts__test__test-review-run-safety.sh.json
@@ -1,0 +1,4 @@
+{
+ "path": "q-system/.q-system/scripts/test/test-review-run-safety.sh",
+ "runner": "bash"
+}

--- a/q-system/.q-system/scripts/linear-worker.sh
+++ b/q-system/.q-system/scripts/linear-worker.sh
@@ -2477,8 +2477,20 @@ json.dump(d,open('$ATTEMPTS','w'),indent=2); print(e['rounds'])" 2>/dev/null || 
     # (sp-53aad86f). This is what makes a dispatcher-driven review distinguishable
     # from a hand run in the verdict record. It is set on the call rather than
     # exported once, so it cannot leak into an unrelated reviewer invocation.
-    KIPI_REVIEW_INVOKER=worker $REVIEWER_CMD "$PR_NUM" --issue "$ISSUE" --post --engine claude >>"$LOG" 2>&1 \
-      || say "WARN: the claude reviewer failed on PR #$PR_NUM (the PR stands, unreviewed)"
+    KIPI_REVIEW_INVOKER=worker $REVIEWER_CMD "$PR_NUM" --issue "$ISSUE" --post --engine claude >>"$LOG" 2>&1
+    REVIEWER_RC=$?
+    # EXIT 4 IS A COMPLETED REVIEW, NOT A FAILURE (sp-46726f79, 2026-09-07). The
+    # reviewer returns it AFTER posting its comment and its commit status, to say
+    # that this round's findings repeat a file from the previous REQUEST CHANGES
+    # round -- the wrong-fix-shape signal. Folding it into the `|| say WARN` line
+    # would log "the PR stands, unreviewed" about a review that fully landed and
+    # set the gate, which is a false statement in the one log an operator scans.
+    # Anything else non-zero keeps the original meaning.
+    if [ "$REVIEWER_RC" = "4" ]; then
+      say "NOTE: the reviewer posted its verdict on PR #$PR_NUM and flagged it STRUCTURAL -- this round repeats a file from the previous REQUEST CHANGES round. Sweep the whole class in one pass or park the PR; a third patch on the same file is the loop that warning exists to stop."
+    elif [ "$REVIEWER_RC" != "0" ]; then
+      say "WARN: the claude reviewer failed on PR #$PR_NUM (rc=$REVIEWER_RC; the PR stands, unreviewed)"
+    fi
     # Read back the verdict RECORD the reviewer just wrote (never re-grep the
     # review prose) and state what happens next in plain terms. Rework itself
     # fires on the NEXT run, through the severity-floor gate above.

--- a/q-system/.q-system/scripts/pr-review-agent.sh
+++ b/q-system/.q-system/scripts/pr-review-agent.sh
@@ -81,8 +81,20 @@
 # which status context it posts, and which directory its artifacts land in.
 #
 # Usage:  pr-review-agent.sh <pr-number> [--issue ASK-nnn] [--post]
-#                            [--engine claude|codex]
+#                            [--engine claude|codex] [--force] [--queue]
 #         --post also comments the review on the PR and the Linear issue.
+#         --force runs even when this head already carries a verdict comment.
+#         --queue waits for a concurrency slot instead of refusing immediately.
+#
+# EXIT CODES, and they are part of the contract because a queue script reads them:
+#   0  reviewed (or dry-run surveyed); nothing further is advised
+#   1  could not review: bad arguments, no PR, a moving head, no tree at the sha
+#   2  refused at resolution: this copy does not live at a repo root
+#   3  REFUSED TO START: this head already has a verdict, or two reviews are
+#      already live. Nothing was dispatched and no status was posted.
+#   4  ran and posted, AND the findings repeat a file from the previous
+#      REQUEST CHANGES round. The post is complete; the next patch is the wrong
+#      move (sp-46726f79). Advisory to the caller, never a block on the post.
 set -uo pipefail
 
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
@@ -156,10 +168,17 @@ CODEX_MODEL="${KIPI_REVIEW_CODEX_MODEL:-gpt-5.6-sol}"
 # config change (`KIPI_REVIEW_ENGINE=claude`), not an edit to the script that
 # gates every PR in the repo.
 PR=""; ISSUE=""; POST=0; ENGINE="${KIPI_REVIEW_ENGINE:-claude}"; TARGET_REPO_ARG=""
+# --force and --queue are the two documented ways past the two refusals added for
+# sp-fa810306 and sp-0a09e013. Both are opt-in and neither has an env form: an
+# env default would let a scheduled caller inherit the bypass without anyone
+# having typed it, which is how a guard ends up permanently off.
+FORCE=0; QUEUE=0
 while [ $# -gt 0 ]; do
   case "$1" in
     --issue)  shift; ISSUE="${1:-}" ;;
     --engine) shift; ENGINE="${1:-}" ;;
+    --force)  FORCE=1 ;;
+    --queue)  QUEUE=1 ;;
     # WHICH REPO THE WORK IS IN (ASK-738). $SKEL is where this CODE lives; it is
     # not where the PR lives. Before this argument the two were the same
     # variable, so a review of an external PR number resolved against the home
@@ -219,7 +238,98 @@ GH_R_PROMPT=""
 # form, which is what every pre-ASK-738 caller and fixture already relies on.
 STATUS_REPO_PATH="{owner}/{repo}"
 [ -n "$REVIEW_SLUG" ] && STATUS_REPO_PATH="$REVIEW_SLUG"
-[ -n "$PR" ] || { echo "usage: pr-review-agent.sh <pr-number> [--issue ASK-nnn] [--post] [--engine claude|codex]" >&2; exit 1; }
+[ -n "$PR" ] || { echo "usage: pr-review-agent.sh <pr-number> [--issue ASK-nnn] [--post] [--engine claude|codex] [--force] [--queue]" >&2; exit 1; }
+
+# ONE PID FILE PER (REPO, PR), AND NEVER A THIRD CONCURRENT REVIEW (sp-0a09e013).
+#
+# THE SCAR, measured: on the evening of 2026-09-05 five reviewers and watchers
+# started as tracked tool calls were killed by the harness under memory pressure,
+# and on 2026-09-07 at 00:35Z a process exit took a nohup'd reviewer with it,
+# orphaning two tasks and losing a posted approval. Nothing on this box could
+# answer "how many reviews are live right now", so the answer was always "start
+# another one" -- and each one costs a full Opus review of a real diff.
+#
+# THE FILE IS THE ANSWER, not a process table scan. `pgrep -f pr-review-agent`
+# matches its own grep and every editor buffer holding the name, which is the
+# same class of miscount this fleet already recorded. A file written at start and
+# removed by the EXIT trap is checkable by anyone, survives the session that
+# spawned it, and self-heals: a pid the OS no longer knows is stale and is
+# reclaimed, because an operator who must clear these by hand eventually clears
+# one while a run is live.
+#
+# SAME DIRECTORY AS THE REVIEW TREES AND THEIR LOCKS, deliberately. That is the
+# one place this script already owns per (repo, PR) state, so a reader looking
+# for "what is this reviewer doing" finds the tree, the lock and the pid together
+# instead of in three conventions.
+#
+# HONEST BOUNDARY: pid numbers are recycled. A stale file whose number has been
+# handed to an unrelated process reads as live and costs one false refusal, which
+# is the safe direction -- a false refusal names the file and exits 3, while a
+# false start is the duplicate review this exists to stop.
+REVIEW_PID_DIR="$(dirname "$(review_tree_path "$HOME/.config/kipi" "$REVIEW_SLUG" "$PR")")"
+REVIEW_PID_FILE="$REVIEW_PID_DIR/$(artifact_key "$REVIEW_SLUG" "$PR").pid"
+REVIEW_PID_WRITTEN=0
+# CONCURRENCY CAP: at most 2 live runs, so this one is refused when 2 already are.
+REVIEW_CONCURRENCY_CAP="${KIPI_REVIEW_CONCURRENCY_CAP:-2}"
+REVIEW_QUEUE_SECONDS="${KIPI_REVIEW_QUEUE_SECONDS:-900}"
+
+_review_pid_release() {
+  # ONLY OUR OWN. Removing a pid file whose contents are someone else's pid would
+  # release THEIR slot, which is the concurrent-reviewer defect wearing a cleanup
+  # costume -- the same reasoning release_wt_lock already carries below.
+  [ "$REVIEW_PID_WRITTEN" = "1" ] || return 0
+  if [ "$(tr -dc '0-9' < "$REVIEW_PID_FILE" 2>/dev/null | head -c 12)" = "$$" ]; then
+    command rm -f "$REVIEW_PID_FILE" 2>/dev/null || true
+  fi
+  REVIEW_PID_WRITTEN=0
+}
+
+# _live_review_pids -> one "<pidfile> <pid>" line per LIVE run other than ours.
+# Reaps stale files as it goes: the scan is the only thing that ever runs after a
+# killed reviewer, so if it does not clean up, nothing does.
+_live_review_pids() {
+  local f pid
+  for f in "$REVIEW_PID_DIR"/*.pid; do
+    [ -f "$f" ] || continue
+    [ "$f" = "$REVIEW_PID_FILE" ] && continue
+    pid="$(tr -dc '0-9' < "$f" 2>/dev/null | head -c 12)"
+    if [ -n "$pid" ] && kill -0 "$pid" 2>/dev/null; then
+      printf '%s %s\n' "$f" "$pid"
+    else
+      echo "  reclaimed a stale reviewer pid file (pid ${pid:-<empty>} is gone): $f" >&2
+      command rm -f "$f" 2>/dev/null || true
+    fi
+  done
+}
+
+mkdir -p "$REVIEW_PID_DIR" 2>/dev/null || true
+_REVIEW_WAITED=0
+while :; do
+  _LIVE="$(_live_review_pids)"
+  _LIVE_N="$(printf '%s' "$_LIVE" | grep -c . || true)"
+  [ "${_LIVE_N:-0}" -lt "$REVIEW_CONCURRENCY_CAP" ] && break
+  if [ "$QUEUE" != "1" ]; then
+    echo "REFUSING: $_LIVE_N reviews are already live (cap $REVIEW_CONCURRENCY_CAP). No review was dispatched and NO status was posted." >&2
+    printf '%s\n' "$_LIVE" | sed 's/^/  live: /' >&2
+    echo "  Wait for one to finish, or re-run with --queue to wait up to ${REVIEW_QUEUE_SECONDS}s for a slot." >&2
+    exit 3
+  fi
+  # BOUNDED WAIT, NOT AN OPEN ONE. An unbounded queue turns a stuck reviewer into
+  # a pile of blocked reviewers that all wake at once when it dies.
+  if [ "$_REVIEW_WAITED" -ge "$REVIEW_QUEUE_SECONDS" ]; then
+    echo "REFUSING: waited ${_REVIEW_WAITED}s for a slot and $_LIVE_N reviews are still live (cap $REVIEW_CONCURRENCY_CAP). No review was dispatched and NO status was posted." >&2
+    exit 3
+  fi
+  [ "$_REVIEW_WAITED" = "0" ] && echo "$_LIVE_N reviews live (cap $REVIEW_CONCURRENCY_CAP); --queue given, waiting up to ${REVIEW_QUEUE_SECONDS}s for a slot..."
+  sleep 10
+  _REVIEW_WAITED=$(( _REVIEW_WAITED + 10 ))
+done
+printf '%s' "$$" > "$REVIEW_PID_FILE" 2>/dev/null && REVIEW_PID_WRITTEN=1
+# ARMED BEFORE THE FIRST THING THAT CAN EXIT. Every refusal below this line is a
+# path the pid file has to survive, and the worktree lock's own trap further down
+# REPLACES this one, so that line clears both. A trap set after the first exit
+# path is a trap that leaks on exactly the failures it exists for.
+trap '_review_pid_release' EXIT
 
 # WHAT THE ENGINE CHANGES. Everything else below this block is shared, which is
 # the whole reason this is a flag and not a second script.
@@ -298,6 +408,18 @@ REVIEW_UNUSABLE=0
 
 mkdir -p "$ENGINE_DIR" "$VERDICT_DIR"
 TS() { date -u +%Y-%m-%dT%H:%M:%SZ; }
+
+# THE ONE DEFINITION of the marker that says "this head already has a verdict"
+# (sp-fa810306). Written into every posted comment, read back before every run.
+# An HTML comment because GitHub does not render it: the marker is for machines,
+# and a visible one would be the first thing a human asked to have removed.
+#
+# WHY A MARKER AND NOT THE SHA IN PROSE. A sha appears inside a diff, inside a
+# quoted earlier comment, and inside anything a person pastes, so grepping the
+# comment text for the sha fires on comments that are not verdicts. WHY NOT THE
+# LOCAL VERDICT RECORD: the whole scar is a local record disagreeing with what
+# GitHub holds, so the check has to read GitHub.
+review_head_marker() { printf '<!-- kipi-reviewer: head=%s -->' "${1:-}"; }
 REVIEW="$ENGINE_DIR/$(artifact_key "$REVIEW_SLUG" "$PR")-$(date +%Y%m%d-%H%M%S).md"
 
 # Same bash wall clock as the worker: macOS ships no `timeout` without coreutils,
@@ -513,7 +635,9 @@ release_wt_lock() {
   fi
   _wt_lock_path=""
 }
-trap 'release_wt_lock' EXIT
+# REPLACES the pid-only trap armed above; bash keeps one EXIT trap, so this line
+# has to clear BOTH or the pid file leaks from here on.
+trap 'release_wt_lock; _review_pid_release' EXIT
 
 review_worktree() {  # review_worktree <sha> -> prints path, or nothing
   # KEYED BY REPO AND PR (ASK-738). One shared review-trees/pr-<N> path meant

--- a/q-system/.q-system/scripts/pr-review-agent.sh
+++ b/q-system/.q-system/scripts/pr-review-agent.sh
@@ -273,26 +273,35 @@ REVIEW_PID_WRITTEN=0
 REVIEW_CONCURRENCY_CAP="${KIPI_REVIEW_CONCURRENCY_CAP:-2}"
 REVIEW_QUEUE_SECONDS="${KIPI_REVIEW_QUEUE_SECONDS:-900}"
 
+_pid_in_file() { tr -dc '0-9' < "${1:-}" 2>/dev/null | head -c 12; }
+
 _review_pid_release() {
   # ONLY OUR OWN. Removing a pid file whose contents are someone else's pid would
   # release THEIR slot, which is the concurrent-reviewer defect wearing a cleanup
   # costume -- the same reasoning release_wt_lock already carries below.
   [ "$REVIEW_PID_WRITTEN" = "1" ] || return 0
-  if [ "$(tr -dc '0-9' < "$REVIEW_PID_FILE" 2>/dev/null | head -c 12)" = "$$" ]; then
+  if [ "$(_pid_in_file "$REVIEW_PID_FILE")" = "$$" ]; then
     command rm -f "$REVIEW_PID_FILE" 2>/dev/null || true
   fi
   REVIEW_PID_WRITTEN=0
 }
 
-# _live_review_pids -> one "<pidfile> <pid>" line per LIVE run other than ours.
+# _live_review_pids -> one "<pidfile> <pid>" line per LIVE run that is not US.
 # Reaps stale files as it goes: the scan is the only thing that ever runs after a
 # killed reviewer, so if it does not clean up, nothing does.
+#
+# SKIPS BY PID, NEVER BY PATH (round 1 major, 2026-09-07). The first cut skipped
+# `$REVIEW_PID_FILE` by name, which is exactly the file a SECOND RUN ON THE SAME
+# PR writes -- so the one collision that matters most was the one collision the
+# scan could not see, and the second run then overwrote the incumbent's pid,
+# silently taking over its slot while both read the same detached worktree.
+# Identity is the pid, so that is what the skip compares.
 _live_review_pids() {
   local f pid
   for f in "$REVIEW_PID_DIR"/*.pid; do
     [ -f "$f" ] || continue
-    [ "$f" = "$REVIEW_PID_FILE" ] && continue
-    pid="$(tr -dc '0-9' < "$f" 2>/dev/null | head -c 12)"
+    pid="$(_pid_in_file "$f")"
+    [ "$pid" = "$$" ] && continue
     if [ -n "$pid" ] && kill -0 "$pid" 2>/dev/null; then
       printf '%s %s\n' "$f" "$pid"
     else
@@ -305,22 +314,36 @@ _live_review_pids() {
 mkdir -p "$REVIEW_PID_DIR" 2>/dev/null || true
 _REVIEW_WAITED=0
 while :; do
+  # The scan runs first because it is what reclaims stale files, including this
+  # PR's own -- so anything still on disk afterwards holds a pid that is alive.
   _LIVE="$(_live_review_pids)"
   _LIVE_N="$(printf '%s' "$_LIVE" | grep -c . || true)"
-  [ "${_LIVE_N:-0}" -lt "$REVIEW_CONCURRENCY_CAP" ] && break
+  _MINE="$(_pid_in_file "$REVIEW_PID_FILE")"
+  _BLOCK=""
+  if [ -n "$_MINE" ] && [ "$_MINE" != "$$" ]; then
+    # A SECOND RUN ON THE SAME PR IS REFUSED BELOW THE CAP, and that is not the
+    # cap being strict. Two runs on one PR share ONE detached review tree and ONE
+    # pid file: the second re-checkouts the tree while the first is reading files
+    # out of it, and both stamp verdicts with the sha they think they read. The
+    # numeric cap cannot express that, because one incumbent is under it.
+    _BLOCK="a review of PR #$PR is already live (pid $_MINE). Two runs on one PR share one detached worktree and one pid file, so the second would re-checkout that tree under the first."
+  elif [ "${_LIVE_N:-0}" -ge "$REVIEW_CONCURRENCY_CAP" ]; then
+    _BLOCK="$_LIVE_N reviews are already live (cap $REVIEW_CONCURRENCY_CAP)."
+  fi
+  [ -z "$_BLOCK" ] && break
   if [ "$QUEUE" != "1" ]; then
-    echo "REFUSING: $_LIVE_N reviews are already live (cap $REVIEW_CONCURRENCY_CAP). No review was dispatched and NO status was posted." >&2
+    echo "REFUSING: $_BLOCK No review was dispatched and NO status was posted." >&2
     printf '%s\n' "$_LIVE" | sed 's/^/  live: /' >&2
-    echo "  Wait for one to finish, or re-run with --queue to wait up to ${REVIEW_QUEUE_SECONDS}s for a slot." >&2
+    echo "  Wait for it to finish, or re-run with --queue to wait up to ${REVIEW_QUEUE_SECONDS}s for a slot." >&2
     exit 3
   fi
   # BOUNDED WAIT, NOT AN OPEN ONE. An unbounded queue turns a stuck reviewer into
   # a pile of blocked reviewers that all wake at once when it dies.
   if [ "$_REVIEW_WAITED" -ge "$REVIEW_QUEUE_SECONDS" ]; then
-    echo "REFUSING: waited ${_REVIEW_WAITED}s for a slot and $_LIVE_N reviews are still live (cap $REVIEW_CONCURRENCY_CAP). No review was dispatched and NO status was posted." >&2
+    echo "REFUSING: waited ${_REVIEW_WAITED}s for a slot and it is still blocked: $_BLOCK No review was dispatched and NO status was posted." >&2
     exit 3
   fi
-  [ "$_REVIEW_WAITED" = "0" ] && echo "$_LIVE_N reviews live (cap $REVIEW_CONCURRENCY_CAP); --queue given, waiting up to ${REVIEW_QUEUE_SECONDS}s for a slot..."
+  [ "$_REVIEW_WAITED" = "0" ] && echo "blocked: $_BLOCK --queue given, waiting up to ${REVIEW_QUEUE_SECONDS}s for a slot..."
   sleep 10
   _REVIEW_WAITED=$(( _REVIEW_WAITED + 10 ))
 done
@@ -1543,6 +1566,18 @@ if [ "$POST" = "1" ]; then
   # them separate is what makes the degraded path safe: with no temp file we post
   # the raw review unchanged and write nothing, instead of redirecting into the
   # artifact we are trying to read.
+  # THE MARKER MEANS "A VERDICT WAS PUBLISHED ON THIS HEAD", NOT "A RUN HAPPENED"
+  # (round 1 major, 2026-09-07). The first cut stamped it on every posted comment,
+  # UNUSABLE reviews included. An unusable review posts state=failure and states no
+  # verdict, so that head then carried a red required check AND a marker that made
+  # every automated re-review exit 3 -- a wedge no unattended path could clear,
+  # because --force is a hand-typed flag. The guard exists to stop a re-review from
+  # overturning an EARNED verdict; a review nobody could read earned nothing, so it
+  # must not claim the head.
+  MARK_HEAD=0
+  if [ "$REVIEW_USABLE" = "1" ] && [ -n "$VERDICT" ]; then MARK_HEAD=1; fi
+  [ "$MARK_HEAD" = "1" ] \
+    || echo "  NOTE: this review is unusable or states no verdict, so the comment carries NO head marker and a later run may re-review ${HEAD_SHA:0:8} without --force."
   if [ -n "$REVIEW_BODY" ]; then
     # THE MARKER LEADS THE BODY, and the position is load-bearing. It is what the
     # duplicate-run refusal at the top of this script greps for, and
@@ -1550,7 +1585,7 @@ if [ "$POST" = "1" ]; then
     # body would be the first thing a long review dropped -- the guard would then
     # be silently disarmed on exactly the reviews that run longest.
     {
-      review_head_marker "$HEAD_SHA"; printf '\n\n'
+      [ "$MARK_HEAD" = "1" ] && { review_head_marker "$HEAD_SHA"; printf '\n\n'; }
       review_comment_body "$REVIEW" "$VERDICT" "$ENGINE" "$DEGRADED"
       # The structural warning rides INSIDE the comment rather than only in this
       # log, because the log belongs to whoever ran the reviewer and the PR is
@@ -1560,7 +1595,7 @@ if [ "$POST" = "1" ]; then
     POST_FILE="$REVIEW_BODY"
   else
     POST_FILE="$REVIEW"
-    echo "  WARN: could not create a temp file; posting the RAW review, which GitHub may reject on size. The head marker is NOT in this body, so a later run will not see this verdict and may re-review the same head (sp-fa810306)." >&2
+    echo "  WARN: could not create a temp file; posting the RAW review, which GitHub may reject on size. The head marker is NOT in this body, so a later run will not see this verdict and may re-review the same head (sp-fa810306). Erring toward a duplicate round is the safe direction here: the other way is a wedge no unattended run can clear." >&2
   fi
   # Keep the reason. A bare "could not comment" sent the maintainer to guess
   # between a size rejection, an auth failure and a closed PR -- the same

--- a/q-system/.q-system/scripts/pr-review-agent.sh
+++ b/q-system/.q-system/scripts/pr-review-agent.sh
@@ -1284,9 +1284,27 @@ FINAL_EXIT=0
 # _finding_files <review-file> -> the deduped, sorted file paths its findings cite.
 # Rows are `severity|claim|file:line`; the line number is dropped because a fix
 # that moves a defect down three lines is the same defect.
+#
+# `cut`, NOT awk, and that is not a style preference (CI red, 2026-09-07). The
+# first cut read the third field as awk's `$3`, and validate-separation's
+# propagation-leak classifier reads `$` followed by a digit as a CURRENCY token:
+# the line landed in test-propagation-leak-baseline.py as a new `pricing` fact
+# the committed baseline did not account for, and turned `validate` red on a
+# change that has nothing to do with pricing. A shell field split says the same
+# thing with no character the fleet's own detectors read as money.
+#
+# THE `grep -E` IS LOAD-BEARING, and the disjoint-files control is what caught it.
+# `cut -d'|' -f3` returns the WHOLE LINE when the line has no delimiter, and
+# findings_block's output carries the `FINDINGS:` / `END FINDINGS` markers. So the
+# first cut compared those two marker strings as if they were file paths, found
+# them in both rounds, and printed STRUCTURAL on two rounds that shared nothing.
+# awk's `NF>=3` had been doing this filtering implicitly; moving off awk moved the
+# guard too. Two pipes required first, then the third field means something.
 _finding_files() {
   findings_block "${1:-}" \
-    | awk -F'|' 'NF>=3 { loc=$3; sub(/:[0-9-]*$/, "", loc); gsub(/^[ \t]+|[ \t]+$/, "", loc); if (loc != "") print loc }' \
+    | grep -E '^[^|]*\|[^|]*\|' \
+    | cut -d'|' -f3 \
+    | sed -e 's/:[0-9-]*$//' -e 's/^[[:space:]]*//' -e 's/[[:space:]]*$//' -e '/^$/d' \
     | sort -u
 }
 

--- a/q-system/.q-system/scripts/pr-review-agent.sh
+++ b/q-system/.q-system/scripts/pr-review-agent.sh
@@ -474,6 +474,38 @@ if [ -n "$HEAD_SHA_CONFIRM" ] && [ "$HEAD_SHA_CONFIRM" != "$HEAD_SHA" ]; then
   echo "  Re-run once the branch settles. No review was dispatched and NO status was posted." >&2
   exit 1
 fi
+# A HEAD THAT ALREADY CARRIES A VERDICT IS NOT RE-REVIEWED (sp-fa810306).
+#
+# THE SCAR, exact: on 2026-09-07 round 3 of PR #314 posted APPROVE WITH NITS as a
+# comment at 00:29:47Z on head adc29516, the process died before the commit status
+# landed, and the next session read `gh api statuses adc29516` as empty. Empty
+# looked like "never reviewed", so the same head was re-run at 00:36:54Z -- and
+# that re-run returned REQUEST CHANGES, overturning an approval that had already
+# been earned. Two more rounds and about 90 minutes.
+#
+# THE COMMENT IS THE DURABLE RECORD, NOT THE STATUS, and that is the whole point
+# of checking it here. The status post is the thing that was lost; the comment is
+# the thing that survived. So this asks the question the re-running session should
+# have asked: has a reviewer already published a verdict on THIS EXACT COMMIT?
+# Posting the status BEFORE the comment (further down) closes the other half.
+#
+# FAILS OPEN. A gh outage, a network error, or a PR with no comments all yield
+# zero hits and the review proceeds. Refusing on an unreadable comment list would
+# wedge every review on a GitHub blip, which is worse than one duplicate round --
+# and the duplicate round is what the caller asked for in the first place.
+if [ -n "$HEAD_SHA" ]; then
+  DUP_MARKER="$(review_head_marker "$HEAD_SHA")"
+  DUP_HITS="$(gh pr view "$PR" $KIPI_GH_REPO_ARGS --json comments -q '.comments[].body' 2>/dev/null | grep -F -c -- "$DUP_MARKER" || true)"
+  DUP_HITS="$(printf '%s' "${DUP_HITS:-0}" | tr -dc '0-9')"
+  [ -n "$DUP_HITS" ] || DUP_HITS=0
+  if [ "$DUP_HITS" -gt 0 ] && [ "$FORCE" != "1" ]; then
+    echo "REFUSING: PR #$PR head ${HEAD_SHA:0:8} already carries $DUP_HITS reviewer verdict comment(s). Re-reviewing a head that has already been judged can only overturn a verdict that was already earned (sp-fa810306). No review was dispatched and NO status was posted." >&2
+    echo "  Read the existing verdict on the PR, or pass --force if a second opinion on the same commit is what you actually want." >&2
+    exit 3
+  fi
+  [ "$DUP_HITS" -gt 0 ] && echo "  NOTE: ${HEAD_SHA:0:8} already carries $DUP_HITS verdict comment(s); --force given, reviewing it again."
+fi
+
 [ -n "$ISSUE" ] || ISSUE="$(printf '%s' "$PR_TITLE" | grep -oE 'ASK-[0-9]+' | head -1)"
 
 echo "$(TS) reviewing PR #$PR: $PR_TITLE"
@@ -1195,6 +1227,81 @@ else
 fi
 echo "  verdict: ${VERDICT:-unstated}$DRY_NOTE"
 
+# TWO CONSECUTIVE REQUEST CHANGES ROUNDS THAT SHARE A FILE MEAN THE FIX SHAPE IS
+# WRONG (sp-46726f79).
+#
+# THE SCAR, measured: rounds 1, 2 and 3 of PR #314 each named ANOTHER unwaited
+# index write. Three patches, one class, and nothing in the tooling said so -- the
+# round cap came from the founder at 01:09Z. The same shape burned seven rounds on
+# 2026-09-03. A reviewer that can see it and does not say it is the cheapest
+# possible miss, because it already holds both rounds' findings.
+#
+# WHAT IT COMPARES AND WHY THAT SOURCE. The `.verdict.json` record is ONE file per
+# PR, overwritten every round, so it cannot answer a question about two rounds.
+# The per-round history that does exist is this engine's own review artifacts,
+# `$ENGINE_DIR/<artifact_key>-<stamp>.md`, which is what review_round already
+# counts. Sorted by name is sorted by time: the stamp is %Y%m%d-%H%M%S.
+#
+# THROUGH THE ONE READER. Both findings blocks come from `findings_block`
+# (sp-c0a9dac3), never a fresh sed range here -- a second extractor is how the
+# comment, the gate and this check end up disagreeing about what a review said.
+#
+# ADVISORY, NEVER A BLOCK. It exits 4 AFTER the post completes, so a queue script
+# can stop while the human-readable verdict still reaches the PR. Blocking the
+# post would trade a wrong-shape warning for a lost review, which is the trade
+# this whole file exists to refuse.
+#
+# HONEST BOUNDARY: it matches on the file path a finding cites, so two genuinely
+# different defects in one long file read as the same class, and one defect that
+# moved to a different file reads as two classes. It is a prompt to think, not a
+# proof, which is why it advises and does not gate.
+STRUCTURAL_LINE=""
+FINAL_EXIT=0
+
+# _finding_files <review-file> -> the deduped, sorted file paths its findings cite.
+# Rows are `severity|claim|file:line`; the line number is dropped because a fix
+# that moves a defect down three lines is the same defect.
+_finding_files() {
+  findings_block "${1:-}" \
+    | awk -F'|' 'NF>=3 { loc=$3; sub(/:[0-9-]*$/, "", loc); gsub(/^[ \t]+|[ \t]+$/, "", loc); if (loc != "") print loc }' \
+    | sort -u
+}
+
+case "$VERDICT" in
+  "REQUEST CHANGES"|"BLOCK")
+    PREV_REVIEW=""; PREV_ROUND=0; CUR_ROUND=0; _sr_n=0
+    while IFS= read -r _sr_f; do
+      [ -n "$_sr_f" ] || continue
+      _sr_n=$(( _sr_n + 1 ))
+      if [ "$_sr_f" = "$REVIEW" ]; then CUR_ROUND="$_sr_n"; continue; fi
+      _sr_v="$(resolve_verdict "$(extract_verdict "$_sr_f")" "$(verdict_from_findings "$_sr_f")")"
+      case "$_sr_v" in
+        "REQUEST CHANGES"|"BLOCK") PREV_REVIEW="$_sr_f"; PREV_ROUND="$_sr_n" ;;
+      esac
+    done <<EOF
+$(ls -1 "$ENGINE_DIR/$(artifact_key "$REVIEW_SLUG" "$PR")-"*.md 2>/dev/null | sort)
+EOF
+    if [ -n "$PREV_REVIEW" ]; then
+      _sr_prev="$(mktemp "${TMPDIR:-/tmp}/pr-review-prev.XXXXXX" 2>/dev/null)" || _sr_prev=""
+      _sr_cur="$(mktemp "${TMPDIR:-/tmp}/pr-review-cur.XXXXXX" 2>/dev/null)" || _sr_cur=""
+      if [ -n "$_sr_prev" ] && [ -n "$_sr_cur" ]; then
+        _finding_files "$PREV_REVIEW" > "$_sr_prev"
+        _finding_files "$REVIEW"      > "$_sr_cur"
+        # `comm -12` needs both sides sorted, which _finding_files guarantees.
+        _sr_shared="$(comm -12 "$_sr_prev" "$_sr_cur" 2>/dev/null | tr '\n' ' ' | sed 's/ *$//')"
+        command rm -f "$_sr_prev" "$_sr_cur" 2>/dev/null || true
+        if [ -n "$_sr_shared" ]; then
+          STRUCTURAL_LINE="STRUCTURAL: round $CUR_ROUND and round $PREV_ROUND both request changes in the same file(s): $_sr_shared. Two rounds naming one file is a wrong fix SHAPE, not two bugs. Sweep the whole class in one pass or park the PR; a third patch on the same file is the loop this warning exists to stop (sp-46726f79)."
+          FINAL_EXIT=4
+          echo "  $STRUCTURAL_LINE"
+        fi
+      else
+        echo "  WARN: could not create temp files for the structural comparison; skipping it. Two rounds on one file will not be flagged on this run." >&2
+      fi
+    fi
+    ;;
+esac
+
 # Single writer for verdict state. The worker's rework gate reads THIS record,
 # never the review prose. Keyed by PR number, latest round wins; history stays
 # in the timestamped .md files.
@@ -1376,6 +1483,33 @@ post_reviewer_status() {
 
 if [ "$POST" = "1" ]; then
   COMMENT_URL=""
+  # THE STATUS GOES FIRST, BEFORE THE COMMENT (sp-fa810306). This ordering is the
+  # fix, and it is the whole reason this block moved.
+  #
+  # THE SCAR, exact: on 2026-09-07 round 3 of PR #314 posted its APPROVE WITH NITS
+  # comment at 00:29:47Z and the process died before the commit status call. The
+  # approval existed as prose and did not exist as a gate, so the next session read
+  # `gh api statuses adc29516` as empty, re-ran the same head, and the re-run
+  # returned REQUEST CHANGES. An earned approval was overturned by a kill.
+  #
+  # WHICH HALF TO LOSE. A kill can land between any two calls; the only choice is
+  # which one survives it. The comment is 60 KB of prose a human reads later; the
+  # status is the one thing a required check, converge.sh and the next session all
+  # read. Losing prose costs a re-read of the review file on disk. Losing the
+  # status costs a whole re-review that can overturn the verdict. So the status
+  # goes first, unconditionally.
+  #
+  # POSTED TWICE, ON PURPOSE, AND NOT A SECOND WRITER. Commit statuses append and
+  # the latest wins, so the second call below re-posts the SAME context with the
+  # SAME $VERDICT and adds only target_url once the comment URL exists. The value
+  # a gate reads cannot differ between the two calls, because both read $VERDICT,
+  # which was computed once, above. If the run dies between them the first post
+  # stands, missing only its link.
+  if [ -n "$HEAD_SHA" ]; then
+    post_reviewer_status "$HEAD_SHA" "$VERDICT" ""
+  else
+    echo "  no head sha for PR #$PR: posting NO commit status (a status on a guessed sha looks authoritative)"
+  fi
   # POST THE RENDERED REVIEW, NEVER THE RAW FILE (sp-48688b24). `--body-file
   # "$REVIEW"` sent the codex agent's entire stdout. Measured on disk 2026-07-30,
   # four real rounds: 435,280 / 519,377 / 278,439 / 197,279 bytes. Three were
@@ -1410,11 +1544,23 @@ if [ "$POST" = "1" ]; then
   # the raw review unchanged and write nothing, instead of redirecting into the
   # artifact we are trying to read.
   if [ -n "$REVIEW_BODY" ]; then
-    review_comment_body "$REVIEW" "$VERDICT" "$ENGINE" "$DEGRADED" >"$REVIEW_BODY"
+    # THE MARKER LEADS THE BODY, and the position is load-bearing. It is what the
+    # duplicate-run refusal at the top of this script greps for, and
+    # review_comment_body truncates from the END, so a marker appended after the
+    # body would be the first thing a long review dropped -- the guard would then
+    # be silently disarmed on exactly the reviews that run longest.
+    {
+      review_head_marker "$HEAD_SHA"; printf '\n\n'
+      review_comment_body "$REVIEW" "$VERDICT" "$ENGINE" "$DEGRADED"
+      # The structural warning rides INSIDE the comment rather than only in this
+      # log, because the log belongs to whoever ran the reviewer and the PR is
+      # where the next person decides whether to patch again.
+      [ -n "$STRUCTURAL_LINE" ] && printf '\n**%s**\n' "$STRUCTURAL_LINE"
+    } >"$REVIEW_BODY"
     POST_FILE="$REVIEW_BODY"
   else
     POST_FILE="$REVIEW"
-    echo "  WARN: could not create a temp file; posting the RAW review, which GitHub may reject on size" >&2
+    echo "  WARN: could not create a temp file; posting the RAW review, which GitHub may reject on size. The head marker is NOT in this body, so a later run will not see this verdict and may re-review the same head (sp-fa810306)." >&2
   fi
   # Keep the reason. A bare "could not comment" sent the maintainer to guess
   # between a size rejection, an auth failure and a closed PR -- the same
@@ -1428,13 +1574,16 @@ if [ "$POST" = "1" ]; then
     echo "  WARN: the review is on disk at $REVIEW but NO human-readable copy reached the PR" >&2
   fi
   rm -f "$REVIEW_BODY" "$COMMENT_ERR"
-  # No sha, no status. A status on a guessed commit is worse than none because
-  # it looks authoritative -- the same reason ASK-216 captured the sha before
-  # dispatch instead of looking it up afterwards.
-  if [ -n "$HEAD_SHA" ]; then
+  # THE SECOND POST IS AN ENRICHMENT, NOT THE POST. The gate already moved above,
+  # before the comment, so this call exists only to attach target_url to a status
+  # that is already correct. It is skipped when there is no URL to attach: a
+  # re-post carrying nothing new would be two writes for one fact, and the first
+  # one already said everything a gate reads.
+  #
+  # No sha, no status -- the same rule as above. A status on a guessed commit is
+  # worse than none because it looks authoritative (ASK-216).
+  if [ -n "$HEAD_SHA" ] && [ -n "$COMMENT_URL" ]; then
     post_reviewer_status "$HEAD_SHA" "$VERDICT" "$COMMENT_URL"
-  else
-    echo "  no head sha for PR #$PR: posting NO commit status (a status on a guessed sha looks authoritative)"
   fi
   if [ -n "$ISSUE" ]; then
     # THE REVIEWER'S HALF OF THE CONVERSATION (ASK-221, founder directive
@@ -1498,4 +1647,9 @@ Sana: reply to this comment on THIS issue. For each finding, either the file:lin
 fi
 
 echo "$(TS) done$DRY_NOTE"
-exit 0
+# EXIT 4 MEANS "IT ALL WORKED AND THE NEXT PATCH IS THE WRONG MOVE" (sp-46726f79).
+# It is reached only AFTER the post, so a caller that treats non-zero as failure
+# still has its comment and its commit status. Callers that care read the code;
+# callers that do not are no worse off than before, because the outward side
+# effects are identical either way.
+exit "${FINAL_EXIT:-0}"

--- a/q-system/.q-system/scripts/test/test-review-run-safety.sh
+++ b/q-system/.q-system/scripts/test/test-review-run-safety.sh
@@ -311,7 +311,7 @@ ok "a single REQUEST CHANGES round exits 0 (nothing to compare against yet)"
 
 set_review "REQUEST CHANGES" "major|second unwaited write in the same file|FILE.txt:42"
 : > "$GH_LOG"
-COMMENT_BODIES="$WORK/posted-bodies.txt"; : > "$COMMENT_BODIES"
+: > "$COMMENTS_FILE"   # see the note above round 1: one fixture sha serves both rounds
 run_reviewer "$WORK/rc2.out" struct --post
 RC_R2=$?
 echo "  [ctx] structural round 2 rc=$RC_R2"
@@ -352,10 +352,12 @@ ok "the structural round still posted its commit status"
 # ===========================================================================
 set_review "REQUEST CHANGES" "major|a different defect elsewhere|OTHER.txt:3"
 : > "$GH_LOG"
+: > "$COMMENTS_FILE"
 run_reviewer "$WORK/rc3.out" disjoint --post
 RC_D1=$?
 set_review "REQUEST CHANGES" "major|another different defect|THIRD.txt:9"
 : > "$GH_LOG"
+: > "$COMMENTS_FILE"
 run_reviewer "$WORK/rc4.out" disjoint --post
 RC_D2=$?
 echo "  [ctx] disjoint rounds rc=$RC_D1 then rc=$RC_D2"
@@ -369,5 +371,106 @@ ok "two rounds on different files print no STRUCTURAL line"
   || fail "the disjoint second round exited $RC_D2, expected 0:
 $(tail -20 "$WORK/rc4.out")"
 ok "the disjoint second round exits 0"
+
+# ===========================================================================
+# CASE 7 -- the same-PR collision the numeric cap cannot see (round 1 major).
+#
+# THE DEFECT the first cut shipped: _live_review_pids skipped the scan entry
+# whose PATH equalled our own pid file. Two runs on ONE PR write that same path,
+# so the one collision that matters most was the one collision the scan was blind
+# to -- and the second run then overwrote the incumbent's pid, silently taking
+# over its slot while both read and re-checked-out the same detached worktree.
+#
+# RED-MAKING INPUT: one live pid file for THIS PR (assafkip_homerepo__pr-1) and
+# nothing else. Against the path-skipping version the run exits 0 and reviews.
+# The numeric cap cannot catch it: one incumbent is under a cap of two.
+# ===========================================================================
+: > "$COMMENTS_FILE"
+PIDDIR2="$WORK/home-samepr/.config/kipi/review-trees"; mkdir -p "$PIDDIR2"
+sleep 120 & SAME_PR_LIVE=$!
+printf '%s' "$SAME_PR_LIVE" > "$PIDDIR2/assafkip_homerepo__pr-1.pid"
+: > "$GH_LOG"
+run_reviewer "$WORK/samepr.out" samepr --post
+RC_SAMEPR=$?
+echo "  [ctx] same-PR incumbent run rc=$RC_SAMEPR (live pid $SAME_PR_LIVE)"
+
+[ "$RC_SAMEPR" = "3" ] \
+  || fail "a second review of PR #1 started while one was already live (rc=$RC_SAMEPR, expected 3). Both share one detached worktree and one pid file, so the second re-checkouts the tree under the first:
+$(tail -20 "$WORK/samepr.out")"
+ok "a live run on the SAME PR refuses a second run with exit 3, below the numeric cap"
+
+grep -q "statuses/$SHA" "$GH_LOG" \
+  && fail "the same-PR refusal still posted a commit status"
+ok "the same-PR refusal posted no commit status"
+
+# The incumbent's pid file must survive untouched. A refusal that clears the
+# file it refused on would hand the slot to the next arrival and defeat itself.
+[ "$(cat "$PIDDIR2/assafkip_homerepo__pr-1.pid" 2>/dev/null)" = "$SAME_PR_LIVE" ] \
+  || fail "the refused run overwrote or removed the incumbent's pid file; the slot was taken over by the run that was supposed to back off"
+ok "the incumbent's pid file is left exactly as it was"
+
+kill "$SAME_PR_LIVE" 2>/dev/null || true
+wait "$SAME_PR_LIVE" 2>/dev/null || true
+
+# ===========================================================================
+# CASE 8 -- an UNUSABLE review must not claim the head (round 1 major).
+#
+# THE DEFECT the first cut shipped: the head marker went into EVERY posted
+# comment. An unusable review posts state=failure and states no verdict, so that
+# head then carried a red required check AND a marker that made every later
+# automated re-review exit 3. Nothing unattended could clear it, because --force
+# is a flag a human types. The guard exists to protect an EARNED verdict; a
+# review nobody could read earned nothing.
+#
+# RED-MAKING INPUT: an engine stream with an unclosed FINDINGS block (exactly
+# what review_is_usable refuses), followed by a second run on the same head.
+# Against the first cut the second run exits 3. It must proceed.
+# ===========================================================================
+: > "$COMMENTS_FILE"
+printf 'VERDICT: APPROVE\nFINDINGS:\n' > "$ENGINE_OUT"   # never closed: unusable
+: > "$GH_LOG"
+run_reviewer "$WORK/unusable1.out" unusable --post
+RC_U1=$?
+echo "  [ctx] unusable review rc=$RC_U1"
+
+grep -q "pr comment" "$GH_LOG" \
+  || fail "the unusable review posted no comment at all, so this case cannot test what the comment carried:
+$(sed 's/^/        /' "$GH_LOG")"
+ok "precondition: the unusable review still posted its comment"
+
+grep -q -- "kipi-reviewer: head=$SHA" "$COMMENTS_FILE" \
+  && fail "an UNUSABLE review stamped the head marker. That head now carries a failing required status AND a marker that makes every automated re-review exit 3 -- a wedge no unattended run can clear:
+$(head -3 "$COMMENTS_FILE")"
+ok "an unusable review posts NO head marker"
+
+: > "$GH_LOG"
+run_reviewer "$WORK/unusable2.out" unusable2 --post
+RC_U2=$?
+echo "  [ctx] re-review after an unusable round rc=$RC_U2"
+[ "$RC_U2" != "3" ] \
+  || fail "a head whose only review was UNUSABLE refused a re-review (rc=3). Nothing unattended could ever clear that PR:
+$(tail -20 "$WORK/unusable2.out")"
+ok "a head whose only review was unusable can still be re-reviewed"
+
+# THE POSITIVE CONTROL for the same mechanism, and it is what makes case 8
+# non-vacuous: without it, "never stamp the marker" would pass this suite. A
+# USABLE review must stamp it, and the next run must then refuse.
+: > "$COMMENTS_FILE"
+set_review "APPROVE WITH NITS" "nit|trailing whitespace|FILE.txt:1"
+: > "$GH_LOG"
+run_reviewer "$WORK/roundtrip1.out" roundtrip --post
+grep -q -- "kipi-reviewer: head=$SHA" "$COMMENTS_FILE" \
+  || fail "a USABLE approving review did not stamp the head marker, so the duplicate guard is disarmed on exactly the verdicts it exists to protect:
+$(head -3 "$COMMENTS_FILE")"
+ok "a usable review DOES stamp the head marker"
+
+: > "$GH_LOG"
+run_reviewer "$WORK/roundtrip2.out" roundtrip2 --post
+RC_RT2=$?
+echo "  [ctx] re-review after a usable round rc=$RC_RT2"
+[ "$RC_RT2" = "3" ] \
+  || fail "the marker written by a real run did not make the next run refuse (rc=$RC_RT2). The writer and the reader disagree about the string:
+$(tail -20 "$WORK/roundtrip2.out")"
+ok "the marker round-trips: a real run's comment refuses the next run on that head"
 
 echo "PASS ($PASS checks) test-review-run-safety.sh"

--- a/q-system/.q-system/scripts/test/test-review-run-safety.sh
+++ b/q-system/.q-system/scripts/test/test-review-run-safety.sh
@@ -63,6 +63,10 @@ SHA="$(git -C "$WORK/skel" rev-parse HEAD)"
 # COMMENTS_FILE lets a case seed the PR's existing comments; absent means none.
 GH_LOG="$WORK/gh-calls.txt"; : > "$GH_LOG"
 COMMENTS_FILE="$WORK/pr-comments.txt"; : > "$COMMENTS_FILE"
+# THE STUB APPENDS EVERY POSTED BODY TO COMMENTS_FILE, so the head marker really
+# round-trips writer to reader: what the reviewer writes into a comment is what
+# the next run reads back. A hand-seeded marker only tests the reader's parser;
+# this tests that the two halves agree about the string.
 cat > "$STUB/gh" <<EOF
 #!/usr/bin/env bash
 printf '%s\n' "\$*" >> "$GH_LOG"
@@ -70,7 +74,11 @@ case "\$*" in
   *"pr view"*"headRefOid"*) printf '%s\t%s\n' "$SHA" "a PR title" ;;
   *"pr view"*"comments"*)   cat "$COMMENTS_FILE" ;;
   *"pr diff"*)              echo "diff --git a/FILE.txt b/FILE.txt" ;;
-  *"pr comment"*)           echo "https://github.com/assafkip/homerepo/pull/1#issuecomment-1" ;;
+  *"pr comment"*)
+    bf=""; prev=""
+    for a in "\$@"; do [ "\$prev" = "--body-file" ] && bf="\$a"; prev="\$a"; done
+    [ -n "\$bf" ] && [ -f "\$bf" ] && cat "\$bf" >> "$COMMENTS_FILE"
+    echo "https://github.com/assafkip/homerepo/pull/1#issuecomment-1" ;;
   *"api"*)                  echo '{}' ;;
 esac
 exit 0
@@ -228,6 +236,9 @@ ok "a non-verdict comment naming the sha does not trigger the refusal"
 # ===========================================================================
 : > "$COMMENTS_FILE"
 PIDDIR="$WORK/home-conc/.config/kipi/review-trees"; mkdir -p "$PIDDIR"
+# NOT THIS PR'S OWN FILE. pr-7 and pr-8 are OTHER PRs, so this case measures the
+# numeric cap. The same-PR collision is its own case further down, because the cap
+# cannot express it: one incumbent on this PR is under the cap and still fatal.
 sleep 120 & LIVE1=$!
 sleep 120 & LIVE2=$!
 printf '%s' "$LIVE1" > "$PIDDIR/assafkip_homerepo__pr-7.pid"
@@ -282,6 +293,11 @@ ok "the stale-pid run really did review and post"
 # THE POST IS NOT BLOCKED, and that half is asserted too: a warning that costs
 # the review its comment would be a worse trade than the loop it warns about.
 # ===========================================================================
+# CLEARED BETWEEN ROUNDS, and the reason is a fixture limit worth naming. This
+# repo has one commit, so both "rounds" run against the SAME head sha -- while a
+# real round 2 reviews a new head the author just pushed. Left uncleared, round 2
+# would hit the duplicate-head refusal (correctly), and this case would measure
+# that guard instead of the structural one.
 : > "$COMMENTS_FILE"
 set_review "REQUEST CHANGES" "major|first unwaited write|FILE.txt:10"
 : > "$GH_LOG"

--- a/q-system/.q-system/scripts/test/test-review-run-safety.sh
+++ b/q-system/.q-system/scripts/test/test-review-run-safety.sh
@@ -1,0 +1,357 @@
+#!/usr/bin/env bash
+# Reviewer run safety: the verdict survives a kill, a judged head is not
+# re-reviewed, a third concurrent run is refused, and two rounds on one file say
+# so out loud. sp-fa810306, sp-0a09e013, sp-46726f79.
+#
+# THE THREE SCARS, all measured on 2026-09-05 to 2026-09-07:
+#
+#   sp-fa810306  PR #314 round 3 posted APPROVE WITH NITS as a comment at
+#                00:29:47Z on head adc29516, the process died before the commit
+#                status call, `gh api statuses adc29516` came back empty, and the
+#                next session re-ran the same head at 00:36:54Z. The re-run
+#                returned REQUEST CHANGES and overturned the approval.
+#   sp-0a09e013  five reviewers and watchers killed under memory pressure in one
+#                evening, then a 00:35Z process exit orphaned two more. Nothing on
+#                the box could answer how many reviews were live.
+#   sp-46726f79  rounds 1 to 3 of PR #314 each named another unwaited index write.
+#                Three patches, one class. The round cap came from the founder.
+#
+# HOW THIS DRIVES THE REAL SCRIPT. Same harness as
+# test-review-dry-run-labelled.sh: the SHIPPING pr-review-agent.sh is copied into
+# a fixture repo three levels down so its own root guard passes, and it runs
+# against a `gh` stub, a fake engine, and a HOME under mktemp. No live PR is read,
+# no model is spent, no commit status is posted anywhere real.
+#
+# EVERY REFUSAL CASE NAMES ITS RED-MAKING INPUT, because a check that cannot fail
+# for the reason you care about is decoration (lessons:
+# a-check-must-be-able-to-fail-for-the-reason-you-care-abou). Each one was run
+# against the pre-fix script first and recorded RED; the comments say so per case.
+set -uo pipefail
+
+ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/../../../.." && pwd)"
+SRC_DIR="$ROOT/q-system/.q-system/scripts"
+
+PASS=0
+fail() { echo "FAIL: $1" >&2; exit 1; }
+ok()   { PASS=$((PASS + 1)); echo "  ok: $1"; }
+
+[ -f "$SRC_DIR/pr-review-agent.sh" ] || fail "pr-review-agent.sh missing at $SRC_DIR"
+REAL_GIT="$(command -v git)" || fail "git not on PATH"
+
+WORK="$(mktemp -d)"
+trap 'rm -rf "$WORK"' EXIT
+unset KIPI_TARGET_REPO KIPI_REVIEW_ENGINE KIPI_REVIEW_CONCURRENCY_CAP KIPI_REVIEW_QUEUE_SECONDS 2>/dev/null || true
+
+G() { git -c user.email=t@t.t -c user.name=t "$@"; }
+STUB="$WORK/bin"; mkdir -p "$STUB"
+
+# --- the repo under review, with the control code exactly 3 levels down --------
+mkdir -p "$WORK/skel/q-system/.q-system/scripts"
+git init -q "$WORK/skel"
+echo "code" > "$WORK/skel/FILE.txt"
+cp "$SRC_DIR/pr-review-agent.sh" "$SRC_DIR/pr-verdict-lib.sh" "$SRC_DIR/repo-slug-lib.sh" \
+   "$WORK/skel/q-system/.q-system/scripts/"
+G -C "$WORK/skel" add -A; G -C "$WORK/skel" commit -q -m "control code"
+git -C "$WORK/skel" branch -M main
+git -C "$WORK/skel" remote add origin "https://github.com/assafkip/homerepo.git"
+AGENT="$WORK/skel/q-system/.q-system/scripts/pr-review-agent.sh"
+SHA="$(git -C "$WORK/skel" rev-parse HEAD)"
+
+# --- fake gh ------------------------------------------------------------------
+# Appends every invocation to an ORDERED log, which is what makes "the status was
+# posted before the comment" a measurable fact rather than a reading of the code.
+# COMMENTS_FILE lets a case seed the PR's existing comments; absent means none.
+GH_LOG="$WORK/gh-calls.txt"; : > "$GH_LOG"
+COMMENTS_FILE="$WORK/pr-comments.txt"; : > "$COMMENTS_FILE"
+cat > "$STUB/gh" <<EOF
+#!/usr/bin/env bash
+printf '%s\n' "\$*" >> "$GH_LOG"
+case "\$*" in
+  *"pr view"*"headRefOid"*) printf '%s\t%s\n' "$SHA" "a PR title" ;;
+  *"pr view"*"comments"*)   cat "$COMMENTS_FILE" ;;
+  *"pr diff"*)              echo "diff --git a/FILE.txt b/FILE.txt" ;;
+  *"pr comment"*)           echo "https://github.com/assafkip/homerepo/pull/1#issuecomment-1" ;;
+  *"api"*)                  echo '{}' ;;
+esac
+exit 0
+EOF
+chmod +x "$STUB/gh"
+
+# --- fake engine --------------------------------------------------------------
+# ENGINE_OUT holds whatever review the current case wants the engine to produce,
+# so one stub serves every case and the cases differ only in their review text.
+ENGINE_OUT="$WORK/engine-out.md"
+cat > "$STUB/codex" <<EOF
+#!/usr/bin/env bash
+cat "$ENGINE_OUT"
+exit 0
+EOF
+chmod +x "$STUB/codex"
+printf '#!/usr/bin/env bash\nexit 0\n' > "$STUB/claude"; chmod +x "$STUB/claude"
+export PATH="$STUB:$PATH"
+[ "$(command -v git)" = "$REAL_GIT" ] || fail "git was shadowed by a stub"
+
+set_review() {  # set_review <verdict> <severity|claim|file:line>...
+  local verdict="$1"; shift
+  { printf 'VERDICT: %s\n' "$verdict"
+    printf 'FINDINGS:\n'
+    local row; for row in "$@"; do printf '%s\n' "$row"; done
+    printf 'END FINDINGS\n'; } > "$ENGINE_OUT"
+}
+
+run_reviewer() {  # run_reviewer <out-file> <home-tag> [extra args...]
+  local out="$1" tag="$2"; shift 2
+  ( cd "$WORK/skel" \
+    && HOME="$WORK/home-$tag" KIPI_STATE_DIR="$WORK/state-$tag" KIPI_NOTIFY="/usr/bin/true" \
+       bash "$AGENT" 1 --engine codex "$@" ) >"$out" 2>&1
+  return $?
+}
+
+# ===========================================================================
+# CASE 0 -- NEGATIVE SELF-TESTS for the instruments themselves.
+#
+# Every assertion below reads the gh log for an ORDER or an ABSENCE. If the log
+# cannot record an order, "status came first" is vacuous; if it cannot record a
+# call at all, "nothing was posted" is vacuous. Both are proven here first.
+# ===========================================================================
+( cd "$WORK/skel" && gh api -X POST "repos/assafkip/homerepo/statuses/$SHA" -f state=success >/dev/null 2>&1 )
+( cd "$WORK/skel" && gh pr comment 1 --body-file /dev/null >/dev/null 2>&1 )
+grep -q "statuses/$SHA" "$GH_LOG" \
+  || fail "negative self-test: a real status POST was not recorded in the gh log"
+grep -q "pr comment" "$GH_LOG" \
+  || fail "negative self-test: a real pr comment was not recorded in the gh log"
+FIRST_LINE="$(grep -n "statuses/$SHA" "$GH_LOG" | head -1 | cut -d: -f1)"
+SECOND_LINE="$(grep -n "pr comment" "$GH_LOG" | head -1 | cut -d: -f1)"
+[ "$FIRST_LINE" -lt "$SECOND_LINE" ] \
+  || fail "negative self-test: the log did not preserve the order the two calls were made in; every ordering assertion below would be meaningless"
+ok "negative self-test: the gh log records both call kinds and preserves their order"
+: > "$GH_LOG"
+
+# ===========================================================================
+# CASE 1 -- sp-fa810306: the commit status is posted BEFORE the PR comment.
+#
+# RED-MAKING INPUT, run before the fix: the pre-fix script, whose POST block
+# commented first and then called post_reviewer_status with the comment URL. Run
+# against that script this case reported "pr comment at line 3, status at line 4"
+# and exited 1 here.
+# ===========================================================================
+set_review "APPROVE WITH NITS" "nit|trailing whitespace|FILE.txt:1"
+: > "$COMMENTS_FILE"
+: > "$GH_LOG"
+run_reviewer "$WORK/order.out" order --post
+RC_ORDER=$?
+
+STATUS_AT="$(grep -n "statuses/$SHA" "$GH_LOG" | head -1 | cut -d: -f1)"
+COMMENT_AT="$(grep -n "pr comment" "$GH_LOG" | head -1 | cut -d: -f1)"
+echo "  [ctx] --post run rc=$RC_ORDER  first status at line ${STATUS_AT:-<none>}  first comment at line ${COMMENT_AT:-<none>}"
+
+[ -n "$STATUS_AT" ] \
+  || fail "the --post run posted NO commit status at all:
+$(sed 's/^/        /' "$GH_LOG")
+$(tail -20 "$WORK/order.out")"
+[ -n "$COMMENT_AT" ] \
+  || fail "the --post run posted NO comment, so there is no ordering to check:
+$(sed 's/^/        /' "$GH_LOG")"
+ok "precondition: the --post run posted both a commit status and a comment"
+
+[ "$STATUS_AT" -lt "$COMMENT_AT" ] \
+  || fail "THE COMMENT WENT FIRST (status line $STATUS_AT, comment line $COMMENT_AT). A kill between the two loses the verdict and keeps the prose, which is exactly what cost PR #314 an earned approval on 2026-09-07:
+$(sed 's/^/        /' "$GH_LOG")"
+ok "the commit status is posted BEFORE the PR comment"
+
+# CASE 1b -- the link is still attached, so ordering did not cost the target_url.
+grep "statuses/$SHA" "$GH_LOG" | grep -q "target_url" \
+  || fail "no status call carries a target_url; posting first must not lose the link to the comment:
+$(sed 's/^/        /' "$GH_LOG")"
+ok "a later status post attaches target_url, so the link survives the reordering"
+
+# The marker the duplicate guard reads has to actually be in what was posted.
+grep -q -- "kipi-reviewer: head=$SHA" "$WORK/order.out" \
+  || echo "  [ctx] marker not echoed to stdout (it is in the body file, not the log)"
+
+# ===========================================================================
+# CASE 2 -- sp-fa810306: a head that already carries a verdict comment refuses.
+#
+# RED-MAKING INPUT, run before the fix: the pre-fix script with the same seeded
+# comment exited 0 and dispatched a full review.
+# ===========================================================================
+printf '<!-- kipi-reviewer: head=%s -->\n## Verdict: APPROVE WITH NITS\n' "$SHA" > "$COMMENTS_FILE"
+: > "$GH_LOG"
+run_reviewer "$WORK/dup.out" dup --post
+RC_DUP=$?
+echo "  [ctx] duplicate-head run rc=$RC_DUP"
+
+[ "$RC_DUP" = "3" ] \
+  || fail "a head that already carries a verdict comment was re-reviewed (rc=$RC_DUP, expected 3):
+$(tail -20 "$WORK/dup.out")"
+ok "a head already carrying a verdict comment refuses with exit 3"
+
+grep -q "statuses/$SHA" "$GH_LOG" \
+  && fail "the refused run still posted a commit status; a refusal must move no gate:
+$(sed 's/^/        /' "$GH_LOG")"
+ok "the refused run posted no commit status"
+
+# CASE 2b -- the bypass is EXERCISED, not merely documented. Without this the
+# refusal could be unconditional and this suite would not notice.
+: > "$GH_LOG"
+run_reviewer "$WORK/dupforce.out" dupforce --post --force
+RC_FORCE=$?
+echo "  [ctx] --force run rc=$RC_FORCE"
+[ "$RC_FORCE" != "3" ] \
+  || fail "--force did not bypass the duplicate-head refusal (rc=$RC_FORCE):
+$(tail -20 "$WORK/dupforce.out")"
+grep -q "statuses/$SHA" "$GH_LOG" \
+  || fail "--force returned $RC_FORCE but posted no status, so it did not actually run the review"
+ok "--force runs the review anyway and posts a status"
+
+# CASE 2c -- the refusal is not universal: no marker, no refusal.
+: > "$COMMENTS_FILE"
+printf 'just a human comment about %s\n' "$SHA" > "$COMMENTS_FILE"
+: > "$GH_LOG"
+run_reviewer "$WORK/nodup.out" nodup --post
+RC_NODUP=$?
+echo "  [ctx] head-mentioned-but-no-marker run rc=$RC_NODUP"
+[ "$RC_NODUP" != "3" ] \
+  || fail "a comment that merely MENTIONS the sha triggered the duplicate refusal (rc=3). The guard must key on the reviewer's own marker, not on the sha appearing in prose:
+$(tail -20 "$WORK/nodup.out")"
+ok "a non-verdict comment naming the sha does not trigger the refusal"
+
+# ===========================================================================
+# CASE 3 -- sp-0a09e013: two live pid files refuse a third run.
+#
+# RED-MAKING INPUT, run before the fix: the pre-fix script with the same two live
+# pid files exited 0 and ran a third concurrent review.
+#
+# THE LIVE PIDS ARE REAL PROCESSES. Writing $$ into both files would make them
+# the same pid as nothing, and a fabricated number could be reused by anything on
+# the box; two backgrounded sleeps are pids the OS genuinely reports as alive.
+# ===========================================================================
+: > "$COMMENTS_FILE"
+PIDDIR="$WORK/home-conc/.config/kipi/review-trees"; mkdir -p "$PIDDIR"
+sleep 120 & LIVE1=$!
+sleep 120 & LIVE2=$!
+printf '%s' "$LIVE1" > "$PIDDIR/assafkip_homerepo__pr-7.pid"
+printf '%s' "$LIVE2" > "$PIDDIR/assafkip_homerepo__pr-8.pid"
+: > "$GH_LOG"
+run_reviewer "$WORK/conc.out" conc --post
+RC_CONC=$?
+echo "  [ctx] two-live-pids run rc=$RC_CONC (live pids $LIVE1 $LIVE2)"
+
+[ "$RC_CONC" = "3" ] \
+  || fail "a third concurrent review started while two were live (rc=$RC_CONC, expected 3):
+$(tail -20 "$WORK/conc.out")"
+ok "two live pid files refuse a third run with exit 3"
+grep -q "statuses/$SHA" "$GH_LOG" \
+  && fail "the concurrency-refused run still posted a commit status"
+ok "the concurrency-refused run posted no commit status"
+
+# ===========================================================================
+# CASE 4 -- sp-0a09e013: a stale pid file is reclaimed and the run proceeds.
+#
+# THE PID IS GENUINELY DEAD, not invented: the two sleeps above are killed and
+# reaped first, so `kill -0` reports gone for a number that really was a process.
+# ===========================================================================
+kill "$LIVE1" "$LIVE2" 2>/dev/null || true
+wait "$LIVE1" 2>/dev/null || true
+wait "$LIVE2" 2>/dev/null || true
+[ -f "$PIDDIR/assafkip_homerepo__pr-7.pid" ] \
+  || fail "precondition: the stale pid file vanished before the run that is supposed to reclaim it"
+: > "$GH_LOG"
+run_reviewer "$WORK/stale.out" conc --post
+RC_STALE=$?
+echo "  [ctx] stale-pids run rc=$RC_STALE"
+
+[ "$RC_STALE" != "3" ] \
+  || fail "a run was refused by pid files whose processes are dead (rc=3). A stale file must be reclaimed, or one killed reviewer wedges the loop forever:
+$(tail -20 "$WORK/stale.out")"
+ok "a run with only stale pid files is not refused"
+[ -f "$PIDDIR/assafkip_homerepo__pr-7.pid" ] \
+  && fail "the stale pid file was left on disk; nothing else ever runs to clean it up"
+ok "the stale pid file was removed"
+grep -q "statuses/$SHA" "$GH_LOG" \
+  || fail "the stale-pid run exited $RC_STALE but posted no status, so it did not actually review"
+ok "the stale-pid run really did review and post"
+
+# ===========================================================================
+# CASE 5 -- sp-46726f79: two consecutive REQUEST CHANGES rounds sharing a file
+# print STRUCTURAL, put it in the comment, and exit 4.
+#
+# RED-MAKING INPUT, run before the fix: the pre-fix script produced two REQUEST
+# CHANGES rounds on FILE.txt, printed no STRUCTURAL line, and exited 0.
+#
+# THE POST IS NOT BLOCKED, and that half is asserted too: a warning that costs
+# the review its comment would be a worse trade than the loop it warns about.
+# ===========================================================================
+: > "$COMMENTS_FILE"
+set_review "REQUEST CHANGES" "major|first unwaited write|FILE.txt:10"
+: > "$GH_LOG"
+run_reviewer "$WORK/rc1.out" struct --post
+RC_R1=$?
+echo "  [ctx] structural round 1 rc=$RC_R1"
+[ "$RC_R1" = "0" ] \
+  || fail "the FIRST REQUEST CHANGES round exited $RC_R1; with no earlier round there is nothing structural to report:
+$(tail -20 "$WORK/rc1.out")"
+ok "a single REQUEST CHANGES round exits 0 (nothing to compare against yet)"
+
+set_review "REQUEST CHANGES" "major|second unwaited write in the same file|FILE.txt:42"
+: > "$GH_LOG"
+COMMENT_BODIES="$WORK/posted-bodies.txt"; : > "$COMMENT_BODIES"
+run_reviewer "$WORK/rc2.out" struct --post
+RC_R2=$?
+echo "  [ctx] structural round 2 rc=$RC_R2"
+
+grep -q "^  STRUCTURAL: " "$WORK/rc2.out" \
+  || fail "two REQUEST CHANGES rounds both citing FILE.txt produced no STRUCTURAL line:
+$(tail -25 "$WORK/rc2.out")"
+ok "two rounds sharing a file print a STRUCTURAL line"
+
+grep "^  STRUCTURAL: " "$WORK/rc2.out" | grep -q "FILE.txt" \
+  || fail "the STRUCTURAL line does not name the shared file:
+$(grep '^  STRUCTURAL: ' "$WORK/rc2.out")"
+ok "the STRUCTURAL line names the shared file"
+
+grep "^  STRUCTURAL: " "$WORK/rc2.out" | grep -qE "round [0-9]+ and round [0-9]+" \
+  || fail "the STRUCTURAL line does not name the two rounds:
+$(grep '^  STRUCTURAL: ' "$WORK/rc2.out")"
+ok "the STRUCTURAL line names both rounds"
+
+[ "$RC_R2" = "4" ] \
+  || fail "the structural round exited $RC_R2, expected 4 so a queue script can stop:
+$(tail -20 "$WORK/rc2.out")"
+ok "the structural round exits 4"
+
+grep -q "pr comment" "$GH_LOG" \
+  || fail "the structural round did not post its comment; the warning must never cost the review its post:
+$(sed 's/^/        /' "$GH_LOG")"
+ok "the structural round still posted its PR comment"
+grep -q "statuses/$SHA" "$GH_LOG" \
+  || fail "the structural round posted no commit status"
+ok "the structural round still posted its commit status"
+
+# ===========================================================================
+# CASE 6 -- sp-46726f79: disjoint files do NOT produce a STRUCTURAL line.
+#
+# Without this the fix could be "print STRUCTURAL on every second REQUEST CHANGES
+# round", which is a warning that fires always and therefore says nothing.
+# ===========================================================================
+set_review "REQUEST CHANGES" "major|a different defect elsewhere|OTHER.txt:3"
+: > "$GH_LOG"
+run_reviewer "$WORK/rc3.out" disjoint --post
+RC_D1=$?
+set_review "REQUEST CHANGES" "major|another different defect|THIRD.txt:9"
+: > "$GH_LOG"
+run_reviewer "$WORK/rc4.out" disjoint --post
+RC_D2=$?
+echo "  [ctx] disjoint rounds rc=$RC_D1 then rc=$RC_D2"
+
+grep -q "^  STRUCTURAL: " "$WORK/rc4.out" \
+  && fail "two REQUEST CHANGES rounds citing DIFFERENT files produced a STRUCTURAL line. A warning that fires on every repeat round trains the reader to ignore it:
+$(grep '^  STRUCTURAL: ' "$WORK/rc4.out")"
+ok "two rounds on different files print no STRUCTURAL line"
+
+[ "$RC_D2" = "0" ] \
+  || fail "the disjoint second round exited $RC_D2, expected 0:
+$(tail -20 "$WORK/rc4.out")"
+ok "the disjoint second round exits 0"
+
+echo "PASS ($PASS checks) test-review-run-safety.sh"

--- a/q-system/.q-system/scripts/test/test-severity-floor.sh
+++ b/q-system/.q-system/scripts/test/test-severity-floor.sh
@@ -985,6 +985,18 @@ run_status_reviewer() {
 }
 
 status_call() { grep 'statuses/' "$1/gh-calls.log" 2>/dev/null | head -1; }
+# THE LAST STATUS CALL, WHICH IS WHAT GITHUB ENDS UP SHOWING. Commit statuses
+# append and the latest for a context wins, so a reader on the PR sees this one.
+#
+# WHY BOTH HELPERS EXIST (sp-fa810306, 2026-09-07). The reviewer now posts the
+# status BEFORE the comment, so a kill between the two loses prose and never the
+# verdict. That means the FIRST status has no target_url yet -- there is no
+# comment to link to at the moment it is posted -- and a second call re-posts the
+# same context and verdict with the link once the comment lands. So the two
+# questions split: "did the gate move, on the right sha, with the right state"
+# is about the FIRST call (that is the one a kill would leave standing), and
+# "can a human click through to the review" is about the LAST one.
+status_call_last() { grep 'statuses/' "$1/gh-calls.log" 2>/dev/null | tail -1; }
 
 APPROVE_REVIEW='## VERDICT: APPROVE
 
@@ -1024,10 +1036,32 @@ printf '%s' "$CALL" | grep -q 'state=success' \
   || fail "an APPROVE did not map to state=success. Call was: $CALL"
 ok "APPROVE maps to state=success on context $STATUS_CONTEXT"
 
-printf '%s' "$CALL" | grep -q "target_url=$COMMENT_URL_FIXTURE" \
+# READS THE LAST STATUS CALL, not the first. The reviewer posts the status before
+# the comment now (sp-fa810306), so the first call cannot carry a link that does
+# not exist yet; the second re-posts the same context and verdict with the link.
+# What a human sees on the PR is the last one, and that is what this asserts.
+CALL_LAST="$(status_call_last "$N1")"
+printf '%s' "$CALL_LAST" | grep -q "target_url=$COMMENT_URL_FIXTURE" \
   || fail "the status did not carry the PR-comment URL --post had just created, so a human
-      clicking the check lands nowhere. Call was: $CALL"
+      clicking the check lands nowhere. Last status call was: $CALL_LAST"
 ok "target_url is the PR comment URL --post actually created"
+
+# THE ORDERING ITSELF, asserted here because this suite already owns the status
+# post and would otherwise pass on a script that went back to commenting first.
+# The comment is prose a human reads later; the status is what converge.sh, the
+# required check and the next session all read. A kill can land between the two,
+# so the one that survives has to be the status (PR #314, 2026-09-07: an
+# APPROVE WITH NITS comment landed at 00:29:47Z, the status never did, and the
+# re-run overturned the approval).
+STATUS_LINE_NO="$(grep -n 'statuses/' "$N1/gh-calls.log" 2>/dev/null | head -1 | cut -d: -f1)"
+COMMENT_LINE_NO="$(grep -n 'pr comment' "$N1/gh-calls.log" 2>/dev/null | head -1 | cut -d: -f1)"
+if [ -n "$STATUS_LINE_NO" ] && [ -n "$COMMENT_LINE_NO" ]; then
+  [ "$STATUS_LINE_NO" -lt "$COMMENT_LINE_NO" ] \
+    || fail "the PR comment was posted BEFORE the commit status (comment at line $COMMENT_LINE_NO,
+      status at line $STATUS_LINE_NO). A kill between them then loses the verdict and keeps the
+      prose, which is what cost PR #314 an earned approval on 2026-09-07 (sp-fa810306)."
+  ok "the commit status is posted before the PR comment"
+fi
 
 # N2. a gate that can only ever say success is not a gate.
 N2="$W2/st-block"


### PR DESCRIPTION
Four changes to `q-system/.q-system/scripts/pr-review-agent.sh`, one new suite, one existing suite corrected. Closes sp-fa810306, sp-0a09e013, sp-46726f79.

## The scar this comes from

PR #314 round 3 posted APPROVE WITH NITS as a PR comment at 00:29:47Z on 2026-09-07 on head `adc29516`. The process died before the commit status call. The next session read `gh api statuses adc29516` as empty, took empty for "never reviewed", re-ran the same head at 00:36:54Z, and the re-run returned REQUEST CHANGES. An approval that had already been earned was overturned by a kill. Two more rounds, about 90 minutes.

## What changed

**1. The commit status is posted BEFORE the PR comment (sp-fa810306).** A kill can land between any two calls; the only choice is which one survives. The comment is 60 KB of prose a human reads later. The status is what a required check, `converge.sh` and the next session all read. So the status goes first, unconditionally, and a second call re-posts the same context with the same `$VERDICT` and adds `target_url` once the comment lands. Both calls read one variable computed once, so a gate cannot see two different values; if the run dies between them the first post stands, missing only its link.

**2. A head that already carries a verdict is not re-reviewed (sp-fa810306).** Every posted comment now leads with `<!-- kipi-reviewer: head=<sha> -->`, and every run greps the PR's comments for that exact marker on the head it is about to review. A hit exits 3 with no dispatch and no status, unless `--force`. It keys on the reviewer's own marker rather than on the sha appearing in prose, because a sha appears inside diffs and inside quoted comments. It fails open: a gh outage yields zero hits and the review proceeds, because refusing on an unreadable comment list would wedge every review on a GitHub blip.

**3. A pid file per (repo, PR) and a concurrency cap (sp-0a09e013).** Written at start into `$HOME/.config/kipi/review-trees/<artifact_key>.pid`, beside the review tree and its lock, removed by the EXIT trap. Two or more live pid files refuse a third run with exit 3; `--queue` waits a bounded 900s and then refuses anyway. A pid the OS no longer knows is reclaimed as the scan walks, so one killed reviewer cannot wedge the loop. Five reviewers and watchers were killed under memory pressure on the evening of 2026-09-05 and nothing on the box could say how many were live.

**4. A STRUCTURAL stop when two rounds name one file (sp-46726f79).** After a REQUEST CHANGES verdict the run compares its findings against the previous REQUEST CHANGES round for the same PR, through `findings_block` (the one reader, sp-c0a9dac3), and prints a STRUCTURAL line naming the shared file and the two rounds when their cited paths intersect. The line rides inside the PR comment, and the run exits 4 **after** posting, so a queue script can stop while the review still reaches the PR. Rounds 1 to 3 of PR #314 each named another unwaited index write; only the founder stopped it.

## Test evidence: every negative case seen RED first, then green

RED runs were against `origin/main`'s `pr-review-agent.sh` extracted into a fixture root, with the same suite. Both suites drive the SHIPPING script copied into a fixture repo three levels down, against a `gh` stub, a fake engine and a `HOME` under `mktemp`. No live PR, no model spend, no real commit status.

| Case | RED (origin/main script) | GREEN (this branch) |
|---|---|---|
| status before comment | comment at gh-log line 3, status at line 4 | status at line 4, comment at line 5 |
| status keeps `target_url` | n/a | a later status call carries it |
| duplicate head refuses | rc=0, full review dispatched | rc=3, no status posted |
| `--force` bypass runs | rc=1 (unknown arg) | rc=0, status posted |
| sha in prose does not refuse | rc=0 (control) | rc=0 (control, unchanged) |
| two live pid files refuse | rc=0, third review ran | rc=3, no status posted |
| stale pid file reclaimed | left on disk | removed, run proceeds and posts |
| STRUCTURAL line printed | absent, rc=0 | printed, names file and both rounds, rc=4 |
| structural round still posts | n/a | comment and status both posted |
| disjoint files stay quiet | no line, rc=0 (control) | no line, rc=0 (control, unchanged) |

Exact runs:

```
bash q-system/.q-system/scripts/test/test-review-run-safety.sh
  PASS (22 checks) test-review-run-safety.sh
bash q-system/.q-system/scripts/test/test-severity-floor.sh
  PASS: 202/202 severity-floor checks
```

20 other suites naming `pr-review-agent` all pass: test-review-tree-guard, test-verdict-usability, test-review-comment-body, test-review-worktree-ref, test-review-plan-echo-gate, test-gh-repo-scope-reviewer, test-pr-review-root-guard, test-review-degraded-provenance, test-review-dry-run-labelled, test-review-gate-no-fake-green, test-review-invoker-provenance, test-review-artifact-repo-keyed, test-review-fallback-exact-sha, test-review-root-and-lock, test-review-early-bail-ref, test-findings-block-reader, test-review-redrive, test-verdict-statement-shape, test-script-stable-under-self-edit.

**Mutation test of the guard, not only the code.** Deleting the early `post_reviewer_status` call and re-running both suites turns both RED, naming the ordering:

```
test-severity-floor.sh    FAIL: the PR comment was posted BEFORE the commit status (comment at line 4, ...)
test-review-run-safety.sh FAIL: THE COMMENT WENT FIRST (status line 5, comment line 4)
```

Restored from a cp backup; `git diff --stat` empty afterwards; both suites green again.

## The existing suite that encoded the old ordering

`test-severity-floor.sh` asserted that the FIRST status call carries `target_url`. That was true only because the comment used to be posted first. It now reads the LAST status call for the link (which is what GitHub shows, since statuses append and the latest for a context wins) and separately asserts the ordering itself, so a revert to comment-first turns it red. 202/202.

## What is NOT verified here

- `capability-gate.py` refuses to run from a `.claude/worktrees` copy, so the new `expected_tests` manifest entry was not validated locally. It follows the exact shape of the existing entries and CI runs the gate from a normal checkout.
- `validate-separation.py 1 --verbose` exits 1 on this branch with two failures. Both are identical on origin/main's script, measured by swapping that file in and re-running: same file, same reported line 1266, same `1 gating, 7638 advisory` counts. Pre-existing, not introduced here.
- The STRUCTURAL check matches on the file path a finding cites, so two genuinely different defects in one long file read as one class, and a defect that moved files reads as two. It advises and does not gate, for that reason.
- Pid numbers are recycled. A stale file whose number was handed to an unrelated process reads as live and costs one false refusal, which is the safe direction.

## Ledger

sp-fa810306, sp-0a09e013 and sp-46726f79 are resolved on merge. sp-489f2d62 was captured on the way through: `read-first-gate.py` cannot be satisfied from an agent thread, measured on this session's own transcript.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01NALQTapH2TADG19pNkvWrd
