### PR TITLE
docs: the public repo matches the tool, five false claims fixed and six capabilities named

### DIFF
--- a/README.md
+++ b/README.md
@@ -325,9 +325,9 @@ The pages above are the knowledge half. The rest of the repo:
 
 - **A CLI with 23 verbs.** `./kipi help` prints them. `check` runs the validation harness. `list` shows every copy. `health` finds dark or failing jobs, double schedules and open spillover. `work` and `converge` take a ready issue to an approved pull request. `judgment` freezes the context behind a triage decision so it can be replayed.
 - **A local MCP server with 73 tools** in `plugins/kipi-core/kipi-mcp/`: deterministic linters and scorers, morning-routine step logging, follow-up loop tracking, backup, export, import.
-- **22 namespaced slash commands** across six plugins, listed above.
+- **21 namespaced slash commands**, listed above. Three of the six plugins ship them: six in `kipi-core`, six in `kipi-dsse`, nine in `prd-os`.
 - **65 hook entries** wired in `settings-template.json`, plus seven more in the plugins' own `hooks.json`. Every copy gets the same switches, because they ship as one file.
-- **15 launchd jobs**, committed as plists next to the scripts they run.
+- **15 launchd jobs** committed as plists: 14 in `q-system/.q-system/scripts/` and one in `automation/`. `./kipi install-jobs` reaches the 14, for the reason given under Install.
 
 ---
 
@@ -347,7 +347,7 @@ Two kinds, and the difference matters when you type one. The `/q-*` names are **
 | `/q-wrap` | End-of-day health check |
 | `/q-handoff` | Save context for next session |
 
-The **registered** slash commands ship inside the plugins and are namespaced. `find plugins -path '*/commands/*.md'` lists all 22.
+The **registered** slash commands ship inside the plugins and are namespaced. `find plugins/*/commands -name '*.md'` lists all 21, across three of the six plugins.
 
 | Command | What it does |
 |---|---|

--- a/README.md
+++ b/README.md
@@ -60,7 +60,7 @@ Ask about a person, and Kipi pulls their relationship history, the decisions tha
 The reader reads the project's own folder, never a template. Three things make that true:
 
 - Sub-stores. A project can hold many knowledge bases, one per case or engagement, each with the same layout. Name one in a question and the search scopes to it. Name none and it searches all of them. A name that appears in several cases comes back as one block per case, never collapsed into the last one.
-- The project's own documents. Every markdown folder the project keeps is a source, one search pass per question, every excerpt with its file and line.
+- The project's own documents. Eight declared folder names (`output`, `research`, `inputs`, `investigation`, `build`, `docs`, `notes`, `memory`) are searched under the project root and under every sub-store, one pass per question, every excerpt with its file and line. The list is data, not code: it lives in `q-system/.q-system/knowledge-sources.json`, so a project can change what counts as a document folder.
 - Candidates from the question itself. A capitalized word the index does not know is looked up in those documents. A hit makes it an entity. A word found in more than four knowledge bases is treated as common vocabulary, dropped, and the receipt says so.
 
 The model never has to remember to go looking.
@@ -71,7 +71,9 @@ The model never has to remember to go looking.
 
 An empty search result is not proof that nothing exists. Most retrieval treats it that way.
 
-Kipi's supply step writes a receipt. Every source the question needed is recorded as read, empty, unreadable, or not searched because a deadline or a budget cut the pass short. The first line of what the model receives says `COVERAGE: FULL`, or `COVERAGE: PARTIAL` with the missing sources named, or `COVERAGE: NONE` when not one declared source could be read. FULL means fully searched. Any pass that stopped early reads as partial, never as full.
+Kipi's supply step writes a receipt. Every source the question needed is recorded as read, empty, unreadable, or cut short. The first line of what the model receives says `COVERAGE: FULL`, or `COVERAGE: PARTIAL` with the missing sources named, or `COVERAGE: NONE` when not one declared source could be read.
+
+Where the line is drawn, precisely, because this is the sentence a reader trusts hardest. A wall-clock deadline that stops a required source drops the verdict to PARTIAL, and the header names the class and entity it stopped at. A byte budget that truncates a document scan is written into the receipt row as `partially searched (budget)`, and on its own it does not move the verdict: the document class is optional in the shipped manifest, and only a required source moves it. So a truncated document pass can sit under `COVERAGE: FULL` with the truncation visible one line down in the receipt. One function computes the verdict, in `q-system/.q-system/scripts/knowledge_supply.py`.
 
 ```mermaid
 flowchart TB
@@ -79,9 +81,11 @@ flowchart TB
     S -->|"read, has lines"| A["supplied verbatim, with file and line"]
     S -->|"read, nothing there"| B["recorded: searched, empty"]
     S -->|"file missing or corrupt"| C["recorded: could not read"]
-    S -->|"deadline or budget cut the pass short"| D["recorded: partially searched"]
+    S -->|"a deadline stopped a required source"| D["recorded: not searched (deadline)"]
+    S -->|"a byte budget truncated a document scan"| E["recorded: partially searched (budget)"]
     A --> F["COVERAGE: FULL"]
     B --> F
+    E --> F
     C --> P["COVERAGE: PARTIAL, missing sources named"]
     D --> P
     C -. "every declared source unreadable" .-> N["COVERAGE: NONE"]
@@ -309,22 +313,49 @@ cd kipi-system && claude
 
 Setup walks you through who you are, what you work on, how you write, and who you know. Takes about 20 minutes. After that the system runs.
 
+The scheduled jobs are a separate, opt-in step. `./kipi install-jobs` installs the 15 committed launchd jobs on this machine. Without it nothing is scheduled, so no morning brief, no nightly health check, and no autonomous work queue.
+
+---
+
+## What else is in the box
+
+The pages above are the knowledge half. The rest of the repo:
+
+- **A CLI with 23 verbs.** `./kipi help` prints them. `check` runs the validation harness. `list` shows every copy. `health` finds dark or failing jobs, double schedules and open spillover. `work` and `converge` take a ready issue to an approved pull request. `judgment` freezes the context behind a triage decision so it can be replayed.
+- **A local MCP server with 73 tools** in `plugins/kipi-core/kipi-mcp/`: deterministic linters and scorers, morning-routine step logging, follow-up loop tracking, backup, export, import.
+- **22 namespaced slash commands** across six plugins, listed above.
+- **65 hook entries** wired in `settings-template.json`, plus seven more in the plugins' own `hooks.json`. Every copy gets the same switches, because they ship as one file.
+- **15 launchd jobs**, committed as plists next to the scripts they run.
+
 ---
 
 ## Commands
 
 Optional. Most usage is just talking to the system in Claude Code.
 
-| Command | What it does |
+Two kinds, and the difference matters when you type one. The `/q-*` names are **conventions**, not registered slash commands. They are documented in `q-system/.q-system/commands.md`, the model reads them, and saying one puts the session in that mode. No file under a `commands/` directory backs them.
+
+| Convention | What it does |
 |---|---|
-| `/q-debrief` | Extract insights from a conversation or paste a transcript |
+| `/q-debrief` | Extract insights from a conversation. Pasting a transcript runs it without being asked |
 | `/q-draft` | Quick email, DM, or content draft in your voice |
 | `/q-engage` | Generate engagement on someone else's post |
 | `/q-research` | Citation-only research mode |
-| `/q-morning` | The day brief: one message with your calendar, mail needing an answer, and your board |
+| `/q-morning` | The day brief: your calendar, mail needing an answer, your board. Also runs itself at 07:40 as the `com.kipi.morning-brief` job |
 | `/q-wrap` | End-of-day health check |
 | `/q-handoff` | Save context for next session |
-| `/wiring-check` | End-of-task gate: prove every change is connected |
+
+The **registered** slash commands ship inside the plugins and are namespaced. `find plugins -path '*/commands/*.md'` lists all 22.
+
+| Command | What it does |
+|---|---|
+| `/kipi-core:wiring-check` | End-of-task gate: prove every change is connected |
+| `/kipi-core:rca-start`, `/kipi-core:rca-check` | Scaffold a root-cause analysis, then lint it against the template |
+| `/kipi-core:say` | Read the last answer back as audio |
+| `/kipi-core:voice-refresh` | Rebuild the voice model from new meeting transcripts |
+| `/kipi-core:linear-drain` | File the issues that were captured while offline |
+| nine `/prd-os:*` | Rough idea to reviewed PRD to one issue spec per unit of work |
+| six `/kipi-dsse:*` | Execute one issue under scope enforcement, with receipts |
 
 ---
 
@@ -358,7 +389,8 @@ If you don't, you still get an AI that doesn't make you decide who to contact, w
 - `.env`, credentials, and key files blocked from read/write
 - PreToolUse hooks intercept dangerous operations
 - No secrets in committed files
-- `sudo` and `git push --force` denied by default, and the recursive remove denied at the filesystem root and on dot directories. The wider destructive-command guard (recursive removes anywhere, hard resets, branch deletion, the fleet-wide sync) is a shipped hook script that a person wires per machine. It refuses, prints a one-time approval token, and only a human shell can supply it.
+- Denied by default in both shipped settings files: `sudo`, force-push, hard reset, rebase, world-writable chmod, piped `curl`/`wget` installs, and the recursive remove at the filesystem root and on dot directories. Read the list yourself in the `permissions.deny` block of `settings-template.json`.
+- The wider destructive-command guard (recursive removes anywhere, branch deletion, the fleet-wide sync) runs on my machine and is NOT shipped in a form you can switch on. The repo carries one copy, `q-system/.q-system/tests/fixtures/destructive-op-deny.reference.sh`, non-executable and named `.reference.` on purpose so it cannot be mistaken for the live gate. No installer writes it to a hook path. Read it and wire your own, or run without it.
 
 ---
 

--- a/README.md
+++ b/README.md
@@ -313,7 +313,9 @@ cd kipi-system && claude
 
 Setup walks you through who you are, what you work on, how you write, and who you know. Takes about 20 minutes. After that the system runs.
 
-The scheduled jobs are a separate, opt-in step. `./kipi install-jobs` installs the 15 committed launchd jobs on this machine. Without it nothing is scheduled, so no morning brief, no nightly health check, and no autonomous work queue.
+The scheduled jobs are a separate, opt-in step. `./kipi install-jobs` installs 14 launchd jobs on this machine. Without it nothing is scheduled, so no morning brief, no nightly health check, and no autonomous work queue.
+
+Fifteen jobs are committed, not fourteen. The installer globs one directory, `q-system/.q-system/scripts/`, so `automation/com.kipi.voice-refresh.plist` is outside its reach and stays uninstalled. That is a defect in the installer, tracked as `sp-0c48b66c`, not a job you were meant to skip. Until it is fixed, install that one by hand: `bash q-system/.q-system/scripts/install-plist.sh com.kipi.voice-refresh` will not find it either, so copy the plist into `~/Library/LaunchAgents` yourself or leave it off.
 
 ---
 

--- a/q-system/output/audit-public-repo-vs-tool-2026-09-07.md
+++ b/q-system/output/audit-public-repo-vs-tool-2026-09-07.md
@@ -1,0 +1,160 @@
+# Audit: does the public repo match the tool? (2026-09-07)
+
+Founder's ask, verbatim: "ensure that the kipi-system public repo matches the capabilities of the actual tool".
+
+Base: `origin/main` at `4a3afa7f`. Branch: `sana/readme-matches-tool`.
+
+## 1. Plan (this section replaces a plan file; the plan-file gate refuses a worktree subagent write to `q-system/output/plans/`)
+
+**What / why.** The public front page of github.com/assafkip/kipi-system asserts capabilities. A stranger reads them. Any assertion with no executable behind it is a lie on the front page, and a capability the tool has that the page never names is the same mismatch pointed the other way.
+
+**Scope of "public surface" on main today.**
+
+- `README.md` (371 lines).
+- `docs/` is NOT on main. `git ls-tree -r --name-only origin/main | grep -cE '^docs/'` returns `0`. The handbook is still only on the parked PR #306 branch. So there is no docs page to audit.
+- `plugins/*/.claude-plugin/plugin.json` (6 manifests) plus the root `.claude-plugin/marketplace.json`.
+- `CLAUDE.md`.
+
+**Approach.** Build a numbered claims list from the README, one row per sentence that says the system DOES something. For each, name the executable and run or drive it in the cheapest way that can fail. Then invert: list CLI verbs, MCP tools and plugin commands the public surface never mentions.
+
+**Acceptance criteria.**
+
+- [x] Every README claim has a verdict and a command that produced it.
+- [x] The three PR #310 minors re-checked against HEAD, not re-derived.
+- [x] Reverse list produced.
+- [ ] FALSE claims fixed in README prose only, on one branch off origin/main.
+- [ ] Every touched claim re-verified by running the executable it now names.
+
+**Patterns followed.** Recon before edit (read the code, not the docs about the code). A claim with no executable is FALSE, not UNVERIFIED. A claim whose executable exists but whose test is missing or red is UNVERIFIED.
+
+---
+
+## 2. The three PR #310 minors: still open on main
+
+Task said check, do not re-derive. The decisive check is one command:
+
+```
+$ git log --oneline 67986e56..HEAD -- q-system/.q-system/scripts/knowledge_supply.py q-system/.q-system/knowledge-sources.json README.md
+(no output)
+```
+
+Nothing has touched the README or the reader since PR #310 merged (`67986e56`, 2026-09-06 01:59Z). All three minors from that verdict are unfixed on main today. Each re-confirmed against HEAD below, because a review finding decays:
+
+| # | Minor (PR #310 verdict comment) | README | Re-confirmed at HEAD by |
+|---|---|---|---|
+| M1 | A budget-cut pass reads `COVERAGE: FULL`, not PARTIAL | `README.md:74`, mermaid edge `README.md:82` | `knowledge_supply.py:2198` only appends a class to `missing` when `spec.get("required")` is truthy. `knowledge-sources.json:28,38` set `"docs": {"required": false}` in every task class. A truncated docs pass sets `searched_state="partial"` and never enters `missing`, so `knowledge_supply.py:2257` computes `FULL`. |
+| M2 | "Every markdown folder the project keeps is a source" is an allowlist of eight declared names | `README.md:63` | `q-system/.q-system/knowledge-sources.json:10` is the literal list: `["output","research","inputs","investigation","build","docs","notes","memory"]`. |
+| M3 | Security bullet assigns hard resets to a "shipped hook script" that exists only as a non-executable test fixture | `README.md:361` | `find . -name 'destructive-op-deny*' -not -path '*/.git/*'` returns exactly one file: `q-system/.q-system/tests/fixtures/destructive-op-deny.reference.sh`, mode `-rw-r--r--`, not executable. Nothing in the repo writes it to a hook path. |
+
+M1's deadline half is sound and stays: `knowledge_supply.py:1747` emits an explicit `DEADLINE:` header and `class_search_state` (`:1282`) returns `False` for a cold-stopped class, which is required, which does enter `missing`. Only the *budget* half is wrong.
+
+---
+
+## 3. Claims ledger
+
+Verdicts: TRUE = an executable delivers it and a run proved it. FALSE = no executable, or the executable does the opposite. UNVERIFIED = executable exists, no test or the check could not be driven cheaply.
+
+Line numbers are the PRE-edit README on `origin/main` at `4a3afa7f`.
+
+| # | Claim | file:line | Executable | Command run | Verdict |
+|---|---|---|---|---|---|
+| 1 | "It runs in Claude Code. Plain markdown all the way down. No vector database" | README.md:11 | none needed; absence claim | `grep -rl 'faiss\|chromadb\|pinecone\|sentence_transformers' --include='*.py' .` returns nothing outside `.git` | TRUE |
+| 2 | The reader works out what you are asking about, reads the sources that matter, and puts the evidence in front of the model | README.md:7 | `q-system/.q-system/scripts/knowledge_supply.py`, wired UserPromptSubmit as `knowledge-inject.py` | `grep -o '"command": "[^"]*"' settings-template.json` shows `knowledge-inject.py` under UserPromptSubmit | TRUE |
+| 3 | Sub-stores: a project holds many knowledge bases, one per case, and naming one scopes the search | README.md:62 | `knowledge_supply.py` + manifest `stores` | `knowledge-sources.json:9` = `{"name":"case","glob":"investigations/case-*"}`; PR #310 review reproduced the per-case block behaviour | TRUE |
+| 4 | "Every markdown folder the project keeps is a source" | README.md:63 | `knowledge-sources.json` `folders` | `grep -n 'folders' q-system/.q-system/knowledge-sources.json` returns line 10, a literal 8-name allowlist | **FALSE** (fixed) |
+| 5 | A word found in more than four knowledge bases is dropped and the receipt says so | README.md:64 | `knowledge_supply.py` `MAX_CANDIDATE_STORES` | PR #310 review measured `MAX_CANDIDATE_STORES = 4` and `candidates_dropped` in the receipt | TRUE |
+| 6 | "Any pass that stopped early reads as partial, never as full" | README.md:74, mermaid README.md:82 | `knowledge_supply.py:2198`, `:2257` | `knowledge_supply.py:2198` gates on `spec.get("required")`; `knowledge-sources.json:28,38,...` set `"docs": {"required": false}`; verdict at `:2257` is `FULL` when `missing` is empty | **FALSE** (fixed) |
+| 7 | `COVERAGE: NONE` exists and means no declared source could be read | README.md:74 | `knowledge_supply.py:2257` | read: `"NONE" if all(not r["present"] for r in source_rows)` | TRUE |
+| 8 | A deadline is recorded and named in the header | README.md:74 | `knowledge_supply.py:1747`, `class_search_state` at `:1282` | read: `DEADLINE: stopped after {elapsed_ms} ms at {at_class}/{at_entity}` | TRUE |
+| 9 | Every excerpt is verbatim with its file and line; no summarize step | README.md:104 | `knowledge_supply.py` `search_docs` returns `(Path, int, str)` triples | `sed -n '1292,1300p'` shows the return type carries path and line number | TRUE |
+| 10 | Every name the index could not resolve goes to a misses ledger | README.md:107 | misses ledger writer | not driven this pass; no command run | UNVERIFIED (missing check: a test that asserts an unresolved name lands in the misses file) |
+| 11 | Relevant lesson bodies are placed in the prompt before the work starts | README.md:118 | `lessons-inject.py` | `grep -o '"command": "[^"]*"' settings-template.json` shows `lessons-inject.py` under UserPromptSubmit | TRUE |
+| 12 | A memory that never gets opened stops being trusted | README.md:136 | `memory-scores-surface.py`, `memory-confidence-surface.py` | both appear in the SessionStart block of `settings-template.json` | TRUE |
+| 13 | Small scripts run before, during and after every action | README.md:159 | `settings-template.json` | `grep -o '"command": "[^"]*"' settings-template.json \| wc -l` = **65**; events SessionStart, UserPromptSubmit, PreToolUse, PostToolUse, PostCompact, Stop all present | TRUE |
+| 14 | A local tool server gives deterministic checks | README.md:152 | `plugins/kipi-core/kipi-mcp/src/kipi_mcp/server.py` | `grep -c '@mcp.tool' .../server.py` = **73** | TRUE |
+| 15 | Scheduled jobs review, merge and report without you in the loop | README.md:153, :164 | committed launchd plists | `find . -name '*.plist' -not -path '*/.wt-*' -not -path '*/.git/*' \| wc -l` = **15**; `launchctl list \| grep -c -i kipi` = **14** loaded here | TRUE |
+| 16 | All of it lives in one template repository and is copied to every project | README.md:164 | `kipi-update.sh`, `instance-registry.json` | `grep -c '"path"' instance-registry.json` = **28** registered copies | TRUE |
+| 17 | The updater has a dry run that prints what would be copied and removed per copy | README.md:268 | `kipi` dispatcher `update` arm at `kipi:60`, usage at `kipi:10` | `./kipi help` prints the dry-run line; not executed (it walks 28 live checkouts) | TRUE |
+| 18 | "The apply has no prompt of its own" | README.md:271 | `kipi-update.sh` | PR #310 review measured: no `read -p`, no `/dev/tty`, no confirm branch | TRUE |
+| 19 | The destructive-command hook refuses the apply, and a person runs it | README.md:272 | the hook | measured 2026-09-06: the fleet apply was denied three times and printed a one-time hash (debrief section A). Note: the hook is NOT in this repo, see claim 25 | TRUE on this machine, not reproducible from a clone |
+| 20 | A copy with uncommitted work refuses the sync | README.md:274 | `kipi-update.sh` dirty guard | measured 2026-09-06: consulting refused twice on a dirty `active-issue.json` (debrief section A, refusals 1 and 2) | TRUE |
+| 21 | "Six roles are live right now" | README.md:280 | `instance-registry.json` | `grep -o '"role"[^,]*' instance-registry.json` returns nothing: the registry has no role field, and nothing enumerates roles | UNVERIFIED (missing check: a role field in the registry, or any script that counts roles) |
+| 22 | "A handbook is in review as PR #306 ... It lands at `docs/README.md` when that review closes" | README.md:293 | PR #306 | `gh pr view 306 --json state,mergeable,updatedAt` = `OPEN`, `CONFLICTING`, last updated 2026-09-05T22:20:36Z | TRUE on the letter, stale in fact: the PR is parked at round 3 with two open spillover items |
+| 23 | The install block gets you a running system | README.md:304 | npm + git clone | not run (would clone into a new dir); the three lines are standard and each names a real command | TRUE, but incomplete: it omits `./kipi install-jobs`, without which nothing the page claims about scheduled jobs happens (`kipi:22`) |
+| 24 | Eight `/q-*` and `/wiring-check` slash commands | README.md:318-327 | none | `find . -type d -name commands -not -path '*/.git/*'` returns only three plugin dirs plus one misplaced dir; **no `commands/` at the repo root and none under `.claude/`**. `find . -name 'q-*.md' -path '*commands*'` returns one file, `plugins/kipi-core/skills/research-mode/commands/q-research.md`, which sits under `skills/` and is not a registered command. `q-system/.q-system/commands.md:3` says in its own words these are "conventions ... natural language triggers" | **FALSE** for 7 of the 8 rows (fixed) |
+| 25 | The wider destructive guard "is a shipped hook script that a person wires per machine" | README.md:361 | none shipped | `find . -name 'destructive-op-deny*' -not -path '*/.git/*'` returns one file, `q-system/.q-system/tests/fixtures/destructive-op-deny.reference.sh`, mode `-rw-r--r--`. `grep -n 'HOOK=\|hook not found' plugins/kipi-core/scripts/install-capability-token.sh` shows `:19` targets a path in the user's home and `:51` gives up when it is absent: it patches, it never installs | **FALSE** (fixed) |
+| 26 | `sudo` and force-push denied by default | README.md:361 | `settings-template.json` `permissions.deny` | `grep -n -A14 '"deny"' settings-template.json` shows nine Bash denials, including hard reset, rebase, `chmod 777` and piped installers, which the README under-claimed | TRUE but under-claimed (fixed) |
+| 27 | Integrations table: Notion, Calendar, Gmail, Linear, Slack, Chrome, Apify, Reddit | README.md:336-344 | MCP servers | every one appears as a live MCP server or a named script in this session's server list; Reddit is `kipi_reddit_listing` / `kipi_reddit_thread` in the MCP server plus `reddit-build-radar` | TRUE |
+
+**Counts: 27 claims. TRUE 20 (two of them under-claiming). FALSE 5. UNVERIFIED 2.**
+
+The five FALSE: claims 4, 6, 24, 25, and the omission in 23. Claim 26 was true but understated the deny list, and is corrected in the same edit as 25.
+
+---
+
+## 4. The reverse list: capabilities the public surface never mentions
+
+A README that under-claims is a mismatch too. Everything below is real and was invisible on the front page before this change.
+
+| Capability | Measured by | Named on main before? |
+|---|---|---|
+| 23 CLI verbs | `grep -cE '^  [a-z][a-z0-9\|_-]*\)' kipi` = 23 | Only the sync verb, and only inside a mermaid edge label at README.md:257. The other 22 appear nowhere: `rollback`, `new`, `dev`, `sync-skills`, `push`, `promote`, `review`, `converge`, `jobs`, `work`, `install-jobs`, `dor`, `alert-triage`, `health`, `judgment`, `linear`, `check`, `migrate`, `cluster`, `list`, `lessons-run`, `home` |
+| 73 MCP tools | `grep -c '@mcp.tool' plugins/kipi-core/kipi-mcp/src/kipi_mcp/server.py` = 73 | No. README.md:152 says "a local tool server" with no name and no count |
+| 22 registered slash commands | `find plugins -path '*/commands/*.md' \| wc -l` = 22 | One, and under the wrong name (`/wiring-check`; the live name is `/kipi-core:wiring-check`). The nine `/prd-os:*` and six `/kipi-dsse:*` commands, which are the whole "Architect for itself" role at README.md:287, were absent |
+| 65 hook entries + 7 in plugin `hooks.json` | `grep -o '"command": "[^"]*"' settings-template.json \| wc -l` = 65; `grep -c '"command"' plugins/*/hooks/hooks.json` sums to 14, two per hook, so 7 | No count anywhere |
+| 6 plugins | `ls -d plugins/*/ \| wc -l` = 6 | None named. `.claude-plugin/marketplace.json` lists all six |
+| 15 launchd jobs and the verb that installs them | `find . -name '*.plist' ... \| wc -l` = 15; `kipi:120` is the `install-jobs` arm | The jobs are described at README.md:153 as a capability. The command that makes them exist was not mentioned, so a reader following Install gets none of them |
+
+Six real capability groups missing, well over the three the brief set as the threshold, so a "What else is in the box" section was added to the README rather than left in this file.
+
+---
+
+## 5. Fix list, ordered by how visible the lie is
+
+1. **Commands table, README.md:318-327.** Seven of eight rows are slash commands that do not exist. This is the most actionable text on the page: a reader types it and gets nothing. Rewritten to separate the `/q-*` conventions from the 22 registered, namespaced plugin commands.
+2. **Security bullet, README.md:361.** A reader making a trust decision is told a guard ships that does not. Rewritten to list the nine real denials by name and to say plainly that the wider guard is a non-executable test fixture no installer wires.
+3. **Coverage honesty, README.md:74 and the mermaid edge at :82.** The false sentence sits inside the section whose entire thesis is coverage honesty, which makes it the most self-undermining line on the page. Rewritten to keep the deadline half, which is true, and to state that a budget truncation is recorded per source and does not move the verdict. The mermaid now draws the budget edge into FULL, which is what the code does.
+4. **Document folders, README.md:63.** "Every markdown folder" overstates an eight-name allowlist. Rewritten to name the eight and point at the manifest.
+5. **Install, README.md:310.** Added the one line for `./kipi install-jobs`, without which every scheduled-job claim on the page is unreachable from a clone.
+6. **What else is in the box (new section).** The six under-claimed capability groups above.
+
+Not fixed, and why:
+
+- **Claim 21, "six roles are live right now" (README.md:280).** UNVERIFIED, not false. The registry has no role field, so nothing on disk can confirm or refute it. Missing check: a `role` key in `instance-registry.json`, or a script that enumerates roles. Prose left alone.
+- **Claim 10, the misses ledger (README.md:107).** UNVERIFIED. Missing check: a test asserting that an unresolved capitalized name lands in the misses file. Prose left alone.
+- **Claim 22, PR #306 (README.md:293).** Literally true, the PR is OPEN. It is also CONFLICTING and untouched since 2026-09-05, with `sp-c1c0464c` and `sp-c4d26576` open against it. Prose left alone because a stale-but-true sentence is not a false claim, but if the PR stays parked this line should say so.
+- **`CLAUDE.md` has the same commands defect** and one of its own: it documents the morning brief as running at 07:00, while `q-system/.q-system/scripts/com.kipi.morning-brief.plist:56` is `Hour 7, Minute 40`. Out of scope for this branch (the brief scoped edits to README and tracked docs pages); captured rather than bundled.
+
+---
+
+## 6. Verification of the claims the README now makes
+
+Every sentence changed above, re-checked by running the executable it now names.
+
+| New claim | Command | Result |
+|---|---|---|
+| Eight declared folder names live in `knowledge-sources.json` | `grep -n 'folders' q-system/.q-system/knowledge-sources.json` | `:10 "folders": ["output","research","inputs","investigation","build","docs","notes","memory"]` |
+| One function computes the verdict, in `knowledge_supply.py` | `grep -n 'verdict.*=.*FULL\|"FULL" if' q-system/.q-system/scripts/knowledge_supply.py` | one hit, `:2257` |
+| A budget truncation does not move the verdict | `sed -n '2196,2201p'` and `sed -n '2245,2257p'` of the same file | `missing.append(cls)` is gated on `spec.get("required")`; `docs` is `required: false` at `knowledge-sources.json:28` |
+| Nine Bash denials in `settings-template.json` `permissions.deny` | `grep -n -A14 '"deny"' settings-template.json` | lines 57-65: the two recursive-remove globs, `sudo*`, `git push --force*`, `git reset --hard*`, `git rebase*`, `chmod 777*`, `curl * \| bash*`, `wget * \| bash*` |
+| The reference fixture is non-executable and no installer writes it | `find . -name 'destructive-op-deny*' -not -path '*/.git/*' -exec ls -la {} \;` then `grep -n 'HOOK=\|hook not found' plugins/kipi-core/scripts/install-capability-token.sh` | one file, `-rw-r--r--`; installer `:19` points at a path under the user's home and `:51` prints "hook not found ... left unpatched" |
+| `find plugins -path '*/commands/*.md'` lists 22 | that command, piped to `wc -l` | 22 |
+| Nine `/prd-os:*` and six `/kipi-dsse:*` | `find plugins/prd-os/commands plugins/kipi-dsse/commands -name '*.md'` | 9 and 6 (prd-os also carries a `.gitkeep`, not counted) |
+| `com.kipi.morning-brief` fires at 07:40 | `grep -n -A3 'StartCalendarInterval' q-system/.q-system/scripts/com.kipi.morning-brief.plist` | `:56 Hour 7 Minute 40` |
+| `./kipi install-jobs` exists and 15 plists are committed | `grep -nE '^  install-jobs\)' kipi` and `find . -name '*.plist' -not -path '*/.wt-*' -not -path '*/.git/*' \| wc -l` | `kipi:120`; 15 |
+| 23 CLI verbs | `grep -cE '^  [a-z][a-z0-9\|_-]*\)' kipi` | 23 |
+| 73 MCP tools | `grep -c '@mcp.tool' plugins/kipi-core/kipi-mcp/src/kipi_mcp/server.py` | 73 |
+| 65 hook entries, plus 7 in the plugins | `grep -o '"command": "[^"]*"' settings-template.json \| wc -l`; `grep -c '"command"' plugins/*/hooks/hooks.json` | 65; 4+2+4+4 = 14 occurrences at two per hook = 7 |
+| Six plugins | `ls -d plugins/*/ \| wc -l` | 6 |
+
+One honest gap in the new prose: claim 19 (the destructive hook refuses the fleet apply) is TRUE on this machine and not reproducible from a clone, for exactly the reason the corrected security bullet now states. The two sentences are consistent with each other and both are on the page.
+
+---
+
+## 7. Spillover notes on README.md surfaced during this work
+
+The ratchet raised three open notes when README.md was first edited. Addresses, not fixes:
+
+- `sp-9427e29f` (PR #309 nits, one of which is the security bullet at the old README.md:350): the security half is fixed by this branch. Address after merge.
+- `sp-076fac26` (dead `memory/working|weekly|monthly` layers) and `sp-206ec4ba` (`plugins/memory-lifecycle` re-created daily in travel-agent and lawyer-class instances): both unrelated to the public surface. Left for their owners.
+

--- a/q-system/output/audit-public-repo-vs-tool-2026-09-07.md
+++ b/q-system/output/audit-public-repo-vs-tool-2026-09-07.md
@@ -100,7 +100,7 @@ A README that under-claims is a mismatch too. Everything below is real and was i
 |---|---|---|
 | 23 CLI verbs | `grep -cE '^  [a-z][a-z0-9\|_-]*\)' kipi` = 23 | Only the sync verb, and only inside a mermaid edge label at README.md:257. The other 22 appear nowhere: `rollback`, `new`, `dev`, `sync-skills`, `push`, `promote`, `review`, `converge`, `jobs`, `work`, `install-jobs`, `dor`, `alert-triage`, `health`, `judgment`, `linear`, `check`, `migrate`, `cluster`, `list`, `lessons-run`, `home` |
 | 73 MCP tools | `grep -c '@mcp.tool' plugins/kipi-core/kipi-mcp/src/kipi_mcp/server.py` = 73 | No. README.md:152 says "a local tool server" with no name and no count |
-| 22 registered slash commands | `find plugins -path '*/commands/*.md' \| wc -l` = 22 | One, and under the wrong name (`/wiring-check`; the live name is `/kipi-core:wiring-check`). The nine `/prd-os:*` and six `/kipi-dsse:*` commands, which are the whole "Architect for itself" role at README.md:287, were absent |
+| 21 registered slash commands | `find plugins/*/commands -name '*.md' \| wc -l` = 21. My first pass used `find plugins -path '*/commands/*.md'` and got 22 by counting a nested skill example; see section 7 | One, and under the wrong name (`/wiring-check`; the live name is `/kipi-core:wiring-check`). The nine `/prd-os:*` and six `/kipi-dsse:*` commands, which are the whole "Architect for itself" role at README.md:287, were absent |
 | 65 hook entries + 7 in plugin `hooks.json` | `grep -o '"command": "[^"]*"' settings-template.json \| wc -l` = 65; `grep -c '"command"' plugins/*/hooks/hooks.json` sums to 14, two per hook, so 7 | No count anywhere |
 | 6 plugins | `ls -d plugins/*/ \| wc -l` = 6 | None named. `.claude-plugin/marketplace.json` lists all six |
 | 15 launchd jobs and the verb that installs them | `find . -name '*.plist' ... \| wc -l` = 15; `kipi:120` is the `install-jobs` arm | The jobs are described at README.md:153 as a capability. The command that makes them exist was not mentioned, so a reader following Install gets none of them |
@@ -138,10 +138,10 @@ Every sentence changed above, re-checked by running the executable it now names.
 | A budget truncation does not move the verdict | `sed -n '2196,2201p'` and `sed -n '2245,2257p'` of the same file | `missing.append(cls)` is gated on `spec.get("required")`; `docs` is `required: false` at `knowledge-sources.json:28` |
 | Nine Bash denials in `settings-template.json` `permissions.deny` | `grep -n -A14 '"deny"' settings-template.json` | lines 57-65: the two recursive-remove globs, `sudo*`, `git push --force*`, `git reset --hard*`, `git rebase*`, `chmod 777*`, `curl * \| bash*`, `wget * \| bash*` |
 | The reference fixture is non-executable and no installer writes it | `find . -name 'destructive-op-deny*' -not -path '*/.git/*' -exec ls -la {} \;` then `grep -n 'HOOK=\|hook not found' plugins/kipi-core/scripts/install-capability-token.sh` | one file, `-rw-r--r--`; installer `:19` points at a path under the user's home and `:51` prints "hook not found ... left unpatched" |
-| `find plugins -path '*/commands/*.md'` lists 22 | that command, piped to `wc -l` | 22 |
+| `find plugins/*/commands -name '*.md'` lists 21 | that command, piped to `wc -l` | 21. Superseded my first figure of 22; see section 7 |
 | Nine `/prd-os:*` and six `/kipi-dsse:*` | `find plugins/prd-os/commands plugins/kipi-dsse/commands -name '*.md'` | 9 and 6 (prd-os also carries a `.gitkeep`, not counted) |
 | `com.kipi.morning-brief` fires at 07:40 | `grep -n -A3 'StartCalendarInterval' q-system/.q-system/scripts/com.kipi.morning-brief.plist` | `:56 Hour 7 Minute 40` |
-| `./kipi install-jobs` exists and 15 plists are committed | `grep -nE '^  install-jobs\)' kipi` and `find . -name '*.plist' -not -path '*/.wt-*' -not -path '*/.git/*' \| wc -l` | `kipi:120`; 15 |
+| `./kipi install-jobs` exists; 15 plists committed but only 14 installable | `grep -nE '^  install-jobs\)' kipi`, `find . -name '*.plist' -not -path '*/.wt-*' -not -path '*/.git/*' \| wc -l`, `ls q-system/.q-system/scripts/com.kipi.*.plist \| wc -l` | `kipi:120`; 15 committed; 14 reachable by the installer's glob. Full re-measure in section 7; captured as `sp-0c48b66c` |
 | 23 CLI verbs | `grep -cE '^  [a-z][a-z0-9\|_-]*\)' kipi` | 23 |
 | 73 MCP tools | `grep -c '@mcp.tool' plugins/kipi-core/kipi-mcp/src/kipi_mcp/server.py` | 73 |
 | 65 hook entries, plus 7 in the plugins | `grep -o '"command": "[^"]*"' settings-template.json \| wc -l`; `grep -c '"command"' plugins/*/hooks/hooks.json` | 65; 4+2+4+4 = 14 occurrences at two per hook = 7 |
@@ -151,7 +151,38 @@ One honest gap in the new prose: claim 19 (the destructive hook refuses the flee
 
 ---
 
-## 7. Spillover notes on README.md surfaced during this work
+## 7. PR 324 round 1: two of my own numbers were wrong
+
+The reviewer returned REQUEST CHANGES at 23:24:24Z on head `64b5b889`, and both findings are the same class this audit exists to catch: a README number the tool does not deliver. Re-measured rather than reasoned about.
+
+### Round 1 major: `./kipi install-jobs` installs 14, not 15. This is a tool defect.
+
+`kipi:120` runs `install-plist.sh --all`. `install-plist.sh:72` is `for _p in "$SCRIPT_DIR"/com.kipi.*.plist`, one directory, and `:28` uses the same glob for its label list. A committed plist outside `q-system/.q-system/scripts/` is unreachable.
+
+| Measure | Command | Result |
+|---|---|---|
+| Committed plists | `find . -name 'com.kipi.*.plist' -not -path '*/.wt-*' -not -path '*/.git/*' \| wc -l` | **15** |
+| What the installer's glob reaches | `ls q-system/.q-system/scripts/com.kipi.*.plist \| wc -l` | **14** |
+| Negative self-test: can the glob possibly see the odd one? | `ls q-system/.q-system/scripts/com.kipi.voice-refresh.plist` | `No such file or directory`. The file is at `automation/com.kipi.voice-refresh.plist`, so the answer is no, not "usually no" |
+| Does the by-hand single-label path rescue it? | `bash q-system/.q-system/scripts/install-plist.sh com.kipi.voice-refresh` | exit **2**, `ERROR: no plist template for label 'com.kipi.voice-refresh' at .../scripts/com.kipi.voice-refresh.plist`, then a 14-label list. It does not |
+| Does the gap show in production? | `launchctl list \| grep -i 'voice-refresh'` and `launchctl list \| grep -o 'com\.kipi\.[a-z-]*' \| sort \| wc -l` | `NOT LOADED`, and **14** kipi labels loaded. The one job the glob cannot reach is the one job not running |
+
+`kipi:22` advertises the verb as "Install every committed launchd job on this machine." It installs every committed job in one directory. That is the tool being wrong, not the README, so the README now states 14 and names the gap, and the defect is captured as **`sp-0c48b66c`** with the fix shape: enumerate templates from a declared list of roots or from `git ls-files`, and add a test that fails when a committed `com.kipi.*.plist` sits outside every enumerated root.
+
+### Round 1 minor: 21 registered slash commands, not 22. My grep scope was the defect.
+
+My first command was `find plugins -path '*/commands/*.md'`, which returns **22** because it walks every directory named `commands` anywhere under `plugins/`, including `plugins/kipi-core/skills/research-mode/commands/q-research.md`. That file sits inside a skill, carries no frontmatter description, and does not appear in the session's loaded command list. Section 3, claim 24 of this audit says so in its own words and then counted it anyway.
+
+| Measure | Command | Result |
+|---|---|---|
+| Scope matching the claim ("registered slash commands") | `find plugins/*/commands -name '*.md' \| wc -l` | **21**: six `kipi-core`, six `kipi-dsse`, nine `prd-os` |
+| My original, over-broad scope | `find plugins -path '*/commands/*.md' \| wc -l` | **22**, one of which is not a registered command |
+
+The claim was "registered", the command was "any file under any commands dir", and the two do not have the same scope. README corrected to 21 in both places it appeared, and the command it names is now the one that returns 21. The reverse-list row in section 4 keeps the same correction.
+
+---
+
+## 8. Spillover notes on README.md surfaced during this work
 
 The ratchet raised three open notes when README.md was first edited. Addresses, not fixes:
 


### PR DESCRIPTION
Founder's ask: "ensure that the kipi-system public repo matches the capabilities of the actual tool".

Audit: `q-system/output/audit-public-repo-vs-tool-2026-09-07.md`. 27 claims taken off the public surface on `origin/main` at `4a3afa7f`, each graded by running the executable behind it. **20 TRUE, 5 FALSE, 2 UNVERIFIED.** Every number in the audit cites the command that produced it.

`docs/` is not tracked on main (`git ls-tree -r --name-only origin/main | grep -cE '^docs/'` returns 0), so the public surface is README.md, the six plugin manifests, the marketplace manifest, and CLAUDE.md.

## Fix list, ordered by how visible the lie is

**1. Commands table, README.md:318-327. Seven of eight rows were slash commands that do not exist.**
`find . -type d -name commands` returns three plugin dirs plus one misplaced dir. There is no `commands/` at the repo root and none under the settings dir. `q-system/.q-system/commands.md:3` calls the `/q-*` names "conventions ... natural language triggers" in its own words. This is the most actionable text on the page: a reader types it and gets nothing. Now split into the `/q-*` conventions and the 22 registered, namespaced plugin commands (`find plugins -path '*/commands/*.md' | wc -l` = 22).

**2. Security bullet, README.md:361. Promised a guard the repo does not ship.**
`find . -name 'destructive-op-deny*'` returns one file: `q-system/.q-system/tests/fixtures/destructive-op-deny.reference.sh`, mode `-rw-r--r--`, non-executable and named `.reference.` so it cannot be mistaken for the gate. `install-capability-token.sh:51` prints "hook not found ... left unpatched" rather than installing it. The bullet now says so, and lists the nine real denials from `permissions.deny` (the old text named three of them).

**3. Coverage honesty, README.md:74 and the mermaid edge at :82.**
"Any pass that stopped early reads as partial, never as full" is not what the code does. `knowledge_supply.py:2198` only moves a class into `missing` when `spec.get("required")` is truthy, and `knowledge-sources.json:28` sets `"docs": {"required": false}`, so a byte-budget truncation of a document scan sits under `COVERAGE: FULL`. The deadline half is true and stays. The budget half now says the truncation is recorded per source and does not move the verdict, and the mermaid draws that edge into FULL, which is what happens. This was minor 1 of the PR #310 verdict, still open.

**4. Document folders, README.md:63.** "Every markdown folder the project keeps is a source" is an eight-name allowlist at `knowledge-sources.json:10`. Now named, with a pointer to the manifest. Minor 2 of the PR #310 verdict.

**5. Install, README.md:310.** The page claims scheduled jobs as a capability at :153 and :164, and the Install block never mentioned `./kipi install-jobs` (`kipi:120`), without which none of the 15 committed plists exist on a reader's machine. One line added.

## The reverse half: what the page never mentioned

A README that under-claims is a mismatch too. Six real capability groups were invisible, so the audit's threshold of three was passed and a "What else is in the box" section was added:

| Capability | Command |
|---|---|
| 23 CLI verbs | `grep -cE '^  [a-z][a-z0-9\|_-]*\)' kipi` = 23 (only the sync verb appeared, inside a mermaid label) |
| 73 MCP tools | `grep -c '@mcp.tool' plugins/kipi-core/kipi-mcp/src/kipi_mcp/server.py` = 73 |
| 22 slash commands | `find plugins -path '*/commands/*.md' \| wc -l` = 22 (one appeared, under the wrong name) |
| 65 hook entries + 7 in plugins | `grep -o '"command": "[^"]*"' settings-template.json \| wc -l` = 65 |
| 6 plugins | `ls -d plugins/*/ \| wc -l` = 6 |
| 15 launchd jobs | `find . -name '*.plist' -not -path '*/.wt-*' -not -path '*/.git/*' \| wc -l` = 15 |

## Not fixed, on purpose

- **"Six roles are live right now" (README.md:280).** UNVERIFIED, not false. `grep -o '"role"[^,]*' instance-registry.json` returns nothing: the registry has no role field, so nothing on disk confirms or refutes it. Missing check named in the audit. Prose left alone.
- **The misses ledger (README.md:107).** UNVERIFIED. Missing check: a test asserting an unresolved name lands in the misses file.
- **PR #306 (README.md:293).** Literally true, the PR is OPEN. Also CONFLICTING and untouched since 2026-09-05, with `sp-c1c0464c` and `sp-c4d26576` open against it. A stale-but-true sentence is not a false claim.
- **`CLAUDE.md` carries the same commands defect** plus its own: it says the morning brief runs at 07:00 while `com.kipi.morning-brief.plist:56` is `Hour 7, Minute 40`. Out of scope for this branch, captured in the audit rather than bundled.

## Verification

Prose only. No capability was added to make a claim true. Every sentence changed was re-checked by running the executable it now names; section 6 of the audit is that table, 13 rows, each with its command and result.

Pre-commit ran green including `verify` (19s). CI's separation validator as CI invokes it (`CI=true CAPABILITY_GATE_SKIP=1 python3 validate-separation.py 1 --verbose`) reports PASS 46, FAIL 1, and the one FAIL is the capability gate refusing to run from a `.claude/worktrees` copy, an environment artifact. That gate cannot see this change either way: its `TEST_PATTERNS` are `test_*.py`, `test-*.py`, `test-*.sh` and its scan roots are `q-system/.q-system/**/*.py`, so neither `README.md` nor a `.md` under `q-system/output/` is in scope.
