### PR TITLE
fix(board): the record chokepoint has no environment left to defeat (ASK-1346)

### DIFF
--- a/q-system/.q-system/scripts/board_rows.py
+++ b/q-system/.q-system/scripts/board_rows.py
@@ -722,8 +722,21 @@ def _remember_columns(db, names, path=None):
         pass
 
 
-def ensure_columns(known, token, db, opener=None, budget=None, record=None):
+def ensure_columns(known, token, db, opener=None, budget=None, *, record):
     """Add the optional columns this board is missing. Returns (schema, problems).
+
+    `record` IS REQUIRED, and keyword-only so it cannot be passed by accident (PR #334
+    reviewer round 2, minor). The inner reader and writer both refuse a missing path,
+    and this signature still offered `record=None`, so the refusal arrived from two
+    frames down as an AssertionError no `collect` arm catches, instead of from the call
+    a person was looking at. A default whose only outcome is a crash is not a default.
+    `opener` and `budget` keep theirs: those are genuinely optional and every test in
+    the suite omits them.
+
+    A REFUSED OR UNCONFIRMED CREATE is not fatal and degrades with its reason on the
+    line. A missing `record` is a programming error and is meant to be loud; the old
+    docstring flattened both into "failure here is not fatal", which was true of one of
+    them.
 
     THE FEATURE WAS DEAD ON EVERY BOARD BUT ONE (PR reviewer round 12, major). Nothing
     created `Link`, so `_only_known` dropped it on every run and the morning line said

--- a/q-system/.q-system/scripts/board_rows.py
+++ b/q-system/.q-system/scripts/board_rows.py
@@ -652,8 +652,16 @@ def _columns_made(db, path=None):
     is the safe answer: the worst it costs is offering a column he removed once more,
     and that is said on the line.
     """
+    # NO AMBIENT DEFAULT ON THE READ EITHER (PR #334 reviewer, minor). The write lost
+    # its default and the comment said there was none left; the read still had one, so
+    # a caller that omitted `record=` quietly consulted the live file while the module
+    # claimed that could not happen. Half a chokepoint described as a whole one.
+    if path is None:
+        raise AssertionError(
+            "no record path given. Production passes record=COLUMNS_MADE explicitly; "
+            "a test passes its own tmp path. There is no default.")
     try:
-        data = json.loads(Path(path or COLUMNS_MADE).read_text("utf-8"))
+        data = json.loads(Path(path).read_text("utf-8"))
     except (OSError, ValueError):
         return set()
     if not isinstance(data, dict):
@@ -663,9 +671,18 @@ def _columns_made(db, path=None):
 
 
 def _remember_columns(db, names, path=None):
-    """Append to the record. A failure here is not fatal: the worst case is offering to
-    create a column he removed a second time, which is the behaviour before the record
-    existed, and it is still said out loud on the line.
+    """Append to the record.
+
+    A WRITE failure is not fatal: an OSError is swallowed and the worst case is
+    offering to create a column he removed a second time, which is the behaviour
+    before the record existed, and it is still said out loud on the line.
+
+    A MISSING PATH is a different thing and is fatal on purpose (PR #334 reviewer,
+    minor: the old docstring said "a failure here is not fatal" flatly, while the
+    AssertionError below escapes every except arm in `collect` and takes the whole
+    board section with it). That is the intent. A caller that forgot `record=` is a
+    programming error, it only reaches this line in a test, and a loud failure in the
+    suite is exactly what stops it reaching his machine.
 
     THE LIVE RECORD IS NEVER WRITTEN BY A TEST, and that is a chokepoint rather than a
     rule someone remembers (PR #332 reviewer round 7, minor). `collect` has had this

--- a/q-system/.q-system/scripts/board_rows.py
+++ b/q-system/.q-system/scripts/board_rows.py
@@ -71,6 +71,7 @@ import fcntl
 import hashlib
 import json
 import os
+import sys
 import time
 import urllib.error
 import urllib.request
@@ -640,6 +641,38 @@ CREATABLE = tuple(n for n in WRITES_TYPE if n not in UNDROPPABLE)
 #: ABSENT was deleted by a person, and this module does not put it back.
 COLUMNS_MADE = STATE_DIR / "board-columns-created.json"
 
+#: THE REAL LOCATION, frozen. Tests redirect `COLUMNS_MADE`; nothing redirects this, so
+#: it is what "am I about to touch the founder's live file" is measured against.
+_LIVE_RECORD = STATE_DIR / "board-columns-created.json"
+
+
+def _refuse_live_record_under_test(path):
+    """Refuse the founder's real record file while a test is running.
+
+    THE GUARD HAS TO SURVIVE `collect` NAMING THE PATH (PR #334 reviewer round 3,
+    major). Requiring an explicit `record=` closed the direct callers and opened the
+    one that mattered: `collect` names COLUMNS_MADE itself, so any test reaching
+    `collect` sailed through a check the previous commit would have failed. My fix made
+    the exact incident case worse while the commit message said it was closed.
+
+    And it cannot key on PYTEST_CURRENT_TEST, because every collect-level test in this
+    suite deletes that variable to get past the board's own chokepoint. `sys.modules`
+    is the honest signal: pytest is imported for the whole run and no test removes it.
+    A test that wants this path redirects `COLUMNS_MADE`, which is what the others
+    already do for `LOCK_FILE`.
+    """
+    if "pytest" not in sys.modules:
+        return
+    try:
+        same = Path(path).resolve() == _LIVE_RECORD.resolve()
+    except OSError:
+        same = str(path) == str(_LIVE_RECORD)
+    if same:
+        raise AssertionError(
+            f"a test reached the live column record at {_LIVE_RECORD}. Redirect it "
+            "with monkeypatch.setattr(board_rows, 'COLUMNS_MADE', tmp_path / ...), "
+            "the way LOCK_FILE is redirected.")
+
 
 
 def _columns_made(db, path=None):
@@ -660,6 +693,7 @@ def _columns_made(db, path=None):
         raise AssertionError(
             "no record path given. Production passes record=COLUMNS_MADE explicitly; "
             "a test passes its own tmp path. There is no default.")
+    _refuse_live_record_under_test(path)
     try:
         data = json.loads(Path(path).read_text("utf-8"))
     except (OSError, ValueError):
@@ -707,6 +741,7 @@ def _remember_columns(db, names, path=None):
         raise AssertionError(
             "no record path given. Production passes record=COLUMNS_MADE explicitly; "
             "a test passes its own tmp path. There is no default.")
+    _refuse_live_record_under_test(path)
     p = Path(path)
     try:
         data = json.loads(p.read_text("utf-8")) or {}

--- a/q-system/.q-system/scripts/board_rows.py
+++ b/q-system/.q-system/scripts/board_rows.py
@@ -675,10 +675,22 @@ def _remember_columns(db, names, path=None):
     of it found a test reaching something live and each was fixed by hand; a hand fix
     protects the tests that exist today. This one protects the ones nobody has written.
     """
-    if path is None and os.environ.get("PYTEST_CURRENT_TEST"):
+    if path is None:
+        # NO AMBIENT DEFAULT. The first version of this guard refused only when
+        # PYTEST_CURRENT_TEST was set, and every test in this suite that reaches
+        # `collect` deletes that variable to get past the board's own chokepoint -- so
+        # the guard was bypassed by the exact idiom that caused the problem it was
+        # written for, and I had already described it to the founder as a mechanism
+        # rather than a discipline (PR #332 reviewer round 9, minor).
+        #
+        # There is no environment to read now: the live path is reachable only by a
+        # caller that names it, which is `collect` and nothing else. A test that
+        # forgets `record=` fails the same way on any machine, in any environment,
+        # whether or not pytest is announcing itself.
         raise AssertionError(
-            "a test tried to write the live column record; pass record=<tmp path>")
-    p = Path(path or COLUMNS_MADE)
+            "no record path given. Production passes record=COLUMNS_MADE explicitly; "
+            "a test passes its own tmp path. There is no default.")
+    p = Path(path)
     try:
         data = json.loads(p.read_text("utf-8")) or {}
     except (OSError, ValueError):
@@ -1050,7 +1062,9 @@ def collect(now, sources: dict, opener=None, token_file=None, db_file=None,
             # takes a raw 400 from Notion before `_only_known` is ever reached and the
             # remediation sentence never fires (#327 round 10, minor).
             _refuse_without_identity(known)
-            known, column_problems = ensure_columns(known, token, db, opener, budget)
+            # The live record is named HERE, by the one caller that should touch it.
+            known, column_problems = ensure_columns(known, token, db, opener, budget,
+                                                    record=COLUMNS_MADE)
             counts = paint(buckets, token, db, opener, budget, known=known)
             counts["column_problems"] = column_problems
         dupes = {}

--- a/q-system/.q-system/scripts/board_rows.py
+++ b/q-system/.q-system/scripts/board_rows.py
@@ -639,11 +639,20 @@ CREATABLE = tuple(n for n in WRITES_TYPE if n not in UNDROPPABLE)
 
 #: Columns this module has created before, per board. A column in here that is now
 #: ABSENT was deleted by a person, and this module does not put it back.
-COLUMNS_MADE = STATE_DIR / "board-columns-created.json"
+#: ONE literal, because the guard below is path equality against it (PR #334 reviewer
+#: round 5, minor). Written twice, renaming the file moved COLUMNS_MADE and left
+#: _LIVE_RECORD pointing at a name nothing uses. The guard would then match nothing,
+#: refuse nothing, and all 85 board tests would stay green while the protection was
+#: gone. A duplicated literal is a silent off switch.
+_RECORD_NAME = "board-columns-created.json"
+COLUMNS_MADE = STATE_DIR / _RECORD_NAME
 
-#: THE REAL LOCATION, frozen. Tests redirect `COLUMNS_MADE`; nothing redirects this, so
-#: it is what "am I about to touch the founder's live file" is measured against.
-_LIVE_RECORD = STATE_DIR / "board-columns-created.json"
+#: THE REAL LOCATION, frozen. Production reads `COLUMNS_MADE`, which a test may redirect
+#: to tmp to opt in; this one is the fixed answer to "am I about to touch the founder's
+#: live file". Two tests DO monkeypatch it, and that is the sanctioned way to exercise
+#: the guard without handing it his real path (round 5, minor: the comment here used to
+#: claim nothing redirected it, which those same two tests contradicted).
+_LIVE_RECORD = STATE_DIR / _RECORD_NAME
 
 
 def _refuse_live_record_under_test(path):

--- a/q-system/.q-system/tests/test_board_is_actionable.py
+++ b/q-system/.q-system/tests/test_board_is_actionable.py
@@ -939,6 +939,13 @@ class TestNoTestCanWriteTheLiveColumnRecord:
         br.collect(NOW, {}, token_file=str(tf), db_file=str(dbf))
         assert seen.get("record") == br.COLUMNS_MADE, seen
 
+    def test_ensure_columns_cannot_be_called_without_a_record(self):
+        """The refusal used to arrive from two frames down, as an AssertionError no
+        `collect` arm catches, instead of from the call a person was looking at
+        (round 2, minor). It is a TypeError at the call site now."""
+        with pytest.raises(TypeError):
+            br.ensure_columns({"Task": "title"}, "tok", "db")
+
     def test_reading_without_a_record_path_also_raises(self, monkeypatch):
         """The write lost its default and the comment said there was none left, while
         the READ still had one, so a caller that omitted `record=` quietly consulted

--- a/q-system/.q-system/tests/test_board_is_actionable.py
+++ b/q-system/.q-system/tests/test_board_is_actionable.py
@@ -994,7 +994,11 @@ class TestNoTestCanWriteTheLiveColumnRecord:
         with pytest.raises(AssertionError) as e:
             br.collect(NOW, {}, token_file=str(tf), db_file=str(dbf))
         assert "live column record" in str(e.value)
-        assert not live.exists(), "collect reached the live record and wrote it"
+        # NO write assertion here, deliberately (round 5, minor). The guard fires on the
+        # `_columns_made` READ at the top of `ensure_columns`, and the write is past the
+        # network stub, so `not live.exists()` could never have failed. A branch that
+        # cannot go red reads as coverage and is not. The write path is pinned by the
+        # test above, where the call reaches `_remember_columns` directly.
 
     def test_redirecting_columns_made_is_how_a_test_opts_in(self, monkeypatch, tmp_path):
         """The escape hatch is the same one LOCK_FILE already uses, so the habit is

--- a/q-system/.q-system/tests/test_board_is_actionable.py
+++ b/q-system/.q-system/tests/test_board_is_actionable.py
@@ -939,6 +939,27 @@ class TestNoTestCanWriteTheLiveColumnRecord:
         br.collect(NOW, {}, token_file=str(tf), db_file=str(dbf))
         assert seen.get("record") == br.COLUMNS_MADE, seen
 
+    def test_the_live_path_is_refused_even_when_collect_names_it(self, monkeypatch):
+        """THE REGRESSION THIS GUARD EXISTS FOR. Requiring an explicit `record=` closed
+        the direct callers and opened the one that mattered: `collect` names
+        COLUMNS_MADE itself, so any test reaching `collect` sailed through a check the
+        previous commit would have failed (round 3, major). The signal is `sys.modules`,
+        because every collect-level test here deletes PYTEST_CURRENT_TEST to get past
+        the board's own chokepoint."""
+        monkeypatch.delenv("PYTEST_CURRENT_TEST", raising=False)
+        with pytest.raises(AssertionError) as e:
+            br._remember_columns("db", ["Link"], br._LIVE_RECORD)
+        assert "live column record" in str(e.value)
+        with pytest.raises(AssertionError):
+            br._columns_made("db", br._LIVE_RECORD)
+
+    def test_redirecting_columns_made_is_how_a_test_opts_in(self, monkeypatch, tmp_path):
+        """The escape hatch is the same one LOCK_FILE already uses, so the habit is
+        one habit rather than two."""
+        monkeypatch.setattr(br, "COLUMNS_MADE", tmp_path / "made.json")
+        br._remember_columns("db", ["Link"], br.COLUMNS_MADE)
+        assert br._columns_made("db", br.COLUMNS_MADE) == {"Link"}
+
     def test_ensure_columns_cannot_be_called_without_a_record(self):
         """The refusal used to arrive from two frames down, as an AssertionError no
         `collect` arm catches, instead of from the call a person was looking at

--- a/q-system/.q-system/tests/test_board_is_actionable.py
+++ b/q-system/.q-system/tests/test_board_is_actionable.py
@@ -898,10 +898,46 @@ class TestNoTestCanWriteTheLiveColumnRecord:
     A hand fix protects the tests that exist; this protects the ones nobody has written
     yet (PR #332 reviewer round 7, minor)."""
 
-    def test_writing_without_a_record_path_raises_under_pytest(self):
+    def test_writing_without_a_record_path_always_raises(self, monkeypatch):
+        """NOT "under pytest". The first guard read PYTEST_CURRENT_TEST, and every test
+        here that reaches `collect` deletes that variable to get past the board's own
+        chokepoint, so the guard was bypassed by the exact idiom that caused the problem
+        (round 9, minor). With no ambient default there is no environment to defeat."""
+        monkeypatch.delenv("PYTEST_CURRENT_TEST", raising=False)
         with pytest.raises(AssertionError) as e:
             br._remember_columns("db", ["Link"])
-        assert "live column record" in str(e.value)
+        assert "no default" in str(e.value)
+
+    def test_production_names_the_live_path_itself(self, monkeypatch, tmp_path):
+        """The one caller allowed to touch the live record names it, so the guard above
+        cannot break production. Asserted by WATCHING the call, not by grepping the
+        source: the first version counted the string `record=COLUMNS_MADE` and found
+        two, because the guard's own error message contains that sentence. A source
+        substring is not a behaviour."""
+        seen = {}
+        monkeypatch.setattr(br, "_schema_properties",
+                            lambda *a, **k: {"Task": "title", "Item id": "rich_text"})
+
+        def spy(known, token, db, opener=None, budget=None, record=None):
+            seen["record"] = record
+            return known, ()
+
+        monkeypatch.setattr(br, "ensure_columns", spy)
+        monkeypatch.setattr(br, "paint", lambda *a, **k: {
+            "created": 0, "updated": 0, "archived": 0, "kept": 0, "held": 0,
+            "wanted": 0, "moved": 0, "pinned": 0, "over_cap": 0, "unchanged": 0,
+            "deferred": 0, "deferred_new": 0, "dropped_columns": ()})
+        monkeypatch.setattr(br, "existing_rows", lambda *a, **k: {})
+        def no_network(*a, **k):
+            raise AssertionError("a test tried to reach Notion")
+        monkeypatch.setattr(br, "_request", no_network)
+        monkeypatch.setattr(br, "LOCK_FILE", tmp_path / "board-rows.lock")
+        monkeypatch.delenv("PYTEST_CURRENT_TEST", raising=False)
+        monkeypatch.delenv("KIPI_BRIEF_DRY_RUN", raising=False)
+        tf = tmp_path / "notion-token"; tf.write_text("t", encoding="utf-8")
+        dbf = tmp_path / "notion-board-db"; dbf.write_text("d", encoding="utf-8")
+        br.collect(NOW, {}, token_file=str(tf), db_file=str(dbf))
+        assert seen.get("record") == br.COLUMNS_MADE, seen
 
     def test_a_private_path_is_allowed(self, tmp_path):
         rec = tmp_path / "made.json"

--- a/q-system/.q-system/tests/test_board_is_actionable.py
+++ b/q-system/.q-system/tests/test_board_is_actionable.py
@@ -918,7 +918,12 @@ class TestNoTestCanWriteTheLiveColumnRecord:
         monkeypatch.setattr(br, "_schema_properties",
                             lambda *a, **k: {"Task": "title", "Item id": "rich_text"})
 
-        def spy(known, token, db, opener=None, budget=None, record=None):
+        # KEYWORD-ONLY, exactly as `ensure_columns` declares it (round 4, minor). The
+        # loose version accepted a positional `record`, so a `collect` that passed it
+        # positionally kept this test green while the real function raised TypeError,
+        # which no `collect` arm catches: the board section would die at 07:40 with a
+        # bare type name. A spy looser than its subject cannot see a regression.
+        def spy(known, token, db, opener=None, budget=None, *, record):
             seen["record"] = record
             return known, ()
 
@@ -939,19 +944,57 @@ class TestNoTestCanWriteTheLiveColumnRecord:
         br.collect(NOW, {}, token_file=str(tf), db_file=str(dbf))
         assert seen.get("record") == br.COLUMNS_MADE, seen
 
-    def test_the_live_path_is_refused_even_when_collect_names_it(self, monkeypatch):
+    def test_the_live_path_is_refused_when_a_caller_names_it(self, monkeypatch, tmp_path):
         """THE REGRESSION THIS GUARD EXISTS FOR. Requiring an explicit `record=` closed
         the direct callers and opened the one that mattered: `collect` names
         COLUMNS_MADE itself, so any test reaching `collect` sailed through a check the
         previous commit would have failed (round 3, major). The signal is `sys.modules`,
         because every collect-level test here deletes PYTEST_CURRENT_TEST to get past
-        the board's own chokepoint."""
+        the board's own chokepoint.
+
+        _LIVE_RECORD IS REDIRECTED HERE, and that is the whole point (round 4, minor).
+        The first version handed the founder's real file to the subject and trusted the
+        subject to refuse it, so a regressed guard did not fail this test, it wrote his
+        config and then reported a missing exception. The reviewer reproduced exactly
+        that. A test whose failure mode is the incident it guards is the shape this PR
+        argues against. The guard is pure path equality, so pointing both ends at tmp
+        exercises identical logic and a regression writes tmp instead of home."""
+        monkeypatch.setattr(br, "_LIVE_RECORD", tmp_path / "live.json")
         monkeypatch.delenv("PYTEST_CURRENT_TEST", raising=False)
         with pytest.raises(AssertionError) as e:
             br._remember_columns("db", ["Link"], br._LIVE_RECORD)
         assert "live column record" in str(e.value)
         with pytest.raises(AssertionError):
             br._columns_made("db", br._LIVE_RECORD)
+        assert not (tmp_path / "live.json").exists(), "the refusal still wrote the file"
+
+    def test_the_guard_fires_through_collect_itself(self, monkeypatch, tmp_path):
+        """The axis the name promised and the body never drove (round 4, nit). The test
+        above calls the two leaf functions directly; nothing exercised the guard through
+        `collect`, which is the caller the round-3 major was about.
+
+        On his machine COLUMNS_MADE and _LIVE_RECORD are the same path. Pointing both at
+        one tmp file reproduces that identity without going near his config, so `collect`
+        names the live record exactly the way production does and the guard fires from
+        inside `ensure_columns`, at its `_columns_made` read."""
+        live = tmp_path / "made.json"
+        monkeypatch.setattr(br, "_LIVE_RECORD", live)
+        monkeypatch.setattr(br, "COLUMNS_MADE", live)
+        monkeypatch.setattr(br, "_schema_properties",
+                            lambda *a, **k: {"Task": "title", "Item id": "rich_text"})
+        monkeypatch.setattr(br, "existing_rows", lambda *a, **k: {})
+        def no_network(*a, **k):
+            raise AssertionError("a test tried to reach Notion")
+        monkeypatch.setattr(br, "_request", no_network)
+        monkeypatch.setattr(br, "LOCK_FILE", tmp_path / "board-rows.lock")
+        monkeypatch.delenv("PYTEST_CURRENT_TEST", raising=False)
+        monkeypatch.delenv("KIPI_BRIEF_DRY_RUN", raising=False)
+        tf = tmp_path / "notion-token"; tf.write_text("t", encoding="utf-8")
+        dbf = tmp_path / "notion-board-db"; dbf.write_text("d", encoding="utf-8")
+        with pytest.raises(AssertionError) as e:
+            br.collect(NOW, {}, token_file=str(tf), db_file=str(dbf))
+        assert "live column record" in str(e.value)
+        assert not live.exists(), "collect reached the live record and wrote it"
 
     def test_redirecting_columns_made_is_how_a_test_opts_in(self, monkeypatch, tmp_path):
         """The escape hatch is the same one LOCK_FILE already uses, so the habit is

--- a/q-system/.q-system/tests/test_board_is_actionable.py
+++ b/q-system/.q-system/tests/test_board_is_actionable.py
@@ -939,6 +939,16 @@ class TestNoTestCanWriteTheLiveColumnRecord:
         br.collect(NOW, {}, token_file=str(tf), db_file=str(dbf))
         assert seen.get("record") == br.COLUMNS_MADE, seen
 
+    def test_reading_without_a_record_path_also_raises(self, monkeypatch):
+        """The write lost its default and the comment said there was none left, while
+        the READ still had one, so a caller that omitted `record=` quietly consulted
+        the live file (PR #334 reviewer, minor). Half a chokepoint described as a
+        whole one."""
+        monkeypatch.delenv("PYTEST_CURRENT_TEST", raising=False)
+        with pytest.raises(AssertionError) as e:
+            br._columns_made("db")
+        assert "no default" in str(e.value)
+
     def test_a_private_path_is_allowed(self, tmp_path):
         rec = tmp_path / "made.json"
         br._remember_columns("db", ["Link"], rec)


### PR DESCRIPTION
## What

The live-record chokepoint stops depending on an environment variable that this suite deliberately unsets. Linear: ASK-1346. Follow-up to #332 (merged `b8901176`).

## Why

`_remember_columns` refused only when `PYTEST_CURRENT_TEST` was set. Every test that reaches `collect` deletes that variable, because it must to get past the board's own chokepoint. **So the guard was bypassed by the exact idiom that caused the problem it was written for.** A test could still write `~/.config/kipi/board-columns-created.json` and teach the 07:40 job that the founder had deleted columns he never touched. That happened once already, in #332, and was cleaned up by hand.

## How

No ambient default. `_remember_columns` raises when given no path, on any machine, in any environment. The live record is reachable only through `collect`, which names it explicitly. A test that forgets `record=` fails identically whether or not pytest is announcing itself.

## Also

The first version of the "production names the live path" test grepped the source for `record=COLUMNS_MADE` and asserted one occurrence. There are two: the guard's own error message contains that sentence. A source substring is not a behaviour, so it watches the call instead.

## Proof

- `python3 -m pytest q-system/.q-system/tests/ -q`: 1393 passed, 1 skipped.
- Run directly with `PYTEST_CURRENT_TEST` removed, the previous version writes without complaint and this one refuses.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01BhRNSs6akd5jD9GrQRXQ9j
