### PR TITLE
fix(board): the morning board carries only what he can act on, and every row can be started

### DIFF
--- a/q-system/.q-system/scripts/board_rows.py
+++ b/q-system/.q-system/scripts/board_rows.py
@@ -540,14 +540,48 @@ def _schema_properties(token, db, opener=None, budget=None):
     except Exception:
         return None
     props = (data or {}).get("properties")
-    return set(props) if isinstance(props, dict) and props else None
+    if not isinstance(props, dict) or not props:
+        return None
+    # NAME AND TYPE, not name alone (PR reviewer round 7, minor). A board carrying a
+    # `Link` column that is rich_text rather than url still takes the 400 this guard
+    # exists to prevent, and the guard would have said the column was fine.
+    return {name: (p or {}).get("type") for name, p in props.items()}
+
+
+#: What `_properties` writes, per column, so a board whose column is a different TYPE
+#: is treated the same as a board that lacks it: dropped, and said out loud.
+WRITES_TYPE = {"Task": "title", "Item id": "rich_text", "Notes": "rich_text",
+               "Domain": "multi_select", "Priority": "select", "Source": "select",
+               "Bucket": "select", "Status": "select", "Link": "url",
+               "Next": "rich_text"}
 
 
 def _only_known(props: dict, known):
-    """`props` minus any column this board does not have. `known` None -> unchanged."""
+    """(props this board can take, names dropped). `known` None -> unchanged, nothing
+    dropped, which is what shipped before the filter existed.
+
+    A column is dropped when the board does not have it OR has it under a different
+    type. The caller REPORTS what was dropped: silently writing a row without its link
+    and then printing "read-back ok" is the quiet half-write this whole file is built
+    to refuse (PR reviewer round 7, major).
+    """
     if known is None:
-        return props
-    return {k: v for k, v in props.items() if k in known}
+        return props, ()
+    keep, dropped = {}, []
+    for k, v in props.items():
+        want = WRITES_TYPE.get(k)
+        if k in known and (want is None or known[k] == want):
+            keep[k] = v
+        else:
+            dropped.append(k)
+    return keep, tuple(sorted(dropped))
+
+
+def _drop_and_note(props, known, sink: set):
+    """`_only_known`, recording what it dropped into `sink` for the caller to report."""
+    keep, dropped = _only_known(props, known)
+    sink.update(dropped)
+    return keep
 
 
 def paint(buckets: dict, token, db, opener=None, budget=None, known=None) -> dict:
@@ -560,6 +594,10 @@ def paint(buckets: dict, token, db, opener=None, budget=None, known=None) -> dic
     """
     if buckets.get("error"):
         raise ValueError(buckets["error"])
+
+    #: Every column this run could not write, so the morning line can say so. A link
+    #: dropped in silence is worse than a crash: the crash gets looked at.
+    dropped_cols: set = set()
 
     wanted, scopes, over_cap, capped = {}, {}, 0, set()
     for key, bucket in BUCKET_OF.items():
@@ -630,9 +668,9 @@ def paint(buckets: dict, token, db, opener=None, budget=None, known=None) -> dic
                 continue
             _request(token, "POST", "/pages",
                      {"parent": {"database_id": db},
-                      "properties": _only_known(
+                      "properties": _drop_and_note(
                           _properties(item, bucket, iid, include_bucket=True,
-                                      status="Not started"), known)},
+                                      status="Not started"), known, dropped_cols)},
                      opener, budget)
             created += 1
         else:
@@ -646,9 +684,9 @@ def paint(buckets: dict, token, db, opener=None, budget=None, known=None) -> dic
             # made the row differ forever: it was PATCHed every run, `unchanged` stayed
             # at zero, and the write budget went on rewriting values nobody changed.
             # What is compared has to be what is written.
-            props = _only_known(
+            props = _drop_and_note(
                 _properties(item, record, iid, include_bucket=write,
-                            record_bucket=record, pinned=pin), known)
+                            record_bucket=record, pinned=pin), known, dropped_cols)
             pinned += 1 if pin else 0
             if _already_holds(page, props):
                 unchanged += 1
@@ -707,7 +745,7 @@ def paint(buckets: dict, token, db, opener=None, budget=None, known=None) -> dic
         archived += 1
 
     return {"created": created, "updated": updated, "archived": archived,
-            "held": held,
+            "held": held, "dropped_columns": tuple(sorted(dropped_cols)),
             "kept": kept, "wanted": len(wanted), "moved": moved, "pinned": pinned,
             "over_cap": over_cap, "unchanged": unchanged, "deferred": deferred,
             # Rows we WANTED but never created: they are not on the board, so the
@@ -790,6 +828,12 @@ def collect(now, sources: dict, opener=None, token_file=None, db_file=None,
             f"{counts['kept']} kept (source quiet), {counts['pinned']} yours (untouched), "
             f"{counts['held']} yours (source stopped reporting it), "
             "read-back ok")
+    if counts["dropped_columns"]:
+        # NEVER SILENT. The filter stops a missing column aborting the paint; it must
+        # not also hide that the rows went out without it. A board missing `Link` wrote
+        # every row without its link and still said "read-back ok" (round 7, major).
+        line += ("; this board has no " + ", ".join(counts["dropped_columns"])
+                 + " column, so those values were not written")
     if counts["over_cap"]:
         line += f"; {counts['over_cap']} row(s) over the {BUDGET_ROWS}-row cap, not written"
     if counts["deferred"]:

--- a/q-system/.q-system/scripts/board_rows.py
+++ b/q-system/.q-system/scripts/board_rows.py
@@ -630,8 +630,9 @@ def paint(buckets: dict, token, db, opener=None, budget=None, known=None) -> dic
                 continue
             _request(token, "POST", "/pages",
                      {"parent": {"database_id": db},
-                      "properties": _properties(item, bucket, iid, include_bucket=True,
-                                                status="Not started")},
+                      "properties": _only_known(
+                          _properties(item, bucket, iid, include_bucket=True,
+                                      status="Not started"), known)},
                      opener, budget)
             created += 1
         else:
@@ -640,8 +641,14 @@ def paint(buckets: dict, token, db, opener=None, budget=None, known=None) -> dic
             # `_bucket_decision` and the module docstring for how his drag is told from
             # our own stale paint.
             write, record, pin = _bucket_decision(page, bucket)
-            props = _properties(item, record, iid, include_bucket=write,
-                                record_bucket=record, pinned=pin)
+            # FILTERED BEFORE THE COMPARISON, not after (PR reviewer round 6, minor).
+            # Comparing the full property set against a board that cannot hold `Link`
+            # made the row differ forever: it was PATCHed every run, `unchanged` stayed
+            # at zero, and the write budget went on rewriting values nobody changed.
+            # What is compared has to be what is written.
+            props = _only_known(
+                _properties(item, record, iid, include_bucket=write,
+                            record_bucket=record, pinned=pin), known)
             pinned += 1 if pin else 0
             if _already_holds(page, props):
                 unchanged += 1
@@ -649,7 +656,7 @@ def paint(buckets: dict, token, db, opener=None, budget=None, known=None) -> dic
             if out_of_write_budget():
                 deferred += 1
                 continue
-            _request(token, "PATCH", f"/pages/{page['id']}", {"properties": _only_known(props, known)},
+            _request(token, "PATCH", f"/pages/{page['id']}", {"properties": props},
                      opener, budget)
             updated += 1
             moved += 1 if write else 0

--- a/q-system/.q-system/scripts/board_rows.py
+++ b/q-system/.q-system/scripts/board_rows.py
@@ -244,6 +244,11 @@ BUCKET_PREFIX = "bucket="
 #: bucket. One flag rather than an inference, because the inference is what would
 #: silently expire (see `_bucket_decision`).
 PINNED_LINE = "pinned=1"
+#: Stamped on a PINNED row once its producer stops emitting it. His placement wins, so
+#: the row is kept; without a word on it, "kept" and "still live" look identical and the
+#: board grows rows nothing can clear, which is exactly sp-7720fce9. The line is plain
+#: English because he is the one who reads it and the one who decides.
+STALE_LINE = "its source no longer reports this row; archive it when you are done"
 #: The note's machinery lines are short and fixed; the free text is capped so they
 #: always fit. Before this the whole note was truncated at the end, so a long detail
 #: could push `scope=` off and the row read back as an unknown scope: kept forever,
@@ -630,8 +635,22 @@ def paint(buckets: dict, token, db, opener=None, budget=None) -> dict:
             # at "Not started" when the producer came back. Filtering white client
             # lines out of the board (DEC-34) makes that flip ordinary rather than
             # rare, which is how the reviewer found it.
+            #
+            # AND IT IS STAMPED ONCE, so keeping it is not the same permanence defect
+            # in a nicer coat (PR reviewer round 2, major: "a pinned row has no exit
+            # from the board"). Keeping it silently would recreate sp-7720fce9, the
+            # thirteen rows no run could ever clear, which had to be archived by hand.
+            # The row stays because he placed it; the stamp says its source stopped
+            # reporting it, so the exit is his and he can see that he has one. Written
+            # once: the next run finds the line already there and skips the write.
             kept += 1
             pinned += 1
+            note = _note_of(page)
+            if STALE_LINE not in note and not out_of_write_budget():
+                _request(token, "PATCH", f"/pages/{page['id']}",
+                         {"properties": {"Notes": {"rich_text": [{"text": {"content":
+                          f"{note}\n{STALE_LINE}"[:NOTE_CAP]}}]}}}, opener, budget)
+                updated += 1
             continue
         if out_of_write_budget():
             # An unarchived row is on the board, so it counts as kept for the read-back

--- a/q-system/.q-system/scripts/board_rows.py
+++ b/q-system/.q-system/scripts/board_rows.py
@@ -555,6 +555,19 @@ WRITES_TYPE = {"Task": "title", "Item id": "rich_text", "Notes": "rich_text",
                "Bucket": "select", "Status": "select", "Link": "url",
                "Next": "rich_text"}
 
+#: NEVER DROPPABLE (PR reviewer round 8, major). `Item id` is the row's identity: every
+#: lookup, every refresh and every archive decision keys on it, and `existing_rows`
+#: queries the board by its prefix. Dropping it does not degrade a row, it creates a
+#: row this module can never find again -- one more per wanted row per run, forever,
+#: with no error anywhere. `Task` is the title, so a row without it is untitled on his
+#: board. Losing either is worse than the 400 the filter exists to prevent, so a board
+#: that cannot take them stops the paint instead of half-writing it.
+UNDROPPABLE = ("Item id", "Task")
+
+
+class MissingIdentityColumn(RuntimeError):
+    """The board cannot take a column the painter cannot work without."""
+
 
 def _only_known(props: dict, known):
     """(props this board can take, names dropped). `known` None -> unchanged, nothing
@@ -574,6 +587,12 @@ def _only_known(props: dict, known):
             keep[k] = v
         else:
             dropped.append(k)
+    hard = [k for k in UNDROPPABLE if k in dropped]
+    if hard:
+        raise MissingIdentityColumn(
+            f"the board cannot take {', '.join(hard)}, which the painter identifies "
+            "rows by. Writing rows without it would create pages this module can never "
+            "find or archive again, one per row per run. Fix the board's columns.")
     return keep, tuple(sorted(dropped))
 
 
@@ -832,8 +851,16 @@ def collect(now, sources: dict, opener=None, token_file=None, db_file=None,
         # NEVER SILENT. The filter stops a missing column aborting the paint; it must
         # not also hide that the rows went out without it. A board missing `Link` wrote
         # every row without its link and still said "read-back ok" (round 7, major).
-        line += ("; this board has no " + ", ".join(counts["dropped_columns"])
-                 + " column, so those values were not written")
+        #
+        # "cannot take", not "has no": the column may be present under the wrong TYPE,
+        # and telling him it is missing sends him looking for something that is there
+        # (round 8, minor). The plural is counted rather than assumed for the same
+        # reason: a line that says "column" about three of them reads as one.
+        names = counts["dropped_columns"]
+        line += ("; this board cannot take the "
+                 + ", ".join(names)
+                 + (" columns" if len(names) > 1 else " column")
+                 + ", so those values were not written")
     if counts["over_cap"]:
         line += f"; {counts['over_cap']} row(s) over the {BUDGET_ROWS}-row cap, not written"
     if counts["deferred"]:

--- a/q-system/.q-system/scripts/board_rows.py
+++ b/q-system/.q-system/scripts/board_rows.py
@@ -244,11 +244,6 @@ BUCKET_PREFIX = "bucket="
 #: bucket. One flag rather than an inference, because the inference is what would
 #: silently expire (see `_bucket_decision`).
 PINNED_LINE = "pinned=1"
-#: Stamped on a PINNED row once its producer stops emitting it. His placement wins, so
-#: the row is kept; without a word on it, "kept" and "still live" look identical and the
-#: board grows rows nothing can clear, which is exactly sp-7720fce9. The line is plain
-#: English because he is the one who reads it and the one who decides.
-STALE_LINE = "its source no longer reports this row; archive it when you are done"
 #: The note's machinery lines are short and fixed; the free text is capped so they
 #: always fit. Before this the whole note was truncated at the end, so a long detail
 #: could push `scope=` off and the row read back as an unknown scope: kept forever,
@@ -579,8 +574,10 @@ def paint(buckets: dict, token, db, opener=None, budget=None) -> dict:
     #: Rows HE pinned whose producer went quiet: kept because he placed them, and
     #: counted apart from `kept` (a quiet source) and `pinned` (a live row he moved),
     #: because the morning line reports all three and they are three different facts.
-    #: `stamped` is the subset that was told so this run, which is once per row ever.
-    held = stamped = 0
+    #: It is a term of the read-back sum below: a held row IS on the board, so leaving
+    #: it out made the proof report a mismatch every run after any pinned row's
+    #: producer went quiet (PR reviewer round 4, major).
+    held = 0
     deferred_new = 0
 
     def out_of_write_budget() -> bool:
@@ -648,32 +645,21 @@ def paint(buckets: dict, token, db, opener=None, budget=None) -> dict:
             # lines out of the board (DEC-34) makes that flip ordinary rather than
             # rare, which is how the reviewer found it.
             #
-            # AND IT IS STAMPED ONCE, so keeping it is not the same permanence defect
-            # in a nicer coat (PR reviewer round 2, major: "a pinned row has no exit
-            # from the board"). Keeping it silently would recreate sp-7720fce9, the
-            # thirteen rows no run could ever clear, which had to be archived by hand.
-            # The row stays because he placed it; the stamp says its source stopped
-            # reporting it, so the exit is his and he can see that he has one. Written
-            # once: the next run finds the line already there and skips the write.
-            # COUNTED AS ITS OWN THING (PR reviewer round 3, minor). Folding these
-            # into `kept` and `pinned` made the morning line say "kept (source quiet),
-            # yours (untouched)" about a row whose source was healthy and which this
-            # loop had just written. A count that describes the wrong event is worse
-            # than no count: it is read as a reassurance.
+            # HIS EXIT IS HIS OWN ARCHIVE, and that is the whole answer to "a pinned
+            # row has no exit" (PR reviewer round 2, major). The first answer was a
+            # stamp written into the row's Notes saying its source had gone quiet. It
+            # cost three findings across two rounds and the last of them was serious:
+            # the note's machinery lines (`scope=`, `bucket=`, `pinned=`) live at the
+            # END, so truncating the note to make room for the stamp deleted the pin
+            # the stamp existed to protect. The file already warns about exactly that
+            # above NOTE_CAP, and the fix walked into it anyway.
+            #
+            # A row he pinned is a row he placed. This module's contract is that the
+            # machine never moves or removes it; removing it is his, in the UI, the
+            # same exit he has for every other row he ever pinned. Counted as `held`
+            # rather than folded into `kept`, because `kept` means the SOURCE went
+            # quiet and this source answered fine.
             held += 1
-            note = _note_of(page)
-            if STALE_LINE not in note and not out_of_write_budget():
-                # THE FREE TEXT IS WHAT GETS CUT, NEVER THE STAMP (PR reviewer round 3,
-                # minor). Truncating the whole string at NOTE_CAP dropped the stamp off
-                # the end of a long note, so `STALE_LINE not in note` stayed true and
-                # the row was re-PATCHed identically every morning: a silent write loop
-                # wearing a write-once comment. Same reasoning as `_note_body`, where
-                # truncating from the end would drop `scope=` first.
-                head = note[:max(0, NOTE_CAP - len(STALE_LINE) - 1)].rstrip()
-                _request(token, "PATCH", f"/pages/{page['id']}",
-                         {"properties": {"Notes": {"rich_text": [{"text": {"content":
-                          f"{head}\n{STALE_LINE}"}}]}}}, opener, budget)
-                stamped += 1
             continue
         if out_of_write_budget():
             # An unarchived row is on the board, so it counts as kept for the read-back
@@ -685,7 +671,7 @@ def paint(buckets: dict, token, db, opener=None, budget=None) -> dict:
         archived += 1
 
     return {"created": created, "updated": updated, "archived": archived,
-            "held": held, "stamped": stamped,
+            "held": held,
             "kept": kept, "wanted": len(wanted), "moved": moved, "pinned": pinned,
             "over_cap": over_cap, "unchanged": unchanged, "deferred": deferred,
             # Rows we WANTED but never created: they are not on the board, so the
@@ -749,17 +735,19 @@ def collect(now, sources: dict, opener=None, token_file=None, db_file=None,
     # board and deliberately not in `wanted`. Round 3 (major): comparing `seen` to
     # `wanted` alone made every quiet source report a false read-back mismatch and mark
     # the whole brief degraded, which would have trained him to ignore the word.
-    expected = counts["wanted"] + counts["kept"] - counts["deferred_new"]
+    expected = (counts["wanted"] + counts["kept"] + counts["held"]
+                - counts["deferred_new"])
     if seen != expected:
         # The write-only-integration scar: a PATCH that returns 200 is not proof the
         # board holds what we think. The read-back is the proof.
         return [], (f"read-back mismatch: expected {expected} row(s) "
                     f"({counts['wanted']} written + {counts['kept']} kept from a quiet "
-                    f"source), board shows {seen}")
+                    f"source + {counts['held']} held for you), board shows {seen}")
     line = (f"board: {counts['created']} new, {counts['updated']} refreshed, "
             f"{counts['unchanged']} unchanged, "
             f"{counts['moved']} rebucketed, {counts['archived']} cleared, "
             f"{counts['kept']} kept (source quiet), {counts['pinned']} yours (untouched), "
+            f"{counts['held']} yours (source stopped reporting it), "
             "read-back ok")
     if counts["over_cap"]:
         line += f"; {counts['over_cap']} row(s) over the {BUDGET_ROWS}-row cap, not written"

--- a/q-system/.q-system/scripts/board_rows.py
+++ b/q-system/.q-system/scripts/board_rows.py
@@ -822,6 +822,13 @@ def collect(now, sources: dict, opener=None, token_file=None, db_file=None,
         # call refuses. Partial writes up to that point are ordinary rows the next
         # paint reconciles; what cannot happen is a write after the brief moved on.
         return [], f"board write timed out: {exc}; no further write lands"
+    except MissingIdentityColumn as exc:
+        # ITS OWN ARM, ahead of the generic one (PR reviewer round 9, minor). This is
+        # the one failure here that a person can actually fix, and the whole point of
+        # raising it is the sentence it carries. Falling through to the generic arm
+        # printed "MissingIdentityColumn" and threw the remediation away, which is the
+        # class-name-instead-of-help shape this file refuses everywhere else.
+        return [], str(exc)
     except (urllib.error.URLError, urllib.error.HTTPError, OSError, ValueError) as exc:
         return [], f"board write failed: {type(exc).__name__}: {exc}"
 

--- a/q-system/.q-system/scripts/board_rows.py
+++ b/q-system/.q-system/scripts/board_rows.py
@@ -527,8 +527,37 @@ def _fair_share(rows, budget):
     return out
 
 
-def paint(buckets: dict, token, db, opener=None, budget=None) -> dict:
-    """Create, refresh and archive. Returns a counts dict. Never moves a row."""
+def _schema_properties(token, db, opener=None, budget=None):
+    """The property names this database actually carries, or None when unreadable.
+
+    None means "do not filter", which is the behaviour that shipped before this
+    existed. A board whose schema cannot be read is not a board whose columns are
+    gone, and refusing to write on a failed read would turn one bad response into a
+    blank morning.
+    """
+    try:
+        data = _request(token, "GET", f"/databases/{db}", None, opener, budget)
+    except Exception:
+        return None
+    props = (data or {}).get("properties")
+    return set(props) if isinstance(props, dict) and props else None
+
+
+def _only_known(props: dict, known):
+    """`props` minus any column this board does not have. `known` None -> unchanged."""
+    if known is None:
+        return props
+    return {k: v for k, v in props.items() if k in known}
+
+
+def paint(buckets: dict, token, db, opener=None, budget=None, known=None) -> dict:
+    """Create, refresh and archive. Returns a counts dict. Never moves a row.
+
+    `known` is the set of property names this board actually has, or None for "write
+    everything", which is what shipped before it existed. It is READ BY THE CALLER and
+    passed in rather than fetched here, so driving `paint` directly makes exactly the
+    requests it always made. See `_schema_properties` for why the filter exists.
+    """
     if buckets.get("error"):
         raise ValueError(buckets["error"])
 
@@ -620,7 +649,7 @@ def paint(buckets: dict, token, db, opener=None, budget=None) -> dict:
             if out_of_write_budget():
                 deferred += 1
                 continue
-            _request(token, "PATCH", f"/pages/{page['id']}", {"properties": props},
+            _request(token, "PATCH", f"/pages/{page['id']}", {"properties": _only_known(props, known)},
                      opener, budget)
             updated += 1
             moved += 1 if write else 0
@@ -710,7 +739,12 @@ def collect(now, sources: dict, opener=None, token_file=None, db_file=None,
         # The lock is held INSIDE the budget: a painter that runs out of time also
         # lets go, so the 07:40 job is not refused by a worker the brief abandoned.
         with exclusive():
-            counts = paint(buckets, token, db, opener, budget)
+            # The schema read happens HERE, once per run, and its answer is handed
+            # to the painter. See `_schema_properties`: a board that predates `Link`
+            # and `Next` would otherwise take a 400 on the first row and lose the
+            # whole morning's paint to a column nobody noticed was missing.
+            counts = paint(buckets, token, db, opener, budget,
+                           known=_schema_properties(token, db, opener, budget))
         dupes = {}
         seen = len(existing_rows(token, db, opener, dupes_out=dupes, budget=budget))
         return counts, dupes, seen

--- a/q-system/.q-system/scripts/board_rows.py
+++ b/q-system/.q-system/scripts/board_rows.py
@@ -421,6 +421,13 @@ def _properties(item, bucket, iid, include_bucket: bool, *, status=None,
         # filtered on -- which is the only thing a domain column is for.
         "Domain": {"multi_select": [{"name": item.get("domain") or "Consulting"}]},
     }
+    # NO PRODUCER EMITS `next` TODAY and that is the point (PR reviewer round 3, nit).
+    # The constant one the inbox lane briefly had restated DONE_BY_SOURCE and was cut in
+    # round 1. The column is filled BY HAND, per row, in his own words -- which is the
+    # half of an actionable row nothing here can know -- and this writer's whole job for
+    # it is to refuse to blank what he wrote. A producer that learns a real next step
+    # later needs no change here.
+    #
     # LINK AND NEXT ARE WRITTEN ONLY WHEN THE PRODUCER SUPPLIES THEM, never blanked.
     # A row whose producer knows neither keeps whatever a human put there; clearing it
     # every morning would make the two columns useless on exactly the rows that needed
@@ -569,6 +576,11 @@ def paint(buckets: dict, token, db, opener=None, budget=None) -> dict:
 
     have = existing_rows(token, db, opener, budget=budget)
     created = updated = archived = moved = pinned = unchanged = deferred = 0
+    #: Rows HE pinned whose producer went quiet: kept because he placed them, and
+    #: counted apart from `kept` (a quiet source) and `pinned` (a live row he moved),
+    #: because the morning line reports all three and they are three different facts.
+    #: `stamped` is the subset that was told so this run, which is once per row ever.
+    held = stamped = 0
     deferred_new = 0
 
     def out_of_write_budget() -> bool:
@@ -643,14 +655,25 @@ def paint(buckets: dict, token, db, opener=None, budget=None) -> dict:
             # The row stays because he placed it; the stamp says its source stopped
             # reporting it, so the exit is his and he can see that he has one. Written
             # once: the next run finds the line already there and skips the write.
-            kept += 1
-            pinned += 1
+            # COUNTED AS ITS OWN THING (PR reviewer round 3, minor). Folding these
+            # into `kept` and `pinned` made the morning line say "kept (source quiet),
+            # yours (untouched)" about a row whose source was healthy and which this
+            # loop had just written. A count that describes the wrong event is worse
+            # than no count: it is read as a reassurance.
+            held += 1
             note = _note_of(page)
             if STALE_LINE not in note and not out_of_write_budget():
+                # THE FREE TEXT IS WHAT GETS CUT, NEVER THE STAMP (PR reviewer round 3,
+                # minor). Truncating the whole string at NOTE_CAP dropped the stamp off
+                # the end of a long note, so `STALE_LINE not in note` stayed true and
+                # the row was re-PATCHed identically every morning: a silent write loop
+                # wearing a write-once comment. Same reasoning as `_note_body`, where
+                # truncating from the end would drop `scope=` first.
+                head = note[:max(0, NOTE_CAP - len(STALE_LINE) - 1)].rstrip()
                 _request(token, "PATCH", f"/pages/{page['id']}",
                          {"properties": {"Notes": {"rich_text": [{"text": {"content":
-                          f"{note}\n{STALE_LINE}"[:NOTE_CAP]}}]}}}, opener, budget)
-                updated += 1
+                          f"{head}\n{STALE_LINE}"}}]}}}, opener, budget)
+                stamped += 1
             continue
         if out_of_write_budget():
             # An unarchived row is on the board, so it counts as kept for the read-back
@@ -662,6 +685,7 @@ def paint(buckets: dict, token, db, opener=None, budget=None) -> dict:
         archived += 1
 
     return {"created": created, "updated": updated, "archived": archived,
+            "held": held, "stamped": stamped,
             "kept": kept, "wanted": len(wanted), "moved": moved, "pinned": pinned,
             "over_cap": over_cap, "unchanged": unchanged, "deferred": deferred,
             # Rows we WANTED but never created: they are not on the board, so the

--- a/q-system/.q-system/scripts/board_rows.py
+++ b/q-system/.q-system/scripts/board_rows.py
@@ -381,10 +381,17 @@ def _properties(item, bucket, iid, include_bucket: bool, *, status=None,
     # actionable; `scope=` and `bucket=` are machinery the painter reads back and
     # belong last.
     done = (item.get("done") or "").strip()
+    detail = (item.get("detail") or "").strip()
     note = ""
     if done:
         note += f"Done signal: {done}\n"
-    note += (item.get("detail") or "")[:1500]
+    # THE DETAIL IS NOT THE DONE SIGNAL REPEATED. Measured on the live board
+    # 2026-09-07: 6 of 12 rows carried "Done signal: X" followed by X character for
+    # character, because the GTM producer passes `done_looks_like` as both. The column
+    # truncates in his table view, so what he read was the opening fragment of a
+    # sentence he was about to read again.
+    if detail and detail != done:
+        note += detail[:1500]
     tail = f"{SCOPE_PREFIX}{item.get('scope') or 'card'}"
     tail += f"\n{BUCKET_PREFIX}{record_bucket if record_bucket is not None else bucket}"
     if pinned:
@@ -403,6 +410,17 @@ def _properties(item, bucket, iid, include_bucket: bool, *, status=None,
         # filtered on -- which is the only thing a domain column is for.
         "Domain": {"multi_select": [{"name": item.get("domain") or "Consulting"}]},
     }
+    # LINK AND NEXT ARE WRITTEN ONLY WHEN THE PRODUCER SUPPLIES THEM, never blanked.
+    # A row whose producer knows neither keeps whatever a human put there; clearing it
+    # every morning would make the two columns useless on exactly the rows that needed
+    # a person to fill them. Same posture as Size, which this module deliberately does
+    # not write (see the note above `buckets`).
+    link = item.get("link")
+    if link:
+        props["Link"] = {"url": str(link)[:2000]}
+    nxt = item.get("next")
+    if nxt:
+        props["Next"] = {"rich_text": [{"text": {"content": str(nxt)[:1900]}}]}
     priority = item.get("priority")
     if priority:
         props["Priority"] = {"select": {"name": priority}}

--- a/q-system/.q-system/scripts/board_rows.py
+++ b/q-system/.q-system/scripts/board_rows.py
@@ -311,6 +311,12 @@ def _prop_value(prop):
         return ((prop.get("select") or {}).get("name") or "") or None
     if "multi_select" in prop:
         return tuple(sorted((o.get("name") or "") for o in prop.get("multi_select") or []))
+    # `url` joined this list with `Link` (PR reviewer, major). Without it every row
+    # carrying a Link read as unreadable, `_already_holds` was always False, and the
+    # painter PATCHed every Gmail row on every run: a write budget spent re-writing
+    # values that had not changed, and a `last_edited_time` that lied about it.
+    if "url" in prop:
+        return prop.get("url") or None
     # A DISTINCT OBJECT, never None (round 13, minor). The docstring below promised
     # that an unreadable property compares unequal and fails toward writing, while
     # None == None made two unreadable shapes compare EQUAL and skip the write, so a
@@ -614,6 +620,18 @@ def paint(buckets: dict, token, db, opener=None, budget=None) -> dict:
             continue
         if _scope_of(page) not in healthy:
             kept += 1                      # its source could not answer; leave it alone
+            continue
+        if _note_field(page, PINNED_LINE.split("=")[0] + "="):
+            # HIS DRAG SURVIVES THE PRODUCER DROPPING THE ROW (PR reviewer, major).
+            # The module's contract is that a row a human moved is never moved or
+            # re-bucketed by the machine, and this loop was the hole in it: a row he
+            # had pinned was still archived the moment its producer stopped emitting
+            # it, taking his placement and his Status with it and recreating the row
+            # at "Not started" when the producer came back. Filtering white client
+            # lines out of the board (DEC-34) makes that flip ordinary rather than
+            # rare, which is how the reviewer found it.
+            kept += 1
+            pinned += 1
             continue
         if out_of_write_budget():
             # An unarchived row is on the board, so it counts as kept for the read-back

--- a/q-system/.q-system/scripts/board_rows.py
+++ b/q-system/.q-system/scripts/board_rows.py
@@ -596,6 +596,21 @@ def _only_known(props: dict, known):
     return keep, tuple(sorted(dropped))
 
 
+def _refuse_without_identity(known):
+    """Raise when the board cannot take a column the painter works by. `known` None
+    (schema unreadable) is not a verdict about the columns, so it passes."""
+    if known is None:
+        return
+    missing = [k for k in UNDROPPABLE
+               if k not in known or known[k] != WRITES_TYPE[k]]
+    if missing:
+        raise MissingIdentityColumn(
+            f"the board cannot take {', '.join(missing)}, which the painter "
+            "identifies rows by. Writing rows without it would create pages this "
+            "module can never find or archive again, one per row per run. Fix the "
+            "board's columns.")
+
+
 def _drop_and_note(props, known, sink: set):
     """`_only_known`, recording what it dropped into `sink` for the caller to report."""
     keep, dropped = _only_known(props, known)
@@ -807,8 +822,14 @@ def collect(now, sources: dict, opener=None, token_file=None, db_file=None,
             # to the painter. See `_schema_properties`: a board that predates `Link`
             # and `Next` would otherwise take a 400 on the first row and lose the
             # whole morning's paint to a column nobody noticed was missing.
-            counts = paint(buckets, token, db, opener, budget,
-                           known=_schema_properties(token, db, opener, budget))
+            known = _schema_properties(token, db, opener, budget)
+            # BEFORE THE FIRST QUERY, not inside the write loop. `existing_rows`
+            # filters on `Item id`, so a board without that column takes a raw 400
+            # from Notion before `_only_known` is ever reached and the remediation
+            # sentence never fires (round 10, minor). Checked here, the one failure a
+            # person can fix is the one they are told about.
+            _refuse_without_identity(known)
+            counts = paint(buckets, token, db, opener, budget, known=known)
         dupes = {}
         seen = len(existing_rows(token, db, opener, dupes_out=dupes, budget=budget))
         return counts, dupes, seen

--- a/q-system/.q-system/scripts/consulting_board.py
+++ b/q-system/.q-system/scripts/consulting_board.py
@@ -612,6 +612,19 @@ DONE_GTM_FALLBACK = "the step is done or you wrote down why it did not happen"
 #: worth saying gets it from whoever knows, and the writer never blanks it.
 GMAIL_THREAD = "https://mail.google.com/mail/u/0/#all/"
 
+#: A Gmail thread id is hex. The mail producer's documented FALLBACK key is
+#: `mail:<sender>|<subject>` (see `_FALLBACK_KEY`), and pasting that after the thread
+#: URL builds a link that opens nothing (PR reviewer round 10, minor). A dead link is
+#: worse than no link: it costs a click and teaches him the column lies. No id it can
+#: recognise means no link, and the row still carries its subject and its done signal.
+_THREAD_ID = re.compile(r"^[0-9a-f]{8,24}$", re.I)
+
+
+def gmail_link(key: str):
+    """The thread URL for a `mail:<thread id>` key, or None when the id is not one."""
+    _, _, rest = str(key or "").partition(":")
+    return GMAIL_THREAD + rest if _THREAD_ID.match(rest) else None
+
 DONE_BY_SOURCE = {
     "Gmail": "you replied in the thread",
     "GroupMe": "you answered in the chat",
@@ -712,8 +725,11 @@ def buckets(now: dt.datetime, sources: dict, paths=None) -> dict:
         #
         # THE KNOWN COST, taken deliberately (PR reviewer round 3, major). A client
         # going ⚪ drops its row from `wanted`, so an UNPINNED one is archived, and the
-        # flip back creates a fresh page at Status "Not started", losing a status he
-        # had set. Kept anyway: he asked for these rows gone in as many words, Status
+        # flip back creates a fresh page: it loses the Status he set AND anything he
+        # typed into Link or Next, which this same change went to trouble never to
+        # blank on a live row (round 10, minor: the comment named only Status and that
+        # undersold it). Kept anyway: he asked for these rows gone in as many words,
+        # Status
         # was measured unused on 2026-09-07 (12 of 12 rows read "Not started", the
         # painter writes it create-only and nothing else moves it), and the only fix
         # that preserves it is restoring the archived page instead of creating a new
@@ -838,7 +854,7 @@ def buckets(now: dt.datetime, sources: dict, paths=None) -> dict:
                     "Every inbox producer must emit morning-brief.Row(line, key); "
                     "keying on the rendered line is the PR #296 rounds 1-4 defect.")
             inbox.append({"title": text, "key": key, "detail": "",
-                          "link": (GMAIL_THREAD + key.split(":", 1)[1]
+                          "link": (gmail_link(key)
                                    if label == "Gmail" and key.startswith("mail:")
                                    else None),
                           "source": label, "scope": f"inbox:{label}",

--- a/q-system/.q-system/scripts/consulting_board.py
+++ b/q-system/.q-system/scripts/consulting_board.py
@@ -578,13 +578,26 @@ PRIORITY_BY_HEALTH = {
 #: AUDHD rule A2 (next physical action) is the same requirement from the other side.
 DONE_DEFAULT = "you have acted on it"
 DONE_BY_KIND = {
-    "client": "you sent the thing you promised",
+    # NOT "you sent the thing you promised". DEC-30, founder-directed 2026-09-06
+    # ("nothing should be mine - Sana is the human"): the promises behind a client
+    # line are Sana's build queue, and a done signal addressed to him made them read
+    # as his to send. What is left for him on a client row is the act no agent can
+    # perform, or the ball moving to their side.
+    "client": "you did the act only you can do, or it moved to their side",
     "reach": "you sent the message",
 }
 #: A GTM step whose plan text carries no "done looks like". Deliberately vague,
 #: because inventing a specific completion test for a step nobody wrote one for would
 #: be this module making up the plan.
 DONE_GTM_FALLBACK = "the step is done or you wrote down why it did not happen"
+#: A row he cannot start from is not a task. The mail producer's key IS the Gmail
+#: thread id (`morning-brief.collect_mail` emits `mail:<thread id>`), so the link needs
+#: no new plumbing and no second source of truth: it is derived from the id the row
+#: already carries. Founder's standing rule: if he cannot copy-paste it, click it or
+#: check it off, it does not belong. Measured 2026-09-07: not one row on the board
+#: carried a URL, including the P0 intro he had to go find in Gmail by hand.
+GMAIL_THREAD = "https://mail.google.com/mail/u/0/#all/"
+
 DONE_BY_SOURCE = {
     "Gmail": "you replied in the thread",
     "GroupMe": "you answered in the chat",
@@ -685,7 +698,20 @@ def buckets(now: dt.datetime, sources: dict, paths=None) -> dict:
         # not emitted by `state_card.py`, the only producer this reads -- `board_sync`
         # uses it on the Clients board -- so this makes two tables in this file agree
         # rather than changing a live path. `_CLIENT_LINE` has always parsed it.
-        (top if row["health"] in ("🔴", "🟠", "📞") else week).append(item)
+        # ⚪ AND 🟢 NEVER REACH THE BOARD. Founder-directed 2026-09-07, verbatim:
+        # *"remove sana stuff from the board"*. ⚪ is "their move" or "Sana owes n" and
+        # 🟢 is "nothing to do"; neither is an act he can perform, so a row for one is
+        # a to-do he cannot start. He still sees them on the Slack card, which is
+        # DEC-30's design and does not change. Measured that evening: five ⚪ rows sat
+        # in This Week carrying his done signal over Sana's build work. DEC-34.
+        if row["health"] in ("⚪", "🟢"):
+            continue
+        # EVERYTHING THE CARD SURFACES IS TOP OF MIND, and This Week is no longer
+        # written from the card. The section's own text says it is his and that
+        # nothing fills it automatically; eleven machine rows were in it on
+        # 2026-09-07. A board where every section is machine-written has no place
+        # that represents a decision he made, and the drag is the point.
+        top.append(item)
 
     # The dates failing is reported ONCE, as its own row, never as a line stapled to
     # every client. A test proves this module still delivers with no registry in the
@@ -789,6 +815,11 @@ def buckets(now: dt.datetime, sources: dict, paths=None) -> dict:
                     "Every inbox producer must emit morning-brief.Row(line, key); "
                     "keying on the rendered line is the PR #296 rounds 1-4 defect.")
             inbox.append({"title": text, "key": key, "detail": "",
+                          "link": (GMAIL_THREAD + key.split(":", 1)[1]
+                                   if label == "Gmail" and key.startswith("mail:")
+                                   else None),
+                          "next": ("Open the thread and reply."
+                                   if label == "Gmail" else "Answer in the chat."),
                           "source": label, "scope": f"inbox:{label}",
                           # Inbox rows are things a person is waiting on. P2: below a
                           # client he owes something to and below a broken source, above

--- a/q-system/.q-system/scripts/consulting_board.py
+++ b/q-system/.q-system/scripts/consulting_board.py
@@ -695,15 +695,22 @@ def buckets(now: dt.datetime, sources: dict, paths=None) -> dict:
         phrase = my_side_phrase(rec, now) if rec else ""
         if phrase:
             item["detail"] = f"{item['detail']}\n{phrase}" if item["detail"] else phrase
-        # 🔴, 🟠 and 📞 are today. Everything else is this week. The split is the card's
-        # own health verdict, not a rule invented here.
+        # THERE IS NO LONGER A TODAY / THIS-WEEK SPLIT HERE, and the comment that
+        # described one is gone with it (PR reviewer round 3, minor). Every dot the
+        # card surfaces to this board is Top of Mind; the two that are not acts he can
+        # perform do not reach the board at all. What the dot still decides is
+        # PRIORITY_BY_HEALTH, which is the card's own verdict translated, never a
+        # second judgement made here.
         #
-        # 🟠 joined the today group in round 7 (minor): PRIORITY_BY_HEALTH calls it P0
-        # "answer them: a person is waiting on a reply" while this line sent it to This
-        # Week, so one module said today and not-today about the same row. The dot is
-        # not emitted by `state_card.py`, the only producer this reads -- `board_sync`
-        # uses it on the Clients board -- so this makes two tables in this file agree
-        # rather than changing a live path. `_CLIENT_LINE` has always parsed it.
+        # THE KNOWN COST, taken deliberately (PR reviewer round 3, major). A client
+        # going ⚪ drops its row from `wanted`, so an UNPINNED one is archived, and the
+        # flip back creates a fresh page at Status "Not started", losing a status he
+        # had set. Kept anyway: he asked for these rows gone in as many words, Status
+        # was measured unused on 2026-09-07 (12 of 12 rows read "Not started", the
+        # painter writes it create-only and nothing else moves it), and the only fix
+        # that preserves it is restoring the archived page instead of creating a new
+        # one, which needs the archived id kept somewhere because Notion's query
+        # returns no archived rows. That is real and is captured, not forgotten.
         # ⚪ AND 🟢 NEVER REACH THE BOARD. Founder-directed 2026-09-07, verbatim:
         # *"remove sana stuff from the board"*. ⚪ is "their move" or "Sana owes n" and
         # 🟢 is "nothing to do"; neither is an act he can perform, so a row for one is

--- a/q-system/.q-system/scripts/consulting_board.py
+++ b/q-system/.q-system/scripts/consulting_board.py
@@ -596,6 +596,12 @@ DONE_GTM_FALLBACK = "the step is done or you wrote down why it did not happen"
 #: already carries. Founder's standing rule: if he cannot copy-paste it, click it or
 #: check it off, it does not belong. Measured 2026-09-07: not one row on the board
 #: carried a URL, including the P0 intro he had to go find in Gmail by hand.
+#:
+#: NO `next` IS WRITTEN FOR AN INBOX ROW (PR reviewer, nit). A constant per source
+#: ("Open the thread and reply.") restates `DONE_BY_SOURCE` in the imperative, which
+#: is the duplication this same change removes from the Notes column. The link plus
+#: the subject is what makes the row startable; a row whose next step is genuinely
+#: worth saying gets it from whoever knows, and the writer never blanks it.
 GMAIL_THREAD = "https://mail.google.com/mail/u/0/#all/"
 
 DONE_BY_SOURCE = {
@@ -706,11 +712,13 @@ def buckets(now: dt.datetime, sources: dict, paths=None) -> dict:
         # in This Week carrying his done signal over Sana's build work. DEC-34.
         if row["health"] in ("⚪", "🟢"):
             continue
-        # EVERYTHING THE CARD SURFACES IS TOP OF MIND, and This Week is no longer
-        # written from the card. The section's own text says it is his and that
-        # nothing fills it automatically; eleven machine rows were in it on
-        # 2026-09-07. A board where every section is machine-written has no place
-        # that represents a decision he made, and the drag is the point.
+        # EVERYTHING THE CARD SURFACES IS TOP OF MIND. THE CARD no longer writes
+        # This Week; `read_week` still does, from the GTM queue and from deliverables
+        # due inside the window, and those are genuinely this week's committed work.
+        # What left the section is the client lane, which was eleven machine rows on
+        # 2026-09-07 in a section whose own text says nothing fills it automatically.
+        # Emptying it completely is not this change: the week rows would then have no
+        # home and would be invisible, which is the defect sp-772d21e9 is about.
         top.append(item)
 
     # The dates failing is reported ONCE, as its own row, never as a line stapled to
@@ -818,8 +826,6 @@ def buckets(now: dt.datetime, sources: dict, paths=None) -> dict:
                           "link": (GMAIL_THREAD + key.split(":", 1)[1]
                                    if label == "Gmail" and key.startswith("mail:")
                                    else None),
-                          "next": ("Open the thread and reply."
-                                   if label == "Gmail" else "Answer in the chat."),
                           "source": label, "scope": f"inbox:{label}",
                           # Inbox rows are things a person is waiting on. P2: below a
                           # client he owes something to and below a broken source, above

--- a/q-system/.q-system/scripts/consulting_board.py
+++ b/q-system/.q-system/scripts/consulting_board.py
@@ -521,10 +521,18 @@ def collect(now: dt.datetime, sources: dict, paths=None):
     shown = card_rows[:MAX_CLIENT_ROWS]
     for row in shown:
         rows.append(f"{row['health']} {row['name']} · {row['detail']}")
-    withheld = len(card_rows) - len(shown)
+    # COUNT ONLY WHAT THE BOARD ACTUALLY CARRIES (PR reviewer round 5, minor). This
+    # said "more on the board" about every row past the cap, and since ⚪ and 🟢 stopped
+    # reaching the board at all, some of those rows are nowhere to go and look at. A
+    # pointer to a place the thing is not is worse than no pointer.
+    withheld = len([r for r in card_rows[MAX_CLIENT_ROWS:]
+                    if r["health"] not in ("⚪", "🟢")])
+    quiet = len(card_rows) - len(shown) - withheld
     if withheld:
         # Never a silent trim. The count is the founder's cue that the board has more.
         rows.append(f"...and {withheld} more on the board")
+    if quiet:
+        rows.append(f"...and {quiet} where the ball is not with you")
     move, gtm_err = read_gtm(paths)
     if gtm_err:
         # A missing GTM move does not void the clients. It is named and the section

--- a/q-system/.q-system/tests/test_board_is_actionable.py
+++ b/q-system/.q-system/tests/test_board_is_actionable.py
@@ -428,3 +428,45 @@ class TestTheSchemaGuardIsActuallyWiredIntoTheRun:
         dbf = tmp_path / "notion-board-db"; dbf.write_text("d", encoding="utf-8")
         br.collect(NOW, {}, token_file=str(tf), db_file=str(dbf))
         assert seen.get("known") == {"Task": "title", "Item id": "rich_text"}, seen
+
+
+class TestTheCardLineDoesNotPointAtRowsThatAreNotThere:
+    """"...and N more on the board" counted every row past the display cap, including
+    ⚪ and 🟢 rows that no longer reach the board at all. A pointer to a place the thing
+    is not is worse than no pointer (PR reviewer round 5, minor; round 9 asked for the
+    test that stops it reverting)."""
+
+    def _card(self, tmp_path, lines):
+        paths = _paths(tmp_path)
+        paths["card"].write_text(
+            "*Your book today* - 2026-09-07\n" + "\n".join(lines), encoding="utf-8")
+        return paths
+
+    def _many(self, health, n):
+        return [f"{health} *Client {i}* · something" for i in range(n)]
+
+    def test_rows_past_the_cap_that_reach_the_board_are_counted_as_on_the_board(self, tmp_path):
+        over = cb.MAX_CLIENT_ROWS + 3
+        paths = self._card(tmp_path, self._many("🔴", over))
+        rows, err = cb.collect(NOW, {}, paths)
+        assert err is None, err
+        assert any("more on the board" in r for r in rows), rows
+        assert not any("ball is not with you" in r for r in rows), rows
+
+    def test_rows_past_the_cap_that_never_reach_it_are_counted_separately(self, tmp_path):
+        over = cb.MAX_CLIENT_ROWS + 3
+        paths = self._card(tmp_path, self._many("⚪", over))
+        rows, err = cb.collect(NOW, {}, paths)
+        assert err is None, err
+        assert not any("more on the board" in r for r in rows), rows
+        assert any("ball is not with you" in r for r in rows), rows
+
+    def test_the_two_counts_do_not_double_count_one_row(self, tmp_path):
+        half = cb.MAX_CLIENT_ROWS
+        paths = self._card(tmp_path, self._many("🔴", half) + self._many("⚪", 4))
+        rows, err = cb.collect(NOW, {}, paths)
+        assert err is None, err
+        board = [r for r in rows if "more on the board" in r]
+        quiet = [r for r in rows if "ball is not with you" in r]
+        assert not board, board
+        assert quiet and "4" in quiet[0], quiet

--- a/q-system/.q-system/tests/test_board_is_actionable.py
+++ b/q-system/.q-system/tests/test_board_is_actionable.py
@@ -195,8 +195,26 @@ class TestHisPlacementSurvivesTheProducerDroppingTheRow:
         counts = br.paint({"top_of_mind": [], "this_week": [], "inbox": [],
                            "healthy_scopes": {"card"}}, "tok", "db")
         assert counts["archived"] == 0, sent
-        assert counts["kept"] == 1, counts
+        # `held`, not `kept`: a quiet source and a row he pinned whose source is
+        # healthy are different facts and the morning line reports both.
+        assert counts["held"] == 1 and counts["kept"] == 0, counts
+        assert counts["stamped"] == 1, counts
         assert not [s for s in sent if s[2].get("archived")], sent
+
+    def test_a_long_note_keeps_the_stamp_and_loses_free_text_instead(self, monkeypatch):
+        """Truncating the whole string dropped the stamp off the end, so the row was
+        re-PATCHed identically every morning (PR reviewer round 3, minor)."""
+        long_note = ("x" * (br.NOTE_CAP - 40)) + "\nscope=card\nbucket=This Week\npinned=1"
+        page = self._page("cb:gone", long_note)
+        sent = []
+        monkeypatch.setattr(br, "existing_rows", lambda *a, **k: {"cb:gone": page})
+        monkeypatch.setattr(br, "_request",
+                            lambda tok, m, path, body, op=None, bud=None: sent.append((m, path, body)))
+        br.paint({"top_of_mind": [], "this_week": [], "inbox": [],
+                  "healthy_scopes": {"card"}}, "tok", "db")
+        written = sent[0][2]["properties"]["Notes"]["rich_text"][0]["text"]["content"]
+        assert br.STALE_LINE in written, written[-120:]
+        assert len(written) <= br.NOTE_CAP, len(written)
 
     def test_a_kept_pinned_row_is_told_its_source_went_quiet(self, monkeypatch):
         """Keeping it silently would be sp-7720fce9 again: a row no run can clear.
@@ -222,7 +240,8 @@ class TestHisPlacementSurvivesTheProducerDroppingTheRow:
         counts = br.paint({"top_of_mind": [], "this_week": [], "inbox": [],
                            "healthy_scopes": {"card"}}, "tok", "db")
         assert sent == [], sent
-        assert counts["archived"] == 0 and counts["kept"] == 1, counts
+        assert counts["archived"] == 0 and counts["held"] == 1, counts
+        assert counts["stamped"] == 0, counts
 
     def test_an_unpinned_row_the_producer_dropped_is_still_archived(self, monkeypatch):
         page = self._page("cb:gone", "Done signal: x\nscope=card\nbucket=This Week")

--- a/q-system/.q-system/tests/test_board_is_actionable.py
+++ b/q-system/.q-system/tests/test_board_is_actionable.py
@@ -118,9 +118,12 @@ class TestEveryMailRowCanBeStartedFromTheRow:
         b = self._mail(tmp_path, "mail:bbbbbbbbbbbbbbbb")["link"]
         assert a != b and a.endswith("aaaaaaaaaaaaaaaa"), (a, b)
 
-    def test_a_gmail_row_says_what_to_do(self, tmp_path):
-        assert self._mail(tmp_path, "mail:1a06eb5b0b03759f")["next"] == (
-            "Open the thread and reply.")
+    def test_the_producer_supplies_no_next_for_an_inbox_row(self, tmp_path):
+        """A constant per source restates DONE_BY_SOURCE in the imperative, which is
+        the duplication this change removes from Notes (PR reviewer, nit). The link
+        and the subject are what make the row startable. Because the writer never
+        blanks a property it was not given, a Next a human wrote there survives."""
+        assert self._mail(tmp_path, "mail:1a06eb5b0b03759f").get("next") is None
 
 
 class TestTheWriterCarriesLinkAndNext:
@@ -170,3 +173,60 @@ class TestTheNoteDoesNotRepeatItself:
                                "cb:x", False)
         note = props["Notes"]["rich_text"][0]["text"]["content"]
         assert "a real extra fact" in note and "signal" in note, note
+
+
+class TestHisPlacementSurvivesTheProducerDroppingTheRow:
+    """The module's contract is that a row a human moved is never moved by the machine.
+    The archive loop was the hole in it: a pinned row was archived the moment its
+    producer stopped emitting it, taking his placement and his Status with it. Filtering
+    white client lines off the board makes that flip ordinary rather than rare."""
+
+    def _page(self, iid, note):
+        return {"id": f"page-{iid}",
+                "properties": {"Item id": {"rich_text": [{"plain_text": iid}]},
+                               "Notes": {"rich_text": [{"plain_text": note}]}}}
+
+    def test_a_pinned_row_is_kept_when_its_producer_stops_emitting_it(self, monkeypatch):
+        page = self._page("cb:gone", "Done signal: x\nscope=card\nbucket=This Week\npinned=1")
+        sent = []
+        monkeypatch.setattr(br, "existing_rows", lambda *a, **k: {"cb:gone": page})
+        monkeypatch.setattr(br, "_request",
+                            lambda tok, m, path, body, op=None, bud=None: sent.append((m, path, body)))
+        counts = br.paint({"top_of_mind": [], "this_week": [], "inbox": [],
+                           "healthy_scopes": {"card"}}, "tok", "db")
+        assert counts["archived"] == 0, sent
+        assert counts["kept"] == 1, counts
+        assert not [s for s in sent if s[2].get("archived")], sent
+
+    def test_an_unpinned_row_the_producer_dropped_is_still_archived(self, monkeypatch):
+        page = self._page("cb:gone", "Done signal: x\nscope=card\nbucket=This Week")
+        sent = []
+        monkeypatch.setattr(br, "existing_rows", lambda *a, **k: {"cb:gone": page})
+        monkeypatch.setattr(br, "_request",
+                            lambda tok, m, path, body, op=None, bud=None: sent.append((m, path, body)))
+        counts = br.paint({"top_of_mind": [], "this_week": [], "inbox": [],
+                           "healthy_scopes": {"card"}}, "tok", "db")
+        assert counts["archived"] == 1, (counts, sent)
+
+
+class TestALinkIsComparable:
+    """Without url in `_prop_value` every row carrying a Link read as unreadable, so
+    `_already_holds` was always False and the painter rewrote every Gmail row every
+    run (PR reviewer, major)."""
+
+    def test_a_url_property_reads_back_as_its_value(self):
+        assert br._prop_value({"url": "https://example.test/x"}) == "https://example.test/x"
+
+    def test_an_unchanged_link_is_not_rewritten(self):
+        props = br._properties({"title": "t", "key": "k", "done": "d",
+                                "link": "https://example.test/x"},
+                               "Inbox", "cb:x", False)
+        page = {"properties": {k: v for k, v in props.items()}}
+        assert br._already_holds(page, props), "a row that already holds its Link was rewritten"
+
+    def test_a_changed_link_is_rewritten(self):
+        props = br._properties({"title": "t", "key": "k", "done": "d",
+                                "link": "https://example.test/new"},
+                               "Inbox", "cb:x", False)
+        page = {"properties": dict(props, Link={"url": "https://example.test/old"})}
+        assert not br._already_holds(page, props)

--- a/q-system/.q-system/tests/test_board_is_actionable.py
+++ b/q-system/.q-system/tests/test_board_is_actionable.py
@@ -198,6 +198,32 @@ class TestHisPlacementSurvivesTheProducerDroppingTheRow:
         assert counts["kept"] == 1, counts
         assert not [s for s in sent if s[2].get("archived")], sent
 
+    def test_a_kept_pinned_row_is_told_its_source_went_quiet(self, monkeypatch):
+        """Keeping it silently would be sp-7720fce9 again: a row no run can clear.
+        The stamp gives him an exit he can see. (PR reviewer round 2, major.)"""
+        page = self._page("cb:gone", "Done signal: x\nscope=card\nbucket=This Week\npinned=1")
+        sent = []
+        monkeypatch.setattr(br, "existing_rows", lambda *a, **k: {"cb:gone": page})
+        monkeypatch.setattr(br, "_request",
+                            lambda tok, m, path, body, op=None, bud=None: sent.append((m, path, body)))
+        br.paint({"top_of_mind": [], "this_week": [], "inbox": [],
+                  "healthy_scopes": {"card"}}, "tok", "db")
+        wrote = [s for s in sent if "Notes" in (s[2].get("properties") or {})]
+        assert len(wrote) == 1, sent
+        assert br.STALE_LINE in wrote[0][2]["properties"]["Notes"]["rich_text"][0]["text"]["content"]
+
+    def test_the_stamp_is_written_once_not_every_run(self, monkeypatch):
+        page = self._page("cb:gone",
+                          f"Done signal: x\nscope=card\nbucket=This Week\npinned=1\n{br.STALE_LINE}")
+        sent = []
+        monkeypatch.setattr(br, "existing_rows", lambda *a, **k: {"cb:gone": page})
+        monkeypatch.setattr(br, "_request",
+                            lambda tok, m, path, body, op=None, bud=None: sent.append((m, path, body)))
+        counts = br.paint({"top_of_mind": [], "this_week": [], "inbox": [],
+                           "healthy_scopes": {"card"}}, "tok", "db")
+        assert sent == [], sent
+        assert counts["archived"] == 0 and counts["kept"] == 1, counts
+
     def test_an_unpinned_row_the_producer_dropped_is_still_archived(self, monkeypatch):
         page = self._page("cb:gone", "Done signal: x\nscope=card\nbucket=This Week")
         sent = []

--- a/q-system/.q-system/tests/test_board_is_actionable.py
+++ b/q-system/.q-system/tests/test_board_is_actionable.py
@@ -200,19 +200,25 @@ class TestHisPlacementSurvivesTheProducerDroppingTheRow:
         assert counts["held"] == 1 and counts["kept"] == 0, counts
         assert not [s for s in sent if s[2].get("archived")], sent
 
-    def test_a_held_row_is_a_term_of_the_read_back_sum(self, monkeypatch):
-        """A held row IS on the board. Leaving it out of the sum made the proof report
-        a mismatch every run once any pinned row's producer went quiet, which is the
-        false-alarm shape that trains him to ignore the word (PR reviewer round 4)."""
+    def test_a_held_row_is_reported_as_held_and_as_nothing_else(self, monkeypatch):
+        """A held row IS on the board, so it has to be a term of `collect`'s read-back
+        sum or the proof reports a mismatch every run once any pinned row's producer
+        goes quiet (PR reviewer round 4, major).
+
+        THIS TEST DOES NOT RECOMPUTE THAT SUM. The first version did, and a test that
+        recomputes the formula it guards stays green when the real one drops a term
+        (round 7, minor). The sum itself is held by
+        test_every_row_on_the_board_is_a_term_of_the_read_back_sum in
+        test_consulting_board.py, which reads the expression `collect` actually uses.
+        What belongs here is the count that expression consumes."""
         page = self._page("cb:gone", "Done signal: x\nscope=card\nbucket=This Week\npinned=1")
         monkeypatch.setattr(br, "existing_rows", lambda *a, **k: {"cb:gone": page})
         monkeypatch.setattr(br, "_request", lambda *a, **k: None)
         counts = br.paint({"top_of_mind": [], "this_week": [], "inbox": [],
                            "healthy_scopes": {"card"}}, "tok", "db")
-        expected = (counts["wanted"] + counts["kept"] + counts["held"]
-                    - counts["deferred_new"])
-        assert expected == 1, counts
-        assert counts["held"] == 1 and counts["kept"] == 0, counts
+        assert counts["held"] == 1, counts
+        assert counts["kept"] == 0 and counts["archived"] == 0, counts
+        assert counts["wanted"] == 0 and counts["deferred_new"] == 0, counts
 
     def test_nothing_is_written_to_a_held_row(self, monkeypatch):
         """The first answer to 'a pinned row has no exit' wrote a stamp into its Notes,
@@ -264,45 +270,44 @@ class TestALinkIsComparable:
 class TestAColumnThisBoardLacksIsNotAWholeLostMorning:
     """`Link` and `Next` are new. Notion answers an unknown property with a 400 that
     aborts the paint mid-write, so a board that predates them would lose every row of
-    that morning to a column nobody noticed was missing (PR reviewer round 5, major)."""
+    that morning to a column nobody noticed was missing (PR reviewer round 5, major).
+
+    `known` maps a column name to its TYPE. Name alone was not enough: a board carrying
+    `Link` as rich_text rather than url takes the same 400 the guard exists to prevent,
+    and the guard would have called the column fine (round 7, minor)."""
 
     ITEM = {"title": "t", "key": "k", "done": "d", "priority": "P1",
             "source": "Gmail", "link": "https://example.test/x", "next": "go"}
+    #: BY HAND, never derived from WRITES_TYPE: a column dropped from that map would
+    #: otherwise take its own test with it and the suite would stay green.
+    OLD_BOARD = {"Task": "title", "Item id": "rich_text", "Notes": "rich_text",
+                 "Domain": "multi_select", "Priority": "select", "Source": "select",
+                 "Bucket": "select", "Status": "select"}
+
+    def _props(self):
+        return br._properties(self.ITEM, "Inbox", "cb:x", False)
 
     def test_a_board_without_the_new_columns_is_written_without_them(self):
-        props = br._properties(self.ITEM, "Inbox", "cb:x", False)
-        assert {"Link", "Next"} <= set(props), sorted(props)
-        old_board = {"Task", "Item id", "Notes", "Domain", "Priority", "Source"}
-        assert set(br._only_known(props, old_board)) == old_board, sorted(props)
+        keep, dropped = br._only_known(self._props(), self.OLD_BOARD)
+        assert "Link" not in keep and "Next" not in keep, sorted(keep)
+        assert dropped == ("Link", "Next"), dropped
 
-    def test_the_create_path_is_filtered_too(self, monkeypatch):
-        """The first fix filtered the PATCH and not the POST, so a board lacking the
-        column still took a 400 on its first NEW row and abandoned the whole paint.
-        The patch printed "write sites filtered: 1" and nobody asked whether there were
-        two (PR reviewer round 6, major)."""
-        sent = []
-        monkeypatch.setattr(br, "existing_rows", lambda *a, **k: {})
-        monkeypatch.setattr(br, "_request",
-                            lambda tok, m, path, body, op=None, bud=None: sent.append((m, path, body)))
-        old_board = {"Task", "Item id", "Notes", "Domain", "Priority", "Source",
-                     "Bucket", "Status"}
-        br.paint({"top_of_mind": [dict(self.ITEM, scope="card")], "this_week": [],
-                  "inbox": [], "healthy_scopes": {"card"}},
-                 "tok", "db", known=old_board)
-        posts = [s for s in sent if s[0] == "POST"]
-        assert posts, sent
-        written = set(posts[0][2]["properties"])
-        assert "Link" not in written and "Next" not in written, sorted(written)
+    def test_a_board_that_has_them_as_the_WRONG_TYPE_drops_them_too(self):
+        board = dict(self.OLD_BOARD, Link="rich_text", Next="rich_text")
+        keep, dropped = br._only_known(self._props(), board)
+        assert dropped == ("Link",), dropped
+        assert "Next" in keep, sorted(keep)
 
     def test_a_board_with_them_keeps_them(self):
-        props = br._properties(self.ITEM, "Inbox", "cb:x", False)
-        assert br._only_known(props, set(props)) == props
+        board = dict(self.OLD_BOARD, Link="url", Next="rich_text")
+        keep, dropped = br._only_known(self._props(), board)
+        assert keep == self._props() and dropped == (), dropped
 
     def test_an_unreadable_schema_writes_everything_exactly_as_before(self):
         """The read failing is not the columns being gone. Refusing to write on a bad
         response would turn one bad answer into a blank morning."""
-        props = br._properties(self.ITEM, "Inbox", "cb:x", False)
-        assert br._only_known(props, None) == props
+        keep, dropped = br._only_known(self._props(), None)
+        assert keep == self._props() and dropped == ()
 
     def test_a_failed_schema_request_is_None_not_an_exception(self, monkeypatch):
         def boom(*a, **k):
@@ -310,8 +315,46 @@ class TestAColumnThisBoardLacksIsNotAWholeLostMorning:
         monkeypatch.setattr(br, "_request", boom)
         assert br._schema_properties("tok", "db") is None
 
-    def test_an_empty_schema_answer_is_None_not_an_empty_set(self, monkeypatch):
-        """An empty set would filter EVERY property out and write nothing at all,
-        which is the same lost morning by a different route."""
+    def test_an_empty_schema_answer_is_None_not_an_empty_map(self, monkeypatch):
+        """An empty map would drop EVERY property and write nothing at all, which is
+        the same lost morning by a different route."""
         monkeypatch.setattr(br, "_request", lambda *a, **k: {"properties": {}})
         assert br._schema_properties("tok", "db") is None
+
+    def test_the_schema_read_keeps_the_type(self, monkeypatch):
+        monkeypatch.setattr(br, "_request", lambda *a, **k: {
+            "properties": {"Task": {"type": "title"}, "Link": {"type": "url"}}})
+        assert br._schema_properties("tok", "db") == {"Task": "title", "Link": "url"}
+
+    def _paint_against(self, monkeypatch, board):
+        sent = []
+        monkeypatch.setattr(br, "existing_rows", lambda *a, **k: {})
+        monkeypatch.setattr(br, "_request",
+                            lambda tok, m, path, body, op=None, bud=None: sent.append((m, path, body)))
+        counts = br.paint({"top_of_mind": [dict(self.ITEM, scope="card")],
+                           "this_week": [], "inbox": [], "healthy_scopes": {"card"}},
+                          "tok", "db", known=board)
+        return counts, sent
+
+    def test_the_create_path_is_filtered_too(self, monkeypatch):
+        """The first fix filtered the PATCH and not the POST, so a board lacking the
+        column still took a 400 on its first NEW row and abandoned the whole paint. The
+        patch printed "write sites filtered: 1" and nobody asked whether there were two
+        (round 6, major)."""
+        counts, sent = self._paint_against(monkeypatch, self.OLD_BOARD)
+        posts = [s for s in sent if s[0] == "POST"]
+        assert posts, sent
+        written = set(posts[0][2]["properties"])
+        assert "Link" not in written and "Next" not in written, sorted(written)
+
+    def test_what_could_not_be_written_is_reported_never_silent(self, monkeypatch):
+        """A board without `Link` wrote every row with no link and still said
+        "read-back ok". A silent half-write is worse than the crash it replaced,
+        because the crash gets looked at (round 7, major)."""
+        counts, _ = self._paint_against(monkeypatch, self.OLD_BOARD)
+        assert counts["dropped_columns"] == ("Link", "Next"), counts["dropped_columns"]
+
+    def test_a_complete_board_reports_nothing_dropped(self, monkeypatch):
+        board = dict(self.OLD_BOARD, Link="url", Next="rich_text")
+        counts, _ = self._paint_against(monkeypatch, board)
+        assert counts["dropped_columns"] == (), counts["dropped_columns"]

--- a/q-system/.q-system/tests/test_board_is_actionable.py
+++ b/q-system/.q-system/tests/test_board_is_actionable.py
@@ -275,6 +275,25 @@ class TestAColumnThisBoardLacksIsNotAWholeLostMorning:
         old_board = {"Task", "Item id", "Notes", "Domain", "Priority", "Source"}
         assert set(br._only_known(props, old_board)) == old_board, sorted(props)
 
+    def test_the_create_path_is_filtered_too(self, monkeypatch):
+        """The first fix filtered the PATCH and not the POST, so a board lacking the
+        column still took a 400 on its first NEW row and abandoned the whole paint.
+        The patch printed "write sites filtered: 1" and nobody asked whether there were
+        two (PR reviewer round 6, major)."""
+        sent = []
+        monkeypatch.setattr(br, "existing_rows", lambda *a, **k: {})
+        monkeypatch.setattr(br, "_request",
+                            lambda tok, m, path, body, op=None, bud=None: sent.append((m, path, body)))
+        old_board = {"Task", "Item id", "Notes", "Domain", "Priority", "Source",
+                     "Bucket", "Status"}
+        br.paint({"top_of_mind": [dict(self.ITEM, scope="card")], "this_week": [],
+                  "inbox": [], "healthy_scopes": {"card"}},
+                 "tok", "db", known=old_board)
+        posts = [s for s in sent if s[0] == "POST"]
+        assert posts, sent
+        written = set(posts[0][2]["properties"])
+        assert "Link" not in written and "Next" not in written, sorted(written)
+
     def test_a_board_with_them_keeps_them(self):
         props = br._properties(self.ITEM, "Inbox", "cb:x", False)
         assert br._only_known(props, set(props)) == props

--- a/q-system/.q-system/tests/test_board_is_actionable.py
+++ b/q-system/.q-system/tests/test_board_is_actionable.py
@@ -259,3 +259,40 @@ class TestALinkIsComparable:
                                "Inbox", "cb:x", False)
         page = {"properties": dict(props, Link={"url": "https://example.test/old"})}
         assert not br._already_holds(page, props)
+
+
+class TestAColumnThisBoardLacksIsNotAWholeLostMorning:
+    """`Link` and `Next` are new. Notion answers an unknown property with a 400 that
+    aborts the paint mid-write, so a board that predates them would lose every row of
+    that morning to a column nobody noticed was missing (PR reviewer round 5, major)."""
+
+    ITEM = {"title": "t", "key": "k", "done": "d", "priority": "P1",
+            "source": "Gmail", "link": "https://example.test/x", "next": "go"}
+
+    def test_a_board_without_the_new_columns_is_written_without_them(self):
+        props = br._properties(self.ITEM, "Inbox", "cb:x", False)
+        assert {"Link", "Next"} <= set(props), sorted(props)
+        old_board = {"Task", "Item id", "Notes", "Domain", "Priority", "Source"}
+        assert set(br._only_known(props, old_board)) == old_board, sorted(props)
+
+    def test_a_board_with_them_keeps_them(self):
+        props = br._properties(self.ITEM, "Inbox", "cb:x", False)
+        assert br._only_known(props, set(props)) == props
+
+    def test_an_unreadable_schema_writes_everything_exactly_as_before(self):
+        """The read failing is not the columns being gone. Refusing to write on a bad
+        response would turn one bad answer into a blank morning."""
+        props = br._properties(self.ITEM, "Inbox", "cb:x", False)
+        assert br._only_known(props, None) == props
+
+    def test_a_failed_schema_request_is_None_not_an_exception(self, monkeypatch):
+        def boom(*a, **k):
+            raise RuntimeError("notion said no")
+        monkeypatch.setattr(br, "_request", boom)
+        assert br._schema_properties("tok", "db") is None
+
+    def test_an_empty_schema_answer_is_None_not_an_empty_set(self, monkeypatch):
+        """An empty set would filter EVERY property out and write nothing at all,
+        which is the same lost morning by a different route."""
+        monkeypatch.setattr(br, "_request", lambda *a, **k: {"properties": {}})
+        assert br._schema_properties("tok", "db") is None

--- a/q-system/.q-system/tests/test_board_is_actionable.py
+++ b/q-system/.q-system/tests/test_board_is_actionable.py
@@ -470,3 +470,63 @@ class TestTheCardLineDoesNotPointAtRowsThatAreNotThere:
         quiet = [r for r in rows if "ball is not with you" in r]
         assert not board, board
         assert quiet and "4" in quiet[0], quiet
+
+
+class TestADeadLinkIsWorseThanNoLink:
+    """The mail producer's documented fallback key is `mail:<sender>|<subject>`.
+    Pasting that after the thread URL builds a link that opens nothing, which costs a
+    click and teaches him the column lies (PR reviewer round 10, minor)."""
+
+    def test_a_real_thread_id_gets_a_link(self):
+        assert cb.gmail_link("mail:1a06eb5b0b03759f") == (
+            "https://mail.google.com/mail/u/0/#all/1a06eb5b0b03759f")
+
+    def test_the_fallback_key_shape_gets_no_link(self):
+        assert cb.gmail_link("mail:someone@example.test|Re: a subject") is None
+
+    def test_an_empty_or_odd_id_gets_no_link(self):
+        assert cb.gmail_link("mail:") is None
+        assert cb.gmail_link("") is None
+        assert cb.gmail_link("mail:not hex at all") is None
+
+    def test_the_row_still_paints_without_its_link(self, tmp_path):
+        class Row(str):
+            pass
+        r = Row("someone@example.test  Re: a subject")
+        r.key = "mail:someone@example.test|Re: a subject"
+        item = cb.buckets(NOW, {"mail": ([r], None)}, _paths(tmp_path))["inbox"][0]
+        assert item["link"] is None and item["title"], item
+
+
+class TestTheIdentityRefusalFiresBeforeTheFirstQuery:
+    """`existing_rows` filters its query on `Item id`, so a board without that column
+    takes a raw 400 from Notion before `_only_known` is reached and the remediation
+    never fires (PR reviewer round 10, minor)."""
+
+    def test_a_board_without_the_id_column_is_refused_up_front(self):
+        with pytest.raises(br.MissingIdentityColumn):
+            br._refuse_without_identity({"Task": "title", "Notes": "rich_text"})
+
+    def test_a_wrongly_typed_id_column_is_refused_too(self):
+        with pytest.raises(br.MissingIdentityColumn):
+            br._refuse_without_identity({"Task": "title", "Item id": "select"})
+
+    def test_a_good_board_passes(self):
+        br._refuse_without_identity({"Task": "title", "Item id": "rich_text"})
+
+    def test_an_unreadable_schema_is_not_a_verdict_about_the_columns(self):
+        br._refuse_without_identity(None)
+
+    def test_the_runner_refuses_before_it_queries(self, monkeypatch, tmp_path):
+        calls = []
+        monkeypatch.setattr(br, "_schema_properties",
+                            lambda *a, **k: {"Task": "title"})
+        monkeypatch.setattr(br, "existing_rows",
+                            lambda *a, **k: calls.append("queried") or {})
+        monkeypatch.delenv("PYTEST_CURRENT_TEST", raising=False)
+        monkeypatch.delenv("KIPI_BRIEF_DRY_RUN", raising=False)
+        tf = tmp_path / "notion-token"; tf.write_text("t", encoding="utf-8")
+        dbf = tmp_path / "notion-board-db"; dbf.write_text("d", encoding="utf-8")
+        rows, err = br.collect(NOW, {}, token_file=str(tf), db_file=str(dbf))
+        assert calls == [], "it queried the board before refusing"
+        assert rows == [] and "identifies rows by" in err, err

--- a/q-system/.q-system/tests/test_board_is_actionable.py
+++ b/q-system/.q-system/tests/test_board_is_actionable.py
@@ -14,6 +14,8 @@ take its own test with it.
 import datetime as dt
 import json
 import sys
+
+import pytest
 from pathlib import Path
 
 SCRIPTS = Path(__file__).resolve().parents[1] / "scripts"
@@ -358,3 +360,71 @@ class TestAColumnThisBoardLacksIsNotAWholeLostMorning:
         board = dict(self.OLD_BOARD, Link="url", Next="rich_text")
         counts, _ = self._paint_against(monkeypatch, board)
         assert counts["dropped_columns"] == (), counts["dropped_columns"]
+
+
+class TestTheIdentityColumnIsNeverDropped:
+    """`Item id` is how every lookup, refresh and archive decision finds a row, and
+    `existing_rows` queries the board by its prefix. Dropping it does not degrade a
+    row: it creates a page this module can never find again, one more per wanted row
+    per run, with no error anywhere (PR reviewer round 8, major)."""
+
+    ITEM = {"title": "t", "key": "k", "done": "d", "priority": "P1", "source": "Gmail"}
+
+    def _props(self):
+        return br._properties(self.ITEM, "Inbox", "cb:x", False)
+
+    def test_a_board_that_cannot_take_the_id_stops_the_paint(self):
+        board = {"Task": "title", "Notes": "rich_text", "Domain": "multi_select",
+                 "Priority": "select", "Source": "select"}
+        with pytest.raises(br.MissingIdentityColumn) as e:
+            br._only_known(self._props(), board)
+        assert "Item id" in str(e.value)
+
+    def test_the_id_under_the_wrong_type_stops_it_too(self):
+        board = {"Task": "title", "Item id": "select", "Notes": "rich_text",
+                 "Domain": "multi_select", "Priority": "select", "Source": "select"}
+        with pytest.raises(br.MissingIdentityColumn):
+            br._only_known(self._props(), board)
+
+    def test_a_missing_title_stops_it(self):
+        board = {"Item id": "rich_text", "Notes": "rich_text",
+                 "Domain": "multi_select", "Priority": "select", "Source": "select"}
+        with pytest.raises(br.MissingIdentityColumn) as e:
+            br._only_known(self._props(), board)
+        assert "Task" in str(e.value)
+
+    def test_an_optional_column_still_only_drops(self):
+        """The refusal is for identity, not for everything. A board missing `Link`
+        still paints, minus the link, and says so."""
+        board = {"Task": "title", "Item id": "rich_text", "Notes": "rich_text",
+                 "Domain": "multi_select", "Priority": "select", "Source": "select"}
+        keep, dropped = br._only_known(
+            br._properties(dict(self.ITEM, link="https://example.test/x"),
+                           "Inbox", "cb:x", False), board)
+        assert dropped == ("Link",) and "Item id" in keep
+
+
+class TestTheSchemaGuardIsActuallyWiredIntoTheRun:
+    """A guard the production path never passes is a guard that does not exist, and the
+    suite would stay green either way (PR reviewer round 8, nit)."""
+
+    def test_the_runner_hands_paint_the_schema_it_read(self, monkeypatch, tmp_path):
+        seen = {}
+        monkeypatch.setattr(br, "_schema_properties",
+                            lambda *a, **k: {"Task": "title", "Item id": "rich_text"})
+
+        def spy_paint(buckets, token, db, opener=None, budget=None, known=None):
+            seen["known"] = known
+            return {"created": 0, "updated": 0, "archived": 0, "kept": 0, "held": 0,
+                    "wanted": 0, "moved": 0, "pinned": 0, "over_cap": 0,
+                    "unchanged": 0, "deferred": 0, "deferred_new": 0,
+                    "dropped_columns": ()}
+
+        monkeypatch.setattr(br, "paint", spy_paint)
+        monkeypatch.setattr(br, "existing_rows", lambda *a, **k: {})
+        monkeypatch.delenv("PYTEST_CURRENT_TEST", raising=False)
+        monkeypatch.delenv("KIPI_BRIEF_DRY_RUN", raising=False)
+        tf = tmp_path / "notion-token"; tf.write_text("t", encoding="utf-8")
+        dbf = tmp_path / "notion-board-db"; dbf.write_text("d", encoding="utf-8")
+        br.collect(NOW, {}, token_file=str(tf), db_file=str(dbf))
+        assert seen.get("known") == {"Task": "title", "Item id": "rich_text"}, seen

--- a/q-system/.q-system/tests/test_board_is_actionable.py
+++ b/q-system/.q-system/tests/test_board_is_actionable.py
@@ -1,0 +1,172 @@
+"""The board carries only what he can act on, and every row he can act on can be started.
+
+Founder-directed 2026-09-07, after a row-by-row walk of the live board: *"remove sana
+stuff from the board"* and *"I want you to revamp the crm so it fits what I asked. Dont
+punt anything to me. Fix it. right now its not useful."* DEC-34 in the consulting
+instance's crm-working.md is the record.
+
+Every case here was RED against the file as it stood that evening; the red run is in
+the PR body. The property-name expectations are written out BY HAND rather than
+derived from the module's own tables: a test that iterates the thing it is testing
+cannot see that thing shrink, so a property silently dropped from the writer would
+take its own test with it.
+"""
+import datetime as dt
+import json
+import sys
+from pathlib import Path
+
+SCRIPTS = Path(__file__).resolve().parents[1] / "scripts"
+sys.path.insert(0, str(SCRIPTS))
+
+import board_rows as br  # noqa: E402
+import consulting_board as cb  # noqa: E402
+
+NOW = dt.datetime(2026, 9, 7, 8, 0, tzinfo=dt.timezone.utc)
+
+#: GENERIC CLIENT LABELS ON PURPOSE. This repo is public and the client-name guard
+#: blocks real ones in staged content; the shapes under test are the health dots and
+#: the line grammar, and neither needs a real engagement's name.
+CARD = """*Your book today* - 4 active - 2026-09-07
+*THE MOVE* 🟡 *Yellow Engagement, LLC* · touch due 13 days ago
+⚪ *White Engagement One* · an agent owes 6: run the long-running search
+⚪ *White Engagement Two* · an agent owes 7: point at the key files
+🟢 *Green Engagement* · nothing to do
+🔴 *Red Engagement* · you said "the intake form" - not sent
+"""
+
+
+def _paths(tmp_path):
+    """The module's OWN path map, rooted at a tmp dir. Restating the file names here
+    would make this a second source of truth for them, and a rename would leave the
+    test green against paths nothing uses."""
+    paths = cb._paths(tmp_path)
+    for f in paths.values():
+        f.parent.mkdir(parents=True, exist_ok=True)
+    paths["card"].write_text(CARD, encoding="utf-8")
+    # The card is withheld unless its heartbeat is stamped TODAY in PT, which is the
+    # freshness rule read_heartbeat enforces. The stamp is derived from the module's
+    # own clock rather than hardcoded, because a hardcoded date is a time bomb.
+    paths["heartbeat"].write_text(json.dumps(
+        {"at": "x", "card": {"date": NOW.astimezone(cb.PT).date().isoformat(),
+                             "counts": {"red": 1, "reach": 0}}}), encoding="utf-8")
+    paths["gtm"].write_text(json.dumps({"rows": {}}), encoding="utf-8")
+    return paths
+
+
+def _card_items(tmp_path):
+    rows, err = cb.read_card(_paths(tmp_path))
+    assert err is None, err
+    return rows
+
+
+class TestSanaNeverReachesHisBoard:
+    """⚪ is 'their move' or 'Sana owes n'. It is reported on the Slack card and is
+    never a row on his board, because it is not an act he can perform (DEC-30/DEC-34)."""
+
+    def test_the_card_still_carries_the_white_lines(self, tmp_path):
+        # The reader is unchanged on purpose: the Slack card keeps its Sana line.
+        healths = [r["health"] for r in _card_items(tmp_path)]
+        assert healths.count("⚪") == 2, healths
+
+    def test_no_white_or_green_line_becomes_a_board_row(self, tmp_path):
+        out = cb.buckets(NOW, {}, _paths(tmp_path))
+        titles = [i["title"] for i in out["top_of_mind"] + out["this_week"] + out["inbox"]]
+        assert not [t for t in titles if t.startswith(("⚪", "🟢"))], titles
+
+    def test_the_rows_he_can_act_on_are_still_there(self, tmp_path):
+        out = cb.buckets(NOW, {}, _paths(tmp_path))
+        titles = [i["title"] for i in out["top_of_mind"]]
+        assert any(t.startswith("🔴") for t in titles), titles
+        assert any(t.startswith("🟡") for t in titles), titles
+
+
+class TestThisWeekIsNotMachineFilledFromTheCard:
+    """The section's own text says it is his and that nothing fills it automatically."""
+
+    def test_the_card_writes_nothing_into_this_week(self, tmp_path):
+        out = cb.buckets(NOW, {}, _paths(tmp_path))
+        from_card = [i for i in out["this_week"] if i.get("scope") == "card"]
+        assert from_card == [], from_card
+
+    def test_a_yellow_row_is_top_of_mind_not_this_week(self, tmp_path):
+        out = cb.buckets(NOW, {}, _paths(tmp_path))
+        assert any(i["title"].startswith("🟡") for i in out["top_of_mind"])
+        assert not any(i["title"].startswith("🟡") for i in out["this_week"])
+
+
+class TestEveryMailRowCanBeStartedFromTheRow:
+    """His standing rule: if he cannot click it, it does not belong."""
+
+    def _mail(self, tmp_path, key):
+        class Row(str):
+            pass
+        r = Row("someone@example.test  Intro: two people")
+        r.key = key
+        out = cb.buckets(NOW, {"mail": ([r], None)}, _paths(tmp_path))
+        return out["inbox"][0]
+
+    def test_a_gmail_row_carries_its_thread_link(self, tmp_path):
+        item = self._mail(tmp_path, "mail:1a06eb5b0b03759f")
+        assert item["link"] == (
+            "https://mail.google.com/mail/u/0/#all/1a06eb5b0b03759f"), item
+
+    def test_the_link_is_derived_from_the_id_not_the_text(self, tmp_path):
+        # Same rendered line, different thread: different link. The PR #296 rounds 1-4
+        # defect was an identity derived from presentation; this must not repeat it.
+        a = self._mail(tmp_path, "mail:aaaaaaaaaaaaaaaa")["link"]
+        b = self._mail(tmp_path, "mail:bbbbbbbbbbbbbbbb")["link"]
+        assert a != b and a.endswith("aaaaaaaaaaaaaaaa"), (a, b)
+
+    def test_a_gmail_row_says_what_to_do(self, tmp_path):
+        assert self._mail(tmp_path, "mail:1a06eb5b0b03759f")["next"] == (
+            "Open the thread and reply.")
+
+
+class TestTheWriterCarriesLinkAndNext:
+    """Written when the producer supplies them, never blanked when it does not."""
+
+    #: BY HAND, not derived from the writer's own map. A property dropped from that map
+    #: would otherwise take its test with it and the suite would still be green.
+    EXPECTED = {"Task", "Item id", "Notes", "Domain", "Priority", "Source",
+                "Link", "Next"}
+
+    def test_link_and_next_are_written(self):
+        props = br._properties({"title": "t", "key": "k", "done": "d",
+                                "link": "https://example.test/x",
+                                "next": "Open the thread and reply.",
+                                "priority": "P1", "source": "Gmail"},
+                               "Inbox", "cb:x", False)
+        assert props["Link"] == {"url": "https://example.test/x"}
+        assert props["Next"]["rich_text"][0]["text"]["content"] == (
+            "Open the thread and reply.")
+
+    def test_the_written_property_set_is_exactly_what_is_expected(self):
+        props = br._properties({"title": "t", "key": "k", "done": "d",
+                                "link": "https://example.test/x", "next": "go",
+                                "priority": "P1", "source": "Gmail"},
+                               "Inbox", "cb:x", False)
+        assert set(props) == self.EXPECTED, set(props) ^ self.EXPECTED
+
+    def test_a_producer_that_knows_neither_clears_neither(self):
+        props = br._properties({"title": "t", "key": "k", "done": "d"},
+                               "Inbox", "cb:x", False)
+        assert "Link" not in props and "Next" not in props, sorted(props)
+
+
+class TestTheNoteDoesNotRepeatItself:
+    """6 of 12 live rows on 2026-09-07 printed one sentence twice."""
+
+    def test_a_detail_equal_to_the_done_signal_is_written_once(self):
+        signal = "the old token is dead and the new one is not in a tracked file."
+        props = br._properties({"title": "t", "key": "k", "done": signal,
+                                "detail": signal}, "This Week", "cb:x", False)
+        note = props["Notes"]["rich_text"][0]["text"]["content"]
+        assert note.count(signal) == 1, note
+
+    def test_a_detail_that_adds_something_is_kept(self):
+        props = br._properties({"title": "t", "key": "k", "done": "signal",
+                                "detail": "a real extra fact"}, "This Week",
+                               "cb:x", False)
+        note = props["Notes"]["rich_text"][0]["text"]["content"]
+        assert "a real extra fact" in note and "signal" in note, note

--- a/q-system/.q-system/tests/test_board_is_actionable.py
+++ b/q-system/.q-system/tests/test_board_is_actionable.py
@@ -198,27 +198,26 @@ class TestHisPlacementSurvivesTheProducerDroppingTheRow:
         # `held`, not `kept`: a quiet source and a row he pinned whose source is
         # healthy are different facts and the morning line reports both.
         assert counts["held"] == 1 and counts["kept"] == 0, counts
-        assert counts["stamped"] == 1, counts
         assert not [s for s in sent if s[2].get("archived")], sent
 
-    def test_a_long_note_keeps_the_stamp_and_loses_free_text_instead(self, monkeypatch):
-        """Truncating the whole string dropped the stamp off the end, so the row was
-        re-PATCHed identically every morning (PR reviewer round 3, minor)."""
-        long_note = ("x" * (br.NOTE_CAP - 40)) + "\nscope=card\nbucket=This Week\npinned=1"
-        page = self._page("cb:gone", long_note)
-        sent = []
+    def test_a_held_row_is_a_term_of_the_read_back_sum(self, monkeypatch):
+        """A held row IS on the board. Leaving it out of the sum made the proof report
+        a mismatch every run once any pinned row's producer went quiet, which is the
+        false-alarm shape that trains him to ignore the word (PR reviewer round 4)."""
+        page = self._page("cb:gone", "Done signal: x\nscope=card\nbucket=This Week\npinned=1")
         monkeypatch.setattr(br, "existing_rows", lambda *a, **k: {"cb:gone": page})
-        monkeypatch.setattr(br, "_request",
-                            lambda tok, m, path, body, op=None, bud=None: sent.append((m, path, body)))
-        br.paint({"top_of_mind": [], "this_week": [], "inbox": [],
-                  "healthy_scopes": {"card"}}, "tok", "db")
-        written = sent[0][2]["properties"]["Notes"]["rich_text"][0]["text"]["content"]
-        assert br.STALE_LINE in written, written[-120:]
-        assert len(written) <= br.NOTE_CAP, len(written)
+        monkeypatch.setattr(br, "_request", lambda *a, **k: None)
+        counts = br.paint({"top_of_mind": [], "this_week": [], "inbox": [],
+                           "healthy_scopes": {"card"}}, "tok", "db")
+        expected = (counts["wanted"] + counts["kept"] + counts["held"]
+                    - counts["deferred_new"])
+        assert expected == 1, counts
+        assert counts["held"] == 1 and counts["kept"] == 0, counts
 
-    def test_a_kept_pinned_row_is_told_its_source_went_quiet(self, monkeypatch):
-        """Keeping it silently would be sp-7720fce9 again: a row no run can clear.
-        The stamp gives him an exit he can see. (PR reviewer round 2, major.)"""
+    def test_nothing_is_written_to_a_held_row(self, monkeypatch):
+        """The first answer to 'a pinned row has no exit' wrote a stamp into its Notes,
+        and truncating the note to fit deleted `pinned=1` itself. Nothing is written
+        now; his exit is his own archive."""
         page = self._page("cb:gone", "Done signal: x\nscope=card\nbucket=This Week\npinned=1")
         sent = []
         monkeypatch.setattr(br, "existing_rows", lambda *a, **k: {"cb:gone": page})
@@ -226,22 +225,7 @@ class TestHisPlacementSurvivesTheProducerDroppingTheRow:
                             lambda tok, m, path, body, op=None, bud=None: sent.append((m, path, body)))
         br.paint({"top_of_mind": [], "this_week": [], "inbox": [],
                   "healthy_scopes": {"card"}}, "tok", "db")
-        wrote = [s for s in sent if "Notes" in (s[2].get("properties") or {})]
-        assert len(wrote) == 1, sent
-        assert br.STALE_LINE in wrote[0][2]["properties"]["Notes"]["rich_text"][0]["text"]["content"]
-
-    def test_the_stamp_is_written_once_not_every_run(self, monkeypatch):
-        page = self._page("cb:gone",
-                          f"Done signal: x\nscope=card\nbucket=This Week\npinned=1\n{br.STALE_LINE}")
-        sent = []
-        monkeypatch.setattr(br, "existing_rows", lambda *a, **k: {"cb:gone": page})
-        monkeypatch.setattr(br, "_request",
-                            lambda tok, m, path, body, op=None, bud=None: sent.append((m, path, body)))
-        counts = br.paint({"top_of_mind": [], "this_week": [], "inbox": [],
-                           "healthy_scopes": {"card"}}, "tok", "db")
         assert sent == [], sent
-        assert counts["archived"] == 0 and counts["held"] == 1, counts
-        assert counts["stamped"] == 0, counts
 
     def test_an_unpinned_row_the_producer_dropped_is_still_archived(self, monkeypatch):
         page = self._page("cb:gone", "Done signal: x\nscope=card\nbucket=This Week")

--- a/q-system/.q-system/tests/test_consulting_board.py
+++ b/q-system/.q-system/tests/test_consulting_board.py
@@ -8,6 +8,7 @@ import io
 import json
 import pathlib
 import os
+import re
 import sys
 import time
 from pathlib import Path
@@ -198,13 +199,29 @@ class TestRound3:
                        _tree(tmp_path))["inbox"][0]["key"]
         assert a == b
 
-    def test_kept_rows_do_not_fake_a_read_back_mismatch(self):
-        """`kept` rows are on the board and deliberately not in `wanted`. Comparing
-        `seen` to `wanted` alone made every quiet source report a mismatch and mark the
-        brief degraded, which trains him to ignore the word."""
+    def test_every_row_on_the_board_is_a_term_of_the_read_back_sum(self):
+        """`kept` and `held` rows are on the board and deliberately not in `wanted`.
+        Comparing `seen` to `wanted` alone made every quiet source report a mismatch and
+        mark the brief degraded, which trains him to ignore the word.
+
+        WIDENED 2026-09-07. The old form matched the literal
+        `expected = counts["wanted"] + counts["kept"]`, which broke when that expression
+        wrapped across two lines even though the property was intact, and could not
+        express a THIRD term at all. `held` (a row he pinned whose producer went quiet)
+        is such a term: it is on the board, so leaving it out reported a mismatch every
+        run after any pinned row went quiet. This asserts the property -- every
+        on-board counter is added, and the deferred-create one is subtracted -- rather
+        than one spelling of it. `collect` refuses to run under pytest by design, so
+        the sum cannot be driven end to end from here.
+        """
         src = (SCRIPTS / "board_rows.py").read_text(encoding="utf-8")
-        assert 'expected = counts["wanted"] + counts["kept"]' in src
-        assert "if seen != expected:" in src
+        m = re.search(r"expected = \(?(.+?)\n\s*if seen != expected:", src, re.S)
+        assert m, "the read-back sum is gone or was renamed"
+        expr = " ".join(m.group(1).split())
+        for on_board in ("wanted", "kept", "held"):
+            assert f'+ counts["{on_board}"]' in expr or expr.startswith(
+                f'counts["{on_board}"]'), (on_board, expr)
+        assert '- counts["deferred_new"]' in expr, expr
 
 
 class TestAQuietSourceNeverArchivesHisRows:

--- a/q-system/.q-system/tests/test_consulting_board.py
+++ b/q-system/.q-system/tests/test_consulting_board.py
@@ -604,7 +604,16 @@ class TestRound4:
 
             def __call__(self, req, timeout):
                 method, url = req.get_method(), req.full_url
-                if "/databases/" in url and not self.calls:
+                # THE SCHEMA READ IS NOT THE QUERY (PR reviewer round 7, minor). A GET
+                # on /databases/<id> was added ahead of the paint, and it took this
+                # fake's "first call" slot, so the slow query below never ran and the
+                # abandoned-worker path this test exists for stopped being exercised.
+                # Matching on the METHOD keeps the two apart.
+                if method == "GET" and "/databases/" in url:
+                    self.calls.append(("schema", timeout))
+                    return io.BytesIO(b'{"properties": {}}')
+                if "/databases/" in url and not [c for c in self.calls
+                                                 if c[0] != "schema"]:
                     self.calls.append(("query-slow", timeout))
                     time.sleep(slow_first_query_s)
                     return io.BytesIO(b'{"results": [], "has_more": false}')

--- a/q-system/.q-system/tests/test_consulting_board.py
+++ b/q-system/.q-system/tests/test_consulting_board.py
@@ -211,8 +211,14 @@ class TestRound3:
         is such a term: it is on the board, so leaving it out reported a mismatch every
         run after any pinned row went quiet. This asserts the property -- every
         on-board counter is added, and the deferred-create one is subtracted -- rather
-        than one spelling of it. `collect` refuses to run under pytest by design, so
-        the sum cannot be driven end to end from here.
+        than one spelling of it.
+
+        A SOURCE READ, and the reason is not "collect cannot run under pytest" (PR
+        reviewer round 6, minor: three tests in this file drive it, and that claim was
+        simply false). It is that the sum lives inline in `collect`, between a paint
+        and a read-back, so reaching it end to end means standing up a fake Notion for
+        both halves in order to assert one arithmetic expression. The expression is the
+        thing that can go wrong, and this reads it directly.
         """
         src = (SCRIPTS / "board_rows.py").read_text(encoding="utf-8")
         m = re.search(r"expected = \(?(.+?)\n\s*if seen != expected:", src, re.S)


### PR DESCRIPTION
## What

The morning board carries only what he can act on, and every row it carries can be started from the row. Founder-directed 2026-09-07 after a row-by-row CRM audit of the live board.

## Why

His words, that evening: *"remove sana stuff from the board"* and *"I want you to revamp the crm so it fits what I asked. Dont punt anything to me. Fix it. right now its not useful."* DEC-34 in the consulting instance's `crm-working.md` is the record.

Measured on the live board, 12 rows: zero carried a URL, six printed one sentence twice, five were Sana's build queue wearing his done signal, and eleven had been machine-written into a section whose own text says nothing fills it automatically. Full audit: `q-consult/output/board-crm-audit-2026-09-07.md` in the consulting instance.

## How

- A ⚪ or 🟢 card line never becomes a board row. Both stay on the Slack card, which is DEC-30's design and does not change; neither is an act he can perform.
- Everything the card does surface goes to Top of Mind. This Week is no longer written from the card.
- A Gmail row carries its thread link, derived from the thread id the row already has (`collect_mail` emits `mail:<thread id>`). No new plumbing, no second source of truth.
- `_properties` writes `Link` and `Next` when a producer supplies them and never blanks them when it does not, so a row a human filled in keeps what they wrote. Same posture as `Size`, which this module still deliberately does not write.
- The detail is not the done signal repeated.
- `DONE_BY_KIND["client"]` no longer reads "you sent the thing you promised", wording that predates DEC-30.

## Proof

- `test_board_is_actionable.py`, 13 cases. **10 were red against these files as they stood**; the 3 that pass either way are the guards (the card still carries its white lines, a producer that knows neither Link nor Next clears neither, a detail that adds something is still kept).
- 237 passed across `test_consulting_board.py`, `test_morning_brief.py`, `test_morning_brief_mail.py` and the new file.
- The expected property set is written out by hand rather than derived from the writer's own map: a test that iterates the thing it tests cannot see that thing shrink.
- Live preview against the founder's real state: the five ⚪ rows are gone from every bucket.

## Known and not fixed here

Two rows archived by hand that evening will be recreated on the next paint. The GTM queue records a constraint (`3.3`, a client's fixed signature order) and a talk-track rule (`5.5`) with fields identical to a real action, so `read_week` cannot tell them apart. That is a fix at the plan, not the painter. Captured as `sp-c06be056`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01BhRNSs6akd5jD9GrQRXQ9j
