### PR TITLE
docs(readme): the four false claims PR #324 fixed and never landed

### DIFF
--- a/README.md
+++ b/README.md
@@ -60,7 +60,7 @@ Ask about a person, and Kipi pulls their relationship history, the decisions tha
 The reader reads the project's own folder, never a template. Three things make that true:
 
 - Sub-stores. A project can hold many knowledge bases, one per case or engagement, each with the same layout. Name one in a question and the search scopes to it. Name none and it searches all of them. A name that appears in several cases comes back as one block per case, never collapsed into the last one.
-- The project's own documents. Every markdown folder the project keeps is a source, one search pass per question, every excerpt with its file and line.
+- The project's own documents. Eight declared folder names (`output`, `research`, `inputs`, `investigation`, `build`, `docs`, `notes`, `memory`) are searched under the project root and under every sub-store, one pass per question, every excerpt with its file and line. The list is data, not code: it is the `folders` key of `q-system/.q-system/knowledge-sources.json`, so a project can change what counts as a document folder.
 - Candidates from the question itself. A capitalized word the index does not know is looked up in those documents. A hit makes it an entity. A word found in more than four knowledge bases is treated as common vocabulary, dropped, and the receipt says so.
 
 The model never has to remember to go looking.
@@ -71,7 +71,9 @@ The model never has to remember to go looking.
 
 An empty search result is not proof that nothing exists. Most retrieval treats it that way.
 
-Kipi's supply step writes a receipt. Every source the question needed is recorded as read, empty, unreadable, or not searched because a deadline or a budget cut the pass short. The first line of what the model receives says `COVERAGE: FULL`, or `COVERAGE: PARTIAL` with the missing sources named, or `COVERAGE: NONE` when not one declared source could be read. FULL means fully searched. Any pass that stopped early reads as partial, never as full.
+Kipi's supply step writes a receipt. Every source the question needed is recorded as read, empty, unreadable, or cut short. The first line of what the model receives says `COVERAGE: FULL`, or `COVERAGE: PARTIAL` with the missing sources named, or `COVERAGE: NONE` when not one declared source could be read.
+
+Where the line is drawn, precisely, because this is the sentence a reader trusts hardest. Only a source the manifest marks `required` can move the verdict. A deadline or a byte cap that cuts a required source short drops it to `COVERAGE: PARTIAL` and names the source. The same truncation on an optional source is written into that source's receipt row as `partially searched (...)` and leaves the verdict alone. In the shipped manifest the document scan is optional in all five task classes, so a truncated document pass can sit under `COVERAGE: FULL` with the truncation one line down in the receipt. If you want it to move the verdict, set `"required": true` for `docs` in `q-system/.q-system/knowledge-sources.json`, which is what the investigation manifest does. One function computes the verdict, in `q-system/.q-system/scripts/knowledge_supply.py`.
 
 ```mermaid
 flowchart TB
@@ -79,9 +81,11 @@ flowchart TB
     S -->|"read, has lines"| A["supplied verbatim, with file and line"]
     S -->|"read, nothing there"| B["recorded: searched, empty"]
     S -->|"file missing or corrupt"| C["recorded: could not read"]
-    S -->|"deadline or budget cut the pass short"| D["recorded: partially searched"]
+    S -->|"cut short, source is required"| D["recorded: partially searched"]
+    S -->|"cut short, source is optional"| E["recorded: partially searched"]
     A --> F["COVERAGE: FULL"]
     B --> F
+    E --> F
     C --> P["COVERAGE: PARTIAL, missing sources named"]
     D --> P
     C -. "every declared source unreadable" .-> N["COVERAGE: NONE"]

--- a/README.md
+++ b/README.md
@@ -323,20 +323,48 @@ The scheduled jobs are a separate step. Nothing above arms them:
 
 ---
 
+## What else is in the box
+
+The pages above are the knowledge half. The rest of the repo, with the command that counts each one:
+
+- **A CLI with 23 verbs** (`grep -cE '^  [a-z][a-z0-9|_-]*\)' kipi`). `./kipi help` prints them. `check` runs the validation harness. `list` shows every copy. `health` finds dark or failing jobs, double schedules and open spillover. `work` and `converge` take a ready issue to an approved pull request. `judgment` freezes the context behind a triage decision so it can be replayed.
+- **A local MCP server with 73 tools** (`grep -c '@mcp.tool' plugins/kipi-core/kipi-mcp/src/kipi_mcp/server.py`): deterministic linters and scorers, morning-routine step logging, follow-up loop tracking, backup, export, import.
+- **21 namespaced slash commands**, listed above. Six in `kipi-core`, six in `kipi-dsse`, nine in `prd-os`.
+- **65 hook entries** in `settings-template.json` (`grep -o '"command": "[^"]*"' settings-template.json | wc -l`), plus seven more in the plugins' own `hooks.json`. Every copy gets the same switches, because they ship as one file.
+- **Six plugins** under `plugins/`, all six listed in `.claude-plugin/marketplace.json`.
+- **16 launchd jobs** committed as plists. `./kipi install-jobs` enumerates them with `git ls-files`, so a plist outside the scripts directory is still reached; run `bash q-system/.q-system/scripts/install-plist.sh` with no arguments to see the label list it will install.
+
+---
+
 ## Commands
 
 Optional. Most usage is just talking to the system in Claude Code.
 
-| Command | What it does |
+Two kinds, and the difference matters when you type one.
+
+The `/q-*` names are **conventions**, not registered slash commands. No file under a `commands/` directory backs them. They are documented in `q-system/.q-system/commands.md`, the model reads that file, and saying one puts the session in that mode.
+
+| Convention | What it does |
 |---|---|
-| `/q-debrief` | Extract insights from a conversation or paste a transcript |
+| `/q-debrief` | Extract insights from a conversation. Pasting a transcript runs it without being asked |
 | `/q-draft` | Quick email, DM, or content draft in your voice |
 | `/q-engage` | Generate engagement on someone else's post |
 | `/q-research` | Citation-only research mode |
-| `/q-morning` | The day brief: one message with your calendar, mail needing an answer, and your board |
+| `/q-morning` | The day brief: your calendar, mail needing an answer, your board. Also runs itself at 07:40 as the `com.kipi.morning-brief` job |
 | `/q-wrap` | End-of-day health check |
 | `/q-handoff` | Save context for next session |
-| `/wiring-check` | End-of-task gate: prove every change is connected |
+
+The **registered** commands ship inside the plugins and are namespaced. Three of the six plugins carry them. `find plugins/*/commands -name '*.md'` lists all 21; the table names the shapes rather than every row, because the list is one command away and a front page is not a manifest.
+
+| Command | What it does |
+|---|---|
+| `/kipi-core:wiring-check` | End-of-task gate: prove every change is connected |
+| `/kipi-core:rca-start`, `/kipi-core:rca-check` | Scaffold a root-cause analysis, then lint it against the template |
+| `/kipi-core:say` | Read the last answer back as audio |
+| `/kipi-core:voice-refresh` | Rebuild the voice model from new meeting transcripts |
+| `/kipi-core:linear-drain` | File the issues that were captured while offline |
+| nine `/prd-os:*` | Rough idea to reviewed PRD to one issue spec per unit of work |
+| six `/kipi-dsse:*` | Execute one issue under scope enforcement, with receipts |
 
 ---
 
@@ -370,7 +398,8 @@ If you don't, you still get an AI that doesn't make you decide who to contact, w
 - `.env`, credentials, and key files blocked from read/write
 - PreToolUse hooks intercept dangerous operations
 - No secrets in committed files
-- `sudo` and `git push --force` denied by default, and the recursive remove denied at the filesystem root and on dot directories. The wider destructive-command guard (recursive removes anywhere, hard resets, branch deletion, the fleet-wide sync) is a shipped hook script that a person wires per machine. It refuses, prints a one-time approval token, and only a human shell can supply it.
+- Nine Bash denials, identical in both shipped settings files: `sudo`, force-push, hard reset, rebase, world-writable chmod, piped `curl` and `wget` installers, and the recursive remove at the filesystem root and on dot directories. Read the list yourself in the `permissions.deny` block of `settings-template.json`.
+- The wider destructive-command guard (recursive removes anywhere, branch deletion, the fleet-wide sync, with a one-time approval token only a human shell can supply) runs on my machine and is **not shipped here in a form you can switch on**. The repo carries one copy, `q-system/.q-system/tests/fixtures/destructive-op-deny.reference.sh`, non-executable and named `.reference.` on purpose so it cannot be mistaken for the live gate. No installer writes it to a hook path: `install-capability-token.sh` patches a hook that already exists and exits without one when it does not. Read it and wire your own, or run without it.
 
 ---
 


### PR DESCRIPTION
The four README claims that PR #324 fixed and never landed, ported onto a branch fresh off `origin/main` at `6be73e14`. The fifth, the scheduled-jobs install verb, is gone from this PR: PR #325 fixed the tool and the prose in its own change, and re-measuring confirms the README is honest there now.

Every claim below was re-measured against main as it stands today. The audit at `q-system/output/audit-public-repo-vs-tool-2026-09-07.md` on the #324 branch says where to look; it does not license a sentence here. My run does.

## Plan (the plan-file gate refuses a worktree write to `q-system/output/plans/`)

**What / why.** Four false claims on the public front page, stranded on a parked draft. Land the still-true half, drop the half #325 superseded, verify each ported sentence by running the executable it names.

**Approach.** Branch off `origin/main`, port by hand rather than cherry-pick, because two of the four sentences needed rewriting against what main says now and one number in the ported section had changed.

**Acceptance criteria.**

- [x] Each of the four re-measured against `6be73e14` before the prose was touched.
- [x] The coverage claim proved by a RUN with negative controls, not by reading the code.
- [x] Every number in the new section re-measured; the stale one corrected.
- [x] Nothing about the install verb carried over.

## Claim 1: the commands table

**Was:** eight `/q-*` and `/wiring-check` rows, presented as slash commands.

**Measured.** For each of `q-debrief q-draft q-engage q-research q-morning q-wrap q-handoff`, `find plugins/*/commands -name "<n>.md"` returns nothing. Seven of eight have no file. `wiring-check` has one, `plugins/kipi-core/commands/wiring-check.md`, and its live name is `/kipi-core:wiring-check`, not `/wiring-check`. `find plugins/*/commands -name '*.md' | wc -l` returns 21: six `kipi-core`, six `kipi-dsse`, nine `prd-os`.

**Shape, and why.** Two tables. The `/q-*` names stay, relabelled as the conventions they are, with the sentence that says no file backs them and the file that documents them. Then the registered commands as twelve rows, not twenty-one: the five `kipi-core` names a reader is most likely to type, then `nine /prd-os:*` and `six /kipi-dsse:*` as shapes. A front page is not a manifest, and the README names the one command that prints all 21. Listing 21 rows would push the Connects-to section below three screens of table to buy nothing a reader could not get from that command.

## Claim 2: the security bullet

**Was:** the wider destructive-command guard "is a shipped hook script that a person wires per machine."

**Measured.** `find . -name 'destructive-op-deny*' -not -path '*/.git/*' -exec ls -la {} \;` returns exactly one file, `q-system/.q-system/tests/fixtures/destructive-op-deny.reference.sh`, mode `-rw-r--r--`. `install-capability-token.sh:50` prints `hook not found at $HOOK; scripts installed, hook left unpatched` and exits 0 when the hook is absent, so it patches an existing hook and never installs one. Separately, `grep -n -A16 '"deny"'` on both `settings-template.json` and `.claude/settings.json` shows the same nine Bash denials, which the old bullet under-claimed at two.

**The judgment call you asked for, stated plainly: this PR describes what ships today.** It does not claim the protection. The bullet now says the guard runs on my machine, is not shipped in a form you can switch on, names the one non-executable reference copy the repo does carry and why it is named `.reference.`, says no installer writes it, and tells a reader to wire their own or run without it. PR #323 is parked at the round cap; if it lands, the honest sentence changes with it and that is a one-line edit then. Claiming it now would be the same defect this audit exists to catch, pointed at a promise instead of a count.

## Claim 3: coverage honesty

**Was:** "Any pass that stopped early reads as partial, never as full."

**Measured by running the code, not reading it.** A probe built the fixture with the repo's own `make_instance` (which copies the shipped `knowledge-sources.json`), flooded one document with 300 matching lines to trip `GREP_MAX_PER_FILE = 200`, and called the shipped `supply()`:

```
--- shipped-truncated ---
  docs.searched = 'partial'   docs.problem = 'partially searched (file cap)'
  coverage.verdict = 'FULL'   missing = []
  header = [knowledge-supply] COVERAGE: FULL. task=entity_lookup entities=Dana Okafor.
```

Two negative controls in the same run, so this cannot be the probe failing to trip the cap:

```
--- shipped-clean ---            docs.searched = True     verdict = 'FULL'
--- investigation-truncated ---  docs.searched = 'partial' verdict = 'PARTIAL'  missing = ['docs']
```

The third case is the same truncation under `knowledge-sources.investigation.json`, where `docs` is `required: true`. So the rule is `required`, not `stopped early`: `knowledge_supply.py:2198` only appends a class to `missing` when `spec.get("required")` is truthy, and the shipped manifest sets `"docs": {"required": false}` in all five task classes. The README now states that rule, says a truncated optional pass sits under FULL with the truncation one line down in the receipt, and names the knob that changes it. The mermaid gained the second edge.

This one is worth flagging: the repo has a test named `test_truncated_docs_search_is_partial_never_full` that passes. It passes because it copies the investigation manifest first. The shipped default behaves the other way, and no test covered that.

## Claim 4: the document folder allowlist

**Was:** "Every markdown folder the project keeps is a source."

**Measured.** `grep -n '"folders"' q-system/.q-system/knowledge-sources.json` returns line 10, a literal eight-name list. The README now names the eight and points at the key, and says the list is data so a project can change it.

## The reverse finding: "What else is in the box"

Kept, and every number re-measured against `6be73e14` rather than carried over. One had changed since the audit ran:

| Claim | Command | Result |
|---|---|---|
| 23 CLI verbs | `grep -cE '^  [a-z][a-z0-9\|_-]*\)' kipi` | 23 |
| 73 MCP tools | `grep -c '@mcp.tool' plugins/kipi-core/kipi-mcp/src/kipi_mcp/server.py` | 73 |
| 21 slash commands | `find plugins/*/commands -name '*.md' \| wc -l` | 21 |
| 65 hook entries | `grep -o '"command": "[^"]*"' settings-template.json \| wc -l` | 65 |
| 7 plugin hooks | `grep -c '"command"' plugins/*/hooks/hooks.json` | 4+4+2+4 = 14 at two per hook = 7 |
| 6 plugins | `ls -d plugins/*/ \| wc -l` | 6 |
| **16** launchd jobs | `git ls-files \| grep -c 'com\.kipi\..*\.plist'` | **16**, not the audit's 15 |

The audit's installer-gap caveat is also gone, and deliberately. It said the installer's glob could reach only 14 of 15. `bash q-system/.q-system/scripts/install-plist.sh` with no arguments now prints `labels available (from git ls-files):` and all 16, including `com.kipi.voice-refresh` which lives outside the scripts directory. PR #325 moved the enumeration to `git ls-files` and PR #326 added the missing template. Repeating the caveat would have been the audit's own defect class: a README sentence the tool no longer matches.

## Not in this PR

- The audit file itself. It stays on the #324 branch, which GitHub keeps after that PR closes. Its section 7 is stale in two places now, and porting it would mean either shipping stale rows or rewriting a 191-line ledger, neither of which is the four prose fixes you asked for.
- `sp-28f981d6` is **not** resolved by this work. It names four reviewer minors; this PR fixes three (the budget-cut FULL, the eight-folder allowlist, the security bullet). The fourth, PR 317's divergence guard running only in verify and not as a required check, is untouched, and so is the item's structural half, making the reviewer wrapper append every minor to the ledger at verdict time.
- Claims 10 and 21 from the audit (the misses ledger, "six roles are live right now") stay UNVERIFIED and their prose is untouched. Neither is false; each is missing a check, and inventing prose around a missing check is how the page got here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01PpVeUeZnvRVSb6uxzTPL28
