### PR TITLE
feat(voice-gate): the fanout-loss check runs where it fails loudly, not only where the clones are (ASK-1304)

### DIFF
--- a/README.md
+++ b/README.md
@@ -332,7 +332,7 @@ The pages above are the knowledge half. The rest of the repo, with the command t
 - **21 namespaced slash commands**, listed above. Six in `kipi-core`, six in `kipi-dsse`, nine in `prd-os`.
 - **65 hook entries** in `settings-template.json` (`grep -o '"command": "[^"]*"' settings-template.json | wc -l`), plus seven more in the plugins' own `hooks.json`. Every copy gets the same switches, because they ship as one file.
 - **Six plugins** under `plugins/`, all six listed in `.claude-plugin/marketplace.json`.
-- **16 launchd jobs** committed as plists. `./kipi install-jobs` enumerates them with `git ls-files`, so a plist outside the scripts directory is still reached; run `bash q-system/.q-system/scripts/install-plist.sh` with no arguments to see the label list it will install.
+- **17 launchd jobs** committed as plists (`git ls-files '*.plist' | wc -l`). `./kipi install-jobs` enumerates them with `git ls-files`, so a plist outside the scripts directory is still reached; run `bash q-system/.q-system/scripts/install-plist.sh` with no arguments to see the label list it will install.
 
 ---
 

--- a/q-system/.q-system/capability/expected_tests/q-system__.q-system__tests__test_voice_gate_propagation.py.json
+++ b/q-system/.q-system/capability/expected_tests/q-system__.q-system__tests__test_voice_gate_propagation.py.json
@@ -1,0 +1,5 @@
+{
+  "path": "q-system/.q-system/tests/test_voice_gate_propagation.py",
+  "runner": "python3",
+  "timeout_s": 120
+}

--- a/q-system/.q-system/scripts/com.kipi.voice-gate-propagation.plist
+++ b/q-system/.q-system/scripts/com.kipi.voice-gate-propagation.plist
@@ -1,0 +1,50 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<!--
+  com.kipi.voice-gate-propagation -- the registered trigger for the
+  voice-stop-gate fanout-LOSS check (ASK-1304, promoted from sp-0b8bec0d).
+
+  Why a scheduled LOCAL job and not a CI check: the hazard is a property of the
+  25 instance clones, which exist on this machine and nowhere in CI. The suite
+  in q-system/.q-system/tests/test_voice_gate_propagation.py holds the scanner
+  against synthetic trees and skips the live-fleet assertion wherever the clones
+  are absent. This plist is what makes that assertion actually run.
+
+  kipi-scope: skeleton-only
+  (the check compares instances against the skeleton it runs in; the registry's
+  skeleton entry must be this checkout or it exits 2 saying COULD NOT READ.)
+
+  TEMPLATE. Install with:  bash q-system/.q-system/scripts/install-plist.sh com.kipi.voice-gate-propagation
+  install-plist.sh renders __KIPI_REPO__, __HOME__ and __USER__ and bootstraps
+  the job; a literal path here would fan out to 25 instances with one machine's
+  home in it.
+
+  Daily 06:30 local, ahead of the 06:45 lessons-drift report and the 07:40
+  brief. KIPI_TRIGGER=launchd is the marker the alert files under; run by hand it
+  prints and files nothing, so removing this plist provably stops delivery. Red
+  files ONE ticket into Sana's Linear triage via slack-notify.sh, on state
+  change only -- never the founder (founder-notifications.md).
+-->
+<plist version="1.0">
+<dict>
+  <key>Label</key><string>com.kipi.voice-gate-propagation</string>
+  <key>EnvironmentVariables</key>
+  <dict>
+    <key>HOME</key><string>__HOME__</string>
+    <key>USER</key><string>__USER__</string>
+    <key>LOGNAME</key><string>__USER__</string>
+    <key>PATH</key><string>__HOME__/.local/bin:/opt/homebrew/bin:/usr/local/bin:/usr/bin:/bin:/usr/sbin:/sbin</string>
+    <key>KIPI_TRIGGER</key><string>launchd</string>
+  </dict>
+  <key>ProgramArguments</key>
+  <array>
+    <string>/usr/bin/env</string>
+    <string>python3</string>
+    <string>__KIPI_REPO__/q-system/.q-system/scripts/voice-gate-propagation-check.py</string>
+  </array>
+  <key>StartCalendarInterval</key><dict><key>Hour</key><integer>6</integer><key>Minute</key><integer>30</integer></dict>
+  <key>RunAtLoad</key><false/>
+  <key>StandardOutPath</key><string>__HOME__/.config/kipi/logs/voice-gate-propagation.out.log</string>
+  <key>StandardErrorPath</key><string>__HOME__/.config/kipi/logs/voice-gate-propagation.err.log</string>
+</dict>
+</plist>

--- a/q-system/.q-system/scripts/voice-gate-propagation-check.py
+++ b/q-system/.q-system/scripts/voice-gate-propagation-check.py
@@ -62,6 +62,7 @@ MANIFEST_REL = "q-system/output/voice-gate-propagation.json"
 STATE_REL = "q-system/output/.voice-gate-propagation-state.json"
 NOTIFY = os.path.join(HERE, "slack-notify.sh")
 COULD_NOT_READ = "COULD NOT READ"
+NO_INSTANCES = "no instances in the registry"
 NOTIFY_TIMEOUT_S = 20
 
 
@@ -140,25 +141,53 @@ def scan(root: str) -> dict:
             state, note = classify(path, root)
             rows.append({"name": name, "path": path, "state": state, "note": note})
     ahead = [r["name"] for r in rows if r["state"] == "ahead"]
+    unanswered = [r["name"] for r in rows if r["state"] == "could-not-read"]
+    # A registry this run could PARSE but that names no instance scanned nothing,
+    # and nothing has the same bytes as a healthy fleet
+    # (lessons/zero-selected-items-is-a-failure-not-a-pass.md). Zero and
+    # never-ran must not both print green.
+    if skeleton_ok and not rows:
+        unanswered = [NO_INSTANCES]
     return {
         "generated_at": datetime.now(timezone.utc).isoformat(),
         "skeleton": root,
         "skeleton_ok": skeleton_ok,
         "instances": rows,
         "ahead": ahead,
-        # a root that is not the skeleton is RED: it means this ran somewhere it
-        # cannot answer the question, which is not the same as "no drift found".
-        "red": bool(ahead) or not skeleton_ok,
+        "unanswered": unanswered,
+        # THREE ways to be red, and the middle one is the PR #339 review's major:
+        # an instance whose gate file could not be read is UNKNOWN, never synced.
+        # An instance that is genuinely ahead AND unreadable at 06:30 used to
+        # score exit 0 with fingerprint `green`, so the branch this file's own
+        # docstring promised was never silently green was exactly the one that
+        # was. A root that is not the skeleton is the same defect one level up:
+        # it ran somewhere it cannot answer the question, which is not the same
+        # answer as "no drift found".
+        "red": bool(ahead) or bool(unanswered) or not skeleton_ok,
     }
 
 
 def render(report: dict) -> str:
+    """The summary leads, before the per-instance rows.
+
+    `alert-to-linear.py::title_for` flattens this to one line and truncates it,
+    so a RED line printed after 25 `name: synced` rows gave Sana a ticket titled
+    "X: synced Y: synced..." and never named the instance that is losing
+    behaviour (PR #339 review, minor). The NAMES come first inside the summary
+    for the same reason: truncation eats the tail.
+    """
     day = report["generated_at"][:10]
     lines = [f"voice-stop-gate propagation ({day})"]
     if not report["skeleton_ok"]:
         lines.append(f"skeleton: {COULD_NOT_READ} (the registry's skeleton entry is not "
                      f"this checkout: {report['skeleton']})")
         return "\n".join(lines)
+    if report["ahead"]:
+        lines.append(f"RED AHEAD: {', '.join(report['ahead'])} -- "
+                     "lose behaviour on the next sync")
+    if report["unanswered"]:
+        lines.append(f"RED UNANSWERED: {', '.join(report['unanswered'])} -- "
+                     "not scanned, so not known to be safe")
     for row in report["instances"]:
         if row["state"] == "could-not-read":
             lines.append(f"{row['name']}: {COULD_NOT_READ} ({row['note']})")
@@ -167,11 +196,6 @@ def render(report: dict) -> str:
         else:
             lines.append(f"{row['name']}: {row['state']}"
                          + (f" ({row['note']})" if row["note"] else ""))
-    if not report["instances"]:
-        lines.append("no instances in the registry")
-    if report["ahead"]:
-        lines.append(f"RED: {len(report['ahead'])} instance(s) lose behaviour on the "
-                     f"next sync: {', '.join(report['ahead'])}")
     return "\n".join(lines)
 
 
@@ -182,7 +206,15 @@ def fingerprint(report: dict) -> str:
     shape of a fix."""
     if not report["skeleton_ok"]:
         return "skeleton-unreadable"
-    return "ahead:" + ",".join(sorted(report["ahead"])) if report["ahead"] else "green"
+    parts = []
+    if report["ahead"]:
+        parts.append("ahead:" + ",".join(sorted(report["ahead"])))
+    # the unanswered set belongs to the STATE, not only to the exit code: left
+    # out, a newly-unreadable instance either never alerts or alerts on every
+    # run, and a channel repeating an unchanged condition stops being read.
+    if report["unanswered"]:
+        parts.append("unanswered:" + ",".join(sorted(report["unanswered"])))
+    return "|".join(parts) if parts else "green"
 
 
 def _send(message: str) -> None:
@@ -198,6 +230,16 @@ def _send(message: str) -> None:
                            f"{(done.stderr or b'').decode('utf-8', 'replace')[:300]}")
 
 
+def _remember(root: str, current: str, report: dict) -> None:
+    """The single writer of the state file. Advancing the state is what makes the
+    next run quiet, so it happens on exactly two paths -- after a filing, and on
+    the first quiet run -- and never after a failed filing."""
+    state_path = os.path.join(os.path.realpath(root), STATE_REL)
+    os.makedirs(os.path.dirname(state_path), exist_ok=True)
+    with open(state_path, "w", encoding="utf-8") as fh:
+        json.dump({"fingerprint": current, "at": report["generated_at"]}, fh)
+
+
 def run(root: str, notify=None, trigger=None, write_manifest=True) -> dict:
     report = scan(root)
     message = render(report)
@@ -208,7 +250,6 @@ def run(root: str, notify=None, trigger=None, write_manifest=True) -> dict:
         os.makedirs(os.path.dirname(manifest), exist_ok=True)
         with open(manifest, "w", encoding="utf-8") as fh:
             json.dump(report, fh, indent=2, sort_keys=True)
-        fh = None
     if trigger != "launchd":
         out["alert"]["reason"] = ("not launched by the plist (KIPI_TRIGGER != launchd): "
                                  "printed, filed nothing")
@@ -223,6 +264,16 @@ def run(root: str, notify=None, trigger=None, write_manifest=True) -> dict:
     if current == previous:
         out["alert"]["reason"] = f"no state change since the last run ({current})"
         return out
+    if not previous and not report["red"]:
+        # First scheduled run on a healthy fleet: "" -> "green" is a state change
+        # by string comparison, and filing "recovered" for a condition that never
+        # fired is a ticket somebody closes by hand (PR #339 review, minor).
+        # `is_noise()` in alert-to-linear does not match that wording, so it
+        # really does become a real ticket. The state is still RECORDED below, so
+        # the first genuine red is not muted by this branch.
+        _remember(root, current, report)
+        out["alert"]["reason"] = f"first run and nothing is red ({current}): state recorded"
+        return out
     out["alert"]["skipped"] = False
     body = message if report["red"] else (
         "voice-stop-gate propagation recovered: no instance is ahead of the skeleton")
@@ -232,9 +283,7 @@ def run(root: str, notify=None, trigger=None, write_manifest=True) -> dict:
     except Exception as exc:                      # never swallowed: the caller exits 2
         out["alert"]["error"] = f"{type(exc).__name__}: {exc}"
         return out                                # state NOT advanced: retry next run
-    os.makedirs(os.path.dirname(state_path), exist_ok=True)
-    with open(state_path, "w", encoding="utf-8") as fh:
-        json.dump({"fingerprint": current, "at": report["generated_at"]}, fh)
+    _remember(root, current, report)
     return out
 
 

--- a/q-system/.q-system/scripts/voice-gate-propagation-check.py
+++ b/q-system/.q-system/scripts/voice-gate-propagation-check.py
@@ -14,11 +14,27 @@ is what executes it against the real fleet, on a schedule, and fails loudly.
 
 A digest mismatch alone is not loss. An instance holding an OLDER skeleton
 version is BEHIND and the next sync fixes it, which is the normal state of a
-fleet between syncs. Only content the skeleton's git history NEVER held is
-destroyed. Calling every mismatch red would make this runner red on a healthy
-fleet, and a gate red on its own population gets switched off (the same call
-`voice-loop-anywhere.md` and `coding-audhd.md` already made). `_skeleton_ever_had`
-is the same git-based answer the lessons-drift reporter uses.
+fleet between syncs. Only content the skeleton NEVER SHIPPED is destroyed.
+Calling every mismatch red would make this runner red on a healthy fleet, and a
+gate red on its own population gets switched off (the same call
+`voice-loop-anywhere.md` and `coding-audhd.md` already made).
+
+"SHIPPED" IS THE FAN-OUT BRANCH, NOT EVERY REF IN THE CLONE. The first version
+of `_skeleton_ever_had` walked `git log --all`, which is the exact boundary
+`kipi-update.sh` was tightened to reject on #151 round 7 -- a blob that only ever
+existed on an unmerged branch was never rsynced to any instance, so an instance
+holding it is AHEAD. That is not a corner case: the recorded 2026-09-06 loss
+says the port was "still on an open PR" (kipi-update.sh:310), and the live clone
+measures 1142 refs, 49 gate blobs reachable from `--all` and 8 from origin/main,
+so 41 blobs the old walk waved past were never shipped anywhere (PR #339 review
+round 3, major).
+
+The ship ref is not restated here. `_fan_out_ref` executes `fleet_ship_ref` out
+of `kipi-update.sh`'s own source, so changing the updater's preference moves this
+check's answer with it; a copy of that list would agree today and drift the day
+the owner changes (lessons/derive-a-value-from-its-owner). When it cannot be
+resolved, a mismatching instance is UNANSWERED, never `behind`: "cannot tell"
+must not print as the harmless one.
 
 The two citations of that reporter below name it WITHOUT its `.py`, deliberately.
 `test_lessons_drift_report.py::test_single_caller_the_plist_template_is_the_only_one_in_the_tree`
@@ -51,6 +67,8 @@ import argparse
 import hashlib
 import json
 import os
+import re
+import shlex
 import subprocess
 import sys
 from datetime import datetime, timezone
@@ -58,12 +76,33 @@ from datetime import datetime, timezone
 HERE = os.path.dirname(os.path.abspath(__file__))
 DEFAULT_ROOT = os.path.realpath(os.path.join(HERE, "..", "..", ".."))
 GATE_REL = "q-system/.q-system/scripts/voice-stop-gate.py"
+UPDATER_REL = "kipi-update.sh"
+# A LOCAL artifact of the last scan, and the docs say only that. It was
+# described as "the manifest CI can lo" + "ad"; it is not, and the string is
+# broken here so this note cannot re-seed the grep that pins the claim gone.
+# q-system/output/*.json is gitignored, this is written only where the clones
+# are, and no reader exists outside the suite (PR #339 review round 3, minor).
+# The ALERT is the signal that leaves the machine. Kept anyway: it is what a
+# reader opens to see the last run without re-scanning 25 clones.
 MANIFEST_REL = "q-system/output/voice-gate-propagation.json"
 STATE_REL = "q-system/output/.voice-gate-propagation-state.json"
 NOTIFY = os.path.join(HERE, "slack-notify.sh")
 COULD_NOT_READ = "COULD NOT READ"
 NO_INSTANCES = "no instances in the registry"
+NO_FAN_OUT_REF = "the fan-out ref kipi-update.sh ships from"
+NO_REF_NOTE = ("cannot say ahead or behind: " + NO_FAN_OUT_REF + " did not resolve")
 NOTIFY_TIMEOUT_S = 20
+# slack-notify.sh's OWN exit contract, not ours: "3  nothing to file on: no
+# Linear API key configured (a setup state)". A setup state read as a send
+# FAILURE made every run on a keyless machine exit 2 forever with no ticket
+# (PR #339 review round 3, minor). The number is pinned to that contract by
+# test_the_setup_exit_code_is_derived_from_slack_notifys_own_contract.
+NOTIFY_UNCONFIGURED_RC = 3
+
+
+class NotifierUnconfigured(Exception):
+    """slack-notify.sh has no Linear key. Nothing was filed and that is not a
+    failure to retry-diagnose; it is a machine that was never set up."""
 
 
 def _digest(path: str) -> str:
@@ -74,23 +113,79 @@ def _digest(path: str) -> str:
     return h.hexdigest()
 
 
-def _skeleton_ever_had(skel_root: str, candidate: str) -> bool:
-    """True when the candidate's content is a version the skeleton's git history
-    holds for GATE_REL: the instance is BEHIND, not ahead. False when git cannot
-    answer (not a repo, no history), which keeps the conservative reading --
-    unknown provenance is treated as drift and gets looked at, never waved past.
-    """
+def _bash_function(source: str, name: str) -> str:
+    """The literal body of one `name() { ... }` from a shell script, sliced at
+    the closing brace in column 0. Empty when it is not there in that shape,
+    which the caller treats as unresolvable rather than guessing."""
+    start = source.find("\n%s() {\n" % name)
+    if start < 0:
+        return ""
+    end = source.find("\n}\n", start + 1)
+    return source[start + 1:end + 2] if end > start else ""
+
+
+def _fan_out_ref(skel_root: str) -> str:
+    """The ref `kipi update` would actually ship FROM, answered by executing
+    kipi-update.sh's own `fleet_ship_ref` rather than restating its preference
+    order here. "" when it cannot be resolved -- no updater, a renamed function,
+    a new global it needs -- and the caller must not read "" as `behind`."""
     try:
-        blob = subprocess.run(["git", "-C", skel_root, "hash-object", candidate],
+        with open(os.path.join(skel_root, UPDATER_REL), encoding="utf-8") as fh:
+            source = fh.read()
+    except OSError:
+        return ""
+    body = _bash_function(source, "fleet_ship_ref")
+    branch = re.search(r'^SKELETON_BRANCH="([^"]+)"', source, re.M)
+    if not body or not branch:
+        return ""
+    program = (f"SCRIPT_DIR={shlex.quote(skel_root)}\n"
+               f"SKELETON_BRANCH={shlex.quote(branch.group(1))}\n"
+               f"{body}\nfleet_ship_ref\n")
+    try:
+        done = subprocess.run(["bash", "-c", program],
                               capture_output=True, text=True, timeout=20)
-        if blob.returncode != 0:
-            return False
-        hits = subprocess.run(["git", "-C", skel_root, "log", "--all", "--format=%H",
-                               "--find-object=" + blob.stdout.strip(), "--", GATE_REL],
-                              capture_output=True, text=True, timeout=120)
-        return hits.returncode == 0 and bool(hits.stdout.strip())
     except (OSError, subprocess.SubprocessError):
-        return False
+        return ""
+    return done.stdout.strip() if done.returncode == 0 else ""
+
+
+def shipped_blobs(skel_root: str, ref: str):
+    """Every blob the skeleton ever SHIPPED for GATE_REL, reachable from `ref`.
+
+    Same algorithm as kipi-update.sh::fleet_authored_blob (walk the ship ref for
+    that path, read the blob at each commit), hoisted out of the per-instance
+    loop: the answer is a property of the skeleton, not of the instance asking.
+    None when git could not answer at all, which is not the same as an empty set.
+    """
+    if not ref:
+        return None
+    try:
+        walk = subprocess.run(["git", "-C", skel_root, "rev-list", ref, "--", GATE_REL],
+                              capture_output=True, text=True, timeout=120)
+        if walk.returncode != 0:
+            return None
+        commits = [c for c in walk.stdout.split() if c]
+        if not commits:
+            return set()
+        batch = subprocess.run(["git", "-C", skel_root, "cat-file",
+                                "--batch-check=%(objectname) %(objecttype)"],
+                               input="".join(f"{c}:{GATE_REL}\n" for c in commits),
+                               capture_output=True, text=True, timeout=120)
+        if batch.returncode != 0:
+            return None
+    except (OSError, subprocess.SubprocessError):
+        return None
+    return {line.split()[0] for line in batch.stdout.splitlines()
+            if line.endswith(" blob")}
+
+
+def _blob_id(skel_root: str, candidate: str) -> str:
+    try:
+        done = subprocess.run(["git", "-C", skel_root, "hash-object", candidate],
+                              capture_output=True, text=True, timeout=20)
+    except (OSError, subprocess.SubprocessError):
+        return ""
+    return done.stdout.strip() if done.returncode == 0 else ""
 
 
 def resolve(root: str):
@@ -112,8 +207,14 @@ def resolve(root: str):
     return skeleton_ok, [p for p in pairs if p[0]]
 
 
-def classify(instance_root: str, skel_root: str) -> tuple:
-    """(state, note) for one instance: synced | behind | ahead | could-not-read."""
+def classify(instance_root: str, skel_root: str, shipped=None) -> tuple:
+    """(state, note) for one instance: synced | behind | ahead | could-not-read.
+
+    `shipped` is the set from shipped_blobs(), passed in rather than recomputed:
+    it is one answer about the skeleton, not 25 answers about the instances.
+    None means the ship ref never resolved, and then a MISMATCH is unanswered --
+    the one thing this file may never do is call an unknown instance `behind`.
+    """
     skel_gate = os.path.join(skel_root, GATE_REL)
     inst_gate = os.path.join(instance_root or "", GATE_REL)
     if not os.path.isfile(skel_gate):
@@ -126,9 +227,14 @@ def classify(instance_root: str, skel_root: str) -> tuple:
         return "could-not-read", str(exc)
     if same:
         return "synced", ""
-    if _skeleton_ever_had(skel_root, inst_gate):
+    if shipped is None:
+        return "could-not-read", NO_REF_NOTE
+    blob = _blob_id(skel_root, inst_gate)
+    if not blob:
+        return "could-not-read", f"git could not hash {inst_gate}"
+    if blob in shipped:
         return "behind", "an older skeleton version; the next sync fixes it"
-    return "ahead", "content the skeleton never had; the next sync DESTROYS it"
+    return "ahead", "content the skeleton never shipped; the next sync DESTROYS it"
 
 
 def scan(root: str) -> dict:
@@ -136,12 +242,20 @@ def scan(root: str) -> dict:
     root = os.path.realpath(root)
     skeleton_ok, pairs = resolve(root)
     rows = []
+    shipped = shipped_blobs(root, _fan_out_ref(root)) if skeleton_ok else None
     if skeleton_ok:
         for name, path in pairs:
-            state, note = classify(path, root)
+            state, note = classify(path, root, shipped)
             rows.append({"name": name, "path": path, "state": state, "note": note})
     ahead = [r["name"] for r in rows if r["state"] == "ahead"]
     unanswered = [r["name"] for r in rows if r["state"] == "could-not-read"]
+    # The CAUSE leads its own rows. An unresolvable ship ref turns every
+    # mismatching instance into an identical `cannot say`, and a title reading
+    # "RED UNANSWERED: a, b, c" names the symptom in 25 places and the reason in
+    # none. Only when it actually bit something: an all-synced fleet was fully
+    # answered, and a sentinel there would be a red with nothing behind it.
+    if any(r["note"] == NO_REF_NOTE for r in rows):
+        unanswered = [NO_FAN_OUT_REF] + unanswered
     # A registry this run could PARSE but that names no instance scanned nothing,
     # and nothing has the same bytes as a healthy fleet
     # (lessons/zero-selected-items-is-a-failure-not-a-pass.md). Zero and
@@ -225,6 +339,9 @@ def _send(message: str) -> None:
         raise FileNotFoundError(f"no notifier at {NOTIFY}; nothing was filed")
     done = subprocess.run(["bash", NOTIFY, message], check=False,
                           capture_output=True, timeout=NOTIFY_TIMEOUT_S)
+    if done.returncode == NOTIFY_UNCONFIGURED_RC:
+        raise NotifierUnconfigured(f"slack-notify.sh exited {NOTIFY_UNCONFIGURED_RC}: "
+                                   "no Linear API key configured")
     if done.returncode != 0:
         raise RuntimeError(f"slack-notify.sh exited {done.returncode}: "
                            f"{(done.stderr or b'').decode('utf-8', 'replace')[:300]}")
@@ -280,6 +397,16 @@ def run(root: str, notify=None, trigger=None, write_manifest=True) -> dict:
     try:
         (notify or _send)(body)
         out["alert"]["filed"] = True
+    except NotifierUnconfigured as exc:
+        # A machine with no Linear key is a SETUP state, which slack-notify.sh
+        # says in its own exit contract. Read as a send failure it made every
+        # 06:30 run there exit 2 into a log nobody reads, forever, and file
+        # nothing -- on a GREEN fleet too (PR #339 review round 3, minor).
+        # Nothing was filed, so the state is still not advanced: the first run
+        # after a key exists files the red that was waiting.
+        out["alert"]["skipped"] = True
+        out["alert"]["reason"] = f"notifier not configured, nothing filed ({exc})"
+        return out
     except Exception as exc:                      # never swallowed: the caller exits 2
         out["alert"]["error"] = f"{type(exc).__name__}: {exc}"
         return out                                # state NOT advanced: retry next run

--- a/q-system/.q-system/scripts/voice-gate-propagation-check.py
+++ b/q-system/.q-system/scripts/voice-gate-propagation-check.py
@@ -1,0 +1,265 @@
+#!/usr/bin/env python3
+"""Which registered instances lose voice-stop-gate behaviour on the next sync.
+
+ASK-1304, promoted from sp-0b8bec0d (source ASK-1197). `kipi update` rsyncs the
+skeleton's q-system/ over every instance, so an instance copy of
+voice-stop-gate.py carrying behaviour the skeleton never had is DESTROYED by the
+next sync. That happened twice in one afternoon on 2026-09-06 (sp-745f5962,
+sp-1ad08728): the instance's pre-commit went red, the restore was undone by the
+following sync, and the only check lived in a test that skips wherever the 25
+instance clones are absent. CI holds the scanner via synthetic trees; this runner
+is what executes it against the real fleet, on a schedule, and fails loudly.
+
+## The AHEAD / BEHIND split is the whole design
+
+A digest mismatch alone is not loss. An instance holding an OLDER skeleton
+version is BEHIND and the next sync fixes it, which is the normal state of a
+fleet between syncs. Only content the skeleton's git history NEVER held is
+destroyed. Calling every mismatch red would make this runner red on a healthy
+fleet, and a gate red on its own population gets switched off (the same call
+`voice-loop-anywhere.md` and `coding-audhd.md` already made). `_skeleton_ever_had`
+is the same git-based answer the lessons-drift reporter uses.
+
+The two citations of that reporter below name it WITHOUT its `.py`, deliberately.
+`test_lessons_drift_report.py::test_single_caller_the_plist_template_is_the_only_one_in_the_tree`
+is an exact-set git grep for its filename, and it is correct to be that blunt: a
+second caller of a scheduled job is exactly what it exists to catch. A docstring
+citing prior art is not a caller, and a grep cannot tell the two apart, so the fix
+is to stop tripping it rather than to loosen it (the same call
+`engineering_route.py` records against the morning-brief slack-notify grep). Do not
+"helpfully" restore the extension; that turns this file into a third caller.
+
+## Where it may ACT
+
+This file sits under the fanned-out scripts directory, so all 25 instances carry
+it (lessons/a-fan-out-installer-must-refuse-where-its-job-cannot-run.md). Run in
+an instance it would compare the fleet against an instance and report the
+skeleton as drifted, so it refuses unless the registry's `skeleton` entry IS its
+own root. The plist carries `kipi-scope: skeleton-only` for `--all`.
+
+## Alerting
+
+Red files ONE ticket into Sana's Linear triage through slack-notify.sh, on state
+CHANGE only, under KIPI_TRIGGER=launchd (which only the plist sets). A ticket
+every run while the fleet stays red is how an alert channel gets muted, and a
+muted channel is worse than none (founder-notifications.md). Run by hand it
+prints and files nothing, so removing the plist provably stops delivery.
+"""
+from __future__ import annotations
+
+import argparse
+import hashlib
+import json
+import os
+import subprocess
+import sys
+from datetime import datetime, timezone
+
+HERE = os.path.dirname(os.path.abspath(__file__))
+DEFAULT_ROOT = os.path.realpath(os.path.join(HERE, "..", "..", ".."))
+GATE_REL = "q-system/.q-system/scripts/voice-stop-gate.py"
+MANIFEST_REL = "q-system/output/voice-gate-propagation.json"
+STATE_REL = "q-system/output/.voice-gate-propagation-state.json"
+NOTIFY = os.path.join(HERE, "slack-notify.sh")
+COULD_NOT_READ = "COULD NOT READ"
+NOTIFY_TIMEOUT_S = 20
+
+
+def _digest(path: str) -> str:
+    h = hashlib.sha256()
+    with open(path, "rb") as fh:
+        for chunk in iter(lambda: fh.read(1 << 16), b""):
+            h.update(chunk)
+    return h.hexdigest()
+
+
+def _skeleton_ever_had(skel_root: str, candidate: str) -> bool:
+    """True when the candidate's content is a version the skeleton's git history
+    holds for GATE_REL: the instance is BEHIND, not ahead. False when git cannot
+    answer (not a repo, no history), which keeps the conservative reading --
+    unknown provenance is treated as drift and gets looked at, never waved past.
+    """
+    try:
+        blob = subprocess.run(["git", "-C", skel_root, "hash-object", candidate],
+                              capture_output=True, text=True, timeout=20)
+        if blob.returncode != 0:
+            return False
+        hits = subprocess.run(["git", "-C", skel_root, "log", "--all", "--format=%H",
+                               "--find-object=" + blob.stdout.strip(), "--", GATE_REL],
+                              capture_output=True, text=True, timeout=120)
+        return hits.returncode == 0 and bool(hits.stdout.strip())
+    except (OSError, subprocess.SubprocessError):
+        return False
+
+
+def resolve(root: str):
+    """(skeleton_ok, [(name, path or None)]) from the registry at `root`.
+
+    The RAW skeleton value is checked before realpath, because realpath("") is
+    the cwd and would pass whenever this ran from its own root (the same hole
+    Codex found in the lessons-drift reporter, issue 13).
+    """
+    root = os.path.realpath(root)
+    try:
+        with open(os.path.join(root, "instance-registry.json"), encoding="utf-8") as fh:
+            registry = json.load(fh)
+    except (OSError, ValueError):
+        return False, []
+    raw = (registry.get("skeleton") or {}).get("path")
+    skeleton_ok = isinstance(raw, str) and bool(raw.strip()) and os.path.realpath(raw) == root
+    pairs = [(e.get("name") or "", e.get("path")) for e in registry.get("instances", [])]
+    return skeleton_ok, [p for p in pairs if p[0]]
+
+
+def classify(instance_root: str, skel_root: str) -> tuple:
+    """(state, note) for one instance: synced | behind | ahead | could-not-read."""
+    skel_gate = os.path.join(skel_root, GATE_REL)
+    inst_gate = os.path.join(instance_root or "", GATE_REL)
+    if not os.path.isfile(skel_gate):
+        return "could-not-read", f"the skeleton has no {GATE_REL}"
+    if not instance_root or not os.path.isfile(inst_gate):
+        return "could-not-read", f"no {GATE_REL} at {instance_root or '(no path)'}"
+    try:
+        same = _digest(inst_gate) == _digest(skel_gate)
+    except OSError as exc:
+        return "could-not-read", str(exc)
+    if same:
+        return "synced", ""
+    if _skeleton_ever_had(skel_root, inst_gate):
+        return "behind", "an older skeleton version; the next sync fixes it"
+    return "ahead", "content the skeleton never had; the next sync DESTROYS it"
+
+
+def scan(root: str) -> dict:
+    """The report. Pure enough for a test to read without a subprocess."""
+    root = os.path.realpath(root)
+    skeleton_ok, pairs = resolve(root)
+    rows = []
+    if skeleton_ok:
+        for name, path in pairs:
+            state, note = classify(path, root)
+            rows.append({"name": name, "path": path, "state": state, "note": note})
+    ahead = [r["name"] for r in rows if r["state"] == "ahead"]
+    return {
+        "generated_at": datetime.now(timezone.utc).isoformat(),
+        "skeleton": root,
+        "skeleton_ok": skeleton_ok,
+        "instances": rows,
+        "ahead": ahead,
+        # a root that is not the skeleton is RED: it means this ran somewhere it
+        # cannot answer the question, which is not the same as "no drift found".
+        "red": bool(ahead) or not skeleton_ok,
+    }
+
+
+def render(report: dict) -> str:
+    day = report["generated_at"][:10]
+    lines = [f"voice-stop-gate propagation ({day})"]
+    if not report["skeleton_ok"]:
+        lines.append(f"skeleton: {COULD_NOT_READ} (the registry's skeleton entry is not "
+                     f"this checkout: {report['skeleton']})")
+        return "\n".join(lines)
+    for row in report["instances"]:
+        if row["state"] == "could-not-read":
+            lines.append(f"{row['name']}: {COULD_NOT_READ} ({row['note']})")
+        elif row["state"] == "ahead":
+            lines.append(f"{row['name']}: AHEAD -- {row['note']}")
+        else:
+            lines.append(f"{row['name']}: {row['state']}"
+                         + (f" ({row['note']})" if row["note"] else ""))
+    if not report["instances"]:
+        lines.append("no instances in the registry")
+    if report["ahead"]:
+        lines.append(f"RED: {len(report['ahead'])} instance(s) lose behaviour on the "
+                     f"next sync: {', '.join(report['ahead'])}")
+    return "\n".join(lines)
+
+
+def fingerprint(report: dict) -> str:
+    """What counts as a STATE for 'alert once on state change'. The set of ahead
+    instances, not the whole report: a new `generated_at` every run would make
+    every run a state change, which is the muted-channel failure wearing the
+    shape of a fix."""
+    if not report["skeleton_ok"]:
+        return "skeleton-unreadable"
+    return "ahead:" + ",".join(sorted(report["ahead"])) if report["ahead"] else "green"
+
+
+def _send(message: str) -> None:
+    """Raise when nothing was filed. An absent notifier is a legitimate no-op on
+    an unconfigured machine and still is NOT a filing -- returning None there is
+    the write-only-integration defect engineering_route.py::send documents."""
+    if not os.path.isfile(NOTIFY):
+        raise FileNotFoundError(f"no notifier at {NOTIFY}; nothing was filed")
+    done = subprocess.run(["bash", NOTIFY, message], check=False,
+                          capture_output=True, timeout=NOTIFY_TIMEOUT_S)
+    if done.returncode != 0:
+        raise RuntimeError(f"slack-notify.sh exited {done.returncode}: "
+                           f"{(done.stderr or b'').decode('utf-8', 'replace')[:300]}")
+
+
+def run(root: str, notify=None, trigger=None, write_manifest=True) -> dict:
+    report = scan(root)
+    message = render(report)
+    out = {"report": report, "message": message,
+           "alert": {"filed": False, "skipped": True, "error": ""}}
+    if write_manifest:
+        manifest = os.path.join(os.path.realpath(root), MANIFEST_REL)
+        os.makedirs(os.path.dirname(manifest), exist_ok=True)
+        with open(manifest, "w", encoding="utf-8") as fh:
+            json.dump(report, fh, indent=2, sort_keys=True)
+        fh = None
+    if trigger != "launchd":
+        out["alert"]["reason"] = ("not launched by the plist (KIPI_TRIGGER != launchd): "
+                                 "printed, filed nothing")
+        return out
+    state_path = os.path.join(os.path.realpath(root), STATE_REL)
+    try:
+        with open(state_path, encoding="utf-8") as fh:
+            previous = json.load(fh).get("fingerprint", "")
+    except (OSError, ValueError):
+        previous = ""
+    current = fingerprint(report)
+    if current == previous:
+        out["alert"]["reason"] = f"no state change since the last run ({current})"
+        return out
+    out["alert"]["skipped"] = False
+    body = message if report["red"] else (
+        "voice-stop-gate propagation recovered: no instance is ahead of the skeleton")
+    try:
+        (notify or _send)(body)
+        out["alert"]["filed"] = True
+    except Exception as exc:                      # never swallowed: the caller exits 2
+        out["alert"]["error"] = f"{type(exc).__name__}: {exc}"
+        return out                                # state NOT advanced: retry next run
+    os.makedirs(os.path.dirname(state_path), exist_ok=True)
+    with open(state_path, "w", encoding="utf-8") as fh:
+        json.dump({"fingerprint": current, "at": report["generated_at"]}, fh)
+    return out
+
+
+def main(argv=None, notify=None) -> int:
+    """Exit 2 when the fleet is red, when this is not the skeleton, or when the
+    plist launched it and the alert did not file. A red fleet whose only alert
+    vanished behind exit 0 is read as fine by launchd and the deadman alike."""
+    ap = argparse.ArgumentParser(description=__doc__.splitlines()[0])
+    ap.add_argument("--root", default=DEFAULT_ROOT)
+    ap.add_argument("--no-manifest", action="store_true", help="print only, write nothing")
+    a = ap.parse_args(argv)
+    trigger = os.environ.get("KIPI_TRIGGER")
+    out = run(a.root, notify=notify, trigger=trigger, write_manifest=not a.no_manifest)
+    print(out["message"])
+    alert = out["alert"]
+    if alert["filed"]:
+        print("alert: filed to Sana's Linear triage")
+    elif alert["error"]:
+        print(f"alert: FAILED, {alert['error']}", file=sys.stderr)
+    else:
+        print("alert: " + alert.get("reason", "not filed"))
+    if alert["error"]:
+        return 2
+    return 2 if out["report"]["red"] else 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/q-system/.q-system/tests/test_voice_gate_propagation.py
+++ b/q-system/.q-system/tests/test_voice_gate_propagation.py
@@ -109,12 +109,31 @@ def test_an_instance_merely_behind_the_skeleton_is_not_loss(tmp_path):
 
 
 def test_an_instance_without_the_gate_file_says_could_not_read(tmp_path):
-    """Never silently green: an unreadable instance is unknown, not synced."""
+    """Never silently green: an unreadable instance is unknown, not synced.
+
+    The EXIT CODE is the assertion that was missing here (PR #339 review, major).
+    An instance that is genuinely ahead but unreadable at 06:30 -- a permission,
+    a renamed directory, a stale registry row, a mid-sync moment -- used to score
+    exit 0 with fingerprint `green`, so the one branch the docstring promised was
+    never silently green was exactly the branch that was.
+    """
     root, clones = _fixture(tmp_path)
     (clones["consulting"] / GATE_REL).unlink()
     r = _run(root)
+    assert r.returncode == 2, (r.returncode, r.stdout, r.stderr)
     assert "COULD NOT READ" in r.stdout, r.stdout
+    assert "UNANSWERED" in r.stdout and "consulting" in r.stdout, r.stdout
     assert "synced" not in r.stdout.split("consulting")[-1].splitlines()[0]
+
+
+def test_a_registry_with_zero_instances_is_not_a_clean_fleet(tmp_path):
+    """lessons/zero-selected-items-is-a-failure-not-a-pass. A registry the run
+    could parse but that names no instance means the scan covered nothing, which
+    has the same bytes as a healthy fleet and none of the meaning."""
+    root, _ = _fixture(tmp_path, instances=())
+    r = _run(root)
+    assert r.returncode == 2, (r.returncode, r.stdout, r.stderr)
+    assert "UNANSWERED" in r.stdout and "no instances in the registry" in r.stdout
 
 
 def test_the_runner_refuses_unless_its_root_is_the_registry_skeleton(tmp_path):
@@ -156,6 +175,64 @@ def test_the_alert_fires_once_per_state_change_not_once_per_run(tmp_path):
     m.run(str(root), notify=notify, trigger="launchd")
     assert len(filed) == 2, "a red -> green transition is a state change"
     assert "recovered" in filed[1].lower(), filed[1]
+
+
+def test_the_first_launchd_run_on_a_green_fleet_records_state_and_files_nothing(tmp_path):
+    """PR #339 review, minor. On install `previous` is "" and `current` is
+    "green", which is a state CHANGE by string comparison and was filed as
+    "recovered" -- a ticket somebody closes by hand for a condition that never
+    fired. `is_noise()` in alert-to-linear does not match that string, so it
+    really does become a real ticket. Recovery still has to fire, so the state is
+    RECORDED on that first quiet run rather than the run being skipped outright.
+    """
+    root, clones = _fixture(tmp_path)
+    m = _mod()
+    filed = []
+    notify = lambda msg: filed.append(msg)
+    out = m.run(str(root), notify=notify, trigger="launchd")
+    assert filed == [], filed
+    assert out["alert"]["skipped"] is True and "first run" in out["alert"]["reason"]
+    (clones["consulting"] / GATE_REL).write_text(AHEAD_GATE)   # now it goes red
+    assert m.run(str(root), notify=notify, trigger="launchd")["alert"]["filed"] is True
+    assert len(filed) == 1, "the quiet first run must not have muted the real one"
+
+
+def test_an_instance_that_cannot_be_read_files_once_not_every_run(tmp_path):
+    """The unanswered set is part of the STATE, not just the exit code. Left out
+    of the fingerprint an unreadable instance would either never alert or alert
+    on every run, and a channel that repeats an unchanged condition stops being
+    read (founder-notifications.md)."""
+    root, clones = _fixture(tmp_path, instances=("consulting", "intel"))
+    (clones["consulting"] / GATE_REL).unlink()
+    m = _mod()
+    filed = []
+    notify = lambda msg: filed.append(msg)
+    assert m.run(str(root), notify=notify, trigger="launchd")["alert"]["filed"] is True
+    assert len(filed) == 1 and "consulting" in filed[0], filed
+    m.run(str(root), notify=notify, trigger="launchd")
+    assert len(filed) == 1, "the same unreadable instance must not file again"
+    (clones["intel"] / GATE_REL).unlink()                      # the set changed
+    m.run(str(root), notify=notify, trigger="launchd")
+    assert len(filed) == 2, "a second unreadable instance is a new state"
+
+
+def test_the_summary_leads_the_message_so_a_truncated_title_still_names_it(tmp_path):
+    """PR #339 review, minor. alert-to-linear flattens the message to one line
+    and truncates it for the ticket title, so a RED summary printed AFTER 25
+    per-instance rows gives Sana a title reading "X: synced Y: synced...". The
+    truncator is imported from the consumer that owns it rather than restated
+    here: a copied 110 stops being the real bound the day that file changes."""
+    names = tuple(f"inst{i:02d}" for i in range(25))
+    root, clones = _fixture(tmp_path, instances=names)
+    (clones["inst23"] / GATE_REL).write_text(AHEAD_GATE)
+    m = _mod()
+    message = m.render(m.scan(str(root)))
+    spec = importlib.util.spec_from_file_location("a2l", SCRIPTS / "alert-to-linear.py")
+    a2l = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(a2l)
+    title = a2l.title_for(message)
+    assert "inst23" in title, title
+    assert message.splitlines()[1].startswith("RED"), message.splitlines()[:3]
 
 
 def test_a_launchd_run_whose_alert_did_not_file_exits_nonzero(tmp_path):

--- a/q-system/.q-system/tests/test_voice_gate_propagation.py
+++ b/q-system/.q-system/tests/test_voice_gate_propagation.py
@@ -6,7 +6,7 @@ skeleton's copy over an instance copy that is AHEAD, destroying behaviour the
 instance's own suite asserts. That happened twice in one afternoon on 2026-09-06
 (sp-745f5962, sp-1ad08728) and the only check for it lived on a machine holding
 the 25 instance clones. This suite pins a runner that FAILS LOUDLY there and
-leaves a manifest CI can load.
+leaves a local manifest of the scan.
 
 Every tree here is tmp; the registry is a fixture. The ONE assertion that needs
 the real fleet carries the ONE skip in this file, and
@@ -19,6 +19,7 @@ import importlib.util
 import json
 import os
 import re
+import shutil
 import subprocess
 import sys
 from pathlib import Path
@@ -30,6 +31,9 @@ SCRIPTS = HERE.parent / "scripts"
 CHECK = SCRIPTS / "voice-gate-propagation-check.py"
 PLIST = SCRIPTS / "com.kipi.voice-gate-propagation.plist"
 GATE_REL = "q-system/.q-system/scripts/voice-stop-gate.py"
+REPO = HERE.parent.parent.parent
+KIPI_UPDATE = REPO / "kipi-update.sh"
+NOTIFY_SH = SCRIPTS / "slack-notify.sh"
 
 SKELETON_GATE = "def main():\n    return 0\n"
 AHEAD_GATE = SKELETON_GATE + "\ndef enforce_route_receipt():\n    raise SystemExit(2)\n"
@@ -47,11 +51,21 @@ def _git(root, *args):
     return subprocess.run(base + list(args), capture_output=True, text=True, check=True)
 
 
-def _fixture(tmp_path, instances=("consulting",), skeleton_path=None, commit=True):
-    """A skeleton git repo plus one clone per name, both holding the gate file."""
+def _fixture(tmp_path, instances=("consulting",), skeleton_path=None, commit=True,
+             updater=True):
+    """A skeleton git repo plus one clone per name, both holding the gate file.
+
+    The skeleton also carries a COPY OF THE REAL `kipi-update.sh`, never a
+    hand-written stand-in: the check derives the fan-out ref by executing that
+    file's own `fleet_ship_ref`, so a fixture updater written here would test
+    this fixture's idea of the updater (lessons/fixtures-come-from-producers).
+    `updater=False` is the negative: an unresolvable ref must not read green.
+    """
     root = tmp_path / "skeleton"
     (root / GATE_REL).parent.mkdir(parents=True)
     (root / GATE_REL).write_text(SKELETON_GATE)
+    if updater:
+        shutil.copy(KIPI_UPDATE, root / "kipi-update.sh")
     clones = {}
     for name in instances:
         clone = tmp_path / name
@@ -106,6 +120,64 @@ def test_an_instance_merely_behind_the_skeleton_is_not_loss(tmp_path):
     r = _run(root)
     assert r.returncode == 0, (r.returncode, r.stdout, r.stderr)
     assert "behind" in r.stdout and "AHEAD" not in r.stdout, r.stdout
+
+
+def test_content_only_on_an_unmerged_branch_is_ahead_not_behind(tmp_path):
+    """THE SECOND REPRODUCER (PR #339 review round 3, major). "The skeleton
+    shipped it" is the FAN-OUT branch, not every ref in the clone. A blob that
+    only ever existed on an unmerged feature branch was never rsynced to any
+    instance, so an instance holding it is AHEAD and the next sync destroys it.
+
+    This is the same boundary `kipi-update.sh` was tightened to on #151 round 7,
+    and the recorded 2026-09-06 loss says the port was "still on an open PR" --
+    exactly this input. Measured in the live clone: 1142 refs, 49 gate blobs
+    reachable from --all, 8 from origin/main, so 41 blobs the old walk accepted
+    were never shipped anywhere.
+    """
+    root, clones = _fixture(tmp_path)
+    head = _git(root, "rev-parse", "--abbrev-ref", "HEAD").stdout.strip()
+    _git(root, "checkout", "-q", "-b", "feat/voice-gate-port")
+    (root / GATE_REL).write_text(AHEAD_GATE)
+    _git(root, "add", "-A")
+    _git(root, "commit", "-q", "-m", "port, never merged")
+    _git(root, "checkout", "-q", head)
+    (clones["consulting"] / GATE_REL).write_text(AHEAD_GATE)
+    r = _run(root)
+    assert r.returncode == 2, (r.returncode, r.stdout, r.stderr)
+    assert "AHEAD" in r.stdout and "consulting" in r.stdout, r.stdout
+    assert "behind" not in r.stdout, r.stdout
+
+
+def test_the_fan_out_ref_is_derived_from_kipi_update_not_restated(tmp_path):
+    """BOUND, not merely equal (lessons/derive-a-value-from-its-owner). The ref
+    order lives in `kipi-update.sh::fleet_ship_ref` and this check executes that
+    function out of its own source. Mutating the owner's preference has to move
+    the answer; a copy of the list here would agree today and drift silently."""
+    root, _ = _fixture(tmp_path)
+    m = _mod()
+    _git(root, "branch", "-q", "shipped-elsewhere")
+    assert m._fan_out_ref(str(root)), "the real updater must resolve a ref"
+    src = (root / "kipi-update.sh").read_text()
+    mutated = src.replace('for ref in "refs/remotes/origin/$SKELETON_BRANCH"',
+                          'for ref in "refs/heads/shipped-elsewhere"', 1)
+    assert mutated != src, "the ref list moved in kipi-update.sh; re-pin this test"
+    (root / "kipi-update.sh").write_text(mutated)
+    assert m._fan_out_ref(str(root)) == "refs/heads/shipped-elsewhere"
+
+
+def test_an_unresolvable_fan_out_ref_is_unanswered_not_behind(tmp_path):
+    """No updater, no answer. Without the ship ref the check cannot tell AHEAD
+    from BEHIND, and "cannot tell" must not print as the harmless one."""
+    root, clones = _fixture(tmp_path, updater=False)
+    (clones["consulting"] / GATE_REL).write_text(AHEAD_GATE)
+    r = _run(root)
+    assert r.returncode == 2, (r.returncode, r.stdout, r.stderr)
+    # the per-instance STATE, not a substring: the note itself says the words
+    # "ahead or behind", and a bare `not in` on the whole message reads that as
+    # a verdict the run never rendered.
+    assert ": behind" not in r.stdout, r.stdout
+    assert "UNANSWERED" in r.stdout and _mod().NO_FAN_OUT_REF in r.stdout, r.stdout
+    assert "COULD NOT READ" in r.stdout, r.stdout
 
 
 def test_an_instance_without_the_gate_file_says_could_not_read(tmp_path):
@@ -249,9 +321,74 @@ def test_a_launchd_run_whose_alert_did_not_file_exits_nonzero(tmp_path):
     assert out["alert"]["filed"] is False and out["alert"]["error"], out["alert"]
 
 
-# ---- the manifest CI can load ------------------------------------------------
+def test_an_unconfigured_notifier_is_a_setup_state_not_a_filing_failure(tmp_path):
+    """PR #339 review round 3, minor. `slack-notify.sh` exit 3 is its own
+    documented "no Linear API key configured (a setup state)". Mapped to a send
+    FAILURE it made every 06:30 run on a keyless machine exit 2 into a log nobody
+    reads, forever, with no ticket -- including on a fleet that is green. Not
+    filed is still not filed, so the state is NOT advanced and the next run
+    retries the moment a key exists."""
+    root, clones = _fixture(tmp_path)
+    m = _mod()
 
-def test_the_run_writes_a_manifest_ci_could_load(tmp_path):
+    def unconfigured(_msg):
+        raise m.NotifierUnconfigured("slack-notify.sh exited 3: no Linear key")
+
+    (clones["consulting"] / GATE_REL).write_text(AHEAD_GATE)
+    out = m.run(str(root), notify=unconfigured, trigger="launchd")
+    assert out["alert"]["error"] == "", out["alert"]
+    assert out["alert"]["filed"] is False and out["alert"]["skipped"] is True
+    assert "not configured" in out["alert"]["reason"], out["alert"]
+    filed = []
+    out2 = m.run(str(root), notify=lambda msg: filed.append(msg), trigger="launchd")
+    assert out2["alert"]["filed"] is True and len(filed) == 1, \
+        "an unconfigured run must not have advanced the state past the real red"
+
+
+def test_send_maps_the_notifiers_setup_exit_and_not_only_the_injected_fake(tmp_path):
+    """The test above injects a fake that RAISES the exception, so it proves how
+    `run` reacts and nothing about `_send`. Measured: deleting the rc-3 branch
+    from `_send` left it green. This one drives a real notifier that exits 3 and
+    one that exits 1, so the mapping itself is what is pinned
+    (lessons/test-passes-for-the-wrong-reason)."""
+    m = _mod()
+    stub = tmp_path / "notify.sh"
+    real = m.NOTIFY
+    try:
+        stub.write_text("#!/bin/bash\nexit %d\n" % m.NOTIFY_UNCONFIGURED_RC)
+        m.NOTIFY = str(stub)
+        with pytest.raises(m.NotifierUnconfigured):
+            m._send("a red fleet")
+        stub.write_text("#!/bin/bash\necho boom >&2\nexit 1\n")
+        with pytest.raises(RuntimeError):
+            m._send("a red fleet")
+    finally:
+        m.NOTIFY = real
+
+
+def test_the_setup_exit_code_is_derived_from_slack_notifys_own_contract():
+    """The 3 is slack-notify.sh's number, not ours. Read out of its EXIT CONTRACT
+    block at test time so a renumbering there fails here instead of silently
+    turning a setup state back into a send failure."""
+    contract = NOTIFY_SH.read_text().split("EXIT CONTRACT", 1)[1].split("Usage:", 1)[0]
+    rows = dict(re.findall(r"^#\s+(\d+)\s+(.*)$", contract, re.M))
+    assert rows, "could not parse slack-notify.sh's exit contract"
+    setup = [code for code, text in rows.items() if "setup state" in text]
+    assert len(setup) == 1, rows
+    assert _mod().NOTIFY_UNCONFIGURED_RC == int(setup[0]), rows
+
+
+# ---- the manifest: a LOCAL run artifact, and the docs say only that -----------
+
+def test_the_run_writes_a_local_manifest_of_the_scan(tmp_path):
+    """PR #339 review round 3, minor. This file used to be described as a
+    manifest continuous integration could load. It is not: `q-system/output/*.json`
+    is gitignored, it is written only where the clones are, and a repo-wide grep
+    finds no reader outside this suite. Deleting it would lose a real local
+    artifact and adding a fake consumer would be worse, so what changed is the
+    CLAIM. The shape is pinned here because a file nothing else parses drifts
+    unnoticed. The prose above spells the phrase out rather than using it, for
+    the same reason the needle below is assembled."""
     root, clones = _fixture(tmp_path)
     (clones["consulting"] / GATE_REL).write_text(AHEAD_GATE)
     r = _run(root)
@@ -259,8 +396,18 @@ def test_the_run_writes_a_manifest_ci_could_load(tmp_path):
     manifest = root / "q-system" / "output" / "voice-gate-propagation.json"
     data = json.loads(manifest.read_text())
     assert data["red"] is True and data["generated_at"]
+    assert set(data) >= {"generated_at", "skeleton", "skeleton_ok", "instances",
+                         "ahead", "unanswered", "red"}, sorted(data)
     rows = {row["name"]: row["state"] for row in data["instances"]}
     assert rows == {"consulting": "ahead"}, rows
+    out = subprocess.run(["git", "-C", str(REPO), "check-ignore", "-q",
+                          "q-system/output/voice-gate-propagation.json"])
+    assert out.returncode == 0, "still gitignored, so no doc may promise CI reads it"
+    # the needle is ASSEMBLED for the same reason the skip counter's is: written
+    # out, this assertion is itself a match and the check measures the checker.
+    needle = "CI " + "can load"
+    assert needle not in CHECK.read_text(), "the script must not re-promise it"
+    assert needle not in Path(__file__).read_text(), "nor this suite"
 
 
 # ---- the live fleet: the ONE skip in this file -------------------------------

--- a/q-system/.q-system/tests/test_voice_gate_propagation.py
+++ b/q-system/.q-system/tests/test_voice_gate_propagation.py
@@ -1,0 +1,263 @@
+#!/usr/bin/env python3
+"""RED FIRST. ASK-1304 (promoted from sp-0b8bec0d, source ASK-1197).
+
+The fanout-LOSS hazard for voice-stop-gate.py is that `kipi update` rsyncs the
+skeleton's copy over an instance copy that is AHEAD, destroying behaviour the
+instance's own suite asserts. That happened twice in one afternoon on 2026-09-06
+(sp-745f5962, sp-1ad08728) and the only check for it lived on a machine holding
+the 25 instance clones. This suite pins a runner that FAILS LOUDLY there and
+leaves a manifest CI can load.
+
+Every tree here is tmp; the registry is a fixture. The ONE assertion that needs
+the real fleet carries the ONE skip in this file, and
+`test_exactly_one_skip_site_lives_in_this_file` pins that count so a second skip
+cannot hide inside it.
+"""
+from __future__ import annotations
+
+import importlib.util
+import json
+import os
+import re
+import subprocess
+import sys
+from pathlib import Path
+
+import pytest
+
+HERE = Path(__file__).resolve().parent
+SCRIPTS = HERE.parent / "scripts"
+CHECK = SCRIPTS / "voice-gate-propagation-check.py"
+PLIST = SCRIPTS / "com.kipi.voice-gate-propagation.plist"
+GATE_REL = "q-system/.q-system/scripts/voice-stop-gate.py"
+
+SKELETON_GATE = "def main():\n    return 0\n"
+AHEAD_GATE = SKELETON_GATE + "\ndef enforce_route_receipt():\n    raise SystemExit(2)\n"
+
+
+def _mod():
+    spec = importlib.util.spec_from_file_location("voice_gate_propagation_check", CHECK)
+    m = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(m)
+    return m
+
+
+def _git(root, *args):
+    base = ["git", "-C", str(root), "-c", "user.email=t@t", "-c", "user.name=t"]
+    return subprocess.run(base + list(args), capture_output=True, text=True, check=True)
+
+
+def _fixture(tmp_path, instances=("consulting",), skeleton_path=None, commit=True):
+    """A skeleton git repo plus one clone per name, both holding the gate file."""
+    root = tmp_path / "skeleton"
+    (root / GATE_REL).parent.mkdir(parents=True)
+    (root / GATE_REL).write_text(SKELETON_GATE)
+    clones = {}
+    for name in instances:
+        clone = tmp_path / name
+        (clone / GATE_REL).parent.mkdir(parents=True)
+        (clone / GATE_REL).write_text(SKELETON_GATE)
+        clones[name] = clone
+    (root / "instance-registry.json").write_text(json.dumps({
+        "skeleton": {"path": str(skeleton_path or root)},
+        "instances": [{"name": n, "path": str(p)} for n, p in clones.items()]}))
+    if commit:
+        _git(root, "init", "-q")
+        _git(root, "add", "-A")
+        _git(root, "commit", "-q", "-m", "base")
+    return root, clones
+
+
+def _run(root, *args, env_extra=None):
+    env = dict(os.environ)
+    env.pop("KIPI_TRIGGER", None)
+    env.update(env_extra or {})
+    return subprocess.run([sys.executable, str(CHECK), "--root", str(root), *args],
+                          capture_output=True, text=True, env=env, timeout=120)
+
+
+# ---- the fanout-LOSS assertion, on synthetic trees (runs everywhere) ----------
+
+def test_an_instance_ahead_of_the_skeleton_is_red(tmp_path):
+    """THE REPRODUCER. The instance holds content the skeleton never had, so the
+    next sync destroys it. Exit 2, the instance named, the word AHEAD present."""
+    root, clones = _fixture(tmp_path)
+    (clones["consulting"] / GATE_REL).write_text(AHEAD_GATE)
+    r = _run(root)
+    assert r.returncode == 2, (r.returncode, r.stdout, r.stderr)
+    assert "consulting" in r.stdout and "AHEAD" in r.stdout, r.stdout
+
+
+def test_a_synced_fleet_is_green(tmp_path):
+    root, clones = _fixture(tmp_path)
+    r = _run(root)
+    assert r.returncode == 0, (r.returncode, r.stdout, r.stderr)
+    assert "AHEAD" not in r.stdout and "synced" in r.stdout, r.stdout
+
+
+def test_an_instance_merely_behind_the_skeleton_is_not_loss(tmp_path):
+    """A digest mismatch alone is not the hazard. The instance holding an OLDER
+    skeleton version loses nothing to the next sync; calling that red would make
+    the runner red on a normal fleet, which is how a gate gets switched off."""
+    root, clones = _fixture(tmp_path)
+    (root / GATE_REL).write_text(SKELETON_GATE + "\n# a later skeleton line\n")
+    _git(root, "add", "-A")
+    _git(root, "commit", "-q", "-m", "skeleton moved on")
+    r = _run(root)
+    assert r.returncode == 0, (r.returncode, r.stdout, r.stderr)
+    assert "behind" in r.stdout and "AHEAD" not in r.stdout, r.stdout
+
+
+def test_an_instance_without_the_gate_file_says_could_not_read(tmp_path):
+    """Never silently green: an unreadable instance is unknown, not synced."""
+    root, clones = _fixture(tmp_path)
+    (clones["consulting"] / GATE_REL).unlink()
+    r = _run(root)
+    assert "COULD NOT READ" in r.stdout, r.stdout
+    assert "synced" not in r.stdout.split("consulting")[-1].splitlines()[0]
+
+
+def test_the_runner_refuses_unless_its_root_is_the_registry_skeleton(tmp_path):
+    """a-fan-out-installer-must-refuse-where-its-job-cannot-run: this script sits
+    under the fanned-out scripts dir, so all 25 instances carry it. Run in one, it
+    would compare the fleet against an instance and call the skeleton drifted."""
+    root, clones = _fixture(tmp_path, skeleton_path=tmp_path / "elsewhere")
+    r = _run(root)
+    assert r.returncode == 2, (r.returncode, r.stdout, r.stderr)
+    assert "skeleton: COULD NOT READ" in r.stdout, r.stdout
+    assert "AHEAD" not in r.stdout
+
+
+# ---- the alert: once, on state change, and only under the plist marker --------
+
+def test_run_by_hand_prints_and_files_nothing(tmp_path):
+    root, clones = _fixture(tmp_path)
+    (clones["consulting"] / GATE_REL).write_text(AHEAD_GATE)
+    m = _mod()
+    filed = []
+    out = m.run(str(root), notify=lambda msg: filed.append(msg), trigger=None)
+    assert filed == [] and out["alert"]["skipped"] is True
+    assert "not launched by the plist" in out["alert"]["reason"]
+
+
+def test_the_alert_fires_once_per_state_change_not_once_per_run(tmp_path):
+    """founder-notifications.md: alert on state change, once. A ticket every run
+    while the fleet stays red is how an alert channel gets muted."""
+    root, clones = _fixture(tmp_path)
+    (clones["consulting"] / GATE_REL).write_text(AHEAD_GATE)
+    m = _mod()
+    filed = []
+    notify = lambda msg: filed.append(msg)
+    assert m.run(str(root), notify=notify, trigger="launchd")["alert"]["filed"] is True
+    assert len(filed) == 1, filed
+    m.run(str(root), notify=notify, trigger="launchd")          # still red, same fleet
+    assert len(filed) == 1, "a second identical red must not file again"
+    (clones["consulting"] / GATE_REL).write_text(SKELETON_GATE)  # recovered
+    m.run(str(root), notify=notify, trigger="launchd")
+    assert len(filed) == 2, "a red -> green transition is a state change"
+    assert "recovered" in filed[1].lower(), filed[1]
+
+
+def test_a_launchd_run_whose_alert_did_not_file_exits_nonzero(tmp_path):
+    """engineering_route.py::send: an absent notifier is not a filing. A red
+    fleet whose only alert vanished behind exit 0 is read as fine by launchd."""
+    root, clones = _fixture(tmp_path)
+    (clones["consulting"] / GATE_REL).write_text(AHEAD_GATE)
+    m = _mod()
+
+    def broken(_msg):
+        raise RuntimeError("slack-notify.sh exited 1")
+
+    out = m.run(str(root), notify=broken, trigger="launchd")
+    assert out["alert"]["filed"] is False and out["alert"]["error"], out["alert"]
+
+
+# ---- the manifest CI can load ------------------------------------------------
+
+def test_the_run_writes_a_manifest_ci_could_load(tmp_path):
+    root, clones = _fixture(tmp_path)
+    (clones["consulting"] / GATE_REL).write_text(AHEAD_GATE)
+    r = _run(root)
+    assert r.returncode == 2
+    manifest = root / "q-system" / "output" / "voice-gate-propagation.json"
+    data = json.loads(manifest.read_text())
+    assert data["red"] is True and data["generated_at"]
+    rows = {row["name"]: row["state"] for row in data["instances"]}
+    assert rows == {"consulting": "ahead"}, rows
+
+
+# ---- the live fleet: the ONE skip in this file -------------------------------
+
+def test_the_real_fleet_has_no_instance_ahead_of_this_checkout():
+    """CI-ONLY SKIP. The fanout-LOSS hazard is a property of the 25 instance
+    clones, which exist on the founder's machine and nowhere in CI. The synthetic
+    trees above pin the SCANNER; only this runs it against the fleet, and the
+    scheduled plist is what makes it run where the clones are. Skipping here is
+    correct; the runner not existing anywhere that fails loudly was the defect.
+    """
+    root = HERE.parent.parent.parent
+    registry = root / "instance-registry.json"
+    if not registry.exists():
+        pytest.skip("no instance-registry.json: not a fleet checkout (CI)")
+    m = _mod()
+    report = m.scan(str(root))
+    if report["skeleton_ok"] is False or not any(
+            row["state"] != "could-not-read" for row in report["instances"]):
+        pytest.skip("no readable sibling clones: not the fleet machine (CI)")
+    ahead = [row["name"] for row in report["instances"] if row["state"] == "ahead"]
+    assert ahead == [], f"these instances lose behaviour on the next sync: {ahead}"
+
+
+def test_exactly_one_skip_site_lives_in_this_file():
+    """The skip above is load-bearing and CI-only. Asserting its COUNT is what
+    stops a second skip hiding inside the first one's justification: a suite that
+    quietly skips its way to green reads exactly like a passing one."""
+    src = Path(__file__).read_text()
+    # the needle is ASSEMBLED, never written out: the first cut spelled it
+    # literally and then counted its own pattern string as a third skip site. A
+    # counter that matches itself measures the counter, not the suite.
+    needle = "pytest" + "." + "skip("
+    marker = "pytest" + "." + "mark" + "." + "skip"
+    sites = re.findall(re.escape(needle) + "|" + re.escape(marker), src)
+    assert len(sites) == 2, f"expected the 2 skip calls of ONE CI-only test, found {sites}"
+    body = src.split("def test_the_real_fleet_has_no_instance_ahead_of_this_checkout")[1]
+    body = body.split("def test_exactly_one_skip_site")[0]
+    assert body.count(needle) == 2, "both skips belong to the live-fleet test"
+    assert "CI-ONLY SKIP" in body, "the skip has to say it is CI-only in the file"
+
+
+# ---- wiring -----------------------------------------------------------------
+
+def test_the_plist_runs_it_and_carries_no_machine_path():
+    src = PLIST.read_text()
+    for placeholder in ("__KIPI_REPO__", "__HOME__", "__USER__"):
+        assert placeholder in src, placeholder
+    assert "/Users/" not in src, "a literal home path would fan out to 25 instances"
+    assert "voice-gate-propagation-check.py</string>" in src
+    assert "<key>KIPI_TRIGGER</key><string>launchd</string>" in src
+    assert "<string>com.kipi.voice-gate-propagation</string>" in src
+    assert "kipi-scope: skeleton-only" in src, "install-plist.sh --all honours this marker"
+
+
+def test_this_file_runs_its_own_tests_under_python3():
+    """The capability manifest declares runner `python3`, so without the
+    __main__ block below `python3 <this file>` exits 0 having run nothing, and
+    the gate reports a vacuous pass. The negative half (-k matching no test)
+    proves the entry can still go red.
+
+    The inner run returns early rather than calling pytest.skip, on purpose:
+    test_exactly_one_skip_site_lives_in_this_file pins the skip count at the ONE
+    CI-only site, and a guard skip here would spend that budget on bookkeeping.
+    """
+    if os.environ.get("KIPI_SELFTEST_INNER"):
+        return
+    env = dict(os.environ, KIPI_SELFTEST_INNER="1")
+    ok = subprocess.run([sys.executable, __file__], capture_output=True, text=True, env=env, timeout=300)
+    assert ok.returncode == 0 and "passed" in ok.stdout, ok.stdout[-600:]
+    none = subprocess.run([sys.executable, __file__, "-k", "no_such_test_zzz"],
+                          capture_output=True, text=True, env=env, timeout=120)
+    assert none.returncode != 0, "a run selecting zero tests must not report success"
+
+
+if __name__ == "__main__":
+    raise SystemExit(pytest.main([__file__, "-q", *sys.argv[1:]]))


### PR DESCRIPTION
Closes ASK-1304 (promoted from spillover `sp-0b8bec0d`, source ASK-1197).

## The hazard

The fleet updater rsyncs the skeleton's `q-system/` over every instance. So an
instance copy of `voice-stop-gate.py` carrying behaviour the skeleton never had is
DESTROYED by the next sync. That is not hypothetical: it happened twice in one
afternoon on 2026-09-06 (`sp-745f5962`, `sp-1ad08728`). The instance's pre-commit
went red, the restore was undone by the following sync.

The only check for it lived in an assertion that skips wherever the 25 instance
clones are absent, which is everywhere except the founder's machine. CI held the
scanner against synthetic trees and never the fleet, so the hazard was guarded by
a test that never ran against a real one.

## What this adds

`q-system/.q-system/scripts/voice-gate-propagation-check.py` resolves the
registry, compares each instance's gate file against this checkout's, and
classifies **synced / behind / ahead / COULD NOT READ**.

The AHEAD-vs-BEHIND split is the design, not a refinement. A digest mismatch alone
is not loss: an instance holding an OLDER skeleton version is fixed by the next
sync, and that is the normal state of a fleet between syncs. Calling every mismatch
red would make this red on a healthy fleet, which is how a gate gets switched off.
`_skeleton_ever_had` is the same git-based answer the lessons-drift reporter uses.

Exit 2 on any ahead instance, on a root that is not the registry's skeleton, and on
a launchd run whose alert did not file. COULD NOT READ is never silently green.

`com.kipi.voice-gate-propagation.plist` is the trigger, daily 06:30, ahead of the
06:45 drift report and the 07:40 brief.

## Alerting

Red files ONE ticket into Sana's Linear triage through `slack-notify.sh`, on state
CHANGE only and only under `KIPI_TRIGGER=launchd`, which only the plist sets. The
state is the SET of ahead instances: a fingerprint carrying the timestamp would
make every run a state change and mute the channel. A failed filing does not
advance the state, so the next run retries. Run by hand it prints and files
nothing, so removing the plist provably stops delivery.

Each run leaves `q-system/output/voice-gate-propagation.json`, a LOCAL artifact of
the last scan. It is gitignored and written only where the clones are, so nothing
in continuous integration reads it and this PR no longer says otherwise (review
round 3, minor). The ALERT is the signal that leaves the machine.

## Where it may act

It sits under the fanned-out scripts directory, so all 25 instances carry it. It
refuses unless the registry's `skeleton` entry is its own root (the lesson
`a-fan-out-installer-must-refuse-where-its-job-cannot-run`). The plist carries
`kipi-scope: skeleton-only` for `install-plist.sh --all`.

## Against the DoR

- [x] The fanout-loss assertion has a runner that executes it against the real
      fleet (the scheduled local job), and the run produces a machine-readable
      manifest of the scan (local, gitignored; see above)
- [x] The runner alerts through `slack-notify.sh` on red, once, on state change
- [x] A test proves it goes RED on a synthetic instance-ahead tree and GREEN on a
      synced one, both executed
- [x] The CI skip stays, says `CI-ONLY SKIP` in the file, and the skip count is
      asserted so a second skip cannot hide inside it

## Two things worth a reviewer's eye

**The skip counter counted itself.** Its first cut spelled `pytest.skip(`
literally and matched its own pattern string as a third site. The needle is now
assembled from pieces, with the reason inline: a counter that matches itself
measures the counter, not the suite.

**The docstring cites the lessons-drift reporter without its `.py`, on purpose.**
That suite's exact-set single-caller grep counted this file as a third caller of
it. The grep is correct to be that blunt, and a docstring citing prior art is not
a caller, so the fix is to stop tripping it rather than to loosen it (the call
`engineering_route.py` already records against the morning-brief notify grep). The
file says so inline so the extension does not get helpfully restored.

## Verification

- `bash q-system/.q-system/verify.sh --staged` -> ok (4 checks), which is the
  same script CI runs
- `python3 -m pytest q-system/.q-system/tests/test_voice_gate_propagation.py
  q-system/.q-system/tests/test_lessons_drift_report.py -q` -> 31 passed,
  1 skipped (the documented CI-only skip)
- **Mutation:** flipping the `ahead` branch to return `behind` killed 3 tests, so
  the check can actually fail rather than decorate
- RED was observed first: 12 failed before the runner existed

## Spillover captured, not fixed here

`sp-dc4cdb89` — `test_notion_board.py::test_no_write_lands_after_the_timeout_was_reported`
is load-flaky. Its budget is 0.05s of wall clock, so under the full 1410-test suite
it is spent before the assertion and the test reds, while the file passes 26/26 in
isolation. It blocked this unrelated pre-commit twice. Pre-existing, out of scope.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

