### PR TITLE
fix(dispatch): pause interview-coach until the worker honours a master default

### DIFF
--- a/instance-registry.json
+++ b/instance-registry.json
@@ -148,8 +148,10 @@
       "type": "subtree",
       "has_git": true,
       "dispatch": {
-        "enabled": true,
-        "expected_remote": "https://github.com/assafkip/kipi-interview-coach.git"
+        "enabled": false,
+        "expected_remote": "https://github.com/assafkip/kipi-interview-coach.git",
+        "decision": "paused 2026-09-12, reinstate with the base-branch fix",
+        "reason": "PAUSED, not refused. Every dispatch here fails before any work: linear-worker.sh cuts each worktree from a hardcoded BASE=\"origin/main\" (line ~1725), and this repo's remote has only `master`, so git fails with `invalid reference: origin/main`. The worker correctly logs it as INFRA and does not charge the issue, but each attempt still spends a slot of the 10/day dispatch budget. Measured 2026-09-12 17:03Z: ASK-1104 dispatched, worktree failed, no PR, 7 seconds. Preflight itself passes. Flip enabled back to true once the worker resolves the remote's default branch."
       }
     },
     {


### PR DESCRIPTION
Every dispatch to `interview-coach` fails before any work is done. `linear-worker.sh` cuts each worktree from a hardcoded `BASE="origin/main"`, and that repo's remote has only `master`:

```
fatal: invalid reference: origin/main
INFRA: could not create worktree for ASK-1104 (not counted against the issue)
```

The worker is right not to charge the issue, but each attempt still spends a slot of the 10/day dispatch budget. The repo had just been brought back through preflight, so it would win a turn every rotation and burn a slot each time.

**Paused, not refused.** The decision and reason are recorded as values, matching the two existing OFF rows (`gtm-partner`, `reddit-build-radar`), so it's obvious what flips it back: the worker resolving the remote's default branch instead of assuming `main`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_018Hfcsb7JQGwhAjNTEofr99