### PR TITLE
feat(spillover): Linear issue at capture, daily retry check, new minors never queued (ASK-1552)

### DIFF
--- a/.claude/rules/no-orphan-findings.md
+++ b/.claude/rules/no-orphan-findings.md
@@ -15,8 +15,8 @@ python3 plugins/prd-os/scripts/prd_runner.py spillover add \
   --source <prd-or-issue-id> --desc "<what it is, concretely>"
 ```
 
-Capture = a ledger row in `.prd-os/spillover.jsonl` AND one Linear issue for Sana (filed via
-`alert-to-linear.py`, id on the row). `gates run` stays RED until resolved. A mention is not capture.
+Capture (medium and up) = a ledger row in `.prd-os/spillover.jsonl` AND one Linear issue for Sana
+(via `alert-to-linear.py`, id on the row). A NEW minor is never queued: fix it now or reject it with a reason.
 
 ## How items leave the ledger (only two ways)
 
@@ -30,10 +30,10 @@ There is no third way. You cannot hand-clear the gate.
 
 ## Deterministic backstops
 
-- A `deferred` disposition AUTO-creates an open spillover item (and its Linear
-  issue) in BOTH findings systems (findings_writer + issue_findings, sp-5bcfbfe8).
+- A `deferred` medium-and-up finding AUTO-creates the item + Linear issue in BOTH findings
+  systems (findings_writer + issue_findings); `add` or defer of a minor/low/nit exits 2.
 - The fable-discipline lint blocks deferral language written into CODE without a
-  capture (`# spillover-skip` acks an already-captured line). Only this blocks.
+  capture (`# spillover-skip` acks an already-captured line).
 - `gates run` fails while any item is open (the enforcement of last resort).
 - `spillover-linear-check.py` (daily launchd) retries failed Linear filings, alerts Sana once; never blocks.
 
@@ -59,7 +59,7 @@ the item, the issue that resolved it, the fix, and how it affected the system.
     "exec": "plugins/prd-os/skills/fable-discipline/scripts/fable-discipline-lint.py",
     "config": "plugins/prd-os/hooks/hooks.json",
     "test": "plugins/prd-os/skills/fable-discipline/scripts/test_fable_discipline_lint.py",
-    "note": "ENFORCED covers only the blocking slice: deferral language in code without a capture. Whether a finding is captured at all is a model decision no hook observes. DETECTED, not blocking: capture-time Linear filing in plugins/prd-os/scripts/prd_runner.py and the daily retry q-system/.q-system/scripts/spillover-linear-check.py, wired in automation/com.kipi.spillover-linear-check.plist, pinned by q-system/.q-system/tests/test_spillover_linear_check.py."
+    "note": "ENFORCED covers the blocking slices: deferral language in code without a capture (this lint), and the refusal of a NEW minor/low/nit by spillover add and by a deferred disposition (exit 2 in plugins/prd-os/scripts/prd_runner.py, findings_writer.py and plugins/kipi-dsse/scripts/issue_findings.py, pinned by plugins/prd-os/tests/test_spillover_files_linear.py; RULE-2026-09-12-A). Whether a finding is captured at all is a model decision no hook observes. DETECTED, not blocking: capture-time Linear filing in plugins/prd-os/scripts/prd_runner.py and the daily retry q-system/.q-system/scripts/spillover-linear-check.py, wired in automation/com.kipi.spillover-linear-check.plist, pinned by q-system/.q-system/tests/test_spillover_linear_check.py."
   }
 ]
 ```

--- a/.claude/rules/no-orphan-findings.md
+++ b/.claude/rules/no-orphan-findings.md
@@ -15,9 +15,8 @@ python3 plugins/prd-os/scripts/prd_runner.py spillover add \
   --source <prd-or-issue-id> --desc "<what it is, concretely>"
 ```
 
-This writes it to `.prd-os/spillover.jsonl`. The standing gate
-(`prd_runner.py gates run`) then stays RED until it is resolved, so it cannot be
-forgotten. "I'll mention it to the founder" is not capture. The file is capture.
+Capture = a ledger row in `.prd-os/spillover.jsonl` AND one Linear issue for Sana (filed via
+`alert-to-linear.py`, id on the row). `gates run` stays RED until resolved. A mention is not capture.
 
 ## How items leave the ledger (only two ways)
 
@@ -31,11 +30,12 @@ There is no third way. You cannot hand-clear the gate.
 
 ## Deterministic backstops
 
-- A `deferred` disposition AUTO-creates an open spillover item in BOTH findings
-  systems (findings_writer + issue_findings, sp-5bcfbfe8). Never terminal.
+- A `deferred` disposition AUTO-creates an open spillover item (and its Linear
+  issue) in BOTH findings systems (findings_writer + issue_findings, sp-5bcfbfe8).
 - The fable-discipline lint blocks deferral language written into CODE without a
-  capture (`# spillover-skip` acks an already-captured line).
+  capture (`# spillover-skip` acks an already-captured line). Only this blocks.
 - `gates run` fails while any item is open (the enforcement of last resort).
+- `spillover-linear-check.py` (daily launchd) retries failed Linear filings, alerts Sana once; never blocks.
 
 ## Reporting
 
@@ -49,3 +49,17 @@ the item, the issue that resolved it, the fix, and how it affected the system.
   no spillover item. "Out of scope" means a real issue deferred, not a non-issue.
 - Pure brainstorming / hypotheticals that are not a defect in real code or a real
   gap in shipped behavior.
+
+<!-- enforcement -->
+```json
+[
+  {
+    "clause": "No Orphan Findings",
+    "status": "ENFORCED",
+    "exec": "plugins/prd-os/skills/fable-discipline/scripts/fable-discipline-lint.py",
+    "config": "plugins/prd-os/hooks/hooks.json",
+    "test": "plugins/prd-os/skills/fable-discipline/scripts/test_fable_discipline_lint.py",
+    "note": "ENFORCED covers only the blocking slice: deferral language in code without a capture. Whether a finding is captured at all is a model decision no hook observes. DETECTED, not blocking: capture-time Linear filing in plugins/prd-os/scripts/prd_runner.py and the daily retry q-system/.q-system/scripts/spillover-linear-check.py, wired in automation/com.kipi.spillover-linear-check.plist, pinned by q-system/.q-system/tests/test_spillover_linear_check.py."
+  }
+]
+```

--- a/.claude/rules/no-orphan-findings.md
+++ b/.claude/rules/no-orphan-findings.md
@@ -12,7 +12,7 @@ capture, not a sentence:
 
 ```bash
 python3 plugins/prd-os/scripts/prd_runner.py spillover add \
-  --source <prd-or-issue-id> --desc "<what it is, concretely>"
+  --source <prd-or-issue-id> --severity <medium|high|major|blocker> --desc "<what it is, concretely>"
 ```
 
 Capture (medium and up) = a ledger row in `.prd-os/spillover.jsonl` AND one Linear issue for Sana

--- a/AUTONOMOUS-SYSTEMS.md
+++ b/AUTONOMOUS-SYSTEMS.md
@@ -24,6 +24,7 @@ launchd jobs are:
 | `com.kipi.fractional-cxo.bolt-on-discovery` | 07:00 | daily consulting-lead discovery |
 | `com.kipi.launchd-health` | 09:30, 21:30 | **watchdog** — Slack-ping on any silent job death |
 | `com.kipi.lessons-daily` | 06:00 | **auto-learn** — distill → publish → propagate → Slack |
+| `com.kipi.spillover-linear-check` | 08:10 | retry the Linear issue for new spillover rows (kipi-system, consulting, chief); one summary alert to Sana if any stay unlinked (ASK-1552) |
 
 Every job is auto-monitored by the watchdog and (for the ones we own) rebuildable from a committed
 installer, so the layer survives a lost `~/Library/LaunchAgents`.

--- a/automation/com.kipi.spillover-linear-check.plist
+++ b/automation/com.kipi.spillover-linear-check.plist
@@ -1,0 +1,41 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<!-- Spillover -> Linear daily check (ASK-1552).
+
+     Founder, 2026-09-12: "Backlog where? In linear or is it going to disappear".
+     Every new spillover row files one Linear issue at capture. This job is the
+     retry and the alarm: it re-files new rows whose link failed (20 per run) and
+     files ONE fingerprint-deduped summary for Sana when rows stay unlinked. Rows
+     from before the script's CREATED_AT_CUTOFF are the pre-existing backlog: it
+     prints their count and never bulk-files them.
+
+     WHY IT CANNOT GO QUIET. It exits non-zero when it cannot read a ledger or
+     cannot send its summary alert, and com.kipi.launchd-health reads every
+     com.kipi.* job's LastExitStatus, so a broken check becomes a ticket too.
+
+     Ledgers: this checkout plus its sibling consulting and chief checkouts. A
+     missing sibling prints "no repo" and is skipped, so the template stays
+     usable on a machine that has only kipi-system.
+
+     TEMPLATE, not a loadable plist: __KIPI_REPO__ and __HOME__ are materialized
+     by install-plist.sh like every sibling.
+
+     Install: bash q-system/.q-system/scripts/install-plist.sh com.kipi.spillover-linear-check -->
+<plist version="1.0">
+<dict>
+  <key>Label</key><string>com.kipi.spillover-linear-check</string>
+  <key>ProgramArguments</key>
+  <array>
+    <string>/bin/bash</string><string>-lc</string>
+    <!-- Login shell so the Linear API key and a modern python3 resolve the same
+         way they do for a human (ASK-718: a job running blind for 19 days). -->
+    <string>python3 __KIPI_REPO__/q-system/.q-system/scripts/spillover-linear-check.py __KIPI_REPO__ __KIPI_REPO__/../consulting __KIPI_REPO__/../chief</string>
+  </array>
+  <!-- Local 08:10: after the overnight review runs have captured their rows,
+       before the 09:30 launchd-health sweep reads this job's exit status. -->
+  <key>StartCalendarInterval</key><dict><key>Hour</key><integer>8</integer><key>Minute</key><integer>10</integer></dict>
+  <key>RunAtLoad</key><false/>
+  <key>StandardOutPath</key><string>__HOME__/.config/kipi/logs/spillover-linear-check.out.log</string>
+  <key>StandardErrorPath</key><string>__HOME__/.config/kipi/logs/spillover-linear-check.err.log</string>
+</dict>
+</plist>

--- a/plugins/kipi-core/.claude-plugin/plugin.json
+++ b/plugins/kipi-core/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "kipi-core",
-  "version": "1.12.5",
+  "version": "1.12.6",
   "description": "Core founder OS \u2014 voice, research, AUDHD, LinkedIn/brand, RCA skills + kipi-mcp server",
   "author": {
     "name": "Assaf Kipnis",

--- a/plugins/kipi-core/commands/linear-drain.md
+++ b/plugins/kipi-core/commands/linear-drain.md
@@ -88,5 +88,5 @@ pending. If anything real turned up that you are not fixing, capture it rather
 than mentioning it:
 
 ```bash
-python3 plugins/prd-os/scripts/prd_runner.py spillover add --source ASK-113 --desc "..."
+python3 plugins/prd-os/scripts/prd_runner.py spillover add --source ASK-113 --severity medium --desc "..."
 ```

--- a/plugins/kipi-dsse/.claude-plugin/plugin.json
+++ b/plugins/kipi-dsse/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "kipi-dsse",
-  "version": "0.14.5",
+  "version": "0.14.6",
   "description": "DSSE issue workflow: scope-enforced edits, per-finding dispositions, Codex review gates. Provides /issue-start, /issue-approve, /issue-verify, /issue-review, /issue-amend, /issue-closeout. Consumes issue specs created by prd-os or dropped in manually.",
   "author": {
     "name": "Assaf Kipnis"

--- a/plugins/kipi-dsse/.claude-plugin/plugin.json
+++ b/plugins/kipi-dsse/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "kipi-dsse",
-  "version": "0.14.6",
+  "version": "0.14.7",
   "description": "DSSE issue workflow: scope-enforced edits, per-finding dispositions, Codex review gates. Provides /issue-start, /issue-approve, /issue-verify, /issue-review, /issue-amend, /issue-closeout. Consumes issue specs created by prd-os or dropped in manually.",
   "author": {
     "name": "Assaf Kipnis"

--- a/plugins/kipi-dsse/scripts/issue_findings.py
+++ b/plugins/kipi-dsse/scripts/issue_findings.py
@@ -68,6 +68,9 @@ SOURCES = (
 )
 DISPOSITIONS = ("pending", "accepted", "rejected", "deferred")
 REQUIRES_RATIONALE = ("rejected", "deferred")
+REFUSED_DEFER_SEVERITIES = ("minor", "low", "nit")
+MINOR_REFUSAL = ("a minor is fixed in this change or rejected with a reason; "
+                 "it is never queued (founder 2026-09-12)")
 ID_RE = re.compile(r"^finding-([0-9]+)$")
 RECORD_FIELDS = (
     "id",
@@ -409,7 +412,6 @@ def _link_spillover(repo_root, ledger: Path, record: dict) -> None:
     except Exception as exc:  # noqa: BLE001
         sys.stderr.write(f"WARNING: spillover Linear filing failed ({exc!r}); the row "
                          "is recorded and spillover-linear-check.py retries it\n")
-        fh.flush()
 
 
 def cmd_set_disposition(args: argparse.Namespace) -> int:
@@ -430,6 +432,15 @@ def cmd_set_disposition(args: argparse.Namespace) -> int:
     target = None
     for rec in records:
         if rec.get("id") == args.finding_id:
+            # Founder 2026-09-12: "New minor findings: fix or reject, never
+            # queue." Refused before the findings file changes. Same tuple and
+            # message as prd_runner.py (this plugin does not import prd-os).
+            if (args.disposition == "deferred"
+                    and str(rec.get("severity") or "minor").strip().lower()
+                    in REFUSED_DEFER_SEVERITIES):
+                sys.stderr.write(f"refused: {MINOR_REFUSAL}. Accept and fix it, or "
+                                 "reject it with --rationale.\n")
+                return 2
             target = rec
             found = True
             old = rec.get("disposition")

--- a/plugins/kipi-dsse/scripts/issue_findings.py
+++ b/plugins/kipi-dsse/scripts/issue_findings.py
@@ -360,9 +360,55 @@ def _sync_spillover(repo_root, issue_id: str, finding: dict) -> None:
     else:
         return
 
+    _append_ledger(ledger, record)
+    if record.get("status") == "open":
+        _link_spillover(repo_root, ledger, record)
+
+
+def _append_ledger(ledger: Path, record: dict) -> None:
+    """This plugin's one ledger write path (append-only, last-write-wins)."""
     ledger.parent.mkdir(parents=True, exist_ok=True)
     with ledger.open("a") as fh:
         fh.write(json.dumps(record) + "\n")
+
+
+def _link_spillover(repo_root, ledger: Path, record: dict) -> None:
+    """File the new deferred row to Linear and append its link (ASK-1552).
+
+    why (founder, 2026-09-12): "Backlog where? In linear or is it going to
+    disappear". The row is already written; this only adds the link, so a
+    filer failure records `failed` + the exit code for the daily check
+    (spillover-linear-check.py) to retry and never loses the row. The filer is
+    the repo's q-system/.q-system/scripts/spillover-linear-check.py, loaded by
+    path so this plugin stays independent of prd-os at import time. Never raises.
+    """
+    import importlib.util
+    path = Path(repo_root) / "q-system" / ".q-system" / "scripts" / "spillover-linear-check.py"
+    if not path.is_file():
+        return  # no filer in this repo yet; the daily check files it later
+    try:
+        spec = importlib.util.spec_from_file_location("spillover_linear_check", path)
+        mod = importlib.util.module_from_spec(spec)
+        spec.loader.exec_module(mod)
+        link = mod.file_record(record, Path(repo_root))
+        # Re-read the CURRENT row so the linked copy never resurrects a state
+        # change made while the filer ran.
+        current = record
+        for raw in ledger.read_text().splitlines():
+            try:
+                rec = json.loads(raw)
+            except json.JSONDecodeError:
+                continue
+            if isinstance(rec, dict) and rec.get("id") == record["id"]:
+                current = rec
+        if current.get("status") != "open":
+            return
+        out = dict(current)
+        out["linear"] = link
+        _append_ledger(ledger, out)
+    except Exception as exc:  # noqa: BLE001
+        sys.stderr.write(f"WARNING: spillover Linear filing failed ({exc!r}); the row "
+                         "is recorded and spillover-linear-check.py retries it\n")
         fh.flush()
 
 

--- a/plugins/kipi-dsse/tests/test_deferred_spillover_files_linear.py
+++ b/plugins/kipi-dsse/tests/test_deferred_spillover_files_linear.py
@@ -1,0 +1,83 @@
+"""ASK-1552: a `deferred` disposition on the DSSE issue path files one Linear
+issue for the spillover row it creates, the same as `spillover add`.
+
+Founder, 2026-09-12: "Backlog where? In linear or is it going to disappear".
+The row is written first through this plugin's existing ledger append; the
+Linear link is appended after. Isolation: tmp repo, the real alert-to-linear.py
+copied into the production layout, KIPI_ALERT_CAPTURE set.
+"""
+from __future__ import annotations
+
+import json
+import os
+import shutil
+import subprocess
+import sys
+from pathlib import Path
+
+import pytest
+
+PLUGIN_ROOT = Path(__file__).resolve().parents[1]
+ISSUE_FINDINGS = PLUGIN_ROOT / "scripts" / "issue_findings.py"
+SKEL_SCRIPTS = PLUGIN_ROOT.parents[1] / "q-system" / ".q-system" / "scripts"
+ISSUE_ID = "c2w-linear"
+SID = f"defer-{ISSUE_ID}-finding-9"
+
+
+@pytest.fixture
+def repo(tmp_path: Path) -> Path:
+    r = tmp_path / "repo"
+    (r / "issues" / "findings").mkdir(parents=True)
+    (r / ".git").mkdir()
+    (r / "issues" / "findings" / f"{ISSUE_ID}-findings.jsonl").write_text(json.dumps({
+        "id": "finding-9", "issue_id": ISSUE_ID, "source": "codex-adversarial",
+        "severity": "major", "disposition": "pending",
+        "body": "exporter drops non-ascii slugs", "out_of_scope": False,
+        "affected_path": "q-consult/pipeline/exporters.py",
+        "created_at": "2026-09-12T00:00:00Z"}) + "\n")
+    dest = r / "q-system" / ".q-system" / "scripts"
+    dest.mkdir(parents=True)
+    for name in ("alert-to-linear.py", "spillover-linear-check.py"):
+        shutil.copy2(SKEL_SCRIPTS / name, dest / name)
+    return r
+
+
+def _defer(repo: Path, capture: Path) -> subprocess.CompletedProcess:
+    env = dict(os.environ, CLAUDE_PROJECT_DIR=str(repo), KIPI_ALERT_CAPTURE=str(capture))
+    return subprocess.run(
+        [sys.executable, str(ISSUE_FINDINGS), "set-disposition", ISSUE_ID, "finding-9",
+         "deferred", "--rationale", "later"],
+        capture_output=True, text=True, env=env, cwd=str(repo), timeout=120)
+
+
+def _ledger(repo: Path) -> dict:
+    items: dict = {}
+    for raw in (repo / ".prd-os" / "spillover.jsonl").read_text().splitlines():
+        if raw.strip():
+            rec = json.loads(raw)
+            items[rec["id"]] = rec
+    return items
+
+
+def test_dsse_deferred_files_exactly_one_issue_and_links_the_row(repo, tmp_path):
+    cap = tmp_path / "capture.txt"
+    out = _defer(repo, cap)
+    assert out.returncode == 0, out.stderr
+    lines = cap.read_text().splitlines() if cap.exists() else []
+    assert len(lines) == 1 and SID in lines[0], lines
+    rec = _ledger(repo)[SID]
+    assert rec["status"] == "open" and rec["linear"]["state"] == "captured"
+
+    # A second defer is idempotent: no second row, no second issue.
+    assert _defer(repo, cap).returncode == 0
+    assert len(cap.read_text().splitlines()) == 1
+
+
+def test_dsse_filer_failure_keeps_the_row(repo, tmp_path):
+    cap = tmp_path / "capture-dir"
+    cap.mkdir()
+    out = _defer(repo, cap)
+    assert out.returncode == 0, out.stderr
+    rec = _ledger(repo)[SID]
+    assert rec["status"] == "open"
+    assert rec["linear"]["state"] == "failed" and rec["linear"]["exit"] == 1

--- a/plugins/kipi-dsse/tests/test_deferred_spillover_files_linear.py
+++ b/plugins/kipi-dsse/tests/test_deferred_spillover_files_linear.py
@@ -81,3 +81,20 @@ def test_dsse_filer_failure_keeps_the_row(repo, tmp_path):
     rec = _ledger(repo)[SID]
     assert rec["status"] == "open"
     assert rec["linear"]["state"] == "failed" and rec["linear"]["exit"] == 1
+
+
+@pytest.mark.parametrize("severity", ["minor", "low"])
+def test_dsse_deferring_a_minor_is_refused(repo, tmp_path, severity):
+    """Founder 2026-09-12: "New minor findings: fix or reject, never queue"."""
+    fpath = repo / "issues" / "findings" / f"{ISSUE_ID}-findings.jsonl"
+    rec = json.loads(fpath.read_text().splitlines()[0])
+    rec["severity"] = severity
+    fpath.write_text(json.dumps(rec) + "\n")
+    cap = tmp_path / "capture.txt"
+    out = _defer(repo, cap)
+    assert out.returncode == 2, out.stdout + out.stderr
+    assert ("a minor is fixed in this change or rejected with a reason; "
+            "it is never queued (founder 2026-09-12)") in out.stderr
+    assert json.loads(fpath.read_text().splitlines()[0])["disposition"] == "pending"
+    assert not (repo / ".prd-os" / "spillover.jsonl").exists()
+    assert not cap.exists()

--- a/plugins/prd-os/.claude-plugin/plugin.json
+++ b/plugins/prd-os/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "prd-os",
-  "version": "0.30.4",
+  "version": "0.30.5",
   "description": "PRD operating system: capture rough ideas, draft reviewable PRDs, run standard and adversarial review (Codex or a Claude senior-staff-engineer subagent, recorded truthfully), triage findings, decompose approved PRDs into atomic issue specs, and execute those issues with scope enforcement, stop-gate receipts, and reviewer-attributed findings.",
   "author": {
     "name": "Assaf Kipnis"

--- a/plugins/prd-os/.claude-plugin/plugin.json
+++ b/plugins/prd-os/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "prd-os",
-  "version": "0.30.5",
+  "version": "0.30.6",
   "description": "PRD operating system: capture rough ideas, draft reviewable PRDs, run standard and adversarial review (Codex or a Claude senior-staff-engineer subagent, recorded truthfully), triage findings, decompose approved PRDs into atomic issue specs, and execute those issues with scope enforcement, stop-gate receipts, and reviewer-attributed findings.",
   "author": {
     "name": "Assaf Kipnis"

--- a/plugins/prd-os/.claude-plugin/plugin.json
+++ b/plugins/prd-os/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "prd-os",
-  "version": "0.30.6",
+  "version": "0.30.7",
   "description": "PRD operating system: capture rough ideas, draft reviewable PRDs, run standard and adversarial review (Codex or a Claude senior-staff-engineer subagent, recorded truthfully), triage findings, decompose approved PRDs into atomic issue specs, and execute those issues with scope enforcement, stop-gate receipts, and reviewer-attributed findings.",
   "author": {
     "name": "Assaf Kipnis"

--- a/plugins/prd-os/.claude-plugin/plugin.json
+++ b/plugins/prd-os/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "prd-os",
-  "version": "0.30.7",
+  "version": "0.30.8",
   "description": "PRD operating system: capture rough ideas, draft reviewable PRDs, run standard and adversarial review (Codex or a Claude senior-staff-engineer subagent, recorded truthfully), triage findings, decompose approved PRDs into atomic issue specs, and execute those issues with scope enforcement, stop-gate receipts, and reviewer-attributed findings.",
   "author": {
     "name": "Assaf Kipnis"

--- a/plugins/prd-os/scripts/findings_writer.py
+++ b/plugins/prd-os/scripts/findings_writer.py
@@ -556,6 +556,16 @@ def cmd_set_disposition(cfg: Config, args: argparse.Namespace) -> int:  # noqa: 
         if target is None:
             sys.stderr.write(f"finding not found: {args.finding_id}\n")
             return 2
+        # Founder 2026-09-12: "New minor findings: fix or reject, never queue."
+        # Refused BEFORE the findings file changes; a missing severity is the
+        # `minor` default the spillover mirror would have stamped.
+        from prd_runner import MINOR_REFUSAL, SPILLOVER_REFUSED_SEVERITIES
+        if (args.disposition == "deferred"
+                and str(target.get("severity") or "minor").strip().lower()
+                in SPILLOVER_REFUSED_SEVERITIES):
+            sys.stderr.write(f"refused: {MINOR_REFUSAL}. Accept and fix it, or "
+                             "reject it with --rationale.\n")
+            return 2
         target["disposition"] = args.disposition
         if getattr(args, "covered_by", "") and args.covered_by.strip():
             # umbrella coverage: this finding is owned by a phase PRD

--- a/plugins/prd-os/scripts/findings_writer.py
+++ b/plugins/prd-os/scripts/findings_writer.py
@@ -459,19 +459,24 @@ def _sync_spillover_for_finding(cfg: Config, prd_id: str, finding: dict) -> None
     issue; moving the finding off `deferred` clears the item. Reuses
     prd_runner's ledger helpers so there is one definition of the format.
     Scar: `deferred` used to be a silent drop -- a rationale and then gone."""
-    from prd_runner import _read_spillover, _spillover_append  # sibling script
+    from prd_runner import (_read_spillover, _spillover_append,  # sibling script
+                            _spillover_file_and_link)
 
     sid = f"defer-{prd_id}-{finding['id']}"
     existing = _read_spillover(cfg).get(sid)
     if finding.get("disposition") == "deferred":
         if existing and existing.get("status") == "open":
             return  # idempotent: already tracked open
-        _spillover_append(cfg, {
+        record = {
             "id": sid, "source": prd_id, "finding_id": finding["id"],
             "description": f"deferred finding {finding['id']}: {str(finding.get('body', ''))[:120]}",
             "severity": finding.get("severity", "minor"),
             "status": "open", "created_at": _now_iso(),
-        })
+        }
+        _spillover_append(cfg, record)
+        # ASK-1552: the row first, then its Linear issue. A filer failure is
+        # recorded on the row for spillover-linear-check.py to retry.
+        _spillover_file_and_link(cfg, record)
     elif existing and existing.get("status") == "open":
         new = dict(existing)
         new.update(status="resolved",

--- a/plugins/prd-os/scripts/prd_runner.py
+++ b/plugins/prd-os/scripts/prd_runner.py
@@ -2424,6 +2424,9 @@ def cmd_spillover(cfg: Config, args) -> int:
     if sub == "ack":
         return _spillover_ack(cfg, args)
     if sub == "add":
+        if (args.severity or "minor").strip().lower() in SPILLOVER_REFUSED_SEVERITIES:
+            sys.stderr.write(f"refused: {MINOR_REFUSAL}\n")
+            return 2
         sid = args.id or f"sp-{_hashlib.sha256((args.source + args.desc).encode()).hexdigest()[:8]}"
         dor = _spillover_read_dor(args)
         blocking = args.severity in SPILLOVER_BLOCKING_SEVERITIES
@@ -2740,6 +2743,18 @@ SPILLOVER_BLOCKING_SEVERITIES = ("blocker", "major", "high")
 # louder the label the quieter the gate got. Fail-closed here and validate at the
 # CLI: an unknown severity is a triage failure, never a silent pass (ASK-402).
 SPILLOVER_NONBLOCKING_SEVERITIES = ("minor", "low", "medium")
+
+# NEW MINORS ARE NEVER QUEUED. Founder, 2026-09-12, verbatim: "New minor findings:
+# fix or reject, never queue." Recorded in canonical/decisions.md as
+# DEC-2026-09-12 [CLAUDE-RECOMMENDED -> APPROVED]. A minor is fixed in the change
+# that found it or rejected with a reason; `spillover add` and a `deferred`
+# disposition both refuse it at the door, so the ledger only receives work that
+# files a Linear issue for Sana (medium and up). kipi-dsse's issue_findings.py
+# carries the same tuple and message: that plugin stays import-independent of
+# prd-os, and test_spillover_files_linear.py pins the two copies equal.
+SPILLOVER_REFUSED_SEVERITIES = ("minor", "low", "nit")
+MINOR_REFUSAL = ("a minor is fixed in this change or rejected with a reason; "
+                 "it is never queued (founder 2026-09-12)")
 
 # RULE-2026-08-24-B [USER-DIRECTED 2026-08-24]: "Everything should be owned
 # by Sana." One constant so the default cannot drift between the add door,

--- a/plugins/prd-os/scripts/prd_runner.py
+++ b/plugins/prd-os/scripts/prd_runner.py
@@ -1508,6 +1508,27 @@ def _spillover_record_link(cfg: Config, sid: str, link: dict) -> bool:
     return True
 
 
+def _spillover_record_close(cfg: Config, sid: str, close: dict) -> bool:
+    """Record that a resolved row's capture ticket was closed (review F2, PR #344).
+
+    Same chokepoint shape as `_spillover_record_link`: under the lock, re-read the
+    CURRENT row and append a full copy. Only a row that is still `resolved` and
+    still carries a capture link is touched, so a reopen in between is never
+    overwritten with a stale resolved copy.
+    """
+    with _spillover_lock(cfg):
+        current = _read_spillover(cfg).get(sid)
+        if current is None or current.get("status") != "resolved":
+            return False
+        link = current.get("linear")
+        if not isinstance(link, dict) or link.get("closed_at"):
+            return False
+        out = dict(current)
+        out["linear"] = {**link, **close}
+        _spillover_append(cfg, out)
+    return True
+
+
 def _spillover_file_and_link(cfg: Config, record: dict) -> dict | None:
     """File one new row to Linear, then record the link. Never raises.
 
@@ -2425,7 +2446,9 @@ def cmd_spillover(cfg: Config, args) -> int:
         return _spillover_ack(cfg, args)
     if sub == "add":
         if (args.severity or "minor").strip().lower() in SPILLOVER_REFUSED_SEVERITIES:
-            sys.stderr.write(f"refused: {MINOR_REFUSAL}\n")
+            sys.stderr.write(f"refused: {MINOR_REFUSAL}\n"
+                             "A real finding at medium or above: pass --severity "
+                             "medium|high|major|blocker.\n")
             return 2
         sid = args.id or f"sp-{_hashlib.sha256((args.source + args.desc).encode()).hexdigest()[:8]}"
         dor = _spillover_read_dor(args)
@@ -2496,8 +2519,10 @@ def cmd_spillover(cfg: Config, args) -> int:
         elif blocking:
             out["promotion"] = {
                 "status": "needs_dor", "owner": "sana",
-                "note": ("blocking severity with no DoR: no Linear issue was created. "
-                         "Drain with `prd_runner.py spillover needs-dor`."),
+                "note": ("blocking severity with no DoR: not promoted, so the worker "
+                         "cannot pick it up yet (the capture ticket in `linear` is for "
+                         "visibility; promotion adopts it). Drain with "
+                         "`prd_runner.py spillover needs-dor`."),
             }
         # ASK-1552: capture = ledger row + Linear issue. After promotion, so a
         # row spillover-promote.py already filed (status promoted, no longer

--- a/plugins/prd-os/scripts/prd_runner.py
+++ b/plugins/prd-os/scripts/prd_runner.py
@@ -2746,7 +2746,7 @@ SPILLOVER_NONBLOCKING_SEVERITIES = ("minor", "low", "medium")
 
 # NEW MINORS ARE NEVER QUEUED. Founder, 2026-09-12, verbatim: "New minor findings:
 # fix or reject, never queue." Recorded in canonical/decisions.md as
-# DEC-2026-09-12 [CLAUDE-RECOMMENDED -> APPROVED]. A minor is fixed in the change
+# RULE-2026-09-12-A [CLAUDE-RECOMMENDED -> APPROVED]. A minor is fixed in the change
 # that found it or rejected with a reason; `spillover add` and a `deferred`
 # disposition both refuse it at the door, so the ledger only receives work that
 # files a Linear issue for Sana (medium and up). kipi-dsse's issue_findings.py

--- a/plugins/prd-os/scripts/prd_runner.py
+++ b/plugins/prd-os/scripts/prd_runner.py
@@ -40,6 +40,7 @@ from __future__ import annotations
 import argparse
 import contextlib
 import fcntl
+import importlib.util
 import json
 import shutil
 import subprocess
@@ -1464,6 +1465,73 @@ def _spillover_append(cfg: Config, record: dict) -> None:
         fh.flush()
 
 
+def _spillover_linear_filer(cfg: Config):
+    """The shared capture-time filer (ASK-1552), or None when absent.
+
+    Loaded from the repo's q-system/.q-system/scripts/spillover-linear-check.py,
+    the same place `_spillover_autopromote` finds its promoter. One definition of
+    the Linear message and of how alert-to-linear's answer is read, shared with
+    kipi-dsse's deferred path and the daily check.
+    """
+    path = Path(cfg.repo_root) / "q-system" / ".q-system" / "scripts" / "spillover-linear-check.py"
+    if not path.is_file():
+        return None
+    try:
+        spec = importlib.util.spec_from_file_location("spillover_linear_check", path)
+        mod = importlib.util.module_from_spec(spec)
+        spec.loader.exec_module(mod)
+        return mod
+    except Exception:  # noqa: BLE001
+        return None
+
+
+def _spillover_record_link(cfg: Config, sid: str, link: dict) -> bool:
+    """Append the row's Linear link through the ledger's one write path.
+
+    Under the lock, re-read the CURRENT row and append a full copy with `linear`
+    set -- never a patch, and never a copy formed before the lock (the resurrect
+    race `_spillover_lock` documents). A row that is no longer open is left
+    alone, and a link that already names an issue is never downgraded by a later
+    failed retry.
+    """
+    with _spillover_lock(cfg):
+        current = _read_spillover(cfg).get(sid)
+        if current is None or current.get("status") != "open":
+            return False
+        prior = current.get("linear")
+        if (isinstance(prior, dict) and prior.get("state") in ("filed", "captured")
+                and link.get("state") not in ("filed", "captured")):
+            return False
+        out = dict(current)
+        out["linear"] = link
+        _spillover_append(cfg, out)
+    return True
+
+
+def _spillover_file_and_link(cfg: Config, record: dict) -> dict | None:
+    """File one new row to Linear, then record the link. Never raises.
+
+    why (founder, 2026-09-12): "Backlog where? In linear or is it going to
+    disappear". The ledger is untracked in git, so a row that exists only there
+    is invisible to Sana's queue. The ROW IS ALREADY WRITTEN before this runs:
+    a filer failure records `failed` + the exit code for the daily check
+    (spillover-linear-check.py) to retry, and can never lose the finding.
+    Returns the link, or None when no filer exists in this repo (the daily
+    check files it once the repo has one).
+    """
+    try:
+        filer = _spillover_linear_filer(cfg)
+        if filer is None:
+            return None
+        link = filer.file_record(record, Path(cfg.repo_root))
+        _spillover_record_link(cfg, record["id"], link)
+        return link
+    except Exception as exc:  # noqa: BLE001
+        sys.stderr.write(f"WARNING: spillover Linear filing failed ({exc!r}); the row "
+                         "is recorded and spillover-linear-check.py retries it\n")
+        return None
+
+
 def _issue_is_closed(cfg: Config, issue_id: str) -> bool:
     """A spillover item may only resolve against an issue that actually closed.
     The deterministic signal is the issue spec's frontmatter `status: closed`,
@@ -2403,6 +2471,14 @@ def cmd_spillover(cfg: Config, args) -> int:
         # this whole mechanism was built to stop, committed inside it.
         if dor:
             record["dor"] = dor
+        # Re-adding a row that is already open and linked carries its link
+        # forward, so a repeated `add` never files a second Linear issue.
+        prior = _read_spillover(cfg).get(sid) or {}
+        prior_link = prior.get("linear")
+        already_linked = (prior.get("status") == "open" and isinstance(prior_link, dict)
+                          and prior_link.get("state") in ("filed", "captured"))
+        if already_linked:
+            record["linear"] = prior_link
         _spillover_append(cfg, record)
         out = {"id": sid, "status": "open"}
         if dor and not getattr(args, "no_promote", False):
@@ -2420,6 +2496,15 @@ def cmd_spillover(cfg: Config, args) -> int:
                 "note": ("blocking severity with no DoR: no Linear issue was created. "
                          "Drain with `prd_runner.py spillover needs-dor`."),
             }
+        # ASK-1552: capture = ledger row + Linear issue. After promotion, so a
+        # row spillover-promote.py already filed (status promoted, no longer
+        # open) is not filed a second time; `_spillover_record_link` skips it.
+        if already_linked:
+            out["linear"] = prior_link
+        elif (_read_spillover(cfg).get(sid) or {}).get("status") == "open":
+            link = _spillover_file_and_link(cfg, record)
+            if link is not None:
+                out["linear"] = link
         print(json.dumps(out))
         return 0
     if sub == "needs-dor":
@@ -2430,7 +2515,7 @@ def cmd_spillover(cfg: Config, args) -> int:
         pending = [r for r in rows
                    if r.get("status") == "open"
                    and r.get("severity") in SPILLOVER_BLOCKING_SEVERITIES
-                   and not r.get("linear")]
+                   and not _promotion_linear(r)]
         for r in pending:
             print(f"{r['id']} [{r.get('severity')}] src={r.get('source')}")
             print(f"    {(r.get('description') or '')[:200]}")
@@ -2792,8 +2877,22 @@ def _spillover_has_tracker_ref(record):
     audit reads. Both count -- keying on one would silently un-address every item
     filed through the other door.
     """
-    return bool(str(record.get("linear") or "").strip()
+    return bool(_promotion_linear(record)
                 or str(record.get("linear_ref") or "").strip())
+
+
+def _promotion_linear(record) -> str:
+    """The string `linear` a promotion wrote, or "".
+
+    ASK-1552 made `linear` a DICT on every new row: the capture-time alert
+    ticket (`_spillover_file_and_link`). That ticket makes the row VISIBLE to
+    Sana; it is not the promotion receipt above. `str(dict)` is truthy, so
+    without this every new blocking row would have minted its own address by
+    default -- the "check its own default satisfies" the comment above refuses.
+    Gate semantics stay exactly as they were before capture filing existed.
+    """
+    value = record.get("linear")
+    return value.strip() if isinstance(value, str) else ""
 
 
 

--- a/plugins/prd-os/skills/prd-os/SKILL.md
+++ b/plugins/prd-os/skills/prd-os/SKILL.md
@@ -47,8 +47,9 @@ Ledger CLI (no slash command; run through `kipi judgment <subcommand>`): the Jud
 An issue found mid-work that is out of scope must be CAPTURED, not mentioned. The
 ledger is `.prd-os/spillover.jsonl`; the standing gate enforces it.
 
-- Capture: `prd_runner.py spillover add --source <id> --desc "..."` (a `deferred`
-  triage disposition does this automatically; `rejected` does not).
+- Capture: `prd_runner.py spillover add --source <id> --severity <medium|high|major|blocker> --desc "..."`
+  (a `deferred` triage disposition does this automatically; `rejected` does not). A new
+  minor/low/nit is refused (exit 2): fix it now or reject it with a reason.
 - Gate: `prd_runner.py gates run` FAILS while any item is `open` — the same
   no-bypass re-proof as the registered gates. Forgetting an item = a red gate.
 - Resolve: `spillover resolve <id> --resolution-ref <closed-issue-id>` (refuses

--- a/plugins/prd-os/tests/legacy_spillover.py
+++ b/plugins/prd-os/tests/legacy_spillover.py
@@ -1,0 +1,46 @@
+"""Seed a PRE-2026-09-12 minor spillover row, the shape `spillover add` wrote.
+
+Founder, 2026-09-12: "New minor findings: fix or reject, never queue." Since
+then `spillover add` refuses minor and low (test_spillover_files_linear.py pins
+the refusal). The rows it wrote before that still exist in every live ledger
+(kipi-system 1,318 open, consulting 529, chief 3, measured 2026-09-12), and the
+gate, triage, resolve and reclassify behaviour for them is still load-bearing.
+Suites that model those rows seed them here, field for field as the old `add`
+wrote them, instead of through a CLI that now correctly refuses them.
+"""
+from __future__ import annotations
+
+import hashlib
+import json
+import subprocess
+from datetime import datetime, timezone
+from pathlib import Path
+
+LEGACY_SEVERITIES = ("minor", "low")
+
+
+def _flag(args: tuple, name: str):
+    return args[args.index(name) + 1] if name in args else None
+
+
+def is_legacy_minor_add(args: tuple) -> bool:
+    return (len(args) >= 2 and args[0] == "spillover" and args[1] == "add"
+            and (_flag(args, "--severity") or "minor").strip().lower() in LEGACY_SEVERITIES)
+
+
+def seed_legacy_add(repo: Path, args: tuple) -> subprocess.CompletedProcess:
+    """Write the row the pre-2026-09-12 `spillover add <args>` wrote; mimic its stdout."""
+    source, desc = _flag(args, "--source"), _flag(args, "--desc")
+    sid = _flag(args, "--id") or f"sp-{hashlib.sha256((source + desc).encode()).hexdigest()[:8]}"
+    rec = {"id": sid, "source": source, "description": desc,
+           "severity": (_flag(args, "--severity") or "minor").strip().lower(),
+           "status": "open",
+           "created_at": datetime.now(timezone.utc).strftime("%Y-%m-%dT%H:%M:%SZ"),
+           "owner": _flag(args, "--owner") or "sana"}
+    ledger = Path(repo) / ".prd-os" / "spillover.jsonl"
+    ledger.parent.mkdir(parents=True, exist_ok=True)
+    with ledger.open("a") as fh:
+        fh.write(json.dumps(rec) + "\n")
+    return subprocess.CompletedProcess(list(args), 0,
+                                       stdout=json.dumps({"id": sid, "status": "open"}) + "\n",
+                                       stderr="")

--- a/plugins/prd-os/tests/test_prd_runner.py
+++ b/plugins/prd-os/tests/test_prd_runner.py
@@ -340,7 +340,8 @@ def test_approve_allowed_when_all_dispositioned(fake_repo, write_config, run_prd
                 "prd_id": prd_id,
                 "source": "manual",
                 "severity": "nit",
-                "disposition": "deferred",
+                # rejected, not deferred: a nit may not be queued (founder 2026-09-12)
+                "disposition": "rejected",
                 "rationale": "later",
                 "body": "tweak wording",
                 "created_at": "2026-04-16T00:00:00Z",
@@ -349,7 +350,7 @@ def test_approve_allowed_when_all_dispositioned(fake_repo, write_config, run_prd
     )
     _capture_receipts(run_findings_writer, fake_repo, prd_id,
                       [("finding-1", "accepted", None),
-                       ("finding-2", "deferred", "later")])
+                       ("finding-2", "rejected", "later")])
     r = run_prd_runner(fake_repo, "advance", "approved")
     assert r.returncode == 0, r.stderr
 

--- a/plugins/prd-os/tests/test_spillover.py
+++ b/plugins/prd-os/tests/test_spillover.py
@@ -19,11 +19,22 @@ from pathlib import Path
 
 import pytest
 
+sys.path.insert(0, str(Path(__file__).resolve().parent))
+from legacy_spillover import is_legacy_minor_add, seed_legacy_add  # noqa: E402
+
 PLUGIN_ROOT = Path(__file__).resolve().parents[1]
 PRD_RUNNER = PLUGIN_ROOT / "scripts" / "prd_runner.py"
 
 
 def run(repo: Path, *args: str) -> subprocess.CompletedProcess:
+    # A minor `add` seeds a pre-2026-09-12 row: the CLI now refuses new minors
+    # (founder 2026-09-12), and those legacy rows are what this suite models.
+    if is_legacy_minor_add(args):
+        return seed_legacy_add(repo, args)
+    return _run_cli(repo, *args)
+
+
+def _run_cli(repo: Path, *args: str) -> subprocess.CompletedProcess:
     return subprocess.run(
         [sys.executable, str(PRD_RUNNER), "--repo-root", str(repo), *args],
         capture_output=True, text=True,
@@ -74,7 +85,8 @@ def _write_issue(repo: Path, issue_id: str, status: str) -> None:
 
 
 def test_add_appends_open_item(repo):
-    r = run(repo, "spillover", "add", "--source", "prd-x", "--desc", "obsidian export skips archived", "--id", "sp1")
+    r = run(repo, "spillover", "add", "--source", "prd-x", "--desc", "obsidian export skips archived", "--id", "sp1",
+            "--severity", "medium")
     assert r.returncode == 0, r.stderr
     lines = _ledger(repo).read_text().splitlines()
     assert len(lines) == 1
@@ -83,8 +95,8 @@ def test_add_appends_open_item(repo):
 
 
 def test_add_is_idempotent_by_id(repo):
-    run(repo, "spillover", "add", "--source", "s", "--desc", "d", "--id", "sp1")
-    run(repo, "spillover", "add", "--source", "s", "--desc", "d", "--id", "sp1")
+    run(repo, "spillover", "add", "--source", "s", "--desc", "d", "--id", "sp1", "--severity", "medium")
+    run(repo, "spillover", "add", "--source", "s", "--desc", "d", "--id", "sp1", "--severity", "medium")
     # last-write-wins read collapses to one effective item, still open
     r = run(repo, "spillover", "list", "--json")
     items = json.loads(r.stdout)

--- a/plugins/prd-os/tests/test_spillover_autopromote.py
+++ b/plugins/prd-os/tests/test_spillover_autopromote.py
@@ -37,15 +37,16 @@ def _init(tmp_path):
     return tmp_path
 
 
-def test_a_minor_note_needs_no_dor_and_files_no_issue(tmp_path):
-    """Notes stay cheap. Demanding a DoR for every passing observation is how a
-    ledger stops being written to at all."""
+def test_a_minor_is_refused_and_files_no_issue(tmp_path):
+    """Superseded 2026-09-12. This used to pin "minor notes stay cheap". Founder,
+    that day: "New minor findings: fix or reject, never queue." A minor is now
+    refused at the door, so it can neither sit in the ledger nor file an issue."""
     repo = _init(tmp_path)
     res = _add(repo, severity="minor")
-    assert res.returncode == 0, res.stderr
-    out = json.loads(res.stdout.strip().splitlines()[-1])
-    assert out["status"] == "open"
-    assert "promotion" not in out
+    assert res.returncode == 2, res.stdout + res.stderr
+    assert "it is never queued (founder 2026-09-12)" in res.stderr
+    assert not (repo / ".prd-os" / "spillover.jsonl").exists() or \
+        (repo / ".prd-os" / "spillover.jsonl").read_text().strip() == ""
 
 
 def test_a_blocking_item_without_a_dor_is_handed_to_sana_not_refused(tmp_path):

--- a/plugins/prd-os/tests/test_spillover_combined_rule.py
+++ b/plugins/prd-os/tests/test_spillover_combined_rule.py
@@ -36,11 +36,22 @@ from pathlib import Path
 
 import pytest
 
+sys.path.insert(0, str(Path(__file__).resolve().parent))
+from legacy_spillover import is_legacy_minor_add, seed_legacy_add  # noqa: E402
+
 PLUGIN_ROOT = Path(__file__).resolve().parents[1]
 PRD_RUNNER = PLUGIN_ROOT / "scripts" / "prd_runner.py"
 
 
 def run(repo: Path, *args: str) -> subprocess.CompletedProcess:
+    # A minor `add` seeds a pre-2026-09-12 row: the CLI now refuses new minors
+    # (founder 2026-09-12), and those legacy rows are what this suite models.
+    if is_legacy_minor_add(args):
+        return seed_legacy_add(repo, args)
+    return _run_cli(repo, *args)
+
+
+def _run_cli(repo: Path, *args: str) -> subprocess.CompletedProcess:
     return subprocess.run(
         [sys.executable, str(PRD_RUNNER), "--repo-root", str(repo), *args],
         capture_output=True, text=True,

--- a/plugins/prd-os/tests/test_spillover_files_linear.py
+++ b/plugins/prd-os/tests/test_spillover_files_linear.py
@@ -203,3 +203,19 @@ def test_the_two_plugin_copies_of_the_minor_rule_agree():
     spec.loader.exec_module(dsse)
     assert dsse.REFUSED_DEFER_SEVERITIES == prd_runner.SPILLOVER_REFUSED_SEVERITIES
     assert dsse.MINOR_REFUSAL == prd_runner.MINOR_REFUSAL == REFUSAL
+
+
+def test_refusal_points_a_real_finding_at_severity(repo, tmp_path):
+    """Review F4: the documented bare `add` defaults to minor and is refused; the
+    refusal must tell an agent holding a real finding what to pass."""
+    res = _add(repo, tmp_path / "c.txt", severity="minor")
+    assert "--severity" in res.stderr
+
+
+def test_add_output_does_not_deny_the_capture_ticket(repo, tmp_path):
+    """Review F6: a blocking row with no DoR used to say "no Linear issue was
+    created" in the same JSON that carried the capture link."""
+    res = _add(repo, tmp_path / "c.txt", severity="major")
+    out = json.loads(res.stdout.strip().splitlines()[-1])
+    assert out["linear"]["state"] == "captured"
+    assert "no Linear issue was created" not in res.stdout

--- a/plugins/prd-os/tests/test_spillover_files_linear.py
+++ b/plugins/prd-os/tests/test_spillover_files_linear.py
@@ -1,0 +1,136 @@
+"""ASK-1552: a new spillover row files one Linear issue at capture.
+
+Founder, 2026-09-12: "Backlog where? In linear or is it going to disappear".
+The ledger is untracked in git and nothing carried it to Linear, so capture now
+means a ledger row AND a Linear issue through alert-to-linear.py.
+
+Isolation: tmp repos, and the filer is the real alert-to-linear.py copied into
+the tmp repo's q-system/.q-system/scripts/ (the production layout) with
+KIPI_ALERT_CAPTURE set, so nothing reaches Linear.
+"""
+from __future__ import annotations
+
+import json
+import os
+import shutil
+import subprocess
+import sys
+from pathlib import Path
+
+import pytest
+
+PLUGIN_ROOT = Path(__file__).resolve().parents[1]
+PRD_RUNNER = PLUGIN_ROOT / "scripts" / "prd_runner.py"
+FINDINGS_WRITER = PLUGIN_ROOT / "scripts" / "findings_writer.py"
+SKEL_SCRIPTS = PLUGIN_ROOT.parents[1] / "q-system" / ".q-system" / "scripts"
+PRD_ID = "prd-demo-2026-09-12"
+
+
+@pytest.fixture
+def repo(tmp_path: Path) -> Path:
+    r = tmp_path / "repo"
+    (r / ".prd-os").mkdir(parents=True)
+    (r / ".git").mkdir()
+    (r / ".prd-os" / "config.json").write_text(json.dumps({
+        "config_schema_version": 1,
+        "prds_dir": ".prd-os/prds",
+        "issues_dir": ".prd-os/issues",
+        "findings_dir": ".prd-os/findings",
+        "state_dir": ".claude/state",
+    }))
+    dest = r / "q-system" / ".q-system" / "scripts"
+    dest.mkdir(parents=True)
+    for name in ("alert-to-linear.py", "spillover-linear-check.py"):
+        shutil.copy2(SKEL_SCRIPTS / name, dest / name)
+    return r
+
+
+def _run(script: Path, repo: Path, capture: Path, *args: str) -> subprocess.CompletedProcess:
+    env = dict(os.environ, KIPI_ALERT_CAPTURE=str(capture))
+    return subprocess.run([sys.executable, str(script), "--repo-root", str(repo), *args],
+                          capture_output=True, text=True, env=env, timeout=120)
+
+
+def _ledger(repo: Path) -> dict:
+    items: dict = {}
+    path = repo / ".prd-os" / "spillover.jsonl"
+    if path.exists():
+        for raw in path.read_text().splitlines():
+            if raw.strip():
+                rec = json.loads(raw)
+                items[rec["id"]] = rec
+    return items
+
+
+def _captured(capture: Path) -> list:
+    return capture.read_text().splitlines() if capture.exists() else []
+
+
+def _add(repo: Path, capture: Path, *extra: str) -> subprocess.CompletedProcess:
+    return _run(PRD_RUNNER, repo, capture, "spillover", "add", "--source", "ASK-1552",
+                "--desc", "ledger rows never reach Linear", "--id", "sp-cap00001", *extra)
+
+
+def test_add_files_exactly_one_issue_and_row_carries_the_link(repo, tmp_path):
+    cap = tmp_path / "capture.txt"
+    res = _add(repo, cap)
+    assert res.returncode == 0, res.stderr
+    lines = _captured(cap)
+    assert len(lines) == 1, lines
+    assert "sp-cap00001" in lines[0] and "ASK-1552" in lines[0]
+    assert "minor" in lines[0] and "ledger rows never reach Linear" in lines[0]
+    rec = _ledger(repo)["sp-cap00001"]
+    assert rec["status"] == "open"
+    assert rec["linear"]["state"] == "captured" and rec["linear"]["exit"] == 0
+    assert json.loads(res.stdout.strip().splitlines()[-1])["linear"]["state"] == "captured"
+
+
+def test_add_rerun_does_not_file_a_second_issue(repo, tmp_path):
+    cap = tmp_path / "capture.txt"
+    assert _add(repo, cap).returncode == 0
+    assert _add(repo, cap).returncode == 0
+    assert len(_captured(cap)) == 1, "re-adding the same open row filed twice"
+    assert _ledger(repo)["sp-cap00001"]["linear"]["state"] == "captured"
+
+
+def test_filer_failure_keeps_the_row_and_marks_it_for_retry(repo, tmp_path):
+    cap = tmp_path / "capture-dir"
+    cap.mkdir()  # alert-to-linear cannot append to a directory: exit 1
+    res = _add(repo, cap)
+    assert res.returncode == 0, res.stderr   # capture never fails on the filer
+    rec = _ledger(repo)["sp-cap00001"]
+    assert rec["status"] == "open" and rec["description"] == "ledger rows never reach Linear"
+    assert rec["linear"]["state"] == "failed" and rec["linear"]["exit"] == 1
+
+
+def test_deferred_disposition_files_exactly_one_issue(repo, tmp_path):
+    d = repo / ".prd-os" / "findings"
+    d.mkdir(parents=True)
+    (d / f"{PRD_ID}-findings.jsonl").write_text(json.dumps({
+        "id": "finding-1", "prd_id": PRD_ID, "source": "codex-review",
+        "severity": "major", "disposition": "pending",
+        "body": "export reads canonical without archive filter",
+        "created_at": "2026-09-12T00:00:00Z"}) + "\n")
+    cap = tmp_path / "capture.txt"
+    res = _run(FINDINGS_WRITER, repo, cap, "set-disposition", PRD_ID, "finding-1",
+               "deferred", "--rationale", "next increment")
+    assert res.returncode == 0, res.stderr
+    sid = f"defer-{PRD_ID}-finding-1"
+    lines = _captured(cap)
+    assert len(lines) == 1 and sid in lines[0], lines
+    rec = _ledger(repo)[sid]
+    assert rec["status"] == "open" and rec["linear"]["state"] == "captured"
+
+
+def test_capture_link_is_not_a_tracker_ref_for_the_gate():
+    """The alert ticket makes the row VISIBLE; it is not the promotion receipt
+    the scopeless gate accepts for a blocking item. Minting that receipt by
+    default would be "a check its own default satisfies" (see the comment on
+    _spillover_has_tracker_ref), so gate semantics stay exactly as they were."""
+    sys.path.insert(0, str(PLUGIN_ROOT / "scripts"))
+    import prd_runner  # noqa: E402
+    row = {"id": "sp-x", "severity": "major", "status": "open",
+           "linear": {"state": "filed", "identifier": "ASK-9", "exit": 0}}
+    assert not prd_runner._spillover_has_tracker_ref(row)
+    assert prd_runner._spillover_blocks(row, None)
+    assert prd_runner._spillover_has_tracker_ref({"linear": "ASK-9"})  # the old door

--- a/plugins/prd-os/tests/test_spillover_files_linear.py
+++ b/plugins/prd-os/tests/test_spillover_files_linear.py
@@ -24,6 +24,8 @@ PRD_RUNNER = PLUGIN_ROOT / "scripts" / "prd_runner.py"
 FINDINGS_WRITER = PLUGIN_ROOT / "scripts" / "findings_writer.py"
 SKEL_SCRIPTS = PLUGIN_ROOT.parents[1] / "q-system" / ".q-system" / "scripts"
 PRD_ID = "prd-demo-2026-09-12"
+REFUSAL = ("a minor is fixed in this change or rejected with a reason; "
+           "it is never queued (founder 2026-09-12)")
 
 
 @pytest.fixture
@@ -66,9 +68,39 @@ def _captured(capture: Path) -> list:
     return capture.read_text().splitlines() if capture.exists() else []
 
 
-def _add(repo: Path, capture: Path, *extra: str) -> subprocess.CompletedProcess:
+def _add(repo: Path, capture: Path, *extra: str, severity: str = "major") -> subprocess.CompletedProcess:
     return _run(PRD_RUNNER, repo, capture, "spillover", "add", "--source", "ASK-1552",
-                "--desc", "ledger rows never reach Linear", "--id", "sp-cap00001", *extra)
+                "--desc", "ledger rows never reach Linear", "--id", "sp-cap00001",
+                "--severity", severity, *extra)
+
+
+@pytest.mark.parametrize("severity", ["minor", "low"])
+def test_add_refuses_a_minor_or_low_and_writes_nothing(repo, tmp_path, severity):
+    """Founder 2026-09-12: "New minor findings: fix or reject, never queue"."""
+    cap = tmp_path / "capture.txt"
+    res = _add(repo, cap, severity=severity)
+    assert res.returncode == 2, res.stdout + res.stderr
+    assert REFUSAL in res.stderr
+    assert _ledger(repo) == {}, "a refused minor still reached the ledger"
+    assert _captured(cap) == [], "a refused minor still reached Linear"
+
+
+def test_add_with_no_severity_is_a_refused_minor(repo, tmp_path):
+    """The CLI default is `minor`, so a bare add is the minor case."""
+    cap = tmp_path / "capture.txt"
+    res = _run(PRD_RUNNER, repo, cap, "spillover", "add", "--source", "ASK-1552",
+               "--desc", "bare add", "--id", "sp-bare0001")
+    assert res.returncode == 2 and REFUSAL in res.stderr
+    assert _ledger(repo) == {}
+
+
+@pytest.mark.parametrize("severity", ["medium", "blocker"])
+def test_add_medium_and_blocker_still_file(repo, tmp_path, severity):
+    cap = tmp_path / "capture.txt"
+    res = _add(repo, cap, severity=severity)
+    assert res.returncode == 0, res.stderr
+    assert len(_captured(cap)) == 1
+    assert _ledger(repo)["sp-cap00001"]["linear"]["state"] == "captured"
 
 
 def test_add_files_exactly_one_issue_and_row_carries_the_link(repo, tmp_path):
@@ -78,7 +110,7 @@ def test_add_files_exactly_one_issue_and_row_carries_the_link(repo, tmp_path):
     lines = _captured(cap)
     assert len(lines) == 1, lines
     assert "sp-cap00001" in lines[0] and "ASK-1552" in lines[0]
-    assert "minor" in lines[0] and "ledger rows never reach Linear" in lines[0]
+    assert "major" in lines[0] and "ledger rows never reach Linear" in lines[0]
     rec = _ledger(repo)["sp-cap00001"]
     assert rec["status"] == "open"
     assert rec["linear"]["state"] == "captured" and rec["linear"]["exit"] == 0
@@ -122,6 +154,30 @@ def test_deferred_disposition_files_exactly_one_issue(repo, tmp_path):
     assert rec["status"] == "open" and rec["linear"]["state"] == "captured"
 
 
+@pytest.mark.parametrize("severity", ["minor", "nit"])
+def test_deferring_a_minor_finding_is_refused(repo, tmp_path, severity):
+    """The only options for a minor are accepted (and fixed) or rejected with a
+    rationale. prd-os findings grade minor-class work as `minor` or `nit`."""
+    d = repo / ".prd-os" / "findings"
+    d.mkdir(parents=True)
+    rec = {"id": "finding-2", "prd_id": PRD_ID, "source": "codex-review",
+           "disposition": "pending", "body": "nit: rename a local",
+           "created_at": "2026-09-12T00:00:00Z"}
+    rec["severity"] = severity
+    fpath = d / f"{PRD_ID}-findings.jsonl"
+    fpath.write_text(json.dumps(rec) + "\n")
+    cap = tmp_path / "capture.txt"
+    res = _run(FINDINGS_WRITER, repo, cap, "set-disposition", PRD_ID, "finding-2",
+               "deferred", "--rationale", "later")
+    assert res.returncode == 2, res.stdout + res.stderr
+    assert REFUSAL in res.stderr
+    assert json.loads(fpath.read_text().splitlines()[0])["disposition"] == "pending"
+    assert _ledger(repo) == {} and _captured(cap) == []
+    ok = _run(FINDINGS_WRITER, repo, cap, "set-disposition", PRD_ID, "finding-2",
+              "rejected", "--rationale", "not worth a change")
+    assert ok.returncode == 0, ok.stderr
+
+
 def test_capture_link_is_not_a_tracker_ref_for_the_gate():
     """The alert ticket makes the row VISIBLE; it is not the promotion receipt
     the scopeless gate accepts for a blocking item. Minting that receipt by
@@ -134,3 +190,16 @@ def test_capture_link_is_not_a_tracker_ref_for_the_gate():
     assert not prd_runner._spillover_has_tracker_ref(row)
     assert prd_runner._spillover_blocks(row, None)
     assert prd_runner._spillover_has_tracker_ref({"linear": "ASK-9"})  # the old door
+
+
+def test_the_two_plugin_copies_of_the_minor_rule_agree():
+    """kipi-dsse keeps its own copy so it stays import-independent of prd-os."""
+    import importlib.util as ilu
+    sys.path.insert(0, str(PLUGIN_ROOT / "scripts"))
+    import prd_runner  # noqa: E402
+    spec = ilu.spec_from_file_location(
+        "issue_findings_copy", PLUGIN_ROOT.parent / "kipi-dsse" / "scripts" / "issue_findings.py")
+    dsse = ilu.module_from_spec(spec)
+    spec.loader.exec_module(dsse)
+    assert dsse.REFUSED_DEFER_SEVERITIES == prd_runner.SPILLOVER_REFUSED_SEVERITIES
+    assert dsse.MINOR_REFUSAL == prd_runner.MINOR_REFUSAL == REFUSAL

--- a/plugins/prd-os/tests/test_spillover_gate_reachability.py
+++ b/plugins/prd-os/tests/test_spillover_gate_reachability.py
@@ -37,6 +37,9 @@ from pathlib import Path
 
 import pytest
 
+sys.path.insert(0, str(Path(__file__).resolve().parent))
+from legacy_spillover import is_legacy_minor_add, seed_legacy_add  # noqa: E402
+
 PLUGIN_ROOT = Path(__file__).resolve().parents[1]
 PRD_RUNNER = PLUGIN_ROOT / "scripts" / "prd_runner.py"
 
@@ -46,6 +49,14 @@ BULK_INHERITED = 300
 
 
 def run(repo: Path, *args: str) -> subprocess.CompletedProcess:
+    # A minor `add` seeds a pre-2026-09-12 row: the CLI now refuses new minors
+    # (founder 2026-09-12), and those legacy rows are what this suite models.
+    if is_legacy_minor_add(args):
+        return seed_legacy_add(repo, args)
+    return _run_cli(repo, *args)
+
+
+def _run_cli(repo: Path, *args: str) -> subprocess.CompletedProcess:
     """Direct invocation. NOTHING is piped: `.returncode` here is the gate's own
     exit status, which is the single property every case in this file turns on."""
     return subprocess.run(

--- a/q-system/.q-system/enforced-claim-baseline.json
+++ b/q-system/.q-system/enforced-claim-baseline.json
@@ -21,7 +21,6 @@
     ".claude/rules/model-allocation.md::model allocation policy",
     ".claude/rules/morning-pipeline.md::preflight fail fast and audit harness",
     ".claude/rules/morning-pipeline.md::self healing loop",
-    ".claude/rules/no-orphan-findings.md::no orphan findings",
     ".claude/rules/quick-plan.md::quick plan mode",
     ".claude/rules/rca-mode.md::rca mode",
     ".claude/rules/remote-coverage.md::remote coverage",

--- a/q-system/.q-system/scripts/linear-worker.sh
+++ b/q-system/.q-system/scripts/linear-worker.sh
@@ -2045,7 +2045,7 @@ Work here. Never `cd` to $TARGET_REPO and never switch this branch -- the founde
    genuinely unexecutable, not when it is merely hard.
 
 Anything real you find and are not fixing: capture it, never just mention it:
-  python3 $SKEL/plugins/prd-os/scripts/prd_runner.py spillover add --source $ISSUE --desc \"...\""
+  python3 $SKEL/plugins/prd-os/scripts/prd_runner.py spillover add --source $ISSUE --severity <medium|high|major|blocker> --desc \"...\" (a minor is fixed now or rejected, never queued)"
 
   # CLEAR BEFORE DISPATCH, so presence AFTER the run means exactly one thing:
   # THIS run wrote it (Codex round 2 on PR #141, major).

--- a/q-system/.q-system/scripts/spillover-linear-check.py
+++ b/q-system/.q-system/scripts/spillover-linear-check.py
@@ -69,6 +69,10 @@ FILER_TIMEOUT_SECONDS = 120
 # file, which is the only delivery a test run is allowed to make.
 LINKED_STATES = ("filed", "captured")
 
+# RULE-2026-09-12-A: a new minor is never queued. Instances that have not synced
+# the refusal yet still write these; the check counts them and files nothing.
+MINOR_CLASS = ("minor", "low", "nit")
+
 _IDENT = re.compile(r"\b(?:filed|repeat #\d+ on) ([A-Z][A-Z0-9]*-\d+)\b")
 
 
@@ -96,6 +100,17 @@ def is_new(rec: dict) -> bool:
     as pre-existing: the safe side of "do not flood Linear"."""
     created = _instant(rec.get("created_at"))
     return created is not None and created >= CUTOFF
+
+
+def is_minor(rec: dict) -> bool:
+    return str(rec.get("severity") or "minor").strip().lower() in MINOR_CLASS
+
+
+def needs_close(rec: dict) -> bool:
+    """A row that left the ledger while its capture ticket is still open."""
+    link = rec.get("linear")
+    return (rec.get("status") == "resolved" and isinstance(link, dict)
+            and link.get("state") in LINKED_STATES and not link.get("closed_at"))
 
 
 def is_linked(rec: dict) -> bool:
@@ -161,6 +176,72 @@ def file_record(rec: dict, repo_root) -> dict:
     return parse_filer_output(res.returncode, res.stdout, res.stderr)
 
 
+ISSUE_FOR_CLOSE = ('query($id:String!){issue(id:$id){id identifier state{type} '
+                   'team{states{nodes{id type}}}}}')
+ISSUE_SET_STATE = ('mutation($id:String!,$input:IssueUpdateInput!)'
+                   '{issueUpdate(id:$id,input:$input){success}}')
+COMMENT_CREATE = ('mutation($input:CommentCreateInput!)'
+                  '{commentCreate(input:$input){success}}')
+
+
+def _load_alert_module():
+    spec = importlib.util.spec_from_file_location("alert_to_linear_slc", FILER)
+    mod = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(mod)
+    return mod
+
+
+def close_record(rec: dict, repo_root, ln=None) -> dict:
+    """Close the capture ticket of a row that left the ledger (review F2, PR #344).
+
+    why: the ticket is Sana's view of the row. A voided row whose ticket stays
+    open is work that does not exist, sitting in the queue a worker drains, and
+    nothing else ever closes it. Voided -> canceled, fixed -> completed, with a
+    comment saying which. Same test contract as the filer: KIPI_ALERT_CAPTURE
+    receives a line instead of a Linear write, and a pytest run with no capture
+    is refused. Never raises; a failure is retried by the next run.
+    """
+    sid = str(rec.get("id") or "?")
+    link = rec.get("linear") or {}
+    ident = link.get("identifier")
+    target = "canceled" if rec.get("void_reason") else "completed"
+    reason = (rec.get("void_reason") or rec.get("resolution_ref")
+              or "resolved in the spillover ledger")
+    capture = os.environ.get("KIPI_ALERT_CAPTURE")
+    if ln is None and capture:
+        try:
+            with open(capture, "a", encoding="utf-8") as fh:
+                fh.write(f"spillover-close {sid} {ident or 'captured'} {target}: {reason}\n")
+        except OSError as exc:
+            return {"close": "failed", "detail": repr(exc)[:300]}
+        return {"close": target, "closed_at": _now_iso()}
+    if ln is None and os.environ.get("PYTEST_CURRENT_TEST"):
+        return {"close": "failed", "detail": "refused under pytest"}
+    if not ident:
+        return {"close": "failed", "detail": "no Linear identifier on the row"}
+    try:
+        if ln is None:
+            ln = _load_alert_module()._load_linear()
+        issue = (ln.graphql(ISSUE_FOR_CLOSE, {"id": ident}) or {}).get("issue") or {}
+        if not issue.get("id"):
+            return {"close": "failed", "detail": f"{ident} not found"}
+        if ((issue.get("state") or {}).get("type") or "") in ("completed", "canceled"):
+            return {"close": "already-closed", "closed_at": _now_iso()}
+        states = ((issue.get("team") or {}).get("states") or {}).get("nodes") or []
+        state_id = next((st["id"] for st in states if st.get("type") == target), None)
+        if not state_id:
+            return {"close": "failed", "detail": f"no {target} state on the team"}
+        ln.graphql(COMMENT_CREATE, {"input": {"issueId": issue["id"], "body": (
+            f"Spillover row `{sid}` left the ledger ({target}): {reason}. "
+            "Closed by spillover-linear-check.py.")}})
+        res = ln.graphql(ISSUE_SET_STATE, {"id": issue["id"], "input": {"stateId": state_id}})
+        if not ((res or {}).get("issueUpdate") or {}).get("success"):
+            return {"close": "failed", "detail": "issueUpdate did not succeed"}
+        return {"close": target, "closed_at": _now_iso()}
+    except Exception as exc:  # noqa: BLE001
+        return {"close": "failed", "detail": repr(exc)[:300]}
+
+
 # --------------------------------------------------------------------------
 # The daily check
 # --------------------------------------------------------------------------
@@ -207,6 +288,7 @@ def main(argv: list | None = None) -> int:
         return 1
 
     budget = max(args.limit, 0)
+    close_budget = max(args.limit, 0)
     failed_read = False
     totals = {"open": 0, "backlog": 0, "filed": 0, "still": 0}
     per_ledger = []
@@ -226,7 +308,9 @@ def main(argv: list | None = None) -> int:
             continue
         open_rows = [r for r in items.values() if r.get("status") == "open"]
         backlog = [r for r in open_rows if not is_new(r) and not is_linked(r)]
-        new_rows = [r for r in open_rows if is_new(r)]
+        new_all = [r for r in open_rows if is_new(r)]
+        new_minor = [r for r in new_all if is_minor(r)]
+        new_rows = [r for r in new_all if not is_minor(r)]
         already = [r for r in new_rows if is_linked(r)]
         todo = sorted((r for r in new_rows if not is_linked(r)),
                       key=lambda r: _instant(r.get("created_at")))
@@ -242,6 +326,17 @@ def main(argv: list | None = None) -> int:
             else:
                 failed_now += 1
         still = len(todo) - filed_now
+        closed_now = close_failed = 0
+        for rec in [r for r in items.values() if needs_close(r)]:
+            if args.dry_run or close_budget <= 0:
+                break
+            close_budget -= 1
+            close = close_record(rec, root)
+            if close.get("closed_at"):
+                runner._spillover_record_close(cfg, rec["id"], close)
+                closed_now += 1
+            else:
+                close_failed += 1
         per_ledger.append((name, still))
         totals["open"] += len(open_rows)
         totals["backlog"] += len(backlog)
@@ -250,7 +345,9 @@ def main(argv: list | None = None) -> int:
         print(f"spillover-linear-check {name}: open={len(open_rows)} "
               f"pre_cutoff_unlinked={len(backlog)} new_open={len(new_rows)} "
               f"already_linked={len(already)} filed_now={filed_now} "
-              f"failed_now={failed_now} still_unlinked={still}")
+              f"failed_now={failed_now} still_unlinked={still} "
+              f"new_minor_skipped={len(new_minor)} closed_now={closed_now} "
+              f"close_failed={close_failed}")
 
     print(f"spillover-linear-check TOTAL: open={totals['open']} "
           f"filed_now={totals['filed']} still_unlinked={totals['still']}")

--- a/q-system/.q-system/scripts/spillover-linear-check.py
+++ b/q-system/.q-system/scripts/spillover-linear-check.py
@@ -1,0 +1,276 @@
+#!/usr/bin/env python3
+"""Spillover -> Linear: file each new ledger row once, and say so when one is not.
+
+ASK-1552. Founder, 2026-09-12, verbatim: "Backlog where? In linear or is it
+going to disappear" and then "You told me you saved this exact thing to memory
+many times. Is not true." Measured by script that day: `.prd-os/spillover.jsonl`
+is untracked in git in chief, consulting and kipi-system, and nothing carried it
+to Linear. A finding that lives only in an untracked file on one laptop is not
+captured, it is parked where Sana's queue cannot see it.
+
+TWO JOBS, ONE DEFINITION.
+
+1. The capture-time filer. `prd_runner.py spillover add`, findings_writer's
+   deferred auto-create and kipi-dsse's issue_findings deferred auto-create all
+   import THIS file for `file_record()`, so there is one definition of "what a
+   spillover row's Linear message says" and "how the filer's answer is read".
+   Each caller keeps writing the ledger through its own existing append; this
+   file never writes a ledger on their behalf.
+
+2. The daily check (`main`). Reads the ledger(s) it is pointed at, retries the
+   Linear link for open rows created on or after CREATED_AT_CUTOFF that have
+   none, bounded per run, and files ONE summary alert (fingerprint-deduped by
+   alert-to-linear) when rows stay unlinked. The link it records goes through
+   prd_runner's `_spillover_record_link`, the ledger's existing locked write
+   path, never a second writer.
+
+WHAT IT DELIBERATELY DOES NOT DO. Rows created before CREATED_AT_CUTOFF are the
+pre-existing backlog (open rows measured 2026-09-12: kipi-system 1,318, consulting 529, chief 3).
+Bulk-filing them, and whether minors should be filed at all, are founder
+decisions still pending, so the check skips them and prints their count on its
+own line instead of folding it into the numbers it acts on.
+
+EXIT CONTRACT (launchd-health reads LastExitStatus, so a non-zero here pages):
+  0  every new open row is linked, or the summary alert about the rest landed
+  1  the check could not do its job: a ledger or prd_runner could not be read,
+     or rows stayed unlinked AND the summary alert failed. A job that cannot
+     alert must not exit 0, or it goes quiet exactly when it matters.
+"""
+from __future__ import annotations
+
+import argparse
+import hashlib
+import importlib.util
+import os
+import re
+import subprocess
+import sys
+import types
+from datetime import datetime, timezone
+from pathlib import Path
+
+HERE = Path(__file__).resolve().parent
+FILER = HERE / "alert-to-linear.py"
+
+# Rows created before this instant are the pre-existing backlog: counted and
+# printed, never filed by this check. Set to the moment the capture-time filer
+# was written (date -u, 2026-09-13T01:30:20Z), so every row captured from then
+# on is either filed at capture or retried here.
+CREATED_AT_CUTOFF = "2026-09-13T01:30:00Z"
+
+# Retries per run, across every ledger. A bound, so a Linear outage or a long
+# un-synced instance cannot turn one run into a flood of tickets.
+DEFAULT_RETRY_LIMIT = 20
+
+FILER_TIMEOUT_SECONDS = 120
+
+# States that mean "this row has a Linear issue". `captured` is the
+# KIPI_ALERT_CAPTURE hatch: the filer accepted the message into the capture
+# file, which is the only delivery a test run is allowed to make.
+LINKED_STATES = ("filed", "captured")
+
+_IDENT = re.compile(r"\b(?:filed|repeat #\d+ on) ([A-Z][A-Z0-9]*-\d+)\b")
+
+
+def _now_iso() -> str:
+    return datetime.now(timezone.utc).strftime("%Y-%m-%dT%H:%M:%SZ")
+
+
+def _instant(value) -> datetime | None:
+    """Parse a created_at as an INSTANT. Strings from different writers compare
+    wrong as strings (a `+00:00` row sorts differently from a `Z` row)."""
+    if not isinstance(value, str) or not value.strip():
+        return None
+    try:
+        dt = datetime.fromisoformat(value.strip().replace("Z", "+00:00"))
+    except ValueError:
+        return None
+    return dt if dt.tzinfo else dt.replace(tzinfo=timezone.utc)
+
+
+CUTOFF = _instant(CREATED_AT_CUTOFF)
+
+
+def is_new(rec: dict) -> bool:
+    """On or after the cutoff. A missing or unparseable created_at is counted
+    as pre-existing: the safe side of "do not flood Linear"."""
+    created = _instant(rec.get("created_at"))
+    return created is not None and created >= CUTOFF
+
+
+def is_linked(rec: dict) -> bool:
+    link = rec.get("linear")
+    return isinstance(link, dict) and link.get("state") in LINKED_STATES
+
+
+def _row_key(sid: str) -> str:
+    """A per-row word that survives alert-to-linear's fingerprint.
+
+    why: that fingerprint strips paths, digits and hex before hashing, so it can
+    collapse a flood of one alert into one ticket. A spillover id is `sp-` plus
+    hex, which it strips, so two rows whose descriptions differ only by a path
+    would land on ONE ticket. Mapping a hash of the id onto the letters g..v
+    (none of them hex) gives a token it keeps: distinct rows get distinct
+    tickets, and re-filing the SAME row still dedups onto its own ticket.
+    """
+    digest = hashlib.sha256(sid.encode("utf-8")).hexdigest()[:12]
+    return "".join(chr(ord("g") + int(c, 16)) for c in digest)
+
+
+def message_for(rec: dict) -> str:
+    """The alert text. Title is its first 110 chars, so the id leads."""
+    sid = str(rec.get("id") or "?")
+    desc = " ".join(str(rec.get("description") or "").split())[:600]
+    return (f"spillover {sid} ({rec.get('severity') or 'minor'}) from "
+            f"{rec.get('source') or '?'}: {desc} | owner {rec.get('owner') or 'sana'}"
+            f" | resolve with prd_runner spillover resolve {sid} | key {_row_key(sid)}")
+
+
+def parse_filer_output(code, stdout: str, stderr: str) -> dict:
+    """Turn alert-to-linear's answer into the row's `linear` link."""
+    link = {"exit": code, "at": _now_iso(), "identifier": None}
+    match = _IDENT.search(stdout or "")
+    if code == 0 and match:
+        link.update(state="filed", identifier=match.group(1))
+    elif code == 0 and "CAPTURED to" in (stderr or ""):
+        link["state"] = "captured"
+    else:
+        # Includes exit 0 with no identifier (a noise suppression): the row has
+        # no issue, so it stays unlinked and the daily check retries it.
+        link["state"] = "failed"
+        link["detail"] = ((stderr or "") + (stdout or "")).strip()[-300:]
+    return link
+
+
+def file_record(rec: dict, repo_root) -> dict:
+    """File one row through alert-to-linear.py. Never raises: a filer failure
+    becomes a `failed` link the daily check retries, never a lost row."""
+    if not FILER.is_file():
+        return {"state": "failed", "exit": None, "identifier": None,
+                "at": _now_iso(), "detail": f"no filer at {FILER}"}
+    env = dict(os.environ)
+    # Route the ticket to the ledger's own repo's Linear project.
+    env.setdefault("KIPI_ALERT_REPO_PATH", str(repo_root))
+    try:
+        res = subprocess.run([sys.executable, str(FILER), message_for(rec)],
+                             capture_output=True, text=True, env=env,
+                             timeout=FILER_TIMEOUT_SECONDS)
+    except Exception as exc:  # noqa: BLE001
+        return {"state": "failed", "exit": None, "identifier": None,
+                "at": _now_iso(), "detail": repr(exc)[:300]}
+    return parse_filer_output(res.returncode, res.stdout, res.stderr)
+
+
+# --------------------------------------------------------------------------
+# The daily check
+# --------------------------------------------------------------------------
+
+def _load_runner():
+    """prd_runner from this checkout: its lock + append are the ledger's one
+    write path, and its reader is the one definition of last-write-wins."""
+    scripts = HERE.parents[2] / "plugins" / "prd-os" / "scripts"
+    sys.path.insert(0, str(scripts))
+    spec = importlib.util.spec_from_file_location("prd_runner_slc", scripts / "prd_runner.py")
+    mod = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(mod)
+    return mod
+
+
+def _repo_root_of(target: str) -> Path:
+    p = Path(target).expanduser().resolve()
+    if p.is_file() and p.name.endswith(".jsonl"):
+        return p.parent.parent
+    return p
+
+
+def _summary_message(per_ledger: list, limit: int) -> str:
+    counts = ", ".join(f"{name} {n}" for name, n in per_ledger)
+    return ("spillover-linear-check: open spillover rows captured after the "
+            "capture-filing cutoff still have no Linear issue after this run's "
+            f"retries. Unlinked per ledger: {counts}. Each run retries up to {limit}. "
+            "Rows from before the cutoff are the pre-existing backlog and are not "
+            "counted here.")
+
+
+def main(argv: list | None = None) -> int:
+    ap = argparse.ArgumentParser(description=__doc__.split("\n")[0])
+    ap.add_argument("targets", nargs="+", help="repo roots or spillover.jsonl paths")
+    ap.add_argument("--limit", type=int, default=DEFAULT_RETRY_LIMIT,
+                    help="max rows to retry per run, across all ledgers")
+    ap.add_argument("--dry-run", action="store_true", help="count only; file nothing")
+    args = ap.parse_args(argv)
+
+    try:
+        runner = _load_runner()
+    except Exception as exc:  # noqa: BLE001
+        print(f"spillover-linear-check: cannot load prd_runner ({exc!r})", file=sys.stderr)
+        return 1
+
+    budget = max(args.limit, 0)
+    failed_read = False
+    totals = {"open": 0, "backlog": 0, "filed": 0, "still": 0}
+    per_ledger = []
+    for target in args.targets:
+        root = _repo_root_of(target)
+        name = root.name
+        if not root.is_dir():
+            print(f"spillover-linear-check {name}: no repo at {root} (skipped)")
+            continue
+        cfg = types.SimpleNamespace(repo_root=root)
+        try:
+            items = runner._read_spillover(cfg)
+        except Exception as exc:  # noqa: BLE001
+            print(f"spillover-linear-check {name}: cannot read ledger ({exc!r})",
+                  file=sys.stderr)
+            failed_read = True
+            continue
+        open_rows = [r for r in items.values() if r.get("status") == "open"]
+        backlog = [r for r in open_rows if not is_new(r) and not is_linked(r)]
+        new_rows = [r for r in open_rows if is_new(r)]
+        already = [r for r in new_rows if is_linked(r)]
+        todo = sorted((r for r in new_rows if not is_linked(r)),
+                      key=lambda r: _instant(r.get("created_at")))
+        filed_now = failed_now = 0
+        for rec in todo:
+            if args.dry_run or budget <= 0:
+                break
+            budget -= 1
+            link = file_record(rec, root)
+            runner._spillover_record_link(cfg, rec["id"], link)
+            if link.get("state") in LINKED_STATES:
+                filed_now += 1
+            else:
+                failed_now += 1
+        still = len(todo) - filed_now
+        per_ledger.append((name, still))
+        totals["open"] += len(open_rows)
+        totals["backlog"] += len(backlog)
+        totals["filed"] += filed_now
+        totals["still"] += still
+        print(f"spillover-linear-check {name}: open={len(open_rows)} "
+              f"pre_cutoff_unlinked={len(backlog)} new_open={len(new_rows)} "
+              f"already_linked={len(already)} filed_now={filed_now} "
+              f"failed_now={failed_now} still_unlinked={still}")
+
+    print(f"spillover-linear-check TOTAL: open={totals['open']} "
+          f"filed_now={totals['filed']} still_unlinked={totals['still']}")
+    print(f"pre-existing unlinked backlog (created before {CREATED_AT_CUTOFF}, "
+          f"not filed by this check): {totals['backlog']}")
+
+    rc = 1 if failed_read else 0
+    if totals["still"] and not args.dry_run:
+        msg = _summary_message(per_ledger, args.limit)
+        try:
+            res = subprocess.run([sys.executable, str(FILER), msg], capture_output=True,
+                                 text=True, timeout=FILER_TIMEOUT_SECONDS)
+            code, out = res.returncode, (res.stdout + res.stderr).strip()
+        except Exception as exc:  # noqa: BLE001
+            code, out = 1, repr(exc)
+        print(f"summary alert: exit {code}: {out[-300:]}")
+        if code != 0:
+            rc = 1
+    return rc
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/q-system/.q-system/scripts/spillover-promote.py
+++ b/q-system/.q-system/scripts/spillover-promote.py
@@ -381,7 +381,8 @@ def promote_locked(args, root: Path, ledger: Path, rec: dict) -> int:
             f"{rec['id']} already has issue {ident}; a previous run created it "
             "and did not record it.\nRecording it now, creating nothing.\n")
     else:
-        ident = create_issue(ls, args, root, build_body(rec, args._dor, root.name))
+        ident = create_issue(ls, args, root, build_body(rec, args._dor, root.name),
+                             adopt=capture_ticket(rec))
         if not isinstance(ident, str):
             return ident      # a refusal/failure code from the create path
 
@@ -485,8 +486,28 @@ def registry_project(root: Path) -> str:
     return ""
 
 
-def create_issue(ls, args, root: Path, body: str):
-    """The issue, or an int exit code when a required name does not resolve."""
+ISSUE_ADOPT = ('mutation($id:String!,$input:IssueUpdateInput!){issueUpdate(id:$id,'
+               'input:$input){success issue{identifier}}}')
+
+
+def capture_ticket(rec: dict):
+    """The Linear issue filed for this row at capture (ASK-1552), or None."""
+    link = rec.get("linear")
+    if isinstance(link, dict) and link.get("state") == "filed" and link.get("identifier"):
+        return str(link["identifier"])
+    return None
+
+
+def create_issue(ls, args, root: Path, body: str, adopt=None):
+    """The issue, or an int exit code when a required name does not resolve.
+
+    ADOPT (review F1, PR #344): a row captured since ASK-1552 already has a Linear
+    issue, filed at capture for visibility. Creating another here made two
+    permanent issues for one finding, and the marker search in existing_issue()
+    could not see the first because its body never carried the marker. So the
+    capture ticket is promoted IN PLACE: same routing and body as a create,
+    written onto the existing issue, whose body then opens with the marker.
+    """
     tid = ls.graphql('query{teams(filter:{key:{eq:"%s"}}){nodes{id}}}' % TEAM_KEY,
                      {})["teams"]["nodes"][0]["id"]
     # Resolved BEFORE the create, so a bad name costs nothing. Resolving after
@@ -526,6 +547,15 @@ def create_issue(ls, args, root: Path, body: str):
             "set KIPI_LINEAR_PROJECT.\n")
         return 2
 
+    if adopt:
+        res = ls.graphql(ISSUE_ADOPT, {"id": adopt, "input": {
+            "title": args.title, "description": body, "priority": args.priority,
+            "labelIds": label_ids, "projectId": pid}})
+        upd = (res or {}).get("issueUpdate") or {}
+        if not upd.get("success"):
+            sys.stderr.write(f"Linear adopt of {adopt} failed: {json.dumps(res)[:300]}\n")
+            return 1
+        return (upd.get("issue") or {}).get("identifier") or adopt
     res = ls.graphql(ls.ISSUE_CREATE, {"input": {
         "teamId": tid, "title": args.title, "description": body,
         "priority": args.priority,

--- a/q-system/.q-system/tests/test_spillover_linear_check.py
+++ b/q-system/.q-system/tests/test_spillover_linear_check.py
@@ -41,7 +41,7 @@ def _now() -> str:
 
 
 def _row(sid: str, created_at: str, status: str = "open", **extra) -> dict:
-    rec = {"id": sid, "source": "ASK-1552", "severity": "minor",
+    rec = {"id": sid, "source": "ASK-1552", "severity": "medium",
            "description": f"finding {sid} needs a Linear issue",
            "status": status, "created_at": created_at, "owner": "sana"}
     rec.update(extra)
@@ -203,3 +203,131 @@ def test_distinct_rows_never_collapse_into_one_ticket():
     b = _row("sp-bbbb2222", _now(), description="stale read in q-consult/b.py")
     assert atl.fingerprint(check.message_for(a)) != atl.fingerprint(check.message_for(b))
     assert atl.fingerprint(check.message_for(a)) == atl.fingerprint(check.message_for(dict(a)))
+
+
+# --- PR #344 review round 1 --------------------------------------------------
+
+def test_check_never_files_a_new_minor_row(repo, tmp_path):
+    """F3. Pre-sync instances still write minors; RULE-2026-09-12-A says a minor
+    is never queued, so the check counts them and files nothing."""
+    _seed(repo, [_row("sp-min00001", _now(), severity="minor"),
+                 _row("sp-nit00001", _now(), severity="nit"),
+                 _row("sp-med00001", _now(), severity="medium")])
+    cap = tmp_path / "capture.txt"
+    res = _check(repo, cap)
+    assert res.returncode == 0, res.stdout + res.stderr
+    lines = _captured(cap)
+    assert len(lines) == 1 and "sp-med00001" in lines[0], lines
+    assert "new_minor_skipped=2" in res.stdout
+
+
+def test_check_closes_the_ticket_of_a_row_that_left_the_ledger(repo, tmp_path):
+    """F2. A resolved or voided row's capture ticket must not stay open forever."""
+    link = {"state": "captured", "identifier": None, "exit": 0, "at": _now()}
+    _seed(repo, [_row("sp-void0001", _now(), status="resolved",
+                      void_reason="not real after all", linear=link),
+                 _row("sp-open0001", _now(), linear=dict(link))])
+    cap = tmp_path / "capture.txt"
+    res = _check(repo, cap)
+    assert res.returncode == 0, res.stdout + res.stderr
+    closes = [ln for ln in _captured(cap) if ln.startswith("spillover-close ")]
+    assert len(closes) == 1 and "sp-void0001" in closes[0], _captured(cap)
+    assert "closed_now=1" in res.stdout
+    assert _ledger(repo)["sp-void0001"]["linear"]["closed_at"]
+    assert "closed_at" not in _ledger(repo)["sp-open0001"]["linear"]
+    # Idempotent: the second run closes nothing.
+    again = _check(repo, cap)
+    assert len([ln for ln in _captured(cap) if ln.startswith("spillover-close ")]) == 1
+    assert "closed_now=0" in again.stdout
+
+
+class _CloseLinear:
+    """Fake linear-sync surface for the close path: one open issue."""
+
+    def __init__(self, state_type="unstarted"):
+        self.state_type, self.updates, self.comments = state_type, [], []
+
+    def graphql(self, query, variables):
+        if "issueUpdate" in query:
+            self.updates.append(variables)
+            return {"issueUpdate": {"success": True}}
+        if "commentCreate" in query:
+            self.comments.append(variables)
+            return {"commentCreate": {"success": True}}
+        if "issue(id" in query:
+            return {"issue": {"id": "uuid-7", "identifier": variables["id"],
+                              "state": {"type": self.state_type},
+                              "team": {"states": {"nodes": [
+                                  {"id": "st-done", "type": "completed"},
+                                  {"id": "st-cancel", "type": "canceled"},
+                                  {"id": "st-todo", "type": "unstarted"}]}}}}
+        raise AssertionError(query)
+
+
+def test_close_record_cancels_a_voided_row_and_completes_a_fixed_one(monkeypatch):
+    monkeypatch.delenv("KIPI_ALERT_CAPTURE", raising=False)
+    check = _load("slc_close", CHECK)
+    base = {"state": "filed", "identifier": "ASK-7", "exit": 0}
+    voided = _row("sp-v", _now(), status="resolved", void_reason="dup", linear=base)
+    fixed = _row("sp-f", _now(), status="resolved", resolution_ref="ASK-9", linear=base)
+    fake = _CloseLinear()
+    assert check.close_record(voided, Path("."), ln=fake)["close"] == "canceled"
+    assert fake.updates[-1]["input"]["stateId"] == "st-cancel"
+    assert check.close_record(fixed, Path("."), ln=fake)["close"] == "completed"
+    assert fake.updates[-1]["input"]["stateId"] == "st-done"
+    assert len(fake.comments) == 2
+    done = _CloseLinear(state_type="completed")
+    assert check.close_record(fixed, Path("."), ln=done)["close"] == "already-closed"
+    assert done.updates == []
+
+
+def test_promotion_adopts_the_capture_ticket_instead_of_filing_a_second(tmp_path):
+    """F1. A blocking row with no DoR files a capture ticket; promoting it later
+    must put the DoR on THAT ticket, not open a second permanent issue."""
+    sys.path.insert(0, str(SCRIPTS))
+    import test_spillover_promote_selection as sel  # the promoter's own stub
+
+    class AdoptLinear(sel.RecordingLinear):
+        def __init__(self, board=None):
+            super().__init__(board)
+            self.updated = None
+
+        def graphql(self, query, variables):
+            if "issueUpdate" in query:
+                self.updated = variables
+                for issue in self.board:
+                    if issue["identifier"] == variables["id"]:
+                        issue["description"] = variables["input"]["description"]
+                return {"issueUpdate": {"success": True,
+                                        "issue": {"identifier": variables["id"]}}}
+            return super().graphql(query, variables)
+
+    root = tmp_path
+    (root / ".prd-os").mkdir()
+    (root / ".prd-os" / "spillover.jsonl").write_text(json.dumps({
+        "id": "sp-test01", "status": "open", "severity": "major", "source": "ASK-451",
+        "description": "the conveyor is dead",
+        "linear": {"state": "filed", "identifier": "ASK-7001", "exit": 0}}) + "\n")
+    mod = sel.load_promote()
+    stub = AdoptLinear(board=[{"identifier": "ASK-7001",
+                               "description": "Filed automatically by the fleet alert path."}])
+    mod.linear_module = lambda: stub
+    dor = root / "dor.md"
+    dor.write_text(sel.DOR)
+    old_argv, old_env = sys.argv, dict(os.environ)
+    sys.argv = ["spillover-promote.py", "sp-test01", "--title", "conveyor",
+                "--dor-file", str(dor), "--repo-root", str(root)]
+    os.environ["KIPI_LINEAR_PROJECT"] = "kipi-system"
+    try:
+        rc = mod.main()
+    finally:
+        sys.argv = old_argv
+        os.environ.clear()
+        os.environ.update(old_env)
+    assert rc == 0
+    assert stub.created is None, "promotion filed a SECOND issue for one finding"
+    assert stub.updated and stub.updated["id"] == "ASK-7001"
+    body = stub.updated["input"]["description"]
+    assert body.startswith(mod.promotion_marker("sp-test01")) and "Definition of Ready" in body
+    rows = [json.loads(x) for x in (root / ".prd-os" / "spillover.jsonl").read_text().splitlines()]
+    assert rows[-1]["status"] == "promoted" and rows[-1]["linear_ref"] == "ASK-7001"

--- a/q-system/.q-system/tests/test_spillover_linear_check.py
+++ b/q-system/.q-system/tests/test_spillover_linear_check.py
@@ -1,0 +1,205 @@
+"""Pins spillover-linear-check.py (ASK-1552): a captured finding cannot sit where
+Sana does not see it.
+
+Founder, 2026-09-12: "Backlog where? In linear or is it going to disappear".
+Measured that day: `.prd-os/spillover.jsonl` is untracked in git in every repo
+that has one and nothing carried it to Linear. These tests pin the daily check
+that retries the Linear link for new rows and says so, loudly, when rows stay
+unlinked.
+
+Isolation: every ledger is a tmp file, and every Linear write goes through
+KIPI_ALERT_CAPTURE (alert-to-linear's own capture hatch), so no test can file a
+real ticket. The one test that needs a real `filed ASK-n` line gets it from the
+PRODUCER (alert-to-linear.file_alert against a fake Linear client), never from a
+string typed here.
+"""
+from __future__ import annotations
+
+import importlib.util
+import json
+import os
+import subprocess
+import sys
+from datetime import datetime, timezone
+from pathlib import Path
+
+import pytest
+
+SCRIPTS = Path(__file__).resolve().parents[1] / "scripts"
+CHECK = SCRIPTS / "spillover-linear-check.py"
+
+
+def _load(name: str, path: Path):
+    spec = importlib.util.spec_from_file_location(name, path)
+    mod = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(mod)
+    return mod
+
+
+def _now() -> str:
+    return datetime.now(timezone.utc).strftime("%Y-%m-%dT%H:%M:%SZ")
+
+
+def _row(sid: str, created_at: str, status: str = "open", **extra) -> dict:
+    rec = {"id": sid, "source": "ASK-1552", "severity": "minor",
+           "description": f"finding {sid} needs a Linear issue",
+           "status": status, "created_at": created_at, "owner": "sana"}
+    rec.update(extra)
+    return rec
+
+
+@pytest.fixture
+def repo(tmp_path: Path) -> Path:
+    r = tmp_path / "repo"
+    (r / ".prd-os").mkdir(parents=True)
+    (r / ".git").mkdir()
+    return r
+
+
+def _seed(repo: Path, rows: list) -> None:
+    path = repo / ".prd-os" / "spillover.jsonl"
+    with path.open("a") as fh:
+        for rec in rows:
+            fh.write(json.dumps(rec) + "\n")
+
+
+def _ledger(repo: Path) -> dict:
+    items: dict = {}
+    for raw in (repo / ".prd-os" / "spillover.jsonl").read_text().splitlines():
+        if raw.strip():
+            rec = json.loads(raw)
+            items[rec["id"]] = rec
+    return items
+
+
+def _check(repo: Path, capture: Path, *args: str) -> subprocess.CompletedProcess:
+    env = dict(os.environ, KIPI_ALERT_CAPTURE=str(capture))
+    return subprocess.run([sys.executable, str(CHECK), *args, str(repo)],
+                          capture_output=True, text=True, env=env, timeout=120)
+
+
+def _captured(capture: Path) -> list:
+    return capture.read_text().splitlines() if capture.exists() else []
+
+
+def test_check_files_new_unlinked_rows_and_skips_pre_cutoff(repo, tmp_path):
+    _seed(repo, [
+        _row("sp-old00001", "2026-01-01T00:00:00Z"),            # pre-existing backlog
+        _row("sp-new00001", _now()),
+        _row("sp-new00002", _now()),
+        _row("sp-done0001", _now(), status="resolved"),         # not open
+    ])
+    cap = tmp_path / "capture.txt"
+    res = _check(repo, cap)
+    assert res.returncode == 0, res.stdout + res.stderr
+
+    lines = _captured(cap)
+    assert len(lines) == 2, lines
+    assert any("sp-new00001" in ln for ln in lines)
+    assert any("sp-new00002" in ln for ln in lines)
+    assert not any("sp-old00001" in ln for ln in lines), "pre-cutoff row was filed"
+
+    items = _ledger(repo)
+    assert items["sp-new00001"]["linear"]["state"] == "captured"
+    assert items["sp-new00002"]["linear"]["state"] == "captured"
+    assert "linear" not in items["sp-old00001"]
+    assert items["sp-done0001"]["status"] == "resolved"
+    # The pre-existing backlog is printed as its own number, not folded in.
+    assert "pre-existing unlinked backlog" in res.stdout
+    assert "pre_cutoff_unlinked=1" in res.stdout
+
+
+def test_rerun_never_double_files(repo, tmp_path):
+    _seed(repo, [_row("sp-new00003", _now())])
+    cap = tmp_path / "capture.txt"
+    assert _check(repo, cap).returncode == 0
+    assert len(_captured(cap)) == 1
+    again = _check(repo, cap)
+    assert again.returncode == 0
+    assert len(_captured(cap)) == 1, "second run filed the same row again"
+    assert "filed_now=0" in again.stdout
+
+
+def test_rows_left_unlinked_raise_exactly_one_summary_alert(repo, tmp_path):
+    _seed(repo, [_row(f"sp-lim0000{i}", _now()) for i in range(3)])
+    cap = tmp_path / "capture.txt"
+    res = _check(repo, cap, "--limit", "1")
+    assert res.returncode == 0, res.stdout + res.stderr
+    lines = _captured(cap)
+    rows_filed = [ln for ln in lines if ln.startswith("spillover sp-")]
+    summaries = [ln for ln in lines if ln.startswith("spillover-linear-check:")]
+    assert len(rows_filed) == 1
+    assert len(summaries) == 1, lines
+    assert "still_unlinked=2" in res.stdout
+
+    # Dedup on the Linear side: tomorrow's summary for the SAME condition must
+    # carry the same alert-to-linear fingerprint, so it counts on one ticket.
+    res2 = _check(repo, cap, "--limit", "1")
+    summaries = [ln for ln in _captured(cap) if ln.startswith("spillover-linear-check:")]
+    assert len(summaries) == 2
+    atl = _load("atl_for_fp", SCRIPTS / "alert-to-linear.py")
+    assert atl.fingerprint(summaries[0]) == atl.fingerprint(summaries[1]), res2.stdout
+
+
+def test_no_summary_alert_when_every_new_row_is_linked(repo, tmp_path):
+    """Negative control for the summary test above: without it, a check that
+    alerted on every run would pass that test too."""
+    _seed(repo, [_row("sp-new00009", _now())])
+    cap = tmp_path / "capture.txt"
+    assert _check(repo, cap).returncode == 0
+    assert not [ln for ln in _captured(cap) if ln.startswith("spillover-linear-check:")]
+
+
+def test_filer_failure_keeps_rows_marks_retry_and_fails_loudly(repo, tmp_path):
+    _seed(repo, [_row("sp-fail0001", _now())])
+    cap = tmp_path / "capture-is-a-directory"
+    cap.mkdir()  # the filer cannot append to a directory: a real exit 1
+    res = _check(repo, cap)
+    # The rows could not be filed AND the summary could not be sent: a job
+    # that cannot alert must not exit 0 (launchd-health reads the exit code).
+    assert res.returncode != 0, res.stdout + res.stderr
+    rec = _ledger(repo)["sp-fail0001"]
+    assert rec["status"] == "open"
+    assert rec["linear"]["state"] == "failed"
+    assert rec["linear"]["exit"] == 1
+
+    # Next run with a working filer retries the failed row.
+    cap2 = tmp_path / "capture.txt"
+    assert _check(repo, cap2).returncode == 0
+    assert _ledger(repo)["sp-fail0001"]["linear"]["state"] == "captured"
+
+
+def test_parser_reads_identifier_from_the_producer_lines(tmp_path, monkeypatch):
+    """The `filed ASK-n` and `repeat #n on ASK-n` lines come from alert-to-linear
+    itself, run against a fake Linear client, so a format change there turns
+    this red instead of silently leaving every row unlinked."""
+    atl = _load("atl_producer", SCRIPTS / "alert-to-linear.py")
+    sys.path.insert(0, str(Path(__file__).resolve().parent))
+    from test_alert_to_linear import FakeLinear  # the suite's own fake client
+
+    fake = FakeLinear()
+    monkeypatch.setattr(atl, "_state_dir", lambda: str(tmp_path))
+    monkeypatch.setattr(atl, "_load_linear", lambda: fake)
+    check = _load("slc_parser", CHECK)
+    msg = check.message_for(_row("sp-prod0001", _now()))
+
+    code, line = atl.file_alert(msg, now=1000.0)
+    link = check.parse_filer_output(code, f"alert-to-linear: {line}\n", "")
+    assert link["state"] == "filed" and link["identifier"] == "ASK-101", line
+
+    code, line = atl.file_alert(msg, now=1001.0)
+    assert fake.created == 1
+    link = check.parse_filer_output(code, f"alert-to-linear: {line}\n", "")
+    assert link["state"] == "filed" and link["identifier"] == "ASK-101", line
+
+
+def test_distinct_rows_never_collapse_into_one_ticket():
+    """alert-to-linear strips paths, digits and hex before fingerprinting, so two
+    rows whose descriptions differ only by a path would share one ticket. The
+    per-row key keeps them apart while a re-file of the SAME row still dedups."""
+    atl = _load("atl_fp2", SCRIPTS / "alert-to-linear.py")
+    check = _load("slc_fp2", CHECK)
+    a = _row("sp-aaaa1111", _now(), description="stale read in q-consult/a.py")
+    b = _row("sp-bbbb2222", _now(), description="stale read in q-consult/b.py")
+    assert atl.fingerprint(check.message_for(a)) != atl.fingerprint(check.message_for(b))
+    assert atl.fingerprint(check.message_for(a)) == atl.fingerprint(check.message_for(dict(a)))

--- a/q-system/canonical/decisions.md
+++ b/q-system/canonical/decisions.md
@@ -340,3 +340,34 @@ Monthly audit (1st of month): count decisions by origin tag. If >60% are rubber-
 - **Date:** 2026-08-30
 - **Revisit:** When the `owner:` labels are complete (21 issues carry none) this
   gets sharper. Re-measure then, do not assume.
+
+## Spillover capture reaches Linear; new minors are never queued (ASK-1552, 2026-09-12)
+
+### RULE-2026-09-12-A: New minors are fixed or rejected; medium and up file a Linear issue at capture
+- **Origin:** [CLAUDE-RECOMMENDED -> APPROVED]
+- **Decision:** A NEW minor finding (severity minor, low or nit) is fixed in the
+  change that found it or rejected with a reason. It is never queued:
+  `prd_runner.py spillover add` refuses it (exit 2), and a `deferred` disposition
+  on it is refused in both findings systems (findings_writer.py and
+  issue_findings.py). Findings at medium, high, major or blocker are captured as a
+  ledger row AND one Linear issue for Sana, filed at capture through
+  alert-to-linear.py, with the identifier recorded on the row.
+  `q-system/.q-system/scripts/spillover-linear-check.py` (launchd
+  `com.kipi.spillover-linear-check`, daily) retries rows whose filing failed and
+  alerts Sana once when any stay unlinked. The existing ledger is cleaned once:
+  majors to Linear, minors older than 30 days voided with a reason, recent minors
+  get one triage pass.
+- **Reason:** Founder, 2026-09-12, verbatim: "Backlog where? In linear or is it
+  going to disappear", then "You told me you saved this exact thing to memory many
+  times. Is not true." and "New minor findings: fix or reject, never queue."
+  Measured by script that day: `.prd-os/spillover.jsonl` is untracked in git in
+  chief, consulting and kipi-system, nothing carried it to Linear, and the open
+  rows were kipi-system 1,318, consulting 529, chief 3. Memory notes are not
+  enforcement; the refusal and the filing are code, pinned by
+  test_spillover_files_linear.py, test_deferred_spillover_files_linear.py and
+  test_spillover_linear_check.py.
+- **Date:** 2026-09-12
+- **Revisit:** After the one-time cleanup of the pre-existing rows (the daily check
+  skips rows created before its CREATED_AT_CUTOFF and prints their count). The
+  review agent's APPROVE WITH NITS path still tries to capture minors as spillover
+  and is now refused; that path is the follow-up.


### PR DESCRIPTION
ASK-1552. Founder, 2026-09-12: "Backlog where? In linear or is it going to disappear". `.prd-os/spillover.jsonl` is untracked in git and nothing carried it to Linear. This makes capture = ledger row + Linear issue, in code.

## What shipped
- **New minors are never queued (founder 2026-09-12: "New minor findings: fix or reject, never queue.").** `spillover add` refuses minor and low (exit 2, before any write; a bare add defaults to minor and is refused). A `deferred` disposition on a minor/low/nit finding is refused in findings_writer.py and issue_findings.py before the findings file changes. Medium, high, major and blocker file one Linear issue at capture. Decision RULE-2026-09-12-A [CLAUDE-RECOMMENDED -> APPROVED] in canonical/decisions.md. Suites modelling the legacy minor rows still in the live ledgers seed them via `plugins/prd-os/tests/legacy_spillover.py`.
- **File at capture.** `spillover add`, the prd-os `deferred` auto-create (findings_writer) and the kipi-dsse `deferred` auto-create (issue_findings) now file one Linear issue per new row through `alert-to-linear.py` (owner:sana + needs-triage, fingerprint dedup). The row is written first; the link is appended after through each path's existing ledger append (`_spillover_record_link` under `_spillover_lock` for prd-os). The row gets `linear: {state: filed|captured|failed, identifier, exit, at}`. A filer failure never loses the row.
- **Daily check that cannot go quiet.** `q-system/.q-system/scripts/spillover-linear-check.py` retries open rows created on or after `CREATED_AT_CUTOFF` (2026-09-13T01:30:00Z) with no link, 20 per run, and files ONE fingerprint-deduped summary alert to Sana when rows stay unlinked. It exits non-zero when it cannot read a ledger or cannot send that alert, and launchd-health reads that exit status.
- **Pre-existing backlog is not touched.** Rows before the cutoff are counted and printed on their own line, never filed. Dry run on the live ledgers printed: kipi-system 1318, consulting 529, chief 3, `pre-existing unlinked backlog ... : 1850`.
- **Gate semantics unchanged.** The capture link is a dict and is NOT a promotion receipt: `_spillover_has_tracker_ref` and `needs-dor` ignore it (pinned by `test_capture_link_is_not_a_tracker_ref_for_the_gate`).
- **Per-row key.** alert-to-linear's fingerprint strips paths, digits and hex, so two rows differing only by a path would share one ticket. The message carries a non-hex per-row key; the same row still dedups onto its own ticket.
- Rule `no-orphan-findings.md` now says capture = row + Linear issue, names the check, and carries an enforcement block (ENFORCED slice = fable-discipline lint; the Linear filing is DETECTED). Instruction budget 512 -> 512.

## Install the daily job (founder-side, not installed by this PR)
```bash
bash /Users/assafkipnis/projects/kipi-system/q-system/.q-system/scripts/install-plist.sh com.kipi.spillover-linear-check
```
Runs 08:10 local over kipi-system, ../consulting, ../chief.

## Tests (each seen RED before GREEN)
- q-system/.q-system/tests/test_spillover_linear_check.py: files new unlinked rows and skips pre-cutoff, rerun never double-files, one summary alert with a stable fingerprint, no summary when all linked (negative control), filer failure keeps rows + exits non-zero + next run retries, parser reads the identifier from alert-to-linear's own `filed`/`repeat` lines, distinct rows never collapse.
- plugins/prd-os/tests/test_spillover_files_linear.py: add files exactly one issue and the row carries the link, re-add does not re-file, filer failure keeps the row marked `failed`, deferred disposition files one, capture link is not a tracker ref, add refuses minor/low and a bare add, medium and blocker still file, deferring a minor/nit finding is refused, the two plugin copies of the minor rule agree.
- plugins/kipi-dsse/tests/test_deferred_spillover_files_linear.py: DSSE deferred files one and links the row, filer failure keeps the row, deferring a minor/low is refused.

## Known consequence
pr-review-agent.sh's APPROVE WITH NITS path captures minors with `spillover add`; those adds are now refused (it counts them, it does not crash). Captured as a follow-up.

## Rollout
The plugin changes reach consulting and chief only through the fleet sync (kipi update). Until then the daily check files their new rows (20 per run across ledgers).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
