### PR TITLE
prd-os: combine the rival gate-registry fixes; the closeout registrar was writing legacy gates

### DIFF
--- a/plugins/kipi-dsse/.claude-plugin/plugin.json
+++ b/plugins/kipi-dsse/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "kipi-dsse",
-  "version": "0.14.5",
+  "version": "0.14.6",
   "description": "DSSE issue workflow: scope-enforced edits, per-finding dispositions, Codex review gates. Provides /issue-start, /issue-approve, /issue-verify, /issue-review, /issue-amend, /issue-closeout. Consumes issue specs created by prd-os or dropped in manually.",
   "author": {
     "name": "Assaf Kipnis"

--- a/plugins/kipi-dsse/.claude-plugin/plugin.json
+++ b/plugins/kipi-dsse/.claude-plugin/plugin.json
@@ -1,10 +1,10 @@
 {
- "name": "kipi-dsse",
- "version": "0.14.4",
- "description": "DSSE issue workflow: scope-enforced edits, per-finding dispositions, Codex review gates. Provides /issue-start, /issue-approve, /issue-verify, /issue-review, /issue-amend, /issue-closeout. Consumes issue specs created by prd-os or dropped in manually.",
- "author": {
-  "name": "Assaf Kipnis"
- },
- "repository": "https://github.com/assafkip/kipi-system",
- "license": "MIT"
+  "name": "kipi-dsse",
+  "version": "0.14.5",
+  "description": "DSSE issue workflow: scope-enforced edits, per-finding dispositions, Codex review gates. Provides /issue-start, /issue-approve, /issue-verify, /issue-review, /issue-amend, /issue-closeout. Consumes issue specs created by prd-os or dropped in manually.",
+  "author": {
+    "name": "Assaf Kipnis"
+  },
+  "repository": "https://github.com/assafkip/kipi-system",
+  "license": "MIT"
 }

--- a/plugins/kipi-dsse/scripts/issue_runner.py
+++ b/plugins/kipi-dsse/scripts/issue_runner.py
@@ -1166,7 +1166,7 @@ def _enforce_spine_contract(paths, fm: dict, marker: dict, issue_id: str) -> str
             cfg = _load_config(paths.repo_root)
             out = _prd_runner.gate_register(
                 cfg, prd_id=marker["prd_id"], issue_id=issue_id,
-                command=bypass_check)
+                command=bypass_check, lifecycle="regression")
         except Exception as exc:
             return (f"cannot close {issue_id}: bypass_check gate registration "
                     f"failed ({exc}) — the permanent registry must record it "

--- a/plugins/kipi-dsse/scripts/issue_runner.py
+++ b/plugins/kipi-dsse/scripts/issue_runner.py
@@ -1164,6 +1164,20 @@ def _enforce_spine_contract(paths, fm: dict, marker: dict, issue_id: str) -> str
             import prd_runner as _prd_runner
             from config import load as _load_config
             cfg = _load_config(paths.repo_root)
+            # LIFECYCLE IS EXPLICIT, NEVER DEFAULTED. Scar 2026-08-24 (ASK-1038):
+            # this call omitted `lifecycle=`, so it took LEGACY_GATE_LIFECYCLE,
+            # which is "historical-receipt" -- the one value `gates run` filters
+            # OUT before executing. The only producer of gates was writing the
+            # one lifecycle the only consumer refuses to run, so `gates run`
+            # printed "all 0 regression gates green" against a 47-gate registry
+            # and had executed nothing since 2026-07-26. 47 closeouts registered
+            # a permanent proof; all 47 were inert from the moment they landed.
+            #
+            # A bypass_check IS a permanent regression proof -- that is what the
+            # registry section header calls it -- so `regression` is the correct
+            # value and it is passed here rather than relied on as a default.
+            # "legacy" in the constant's name reads as "applies to old rows" to
+            # every reviewer, which is exactly why nobody caught it for 29 days.
             out = _prd_runner.gate_register(
                 cfg, prd_id=marker["prd_id"], issue_id=issue_id,
                 command=bypass_check, lifecycle="regression")

--- a/plugins/prd-os/.claude-plugin/plugin.json
+++ b/plugins/prd-os/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "prd-os",
-  "version": "0.30.3",
+  "version": "0.30.4",
   "description": "PRD operating system: capture rough ideas, draft reviewable PRDs, run standard and adversarial review (Codex or a Claude senior-staff-engineer subagent, recorded truthfully), triage findings, decompose approved PRDs into atomic issue specs, and execute those issues with scope enforcement, stop-gate receipts, and reviewer-attributed findings.",
   "author": {
     "name": "Assaf Kipnis"

--- a/plugins/prd-os/.claude-plugin/plugin.json
+++ b/plugins/prd-os/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "prd-os",
-  "version": "0.30.4",
+  "version": "0.30.5",
   "description": "PRD operating system: capture rough ideas, draft reviewable PRDs, run standard and adversarial review (Codex or a Claude senior-staff-engineer subagent, recorded truthfully), triage findings, decompose approved PRDs into atomic issue specs, and execute those issues with scope enforcement, stop-gate receipts, and reviewer-attributed findings.",
   "author": {
     "name": "Assaf Kipnis"

--- a/plugins/prd-os/.claude-plugin/plugin.json
+++ b/plugins/prd-os/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "prd-os",
-  "version": "0.30.5",
+  "version": "0.30.6",
   "description": "PRD operating system: capture rough ideas, draft reviewable PRDs, run standard and adversarial review (Codex or a Claude senior-staff-engineer subagent, recorded truthfully), triage findings, decompose approved PRDs into atomic issue specs, and execute those issues with scope enforcement, stop-gate receipts, and reviewer-attributed findings.",
   "author": {
     "name": "Assaf Kipnis"

--- a/plugins/prd-os/.claude-plugin/plugin.json
+++ b/plugins/prd-os/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "prd-os",
-  "version": "0.30.2",
+  "version": "0.30.3",
   "description": "PRD operating system: capture rough ideas, draft reviewable PRDs, run standard and adversarial review (Codex or a Claude senior-staff-engineer subagent, recorded truthfully), triage findings, decompose approved PRDs into atomic issue specs, and execute those issues with scope enforcement, stop-gate receipts, and reviewer-attributed findings.",
   "author": {
     "name": "Assaf Kipnis"

--- a/plugins/prd-os/.claude-plugin/plugin.json
+++ b/plugins/prd-os/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "prd-os",
-  "version": "0.30.6",
+  "version": "0.30.7",
   "description": "PRD operating system: capture rough ideas, draft reviewable PRDs, run standard and adversarial review (Codex or a Claude senior-staff-engineer subagent, recorded truthfully), triage findings, decompose approved PRDs into atomic issue specs, and execute those issues with scope enforcement, stop-gate receipts, and reviewer-attributed findings.",
   "author": {
     "name": "Assaf Kipnis"

--- a/plugins/prd-os/scripts/prd_runner.py
+++ b/plugins/prd-os/scripts/prd_runner.py
@@ -1187,7 +1187,48 @@ def _reject_unrunnable_gate(command: str) -> None:
     # 2. Is the first word a real command? Catches the prose class, which is the
     #    one that actually happened seven times. Builtins resolve too, so
     #    `cd x && ...` passes; `check:the ...` does not.
-    first = cmd.split()[0]
+    #
+    # THE RAW FIRST TOKEN IS NOT THE COMMAND NAME, and assuming it was made this
+    # guard refuse commands bash runs perfectly (review of PR #330, MAJOR 1,
+    # reproduced against real specs in this repo). Two shapes:
+    #
+    #   PYTHONPATH=src python3 -m pytest ...   -> first token is an ASSIGNMENT
+    #   (cd plugins/prd-os && pytest -q)       -> first token is a SUBSHELL open
+    #
+    # Census over all 204 decoded bypass_checks in .prd-os/issues/: 16 refused, 2
+    # of them this false-positive class (srsa-authoritative-path-contract.md,
+    # srsa-check-repairs-survived-merge.md). That is not a cosmetic miss --
+    # issue_runner RUNS the bypass_check and requires exit 0 BEFORE registering,
+    # so the command is PROVEN runnable and then refused at the door, and
+    # issue_runner turns any exception here into a hard `cannot close`. An
+    # unattended closeout died on a check that had just gone green, with an error
+    # blaming prose.
+    #
+    # Leading assignments are stripped, and a command opening a group or subshell
+    # is accepted on bash's own verdict: step 1 already parsed it with `bash -n`,
+    # which is a stronger statement about `(cd x && y)` than any token probe.
+    probe_cmd = cmd
+    while True:
+        head = probe_cmd.split(None, 1)
+        if not head:
+            break
+        # NAME=value, the POSIX assignment prefix. Deliberately strict about the
+        # NAME half so `check:the=thing` prose cannot masquerade as one.
+        if re.match(r"^[A-Za-z_][A-Za-z0-9_]*=", head[0]):
+            if len(head) == 1:
+                # An assignment and nothing else runs no check at all.
+                raise ValueError(
+                    "gate command is only environment assignments, so it runs "
+                    f"no check.\n  command: {cmd[:160]}")
+            probe_cmd = head[1]
+            continue
+        break
+    stripped = probe_cmd.lstrip()
+    # `(`, `{`, `!` and a leading redirect open shell GRAMMAR, not a command name.
+    # `bash -n` above already accepted the whole line, which is the real check.
+    if stripped[:1] in ("(", "{", "!", "<", ">"):
+        return
+    first = stripped.split()[0]
     probe = _sp.run(["bash", "-lc", f"command -v {shlex.quote(first)} >/dev/null 2>&1"],
                     capture_output=True, text=True)
     if probe.returncode != 0 and not shutil.which(first):
@@ -1215,7 +1256,15 @@ def gate_register(
             f"invalid gate lifecycle {lifecycle!r}; "
             f"expected one of {', '.join(GATE_LIFECYCLES)}"
         )
-    _reject_unrunnable_gate(command)
+    # THE DOOR IS CHECKED AFTER IDEMPOTENCY, NOT BEFORE (review of PR #330, MAJOR 2).
+    # gate_id is issue_id + sha256(command), so a RE-CLOSE of the same issue with the
+    # same bypass_check resolves to a row that already exists and must be a no-op.
+    # Validating first turned that no-op into a raise, and issue_runner converts any
+    # raise here into `cannot close` -- so tightening the door would have broken
+    # re-close, a workflow issue_runner documents ("spec closed once, reopened,
+    # amended, closed again"). A row already in the registry got past whatever door
+    # existed when it was written; re-litigating it at read time is not this guard's
+    # job. New rows are still validated below.
     gate_id = f"{issue_id}-{_hashlib.sha256(command.encode()).hexdigest()[:8]}"
     path = _gates_path(cfg)
     if path.is_file():
@@ -1225,13 +1274,30 @@ def gate_register(
                 if existing.get("gate_id") == gate_id:
                     existing_lifecycle = _gate_lifecycle(existing)
                     if existing_lifecycle != lifecycle:
+                        # NAME THE RECOVERY. Every gate this fleet's closeout wrote
+                        # before the lifecycle fix took LEGACY_GATE_LIFECYCLE, so the
+                        # FIRST re-close of any such issue lands here, and the caller
+                        # (issue_runner) turns it into a bare `cannot close`. The
+                        # recovery exists and lives outside the closeout flow; an
+                        # error that does not name it is a dead end at 3am.
                         raise ValueError(
                             f"gate {gate_id!r} already registered as "
-                            f"{existing_lifecycle!r}, not {lifecycle!r}"
+                            f"{existing_lifecycle!r}, not {lifecycle!r}. "
+                            "The registry is append-only, so this is not edited in "
+                            "place: run `python3 plugins/prd-os/scripts/"
+                            f"migrate_gate_lifecycle.py --regression {gate_id} "
+                            "--apply`, then close again."
                         )
                     return {"gate_id": gate_id, "registered": False}
             except json.JSONDecodeError:
                 continue
+    # THE DOOR, for a genuinely NEW row only. Everything above this line either
+    # returned a no-op or raised on a lifecycle conflict, so an already-permanent
+    # gate never reaches it -- which is the whole point of the ordering (MAJOR 2).
+    # This line is what test_gate_register_ACTUALLY_CALLS_the_unrunnable_guard
+    # defends; deleting it while re-ordering is exactly the mistake that test
+    # caught during the review fix, 2026-09-07.
+    _reject_unrunnable_gate(command)
     record = {"gate_id": gate_id, "prd_id": prd_id, "issue_id": issue_id,
               "command": command,
               "lifecycle": lifecycle,

--- a/plugins/prd-os/scripts/prd_runner.py
+++ b/plugins/prd-os/scripts/prd_runner.py
@@ -1224,9 +1224,23 @@ def _reject_unrunnable_gate(command: str) -> None:
             continue
         break
     stripped = probe_cmd.lstrip()
-    # `(`, `{`, `!` and a leading redirect open shell GRAMMAR, not a command name.
-    # `bash -n` above already accepted the whole line, which is the real check.
-    if stripped[:1] in ("(", "{", "!", "<", ">"):
+    # `!` IS NOT AN ACCEPT, and grouping it with the others was a hole I opened
+    # (review of PR #330 round 3, MINOR). `!` NEGATES the pipeline's status, so
+    # `! check:the ledger is append-only` runs a command that does not exist, gets
+    # 127, and the negation turns that into exit 0 -- a gate that passes forever,
+    # in an append-only registry. It is stripped and probing continues, so the
+    # prose behind it is still caught.
+    while stripped[:1] == "!":
+        stripped = stripped[1:].lstrip()
+        if not stripped:
+            raise ValueError(
+                "gate command is only a negation, so it runs no check.\n"
+                f"  command: {cmd[:160]}")
+    # `(`, `{` and a leading redirect open shell GRAMMAR, not a command name, and
+    # `bash -n` above already accepted the whole line. Prose inside a subshell
+    # still fails LOUDLY at run time (127), which is the tolerable direction; the
+    # negation above was the one that fails silently green.
+    if stripped[:1] in ("(", "{", "<", ">"):
         return
     first = stripped.split()[0]
     probe = _sp.run(["bash", "-lc", f"command -v {shlex.quote(first)} >/dev/null 2>&1"],
@@ -3029,9 +3043,18 @@ def cmd_gates(cfg: Config, args) -> int:
         print(f"[WARN] gates: {registered_total} gate(s) registered, NONE "
               f"executed -- {why}, so no regression check ran. "
               f"Exit 0 below covers the spillover verdict ONLY.")
-    print(f"all {len(records)} regression gates green "
-          f"({registered_total} registered); "
-          f"{len(blocking)} blocking spillover item(s)")
+    # THE FINAL LINE MUST NOT CONTRADICT THE WARN (review of PR #330 round 3,
+    # MINOR). It printed "all 0 regression gates green" immediately under a WARN
+    # saying nothing executed -- which is the exact ASK-1038 sentence, still
+    # there, three lines below its own alarm. A reader who scrolls to the last
+    # line, or a script that greps it, sees the reassurance and not the warning.
+    if executed <= 0:
+        print(f"NO regression gate executed ({registered_total} registered); "
+              f"{len(blocking)} blocking spillover item(s)")
+    else:
+        print(f"all {executed} regression gates green "
+              f"({registered_total} registered); "
+              f"{len(blocking)} blocking spillover item(s)")
     return 0
 
 

--- a/plugins/prd-os/scripts/prd_runner.py
+++ b/plugins/prd-os/scripts/prd_runner.py
@@ -46,6 +46,7 @@ import subprocess
 import tempfile
 import os
 import re
+import shlex
 import sys
 from datetime import datetime, timezone
 from pathlib import Path
@@ -1154,6 +1155,49 @@ def _gate_lifecycle(record: dict) -> str:
     return lifecycle
 
 
+def _reject_unrunnable_gate(command: str) -> None:
+    """Refuse a gate whose command cannot run. Validated AT THE DOOR.
+
+    Scar 2026-08-24 (ASK-1040), measured by executing all 47 registered gates:
+    12 were not runnable at all. SEVEN held PROSE in the command slot -- the
+    shell was being asked to run `check:the`, `check:adding`, `asserting` --
+    because somebody wrote a DESCRIPTION of the check where the check goes.
+    Three were shell syntax errors. Registration accepted every one of them
+    without a word, and each was then recorded as permanent protection.
+
+    A gate that cannot execute is worse than no gate: it is counted, reported,
+    and believed. The registry is append-only, so a bad row is close to
+    permanent -- which is exactly why the check belongs here and not downstream.
+
+    NOT validated here: whether the command TESTS anything real. `true` is a
+    legal gate and a useless one. This refuses the unrunnable, not the useless;
+    the zero-collecting pytest class is its own item.
+    """
+    cmd = (command or "").strip()
+    if not cmd:
+        raise ValueError("gate command is empty; a gate that runs nothing is not a gate")
+    import shutil
+    import subprocess as _sp
+    # 1. Does it parse? Catches the unterminated-heredoc class.
+    syntax = _sp.run(["bash", "-n", "-c", cmd], capture_output=True, text=True)
+    if syntax.returncode != 0:
+        raise ValueError(
+            f"gate command is not valid shell: {syntax.stderr.strip()[:200]}\n"
+            f"  command: {cmd[:160]}")
+    # 2. Is the first word a real command? Catches the prose class, which is the
+    #    one that actually happened seven times. Builtins resolve too, so
+    #    `cd x && ...` passes; `check:the ...` does not.
+    first = cmd.split()[0]
+    probe = _sp.run(["bash", "-lc", f"command -v {shlex.quote(first)} >/dev/null 2>&1"],
+                    capture_output=True, text=True)
+    if probe.returncode != 0 and not shutil.which(first):
+        raise ValueError(
+            f"gate command does not start with a runnable command: {first!r}. "
+            "This is the prose-in-the-command-slot class (ASK-1040): write the "
+            "CHECK here, not a description of it.\n"
+            f"  command: {cmd[:160]}")
+
+
 def gate_register(
     cfg: Config,
     *,
@@ -1171,6 +1215,7 @@ def gate_register(
             f"invalid gate lifecycle {lifecycle!r}; "
             f"expected one of {', '.join(GATE_LIFECYCLES)}"
         )
+    _reject_unrunnable_gate(command)
     gate_id = f"{issue_id}-{_hashlib.sha256(command.encode()).hexdigest()[:8]}"
     path = _gates_path(cfg)
     if path.is_file():
@@ -2752,6 +2797,7 @@ def cmd_gates(cfg: Config, args) -> int:
             "other lifecycles are retained as non-current evidence\n"
         )
         return 2
+    registered_total = len(records)
     records = [
         record for record in records
         if record["lifecycle"] == "regression"
@@ -2890,7 +2936,19 @@ def cmd_gates(cfg: Config, args) -> int:
         for gid, tail in failures:
             sys.stderr.write(f"GATE RED: {gid}\n{tail}\n")
         return 1
-    print(f"all {len(records)} regression gates green; "
+    if not records and registered_total:
+        # AN EMPTY EXECUTED SET IS NOT A PASS, and it must never be printed as
+        # one. Scar 2026-08-24 (ASK-1038): this line said "all 0 regression
+        # gates green" against a 47-gate registry, and the sentence was TRUE --
+        # vacuously, because the closeout registrar wrote every gate as
+        # historical-receipt, the one lifecycle filtered out just above. Exit 0
+        # was read as "the gates are green" for 29 days while nothing ran.
+        # A count of zero is now stated as the anomaly it is.
+        print(f"[WARN] gates: {registered_total} gate(s) registered, NONE "
+              f"executable -- 0 have lifecycle 'regression', so no regression "
+              f"check ran. Exit 0 below covers the spillover verdict ONLY.")
+    print(f"all {len(records)} regression gates green "
+          f"({registered_total} registered); "
           f"{len(blocking)} blocking spillover item(s)")
     return 0
 

--- a/plugins/prd-os/scripts/prd_runner.py
+++ b/plugins/prd-os/scripts/prd_runner.py
@@ -1233,6 +1233,12 @@ def _reject_unrunnable_gate(command: str) -> None:
     while stripped[:1] == "!":
         stripped = stripped[1:].lstrip()
         if not stripped:
+            # NOT DEAD CODE, though it looks it on macOS. `bash -n -c '!'` is a
+            # syntax error under bash 3.2 (so step 1 refuses first) and PARSES
+            # under the bash 5.x that CI runs, where this is the only thing
+            # standing between a bare `!` and `stripped.split()[0]` on an empty
+            # string. CI proved it by failing on a test that had pinned the macOS
+            # door. Platform-split behaviour, kept deliberately.
             raise ValueError(
                 "gate command is only a negation, so it runs no check.\n"
                 f"  command: {cmd[:160]}")

--- a/plugins/prd-os/scripts/prd_runner.py
+++ b/plugins/prd-os/scripts/prd_runner.py
@@ -1284,8 +1284,14 @@ def gate_register(
                             f"gate {gate_id!r} already registered as "
                             f"{existing_lifecycle!r}, not {lifecycle!r}. "
                             "The registry is append-only, so this is not edited in "
+                            # --registry is required=True in that script, so the
+                            # first version of this message printed a command that
+                            # exits 2 (review of PR #330 round 2, MINOR 1). A
+                            # recovery pointer that does not run is the dead end it
+                            # was written to remove.
                             "place: run `python3 plugins/prd-os/scripts/"
-                            f"migrate_gate_lifecycle.py --regression {gate_id} "
+                            "migrate_gate_lifecycle.py --registry "
+                            f"{_gates_path(cfg)} --regression {gate_id} "
                             "--apply`, then close again."
                         )
                     return {"gate_id": gate_id, "registered": False}
@@ -3002,7 +3008,15 @@ def cmd_gates(cfg: Config, args) -> int:
         for gid, tail in failures:
             sys.stderr.write(f"GATE RED: {gid}\n{tail}\n")
         return 1
-    if not records and registered_total:
+    # `skipped_self_ref` joins the condition (review of PR #330 round 2, MINOR 2).
+    # Keying only on len(records)==0 missed the other way to execute nothing: a
+    # registry whose regression gates are ALL skipped as self-referential has
+    # records non-empty and zero commands run, and printed the same "all N
+    # regression gates green" at exit 0. The counter was already incremented and
+    # never read. No producer emits this shape today (censused: 0 of 204
+    # bypass_checks are self-referential), which is exactly when a hole gets in.
+    executed = len(records) - skipped_self_ref
+    if executed <= 0 and registered_total:
         # AN EMPTY EXECUTED SET IS NOT A PASS, and it must never be printed as
         # one. Scar 2026-08-24 (ASK-1038): this line said "all 0 regression
         # gates green" against a 47-gate registry, and the sentence was TRUE --
@@ -3010,9 +3024,11 @@ def cmd_gates(cfg: Config, args) -> int:
         # historical-receipt, the one lifecycle filtered out just above. Exit 0
         # was read as "the gates are green" for 29 days while nothing ran.
         # A count of zero is now stated as the anomaly it is.
+        why = ("0 have lifecycle 'regression'" if not records
+               else f"all {skipped_self_ref} skipped as self-referential")
         print(f"[WARN] gates: {registered_total} gate(s) registered, NONE "
-              f"executable -- 0 have lifecycle 'regression', so no regression "
-              f"check ran. Exit 0 below covers the spillover verdict ONLY.")
+              f"executed -- {why}, so no regression check ran. "
+              f"Exit 0 below covers the spillover verdict ONLY.")
     print(f"all {len(records)} regression gates green "
           f"({registered_total} registered); "
           f"{len(blocking)} blocking spillover item(s)")

--- a/plugins/prd-os/tests/test_gate_lifecycle.py
+++ b/plugins/prd-os/tests/test_gate_lifecycle.py
@@ -167,14 +167,26 @@ def test_a_NEGATED_prose_command_is_refused(repo):
     mod = _runner_module()
     with pytest.raises(ValueError, match="does not start with a runnable command"):
         mod._reject_unrunnable_gate("! check:the ledger is append-only")
-    # A BARE `!` is refused, but by bash's own parser at step 1, not by the
-    # negation branch -- `bash -n -c '!'` is a syntax error. Asserting the
-    # branch's own wording here failed, and the honest fix is to assert the
-    # OUTCOME and name which guard actually produces it. The branch stays as
-    # belt-and-braces so the strip loop cannot hand an empty string to
-    # `.split()[0]`; it is deliberately not claimed to be covered.
-    with pytest.raises(ValueError, match="not valid shell"):
+    # A BARE `!` IS REFUSED ON BOTH PLATFORMS, BY DIFFERENT GUARDS, and pinning
+    # either one is how this test went red in CI while passing locally.
+    #
+    #   macOS, bash 3.2.57  : `bash -n -c '!'` is a SYNTAX ERROR
+    #                         -> step 1 refuses with "not valid shell"
+    #   CI, Linux bash 5.x  : `bash -n -c '!'` PARSES
+    #                         -> the negation branch refuses with "only a negation"
+    #
+    # Measured, after CI failed on exactly this: 'Expected regex: not valid shell /
+    # Actual message: gate command is only a negation'. The previous comment here
+    # called that branch unreachable belt-and-braces. That was WRONG -- on the
+    # platform CI actually runs, it is the live guard, and the version of this
+    # comment that called it dead code would have justified deleting it.
+    #
+    # So the assertion is on the OUTCOME (refused, with a reason naming the input)
+    # rather than on which of the two doors closed.
+    with pytest.raises(ValueError) as bare:
         mod._reject_unrunnable_gate("!")
+    assert "not valid shell" in str(bare.value) or "only a negation" in str(bare.value), \
+        f"a bare negation must be refused with a reason, got: {bare.value}"
     # and a genuinely negated REAL command still passes, so the fix is not a ban
     mod._reject_unrunnable_gate("! false")
 

--- a/plugins/prd-os/tests/test_gate_lifecycle.py
+++ b/plugins/prd-os/tests/test_gate_lifecycle.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 import importlib.util
 import json
+import re
 import subprocess
 import sys
 from pathlib import Path
@@ -125,6 +126,87 @@ def test_gate_register_validates_and_persists_lifecycle(repo):
             command="true",
             lifecycle="sometimes",
         )
+
+
+@pytest.mark.parametrize("cmd", [
+    # The two shapes that live specs in this repo actually use. Both are refused by
+    # a raw `cmd.split()[0]` probe and both are run fine by bash.
+    "PYTHONPATH=plugins/kipi-core/kipi-mcp/src python3 -m pytest -q tests/test_paths.py",
+    "PYTHONPATH=. python3 -m pytest plugins/prd-os/tests -q",
+    "(cd plugins/prd-os && python3 -m pytest -q)",
+    "FOO=1 BAR=2 true",
+    "{ true; }",
+])
+def test_a_command_bash_can_run_is_not_called_prose(cmd):
+    """The door must not refuse a shape the shell executes (PR #330 review, MAJOR 1).
+
+    This is not hypothetical and it is not cosmetic. `issue_runner` RUNS the
+    bypass_check and requires exit 0 BEFORE it registers, so by the time this guard
+    sees the command it is PROVEN runnable -- and issue_runner turns any raise here
+    into a hard `cannot close`. Census over all 204 decoded bypass_checks in
+    .prd-os/issues/: 16 refused, 2 of them this false-positive class. An unattended
+    closeout died on a check that had just gone green, blaming prose.
+
+    The first token of `PYTHONPATH=x python3 ...` is an ASSIGNMENT, and of
+    `(cd x && y)` is shell GRAMMAR. Neither is a command name.
+    """
+    _runner_module()._reject_unrunnable_gate(cmd)
+
+
+def test_prose_is_STILL_refused_after_the_assignment_fix():
+    """The negative half: widening the door must not open it (MAJOR 1 fix control).
+
+    An assignment-looking prefix must not become a way to smuggle prose past the
+    guard, and prose that merely follows an assignment is still prose.
+    """
+    mod = _runner_module()
+    for bad in ("check:the ledger is append-only",
+                "PYTHONPATH=. check:the ledger is append-only",
+                "asserting the gate runs"):
+        with pytest.raises(ValueError, match="does not start with a runnable command"):
+            mod._reject_unrunnable_gate(bad)
+    # An assignment with no command runs no check, and says so in its own words.
+    with pytest.raises(ValueError, match="only environment assignments"):
+        mod._reject_unrunnable_gate("PYTHONPATH=.")
+
+
+def test_re_registering_an_existing_gate_is_a_no_op_not_a_raise(repo):
+    """Re-close must stay possible (PR #330 review, MAJOR 2).
+
+    gate_id is issue_id + sha256(command), so re-closing an issue with the same
+    bypass_check resolves to an existing row. Validating the command BEFORE the
+    idempotency lookup turned that no-op into a raise, and issue_runner converts
+    any raise into `cannot close` -- breaking a workflow issue_runner itself
+    documents ("spec closed once, reopened, amended, closed again").
+
+    Registered here with a command the door accepts, then re-registered, which is
+    the path a real re-close takes.
+    """
+    module = _runner_module()
+    cfg = module.load_config(repo)
+    first = module.gate_register(cfg, prd_id="prd-x", issue_id="issue-recl",
+                                 command="true", lifecycle="regression")
+    assert first["registered"] is True
+    again = module.gate_register(cfg, prd_id="prd-x", issue_id="issue-recl",
+                                 command="true", lifecycle="regression")
+    assert again == {"gate_id": first["gate_id"], "registered": False}
+
+
+def test_a_lifecycle_conflict_names_its_recovery(repo):
+    """A dead-end error at 3am is a defect (PR #330 review, MAJOR 2).
+
+    Every gate this fleet's closeout wrote before the lifecycle fix took
+    LEGACY_GATE_LIFECYCLE, so the FIRST re-close of any such issue hits this
+    branch. The recovery exists but lives outside the closeout flow, so the
+    message has to carry it.
+    """
+    module = _runner_module()
+    cfg = module.load_config(repo)
+    module.gate_register(cfg, prd_id="prd-x", issue_id="issue-conf",
+                         command="true", lifecycle="historical-receipt")
+    with pytest.raises(ValueError, match="migrate_gate_lifecycle.py"):
+        module.gate_register(cfg, prd_id="prd-x", issue_id="issue-conf",
+                             command="true", lifecycle="regression")
 
 
 def test_gate_register_ACTUALLY_CALLS_the_unrunnable_guard(repo):
@@ -292,13 +374,24 @@ def test_the_closeout_registrar_asks_for_regression_at_the_call_site(repo):
     which reads to every reviewer as "applies to rows written before the field
     existed". It was in fact the live default for every new registration. A test
     on the function's default would have passed throughout the outage.
+
+    EVERY call site, not `src.index(...)` (review of PR #330, MINOR 3). The first
+    version inspected only the first match plus 260 characters, so a SECOND
+    registrar added later with no lifecycle kept it green. There is exactly one
+    call site today, which is what made that a latent hole rather than a live one
+    -- and exactly the condition under which nobody notices.
     """
     src = (PLUGIN_ROOT.parent / "kipi-dsse" / "scripts" / "issue_runner.py").read_text()
-    i = src.index("_prd_runner.gate_register(")
-    call = src[i:i + 260]
-    assert 'lifecycle="regression"' in call, (
-        "the closeout registrar must name its lifecycle explicitly; "
-        f"call site reads:\n{call}")
+    starts = [m.start() for m in re.finditer(r"_prd_runner\.gate_register\(", src)]
+    assert starts, "no gate_register call site found at all -- the test lost its subject"
+    unlifecycled = [
+        src[i:i + 260] for i in starts
+        if 'lifecycle="regression"' not in src[i:i + 260]
+    ]
+    assert not unlifecycled, (
+        f"{len(unlifecycled)} of {len(starts)} closeout registrar call site(s) do not "
+        "name their lifecycle, so they take LEGACY_GATE_LIFECYCLE and `gates run` "
+        "filters them out:\n" + "\n---\n".join(unlifecycled))
 
 
 # ---------------------------------------------------------------------------

--- a/plugins/prd-os/tests/test_gate_lifecycle.py
+++ b/plugins/prd-os/tests/test_gate_lifecycle.py
@@ -127,6 +127,41 @@ def test_gate_register_validates_and_persists_lifecycle(repo):
         )
 
 
+def test_gate_register_ACTUALLY_CALLS_the_unrunnable_guard(repo):
+    """The guard is WIRED, not merely present. This is the wiring half.
+
+    The four tests below drive `_reject_unrunnable_gate` DIRECTLY, so all four stay
+    green even when nothing calls it. Measured 2026-09-07 while carrying this guard
+    upstream: deleting the single `_reject_unrunnable_gate(command)` line from
+    `gate_register` left the whole file green at 17 passed. A guard nobody invokes
+    reads exactly like one that works, and the registry it protects is append-only,
+    so a bad row is close to permanent.
+
+    This one goes through the real entry point with the exact shape that happened
+    seven times -- prose where the command goes -- and it is the test that dies if
+    the call site is ever dropped again.
+    """
+    spec = importlib.util.spec_from_file_location("prd_runner_wiring", PRD_RUNNER)
+    module = importlib.util.module_from_spec(spec)
+    sys.path.insert(0, str(PRD_RUNNER.parent))
+    spec.loader.exec_module(module)
+    cfg = module.load_config(repo)
+
+    with pytest.raises(ValueError, match="does not start with a runnable command"):
+        module.gate_register(
+            cfg,
+            prd_id="prd-x",
+            issue_id="issue-wiring",
+            command="check:the ledger is append-only",
+            lifecycle="regression",
+        )
+
+    # AND IT REFUSED BEFORE WRITING. A guard that raises after the append still
+    # leaves the permanent row it exists to prevent.
+    gates = repo / ".prd-os" / "gates.jsonl"
+    assert not gates.exists() or "issue-wiring" not in gates.read_text()
+
+
 def test_migration_classifies_every_record_without_deleting_receipts(repo):
     write_gates(
         repo,
@@ -209,3 +244,121 @@ def test_incremental_migration_preserves_existing_lifecycles(repo):
         "retired",
         "external",
     ]
+
+
+# ---------------------------------------------------------------------------
+# ASK-1038: the run half went inert for 29 days and reported success
+# ---------------------------------------------------------------------------
+
+
+def test_a_failing_regression_gate_actually_turns_the_run_red(repo):
+    """POSITIVE CONTROL. The check nobody had, and its absence cost 29 days.
+
+    Every other test here asserts which gates are SELECTED. None asserted that a
+    selected gate can fail the run. So when the closeout registrar started
+    writing every gate as historical-receipt, the executed set went to zero, the
+    command printed "all 0 regression gates green" and exited 0, and the suite
+    stayed green because nothing ever demanded that a red gate produce a red run.
+    A gate set that cannot fail is decoration.
+    """
+    write_gates(repo, [{"gate_id": "boom", "command": "exit 7",
+                        "lifecycle": "regression"}])
+    result = run(repo, "gates", "run")
+    assert result.returncode != 0, (
+        "a failing regression gate MUST fail the run; got "
+        f"rc={result.returncode}\n{result.stdout}\n{result.stderr}")
+    assert "boom" in (result.stdout + result.stderr)
+
+
+def test_a_registry_with_nothing_executable_is_not_reported_as_green(repo):
+    """A count of zero is an anomaly, not a pass.
+
+    "all 0 regression gates green" is TRUE and reads as reassurance, which is
+    exactly how it survived. With a non-empty registry and an empty executed
+    set, the run must say so out loud.
+    """
+    write_gates(repo, [{"gate_id": "inert", "command": "exit 1",
+                        "lifecycle": "historical-receipt"}])
+    result = run(repo, "gates", "run")
+    out = result.stdout + result.stderr
+    assert "NONE executable" in out, out
+    assert "1 registered" in out, out
+
+
+def test_the_closeout_registrar_asks_for_regression_at_the_call_site(repo):
+    """Pinned at the CALL SITE, not at gate_register's default.
+
+    The default is `historical-receipt` and is named LEGACY_GATE_LIFECYCLE,
+    which reads to every reviewer as "applies to rows written before the field
+    existed". It was in fact the live default for every new registration. A test
+    on the function's default would have passed throughout the outage.
+    """
+    src = (PLUGIN_ROOT.parent / "kipi-dsse" / "scripts" / "issue_runner.py").read_text()
+    i = src.index("_prd_runner.gate_register(")
+    call = src[i:i + 260]
+    assert 'lifecycle="regression"' in call, (
+        "the closeout registrar must name its lifecycle explicitly; "
+        f"call site reads:\n{call}")
+
+
+# ---------------------------------------------------------------------------
+# ASK-1040: prose in the command slot, accepted 47 times without a word
+# ---------------------------------------------------------------------------
+
+
+def _runner_module():
+    spec = importlib.util.spec_from_file_location("pr_mod", PRD_RUNNER)
+    mod = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(mod)
+    return mod
+
+
+@pytest.mark.parametrize("prose", [
+    "check:the brake never leaks into the test suite",
+    "check:adding a demo sentence fails the approval test",
+    "asserting the X body stays under the ceiling",
+])
+def test_prose_in_the_command_slot_is_refused(prose):
+    """The class that actually happened, seven times, verbatim from the registry.
+
+    Somebody wrote a DESCRIPTION of the check where the check goes. The shell
+    was then asked to run `check:the` and exited 127, and every one of those was
+    recorded as permanent protection.
+    """
+    mod = _runner_module()
+    with pytest.raises(ValueError, match="does not start with a runnable command"):
+        mod._reject_unrunnable_gate(prose)
+
+
+def test_a_shell_syntax_error_is_refused():
+    """`bash -n` is more permissive than it looks, and that is worth pinning.
+
+    The first draft of this test used an unterminated heredoc, assuming that was
+    a syntax error. `bash -n -c` accepts it (rc=0), so the test failed and the
+    CODE was fine. Pinned here with a construct bash genuinely rejects, so the
+    next reader does not re-derive that the heredoc case is NOT covered.
+    """
+    mod = _runner_module()
+    with pytest.raises(ValueError, match="not valid shell"):
+        mod._reject_unrunnable_gate("if true; then")
+
+
+def test_an_empty_command_is_refused():
+    mod = _runner_module()
+    with pytest.raises(ValueError, match="runs nothing"):
+        mod._reject_unrunnable_gate("   ")
+
+
+@pytest.mark.parametrize("good", [
+    "cd q-consult && python3 -m pytest pipeline/tests/test_sameness.py -q",
+    "bash -c '! grep -rn VOICE_SOURCE_GLOBS q-consult/pipeline/*.py'",
+    "python3 -c \"import sys; sys.exit(0)\"",
+])
+def test_real_gate_commands_are_not_false_positived(good):
+    """THE CONTROL THAT MATTERS MORE THAN THE REFUSAL.
+
+    A door check that rejects valid gates would push people to stop registering
+    them, which is worse than the prose it prevents. Verified 2026-08-24 against
+    the live registry: all 34 regression gates pass this, 0 false positives.
+    """
+    _runner_module()._reject_unrunnable_gate(good)

--- a/plugins/prd-os/tests/test_gate_lifecycle.py
+++ b/plugins/prd-os/tests/test_gate_lifecycle.py
@@ -154,6 +154,48 @@ def test_a_command_bash_can_run_is_not_called_prose(cmd):
     _runner_module()._reject_unrunnable_gate(cmd)
 
 
+def test_a_NEGATED_prose_command_is_refused(repo):
+    """`!` inverts, so accepting it makes a gate that passes forever.
+
+    Round 3 of the PR #330 review found this hole, which I opened myself by
+    grouping `!` with `(` and `{` as "shell grammar, bash already parsed it".
+    The difference is the direction of failure: prose inside a subshell exits 127
+    and the gate goes RED loudly, but `! <prose>` runs the same missing command,
+    gets 127, and the negation turns it into exit 0. In an append-only registry
+    that is a permanent green gate that never executed anything.
+    """
+    mod = _runner_module()
+    with pytest.raises(ValueError, match="does not start with a runnable command"):
+        mod._reject_unrunnable_gate("! check:the ledger is append-only")
+    # A BARE `!` is refused, but by bash's own parser at step 1, not by the
+    # negation branch -- `bash -n -c '!'` is a syntax error. Asserting the
+    # branch's own wording here failed, and the honest fix is to assert the
+    # OUTCOME and name which guard actually produces it. The branch stays as
+    # belt-and-braces so the strip loop cannot hand an empty string to
+    # `.split()[0]`; it is deliberately not claimed to be covered.
+    with pytest.raises(ValueError, match="not valid shell"):
+        mod._reject_unrunnable_gate("!")
+    # and a genuinely negated REAL command still passes, so the fix is not a ban
+    mod._reject_unrunnable_gate("! false")
+
+
+def test_a_run_that_executed_nothing_never_prints_the_green_sentence(repo):
+    """The last line must not contradict the WARN three lines above it.
+
+    It printed "all 0 regression gates green" directly under a WARN saying
+    nothing executed. That is the ASK-1038 sentence itself, still present, under
+    its own alarm -- and a reader who scrolls to the end, or a script that greps
+    the last line, sees only the reassurance.
+    """
+    write_gates(repo, [{"gate_id": "inert", "command": "exit 1",
+                        "lifecycle": "historical-receipt"}])
+    result = run(repo, "gates", "run")
+    out = result.stdout + result.stderr
+    assert "NO regression gate executed" in out, out
+    assert "regression gates green" not in out, (
+        "the run executed nothing and still printed the green sentence:\n" + out)
+
+
 def test_prose_is_STILL_refused_after_the_assignment_fix():
     """The negative half: widening the door must not open it (MAJOR 1 fix control).
 

--- a/plugins/prd-os/tests/test_gate_lifecycle.py
+++ b/plugins/prd-os/tests/test_gate_lifecycle.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import importlib.util
+import ast
 import json
 import re
 import subprocess
@@ -204,9 +205,19 @@ def test_a_lifecycle_conflict_names_its_recovery(repo):
     cfg = module.load_config(repo)
     module.gate_register(cfg, prd_id="prd-x", issue_id="issue-conf",
                          command="true", lifecycle="historical-receipt")
-    with pytest.raises(ValueError, match="migrate_gate_lifecycle.py"):
+    with pytest.raises(ValueError) as exc:
         module.gate_register(cfg, prd_id="prd-x", issue_id="issue-conf",
                              command="true", lifecycle="regression")
+    msg = str(exc.value)
+    assert "migrate_gate_lifecycle.py" in msg
+    # THE FLAG, not just the filename (review of PR #330 round 2, MINOR 1). The
+    # first version matched the substring and stayed green against a command that
+    # exits 2, because --registry is required=True in that script. A recovery
+    # pointer is only a recovery if it runs.
+    assert "--registry" in msg, f"recovery command omits a required flag:\n{msg}"
+    quoted = msg.split("`")[1]
+    for flag in ("--registry", "--regression", "--apply"):
+        assert flag in quoted, f"{flag} missing from the printed command: {quoted}"
 
 
 def test_gate_register_ACTUALLY_CALLS_the_unrunnable_guard(repo):
@@ -363,8 +374,34 @@ def test_a_registry_with_nothing_executable_is_not_reported_as_green(repo):
                         "lifecycle": "historical-receipt"}])
     result = run(repo, "gates", "run")
     out = result.stdout + result.stderr
-    assert "NONE executable" in out, out
+    # "executable" was the wrong word and is now "executed": these gates ARE
+    # executable, they simply did not run. The distinction is the whole finding.
+    assert "[WARN]" in out, out
+    assert "NONE executed" in out, out
     assert "1 registered" in out, out
+
+
+def test_a_registry_whose_gates_are_ALL_SKIPPED_is_not_reported_as_green(repo):
+    """The other way to execute nothing (review of PR #330 round 2, MINOR 2).
+
+    The WARN keyed on `len(records) == 0`. A registry whose regression gates are
+    all skipped as self-referential has records NON-empty and zero commands run,
+    so it printed "all 1 regression gates green" at exit 0 with nothing executed --
+    the identical sentence ASK-1038 was written to stop. `skipped_self_ref` was
+    already being counted and never read.
+
+    No producer emits this shape today (0 of 204 bypass_checks in .prd-os/issues
+    are self-referential), which is precisely the condition under which a hole
+    survives unnoticed.
+    """
+    write_gates(repo, [{"gate_id": "selfref",
+                        "command": "python3 plugins/prd-os/scripts/prd_runner.py gates run",
+                        "lifecycle": "regression"}])
+    result = run(repo, "gates", "run")
+    out = result.stdout + result.stderr
+    assert "[WARN]" in out, out
+    assert "NONE executed" in out, out
+    assert "self-referential" in out, out
 
 
 def test_the_closeout_registrar_asks_for_regression_at_the_call_site(repo):
@@ -380,18 +417,39 @@ def test_the_closeout_registrar_asks_for_regression_at_the_call_site(repo):
     registrar added later with no lifecycle kept it green. There is exactly one
     call site today, which is what made that a latent hole rather than a live one
     -- and exactly the condition under which nobody notices.
+
+    THE ARGUMENT LIST IS PARSED, NOT WINDOWED (review of PR #330 round 2, MINOR 3).
+    The first fix replaced `src.index(...)` with every match but kept a 260-char
+    forward window per match, so two ADJACENT registrars fall inside each other's
+    window and a lifecycled second call donates its `lifecycle="regression"` to an
+    unlifecycled first. Reproduced: 2 call sites, first one unlifecycled, verdict
+    GREEN. Adjacency is the likeliest arrangement for the very second registrar this
+    test exists to catch, so `ast` removes the window rather than widening it.
     """
     src = (PLUGIN_ROOT.parent / "kipi-dsse" / "scripts" / "issue_runner.py").read_text()
-    starts = [m.start() for m in re.finditer(r"_prd_runner\.gate_register\(", src)]
-    assert starts, "no gate_register call site found at all -- the test lost its subject"
-    unlifecycled = [
-        src[i:i + 260] for i in starts
-        if 'lifecycle="regression"' not in src[i:i + 260]
-    ]
-    assert not unlifecycled, (
-        f"{len(unlifecycled)} of {len(starts)} closeout registrar call site(s) do not "
-        "name their lifecycle, so they take LEGACY_GATE_LIFECYCLE and `gates run` "
-        "filters them out:\n" + "\n---\n".join(unlifecycled))
+
+    def _is_gate_register(node):
+        f = node.func
+        return (isinstance(f, ast.Attribute) and f.attr == "gate_register") or (
+            isinstance(f, ast.Name) and f.id == "gate_register")
+
+    calls = [n for n in ast.walk(ast.parse(src))
+             if isinstance(n, ast.Call) and _is_gate_register(n)]
+    assert calls, "no gate_register call site found at all -- the test lost its subject"
+    bad = []
+    for n in calls:
+        kw = {k.arg: k for k in n.keywords if k.arg}
+        val = kw.get("lifecycle")
+        ok = (val is not None
+              and isinstance(val.value, ast.Constant)
+              and val.value.value == "regression")
+        if not ok:
+            bad.append(f"line {n.lineno}: lifecycle="
+                       f"{ast.unparse(val.value) if val is not None else '<absent>'}")
+    assert not bad, (
+        f"{len(bad)} of {len(calls)} closeout registrar call site(s) do not pass "
+        'lifecycle="regression", so they take LEGACY_GATE_LIFECYCLE and `gates run` '
+        "filters them out:\n" + "\n".join(bad))
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## The fork

`plugins/prd-os/scripts/prd_runner.py` had diverged between this repo and the consulting
instance, and **each side carried a guard the other lacked**:

| | had |
|---|---|
| this repo | ASK-988 reopen-aware archive coverage, `SPILLOVER_SEVERITY_ORDER` |
| the instance | ASK-1040 `_reject_unrunnable_gate`, ASK-1038 vacuous-pass WARN |

`plugins/` in an instance is an `rsync --delete` destination from this tree, so the next
fleet sync would have deleted the instance's two guards silently. Neither side is adopted
wholesale; both fixes are kept. Every hunk was applied against an anchor asserted to
appear exactly once.

## The defect this surfaced, which is the real content of the PR

Adopting the instance's `test_gate_lifecycle.py` (a strict superset — zero removals)
turned `test_the_closeout_registrar_asks_for_regression_at_the_call_site` **RED here**.
It was right.

`issue_runner.py` called `gate_register(...)` with no lifecycle, so it took
`LEGACY_GATE_LIFECYCLE`, and `gates run` filters legacy out. **Every gate this repo's
closeout registered went into the permanent registry as non-executable.** That is
ASK-1038's exact shape, live: "all 0 regression gates green" against a populated
registry, true vacuously, exit 0. One line fixes it; the WARN carried in from the
instance is what makes the next occurrence visible instead of silent.

## The guard was present but NOT WIRED, and its own tests could not tell

The four ASK-1040 tests call `_reject_unrunnable_gate` **directly**. Measured: deleting
the single call site from `gate_register` left the file green at **17 passed**. A guard
nobody invokes reads exactly like one that works, and `gates.jsonl` is append-only, so a
bad row is close to permanent.

Added `test_gate_register_ACTUALLY_CALLS_the_unrunnable_guard`: drives the real entry
point with the shape that happened seven times (prose in the command slot), and asserts
it refused **before writing**. Same mutant re-run against it: **1 failed, 17 passed**.
It kills what the other four could not see.

## Verified

- merged file compiles; carries ASK-988 (2), `reopened_at` (2), `SPILLOVER_SEVERITY_ORDER`
  (3), `_reject_unrunnable_gate` (2), ASK-1040 (2), ASK-1038 (1)
- prd-os **692 passed, 1 skipped** (was 690 passed / **1 failed** before the dsse fix)
- kipi-dsse **4 passed**

Spillover `sp-c546f6a4`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_011U1WvYQqmjFMdfdHp4r9w1