### PR TITLE
voiceloop: the founder-data vacuous-pass guard was tautological

### DIFF
--- a/plugins/kipi-core/.claude-plugin/plugin.json
+++ b/plugins/kipi-core/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "kipi-core",
-  "version": "1.12.4",
+  "version": "1.12.5",
   "description": "Core founder OS \u2014 voice, research, AUDHD, LinkedIn/brand, RCA skills + kipi-mcp server",
   "author": {
     "name": "Assaf Kipnis",

--- a/plugins/kipi-core/voiceloop/tests/test_no_founder_data.py
+++ b/plugins/kipi-core/voiceloop/tests/test_no_founder_data.py
@@ -80,20 +80,35 @@ def test_the_tree_has_files_to_check():
     NIT), so a walk that returned 8 files would have passed while grepping
     almost nothing. A floor that cannot notice a 36-file shortfall is decoration.
 
-    The honest version compares against the thing that must be there: every .py
-    the package ships has to appear in the scanned set. A truncated or
-    misfiltered walk fails this; a healthy one cannot.
+    ITS FIRST VERSION WAS TAUTOLOGICAL, and the fix is the whole point of this
+    docstring (PR #105 review, MINOR, 2026-09-07). It derived the expected set as
+    every `.py` on disk. But `.py` matches no `_BINARY_SUFFIXES` entry, so a `.py`
+    file is in the scanned set BY CONSTRUCTION and `py_on_disk - scanned` was empty
+    no matter what `_tree_files` did. Its only reachable failure was a walk that
+    returned literally nothing.
+
+    Measured against the exact regression it exists to prevent -- putting the old
+    `.py/.json/.jsonl/.md` allowlist back:
+
+        hardened scan sees 45 files, allowlist scan sees 44
+        missed by the allowlist: requirements-authorship.txt
+        py-derived assertion   -> PASSES under both        <- blind
+        non-binary assertion   -> FAILS under the allowlist <- catches it
+
+    So the expected set is derived with the SAME predicate the scan uses, negated
+    off a raw walk. Now the only way to satisfy it is to actually scan everything
+    that is not binary, which is the property the file is about.
     """
     scanned = set(_tree_files())
-    py_on_disk = {
+    on_disk = {
         os.path.join(root, f)
         for root, dirs, files in os.walk(PKG)
         if "__pycache__" not in root
         for f in files
-        if f.endswith(".py")
+        if not f.endswith(_BINARY_SUFFIXES)
     }
-    assert py_on_disk, "the walk found no .py at all -- it is broken"
-    missing = sorted(py_on_disk - scanned)
+    assert on_disk, "the walk found no files at all -- it is broken"
+    missing = sorted(on_disk - scanned)
     assert not missing, "the scan skipped shipped files: %s" % ", ".join(missing)
 
 


### PR DESCRIPTION
## The guard could not do its job

`test_the_tree_has_files_to_check` exists so that a broken or misfiltered walk cannot
let `test_no_founder_data_in_the_plugin_tree` grep almost nothing and report clean.

It derived its expected set as **every `.py` on disk**. `.py` matches no
`_BINARY_SUFFIXES` entry, so a `.py` file is in the scanned set *by construction* and
`py_on_disk - scanned` was empty regardless of what `_tree_files` did. Its only
reachable failure was a walk returning literally nothing.

Found by review on `ASK_AI_consultant#105` (MINOR), while carrying this guard into the
consulting instance.

## Measured against the exact regression it exists to prevent

Restoring the old `.py/.json/.jsonl/.md` allowlist that PR #311 removed:

```
hardened scan sees 45 files, allowlist scan sees 44
missed by the allowlist: requirements-authorship.txt

py-derived assertion   -> PASSES under both          <- blind
non-binary assertion   -> FAILS under the allowlist  <- catches it
```

Same shape as the `>= 7` floor PR #311 replaced: a guard watching a 45-file tree drop to
44, with the very file the hardening was written about among the missing, reporting
healthy.

## The fix

Derive the expected set with the **same predicate the scan uses**, negated off a raw
walk. The only way to satisfy it is now to actually scan every non-binary file, which is
the property the file is about.

## Verified, both directions

| state | result |
|---|---|
| as shipped | **4 passed** |
| allowlist put back | **1 failed** (`test_the_tree_has_files_to_check`), 3 passed |
| full package suite | **229 passed** |

This guard protects the PUBLIC mirror (`github assafkip/voice-loop`), which is why it
gets a real assertion rather than a decorative one.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_011U1WvYQqmjFMdfdHp4r9w1