### PR TITLE
fix(install-jobs): enumerate committed plists from the repo, and report what it could not install

### DIFF
--- a/README.md
+++ b/README.md
@@ -309,6 +309,14 @@ cd kipi-system && claude
 
 Setup walks you through who you are, what you work on, how you write, and who you know. Takes about 20 minutes. After that the system runs.
 
+The scheduled jobs are a separate step. Nothing above arms them:
+
+```bash
+./kipi install-jobs
+```
+
+`install-plist.sh --all` enumerates every committed `com.kipi.*.plist` with `git ls-files`, renders each one against your checkout, loads it, and prints `N installed, N skipped, N failed (of N committed)`. Two jobs (`com.kipi.lessons-daily`, `com.kipi.lessons-drift`) are skipped outside the skeleton by design, because they shell the fleet updater; the run names them when it skips them. It exits non-zero and names any committed job it could not install, so a partial install is not silence.
+
 ---
 
 ## Commands

--- a/q-system/.q-system/capability/expected_tests/q-system__.q-system__scripts__test__test-install-jobs-coverage.py.json
+++ b/q-system/.q-system/capability/expected_tests/q-system__.q-system__scripts__test__test-install-jobs-coverage.py.json
@@ -1,0 +1,4 @@
+{
+ "path": "q-system/.q-system/scripts/test/test-install-jobs-coverage.py",
+ "runner": "python3"
+}

--- a/q-system/.q-system/scripts/install-plist.sh
+++ b/q-system/.q-system/scripts/install-plist.sh
@@ -22,11 +22,71 @@ SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 # scripts/ -> .q-system/ -> q-system/ -> repo root
 KIPI_REPO="$(cd "$SCRIPT_DIR/../../.." && pwd)"
 
+# THE ENUMERATOR. One function, and every caller below goes through it: --all, the
+# usage listing, and the single-label lookup. Measured 2026-09-07: this used to be
+# `"$SCRIPT_DIR"/com.kipi.*.plist` written out three times, so the promise in
+# `kipi:22` ("install every committed launchd job") was scoped to ONE directory.
+# 15 plists were committed, 12 installed, 2 announced as skipped, and
+# automation/com.kipi.voice-refresh.plist was never mentioned at all -- the run
+# exited 0. A partial install that reports success is worse than a failed one:
+# detect_dark_jobs in fleet-health-daily.py enumerates ~/Library/LaunchAgents, so a
+# job never installed even once is invisible to the watchdog as well.
+#
+# The set comes from the REPO (git ls-files), not from a directory listing, because
+# "committed" is what the verb promises and only git knows it. The glob survives as
+# the fallback for a tree that is not a git checkout (an extracted template), and
+# the two are never silently interchangeable: templates_source() says which ran.
+templates_source() {
+  if git -C "$KIPI_REPO" rev-parse --git-dir >/dev/null 2>&1; then
+    echo "git ls-files"
+  else
+    echo "directory glob (not a git checkout)"
+  fi
+}
+
+# Emits absolute paths, one per line, sorted. A tracked-but-deleted file is dropped
+# here rather than becoming a confusing "no template" error three functions later.
+committed_templates() {
+  if [ "$(templates_source)" = "git ls-files" ]; then
+    git -C "$KIPI_REPO" ls-files -- '*/com.kipi.*.plist' 'com.kipi.*.plist' \
+      | while IFS= read -r rel; do
+          [ -f "$KIPI_REPO/$rel" ] && echo "$KIPI_REPO/$rel"
+        done | sort
+  else
+    for p in "$SCRIPT_DIR"/com.kipi.*.plist; do
+      [ -e "$p" ] && echo "$p"
+    done | sort
+  fi
+}
+
+# Resolve a label to its template path, from the same set --all walks. Before this,
+# `install-plist.sh com.kipi.voice-refresh` answered "no plist template for label"
+# about a template that was committed two directories away.
+#
+# No `| head -1` here, and that is the whole reason this is a loop with a `return`
+# instead of a one-liner. `committed_templates | ... | head -1` closes the pipe as
+# soon as it has its line, the upstream loop dies of SIGPIPE with status 141, and
+# `set -o pipefail` hands that to the assignment, where `set -e` kills the script
+# with no message. It looked like every template was broken: 12 of 13 labels failed
+# and only com.kipi.weekly-improve, the alphabetically LAST one, survived, because
+# it is the only label where head never closes the pipe early.
+template_for_label() {
+  local want="$1" p
+  while IFS= read -r p; do
+    if [ "$(basename "$p" .plist)" = "$want" ]; then
+      echo "$p"
+      return 0
+    fi
+  done <<EOF
+$(committed_templates)
+EOF
+  return 0
+}
+
 usage() {
   echo "usage: install-plist.sh <label> [--render-only <output-path>]" >&2
-  echo "labels available:" >&2
-  for p in "$SCRIPT_DIR"/com.kipi.*.plist; do
-    [ -e "$p" ] || continue
+  echo "labels available (from $(templates_source)):" >&2
+  committed_templates | while IFS= read -r p; do
     echo "  $(basename "$p" .plist)" >&2
   done
 }
@@ -69,24 +129,50 @@ if [ "$1" = "--all" ]; then
     _skeleton="$(python3 -c 'import json,sys,os; print(os.path.realpath(json.load(open(sys.argv[1]))["skeleton"]["path"]))' "$KIPI_REPO/instance-registry.json" 2>/dev/null || true)"
   fi
   rc=0
-  for _p in "$SCRIPT_DIR"/com.kipi.*.plist; do
+  _n_installed=0
+  _n_skipped=0
+  _n_failed=0
+  _failed_labels=""
+  echo "install-jobs: enumerating committed templates via $(templates_source)"
+  while IFS= read -r _p; do
     [ -e "$_p" ] || continue
     _label="$(basename "$_p" .plist)"
     if grep -q "kipi-scope: skeleton-only" "$_p" && [ "$(cd "$KIPI_REPO" && pwd -P)" != "$_skeleton" ]; then
       echo "  skipped (skeleton-only): $_label"
+      _n_skipped=$((_n_skipped + 1))
       continue
     fi
-    if bash "$0" "$_label"; then :; else rc=1; echo "  FAILED: $_label" >&2; fi
-  done
+    if bash "$0" "$_label"; then
+      _n_installed=$((_n_installed + 1))
+    else
+      rc=1
+      _n_failed=$((_n_failed + 1))
+      _failed_labels="$_failed_labels $_label"
+      echo "  FAILED: $_label" >&2
+    fi
+  done <<EOF
+$(committed_templates)
+EOF
+
+  # THE COUNT IS THE POINT. Before 2026-09-07 this loop ended at `exit "$rc"` and
+  # printed no total, so a run that installed 12 of 15 committed jobs looked exactly
+  # like a run that installed all of them: a wall of per-job success lines and exit
+  # 0. The founder's only signal was silence. Every committed label now lands in
+  # exactly one of these three counts, and a template that could not be installed
+  # is named and carries the exit code out.
+  echo "install-jobs: $_n_installed installed, $_n_skipped skipped, $_n_failed failed (of $((_n_installed + _n_skipped + _n_failed)) committed)"
+  if [ "$_n_failed" -gt 0 ]; then
+    echo "install-jobs: could not install:$_failed_labels" >&2
+  fi
   exit "$rc"
 fi
 
 LABEL="$1"
 shift
-TEMPLATE="$SCRIPT_DIR/$LABEL.plist"
+TEMPLATE="$(template_for_label "$LABEL")"
 
-if [ ! -f "$TEMPLATE" ]; then
-  echo "ERROR: no plist template for label '$LABEL' at $TEMPLATE" >&2
+if [ -z "$TEMPLATE" ] || [ ! -f "$TEMPLATE" ]; then
+  echo "ERROR: no committed plist template for label '$LABEL' (searched via $(templates_source))" >&2
   usage
   exit 2
 fi
@@ -115,18 +201,38 @@ fi
 # CONTROL case exited 127 and the whole probe proved nothing. The test was right
 # and the code was wrong: a renderer whose shape the harness depends on is part of
 # the harness contract.
+# __ROOT__ joined the set 2026-09-07 with the enumerator widening. It is
+# automation/com.kipi.voice-refresh.plist's spelling of the repo root: that template
+# was written against its own installer (automation/install-voice-refresh.sh) while
+# it sat outside the glob, so it never had to agree with anything. Now that --all
+# reaches it, one substituter handles both spellings rather than the file being
+# reachable and unrenderable, which is a louder failure than the silence it replaces
+# but still a failure.
 RENDER_USER="$(id -un)"
 render() {
   # sed with | as the delimiter: the path replacements contain /.
-  sed -e "s|__KIPI_REPO__|$KIPI_REPO|g" -e "s|__HOME__|$HOME|g" -e "s|__USER__|$RENDER_USER|g" "$TEMPLATE"
+  sed -e "s|__KIPI_REPO__|$KIPI_REPO|g" -e "s|__ROOT__|$KIPI_REPO|g" -e "s|__HOME__|$HOME|g" -e "s|__USER__|$RENDER_USER|g" "$TEMPLATE"
 }
 
 # A template that still carries a placeholder after substitution is a broken
 # render, and launchd would accept it silently and fail at fire time. Fail loud.
+#
+# The pattern is the CLASS (__ANY_TOKEN__), not the four names this script
+# substitutes. Measured 2026-09-07: an allowlist of known tokens passes any
+# template written against a fifth spelling -- exactly how __ROOT__ went four weeks
+# unnoticed. Catching the shape means a new token is a loud failure on the first
+# run instead of a job that plutil accepts and launchd fails at fire time.
 assert_rendered() {
   local rendered_file="$1"
-  if grep -q "__KIPI_REPO__\|__HOME__\|__USER__" "$rendered_file"; then
-    echo "ERROR: unsubstituted placeholder remains in $rendered_file" >&2
+  local left
+  # `|| true` is load-bearing, not defensive noise. grep exits 1 when it matches
+  # NOTHING, which here is the healthy case; under `set -e` the assignment then
+  # killed the script with exit 1 and no message at all. Caught 2026-09-07 by the
+  # reproducer going from 1 failing label to 13, which is what a guard that fires
+  # on every input looks like from the outside.
+  left="$(grep -o '__[A-Z][A-Z0-9_]*__' "$rendered_file" | sort -u | tr '\n' ' ' || true)"
+  if [ -n "$left" ]; then
+    echo "ERROR: unsubstituted placeholder remains in $rendered_file: $left" >&2
     exit 1
   fi
 }
@@ -141,13 +247,21 @@ fi
 
 PLIST="$HOME/Library/LaunchAgents/$LABEL.plist"
 mkdir -p "$HOME/Library/LaunchAgents" "$HOME/.config/kipi"
-render > "$PLIST"
-assert_rendered "$PLIST"
+
+# STAGE, VALIDATE, THEN MOVE. This used to render straight onto $PLIST and check
+# afterwards, so a template that failed either check left the broken copy sitting in
+# LaunchAgents -- and on a REinstall it had already overwritten a job that worked.
+# The move is last, so a refusal leaves the machine exactly as it was.
+STAGED="$(mktemp "${TMPDIR:-/tmp}/kipi-plist-XXXXXX")"
+trap 'rm -f "$STAGED"' EXIT
+render > "$STAGED"
+assert_rendered "$STAGED"
 
 # plutil is the only thing that proves the rendered XML is a loadable plist.
 if command -v plutil >/dev/null 2>&1; then
-  plutil -lint "$PLIST" >/dev/null
+  plutil -lint "$STAGED" >/dev/null
 fi
+mv "$STAGED" "$PLIST"
 
 UID_="$(id -u)"
 # KIPI_LAUNCHCTL is a test seam only (test_lessons_daily_label.py runs --all in a

--- a/q-system/.q-system/scripts/test/test-install-jobs-coverage.py
+++ b/q-system/.q-system/scripts/test/test-install-jobs-coverage.py
@@ -1,0 +1,237 @@
+#!/usr/bin/env python3
+"""Pairs with `kipi install-jobs` -> install-plist.sh --all (sp-0c48b66c, sp-d621b67d).
+
+THE SCAR THIS PINS. `kipi:22` advertises the verb as "Install every committed
+launchd job on this machine". Measured 2026-09-07 from a checkout of main at an
+arbitrary path, with a stub launchctl and a throwaway HOME:
+
+    committed com.kipi.*.plist ......... 15   (git ls-files)
+    installed by `--all` ............... 12
+    announced as skipped ............... 2    (skeleton-only, by design)
+    NEVER MENTIONED AT ALL ............. 1    (automation/com.kipi.voice-refresh.plist)
+    exit code .......................... 0
+
+`install-plist.sh` enumerated `"$SCRIPT_DIR"/com.kipi.*.plist`: ONE directory. A
+committed template outside `q-system/.q-system/scripts/` was unreachable, and the
+run said nothing and exited 0. A partial install that reports success is worse
+than a failed one, because nothing downstream ever looks again: `detect_dark_jobs`
+in fleet-health-daily.py enumerates `~/Library/LaunchAgents/*.plist`, so a job that
+was never installed once is invisible to the watchdog too.
+
+WHAT THIS TEST HOLDS (three properties, each able to go red on its own):
+  1. COVERAGE   every committed label is either installed or announced as skipped
+  2. RESOLVABLE every installed job's program path exists, with no live token left
+  3. LOUD       a committed template that cannot be installed makes the run exit
+                non-zero and names the label
+
+The fixture is a real checkout built from the WORKING TREE at an arbitrary temp
+path, not from HEAD: a reproducer that reads HEAD cannot see the fix you are
+writing. The first cut of this measurement cloned the source repo's HEAD, landed
+on a stale branch carrying 10 of the 15 plists, and described the fixture instead
+of the installer. Hence _build_checkout below prints the tree it actually made.
+
+Run: python3 q-system/.q-system/scripts/test/test-install-jobs-coverage.py
+Exit 0 = pass.
+"""
+
+import importlib.util
+import os
+import plistlib
+import re
+import shutil
+import subprocess
+import sys
+import tempfile
+from pathlib import Path
+
+HERE = Path(__file__).resolve().parent
+REPO = HERE.parents[3]
+
+# The committed templates carry `--` inside their XML comments (prose blocks
+# citing PR rounds). CoreFoundation accepts that, so launchd loads them, but
+# expat rejects the document outright. Borrow fleet-health-daily.py's own comment
+# stripper rather than writing a second one: a fixture parser that drifts from
+# the detector's parser measures a document neither of them sees.
+_fh_spec = importlib.util.spec_from_file_location(
+    "fh_for_coverage", HERE.parent / "fleet-health-daily.py")
+_fh = importlib.util.module_from_spec(_fh_spec)
+_fh_spec.loader.exec_module(_fh)
+
+
+def _parse_plist(path: Path):
+    return plistlib.loads(_fh._XML_COMMENT_RE.sub("", path.read_text()).encode())
+
+failures = []
+
+
+def check(name, got, want):
+    if got != want:
+        failures.append(f"{name}: got {got!r}, want {want!r}")
+        print(f"  FAIL: {name}: got {got!r}, want {want!r}")
+    else:
+        print(f"  ok: {name}")
+
+
+def _git(args, cwd, **kw):
+    return subprocess.run(["git"] + args, cwd=str(cwd), capture_output=True,
+                          text=True, timeout=180, **kw)
+
+
+def committed_labels(tree: Path):
+    """The set the verb promises, derived with git ls-files, never a glob."""
+    out = _git(["ls-files", "*.plist"], tree).stdout.split()
+    return sorted(Path(p).stem for p in out if Path(p).name.startswith("com.kipi."))
+
+
+def _build_checkout(work: Path) -> Path:
+    """A real primary checkout of the WORKING TREE, at a path nothing hardcodes.
+
+    tar over `git ls-files` and not `git clone`: clone copies HEAD, and the whole
+    point is to run the installer as it exists in the tree being reviewed. `git
+    init` + one commit makes `.git` a DIRECTORY, which is what install-plist.sh
+    requires before it will run --all (it refuses from a worktree on purpose).
+    """
+    dest = work / "an-arbitrary-checkout-path"
+    dest.mkdir(parents=True)
+    files = _git(["ls-files", "-z"], REPO).stdout.split("\0")
+    listing = work / "tracked.txt"
+    listing.write_text("\n".join(f for f in files if f))
+    tar_c = subprocess.run(
+        ["tar", "-cf", str(work / "tree.tar"), "-T", str(listing)],
+        cwd=str(REPO), capture_output=True, text=True, timeout=300)
+    if tar_c.returncode != 0:
+        print(tar_c.stderr, file=sys.stderr)
+        raise SystemExit("could not stage the working tree")
+    subprocess.run(["tar", "-xf", str(work / "tree.tar")], cwd=str(dest),
+                   capture_output=True, timeout=300)
+    _git(["init", "-q"], dest)
+    _git(["add", "-A"], dest)
+    _git(["-c", "user.email=test@example.invalid", "-c", "user.name=coverage test",
+          "commit", "-q", "-m", "fixture"], dest)
+    return dest
+
+
+def _stub_launchctl(work: Path) -> Path:
+    """launchctl must never be the real one: this test would bootstrap live jobs."""
+    stub = work / "bin" / "launchctl-stub"
+    stub.parent.mkdir(parents=True, exist_ok=True)
+    stub.write_text("#!/bin/bash\nexit 0\n")
+    stub.chmod(0o755)
+    return stub
+
+
+def run_all(checkout: Path, work: Path, tag: str):
+    home = work / f"home-{tag}"
+    (home / "Library" / "LaunchAgents").mkdir(parents=True)
+    env = dict(os.environ)
+    env["HOME"] = str(home)
+    env["KIPI_LAUNCHCTL"] = str(_stub_launchctl(work))
+    proc = subprocess.run(
+        ["bash", str(checkout / "q-system/.q-system/scripts/install-plist.sh"), "--all"],
+        capture_output=True, text=True, timeout=600, env=env)
+    return proc, home / "Library" / "LaunchAgents"
+
+
+_INSTALLED = re.compile(r"^installed (com\.kipi\.[a-z0-9.-]+)", re.M)
+_SKIPPED = re.compile(r"^\s*skipped \([^)]+\): (com\.kipi\.[a-z0-9.-]+)", re.M)
+
+
+def main():
+    work = Path(tempfile.mkdtemp(prefix="install-jobs-coverage-"))
+    try:
+        checkout = _build_checkout(work)
+        print(f"fixture checkout: {checkout}")
+        print(f"  .git is a directory: {(checkout / '.git').is_dir()}")
+
+        promised = committed_labels(checkout)
+        print(f"  committed com.kipi labels in the fixture: {len(promised)}")
+        check("the fixture carries the same committed set as the repo",
+              promised, committed_labels(REPO))
+
+        proc, agents = run_all(checkout, work, "main")
+        out = proc.stdout + proc.stderr
+        print("---- installer output ----")
+        print(out.rstrip())
+        print("--------------------------")
+
+        installed = set(_INSTALLED.findall(out))
+        skipped = set(_SKIPPED.findall(out))
+
+        # === 1. COVERAGE ===================================================
+        unaccounted = sorted(set(promised) - installed - skipped)
+        check("every committed label is installed or announced as skipped",
+              unaccounted, [])
+
+        check("every non-skipped committed label has a file in LaunchAgents",
+              sorted(l for l in promised
+                     if l not in skipped and not (agents / f"{l}.plist").exists()),
+              [])
+
+        # === 2. RESOLVABLE =================================================
+        # A rendered plist that still carries __TOKEN__ is a job launchd accepts
+        # and fails at fire time, silently. A program path that does not exist is
+        # the same failure one step later.
+        left_tokens, dead_paths = [], []
+        for f in sorted(agents.glob("com.kipi.*.plist")):
+            text = f.read_text()
+            if re.search(r"__[A-Z_]+__", text):
+                left_tokens.append(f.stem)
+            args = _parse_plist(f).get("ProgramArguments", [])
+            for a in args[1:]:
+                if a.startswith("/") and not Path(a).exists():
+                    dead_paths.append(f"{f.stem}: {a}")
+                    break
+        check("no installed job carries an unsubstituted placeholder", left_tokens, [])
+        check("every installed job's program path resolves", dead_paths, [])
+
+        # === 3. LOUD =======================================================
+        check("a fully-covered run reports a summary line",
+              bool(re.search(r"install-jobs: \d+ installed", out)), True)
+        check("a fully-covered run exits 0", proc.returncode, 0)
+
+        # === THE NEGATIVE SELF-TEST ========================================
+        # A control that fails the way an unrelated breakage fails proves nothing.
+        # This one commits ONE template whose token no substituter knows, and the
+        # assertion is not merely "non-zero": it is that this label is named in the
+        # output and that the exit code is the installer's own partial-install code.
+        control_label = "com.kipi.zz-unrenderable-control"
+        ctrl = checkout / "automation" / f"{control_label}.plist"
+        ctrl.write_text(
+            '<?xml version="1.0" encoding="UTF-8"?>\n'
+            '<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" '
+            '"http://www.apple.com/DTDs/PropertyList-1.0.dtd">\n'
+            '<plist version="1.0"><dict>\n'
+            f'  <key>Label</key><string>{control_label}</string>\n'
+            '  <key>ProgramArguments</key><array><string>/bin/bash</string>'
+            '<string>__NO_SUBSTITUTER_KNOWS_THIS__/x.sh</string></array>\n'
+            '</dict></plist>\n')
+        _git(["add", "-A"], checkout)
+        _git(["-c", "user.email=test@example.invalid", "-c", "user.name=coverage test",
+              "commit", "-q", "-m", "negative control"], checkout)
+
+        proc2, agents2 = run_all(checkout, work, "control")
+        out2 = proc2.stdout + proc2.stderr
+        check("the control template is REACHED by the enumerator (it is named)",
+              control_label in out2, True)
+        check("the control makes the run exit non-zero", proc2.returncode != 0, True)
+        check("the control is reported as a failure, not as installed",
+              control_label in set(_INSTALLED.findall(out2)), False)
+        check("the control's broken render never reaches LaunchAgents",
+              (agents2 / f"{control_label}.plist").exists(), False)
+        check("the healthy labels still installed alongside the failing one",
+              sorted(set(promised) - set(_INSTALLED.findall(out2)) - set(_SKIPPED.findall(out2))),
+              [])
+    finally:
+        shutil.rmtree(work, ignore_errors=True)
+
+    if failures:
+        print("\nFAILED:")
+        for f in failures:
+            print(f"  - {f}")
+        return 1
+    print("\nall install-jobs coverage checks passed")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/q-system/.q-system/scripts/test/test-install-plist.sh
+++ b/q-system/.q-system/scripts/test/test-install-plist.sh
@@ -91,10 +91,12 @@ bash "$NEG/install-plist.sh" com.kipi.broken-probe --render-only "$TMP/broken.pl
 BROKEN_EXIT=$?
 set -e
 
-# __UNRESOLVED_TOKEN__ is not one of the two the guard greps for, so the render
-# succeeds -- and that is the honest limit of the guard: it catches the two known
-# placeholders, not arbitrary ones. Assert the guard's real contract instead:
-# a file still containing a KNOWN placeholder must be rejected.
+# __UNRESOLVED_TOKEN__ used to render fine: the guard grepped for the specific
+# names it substitutes, so any other spelling passed. That allowlist is how
+# automation/com.kipi.voice-refresh.plist's __ROOT__ went unnoticed while the
+# enumerator could not reach it. Since 2026-09-07 assert_rendered matches the
+# CLASS (__ANY_TOKEN__), so an unknown token is a rejection, and this is now an
+# assertion rather than the info line it was.
 cat > "$NEG/com.kipi.noop-probe.plist" <<'PLIST'
 <?xml version="1.0" encoding="UTF-8"?>
 <plist version="1.0"><dict><key>Repo</key><string>__KIPI_REPO__</string></dict></plist>
@@ -130,7 +132,11 @@ else
   fail "negative self-test control: placeholder-free template failed (exit $CLEAN_EXIT), so the probe proves nothing"
 fi
 
-echo "  (info: unknown-token render exited $BROKEN_EXIT; the guard covers the two known placeholders by design)"
+if [ "$BROKEN_EXIT" -ne 0 ]; then
+  pass "an UNKNOWN placeholder is rejected too (exit $BROKEN_EXIT), so the guard covers the class"
+else
+  fail "unknown-token render exited 0: assert_rendered is back to an allowlist of known placeholders, which is how __ROOT__ went unnoticed"
+fi
 
 echo
 if [ "$FAILS" -eq 0 ]; then


### PR DESCRIPTION
## The plan (the plan-file gate refuses worktree writes, so it lives here)

1. Ground the defect read-only, seven measurements, each with the command that produced it. Falsifier set up front: if every committed job is installable from any checkout path, report no defect and stop.
2. Reproducer first, watched red: install into a temp HOME from a checkout at an arbitrary path, assert every committed job is installed or announced, and that every installed job's program path resolves.
3. Fix the enumerator to derive from the repo, render every template, and report what it skipped instead of exiting zero.
4. Prose last, stating only what the fixed code does.

## Phase 1: seven measurements

| # | Question | Command | Result |
|---|---|---|---|
| 1 | How many job files are committed? | `git ls-files '*.plist'` | **15** |
| 2 | How many does the installer enumerate? | `ls q-system/.q-system/scripts/com.kipi.*.plist` (the glob at `install-plist.sh:72`) | **14** |
| 3 | Which is missing, and why? | `git ls-files '*.plist' \| grep -v '^q-system/'` | `automation/com.kipi.voice-refresh.plist`. `install-plist.sh:72` was `for _p in "$SCRIPT_DIR"/com.kipi.*.plist`: one directory. `:28` used the same glob for the label list, so `install-plist.sh com.kipi.voice-refresh` also answered "no plist template" |
| 4 | Any unrendered template or unresolvable path? | placeholder scan over all 15, then `ls automation/voice-refresh-nudge.sh` | The odd one out carries `__ROOT__`, which `render()` did not substitute **and `assert_rendered` did not check**. Its program path does resolve. So widening the glob alone would have installed a job with a literal `__ROOT__` in it, silently |
| 5 | Does enumeration depend on a hardcoded absolute path? | ran `--all` from a clone of `main` at a temp path, stub launchctl, throwaway HOME | **No.** `SCRIPT_DIR` is `BASH_SOURCE`-relative and it worked from an arbitrary path. `--all` refuses from a git worktree, by design |
| 6 | What is loaded on this machine? | `launchctl list \| grep com.kipi` | 14 labels loaded. `com.kipi.voice-refresh` **NOT LOADED**. Also loaded-but-uncommitted: `audit-rotate`, `launchd-health`, `pr86-review` |
| 7 | Does a fix or a test already exist? | searched `install-plist` across the repo; read PR #324's audit section 7 | No. `test-plist-drift.py` compares committed vs installed for jobs that ARE installed; `detect_dark_jobs` enumerates `~/Library/LaunchAgents`, so a job never installed once is invisible to it too. The audit had already named the fix shape; not re-derived |

**The falsifier did not fire.** The measured run from an arbitrary checkout path:

```
installed 12 | skipped 2 (skeleton-only, announced) | never mentioned 1 | exit 0
```

`kipi:22` advertises "Install every committed launchd job on this machine". It installed every committed job in one directory and said nothing about the rest.

## Phase 2: reproducer red, then green

`q-system/.q-system/scripts/test/test-install-jobs-coverage.py`. Fixture is a real primary checkout built from the **working tree** (not HEAD, which cannot see the fix under review) at a temp path, with a stubbed launchctl and a throwaway HOME.

RED at `5030f4da`, six assertions:

```
FAIL every committed label is installed or announced as skipped: ['com.kipi.voice-refresh']
FAIL every non-skipped committed label has a file in LaunchAgents: ['com.kipi.voice-refresh']
FAIL a fully-covered run reports a summary line: got False
FAIL the control template is REACHED by the enumerator (it is named): got False
FAIL the control makes the run exit non-zero: got False
FAIL the healthy labels still installed alongside the failing one: ['com.kipi.voice-refresh']
```

GREEN at `b5a42797`, 11 of 11:

```
install-jobs: enumerating committed templates via git ls-files
  skipped (skeleton-only): com.kipi.lessons-daily
  skipped (skeleton-only): com.kipi.lessons-drift
install-jobs: 13 installed, 2 skipped, 0 failed (of 15 committed)
all install-jobs coverage checks passed        (exit 0)
```

### The negative control

One template committed into the fixture carrying `__NO_SUBSTITUTER_KNOWS_THIS__`. The assertion is not merely "non-zero": the control must be **named** in the output, must not be counted as installed, must not leave its broken render in LaunchAgents, and the healthy labels must still install alongside it. All four pass.

### Two shell defects the reproducer caught, both mine, both invisible without it

- `left="$(grep -o ...)"` — grep exits 1 when it matches nothing, which is the healthy case; under `set -e` that killed the script with exit 1 and no message. **13 of 13 labels failed.**
- `committed_templates | ... | head -1` — head closes the pipe, the upstream loop dies of SIGPIPE 141, `pipefail` hands it to the assignment. **12 of 13 failed and only `com.kipi.weekly-improve` survived**, because the alphabetically last label is the only one where head never closes the pipe early.

Both are recorded as why-comments at the lines that carry them.

## What changed

- `committed_templates()` derives the set from `git ls-files`, with the old directory glob kept as the fallback for a tree that is not a git checkout. `templates_source()` names which ran, so the two are never silently interchangeable.
- `--all`, `usage()`, and the single-label lookup all go through that one function.
- `render()` substitutes `__ROOT__` as well as `__KIPI_REPO__`.
- `assert_rendered` rejects the **class** (`__ANY_TOKEN__`), not the four names this script substitutes. An allowlist of known tokens is exactly how `__ROOT__` went unnoticed.
- The render is **staged to a temp file and moved into place only after both checks pass**. It used to write straight into LaunchAgents and validate after, so a refusal left the broken copy behind, having already overwritten a job that worked.
- `--all` prints `install-jobs: N installed, N skipped, N failed (of N committed)` and exits non-zero naming what it could not install.

## Gates run before pushing

```
test-install-jobs-coverage.py ............... exit 0
test-install-plist.sh ....................... PASS, exit 0
test-plist-drift.py ......................... exit 0
automation/test_voice_refresh_schedule.py ... exit 0
```

`capability-gate.py` refuses to run from a `.claude/worktrees` copy by design; it runs from the primary checkout after merge.

## Deliberately not in this PR

- `automation/install-voice-refresh.sh` remains a **second writer** of the same `~/Library/LaunchAgents/com.kipi.voice-refresh.plist`, and it is the only one that registers with the launchd-health watchdog. So a job armed by `install-jobs` is unregistered with that watchdog. Real, adjacent, and a different change; captured rather than bundled.
- Three labels are loaded on this machine with no committed template (`com.kipi.audit-rotate`, `com.kipi.launchd-health`, `com.kipi.pr86-review`). That is the reverse direction of this defect. `sp-ff4f494a` already covers `launchd-health`.
- PR #324's wider README audit is untouched. This branch is cut from `origin/main` and does not rebase onto or resurrect it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01PpVeUeZnvRVSb6uxzTPL28
